### PR TITLE
solver: set a default timeout after 10 mins.

### DIFF
--- a/etc/spack/defaults/base/concretizer.yaml
+++ b/etc/spack/defaults/base/concretizer.yaml
@@ -82,7 +82,7 @@ concretizer:
     explicit: []
     automatic: false
   # Maximum time, in seconds, allowed for the 'solve' phase. If set to 0, there is no time limit.
-  timeout: 0
+  timeout: 600
   # If set to true, exceeding the timeout will always result in a concretization error. If false,
   # the best (suboptimal) model computed before the timeout is used.
   #


### PR DESCRIPTION
Change default settings to time out with an error if concretization couldn't produce a concrete spec after 10 mins.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
