### PR TITLE
environment: Make mutate capable of handling multiple selectors/mutators in one pass.

### DIFF
--- a/lib/spack/spack/cmd/change.py
+++ b/lib/spack/spack/cmd/change.py
@@ -80,7 +80,12 @@ def change(parser, args):
                 raise ValueError(msg) from e
 
         if args.concrete or args.concrete_only:
+            selectors = []
+            mutators = []
             for spec in specs:
-                env.mutate(selector=match_spec or spack.spec.Spec(spec.name), mutator=spec)
+                selectors.append(match_spec or spack.spec.Spec(spec.name))
+                mutators.append(spec)
+
+            env.mutate(selectors=selectors, mutators=mutators)
 
         env.write()

--- a/lib/spack/spack/cmd/develop.py
+++ b/lib/spack/spack/cmd/develop.py
@@ -183,7 +183,7 @@ def update_env(
 
         # If we are automatically mutating the concrete specs for dev provenance, do so
         if apply_changes:
-            env.apply_develop(spec, _abs_code_path(env, spec, specified_path))
+            env.apply_develop([spec], [_abs_code_path(env, spec, specified_path)])
 
 
 def _clone(spec: spack.spec.Spec, abspath: str, force: bool = False):

--- a/lib/spack/spack/cmd/undevelop.py
+++ b/lib/spack/spack/cmd/undevelop.py
@@ -59,8 +59,7 @@ def undevelop(parser, args):
     with env.write_transaction():
         _update_config(remove_specs)
         if args.apply_changes:
-            for spec in remove_specs:
-                env.apply_develop(spec, path=None)
+            env.apply_develop(remove_specs, paths=None)
 
     updated_all_dev_specs = set(spack.config.get("develop"))
 

--- a/lib/spack/spack/environment/environment.py
+++ b/lib/spack/spack/environment/environment.py
@@ -1623,9 +1623,21 @@ class Environment:
         # Find all specs that this mutation applies to
         modify_specs = []
         modified_specs = []
-        assert len(selectors) == len(mutators)
-        assert not validators or len(validators) == len(selectors)
-        assert not msgs or len(msgs) == len(selectors)
+        if len(selectors) != len(mutators):
+            raise ValueError(
+                f"Length mismatch: selectors ({len(selectors)}) != mutators ({len(mutators)})"
+            )
+
+        if validators and len(validators) != len(selectors):
+            raise ValueError(
+                f"Length mismatch: validators ({len(validators)}) != selectors ({len(selectors)})"
+            )
+
+        if msgs and len(msgs) != len(selectors):
+            raise ValueError(
+                f"Length mismatch: msgs ({len(msgs)}) != selectors ({len(selectors)})"
+            )
+
         for dep in self.all_specs_generator():
             for selector, mutator, validator, msg in zip_longest(
                 selectors, mutators, validators or [], msgs or [], fillvalue=None

--- a/lib/spack/spack/environment/environment.py
+++ b/lib/spack/spack/environment/environment.py
@@ -26,6 +26,7 @@ from typing import (
     Tuple,
     Union,
 )
+from itertools import zip_longest
 
 import spack
 import spack.config
@@ -1573,34 +1574,43 @@ class Environment:
         """Returns true when the spec is built from local sources"""
         return spec.name in self.dev_specs
 
-    def apply_develop(self, spec: spack.spec.Spec, path: Optional[str] = None):
+    def apply_develop(self, specs: List[spack.spec.Spec], paths: Optional[List[str]] = None):
         """Mutate concrete specs to include dev_path provenance pointing to path.
 
         This will fail if any existing concrete spec for the same package does not satisfy the
 
         given develop spec."""
-        selector = spack.spec.Spec(spec.name)
+        selectors = []
+        mutators = []
+        msgs = []
 
-        mutator = spack.spec.Spec()
-        if path:
-            variant = vt.SingleValuedVariant("dev_path", path)
-        else:
-            variant = vt.VariantValueRemoval("dev_path")
-        mutator.variants["dev_path"] = variant
+        for spec, path in zip_longest(specs, paths or [], fillvalue=None):
+            selector = spack.spec.Spec(spec.name)
 
-        msg = (
-            f"Develop spec '{spec}' conflicts with concrete specs in environment."
-            " Try again with 'spack develop --no-modify-concrete-specs'"
-            " and run 'spack concretize --force' to apply your changes."
-        )
-        self.mutate(selector, mutator, validator=spec, msg=msg)
+            mutator = spack.spec.Spec()
+            if path:
+                variant = vt.SingleValuedVariant("dev_path", path)
+            else:
+                variant = vt.VariantValueRemoval("dev_path")
+            mutator.variants["dev_path"] = variant
+
+            msg = (
+                f"Develop spec '{spec}' conflicts with concrete specs in environment."
+                " Try again with 'spack develop --no-modify-concrete-specs'"
+                " and run 'spack concretize --force' to apply your changes."
+            )
+            selectors.append(selector)
+            mutators.append(mutator)
+            msgs.append(msg)
+
+        self.mutate(selectors, mutators, validators=specs, msgs=msgs)
 
     def mutate(
         self,
-        selector: spack.spec.Spec,
-        mutator: spack.spec.Spec,
-        validator: Optional[spack.spec.Spec] = None,
-        msg: Optional[str] = None,
+        selectors: List[spack.spec.Spec],
+        mutators: List[spack.spec.Spec],
+        validators: Optional[List[spack.spec.Spec]] = None,
+        msgs: Optional[List[str]] = None,
     ):
         """Mutate concrete specs of an environment
 
@@ -1612,16 +1622,17 @@ class Environment:
         modify_specs = []
         modified_specs = []
         for dep in self.all_specs_generator():
-            if dep.satisfies(selector):
-                if not dep.satisfies(validator or selector):
-                    if not msg:
-                        msg = f"spec {dep} satisfies selector {selector}"
-                        msg += f" but not validator {validator}"
-                    raise SpackEnvironmentDevelopError(msg)
-                modify_specs.append(dep)
+            for selector, mutator, validator, msg in zip_longest(selectors,mutators, validators or [], msgs or [], fillvalue=None):
+                if dep.satisfies(selector):
+                    if not dep.satisfies(validator or selector):
+                        if not msg:
+                            msg = f"spec {dep} satisfies selector {selector}"
+                            msg += f" but not validator {validator}"
+                        raise SpackEnvironmentDevelopError(msg)
+                    modify_specs.append((dep, mutator))
 
         # Manipulate selected specs
-        for s in modify_specs:
+        for s, mutator in modify_specs:
             modified = s.mutate(mutator, rehash=False)
             if modified:
                 modified_specs.append(s)

--- a/lib/spack/spack/environment/environment.py
+++ b/lib/spack/spack/environment/environment.py
@@ -1622,7 +1622,9 @@ class Environment:
         modify_specs = []
         modified_specs = []
         for dep in self.all_specs_generator():
-            for selector, mutator, validator, msg in zip_longest(selectors,mutators, validators or [], msgs or [], fillvalue=None):
+            for selector, mutator, validator, msg in zip_longest(
+                selectors, mutators, validators or [], msgs or [], fillvalue=None
+            ):
                 if dep.satisfies(selector):
                     if not dep.satisfies(validator or selector):
                         if not msg:

--- a/lib/spack/spack/environment/environment.py
+++ b/lib/spack/spack/environment/environment.py
@@ -13,6 +13,7 @@ import shutil
 import stat
 import warnings
 from collections.abc import KeysView
+from itertools import zip_longest
 from typing import (
     Any,
     Callable,
@@ -26,7 +27,6 @@ from typing import (
     Tuple,
     Union,
 )
-from itertools import zip_longest
 
 import spack
 import spack.config

--- a/lib/spack/spack/environment/environment.py
+++ b/lib/spack/spack/environment/environment.py
@@ -1584,7 +1584,9 @@ class Environment:
         mutators = []
         msgs = []
 
+        assert not paths or len(specs) == len(paths)
         for spec, path in zip_longest(specs, paths or [], fillvalue=None):
+            assert spec
             selector = spack.spec.Spec(spec.name)
 
             mutator = spack.spec.Spec()
@@ -1621,10 +1623,15 @@ class Environment:
         # Find all specs that this mutation applies to
         modify_specs = []
         modified_specs = []
+        assert len(selectors) == len(mutators)
+        assert not validators or len(validators) == len(selectors)
+        assert not msgs or len(msgs) == len(selectors)
         for dep in self.all_specs_generator():
             for selector, mutator, validator, msg in zip_longest(
                 selectors, mutators, validators or [], msgs or [], fillvalue=None
             ):
+                assert selector
+                assert mutator
                 if dep.satisfies(selector):
                     if not dep.satisfies(validator or selector):
                         if not msg:

--- a/lib/spack/spack/test/environment/mutate.py
+++ b/lib/spack/spack/test/environment/mutate.py
@@ -63,7 +63,7 @@ def test_mutate_internals(dep, orig_constraint, mutated_constraint):
 
     selector = spack.spec.Spec("cmake")
     mutator = spack.spec.Spec(mutated_constraint)
-    env.mutate(selector=selector, mutator=mutator)
+    env.mutate(selectors=[selector], mutators=[mutator])
     cmake_spec.mutate(mutator)
 
     for spec in env.all_specs_generator():

--- a/lib/spack/spack/test/environment/mutate.py
+++ b/lib/spack/spack/test/environment/mutate.py
@@ -81,6 +81,46 @@ def test_mutate_internals(dep, orig_constraint, mutated_constraint):
     assert root_spec.dag_hash() == new_hash
 
 
+def test_mutate_internals_multiple_mutations():
+    """
+    Check that Environment.mutate correctly applies multiple mutations to different selected Specs.
+    """
+    ev.create("test")
+    env = ev.read("test")
+
+    root_name = "cmake-client"
+    env.add(root_name)
+    env.concretize()
+
+    planned_mutations = [
+        ("cmake", "@3.23.1", "@3.4.3"),
+        ("cmake-client", "+truthy", "~truthy"),
+        ("platform=test", "os=debian6", "os=redhat6"),
+    ]
+
+    orig_hash = next(env.roots()).dag_hash()
+
+    selectors = []
+    mutators = []
+
+    for selector, orig_constraint, mutated_constraint in planned_mutations:
+        selectors.append(spack.spec.Spec(selector))
+        mutators.append(spack.spec.Spec(mutated_constraint))
+        for spec in env.all_specs_generator():
+            if spec.satisfies(selector):
+                assert spec.satisfies(orig_constraint)
+
+    env.mutate(selectors=selectors, mutators=mutators)
+
+    for selector, orig_constraint, mutated_constraint in planned_mutations:
+        for spec in env.all_specs_generator():
+            if spec.satisfies(selector):
+                assert spec.satisfies(mutated_constraint)
+
+    new_hash = next(env.roots()).dag_hash()
+    assert new_hash != orig_hash
+
+
 @pytest.mark.parametrize("constraint", ["foo", "foo.bar", "foo%cmake@1.0", "foo@1.1:", "foo/abc"])
 def test_mutate_spec_invalid(constraint):
     spec = spack.concretize.concretize_one("cmake-client")

--- a/lib/spack/spack/test/environment/mutate.py
+++ b/lib/spack/spack/test/environment/mutate.py
@@ -89,7 +89,7 @@ def test_mutate_internals_multiple_mutations():
     env = ev.read("test")
 
     root = "cmake-client+truthy os=debian6 %cmake@3.23.1 os=debian6"
-    env.add(root_name)
+    env.add(root)
     env.concretize()
 
     planned_mutations = [
@@ -100,7 +100,18 @@ def test_mutate_internals_multiple_mutations():
 
     orig_hash = next(env.roots()).dag_hash()
 
-    selectors, mutators = zip(*planned_mutations) 
+    selectors, mutators = zip(
+        *[(spack.spec.Spec(s), spack.spec.Spec(m)) for s, m in planned_mutations]
+    )
+
+    with pytest.raises(ValueError, match="Length mismatch: selectors"):
+        env.mutate(selectors=[], mutators=mutators)
+
+    with pytest.raises(ValueError, match="Length mismatch: validators"):
+        env.mutate(selectors=selectors, mutators=mutators, validators=["cmake@3.4.3"])
+
+    with pytest.raises(ValueError, match="Length mismatch: msgs"):
+        env.mutate(selectors=selectors, mutators=mutators, msgs=["A message"])
 
     env.mutate(selectors=selectors, mutators=mutators)
 

--- a/lib/spack/spack/test/environment/mutate.py
+++ b/lib/spack/spack/test/environment/mutate.py
@@ -88,31 +88,23 @@ def test_mutate_internals_multiple_mutations():
     ev.create("test")
     env = ev.read("test")
 
-    root_name = "cmake-client"
+    root = "cmake-client+truthy os=debian6 %cmake@3.23.1 os=debian6"
     env.add(root_name)
     env.concretize()
 
     planned_mutations = [
-        ("cmake", "@3.23.1", "@3.4.3"),
-        ("cmake-client", "+truthy", "~truthy"),
-        ("platform=test", "os=debian6", "os=redhat6"),
+        ("cmake", "@3.4.3"),
+        ("cmake-client", "~truthy"),
+        ("platform=test", "os=redhat6"),
     ]
 
     orig_hash = next(env.roots()).dag_hash()
 
-    selectors = []
-    mutators = []
-
-    for selector, orig_constraint, mutated_constraint in planned_mutations:
-        selectors.append(spack.spec.Spec(selector))
-        mutators.append(spack.spec.Spec(mutated_constraint))
-        for spec in env.all_specs_generator():
-            if spec.satisfies(selector):
-                assert spec.satisfies(orig_constraint)
+    selectors, mutators = zip(*planned_mutations) 
 
     env.mutate(selectors=selectors, mutators=mutators)
 
-    for selector, orig_constraint, mutated_constraint in planned_mutations:
+    for selector, mutated_constraint in planned_mutations:
         for spec in env.all_specs_generator():
             if spec.satisfies(selector):
                 assert spec.satisfies(mutated_constraint)


### PR DESCRIPTION
To amortize the cost of recomputing hashes, updating views, etc. when making different changes to multiple specs at once. For example starting with an installed environment with a view and multiple develop packages and running 'spack undevelop -a' would previously run ~10 view regenerations and take ~15s on my machine. It now runs 1 view regeneration and takes ~3s.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
