### PR TITLE
modules: improve refresh with `--delete-tree`

### DIFF
--- a/lib/spack/spack/cmd/modules/__init__.py
+++ b/lib/spack/spack/cmd/modules/__init__.py
@@ -8,6 +8,7 @@ import collections
 import os
 import shutil
 import sys
+import tempfile
 
 import spack.cmd
 import spack.config
@@ -329,24 +330,44 @@ def refresh(module_type, specs, args):
 
     # Proceed regenerating module files
     tty.msg("Regenerating {name} module files".format(name=module_type))
-    if os.path.isdir(module_type_root) and args.delete_tree:
-        shutil.rmtree(module_type_root, ignore_errors=False)
-    filesystem.mkdirp(module_type_root)
 
-    # Dump module index after potentially removing module tree
-    spack.modules.common.generate_module_index(
-        module_type_root, writers, overwrite=args.delete_tree
-    )
+    # Prepare new module root
+    swap = args.delete_tree and os.path.isdir(module_type_root)
+    if swap:
+        parent = os.path.dirname(module_type_root.rstrip(os.sep))
+        temp_root = tempfile.mkdtemp(dir=parent)
+        backup = module_type_root + ".bak"
+        write_root = temp_root
+    else:
+        filesystem.mkdirp(module_type_root)
+        write_root = module_type_root
+
+    # Write module index and module files
+    spack.modules.common.generate_module_index(write_root, writers, overwrite=args.delete_tree)
     errors = []
     for x in writers:
+        target = (
+            os.path.join(write_root, os.path.relpath(x.layout.filename, module_type_root))
+            if swap
+            else None
+        )
         try:
-            x.write(overwrite=True)
-        except spack.error.SpackError as e:
-            msg = f"{x.layout.filename}: {e.message}"
-            errors.append(msg)
+            x.write(overwrite=True, target_filename=target)
         except Exception as e:
-            msg = f"{x.layout.filename}: {str(e)}"
-            errors.append(msg)
+            errors.append(f"{x.layout.filename}: {getattr(e, 'message', str(e))}")
+
+    # Swap new module root into place if requested
+    if swap:
+        try:
+            os.rename(module_type_root, backup)
+            os.rename(temp_root, module_type_root)
+        except BaseException:
+            if not os.path.exists(module_type_root) and os.path.exists(backup):
+                os.rename(backup, module_type_root)
+            if os.path.exists(temp_root):
+                shutil.rmtree(temp_root, ignore_errors=True)
+            raise
+        shutil.rmtree(backup, ignore_errors=True)
 
     if errors:
         errors.insert(0, color.colorize("@*{some module files could not be written}"))

--- a/lib/spack/spack/modules/common.py
+++ b/lib/spack/spack/modules/common.py
@@ -23,6 +23,7 @@ and is divided among four classes:
 Each of the four classes needs to be sub-classed when implementing a new
 module type.
 """
+
 import collections
 import contextlib
 import copy
@@ -837,13 +838,15 @@ class BaseModuleFileWriter:
         # ... and return the first match
         return choices.pop(0)
 
-    def write(self, overwrite=False):
+    def write(self, overwrite=False, target_filename=None):
         """Writes the module file.
 
         Args:
             overwrite (bool): if True it is fine to overwrite an already
                 existing file. If False the operation is skipped an we print
                 a warning to the user.
+            target_filename (str): if set, write to this path instead of the
+                layout-derived filename.
         """
         # Return immediately if the module is excluded
         if self.conf.excluded:
@@ -851,20 +854,22 @@ class BaseModuleFileWriter:
             tty.debug(msg.format(self.spec.cshort_spec))
             return
 
+        filename = target_filename or self.layout.filename
+
         # Print a warning in case I am accidentally overwriting
         # a module file that is already there (name clash)
-        if not overwrite and os.path.exists(self.layout.filename):
-            message = "Module file {0.filename} exists and will not be overwritten"
-            tty.warn(message.format(self.layout))
+        if not overwrite and os.path.exists(filename):
+            message = "Module file {0} exists and will not be overwritten"
+            tty.warn(message.format(filename))
             return
 
         # If we are here it means it's ok to write the module file
         msg = "\tWRITE: {0} [{1}]"
-        tty.debug(msg.format(self.spec.cshort_spec, self.layout.filename))
+        tty.debug(msg.format(self.spec.cshort_spec, filename))
 
         # If the directory where the module should reside does not exist
         # create it
-        module_dir = os.path.dirname(self.layout.filename)
+        module_dir = os.path.dirname(filename)
         if not os.path.exists(module_dir):
             spack.llnl.util.filesystem.mkdirp(module_dir)
 
@@ -902,38 +907,46 @@ class BaseModuleFileWriter:
         # Render the template
         text = template.render(context)
         # Write it to file
-        with open(self.layout.filename, "w", encoding="utf-8") as f:
+        with open(filename, "w", encoding="utf-8") as f:
             f.write(text)
 
         # Set the file permissions of the module to match that of the package
-        if os.path.exists(self.layout.filename):
-            fp.set_permissions_by_spec(self.layout.filename, self.spec)
+        if os.path.exists(filename):
+            fp.set_permissions_by_spec(filename, self.spec)
 
         # Symlink defaults if needed
-        self.update_module_defaults()
+        self.update_module_defaults(target_filename=target_filename)
 
         # record module hiddenness if implicit
-        self.update_module_hiddenness()
+        self.update_module_hiddenness(target_filename=target_filename)
 
-    def update_module_defaults(self):
+    def update_module_defaults(self, target_filename=None):
         if any(self.spec.satisfies(default) for default in self.conf.defaults):
             # This spec matches a default, it needs to be symlinked to default
             # Symlink to a tmp location first and move, so that existing
             # symlinks do not cause an error.
-            default_path = os.path.join(os.path.dirname(self.layout.filename), "default")
-            default_tmp = os.path.join(os.path.dirname(self.layout.filename), ".tmp_spack_default")
+            module_dir = os.path.dirname(target_filename or self.layout.filename)
+            default_path = os.path.join(module_dir, "default")
+            default_tmp = os.path.join(module_dir, ".tmp_spack_default")
             os.symlink(self.layout.filename, default_tmp)
             os.rename(default_tmp, default_path)
 
-    def update_module_hiddenness(self, remove=False):
+    def update_module_hiddenness(self, remove=False, target_filename=None):
         """Update modulerc file corresponding to module to add or remove
         command that hides module depending on its hidden state.
 
         Args:
             remove (bool): if True, hiddenness information for module is
                 removed from modulerc.
+            target_filename (str): if set, derive modulerc path from this
+                instead of self.layout.filename.
         """
-        modulerc_path = self.layout.modulerc
+        if target_filename:
+            modulerc_path = os.path.join(
+                os.path.dirname(target_filename), os.path.basename(self.layout.modulerc)
+            )
+        else:
+            modulerc_path = self.layout.modulerc
         hide_module_cmd = self.hide_cmd_format % self.layout.use_name
         hidden = self.conf.hidden and not remove
         modulerc_exists = os.path.exists(modulerc_path)

--- a/lib/spack/spack/test/cmd/module.py
+++ b/lib/spack/spack/test/cmd/module.py
@@ -221,3 +221,32 @@ def test_setdefault_command(mutable_database, mutable_config):
         assert os.path.exists(writers[k].layout.filename)
     assert os.path.exists(link_name) and os.path.islink(link_name)
     assert os.path.realpath(link_name) == os.path.realpath(writers[preferred].layout.filename)
+
+
+@pytest.mark.db
+def test_refresh_with_delete_tree(mutable_database, mutable_config, tmp_path):
+    """Test that refresh --delete-tree regenerates via swap."""
+    import glob
+
+    module_root = str(tmp_path / "test_modules")
+    spack.config.set("modules", {"default": {"enable": ["tcl"], "roots": {"tcl": module_root}}})
+
+    for spec_str in ("libelf", "libdwarf"):
+        spec = spack.concretize.concretize_one(spec_str)
+        PackageInstaller([spec.package], explicit=True, fake=True).install()
+
+    module("tcl", "refresh", "-y", "libelf", "libdwarf")
+    initial_files = [
+        f for f in glob.glob(f"{module_root}/**/*", recursive=True) if os.path.isfile(f)
+    ]
+    assert initial_files
+
+    module("tcl", "refresh", "-y", "--delete-tree", "libelf", "libdwarf")
+    final_files = [
+        f for f in glob.glob(f"{module_root}/**/*", recursive=True) if os.path.isfile(f)
+    ]
+    assert final_files
+
+    parent = os.path.dirname(module_root)
+    assert not glob.glob(os.path.join(parent, "*.bak"))
+    assert not glob.glob(os.path.join(parent, "*.tmp"))


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->

Full disclosure up front: parts of this PR have been developed with AI assistance, but I have reviewed, tested, and take full responsibility for all changes. Currently running in our development cluster with this PR enabled against spack v1.1.1, which works like a charm for me.

### Problem statement

When running `spack module lmod refresh --delete-tree` on a shared NFS filesystem with a large number of modules, users experience `module not found` errors during the rebuild window. The current implementation:

1. Deletes the entire module tree (`shutil.rmtree`)
2. Rebuilds every module file one-by-one in the same location

On NFS with hundreds of modules, this can take a long time (minutes). During this window the module directory is either missing or incomplete, causing any user running `module load <package>` to fail with confusing `module not found` errors. This is particularly painful on HPC clusters with a shared spack module installation, where module refresh is typically run by admins while the system is in active use.

### Solution

This PR introduces a directory swap strategy when `--delete-tree` is used:

*  **Stage** — Module files are generated into a temporary directory on the same filesystem as the module root (ensuring `os.rename` is atomic).
*  **Swap** — The old module root is renamed to a timestamped backup, and the new temp directory is renamed into place. The downtime window is reduced from the full rebuild time to a double `rename()` syscall.
*  **Cleanup** — The old backup directory is removed after a successful swap.
*  **Rollback** — If the swap fails for any reason, the original module tree is restored from the backup automatically.

Template content (e.g. `MODULEPATH` entries) continues to reference the **real production path**, so modules work correctly immediately after the swap without any path fixups. (in an earlier simpler implementation I tried to adjust the module root configuration, but that led to templates with temporary paths)

The original in-place behavior is preserved for incremental refreshes (without `--delete-tree`).

### Key changes

- **`lib/spack/spack/cmd/modules/__init__.py`**
  - New helper `_write_module_to_dir()` — renders a module file into an arbitrary target directory while keeping template paths pointed at the real root.
  - New helper `_refresh_with_atomic_swap()` — orchestrates the temp-dir build → atomic rename → cleanup/rollback flow.
  - `refresh()` now delegates to `_refresh_with_atomic_swap()` when `--delete-tree` is set and the module root already exists; falls back to the original logic otherwise.

- **`lib/spack/spack/test/cmd/module.py`**
  - New test `test_refresh_with_delete_tree_atomic_swap` validates the full cycle: initial module generation → atomic refresh → modules still present → no leftover temp/backup directories.

### Docker test output

Tested this  using the `spack/rockylinux9:1.1` docker image, test output looks like this:
```
[root@658e875aa4a3 ~]# /root/spack-patched-2/bin/spack -d module lmod refresh --delete-tree -y
==> [2026-02-13-14:30:18.888783] Reading config from file /root/spack-patched-2/etc/spack/defaults/base/config.yaml
==> [2026-02-13-14:30:18.913246] Imported module from built-in commands
==> [2026-02-13-14:30:18.914905] Imported module from built-in commands
==> [2026-02-13-14:30:18.915429] DATABASE LOCK TIMEOUT: 60s
==> [2026-02-13-14:30:18.915461] PACKAGE LOCK TIMEOUT: No timeout
==> [2026-02-13-14:30:18.917702] Reading config from file /root/spack-patched-2/etc/spack/defaults/base/packages.yaml
==> [2026-02-13-14:30:18.932978] Reading config from file /root/.spack/packages.yaml
==> [2026-02-13-14:30:18.934465] Reading config from file /root/spack-patched-2/etc/spack/defaults/base/repos.yaml
==> [2026-02-13-14:30:18.936990] Reading config from file /root/spack-patched-2/etc/spack/defaults/base/modules.yaml
==> [2026-02-13-14:30:18.941031] Reading config from file /root/spack-patched-2/etc/spack/defaults/linux/modules.yaml
==> [2026-02-13-14:30:18.941702] Reading config from file /root/.spack/modules.yaml
==> [2026-02-13-14:30:19.067870] Regenerating lmod module files
==> [2026-02-13-14:30:19.068012] Module refresh temporary directory: /root/spack-patched-2/share/spack/lmod-new.4gp8nq_d.1770993019.tmp
==> [2026-02-13-14:30:19.068031] Building 19 module files in temporary location
==> [2026-02-13-14:30:19.079100]        WRITE: bzip2@1.0.8~debug~pic+shared build_system=generic platform=linux os=rocky9 target=skylake/66r525q [/root/spack-patched-2/share/spack/lmod-new.4gp8nq_d.1770993019.tmp/linux-rocky9-x86_64/Core/bzip2/1.0.8-66r525q.lua]
==> [2026-02-13-14:30:19.121159]        WRITE: compiler-wrapper@1.0 build_system=generic platform=linux os=rocky9 target=skylake/glb3np7 [/root/spack-patched-2/share/spack/lmod-new.4gp8nq_d.1770993019.tmp/linux-rocky9-x86_64/Core/compiler-wrapper/1.0-glb3np7.lua]
==> [2026-02-13-14:30:19.146244]        WRITE: diffutils@3.12 build_system=autotools platform=linux os=rocky9 target=skylake/pdubafn [/root/spack-patched-2/share/spack/lmod-new.4gp8nq_d.1770993019.tmp/linux-rocky9-x86_64/Core/diffutils/3.12-pdubafn.lua]
==> [2026-02-13-14:30:19.173024]        WRITE: findutils@4.10.0 build_system=autotools patches:=440b954 platform=linux os=rocky9 target=skylake/prxvsmx [/root/spack-patched-2/share/spack/lmod-new.4gp8nq_d.1770993019.tmp/linux-rocky9-x86_64/Core/findutils/4.10.0-prxvsmx.lua]
==> [2026-02-13-14:30:19.199138]        WRITE: gcc@11.5.0~binutils+bootstrap~graphite~nvptx~piclibs~profiled~strip build_system=autotools build_type=RelWithDebInfo languages:='c,c++,fortran' platform=linux os=rocky9 target=x86_64/63hlrqk [/root/spack-patched-2/share/spack/lmod-new.4gp8nq_d.1770993019.tmp/linux-rocky9-x86_64/Core/gcc/11.5.0-63hlrqk.lua]
==> [2026-02-13-14:30:19.240296]        WRITE: gcc-runtime@11.5.0 build_system=generic platform=linux os=rocky9 target=skylake/cjimgks [/root/spack-patched-2/share/spack/lmod-new.4gp8nq_d.1770993019.tmp/linux-rocky9-x86_64/Core/gcc-runtime/11.5.0-cjimgks.lua]
==> [2026-02-13-14:30:19.266079]        WRITE: gettext@0.23.1+bzip2+curses+git~libunistring+libxml2+pic+shared+tar+xz build_system=autotools platform=linux os=rocky9 target=skylake/weadus3 [/root/spack-patched-2/share/spack/lmod-new.4gp8nq_d.1770993019.tmp/linux-rocky9-x86_64/Core/gettext/0.23.1-weadus3.lua]
==> [2026-02-13-14:30:19.295381]        WRITE: glibc@2.34 build_system=autotools platform=linux os=rocky9 target=x86_64/z4aqp7y [/root/spack-patched-2/share/spack/lmod-new.4gp8nq_d.1770993019.tmp/linux-rocky9-x86_64/Core/glibc/2.34-z4aqp7y.lua]
==> [2026-02-13-14:30:19.321454]        WRITE: gmake@4.4.1~guile build_system=generic platform=linux os=rocky9 target=skylake/cnss7du [/root/spack-patched-2/share/spack/lmod-new.4gp8nq_d.1770993019.tmp/linux-rocky9-x86_64/Core/gmake/4.4.1-cnss7du.lua]
==> [2026-02-13-14:30:19.349797]        WRITE: libiconv@1.18 build_system=autotools libs:=shared,static platform=linux os=rocky9 target=skylake/5zgcp4r [/root/spack-patched-2/share/spack/lmod-new.4gp8nq_d.1770993019.tmp/linux-rocky9-x86_64/Core/libiconv/1.18-5zgcp4r.lua]
==> [2026-02-13-14:30:19.377137]        WRITE: libxml2@2.13.5~http+pic~python+shared build_system=autotools platform=linux os=rocky9 target=skylake/o7ni4b5 [/root/spack-patched-2/share/spack/lmod-new.4gp8nq_d.1770993019.tmp/linux-rocky9-x86_64/Core/libxml2/2.13.5-o7ni4b5.lua]
==> [2026-02-13-14:30:19.405320]        WRITE: ncurses@6.5-20250705~symlinks+termlib abi=none build_system=autotools patches:=7a351bc platform=linux os=rocky9 target=skylake/hmyiuj6 [/root/spack-patched-2/share/spack/lmod-new.4gp8nq_d.1770993019.tmp/linux-rocky9-x86_64/Core/ncurses/6.5-20250705-hmyiuj6.lua]
==> [2026-02-13-14:30:19.432451]        WRITE: pigz@2.8 build_system=makefile platform=linux os=rocky9 target=skylake/ciu6w4l [/root/spack-patched-2/share/spack/lmod-new.4gp8nq_d.1770993019.tmp/linux-rocky9-x86_64/Core/pigz/2.8-ciu6w4l.lua]
==> [2026-02-13-14:30:19.459607]        WRITE: pkgconf@2.5.1 build_system=autotools platform=linux os=rocky9 target=skylake/ji4ydnv [/root/spack-patched-2/share/spack/lmod-new.4gp8nq_d.1770993019.tmp/linux-rocky9-x86_64/Core/pkgconf/2.5.1-ji4ydnv.lua]
==> [2026-02-13-14:30:19.487160]        WRITE: tar@1.35 build_system=autotools zip=pigz platform=linux os=rocky9 target=skylake/pdsw3q5 [/root/spack-patched-2/share/spack/lmod-new.4gp8nq_d.1770993019.tmp/linux-rocky9-x86_64/Core/tar/1.35-pdsw3q5.lua]
==> [2026-02-13-14:30:19.515883]        WRITE: vim@9.1.1194~cscope~gui~lua~perl~python~ruby~x build_system=autotools features=normal platform=linux os=rocky9 target=skylake/4kxa5fd [/root/spack-patched-2/share/spack/lmod-new.4gp8nq_d.1770993019.tmp/linux-rocky9-x86_64/Core/vim/9.1.1194-4kxa5fd.lua]
==> [2026-02-13-14:30:19.543361]        WRITE: xz@5.6.3~pic build_system=autotools libs:=shared,static platform=linux os=rocky9 target=skylake/xo7jdcp [/root/spack-patched-2/share/spack/lmod-new.4gp8nq_d.1770993019.tmp/linux-rocky9-x86_64/Core/xz/5.6.3-xo7jdcp.lua]
==> [2026-02-13-14:30:19.570257]        WRITE: zlib-ng@2.2.4+compat+new_strategies+opt+pic+shared build_system=autotools platform=linux os=rocky9 target=skylake/g6knvu5 [/root/spack-patched-2/share/spack/lmod-new.4gp8nq_d.1770993019.tmp/linux-rocky9-x86_64/Core/zlib-ng/2.2.4-g6knvu5.lua]
==> [2026-02-13-14:30:19.596870]        WRITE: zstd@1.5.7+programs build_system=makefile compression:=none libs:=shared,static platform=linux os=rocky9 target=skylake/erwk7it [/root/spack-patched-2/share/spack/lmod-new.4gp8nq_d.1770993019.tmp/linux-rocky9-x86_64/Core/zstd/1.5.7-erwk7it.lua]
==> [2026-02-13-14:30:19.622789] Performing atomic directory swap
==> [2026-02-13-14:30:19.622808] Moving /root/spack-patched-2/share/spack/lmod to /root/spack-patched-2/share/spack/lmod-old.1770993019.backup
==> [2026-02-13-14:30:19.622830] Moving /root/spack-patched-2/share/spack/lmod-new.4gp8nq_d.1770993019.tmp to /root/spack-patched-2/share/spack/lmod
==> [2026-02-13-14:30:19.622843] Module files refreshed successfully
==> [2026-02-13-14:30:19.622850] Removing old module directory: /root/spack-patched-2/share/spack/lmod-old.1770993019.backup
```