### PR TITLE
solver: cache concretization results immediately after solve

### DIFF
--- a/etc/spack/defaults/base/concretizer.yaml
+++ b/etc/spack/defaults/base/concretizer.yaml
@@ -99,7 +99,7 @@ concretizer:
   # Feature is experimental: enabling may result in potentially invalid concretizations
   # if package recipes are changed, see: https://github.com/spack/spack/issues/51553
   concretization_cache:
-    enable: false
+    enable: true
 
   # Options to control the behavior of the concretizer with external specs
   externals:

--- a/etc/spack/defaults/base/concretizer.yaml
+++ b/etc/spack/defaults/base/concretizer.yaml
@@ -96,8 +96,6 @@ concretizer:
 
   # If enabled, concretizations are cached in the misc_cache. The cache is keyed by the hash
   # of solver inputs, so we only need to run setup (not solve) if there is a cache hit.
-  # Feature is experimental: enabling may result in potentially invalid concretizations
-  # if package recipes are changed, see: https://github.com/spack/spack/issues/51553
   concretization_cache:
     enable: true
 

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -597,8 +597,8 @@ class ConcretizationCache:
         """Remove a corrupt or outdated cache entry, ignoring errors if it's already gone."""
         try:
             cache_path.unlink()
-        except OSError:
-            pass
+        except OSError as e:
+            tty.debug(f"Error removing entry: {e}")
 
     def _cache_path_from_problem(self, problem: str) -> pathlib.Path:
         """Returns a Path object representing the path to the cache
@@ -658,27 +658,39 @@ class ConcretizationCache:
         try:
             with gzip.open(cache_path, "rb") as f:
                 cache_content = json.loads(f.read().decode("utf-8"))
-        except (OSError, json.JSONDecodeError):
-            # file is corrupt, truncated, or disappeared since the exists() check
+        except (OSError, json.JSONDecodeError) as e:
+            tty.debug(
+                f"ConcretizationCache.fetch(): force-removing {cache_path} because it is "
+                f"corrupt, truncated, or removed since the exists() check: {e}"
+            )
             self._remove_entry(cache_path)
             return None, None
 
         cache_version = cache_content.get("_meta", {}).get("version")
         if cache_version != ConcretizationCache.VERSION:
-            # outdated format that we can't read; remove so it's regenerated
+            tty.debug(
+                f"ConcretizationCache.fetch(): force-removing {cache_path} because it is "
+                "in an outdated format."
+            )
             self._remove_entry(cache_path)
             return None, None
 
         results = cache_content.get("results")
         if results is None:
-            # malformed cache dictionary
+            tty.debug(
+                f"ConcretizationCache.fetch(): force-removing {cache_path} because 'results' is "
+                "missing from cache dictionary."
+            )
             self._remove_entry(cache_path)
             return None, None
 
         try:
             result = Result.from_dict(results)
-        except (KeyError, TypeError, ValueError, spack.error.SpecSyntaxError):
-            # valid JSON but spec data is malformed or incompatible
+        except (KeyError, TypeError, ValueError, spack.error.SpecSyntaxError) as e:
+            tty.debug(
+                f"ConcretizationCache.fetch(): force-removing {cache_path}. "
+                f"Valid JSON but spec data is malformed or incompatible: {e}"
+            )
             self._remove_entry(cache_path)
             return None, None
 

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -3678,7 +3678,7 @@ def reorder_flags(specs: SpecDict) -> None:
             # 2. Add all sources (the compiler is one of them, so skip any
             # flag group that matches it exactly)
             flag_groups = set()
-            for flag in specs[node].compiler_flags.get(flag_type, []):
+            for flag in spec.compiler_flags.get(flag_type, []):
                 flag_groups.add(
                     spack.spec.CompilerFlag(
                         flag.flag_group,

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -318,11 +318,15 @@ def spec_dict_to_json(spec_dict: SpecDict) -> Dict:
     # Make a dictionary preserving the NodeIds from input.
     node_id_for: Dict[int, NodeId] = {id(spec): nid for nid, spec in spec_dict.items()}
 
+    # make a list of all nodes in specs and their build_specs
+    specs = list(spec_dict.values())
+    specs += [spec.build_spec for spec in specs if spec.build_spec is not spec]
+
     # Traverse every spec reachable from spec_dict's values, deduped by hash, and add them
     # to the serialized entires either a) with their original NodeId, or b) with None if they
     # don't have a NodeId. This ensures that all nodes are added and NodeIds are preserved.
     entries = []
-    for dep in spack.traverse.traverse_nodes(list(spec_dict.values()), key=lambda s: s.dag_hash()):
+    for dep in spack.traverse.traverse_nodes(specs, key=lambda s: s.dag_hash()):
         node = dep.to_node_dict()
         node["hash"] = dep.dag_hash()
         entries.append((node_id_for.get(id(dep)), node))

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -348,6 +348,11 @@ def spec_dict_from_json(data: Dict) -> SpecDict:
     nodes = [node for _, node in entries]
     specs_by_hash = spack.spec.wire_spec_nodes(nodes, "hash", reader)
 
+    # clear the hashes we cached on any abstract specs, so that they can be recomputed later
+    for spec in spack.traverse.traverse_nodes(list(specs_by_hash.values()), key=id):
+        if not spec.concrete:
+            spec.clear_caches()
+
     # Anonymous nodes (nid=None) are reachable transitively through named roots' edges, and
     # are handled by wire_spec_nodes() above. Skip them here to preserve SpecDict on round-trip.
     return {NodeId(*nid): specs_by_hash[node["hash"]] for nid, node in entries if nid is not None}

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -635,11 +635,12 @@ class ConcretizationCache:
             with os.fdopen(fd, "wb") as raw_f:
                 with gzip.open(raw_f, "wb", compresslevel=6) as f:
                     f.write(json.dumps(cache_dict).encode())
-            os.rename(tmp_path, cache_path)
-        except BaseException:
-            # Clean up temp file on any failure (including if another process won the race)
+            os.replace(tmp_path, cache_path)
+        except OSError as e:
+            # Cache store is best-effort; failures shouldn't block a successful concretization.
+            tty.debug(f"Failed to store concretization cache entry {cache_path}: {e}")
             self._remove_entry(pathlib.Path(tmp_path))
-            raise
+            return
 
     def fetch(self, problem: str) -> Union[Tuple[Result, Dict], Tuple[None, None]]:
         """Returns the concretization cache result for a lookup based on the given problem.

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -874,7 +874,7 @@ class PyclingoDriver:
         problem_str: str,
         control_file_paths: List[str],
         timer: spack.util.timer.Timer,
-    ) -> Tuple[Result, Union[SpliceDict, None]]:
+    ) -> Result:
         """Actually run clingo and generate a result.
 
         This is the core solve logic once the setup is done and once we know we can't
@@ -931,9 +931,8 @@ class PyclingoDriver:
         # once done, construct the solve result
         result = Result(specs)
         result.satisfiable = solve_result.satisfiable
-
         if not result.satisfiable:
-            return result, None
+            return result
 
         timer.start("construct_specs")
         # get the best model
@@ -946,7 +945,7 @@ class PyclingoDriver:
 
         # build specs from spec attributes in the model
         spec_attrs = [(name, tuple(rest)) for name, *rest in extract_args(best_model, "attr")]
-        spec_dict, splices = builder.build_specs(spec_attrs)
+        spec_dict = builder.build_specs(spec_attrs)
 
         # add best spec to the results
         result.answers.append((list(min_cost), 0, spec_dict))
@@ -963,7 +962,7 @@ class PyclingoDriver:
         timer.stop("construct_specs")
         timer.stop()
 
-        return result, splices
+        return result
 
     def solve(
         self,
@@ -1061,9 +1060,7 @@ class PyclingoDriver:
         # run the solver
         if not result:
             tty.debug("Starting concretizer")
-            result, splices = self._run_clingo(
-                specs, setup, "\n".join(problem), control_file_paths, timer
-            )
+            result = self._run_clingo(specs, setup, "\n".join(problem), control_file_paths, timer)
             result.raise_if_unsat()
             concretization_stats = self.control.statistics
 
@@ -3536,7 +3533,8 @@ class SpecBuilder:
         )
         self._splices.setdefault(parent_spec, []).append(splice)
 
-    def build_specs(self, function_tuples: List[FunctionTupleT]) -> Tuple[SpecDict, SpliceDict]:
+    def build_specs(self, function_tuples: List[FunctionTupleT]) -> SpecDict:
+        """Reassemble Spec objects from the solve results."""
 
         attr_key = {
             # hash attributes are handled first, since they imply entire concrete specs
@@ -3592,7 +3590,8 @@ class SpecBuilder:
 
         # apply post-solve concretization steps to specs in the result
         post_process_fresh_solve(self._specs, self._splices)
-        return self._specs, self._splices
+
+        return self._specs
 
 
 def reorder_flags(specs: SpecDict) -> None:

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -299,7 +299,7 @@ def _reorder_flags(flag_list: List[spack.spec.CompilerFlag]) -> List[spack.spec.
 # yet final, because there are spec changes yet to be made in post-processing that will
 # change the hashes. We still need an identifier for the nodes in the spec DAG, though.
 # So, we use hashes as ids during serialization, but we must clear them afterwards so
-# that they are not cached, and they can be set again the final changes are made.
+# that they are not cached, and they can be set again when the final changes are made.
 
 
 def spec_dict_to_json(spec_dict: SpecDict) -> Dict:
@@ -323,7 +323,7 @@ def spec_dict_to_json(spec_dict: SpecDict) -> Dict:
     specs += [spec.build_spec for spec in specs if spec.build_spec is not spec]
 
     # Traverse every spec reachable from spec_dict's values, deduped by hash, and add them
-    # to the serialized entires either a) with their original NodeId, or b) with None if they
+    # to the serialized entries either a) with their original NodeId, or b) with None if they
     # don't have a NodeId. This ensures that all nodes are added and NodeIds are preserved.
     entries = []
     for dep in spack.traverse.traverse_nodes(specs, key=lambda s: s.dag_hash()):

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -3775,7 +3775,7 @@ def post_process_concretization_result(specs: SpecDict) -> None:
     # TODO: remove this local import and get rid of dependency on globals
     import spack.environment as ev
 
-    # inject patches -- note that we' can't use set() to unique the
+    # inject patches -- note that we can't use set() to unique the
     # roots here, because the specs aren't complete, and the hash
     # function will loop forever.
     roots = [spec.root for spec in specs.values()]

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -68,7 +68,6 @@ from spack import traverse
 from spack.compilers.libraries import CompilerPropertyDetector
 from spack.llnl.util.lang import elide_list
 from spack.spec import EMPTY_SPEC
-from spack.util.compression import GZipFileType
 
 from .compat import default_clingo_control, make_error_control
 from .core import AspFunction, AspVar, NodeId, SourceContext, extract_args, fn
@@ -510,11 +509,19 @@ class ConcretizationCache:
     asp problem and the involved control files.
     """
 
+    # Used to version cache files. Bump this when the cache format changes.
+    VERSION = 1
+
     def __init__(self, root: Union[str, None] = None):
         root = root or spack.config.get("concretizer:concretization_cache:url", None)
         if root is None:
             root = os.path.join(spack.caches.misc_cache_location(), "concretization")
+
+        # cache is versioned so that we can easily upgrade it over time
         self.root = pathlib.Path(spack.util.path.canonicalize_path(root))
+        self.root /= f"v{ConcretizationCache.VERSION}"
+
+        # create root and lockfile
         self.root.mkdir(parents=True, exist_ok=True)
         self._lockfile = self.root / ".cc_lock"
 
@@ -566,27 +573,6 @@ class ConcretizationCache:
             # old style concretization cache entries are in directories
             if not cache_entry.name.startswith(".") and cache_entry.is_file():
                 yield cache_entry
-
-    def _results_from_cache(self, cache_entry_file: str) -> Union[Result, None]:
-        """Returns a Results object from the concretizer cache
-
-        Reads the cache hit and uses `Result`'s own deserializer
-        to produce a new Result object
-        """
-
-        cache_entry = json.loads(cache_entry_file)
-        result_json = cache_entry["results"]
-        return Result.from_dict(result_json)
-
-    def _stats_from_cache(self, cache_entry_file: str) -> Union[Dict, None]:
-        """Returns concretization statistic from the
-        concretization associated with the cache.
-
-        Deserializes the the json representation of the
-        statistics covering the cached concretization run
-        and returns the Python data structures
-        """
-        return json.loads(cache_entry_file)["statistics"]
 
     def _prefix_digest(self, problem: str) -> str:
         """Return the first two characters of, and the full, sha256 of the given asp problem"""
@@ -663,6 +649,8 @@ class ConcretizationCache:
         problem.
         """
         cache_path = self._cache_path_from_problem(problem)
+        cache_path.parent.mkdir(parents=True, exist_ok=True)
+
         with self.write_transaction(cache_path, timeout=30):
             if cache_path.exists():
                 # if cache path file exists, we already have a cache entry, likely created
@@ -670,7 +658,11 @@ class ConcretizationCache:
                 return
 
             with gzip.open(cache_path, "xb", compresslevel=6) as cache_entry:
-                cache_dict = {"results": result.to_dict(), "statistics": statistics}
+                cache_dict = {
+                    "_meta": {"version": ConcretizationCache.VERSION},
+                    "results": result.to_dict(),
+                    "statistics": statistics,
+                }
                 cache_entry.write(json.dumps(cache_dict).encode())
 
     def fetch(self, problem: str) -> Union[Tuple[Result, Dict], Tuple[None, None]]:
@@ -691,19 +683,13 @@ class ConcretizationCache:
                     with gzip.open(cache_path, "rb", compresslevel=6) as f:
                         f.peek(1)  # Try to read at least one byte
                         f.seek(0)
-                        cache_content = f.read().decode("utf-8")
+                        cache_data = f.read().decode("utf-8")
+                        cache_content = json.loads(cache_data)
 
-                except OSError:
-                    # Cache may have been created pre compression check if gzip, and if not,
-                    # read from plaintext otherwise re raise
-                    with open(cache_path, "rb") as f:
-                        # raise if this is a gzip file we failed to open
-                        if GZipFileType().matches_magic(f):
-                            raise
-                        cache_content = f.read().decode()
-
-                except FileNotFoundError:
-                    pass  # cache miss, already cleaned up
+                except (OSError, FileNotFoundError, json.JSONDecodeError):
+                    # If any of this happens, it's a cache miss.
+                    # We'll just overwrite the corrupt file with a new one.
+                    pass
 
         except lk.LockTimeoutError:
             pass  # if the lock times, out skip the cache
@@ -711,9 +697,19 @@ class ConcretizationCache:
         if not cache_content:
             return None, None
 
+        # miss if the metadata we find is not the same version as we're using here.
+        cache_version = cache_content.get("_meta", {}).get("version")
+        if not cache_version or cache_version != ConcretizationCache.VERSION:
+            return None, None
+
         # update mod/access time for use w/ LRU cleanup
         os.utime(cache_path)
-        return (self._results_from_cache(cache_content), self._stats_from_cache(cache_content))  # type: ignore
+        try:
+            result = Result.from_dict(cache_content["results"])
+            return result, cache_content["statistics"]
+
+        except (KeyError, spack.error.SpecSyntaxError):
+            return None, None
 
 
 def _is_checksummed_git_version(v):

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -3663,6 +3663,11 @@ def reorder_flags(specs: SpecDict) -> None:
             # the input order from flag.flag_group
             flagmap_from_cli[flag_type] = _reorder_flags(flags)
 
+        # For flags that are applied by dependents, put flags from parents
+        # before children; we depend on the stability of traverse() to
+        # achieve a stable flag order for flags introduced in this manner.
+        topo_order = list(s.name for s in spec.traverse(order="post", direction="parents"))
+
         for flag_type in spec.compiler_flags.valid_compiler_flags():
             ordered_flags: List[str] = []
 
@@ -3683,10 +3688,9 @@ def reorder_flags(specs: SpecDict) -> None:
                     )
                 )
 
-            # For flags that are applied by dependents, put flags from parents
-            # before children; we depend on the stability of traverse() to
-            # achieve a stable flag order for flags introduced in this manner.
-            topo_order = list(s.name for s in spec.traverse(order="post", direction="parents"))
+            # If for x->y, x has multiple depends_on declarations that
+            # are activated, and each adds cflags to y, we fall back on
+            # alphabetical ordering to maintain a total order
             lex_order = list(sorted(flag_groups))
 
             def _order_index(flag_group):
@@ -3696,9 +3700,6 @@ def reorder_flags(specs: SpecDict) -> None:
                 type_index, pkg_source = ConstraintOrigin.strip_type_suffix(source)
                 if pkg_source in topo_order:
                     major_index = topo_order.index(pkg_source)
-                    # If for x->y, x has multiple depends_on declarations that
-                    # are activated, and each adds cflags to y, we fall back on
-                    # alphabetical ordering to maintain a total order
                     minor_index = lex_order.index(flag_group)
                 else:
                     major_index = len(topo_order) + lex_order.index(flag_group)

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -25,6 +25,7 @@ from typing import (
     Iterable,
     Iterator,
     List,
+    MutableSequence,
     NamedTuple,
     Optional,
     Sequence,
@@ -45,6 +46,7 @@ import spack.config
 import spack.deptypes as dt
 import spack.error
 import spack.externals_config
+import spack.hash_types as ht
 import spack.llnl.util.lang
 import spack.llnl.util.tty as tty
 import spack.package_base
@@ -124,6 +126,10 @@ build_priority_offset = 200
 
 #: Priority offset of "fixed" criteria (those w/o build criteria)
 fixed_priority_offset = 100
+
+# type aliases for the data structures we get back from the solver
+SpecDict = Dict[NodeId, spack.spec.Spec]
+SpliceDict = Dict[spack.spec.Spec, List[spack.solver.splicing.Splice]]
 
 
 class OptimizationKind:
@@ -248,7 +254,7 @@ def c_compiler_runs(compiler) -> bool:
     return CompilerPropertyDetector(compiler).compiler_verbose_output() is not None
 
 
-def extend_flag_list(flag_list, new_flags):
+def extend_flag_list(flag_list: MutableSequence[str], new_flags: Sequence[str]) -> None:
     """Extend a list of flags, preserving order and precedence.
 
     Add new_flags at the end of flag_list.  If any flags in new_flags are
@@ -286,6 +292,59 @@ def _reorder_flags(flag_list: List[spack.spec.CompilerFlag]) -> List[spack.spec.
             flag_group, propagate=flag_propagate
         )
     ]
+
+
+# We have to take some care with how we serialize a `SpecDict` fresh from a solve,
+# because it contains specs that are in between concrete and abstract. The hash is not
+# yet final, because there are spec changes yet to be made in post-processing that will
+# change the hashes. We still need an identifier for the nodes in the spec DAG, though.
+# So, we use hashes as ids during serialization, but we must clear them afterwards so
+# that they are not cached, and they can be set again the final changes are made.
+
+
+def spec_dict_to_json(spec_dict: SpecDict) -> Dict:
+    """Serialize a SpecDict to JSON, taking care to preserve node structure in serialized specs."""
+    # A SpecDict has one entry for each spec in a solution, but some are abstract and some
+    # are concrete. We need DAG hashes for the abstract specs to serialize them, so force-cache
+    # them to avoid lots of redundant computation.
+    # TODO: spec serialization was really designed for concrete and small abstract specs.
+    # This should really be handled by Spec, but it will take some work to adjust the format.
+    for spec in spec_dict.values():
+        if not spec.concrete:
+            spec._cached_hash(ht.dag_hash, force=True)
+
+    entries = []
+    for (id, pkg), spec in spec_dict.items():
+        node = spec.to_node_dict()
+        node["hash"] = spec.dag_hash()
+        entries.append((id, pkg, node))
+
+    # Clear the hashes cached above, as they will need to be recomputed after post-concretization.
+    # They're only used here as keys for reading and writing spec DAGs.
+    for spec in spec_dict.values():
+        if not spec.concrete:
+            spec.clear_caches()
+
+    return {"_meta": {"spec_version": spack.spec.SpecfileLatest.SPEC_VERSION}, "specs": entries}
+
+
+def spec_dict_from_json(data: Dict) -> SpecDict:
+    """Deserialize a SpecDict from JSON, taking care not to duplicate nodes."""
+    try:
+        spec_version = int(data["_meta"]["spec_version"])
+        entries = data["specs"]
+    except (KeyError, ValueError):
+        raise ValueError(f"Invalid spec dict data: {data}")
+
+    reader = spack.spec.specfile_reader_for_version(spec_version)
+    node_ids_by_hash = {node["hash"]: (id, pkg) for id, pkg, node in entries}
+    nodes = [node for _, _, node in entries]
+
+    specs_by_hash = spack.spec.wire_spec_nodes(nodes, "hash", reader)
+    return {
+        NodeId(id, pkg): specs_by_hash[dag_hash]
+        for dag_hash, (id, pkg) in node_ids_by_hash.items()
+    }
 
 
 class Result:
@@ -406,79 +465,39 @@ class Result:
         Does not include anything related to unsatisfiability as we
         are only interested in storing satisfiable results
         """
-        serial_node_arg = lambda node_dict: (
-            f"""{{"id": "{node_dict.id}", "pkg": "{node_dict.pkg}"}}"""
-        )
-        ret = dict()
-        ret["criteria"] = self.criteria
-        ret["optimal"] = self.optimal
-        ret["warnings"] = self.warnings
-        ret["nmodels"] = self.nmodels
-        ret["abstract_specs"] = [str(x) for x in self.abstract_specs]
-        ret["satisfiable"] = self.satisfiable
-        serial_answers = []
-        for answer in self.answers:
-            serial_answer = answer[:2]
-            serial_answer_dict = {}
-            for node, spec in answer[2].items():
-                serial_answer_dict[serial_node_arg(node)] = spec.to_dict()
-            serial_answer = serial_answer + (serial_answer_dict,)
-            serial_answers.append(serial_answer)
-        ret["answers"] = serial_answers
-        ret["specs_by_input"] = {}
-        input_specs = {} if not self.specs_by_input else self.specs_by_input
-        for input, spec in input_specs.items():
-            ret["specs_by_input"][str(input)] = spec.to_dict()
-        return ret
+
+        # NOTE: _unsolved_specs, _concrete_specs_by_input, and _concrete_specs are all
+        # computed dynamically from self.answers, so they're not serialized.
+        return {
+            "criteria": self.criteria,
+            "optimal": self.optimal,
+            "warnings": self.warnings,
+            "nmodels": self.nmodels,
+            "abstract_specs": [s.to_dict() for s in self.abstract_specs],
+            "satisfiable": self.satisfiable,
+            "answers": [
+                (opt, i, spec_dict_to_json(spec_dict)) for opt, i, spec_dict in self.answers
+            ],
+        }
 
     @staticmethod
     def from_dict(obj: dict):
         """Returns Result object from compatible dictionary"""
 
-        def _dict_to_node_argument(dict):
-            id = dict["id"]
-            pkg = dict["pkg"]
-            return NodeId(id=id, pkg=pkg)
+        abstract_specs = [spack.spec.Spec.from_dict(s) for s in obj["abstract_specs"]]
 
-        def _str_to_spec(spec_str):
-            return spack.spec.Spec(spec_str)
+        result = Result(abstract_specs)
+        result.criteria = [OptimizationCriteria(*t) for t in obj["criteria"]]
+        result.optimal = obj["optimal"]
+        result.warnings = obj["warnings"]
+        result.nmodels = obj["nmodels"]
+        result.satisfiable = obj["satisfiable"]
+        result.answers = [
+            (opt, i, spec_dict_from_json(spec_dict)) for opt, i, spec_dict in obj["answers"]
+        ]
+        # NOTE: _unsolved_specs, _concrete_specs_by_input, and _concrete_specs are all
+        # computed dynamically from self.answers, so they're not serialized.
 
-        def _dict_to_spec(spec_dict):
-            loaded_spec = spack.spec.Spec.from_dict(spec_dict)
-            _ensure_external_path_if_external(loaded_spec)
-            spack.spec.Spec.ensure_no_deprecated(loaded_spec)
-            return loaded_spec
-
-        spec_list = obj.get("abstract_specs")
-        if not spec_list:
-            raise RuntimeError("Invalid json for concretization Result object")
-        if spec_list:
-            spec_list = [_str_to_spec(x) for x in spec_list]
-        result = Result(spec_list)
-
-        criteria = obj.get("criteria")
-        result.criteria = (
-            None if criteria is None else [OptimizationCriteria(*t) for t in criteria]
-        )
-        result.optimal = obj.get("optimal")
-        result.warnings = obj.get("warnings")
-        result.nmodels = obj.get("nmodels")
-        result.satisfiable = obj.get("satisfiable")
-        result._unsolved_specs = []
-        answers = []
-        for answer in obj.get("answers", []):
-            loaded_answer = answer[:2]
-            answer_node_dict = {}
-            for node, spec in answer[2].items():
-                answer_node_dict[_dict_to_node_argument(json.loads(node))] = _dict_to_spec(spec)
-            loaded_answer.append(answer_node_dict)
-            answers.append(tuple(loaded_answer))
-        result.answers = answers
-        result._concrete_specs_by_input = {}
-        result._concrete_specs = []
-        for input, spec in obj.get("specs_by_input", {}).items():
-            result._concrete_specs_by_input[_str_to_spec(input)] = _dict_to_spec(spec)
-            result._concrete_specs.append(_dict_to_spec(spec))
         return result
 
     def __eq__(self, other):
@@ -490,12 +509,11 @@ class Result:
             self.criteria == other.criteria,
             self.answers == other.answers,
             self.abstract_specs == other.abstract_specs,
-            self._concrete_specs_by_input == other._concrete_specs_by_input,
-            self._concrete_specs == other._concrete_specs,
-            self._unsolved_specs == other._unsolved_specs,
             # Not considered for equality
-            # self.control
-            # self.possible_dependencies
+            # self._concrete_specs_by_input   # These three are computed
+            # self._concrete_specs
+            # self._unsolved_specs
+            # self.control                    # Currently we just don't serialize these
             # self.possible_dependencies
         )
         return all(eq)
@@ -917,7 +935,7 @@ class PyclingoDriver:
         problem_str: str,
         control_file_paths: List[str],
         timer: spack.util.timer.Timer,
-    ) -> Result:
+    ) -> Tuple[Result, Union[SpliceDict, None]]:
         """Actually run clingo and generate a result.
 
         This is the core solve logic once the setup is done and once we know we can't
@@ -975,41 +993,38 @@ class PyclingoDriver:
         result = Result(specs)
         result.satisfiable = solve_result.satisfiable
 
-        if result.satisfiable:
-            timer.start("construct_specs")
-            # get the best model
-            builder = SpecBuilder(specs, hash_lookup=setup.reusable_and_possible)
-            min_cost, best_model = min(models)
+        if not result.satisfiable:
+            return result, None
 
-            # first check for errors
-            error_handler = ErrorHandler(best_model, specs)
-            error_handler.raise_if_errors()
+        timer.start("construct_specs")
+        # get the best model
+        builder = SpecBuilder(specs, hash_lookup=setup.reusable_and_possible)
+        min_cost, best_model = min(models)
 
-            # build specs from spec attributes in the model
-            spec_attrs = [(name, tuple(rest)) for name, *rest in extract_args(best_model, "attr")]
-            answers = builder.build_specs(spec_attrs)
+        # first check for errors
+        error_handler = ErrorHandler(best_model, specs)
+        error_handler.raise_if_errors()
 
-            # add best spec to the results
-            result.answers.append((list(min_cost), 0, answers))
+        # build specs from spec attributes in the model
+        spec_attrs = [(name, tuple(rest)) for name, *rest in extract_args(best_model, "attr")]
+        spec_dict, splices = builder.build_specs(spec_attrs)
 
-            # get optimization criteria
-            criteria_args = extract_args(best_model, "opt_criterion")
-            result.criteria = build_criteria_names(min_cost, criteria_args)
+        # add best spec to the results
+        result.answers.append((list(min_cost), 0, spec_dict))
 
-            # record the number of models the solver considered
-            result.nmodels = len(models)
+        # get optimization criteria
+        criteria_args = extract_args(best_model, "opt_criterion")
+        result.criteria = build_criteria_names(min_cost, criteria_args)
 
-            # record the possible dependencies in the solve
-            result.possible_dependencies = setup.pkgs
-            timer.stop("construct_specs")
-            timer.stop()
+        # record the number of models the solver considered
+        result.nmodels = len(models)
 
-        result.raise_if_unsat()
+        # record the possible dependencies in the solve
+        result.possible_dependencies = setup.pkgs
+        timer.stop("construct_specs")
+        timer.stop()
 
-        if result.satisfiable and result.unsolved_specs and setup.concretize_everything:
-            raise OutputDoesNotSatisfyInputError(result.unsolved_specs)
-
-        return result
+        return result, splices
 
     def solve(
         self,
@@ -1102,19 +1117,27 @@ class PyclingoDriver:
         result = None
         if cache:
             result, concretization_stats = cache.fetch(cache_key)
-
         timer.stop("cache-check")
-
-        tty.debug("Starting concretizer")
 
         # run the solver
         if not result:
-            result = self._run_clingo(specs, setup, "\n".join(problem), control_file_paths, timer)
+            tty.debug("Starting concretizer")
+            result, splices = self._run_clingo(
+                specs, setup, "\n".join(problem), control_file_paths, timer
+            )
+            result.raise_if_unsat()
             concretization_stats = self.control.statistics
 
-            # write result back to the cache
+            # write result back to the cache *before* post-processing
             if cache:
                 cache.store(cache_key, result, self.control.statistics)
+
+        # apply post-concretization transformations
+        for _, _, spec_dict in result.answers:
+            post_process_concretization_result(spec_dict)
+
+        if result.satisfiable and result.unsolved_specs and setup.concretize_everything:
+            raise OutputDoesNotSatisfyInputError(result.unsolved_specs)
 
         if output.timers:
             timer.write_tty()
@@ -3494,12 +3517,7 @@ class SpecBuilder:
         self._specs: Dict[NodeId, spack.spec.Spec] = {}
 
         # Matches parent nodes to splice node
-        self._splices: Dict[spack.spec.Spec, List[spack.solver.splicing.Splice]] = {}
-        self._result = None
-        self._command_line_specs = specs
-        self._flag_sources: Dict[Tuple[NodeId, str], Set[str]] = collections.defaultdict(
-            lambda: set()
-        )
+        self._splices: SpliceDict = {}
 
         # Pass in as arguments reusable specs and plug them in
         # from this dictionary during reconstruction
@@ -3566,116 +3584,6 @@ class SpecBuilder:
         assert len(dependencies) == 1, f"{virtual}: {provider_node.pkg}"
         dependencies[0].update_virtuals(virtual)
 
-    def reorder_flags(self):
-        """For each spec, determine the order of compiler flags applied to it.
-
-        The solver determines which flags are on nodes; this routine
-        imposes order afterwards. The order is:
-
-        1. Flags applied in compiler definitions should come first
-        2. Flags applied by dependents are ordered topologically (with a
-           dependency on ``traverse`` to resolve the partial order into a
-           stable total order)
-        3. Flags from requirements are then applied (requirements always
-           come from the package and never a parent)
-        4. Command-line flags should come last
-
-        Additionally, for each source (requirements, compiler, command line, and
-        dependents), flags from that source should retain their order and grouping:
-        e.g. for ``y cflags="-z -a"`` ``-z`` and ``-a`` should never have any intervening
-        flags inserted, and should always appear in that order.
-        """
-        for node, spec in self._specs.items():
-            # if bootstrapping, compiler is not in config and has no flags
-            flagmap_from_compiler = {
-                flag_type: [x for x in values if x.source == "compiler"]
-                for flag_type, values in spec.compiler_flags.items()
-            }
-
-            flagmap_from_cli = {}
-            for flag_type, values in spec.compiler_flags.items():
-                if not values:
-                    continue
-
-                flags = [x for x in values if x.source == "literal"]
-                if not flags:
-                    continue
-
-                # For compiler flags from literal specs, reorder any flags to
-                # the input order from flag.flag_group
-                flagmap_from_cli[flag_type] = _reorder_flags(flags)
-
-            for flag_type in spec.compiler_flags.valid_compiler_flags():
-                ordered_flags = []
-
-                # 1. Put compiler flags first
-                from_compiler = tuple(flagmap_from_compiler.get(flag_type, []))
-                extend_flag_list(ordered_flags, from_compiler)
-
-                # 2. Add all sources (the compiler is one of them, so skip any
-                # flag group that matches it exactly)
-                flag_groups = set()
-                for flag in self._specs[node].compiler_flags.get(flag_type, []):
-                    flag_groups.add(
-                        spack.spec.CompilerFlag(
-                            flag.flag_group,
-                            propagate=flag.propagate,
-                            flag_group=flag.flag_group,
-                            source=flag.source,
-                        )
-                    )
-
-                # For flags that are applied by dependents, put flags from parents
-                # before children; we depend on the stability of traverse() to
-                # achieve a stable flag order for flags introduced in this manner.
-                topo_order = list(s.name for s in spec.traverse(order="post", direction="parents"))
-                lex_order = list(sorted(flag_groups))
-
-                def _order_index(flag_group):
-                    source = flag_group.source
-                    # Note: if 'require: ^dependency cflags=...' is ever possible,
-                    # this will topologically sort for require as well
-                    type_index, pkg_source = ConstraintOrigin.strip_type_suffix(source)
-                    if pkg_source in topo_order:
-                        major_index = topo_order.index(pkg_source)
-                        # If for x->y, x has multiple depends_on declarations that
-                        # are activated, and each adds cflags to y, we fall back on
-                        # alphabetical ordering to maintain a total order
-                        minor_index = lex_order.index(flag_group)
-                    else:
-                        major_index = len(topo_order) + lex_order.index(flag_group)
-                        minor_index = 0
-                    return (type_index, major_index, minor_index)
-
-                prioritized_groups = sorted(flag_groups, key=lambda x: _order_index(x))
-
-                for grp in prioritized_groups:
-                    grp_flags = tuple(
-                        x for (x, y) in spack.compilers.flags.tokenize_flags(grp.flag_group)
-                    )
-                    if grp_flags == from_compiler:
-                        continue
-                    as_compiler_flags = list(
-                        spack.spec.CompilerFlag(
-                            x,
-                            propagate=grp.propagate,
-                            flag_group=grp.flag_group,
-                            source=grp.source,
-                        )
-                        for x in grp_flags
-                    )
-                    extend_flag_list(ordered_flags, as_compiler_flags)
-
-                # 3. Now put cmd-line flags last
-                if flag_type in flagmap_from_cli:
-                    extend_flag_list(ordered_flags, flagmap_from_cli[flag_type])
-
-                compiler_flags = spec.compiler_flags.get(flag_type, [])
-                msg = f"{set(compiler_flags)} does not equal {set(ordered_flags)}"
-                assert set(compiler_flags) == set(ordered_flags), msg
-
-                spec.compiler_flags.update({flag_type: ordered_flags})
-
     def deprecated(self, node: NodeId, version: str) -> None:
         tty.warn(f'using "{node.pkg}@{version}" which is a deprecated version')
 
@@ -3689,9 +3597,7 @@ class SpecBuilder:
         )
         self._splices.setdefault(parent_spec, []).append(splice)
 
-    def build_specs(self, function_tuples: List[FunctionTupleT]) -> List[spack.spec.Spec]:
-        # TODO: remove this local import and get rid of dependency on globals
-        import spack.environment as ev
+    def build_specs(self, function_tuples: List[FunctionTupleT]) -> Tuple[SpecDict, SpliceDict]:
 
         attr_key = {
             # hash attributes are handled first, since they imply entire concrete specs
@@ -3745,101 +3651,243 @@ class SpecBuilder:
 
             action(*args)
 
-        # fix flags after all specs are constructed
-        self.reorder_flags()
+        # apply post-solve concretization steps to specs in the result
+        post_process_fresh_solve(self._specs, self._splices)
+        return self._specs, self._splices
 
-        # inject patches -- note that we' can't use set() to unique the
-        # roots here, because the specs aren't complete, and the hash
-        # function will loop forever.
-        roots = [spec.root for spec in self._specs.values()]
-        roots = dict((id(r), r) for r in roots)
-        for root in roots.values():
-            spack.spec._inject_patches_variant(root)
 
-        # Add external paths to specs with just external modules
-        for s in self._specs.values():
-            _ensure_external_path_if_external(s)
+def reorder_flags(specs: SpecDict) -> None:
+    """For each spec, determine the order of compiler flags applied to it.
 
-        for s in self._specs.values():
-            _develop_specs_from_env(s, ev.active_environment())
+    The solver determines which flags are on nodes; this routine
+    imposes order afterwards. The order is:
 
-        # check for commits must happen after all version adaptations are complete
-        for s in self._specs.values():
-            _specs_with_commits(s)
+    1. Flags applied in compiler definitions should come first
+    2. Flags applied by dependents are ordered topologically (with a
+       dependency on ``traverse`` to resolve the partial order into a
+       stable total order)
+    3. Flags from requirements are then applied (requirements always
+       come from the package and never a parent)
+    4. Command-line flags should come last
 
-        # mark concrete and assign hashes to all specs in the solve
-        for root in roots.values():
-            root._finalize_concretization()
+    Additionally, for each source (requirements, compiler, command line, and
+    dependents), flags from that source should retain their order and grouping:
+    e.g. for ``y cflags="-z -a"`` ``-z`` and ``-a`` should never have any intervening
+    flags inserted, and should always appear in that order.
+    """
+    for node, spec in specs.items():
+        # if bootstrapping, compiler is not in config and has no flags
+        flagmap_from_compiler = {
+            flag_type: [x for x in values if x.source == "compiler"]
+            for flag_type, values in spec.compiler_flags.items()
+        }
 
-        # Unify hashes (this is to avoid duplicates of runtimes and compilers)
-        unifier = ConcreteSpecsByHash()
-        keys = list(self._specs)
-        for key in keys:
-            current_spec = self._specs[key]
-            unifier.add(current_spec)
-            self._specs[key] = unifier[current_spec.dag_hash()]
+        flagmap_from_cli = {}
+        for flag_type, values in spec.compiler_flags.items():
+            if not values:
+                continue
 
-        # Only attempt to resolve automatic splices if the solver produced any
-        if self._splices:
-            resolved_splices = spack.solver.splicing._resolve_collected_splices(
-                list(self._specs.values()), self._splices
-            )
-            new_specs = {}
-            for node, spec in self._specs.items():
-                new_specs[node] = resolved_splices.get(spec, spec)
-            self._specs = new_specs
+            flags = [x for x in values if x.source == "literal"]
+            if not flags:
+                continue
 
-        for s in self._specs.values():
-            spack.spec.Spec.ensure_no_deprecated(s)
+            # For compiler flags from literal specs, reorder any flags to
+            # the input order from flag.flag_group
+            flagmap_from_cli[flag_type] = _reorder_flags(flags)
 
-        # Add git version lookup info to concrete Specs (this is generated for
-        # abstract specs as well but the Versions may be replaced during the
-        # concretization process)
-        for root in self._specs.values():
-            for spec in root.traverse():
-                if isinstance(spec.version, vn.GitVersion):
-                    spec.version.attach_lookup(
-                        spack.version.git_ref_lookup.GitRefLookup(spec.fullname)
+        for flag_type in spec.compiler_flags.valid_compiler_flags():
+            ordered_flags: List[str] = []
+
+            # 1. Put compiler flags first
+            from_compiler = tuple(flagmap_from_compiler.get(flag_type, []))
+            extend_flag_list(ordered_flags, from_compiler)
+
+            # 2. Add all sources (the compiler is one of them, so skip any
+            # flag group that matches it exactly)
+            flag_groups = set()
+            for flag in specs[node].compiler_flags.get(flag_type, []):
+                flag_groups.add(
+                    spack.spec.CompilerFlag(
+                        flag.flag_group,
+                        propagate=flag.propagate,
+                        flag_group=flag.flag_group,
+                        source=flag.source,
                     )
-
-        specs = self.execute_explicit_splices()
-        return specs
-
-    def execute_explicit_splices(self):
-        splice_config = spack.config.CONFIG.get("concretizer:splice:explicit", [])
-        splice_triples = []
-        for splice_set in splice_config:
-            target = splice_set["target"]
-            replacement = spack.spec.Spec(splice_set["replacement"])
-
-            if not replacement.abstract_hash:
-                location = getattr(
-                    splice_set["replacement"], "_start_mark", " at unknown line number"
                 )
-                msg = f"Explicit splice replacement '{replacement}' does not include a hash.\n"
-                msg += f"{location}\n\n"
-                msg += "    Splice replacements must be specified by hash"
-                raise InvalidSpliceError(msg)
 
-            transitive = splice_set.get("transitive", False)
-            splice_triples.append((target, replacement, transitive))
+            # For flags that are applied by dependents, put flags from parents
+            # before children; we depend on the stability of traverse() to
+            # achieve a stable flag order for flags introduced in this manner.
+            topo_order = list(s.name for s in spec.traverse(order="post", direction="parents"))
+            lex_order = list(sorted(flag_groups))
 
-        specs = {}
-        for key, spec in self._specs.items():
-            current_spec = spec
-            for target, replacement, transitive in splice_triples:
-                if target in current_spec:
-                    # matches root or non-root
-                    # e.g. mvapich2%gcc
+            def _order_index(flag_group):
+                source = flag_group.source
+                # Note: if 'require: ^dependency cflags=...' is ever possible,
+                # this will topologically sort for require as well
+                type_index, pkg_source = ConstraintOrigin.strip_type_suffix(source)
+                if pkg_source in topo_order:
+                    major_index = topo_order.index(pkg_source)
+                    # If for x->y, x has multiple depends_on declarations that
+                    # are activated, and each adds cflags to y, we fall back on
+                    # alphabetical ordering to maintain a total order
+                    minor_index = lex_order.index(flag_group)
+                else:
+                    major_index = len(topo_order) + lex_order.index(flag_group)
+                    minor_index = 0
+                return (type_index, major_index, minor_index)
 
-                    # The first iteration, we need to replace the abstract hash
-                    if not replacement.concrete:
-                        replacement.replace_hash()
-                    current_spec = current_spec.splice(replacement, transitive)
-            new_key = NodeId(id=key.id, pkg=current_spec.name)
-            specs[new_key] = current_spec
+            prioritized_groups = sorted(flag_groups, key=lambda x: _order_index(x))
 
-        return specs
+            for grp in prioritized_groups:
+                grp_flags = tuple(
+                    x for (x, y) in spack.compilers.flags.tokenize_flags(grp.flag_group)
+                )
+                if grp_flags == from_compiler:
+                    continue
+                as_compiler_flags = list(
+                    spack.spec.CompilerFlag(
+                        x, propagate=grp.propagate, flag_group=grp.flag_group, source=grp.source
+                    )
+                    for x in grp_flags
+                )
+                extend_flag_list(ordered_flags, as_compiler_flags)
+
+            # 3. Now put cmd-line flags last
+            if flag_type in flagmap_from_cli:
+                extend_flag_list(ordered_flags, flagmap_from_cli[flag_type])
+
+            compiler_flags = spec.compiler_flags.get(flag_type, [])
+            msg = f"{set(compiler_flags)} does not equal {set(ordered_flags)}"
+            assert set(compiler_flags) == set(ordered_flags), msg
+
+            spec.compiler_flags.update({flag_type: ordered_flags})
+
+
+def post_process_fresh_solve(specs: SpecDict, splices: Optional[SpliceDict]) -> None:
+    """Post-processing steps that need information present from a run of clingo.
+
+    These post-steps are run after solves, but not on every cached result from the
+    concretization cache. They can only depend only on solve information (e.g., flag
+    ordering info, splice data, etc.)
+
+    Post-steps that should be run on cached concretizations as well as fresh solves go
+    in post_process_concretization_result..
+
+    This method updates the SpecDict in place.
+
+    """
+    # fix flags after all specs are constructed
+    reorder_flags(specs)
+
+    # Only attempt to resolve automatic splices if the solver produced any
+    if splices:
+        resolved_splices = spack.solver.splicing._resolve_collected_splices(
+            list(specs.values()), splices
+        )
+        new_specs = {}
+        for node, spec in specs.items():
+            new_specs[node] = resolved_splices.get(spec, spec)
+
+        specs.clear()
+        specs.update(new_specs)
+
+
+def post_process_concretization_result(specs: SpecDict) -> None:
+    """Update concretization results after *every* concretization, even cached ones.
+
+    These post-steps depend on package information like patches, package hash, etc. They
+    must be run even on cached concretizations, as the information they update may have
+    changed since the original solve.
+
+    This method updates the SpecDict in place.
+
+    """
+    # TODO: remove this local import and get rid of dependency on globals
+    import spack.environment as ev
+
+    # inject patches -- note that we' can't use set() to unique the
+    # roots here, because the specs aren't complete, and the hash
+    # function will loop forever.
+    roots = [spec.root for spec in specs.values()]
+    roots = dict((id(r), r) for r in roots)
+    for root in roots.values():
+        spack.spec._inject_patches_variant(root)
+
+    # Add external paths to specs with just external modules
+    for s in specs.values():
+        _ensure_external_path_if_external(s)
+
+    for s in specs.values():
+        _develop_specs_from_env(s, ev.active_environment())
+
+    # check for commits must happen after all version adaptations are complete
+    for s in specs.values():
+        _specs_with_commits(s)
+
+    # mark concrete and assign hashes to all specs in the solve
+    for root in roots.values():
+        root._finalize_concretization()
+
+    # Unify hashes (this is to avoid duplicates of runtimes and compilers)
+    unifier = ConcreteSpecsByHash()
+    keys = list(specs)
+    for key in keys:
+        current_spec = specs[key]
+        unifier.add(current_spec)
+        specs[key] = unifier[current_spec.dag_hash()]
+
+    for s in specs.values():
+        spack.spec.Spec.ensure_no_deprecated(s)
+
+    # Add git version lookup info to concrete Specs (this is generated for
+    # abstract specs as well but the Versions may be replaced during the
+    # concretization process)
+    for root in specs.values():
+        for spec in root.traverse():
+            if isinstance(spec.version, vn.GitVersion):
+                spec.version.attach_lookup(
+                    spack.version.git_ref_lookup.GitRefLookup(spec.fullname)
+                )
+
+    new_specs = execute_explicit_splices(specs)
+    specs.clear()
+    specs.update(new_specs)
+
+
+def execute_explicit_splices(specs: SpecDict) -> SpecDict:
+    splice_config = spack.config.CONFIG.get("concretizer:splice:explicit", [])
+    splice_triples = []
+    for splice_set in splice_config:
+        target = splice_set["target"]
+        replacement = spack.spec.Spec(splice_set["replacement"])
+
+        if not replacement.abstract_hash:
+            location = getattr(splice_set["replacement"], "_start_mark", " at unknown line number")
+            msg = f"Explicit splice replacement '{replacement}' does not include a hash.\n"
+            msg += f"{location}\n\n"
+            msg += "    Splice replacements must be specified by hash"
+            raise InvalidSpliceError(msg)
+
+        transitive = splice_set.get("transitive", False)
+        splice_triples.append((target, replacement, transitive))
+
+    new_specs = {}
+    for key, spec in specs.items():
+        current_spec = spec
+        for target, replacement, transitive in splice_triples:
+            if target in current_spec:
+                # matches root or non-root
+                # e.g. mvapich2%gcc
+
+                # The first iteration, we need to replace the abstract hash
+                if not replacement.concrete:
+                    replacement.replace_hash()
+                current_spec = current_spec.splice(replacement, transitive)
+        new_key = NodeId(id=key.id, pkg=current_spec.name)
+        new_specs[new_key] = current_spec
+
+    return new_specs
 
 
 def _specs_with_commits(spec):

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -313,11 +313,19 @@ def spec_dict_to_json(spec_dict: SpecDict) -> Dict:
         if not spec.concrete:
             spec._cached_hash(ht.dag_hash, force=True)
 
+    # Specs are keyed in spec_dict by their solver-assigned NodeId, but reused concrete
+    # specs may have transitive dependencies or build_specs that do not have a NodeId.
+    # Make a dictionary preserving the NodeIds from input.
+    node_id_for: Dict[int, NodeId] = {id(spec): nid for nid, spec in spec_dict.items()}
+
+    # Traverse every spec reachable from spec_dict's values, deduped by hash, and add them
+    # to the serialized entires either a) with their original NodeId, or b) with None if they
+    # don't have a NodeId. This ensures that all nodes are added and NodeIds are preserved.
     entries = []
-    for (id, pkg), spec in spec_dict.items():
-        node = spec.to_node_dict()
-        node["hash"] = spec.dag_hash()
-        entries.append((id, pkg, node))
+    for dep in spack.traverse.traverse_nodes(list(spec_dict.values()), key=lambda s: s.dag_hash()):
+        node = dep.to_node_dict()
+        node["hash"] = dep.dag_hash()
+        entries.append((node_id_for.get(id(dep)), node))
 
     # Clear the hashes cached above, as they will need to be recomputed after post-concretization.
     # They're only used here as keys for reading and writing spec DAGs.
@@ -337,14 +345,12 @@ def spec_dict_from_json(data: Dict) -> SpecDict:
         raise ValueError(f"Invalid spec dict data: {data}")
 
     reader = spack.spec.specfile_reader_for_version(spec_version)
-    node_ids_by_hash = {node["hash"]: (id, pkg) for id, pkg, node in entries}
-    nodes = [node for _, _, node in entries]
-
+    nodes = [node for _, node in entries]
     specs_by_hash = spack.spec.wire_spec_nodes(nodes, "hash", reader)
-    return {
-        NodeId(id, pkg): specs_by_hash[dag_hash]
-        for dag_hash, (id, pkg) in node_ids_by_hash.items()
-    }
+
+    # Anonymous nodes (nid=None) are reachable transitively through named roots' edges, and
+    # are handled by wire_spec_nodes() above. Skip them here to preserve SpecDict on round-trip.
+    return {NodeId(*nid): specs_by_hash[node["hash"]] for nid, node in entries if nid is not None}
 
 
 class Result:
@@ -657,9 +663,15 @@ class ConcretizationCache:
             self._remove_entry(cache_path)
             return None, None
 
+        results = cache_content.get("results")
+        if results is None:
+            # malformed cache dictionary
+            self._remove_entry(cache_path)
+            return None, None
+
         try:
-            result = Result.from_dict(cache_content["results"])
-        except (KeyError, ValueError, spack.error.SpecSyntaxError):
+            result = Result.from_dict(results)
+        except (KeyError, TypeError, ValueError, spack.error.SpecSyntaxError):
             # valid JSON but spec data is malformed or incompatible
             self._remove_entry(cache_path)
             return None, None

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -550,8 +550,6 @@ class ConcretizationCache:
         self.root = pathlib.Path(spack.util.path.canonicalize_path(root))
         self.root /= f"v{ConcretizationCache.VERSION}"
 
-        self.root.mkdir(parents=True, exist_ok=True)
-
     def cleanup(self):
         """Prunes the concretization cache according to configured entry
         count limits. Cleanup is done in LRU ordering."""
@@ -583,6 +581,8 @@ class ConcretizationCache:
 
     def cache_entries(self):
         """Generator producing cache entries within a bucket"""
+        if not self.root.exists():
+            return
         for cache_entry in self.root.iterdir():
             # skip dotfiles and old-style directory entries
             if not cache_entry.name.startswith(".") and cache_entry.is_file():

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -3783,15 +3783,12 @@ def post_process_concretization_result(specs: SpecDict) -> None:
     for root in roots.values():
         spack.spec._inject_patches_variant(root)
 
-    # Add external paths to specs with just external modules
     for s in specs.values():
+        # Add external paths to specs with just external modules
         _ensure_external_path_if_external(s)
-
-    for s in specs.values():
         _develop_specs_from_env(s, ev.active_environment())
 
-    # check for commits must happen after all version adaptations are complete
-    for s in specs.values():
+        # check for commits must happen after all version adaptations are complete
         _specs_with_commits(s)
 
     # mark concrete and assign hashes to all specs in the solve
@@ -3806,6 +3803,7 @@ def post_process_concretization_result(specs: SpecDict) -> None:
         unifier.add(current_spec)
         specs[key] = unifier[current_spec.dag_hash()]
 
+    # needs to happen after finalize_concretization, as it looks up hashes
     for s in specs.values():
         spack.spec.Spec.ensure_no_deprecated(s)
 

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -15,6 +15,7 @@ import pprint
 import random
 import re
 import sys
+import tempfile
 import time
 import warnings
 from typing import (
@@ -59,7 +60,6 @@ import spack.store
 import spack.traverse
 import spack.util.crypto
 import spack.util.hash
-import spack.util.lock as lk
 import spack.util.module_cmd as md
 import spack.util.path
 import spack.util.timer
@@ -539,9 +539,7 @@ class ConcretizationCache:
         self.root = pathlib.Path(spack.util.path.canonicalize_path(root))
         self.root /= f"v{ConcretizationCache.VERSION}"
 
-        # create root and lockfile
         self.root.mkdir(parents=True, exist_ok=True)
-        self._lockfile = self.root / ".cc_lock"
 
     def cleanup(self):
         """Prunes the concretization cache according to configured entry
@@ -570,25 +568,12 @@ class ConcretizationCache:
 
         # Try to remove the oldest half of the cache.
         for _, entry_to_rm in removal_queue[: entry_limit // 2]:
-            # cache bucket was removed by another process -- that's fine; move on
-            if not entry_to_rm.exists():
-                continue
-
-            try:
-                with self.write_transaction(entry_to_rm, timeout=1e-6):
-                    self._safe_remove(entry_to_rm)
-            except lk.LockTimeoutError:
-                # if we can't get a lock, it's either
-                # 1) being read, so it's been used recently, i.e. not a good candidate for LRU,
-                # 2) it's already being removed by another process, so we don't care, or
-                # 3) system is busy, but we don't really need to wait just for cache cleanup.
-                pass  # so skip it
+            self._remove_entry(entry_to_rm)
 
     def cache_entries(self):
         """Generator producing cache entries within a bucket"""
         for cache_entry in self.root.iterdir():
-            # Lockfile starts with "."
-            # old style concretization cache entries are in directories
+            # skip dotfiles and old-style directory entries
             if not cache_entry.name.startswith(".") and cache_entry.is_file():
                 yield cache_entry
 
@@ -596,67 +581,19 @@ class ConcretizationCache:
         """Return the first two characters of, and the full, sha256 of the given asp problem"""
         return spack.util.hash.b32_hash(problem)
 
+    @staticmethod
+    def _remove_entry(cache_path: pathlib.Path) -> None:
+        """Remove a corrupt or outdated cache entry, ignoring errors if it's already gone."""
+        try:
+            cache_path.unlink()
+        except OSError:
+            pass
+
     def _cache_path_from_problem(self, problem: str) -> pathlib.Path:
         """Returns a Path object representing the path to the cache
         entry for the given problem where the problem is the sha256 of the given asp problem"""
         prefix = self._prefix_digest(problem)
         return self.root / prefix
-
-    def _safe_remove(self, cache_dir: pathlib.Path) -> bool:
-        """Removes cache entries with handling for the case where the entry has been
-        removed already or there are multiple cache entries in a directory"""
-        try:
-            cache_dir.unlink()
-            return True
-        except FileNotFoundError:
-            # That's fine, removal is idempotent
-            pass
-        except OSError as e:
-            # Catch other timing/access related issues
-            tty.debug(
-                f"Exception occurred while attempting to remove Concretization Cache entry, {e}"
-            )
-            pass
-        return False
-
-    def _lock(self, path: pathlib.Path) -> lk.Lock:
-        """Returns a lock over the byte range corresponding to the hash of the asp problem.
-
-        ``path`` is a path to a file in the cache, and its basename is the hash of the problem.
-
-        Args:
-            path: absolute or relative path to concretization cache entry to be locked
-        """
-        return lk.Lock(
-            str(self._lockfile),
-            start=spack.util.hash.base32_prefix_bits(
-                path.name, spack.util.crypto.bit_length(sys.maxsize)
-            ),
-            length=1,
-            desc=f"Concretization cache lock for {path}",
-        )
-
-    def read_transaction(
-        self, path: pathlib.Path, timeout: Optional[float] = None
-    ) -> lk.ReadTransaction:
-        """Read transactions for concretization cache entries.
-
-        Args:
-            path: absolute or relative path to the concretization cache entry to be locked
-            timeout: give up after this many seconds
-        """
-        return lk.ReadTransaction(self._lock(path), timeout=timeout)
-
-    def write_transaction(
-        self, path: pathlib.Path, timeout: Optional[float] = None
-    ) -> lk.WriteTransaction:
-        """Write transactions for concretization cache entries
-
-        Args:
-            path: absolute or relative path to the concretization cache entry to be locked
-            timeout: give up after this many seconds
-        """
-        return lk.WriteTransaction(self._lock(path), timeout=timeout)
 
     def store(self, problem: str, result: Result, statistics: List) -> None:
         """Creates entry in concretization cache for problem if none exists,
@@ -667,21 +604,31 @@ class ConcretizationCache:
         problem.
         """
         cache_path = self._cache_path_from_problem(problem)
+
+        # Content-keyed: if the file exists, it already has the right content.
+        if cache_path.exists():
+            return
+
         cache_path.parent.mkdir(parents=True, exist_ok=True)
 
-        with self.write_transaction(cache_path, timeout=30):
-            if cache_path.exists():
-                # if cache path file exists, we already have a cache entry, likely created
-                # by another process.  Exit early.
-                return
+        cache_dict = {
+            "_meta": {"version": ConcretizationCache.VERSION},
+            "results": result.to_dict(),
+            "statistics": statistics,
+        }
 
-            with gzip.open(cache_path, "xb", compresslevel=6) as cache_entry:
-                cache_dict = {
-                    "_meta": {"version": ConcretizationCache.VERSION},
-                    "results": result.to_dict(),
-                    "statistics": statistics,
-                }
-                cache_entry.write(json.dumps(cache_dict).encode())
+        # Write to a temp file in the same directory, then atomically rename.
+        # mkstemp appends random characters after the prefix, so names are unique.
+        fd, tmp_path = tempfile.mkstemp(dir=self.root, prefix=".tmp_")
+        try:
+            with os.fdopen(fd, "wb") as raw_f:
+                with gzip.open(raw_f, "wb", compresslevel=6) as f:
+                    f.write(json.dumps(cache_dict).encode())
+            os.rename(tmp_path, cache_path)
+        except BaseException:
+            # Clean up temp file on any failure (including if another process won the race)
+            self._remove_entry(pathlib.Path(tmp_path))
+            raise
 
     def fetch(self, problem: str) -> Union[Tuple[Result, Dict], Tuple[None, None]]:
         """Returns the concretization cache result for a lookup based on the given problem.
@@ -692,42 +639,34 @@ class ConcretizationCache:
         """
         cache_path = self._cache_path_from_problem(problem)
         if not cache_path.exists():
-            return None, None  # if exists is false, then there's no chance of a hit
-
-        cache_content = None
-        try:
-            with self.read_transaction(cache_path, timeout=2):
-                try:
-                    with gzip.open(cache_path, "rb", compresslevel=6) as f:
-                        f.peek(1)  # Try to read at least one byte
-                        f.seek(0)
-                        cache_data = f.read().decode("utf-8")
-                        cache_content = json.loads(cache_data)
-
-                except (OSError, FileNotFoundError, json.JSONDecodeError):
-                    # If any of this happens, it's a cache miss.
-                    # We'll just overwrite the corrupt file with a new one.
-                    pass
-
-        except lk.LockTimeoutError:
-            pass  # if the lock times, out skip the cache
-
-        if not cache_content:
             return None, None
 
-        # miss if the metadata we find is not the same version as we're using here.
+        # Each failure below removes the cache entry so that corrupt or outdated files
+        # don't persist and cause repeated failed lookups.
+        try:
+            with gzip.open(cache_path, "rb") as f:
+                cache_content = json.loads(f.read().decode("utf-8"))
+        except (OSError, json.JSONDecodeError):
+            # file is corrupt, truncated, or disappeared since the exists() check
+            self._remove_entry(cache_path)
+            return None, None
+
         cache_version = cache_content.get("_meta", {}).get("version")
-        if not cache_version or cache_version != ConcretizationCache.VERSION:
+        if cache_version != ConcretizationCache.VERSION:
+            # outdated format that we can't read; remove so it's regenerated
+            self._remove_entry(cache_path)
+            return None, None
+
+        try:
+            result = Result.from_dict(cache_content["results"])
+        except (KeyError, ValueError, spack.error.SpecSyntaxError):
+            # valid JSON but spec data is malformed or incompatible
+            self._remove_entry(cache_path)
             return None, None
 
         # update mod/access time for use w/ LRU cleanup
         os.utime(cache_path)
-        try:
-            result = Result.from_dict(cache_content["results"])
-            return result, cache_content["statistics"]
-
-        except (KeyError, spack.error.SpecSyntaxError):
-            return None, None
+        return result, cache_content["statistics"]
 
 
 def _is_checksummed_git_version(v):

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -1095,30 +1095,35 @@ class PyclingoDriver:
         timer.stop("ordering")
 
         timer.start("cache-check")
+        use_cache = spack.config.get("concretizer:concretization_cache:enable", False)
+        cache = self._conc_cache if use_cache else None
+
         # load control files to add to the input representation
         control_file_paths = self._control_file_paths(control_files)
         cache_key = self._make_cache_key(problem, control_file_paths)
 
-        result, concretization_stats = None, None
-        conc_cache_enabled = spack.config.get("concretizer:concretization_cache:enable", False)
-        if conc_cache_enabled and self._conc_cache:
-            result, concretization_stats = self._conc_cache.fetch(cache_key)
+        # try to fetch from the cache
+        result = None
+        if cache:
+            result, concretization_stats = cache.fetch(cache_key)
+
         timer.stop("cache-check")
 
         tty.debug("Starting concretizer")
 
-        # run the solver and store the result, if it wasn't cached already
+        # run the solver
         if not result:
-            problem_repr = "\n".join(problem)
-            result = self._run_clingo(specs, setup, problem_repr, control_file_paths, timer)
-            if conc_cache_enabled and self._conc_cache:
-                self._conc_cache.store(cache_key, result, self.control.statistics)
+            result = self._run_clingo(specs, setup, "\n".join(problem), control_file_paths, timer)
+            concretization_stats = self.control.statistics
+
+            # write result back to the cache
+            if cache:
+                cache.store(cache_key, result, self.control.statistics)
 
         if output.timers:
             timer.write_tty()
             print()
 
-        concretization_stats = concretization_stats or self.control.statistics
         if output.stats:
             print("Statistics:")
             pprint.pprint(concretization_stats)

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -46,6 +46,7 @@ line is a spec for a particular installation of the mpileaks package.
 
 6. The architecture to build with.
 """
+
 import abc
 import collections
 import collections.abc
@@ -5620,24 +5621,30 @@ class SpecfileV1(SpecfileReaderBase):
         return cls.read_specfile_dep_specs(node["dependencies"])
 
     @classmethod
-    def read_specfile_dep_specs(cls, deps, hash_type=ht.dag_hash.name):
+    def read_specfile_dep_specs(cls, deps, hash_type=ht.dag_hash.name) -> List[DepSpecComponents]:
         """Read the DependencySpec portion of a YAML-formatted Spec.
         This needs to be backward-compatible with older spack spec
         formats so that reindex will work on old specs/databases.
         """
+        dspec_list: List[DepSpecComponents] = []
         for dep_name, elt in deps.items():
             if isinstance(elt, dict):
                 for h in ht.HASHES:
                     if h.name in elt:
                         dep_hash, deptypes = elt[h.name], elt["type"]
                         hash_type = h.name
-                        virtuals = []
+                        virtuals: Tuple[str, ...] = ()
                         break
                 else:  # We never determined a hash type...
                     raise spack.error.SpecError("Couldn't parse dependency spec.")
             else:
                 raise spack.error.SpecError("Couldn't parse dependency types in spec.")
-            yield dep_name, dep_hash, list(deptypes), hash_type, list(virtuals), True
+
+            dspec_list.append(
+                (dep_name, dep_hash, list(deptypes), hash_type, tuple(virtuals), True)
+            )
+
+        return dspec_list
 
 
 class SpecfileV2(SpecfileReaderBase):

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -63,6 +63,7 @@ import warnings
 from typing import (
     Any,
     Callable,
+    ClassVar,
     Dict,
     Iterable,
     List,
@@ -5379,25 +5380,19 @@ def reconstruct_virtuals_on_edges(spec: Spec) -> None:
 DepSpecComponents = Tuple[str, str, List, str, Tuple[str, ...], bool]
 
 
-class SpecfileReaderMeta(abc.ABCMeta):
-    """Metaclass to automatically register all specfile versions.
-
-    This allows us to track available versions of SpecfileReaderBase subclasses.
-    """
-
-    def __new__(cls, name, bases, dct):
-        new_class = super().__new__(cls, name, bases, dct)
-        if hasattr(new_class, "SPEC_VERSION"):
-            new_class.versions[new_class.SPEC_VERSION] = new_class
-
-        return new_class
+_SPECFILE_READERS: Dict[int, Type["SpecfileReaderBase"]] = {}
 
 
-class SpecfileReaderBase(metaclass=SpecfileReaderMeta):
-    SPEC_VERSION: int
+def register_reader(cls: Type["SpecfileReaderBase"]) -> Type["SpecfileReaderBase"]:
+    """Register a SpecfileReaderBase subclass under its SPEC_VERSION."""
+    if "SPEC_VERSION" not in cls.__dict__:
+        raise TypeError(f"{cls.__name__} must define SPEC_VERSION to be registered")
+    _SPECFILE_READERS[cls.SPEC_VERSION] = cls
+    return cls
 
-    # all specfile versions
-    versions: Dict[int, Type["SpecfileReaderBase"]] = {}
+
+class SpecfileReaderBase(abc.ABC):
+    SPEC_VERSION: ClassVar[int]
 
     @classmethod
     @abc.abstractmethod
@@ -5581,6 +5576,7 @@ def wire_spec_nodes(
     return specs_by_hash
 
 
+@register_reader
 class SpecfileV1(SpecfileReaderBase):
     SPEC_VERSION = 1
 
@@ -5657,6 +5653,7 @@ class SpecfileV1(SpecfileReaderBase):
         return dspec_list
 
 
+@register_reader
 class SpecfileV2(SpecfileReaderBase):
     SPEC_VERSION = 2
 
@@ -5716,10 +5713,12 @@ class SpecfileV2(SpecfileReaderBase):
         return build_spec_dict["name"], build_spec_dict[hash_type], hash_type
 
 
+@register_reader
 class SpecfileV3(SpecfileV2):
     SPEC_VERSION = 3
 
 
+@register_reader
 class SpecfileV4(SpecfileV2):
     SPEC_VERSION = 4
 
@@ -5737,6 +5736,7 @@ class SpecfileV4(SpecfileV2):
         return cls._load(data)
 
 
+@register_reader
 class SpecfileV5(SpecfileV4):
     SPEC_VERSION = 5
 
@@ -5760,7 +5760,7 @@ SpecfileLatest = SpecfileV5
 
 def specfile_reader_for_version(version: int) -> Type[SpecfileReaderBase]:
     """Get a SpecfileReader for the provided version, or raise an error."""
-    reader = SpecfileReaderBase.versions.get(version)
+    reader = _SPECFILE_READERS.get(version)
 
     if not reader:
         raise ValueError(f"Unknown Specfile version: {version}")

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -5463,8 +5463,6 @@ class SpecfileReaderBase(abc.ABC):
         # specs read in are concrete unless marked abstract
         if node.get("concrete", True):
             spec._mark_root_concrete()
-        else:
-            spec.clear_caches()
 
         if "patches" in node:
             patches = node["patches"]

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -5649,6 +5649,13 @@ class SpecfileV1(SpecfileReaderBase):
 
         return dspec_list
 
+    @classmethod
+    def extract_build_spec_info_from_node_dict(
+        cls, node, hash_type=ht.dag_hash.name
+    ) -> Tuple[str, str, str]:
+        """Not used for SpecfileV1; raises NotImplementedError."""
+        raise NotImplementedError
+
 
 @register_reader
 class SpecfileV2(SpecfileReaderBase):

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -46,7 +46,7 @@ line is a spec for a particular installation of the mpileaks package.
 
 6. The architecture to build with.
 """
-
+import abc
 import collections
 import collections.abc
 import enum
@@ -5378,7 +5378,7 @@ def reconstruct_virtuals_on_edges(spec: Spec) -> None:
 DepSpecComponents = Tuple[str, str, List, str, Tuple[str, ...], bool]
 
 
-class SpecfileReaderMeta(type):
+class SpecfileReaderMeta(abc.ABCMeta):
     """Metaclass to automatically register all specfile versions.
 
     This allows us to track available versions of SpecfileReaderBase subclasses.
@@ -5399,24 +5399,24 @@ class SpecfileReaderBase(metaclass=SpecfileReaderMeta):
     versions: Dict[int, Type["SpecfileReaderBase"]] = {}
 
     @classmethod
-    def load(cls, data) -> Spec:
-        raise NotImplementedError
+    @abc.abstractmethod
+    def load(cls, data) -> Spec: ...
 
     @classmethod
-    def dependencies_from_node_dict(cls, node) -> List[DepSpecComponents]:
-        raise NotImplementedError
+    @abc.abstractmethod
+    def dependencies_from_node_dict(cls, node) -> List[DepSpecComponents]: ...
 
     @classmethod
+    @abc.abstractmethod
     def read_specfile_dep_specs(
         cls, deps: Dict, hash_type: str = ht.dag_hash.name
-    ) -> List[DepSpecComponents]:
-        raise NotImplementedError
+    ) -> List[DepSpecComponents]: ...
 
     @classmethod
+    @abc.abstractmethod
     def extract_build_spec_info_from_node_dict(
         cls, node, hash_type=ht.dag_hash.name
-    ) -> Tuple[str, str, str]:
-        raise NotImplementedError
+    ) -> Tuple[str, str, str]: ...
 
     @classmethod
     def from_node_dict(cls, node):

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -5506,10 +5506,12 @@ class SpecfileReaderBase(abc.ABC):
         """
         # Current specfile format
         nodes = data["spec"]["nodes"]
-        hash_type = None
-        any_deps = False
+        if not nodes:
+            raise spack.error.SpecError("Spec dictionary contains no nodes.")
 
         # Pass 0: Determine hash type
+        hash_type = None
+        any_deps = False
         for node in nodes:
             for _, _, _, dhash_type, _, _ in cls.dependencies_from_node_dict(node):
                 any_deps = True
@@ -5523,9 +5525,6 @@ class SpecfileReaderBase(abc.ABC):
             raise spack.error.SpecError(
                 "Spec dictionary contains malformed dependencies. Old format?"
             )
-
-        if not nodes:
-            raise spack.error.SpecError("Spec dictionary contains no nodes.")
 
         specs_by_hash = wire_spec_nodes(nodes, hash_type, cls)
         root_spec_hash = nodes[0][hash_type]

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -70,6 +70,7 @@ from typing import (
     Sequence,
     Set,
     Tuple,
+    Type,
     Union,
     overload,
 )
@@ -2600,8 +2601,12 @@ class Spec:
         return {"spec": {"_meta": {"version": SPECFILE_FORMAT_VERSION}, "nodes": node_list}}
 
     def node_dict_with_hashes(self, hash: ht.SpecHashDescriptor = ht.dag_hash) -> Dict[str, Any]:
-        """Returns a node dict of this spec with the dag hash, and the provided hash (if not
-        the dag hash)."""
+        """Returns a dict of this spec with the dag hash, and optionally another hash or id.
+
+        Arguments:
+            hash: Optional other hash to include. If this is the dag hash, it's only included once.
+
+        """
         node = self.to_node_dict(hash)
         # All specs have at least a DAG hash
         node[ht.dag_hash.name] = self.dag_hash()
@@ -2806,19 +2811,17 @@ class Spec:
         Args:
             data: a nested dict/list data structure read from YAML or JSON.
         """
-        # Legacy specfile format
+        # Figure out the specfile format
         if isinstance(data["spec"], list):
-            spec = SpecfileV1.load(data)
-        elif int(data["spec"]["_meta"]["version"]) == 2:
-            spec = SpecfileV2.load(data)
-        elif int(data["spec"]["_meta"]["version"]) == 3:
-            spec = SpecfileV3.load(data)
-        elif int(data["spec"]["_meta"]["version"]) == 4:
-            spec = SpecfileV4.load(data)
+            version = 1
         else:
-            spec = SpecfileV5.load(data)
+            version = int(data["spec"]["_meta"]["version"])
 
-        # Any git version should
+        # get the right reader
+        reader = specfile_reader_for_version(version)
+        spec = reader.load(data)
+
+        # Handle git versions
         for s in spec.traverse():
             s.attach_git_version_lookup()
 
@@ -5372,8 +5375,48 @@ def reconstruct_virtuals_on_edges(spec: Spec) -> None:
             edge.update_virtuals(virtuals_to_add)
 
 
-class SpecfileReaderBase:
+DepSpecComponents = Tuple[str, str, List, str, Tuple[str, ...], bool]
+
+
+class SpecfileReaderMeta(type):
+    """Metaclass to automatically register all specfile versions.
+
+    This allows us to track available versions of SpecfileReaderBase subclasses.
+    """
+
+    def __new__(cls, name, bases, dct):
+        new_class = super().__new__(cls, name, bases, dct)
+        if hasattr(new_class, "SPEC_VERSION"):
+            new_class.versions[new_class.SPEC_VERSION] = new_class
+
+        return new_class
+
+
+class SpecfileReaderBase(metaclass=SpecfileReaderMeta):
     SPEC_VERSION: int
+
+    # all specfile versions
+    versions: Dict[int, Type["SpecfileReaderBase"]] = {}
+
+    @classmethod
+    def load(cls, data) -> Spec:
+        raise NotImplementedError
+
+    @classmethod
+    def dependencies_from_node_dict(cls, node) -> List[DepSpecComponents]:
+        raise NotImplementedError
+
+    @classmethod
+    def read_specfile_dep_specs(
+        cls, deps: Dict, hash_type: str = ht.dag_hash.name
+    ) -> List[DepSpecComponents]:
+        raise NotImplementedError
+
+    @classmethod
+    def extract_build_spec_info_from_node_dict(
+        cls, node, hash_type=ht.dag_hash.name
+    ) -> Tuple[str, str, str]:
+        raise NotImplementedError
 
     @classmethod
     def from_node_dict(cls, node):
@@ -5424,6 +5467,8 @@ class SpecfileReaderBase:
         # specs read in are concrete unless marked abstract
         if node.get("concrete", True):
             spec._mark_root_concrete()
+        else:
+            spec.clear_caches()
 
         if "patches" in node:
             patches = node["patches"]
@@ -5456,7 +5501,7 @@ class SpecfileReaderBase:
         return Spec(f"{d['name']}@{vn.VersionList.from_dict(d)}")
 
     @classmethod
-    def _load(cls, data):
+    def _load(cls, data) -> Spec:
         """Construct a spec from JSON/YAML using the format version 2.
 
         This format is used in Spack v0.17, was introduced in
@@ -5485,51 +5530,51 @@ class SpecfileReaderBase:
                 "Spec dictionary contains malformed dependencies. Old format?"
             )
 
-        hash_dict = {}
-        root_spec_hash = None
-
-        # Pass 1: Create a single lookup dictionary by hash
-        for i, node in enumerate(nodes):
-            node_hash = node[hash_type]
-            node_spec = cls.from_node_dict(node)
-            hash_dict[node_hash] = node
-            hash_dict[node_hash]["node_spec"] = node_spec
-            if i == 0:
-                root_spec_hash = node_hash
-
-        if not root_spec_hash:
+        if not nodes:
             raise spack.error.SpecError("Spec dictionary contains no nodes.")
 
-        # Pass 2: Finish construction of all DAG edges (including build specs)
-        for node_hash, node in hash_dict.items():
-            node_spec = node["node_spec"]
-            for _, dhash, dtype, _, virtuals, direct in cls.dependencies_from_node_dict(node):
-                node_spec._add_dependency(
-                    hash_dict[dhash]["node_spec"],
-                    depflag=dt.canonicalize(dtype),
-                    virtuals=virtuals,
-                    direct=direct,
-                )
-            if "build_spec" in node.keys():
-                _, bhash, _ = cls.extract_build_spec_info_from_node_dict(node, hash_type=hash_type)
-                node_spec._build_spec = hash_dict[bhash]["node_spec"]
+        specs_by_hash = wire_spec_nodes(nodes, hash_type, cls)
+        root_spec_hash = nodes[0][hash_type]
+        return specs_by_hash[root_spec_hash]
 
-        return hash_dict[root_spec_hash]["node_spec"]
 
-    @classmethod
-    def extract_build_spec_info_from_node_dict(cls, node, hash_type=ht.dag_hash.name):
-        raise NotImplementedError("Subclasses must implement this method.")
+def wire_spec_nodes(
+    nodes: List[Dict], hash_type: str, reader: Type[SpecfileReaderBase]
+) -> Dict[str, Spec]:
+    """Given a list of spec node dicts, wire them together and return a dict keyed by hash.
 
-    @classmethod
-    def read_specfile_dep_specs(cls, deps, hash_type=ht.dag_hash.name):
-        raise NotImplementedError("Subclasses must implement this method.")
+    This is the part of SpecfileV2 and onwards that wires up specs, based on hashes in
+    JSON spec data.
+
+    """
+    # Pass 1: Create a single lookup dictionary by hash
+    specs_by_hash = {node[hash_type]: reader.from_node_dict(node) for node in nodes}
+
+    # Pass 2: Finish construction of all DAG edges (including build specs)
+    for node in nodes:
+        node_hash = node[hash_type]
+        node_spec = specs_by_hash[node_hash]
+
+        for _, dhash, dtype, _, virtuals, direct in reader.dependencies_from_node_dict(node):
+            node_spec._add_dependency(
+                specs_by_hash[dhash],
+                depflag=dt.canonicalize(dtype),
+                virtuals=virtuals,
+                direct=direct,
+            )
+
+        if "build_spec" in node.keys():
+            _, bhash, _ = reader.extract_build_spec_info_from_node_dict(node, hash_type=hash_type)
+            node_spec._build_spec = specs_by_hash[bhash]
+
+    return specs_by_hash
 
 
 class SpecfileV1(SpecfileReaderBase):
     SPEC_VERSION = 1
 
     @classmethod
-    def load(cls, data):
+    def load(cls, data) -> Spec:
         """Construct a spec from JSON/YAML using the format version 1.
 
         Note: Version 1 format has no notion of a build_spec, and names are
@@ -5568,12 +5613,11 @@ class SpecfileV1(SpecfileReaderBase):
         return name, node
 
     @classmethod
-    def dependencies_from_node_dict(cls, node):
+    def dependencies_from_node_dict(cls, node) -> List[DepSpecComponents]:
         if "dependencies" not in node:
             return []
 
-        for t in cls.read_specfile_dep_specs(node["dependencies"]):
-            yield t
+        return cls.read_specfile_dep_specs(node["dependencies"])
 
     @classmethod
     def read_specfile_dep_specs(cls, deps, hash_type=ht.dag_hash.name):
@@ -5600,7 +5644,7 @@ class SpecfileV2(SpecfileReaderBase):
     SPEC_VERSION = 2
 
     @classmethod
-    def load(cls, data):
+    def load(cls, data) -> Spec:
         result = cls._load(data)
         reconstruct_virtuals_on_edges(result)
         return result
@@ -5610,11 +5654,11 @@ class SpecfileV2(SpecfileReaderBase):
         return node["name"], node
 
     @classmethod
-    def dependencies_from_node_dict(cls, node):
+    def dependencies_from_node_dict(cls, node) -> List[DepSpecComponents]:
         return cls.read_specfile_dep_specs(node.get("dependencies", []))
 
     @classmethod
-    def read_specfile_dep_specs(cls, deps, hash_type=ht.dag_hash.name):
+    def read_specfile_dep_specs(cls, deps, hash_type=ht.dag_hash.name) -> List[DepSpecComponents]:
         """Read the DependencySpec portion of a YAML-formatted Spec.
         This needs to be backward-compatible with older spack spec
         formats so that reindex will work on old specs/databases.
@@ -5638,7 +5682,7 @@ class SpecfileV2(SpecfileReaderBase):
                     raise spack.error.SpecError("Couldn't parse dependency spec.")
             else:
                 raise spack.error.SpecError("Couldn't parse dependency types in spec.")
-            result.append((dep_name, dep_hash, list(deptypes), hash_type, list(virtuals), direct))
+            result.append((dep_name, dep_hash, list(deptypes), hash_type, tuple(virtuals), direct))
         return result
 
     @classmethod
@@ -5672,7 +5716,7 @@ class SpecfileV4(SpecfileV2):
         return dep_hash, deptypes, hash_type, virtuals, direct
 
     @classmethod
-    def load(cls, data):
+    def load(cls, data) -> Spec:
         return cls._load(data)
 
 
@@ -5695,6 +5739,16 @@ class SpecfileV5(SpecfileV4):
 
 #: Alias to the latest version of specfiles
 SpecfileLatest = SpecfileV5
+
+
+def specfile_reader_for_version(version: int) -> Type[SpecfileReaderBase]:
+    """Get a SpecfileReader for the provided version, or raise an error."""
+    reader = SpecfileReaderBase.versions.get(version)
+
+    if not reader:
+        raise ValueError(f"Unknown Specfile version: {version}")
+
+    return reader
 
 
 class LazySpecCache(collections.defaultdict):

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -5547,26 +5547,36 @@ def wire_spec_nodes(
     This is the part of SpecfileV2 and onwards that wires up specs, based on hashes in
     JSON spec data.
 
+    Raises:
+        MissingSpecHashError: if a node references a hash not present in ``nodes``.
     """
     # Pass 1: Create a single lookup dictionary by hash
     specs_by_hash = {node[hash_type]: reader.from_node_dict(node) for node in nodes}
 
     # Pass 2: Finish construction of all DAG edges (including build specs)
     for node in nodes:
-        node_hash = node[hash_type]
-        node_spec = specs_by_hash[node_hash]
+        node_spec = specs_by_hash[node[hash_type]]
 
-        for _, dhash, dtype, _, virtuals, direct in reader.dependencies_from_node_dict(node):
+        for dname, dhash, dtype, _, virtuals, direct in reader.dependencies_from_node_dict(node):
+            dep_spec = specs_by_hash.get(dhash)
+            if dep_spec is None:
+                raise MissingSpecHashError(
+                    f"node '{node['name']}' references missing dep hash {dname}/{dhash}"
+                )
             node_spec._add_dependency(
-                specs_by_hash[dhash],
-                depflag=dt.canonicalize(dtype),
-                virtuals=virtuals,
-                direct=direct,
+                dep_spec, depflag=dt.canonicalize(dtype), virtuals=virtuals, direct=direct
             )
 
         if "build_spec" in node.keys():
-            _, bhash, _ = reader.extract_build_spec_info_from_node_dict(node, hash_type=hash_type)
-            node_spec._build_spec = specs_by_hash[bhash]
+            bname, bhash, _ = reader.extract_build_spec_info_from_node_dict(
+                node, hash_type=hash_type
+            )
+            build_spec = specs_by_hash.get(bhash)
+            if build_spec is None:
+                raise MissingSpecHashError(
+                    f"node '{node['name']}' references missing build_spec hash {bname}/{bhash}"
+                )
+            node_spec._build_spec = build_spec
 
     return specs_by_hash
 
@@ -6054,6 +6064,10 @@ class InvalidEdgeError(spack.error.SpecError):
 
 class SpecMutationError(spack.error.SpecError):
     """Raised when a mutation is attempted with invalid attributes."""
+
+
+class MissingSpecHashError(spack.error.SpecError):
+    """Raised when a serialized spec node references a hash not present in a node list."""
 
 
 class _ImmutableSpec(Spec):

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -5377,7 +5377,7 @@ def reconstruct_virtuals_on_edges(spec: Spec) -> None:
             edge.update_virtuals(virtuals_to_add)
 
 
-DepSpecComponents = Tuple[str, str, List, str, Tuple[str, ...], bool]
+DepSpecComponents = Tuple[str, str, List[str], str, Tuple[str, ...], bool]
 
 
 _SPECFILE_READERS: Dict[int, Type["SpecfileReaderBase"]] = {}

--- a/lib/spack/spack/test/concretization/core.py
+++ b/lib/spack/spack/test/concretization/core.py
@@ -4490,12 +4490,6 @@ def test_spec_dict_roundtrip(mock_packages, config, spec_str):
     assert roundtrip[nid] == spec
 
 
-@pytest.fixture
-def enable_reuse():
-    with spack.config.override("concretizer:reuse", True):
-        yield
-
-
 @pytest.mark.parametrize(
     "spec,reused_dep",
     [
@@ -4530,7 +4524,7 @@ def test_concretization_cache_roundtrip(
         request.getfixturevalue("install_mockery")
         dep = spack.concretize.concretize_one(reused_dep)
         PackageInstaller([dep.package], fake=True, explicit=True).install()
-        request.getfixturevalue("enable_reuse")
+        mutable_config.set("concretizer:reuse", True)
 
     # run one standard concretization to populate the cache and the setup method
     # memoization

--- a/lib/spack/spack/test/concretization/core.py
+++ b/lib/spack/spack/test/concretization/core.py
@@ -5197,3 +5197,72 @@ def test_specs_from_mirror_warns_when_index_missing(monkeypatch):
 
     with pytest.warns(UserWarning, match="cannot be used in concretization"):
         spack.solver.reuse._specs_from_mirror()
+
+
+@pytest.mark.parametrize(
+    "data",
+    [
+        {},
+        {"_meta": {}},
+        {"_meta": {"spec_version": "not_an_int"}, "specs": []},
+        {"specs": []},
+        {"_meta": {"bad_label": 6}},
+    ],
+)
+def test_spec_dict_from_json_invalid_data(data):
+    """spec_dict_from_json raises ValueError on missing or malformed input."""
+    with pytest.raises(ValueError, match="Invalid spec dict data"):
+        spack.solver.asp.spec_dict_from_json(data)
+
+
+def test_concretization_cache_remove_entry_oserror(tmp_path):
+    """_remove_entry silently ignores OSError (e.g. file already gone)."""
+    gone = tmp_path / "nonexistent"
+    # Should not raise even though the file doesn't exist
+    spack.solver.asp.ConcretizationCache._remove_entry(gone)
+
+
+def test_concretization_cache_store_skips_existing(use_concretization_cache):
+    """store() is a no-op when the cache path already exists."""
+    cache = spack.solver.asp.ConcretizationCache(str(use_concretization_cache))
+    problem = "duplicate store test"
+    cache_path = cache._cache_path_from_problem(problem)
+    cache_path.parent.mkdir(parents=True, exist_ok=True)
+
+    # Pre-create the file with sentinel content
+    cache_path.write_bytes(b"sentinel")
+
+    # Build a minimal Result so store() has something to serialize
+    result = Result(specs=[])
+
+    cache.store(problem, result, statistics=[])
+
+    # The file should still contain the sentinel, proving store() returned early
+    assert cache_path.read_bytes() == b"sentinel"
+
+
+def test_concretization_cache_store_cleans_temp_on_error(use_concretization_cache, monkeypatch):
+    """store() removes the temp file and re-raises when the rename fails.
+
+    This simulates a race where two processes both pass the exists() check and write temp files,
+    but one fails on rename.
+    """
+    cache = spack.solver.asp.ConcretizationCache(str(use_concretization_cache))
+    problem = "write failure test"
+
+    # Simulate a rename failure (e.g. race condition between concurrent solves)
+    def failing_rename(src, dst):
+        raise OSError("rename failed")
+
+    monkeypatch.setattr(os, "rename", failing_rename)
+
+    with pytest.raises(OSError, match="rename failed"):
+        cache.store(problem, Result(specs=[]), statistics=[])
+
+    # The final cache path should not exist
+    cache_path = cache._cache_path_from_problem(problem)
+    assert not cache_path.exists()
+
+    # No leftover temp files
+    temps = list(cache.root.glob(".tmp_*"))
+    assert temps == []

--- a/lib/spack/spack/test/concretization/core.py
+++ b/lib/spack/spack/test/concretization/core.py
@@ -4514,7 +4514,7 @@ def test_concretization_cache_reapplies_patches_on_hit(
     """Tests that adding a patch to a recipe is taken into account when we hit the cache.
 
     Patches are not part of the ASP facts, so adding a patch to a recipe does not change the cache
-    key. This ensure we do post-processing of solve output correctly after a cache hit.
+    key. This ensures we do post-processing of solve output correctly after a cache hit.
     """
     EXTRA_SHA256 = "a" * 64  # synthetic sha256 simulating a newly added patch
 

--- a/lib/spack/spack/test/concretization/core.py
+++ b/lib/spack/spack/test/concretization/core.py
@@ -2,7 +2,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 import difflib
-import json
 import os
 import pathlib
 import platform
@@ -39,6 +38,7 @@ import spack.solver.input_analysis
 import spack.solver.reuse
 import spack.spec
 import spack.spec_filter
+import spack.traverse
 import spack.util.file_cache
 import spack.util.hash
 import spack.util.spack_yaml as syaml
@@ -4428,6 +4428,32 @@ def test_when_possible_above_all(mutable_config, mock_packages):
     for result in solver.solve_in_rounds(specs):
         criteria = sorted(result.criteria, reverse=True)
         assert criteria[0].name == "number of input specs not concretized"
+
+
+@pytest.mark.parametrize(
+    "specs",
+    [
+        [Spec("hdf5"), Spec("mpich")],
+        [Spec("hdf5")],
+        [Spec("mpich")],
+        [Spec("pkg-a"), Spec("pkg-b"), Spec("pkg-c")],
+    ],
+)
+def test_result_roundtrip(mock_packages, config, specs):
+    """Test that a solve result can be serialized and brought back."""
+    solver = spack.solver.asp.Solver()
+    result = solver.solve(specs)
+    roundtrip = spack.solver.asp.Result.from_dict(result.to_dict())
+
+    # ensure that we didn't duplicate spec objects during the round trip -- specs need
+    # to come back as exactly the same graph they were before.
+    assert len(result.answers) == len(roundtrip.answers)
+    for (_, _, lspecs), (_, _, rspecs) in zip(result.answers, roundtrip.answers):
+        lids = set(id(lspec) for lspec in spack.traverse.traverse_nodes(lspecs.values()))
+        rids = set(id(rspec) for rspec in spack.traverse.traverse_nodes(rspecs.values()))
+        assert len(lids) == len(rids)
+
+    assert roundtrip == result
 
 
 def test_concretization_cache_roundtrip(

--- a/lib/spack/spack/test/concretization/core.py
+++ b/lib/spack/spack/test/concretization/core.py
@@ -4458,17 +4458,83 @@ def test_result_roundtrip(mock_packages, config, specs):
     assert roundtrip == result
 
 
+@pytest.mark.parametrize(
+    "spec_str", ["hdf5", "hdf5^zmpi", "pkg-with-zlib-dep", "hypre^openblas-with-lapack"]
+)
+def test_spec_dict_roundtrip(mock_packages, config, spec_str):
+    """spec_dict_to_json/from_json preserves SpecDict shape and the full reachable graph.
+
+    Builds a SpecDict that holds only the root as a named entry -- transitive deps live
+    in the root's in-memory DAG but aren't separate NodeId entries. This mirrors how
+    reused specs appear in a SpecDict (pure build deps come along on the in-memory spec
+    but never become solver nodes), and is the case that triggered the original
+    dangling-hash bug in wire_spec_nodes.
+    """
+    spec = spack.concretize.concretize_one(spec_str)
+    nid = spack.solver.asp.SpecBuilder.make_node(pkg=spec.name)
+    spec_dict = {nid: spec}
+
+    roundtrip = spack.solver.asp.spec_dict_from_json(spack.solver.asp.spec_dict_to_json(spec_dict))
+
+    # SpecDict shape is preserved exactly (no synthetic NodeIds leak into the dict)
+    assert list(roundtrip.keys()) == [nid]
+
+    # Every spec reachable from the original is reachable from the roundtripped value,
+    # even though only the root was a SpecDict entry. This is the regression target:
+    # transitive deps must still be wired up through the root's edges.
+    original_hashes = {s.dag_hash() for s in spec.traverse()}
+    roundtrip_hashes = {s.dag_hash() for s in roundtrip[nid].traverse()}
+    assert original_hashes == roundtrip_hashes
+
+    # Deep equality on the root spec
+    assert roundtrip[nid] == spec
+
+
+@pytest.fixture
+def enable_reuse():
+    with spack.config.override("concretizer:reuse", True):
+        yield
+
+
+@pytest.mark.parametrize(
+    "spec,reused_dep",
+    [
+        # fresh solves
+        ("hdf5", None),
+        ("hdf5^zmpi", None),
+        ("zmpi", None),
+        ("pkg-with-zlib-dep", None),
+        ("hypre^openblas-with-lapack", None),
+        # simple link dep reuse
+        ("pkg-with-zlib-dep", "zlib"),
+        # self reuse, no compiler-wrapper
+        ("zlib", "zlib"),
+        # self reuse, with compiler-wrapper
+        ("hdf5", "hdf5"),
+        ("zmpi", "zmpi"),
+        # reuse deps with compiler-wrapper
+        ("hdf5^zmpi", "zmpi"),
+        ("hypre^openblas-with-lapack", "openblas-with-lapack"),
+    ],
+)
 def test_concretization_cache_roundtrip(
-    mock_packages, use_concretization_cache, monkeypatch, mutable_config
+    spec, reused_dep, mock_packages, use_concretization_cache, monkeypatch, mutable_config, request
 ):
     """Tests whether we can write the results of a clingo solve to the cache
     and load the same spec request from the cache to produce identical specs"""
 
     assert spack.config.get("concretizer:concretization_cache:enable")
 
+    # when reusing, install the requested dependency and enable reuse for the solve
+    if reused_dep:
+        request.getfixturevalue("install_mockery")
+        dep = spack.concretize.concretize_one(reused_dep)
+        PackageInstaller([dep.package], fake=True, explicit=True).install()
+        request.getfixturevalue("enable_reuse")
+
     # run one standard concretization to populate the cache and the setup method
     # memoization
-    h = spack.concretize.concretize_one("hdf5")
+    h = spack.concretize.concretize_one(spec)
 
     # ASP output should be stable, concretizing the same spec
     # should have the same problem output
@@ -4488,10 +4554,11 @@ def test_concretization_cache_roundtrip(
 
     monkeypatch.setattr(spack.solver.asp.ConcretizationCache, "store", _ensure_no_store)
     monkeypatch.setattr(spack.solver.asp.ConcretizationCache, "fetch", _ensure_cache_hits)
+
     # ensure subsequent concretizations of the same spec produce the same spec
     # object
-    for _ in range(5):
-        hdf5 = spack.concretize.concretize_one("hdf5")
+    for _ in range(3):
+        hdf5 = spack.concretize.concretize_one(spec)
 
         assert h.to_json(pretty=True) == hdf5.to_json(pretty=True)
         assert h == hdf5

--- a/lib/spack/spack/test/concretization/core.py
+++ b/lib/spack/spack/test/concretization/core.py
@@ -4483,7 +4483,8 @@ def test_concretization_cache_roundtrip_result(use_concretization_cache):
 def test_concretization_cache_count_cleanup(use_concretization_cache, mutable_config):
     """Tests to ensure we are cleaning the cache when we should be respective to the
     number of entries allowed in the cache"""
-    conc_cache_dir = use_concretization_cache
+    conc_cache_dir = use_concretization_cache / f"v{spack.solver.asp.ConcretizationCache.VERSION}"
+    conc_cache_dir.mkdir(parents=True)
 
     spack.config.set("concretizer:concretization_cache:entry_limit", 1000)
 
@@ -4511,26 +4512,6 @@ def test_concretization_cache_count_cleanup(use_concretization_cache, mutable_co
     after = names()
     assert len(after) == 501
     assert len(after - before) == 1  # one additional hash added by 1001st concretization
-
-
-def test_concretization_cache_uncompressed_entry(use_concretization_cache, monkeypatch):
-    def _store(self, problem, result, statistics):
-        cache_path = self._cache_path_from_problem(problem)
-        with self.write_transaction(cache_path) as exists:
-            if exists:
-                return
-            try:
-                with open(cache_path, "x", encoding="utf-8") as cache_entry:
-                    cache_dict = {"results": result.to_dict(), "statistics": statistics}
-                    cache_entry.write(json.dumps(cache_dict))
-            except FileExistsError:
-                pass
-
-    monkeypatch.setattr(spack.solver.asp.ConcretizationCache, "store", _store)
-    # Store the results in plaintext
-    spack.concretize.concretize_one("zlib")
-    # Ensure fetch can handle the plaintext cache entry
-    spack.concretize.concretize_one("zlib")
 
 
 @pytest.mark.parametrize(

--- a/lib/spack/spack/test/concretization/core.py
+++ b/lib/spack/spack/test/concretization/core.py
@@ -5326,3 +5326,48 @@ def test_concretization_cache_store_cleans_temp_on_error(use_concretization_cach
     # No leftover temp files
     temps = list(cache.root.glob(".tmp_*"))
     assert temps == []
+
+
+def test_concretization_cache_roundtrip_with_automatic_splice(
+    use_concretization_cache, mutable_config, monkeypatch, install_mockery
+):
+    """Test that cache entries written after an automatic splice are readable on the next solve."""
+    mutable_config.set("concretizer:reuse", True)
+
+    # Install the old version.  splice-t depends on splice-h, which has:
+    #   can_splice("splice-h@1.0.0 +compat", when="@1.0.1 +compat")
+    # so splice-h@1.0.0+compat can be spliced in wherever splice-h@1.0.1+compat is needed.
+    old = spack.concretize.concretize_one(
+        "splice-t@1 ^splice-h@1.0.0+compat ^splice-z@1.0.0+compat"
+    )
+    PackageInstaller([old.package], fake=True, explicit=True).install()
+
+    # Make splice-t non-buildable so the solver is forced to reuse it via a splice.
+    mutable_config.set("packages", {"splice-t": {"buildable": False}})
+    mutable_config.set("concretizer:splice", {"automatic": True})
+
+    goal = "splice-t@1 ^splice-h@1.0.1+compat ^splice-z@1.0.0+compat"
+
+    # First solve: the auto-splice fires, producing a spec with ._build_spec set.
+    # The result is stored in the cache by spec_dict_to_json().
+    spec1 = spack.concretize.concretize_one(goal)
+
+    # Confirm the splice actually occurred -- if it didn't, the test doesn't cover the bug.
+    assert spec1.build_spec is not spec1, (
+        "expected auto-splice to produce a build_spec on the root; "
+        "the test premise is wrong if no splice occurred"
+    )
+
+    # Second solve must be a pure cache hit: clingo must not run again.
+    # If the cache entry is unreadable (the bug), fetch() deletes it and falls through
+    # to _run_clingo, which calls store() -- triggering this assertion.
+    def _assert_no_store(self, problem, result, statistics):
+        raise AssertionError(
+            "cache should have been hit on the second solve, "
+            "but the cache entry was unreadable and clingo ran again"
+        )
+
+    monkeypatch.setattr(spack.solver.asp.ConcretizationCache, "store", _assert_no_store)
+
+    spec2 = spack.concretize.concretize_one(goal)
+    assert spec1 == spec2

--- a/lib/spack/spack/test/concretization/core.py
+++ b/lib/spack/spack/test/concretization/core.py
@@ -2,6 +2,8 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 import difflib
+import gzip
+import json
 import os
 import pathlib
 import platform
@@ -4586,6 +4588,58 @@ def test_concretization_cache_count_cleanup(use_concretization_cache, mutable_co
     after = names()
     assert len(after) == 501
     assert len(after - before) == 1  # one additional hash added by 1001st concretization
+
+
+@pytest.fixture()
+def corrupt_cache_entry(use_concretization_cache):
+    """Yields a cache and path for a fake entry. After the test body writes a corrupt file
+    to the path, the fixture asserts that fetch returns a miss and removes the file."""
+    cache = spack.solver.asp.ConcretizationCache(str(use_concretization_cache))
+    problem = "some asp problem"
+    cache_path = cache._cache_path_from_problem(problem)
+    cache_path.parent.mkdir(parents=True, exist_ok=True)
+
+    def write_gzip_json(obj):
+        with gzip.open(cache_path, "wb") as f:
+            f.write(json.dumps(obj).encode())
+
+    yield cache, cache_path, write_gzip_json
+
+    assert cache_path.exists(), "test should have written a corrupt file"
+    result, stats = cache.fetch(problem)
+    assert result is None
+    assert stats is None
+    assert not cache_path.exists(), "corrupt cache entry should have been removed"
+
+
+def test_concretization_cache_removes_corrupt_gzip(corrupt_cache_entry):
+    """A file that isn't valid gzip is removed on fetch."""
+    _, cache_path, _ = corrupt_cache_entry
+    cache_path.write_bytes(b"this is not gzip")
+
+
+def test_concretization_cache_removes_corrupt_json(corrupt_cache_entry):
+    """A file that is valid gzip but not valid JSON is removed on fetch."""
+    _, cache_path, _ = corrupt_cache_entry
+    with gzip.open(cache_path, "wb") as f:
+        f.write(b"not json{{{")
+
+
+def test_concretization_cache_removes_wrong_version(corrupt_cache_entry):
+    """A cache entry with an unsupported version is removed on fetch."""
+    _, _, write_gzip_json = corrupt_cache_entry
+    write_gzip_json({"_meta": {"version": -1}})
+
+
+def test_concretization_cache_removes_bad_spec_data(corrupt_cache_entry):
+    """A cache entry with valid JSON/version but malformed spec data is removed on fetch."""
+    _, _, write_gzip_json = corrupt_cache_entry
+    write_gzip_json(
+        {
+            "_meta": {"version": spack.solver.asp.ConcretizationCache.VERSION},
+            "results": {"not": "valid"},
+        }
+    )
 
 
 @pytest.mark.parametrize(

--- a/lib/spack/spack/test/concretization/core.py
+++ b/lib/spack/spack/test/concretization/core.py
@@ -4506,6 +4506,54 @@ def test_concretization_cache_roundtrip_result(use_concretization_cache):
     assert result1 == result2
 
 
+def test_concretization_cache_reapplies_patches_on_hit(
+    mock_packages, use_concretization_cache, monkeypatch
+):
+    """Tests that adding a patch to a recipe is taken into account when we hit the cache.
+
+    Patches are not part of the ASP facts, so adding a patch to a recipe does not change the cache
+    key. This ensure we do post-processing of solve output correctly after a cache hit.
+    """
+    EXTRA_SHA256 = "a" * 64  # synthetic sha256 simulating a newly added patch
+
+    # First solve: populate the cache. patch@1.0 has foo.patch and baz.patch.
+    spec1 = spack.concretize.concretize_one("patch@1.0")
+    assert "patches" in spec1.variants
+    initial_sha256s = frozenset(spec1.variants["patches"].value)
+
+    # Simulate a recipe change: wrap _inject_patches_variant to inject an extra sha256,
+    # as if a new patch directive had been added to the package.
+    original_inject = spack.spec._inject_patches_variant
+
+    def inject_with_new_patch(root):
+        original_inject(root)
+        for s in root.traverse():
+            if s.name == "patch" and not s.concrete and "patches" in s.variants:
+                existing = list(s.variants["patches"].value)
+                s.variants["patches"].set(*existing, EXTRA_SHA256)
+                break
+
+    monkeypatch.setattr(spack.spec, "_inject_patches_variant", inject_with_new_patch)
+
+    # The cache key has not changed (patches are not in ASP facts), so the second
+    # solve must hit the cache without running clingo again.
+    def _assert_no_store(self, problem, result, statistics, test=False):
+        raise AssertionError("Cache should be hit, not re-solved and stored")
+
+    monkeypatch.setattr(spack.solver.asp.ConcretizationCache, "store", _assert_no_store)
+
+    # Second solve: cache hit + post_process_concretization_result re-runs.
+    spec2 = spack.concretize.concretize_one("patch@1.0")
+
+    assert "patches" in spec2.variants
+    new_sha256s = frozenset(spec2.variants["patches"].value)
+
+    # The new patch must appear (post_process_concretization_result re-ran on hit).
+    assert EXTRA_SHA256 in new_sha256s, "Expected the new patch to be injected on a cache hit"
+    # The original patches are still present.
+    assert initial_sha256s <= new_sha256s
+
+
 def test_concretization_cache_count_cleanup(use_concretization_cache, mutable_config):
     """Tests to ensure we are cleaning the cache when we should be respective to the
     number of entries allowed in the cache"""

--- a/lib/spack/spack/test/concretization/core.py
+++ b/lib/spack/spack/test/concretization/core.py
@@ -5309,22 +5309,21 @@ def test_concretization_cache_store_skips_existing(use_concretization_cache):
 
 
 def test_concretization_cache_store_cleans_temp_on_error(use_concretization_cache, monkeypatch):
-    """store() removes the temp file and re-raises when the rename fails.
+    """store() swallows OSError, logs, and cleans up the temp file.
 
-    This simulates a race where two processes both pass the exists() check and write temp files,
-    but one fails on rename.
+    A failed cache store must not propagate as a concretization failure -- the cache is an
+    optimization, and the concretization that produced ``result`` already succeeded.
     """
     cache = spack.solver.asp.ConcretizationCache(str(use_concretization_cache))
     problem = "write failure test"
 
-    # Simulate a rename failure (e.g. race condition between concurrent solves)
-    def failing_rename(src, dst):
-        raise OSError("rename failed")
+    def failing_replace(src, dst):
+        raise OSError("replace failed")
 
-    monkeypatch.setattr(os, "rename", failing_rename)
+    monkeypatch.setattr(os, "replace", failing_replace)
 
-    with pytest.raises(OSError, match="rename failed"):
-        cache.store(problem, Result(specs=[]), statistics=[])
+    # store() must not raise even though os.replace did
+    cache.store(problem, Result(specs=[]), statistics=[])
 
     # The final cache path should not exist
     cache_path = cache._cache_path_from_problem(problem)

--- a/lib/spack/spack/test/conftest.py
+++ b/lib/spack/spack/test/conftest.py
@@ -445,7 +445,6 @@ def pytest_collection_modifyitems(config, items):
 def use_concretization_cache(mock_packages, mutable_config, tmp_path: Path):
     """Enables the use of the concretization cache"""
     conc_cache_dir = tmp_path / "concretization"
-    conc_cache_dir.mkdir()
 
     # ensure we have an isolated concretization cache while using fixture
     with spack.config.override(

--- a/lib/spack/spack/test/spec_yaml.py
+++ b/lib/spack/spack/test/spec_yaml.py
@@ -23,6 +23,7 @@ import spack.vendor.ruamel.yaml
 
 import spack.concretize
 import spack.config
+import spack.error
 import spack.hash_types as ht
 import spack.paths
 import spack.repo
@@ -570,3 +571,17 @@ def test_pickle_preserves_identity_and_prefix(default_mock_concretization):
 
     # Test that the specs are the same as dicts
     assert mpileaks_before.to_dict() == mpileaks_after.to_dict()
+
+
+def test_load_specfile_with_no_nodes():
+    """Test that _load raises an error when the spec dict has an empty nodes list."""
+    data = {"spec": {"_meta": {"version": 4}, "nodes": []}}
+    with pytest.raises(spack.error.SpecError, match="contains no nodes"):
+        spack.spec.SpecfileV4.load(data)
+
+
+@pytest.mark.parametrize("version", [0, -1])
+def test_specfile_reader_for_invalid_version(version):
+    """Test that requesting an invalid specfile version raises."""
+    with pytest.raises(ValueError, match="Unknown Specfile version"):
+        spack.spec.specfile_reader_for_version(version)

--- a/lib/spack/spack/test/spec_yaml.py
+++ b/lib/spack/spack/test/spec_yaml.py
@@ -585,3 +585,29 @@ def test_specfile_reader_for_invalid_version(version):
     """Test that requesting an invalid specfile version raises."""
     with pytest.raises(ValueError, match="Unknown Specfile version"):
         spack.spec.specfile_reader_for_version(version)
+
+
+def test_wire_spec_nodes_missing_dep_hash():
+    """wire_spec_nodes raises when a dep edge references a hash not in the node list."""
+    nodes = [
+        {
+            "name": "root",
+            "hash": "r" * 32,
+            "dependencies": [
+                {
+                    "name": "ghost",
+                    "hash": "g" * 32,
+                    "parameters": {"deptypes": ("link",), "virtuals": ()},
+                }
+            ],
+        }
+    ]
+    with pytest.raises(spack.spec.MissingSpecHashError, match=r"missing dep hash ghost/g+"):
+        spack.spec.wire_spec_nodes(nodes, "hash", spack.spec.SpecfileLatest)
+
+
+def test_wire_spec_nodes_missing_build_spec_hash():
+    """wire_spec_nodes raises when a build_spec references a hash not in the node list."""
+    nodes = [{"name": "root", "hash": "r" * 32, "build_spec": {"name": "ghost", "hash": "g" * 32}}]
+    with pytest.raises(spack.spec.MissingSpecHashError, match=r"missing build_spec hash ghost/g+"):
+        spack.spec.wire_spec_nodes(nodes, "hash", spack.spec.SpecfileLatest)


### PR DESCRIPTION
Previously, the concretization cache was written after all post-processing (finalization, hash assignment, patching, splicing, etc.), which meant that cached results were fully concrete and could not have post-processing steps re-applied when packages changed. This moves the cache write to immediately after the solve and flag reordering, but *before* finalization.

This requires care with serialization, because specs at cache time are not yet concrete and don't have stable hashes. To handle this:

- Add versioning to the concretization cache location, so that we don't have to worry about reading old cache formats in newer spack. Cache files for all versions are still cleared with `spack clean -m`.
- Don't bother trying to read non-gzipped cache files -- just treat this as a miss. They didn't exist for long, and they complicate the code. We can just recompute a gzipped cache file.
- Add `spec_dict_to_json()` / `spec_dict_from_json()` to serialize solver answer SpecDicts. These force-cache dag_hash on non-concrete specs for use as node identity keys, then clear those caches after serialization so `_finalize_concretization()` computes fresh hashes.
- Refactor the spec wiring logic in `SpecfileReader` to be reusable for `SpecDict`
    - Add `wire_spec_nodes()` to `spec.py`, extracting the two-pass node wiring logic (build specs by hash, then connect edges) from `_load()` into a reusable function. Both `_load()` and `spec_dict_from_json()` use it.
    - Add `specfile_reader_for_version()` backed by a `SpecfileReaderMeta` metaclass that auto-registers reader subclasses, so the cache format embeds and dispatches on the specfile version.
- `build_specs()` now returns a `SpecDict` object instead of doing post-processing internally.
- Split post-processing in two:
    - `post_process_fresh_solve()`: flag reordering, auto-splices, only executed after fresh solves, and
    - `post_process_concretization_result()`: patches, finalization, hash unification, explicit splices, called after every concretization including cache hits
    - Move both, along with `reorder_flags()` and `execute_explicit_splices()`, out of `SpecBuilder` into free functions.
- Tests for `SpecDict` serialization
- Tests for concretization caching with:
    - fresh solves
    - reuse solves
    - spliced solves
- Re-enable caching by default