### PR TITLE
Add a check that load_module succeeds

### DIFF
--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -79,6 +79,7 @@ import spack.stage
 import spack.store
 import spack.subprocess_context
 import spack.util.executable
+import spack.util.module_cmd
 from spack import traverse
 from spack.context import Context
 from spack.error import InstallError, NoHeadersError, NoLibrariesError
@@ -100,7 +101,6 @@ from spack.util.environment import (
 )
 from spack.util.executable import Executable
 from spack.util.log_parse import make_log_context, parse_log_events
-from spack.util.module_cmd import load_module
 
 #
 # This can be set by the user to globally disable parallel builds.
@@ -1117,7 +1117,7 @@ def load_external_modules(context: SetupContext) -> None:
     for spec, _ in context.external:
         external_modules = spec.external_modules or []
         for external_module in external_modules:
-            load_module(external_module)
+            spack.util.module_cmd.load_module(external_module)
 
 
 def _setup_pkg_and_run(

--- a/lib/spack/spack/test/build_environment.py
+++ b/lib/spack/spack/test/build_environment.py
@@ -160,7 +160,7 @@ def test_cc_not_changed_by_modules(monkeypatch, mutable_config, working_env, com
         os.environ["CC"] = "NOT_THIS_PLEASE"
         os.environ["ANOTHER_VAR"] = "THIS_IS_SET"
 
-    monkeypatch.setattr(spack.build_environment, "load_module", _set_wrong_cc)
+    monkeypatch.setattr(spack.util.module_cmd, "load_module", _set_wrong_cc)
 
     s = spack.concretize.concretize_one("cmake %gcc@14")
     spack.build_environment.setup_package(s.package, dirty=False)
@@ -312,7 +312,7 @@ def test_load_external_modules_error(working_env, monkeypatch):
     # Mock the load_module function to raise an exception
     def mock_load_module(module_name):
         # Simulate module load failure
-        raise spack.util.module_cmd.ModuleLoadError("mock-external-spec", module_name)
+        raise spack.util.module_cmd.ModuleLoadError(module_name)
 
     monkeypatch.setattr(spack.util.module_cmd, "load_module", mock_load_module)
 
@@ -354,7 +354,7 @@ def test_spack_paths_before_module_paths(
     def _set_wrong_cc(x):
         os.environ["PATH"] = module_path + os.pathsep + os.environ["PATH"]
 
-    monkeypatch.setattr(spack.build_environment, "load_module", _set_wrong_cc)
+    monkeypatch.setattr(spack.util.module_cmd, "load_module", _set_wrong_cc)
 
     s = spack.concretize.concretize_one("cmake")
 

--- a/lib/spack/spack/test/build_environment.py
+++ b/lib/spack/spack/test/build_environment.py
@@ -20,6 +20,7 @@ import spack.deptypes as dt
 import spack.package_base
 import spack.spec
 import spack.util.environment
+import spack.util.module_cmd
 import spack.util.spack_yaml as syaml
 from spack.build_environment import UseMode, _static_to_shared_library, dso_suffix
 from spack.context import Context
@@ -285,6 +286,38 @@ def test_compiler_config_modifications(
             assert os.environ[name] == value
             continue
         assert name not in os.environ
+
+
+@pytest.mark.not_on_windows("Module files are not supported on Windows")
+def test_load_external_modules_error(working_env, monkeypatch):
+    """Test that load_external_modules raises an exception when a module cannot be loaded"""
+    # Create a mock spec object with the minimum attributes needed for the test
+    class MockSpec:
+        def __init__(self):
+            self.external_modules = ["non_existent_module"]
+
+        def __str__(self):
+            return "mock-external-spec"
+
+    mock_spec = MockSpec()
+
+    # Create a simplified SetupContext-like class that only contains what we need
+    class MockSetupContext:
+        def __init__(self, spec):
+            self.external = [(spec, None)]
+
+    context = MockSetupContext(mock_spec)
+
+    # Mock the load_module function to raise an exception
+    def mock_load_module(module_name):
+        # Simulate module load failure
+        raise spack.util.module_cmd.ModuleLoadError('mock-external-spec', module_name)
+
+    monkeypatch.setattr(spack.util.module_cmd, "load_module", mock_load_module)
+
+    # Test that load_external_modules raises ModuleLoadError
+    with pytest.raises(spack.util.module_cmd.ModuleLoadError):
+        spack.build_environment.load_external_modules(context)
 
 
 def test_external_config_env(mock_packages, mutable_config, working_env):

--- a/lib/spack/spack/test/build_environment.py
+++ b/lib/spack/spack/test/build_environment.py
@@ -291,6 +291,7 @@ def test_compiler_config_modifications(
 @pytest.mark.not_on_windows("Module files are not supported on Windows")
 def test_load_external_modules_error(working_env, monkeypatch):
     """Test that load_external_modules raises an exception when a module cannot be loaded"""
+
     # Create a mock spec object with the minimum attributes needed for the test
     class MockSpec:
         def __init__(self):
@@ -311,7 +312,7 @@ def test_load_external_modules_error(working_env, monkeypatch):
     # Mock the load_module function to raise an exception
     def mock_load_module(module_name):
         # Simulate module load failure
-        raise spack.util.module_cmd.ModuleLoadError('mock-external-spec', module_name)
+        raise spack.util.module_cmd.ModuleLoadError("mock-external-spec", module_name)
 
     monkeypatch.setattr(spack.util.module_cmd, "load_module", mock_load_module)
 

--- a/lib/spack/spack/test/compilers/libraries.py
+++ b/lib/spack/spack/test/compilers/libraries.py
@@ -130,13 +130,14 @@ class TestCompilerPropertyDetector:
     @pytest.mark.not_on_windows("Module files are not supported on Windows")
     def test_compiler_invalid_module_raises(self, working_env, mock_gcc, monkeypatch):
         """Test if an exception is raised when a module cannot be loaded"""
+
         def mock_load_module(module_name):
             # Simulate module load failure
-            raise spack.util.module_cmd.ModuleLoadError('mock_gcc', module_name)
+            raise spack.util.module_cmd.ModuleLoadError("mock_gcc", module_name)
 
-        monkeypatch.setattr(spack.util.module_cmd, 'load_module', mock_load_module)
+        monkeypatch.setattr(spack.util.module_cmd, "load_module", mock_load_module)
 
-        mock_gcc.external_modules = ['non_existent']
+        mock_gcc.external_modules = ["non_existent"]
         detector = spack.compilers.libraries.CompilerPropertyDetector(mock_gcc)
 
         with pytest.raises(spack.util.module_cmd.ModuleLoadError):

--- a/lib/spack/spack/test/compilers/libraries.py
+++ b/lib/spack/spack/test/compilers/libraries.py
@@ -133,7 +133,7 @@ class TestCompilerPropertyDetector:
 
         def mock_load_module(module_name):
             # Simulate module load failure
-            raise spack.util.module_cmd.ModuleLoadError("mock_gcc", module_name)
+            raise spack.util.module_cmd.ModuleLoadError(module_name)
 
         monkeypatch.setattr(spack.util.module_cmd, "load_module", mock_load_module)
 

--- a/lib/spack/spack/test/compilers/libraries.py
+++ b/lib/spack/spack/test/compilers/libraries.py
@@ -94,6 +94,7 @@ class TestCompilerPropertyDetector:
                 return ""
             elif args[0] == "load":
                 monkeypatch.setenv("MODULE_LOADED", "1")
+                monkeypatch.setenv("LOADEDMODULES", "turn_on")
 
         monkeypatch.setattr(spack.util.module_cmd, "module", module)
 
@@ -125,3 +126,19 @@ class TestCompilerPropertyDetector:
         detector = spack.compilers.libraries.CompilerPropertyDetector(mock_gcc)
         with detector.compiler_environment():
             assert os.environ["TEST"] == "yes"
+
+    @pytest.mark.not_on_windows("Module files are not supported on Windows")
+    def test_compiler_invalid_module_raises(self, working_env, mock_gcc, monkeypatch):
+        """Test if an exception is raised when a module cannot be loaded"""
+        def mock_load_module(module_name):
+            # Simulate module load failure
+            raise spack.util.module_cmd.ModuleLoadError('mock_gcc', module_name)
+
+        monkeypatch.setattr(spack.util.module_cmd, 'load_module', mock_load_module)
+
+        mock_gcc.external_modules = ['non_existent']
+        detector = spack.compilers.libraries.CompilerPropertyDetector(mock_gcc)
+
+        with pytest.raises(spack.util.module_cmd.ModuleLoadError):
+            with detector.compiler_environment():
+                pass

--- a/lib/spack/spack/test/util/module_cmd.py
+++ b/lib/spack/spack/test/util/module_cmd.py
@@ -10,7 +10,10 @@ import spack.util.module_cmd
 
 @pytest.mark.not_on_windows("Module files are not supported on Windows")
 def test_load_module_success(monkeypatch, working_env):
-    """Test that load_module properly handles successful module loads."""
+    """Test that load_module properly handles successful module loads.
+
+    This is a very lightweight test that only confirms that successful
+    loads are not flagged as failed."""
 
     # Mock the module function to simulate a successful module load
     def mock_module(*args, **kwargs):
@@ -26,18 +29,12 @@ def test_load_module_success(monkeypatch, working_env):
 
     monkeypatch.setattr(spack.util.module_cmd, "module", mock_module)
 
-    # Test loading a module
-    test_module = "test_module"
-
-    # Clear LOADEDMODULES before testing
-    if "LOADEDMODULES" in os.environ:
-        del os.environ["LOADEDMODULES"]
-
     # This should succeed
-    spack.util.module_cmd.load_module(test_module)
+    spack.util.module_cmd.load_module("test_module")
+    spack.util.module_cmd.load_module("test_module_2")
 
-    # Check that the module was added to LOADEDMODULES
-    assert test_module in os.environ.get("LOADEDMODULES", "").split(":")
+    # Confirm LOADEDMODULES was modified
+    assert "test_module:test_module_2" in os.environ["LOADEDMODULES"]
 
 
 @pytest.mark.not_on_windows("Module files are not supported on Windows")
@@ -54,13 +51,6 @@ def test_load_module_failure(monkeypatch, working_env):
 
     monkeypatch.setattr(spack.util.module_cmd, "module", mock_module)
 
-    # Test loading a module that will fail
-    test_module = "non_existent_module"
-
-    # Clear LOADEDMODULES before testing
-    if "LOADEDMODULES" in os.environ:
-        del os.environ["LOADEDMODULES"]
-
     # This should fail with ModuleLoadError
     with pytest.raises(spack.util.module_cmd.ModuleLoadError):
-        spack.util.module_cmd.load_module(test_module)
+        spack.util.module_cmd.load_module("non_existent_module")

--- a/lib/spack/spack/test/util/module_cmd.py
+++ b/lib/spack/spack/test/util/module_cmd.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 import os
+
 import pytest
 
 import spack.util.module_cmd

--- a/lib/spack/spack/test/util/module_cmd.py
+++ b/lib/spack/spack/test/util/module_cmd.py
@@ -1,0 +1,66 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+import os
+import pytest
+
+import spack.util.module_cmd
+
+
+@pytest.mark.not_on_windows("Module files are not supported on Windows")
+def test_load_module_success(monkeypatch, working_env):
+    """Test that load_module properly handles successful module loads."""
+
+    # Mock the module function to simulate a successful module load
+    def mock_module(*args, **kwargs):
+        if args[0] == "show":
+            return ""
+        elif args[0] == "load":
+            # Simulate successful module load by adding to LOADEDMODULES
+            current_modules = os.environ.get("LOADEDMODULES", "")
+            if current_modules:
+                os.environ["LOADEDMODULES"] = f"{current_modules}:{args[1]}"
+            else:
+                os.environ["LOADEDMODULES"] = args[1]
+
+    monkeypatch.setattr(spack.util.module_cmd, "module", mock_module)
+
+    # Test loading a module
+    test_module = "test_module"
+
+    # Clear LOADEDMODULES before testing
+    if "LOADEDMODULES" in os.environ:
+        del os.environ["LOADEDMODULES"]
+
+    # This should succeed
+    spack.util.module_cmd.load_module(test_module)
+
+    # Check that the module was added to LOADEDMODULES
+    assert test_module in os.environ.get("LOADEDMODULES", "").split(":")
+
+
+@pytest.mark.not_on_windows("Module files are not supported on Windows")
+def test_load_module_failure(monkeypatch, working_env):
+    """Test that load_module raises an exception when a module load fails."""
+
+    # Mock the module function to simulate a failed module load
+    def mock_module(*args, **kwargs):
+        if args[0] == "show":
+            return ""
+        elif args[0] == "load":
+            # Simulate module load failure by not changing LOADEDMODULES
+            pass
+
+    monkeypatch.setattr(spack.util.module_cmd, "module", mock_module)
+
+    # Test loading a module that will fail
+    test_module = "non_existent_module"
+
+    # Clear LOADEDMODULES before testing
+    if "LOADEDMODULES" in os.environ:
+        del os.environ["LOADEDMODULES"]
+
+    # This should fail with ModuleLoadError
+    with pytest.raises(spack.util.module_cmd.ModuleLoadError):
+        spack.util.module_cmd.load_module(test_module)

--- a/lib/spack/spack/util/module_cmd.py
+++ b/lib/spack/spack/util/module_cmd.py
@@ -12,6 +12,7 @@ import subprocess
 from typing import MutableMapping, Optional
 
 import spack.llnl.util.tty as tty
+from spack.error import SpackError
 
 # This list is not exhaustive. Currently we only use load and unload
 # If we need another option that changes the environment, add it here.
@@ -87,6 +88,9 @@ def load_module(mod):
     """Takes a module name and removes modules until it is possible to
     load that module. It then loads the provided module. Depends on the
     modulecmd implementation of modules used in cray and lmod.
+
+    Raises:
+        ModuleLoadError: if the module could not be loaded
     """
     tty.debug("module_cmd.load_module: {0}".format(mod))
     # Read the module and remove any conflicting modules
@@ -98,9 +102,19 @@ def load_module(mod):
         if word == "conflict":
             module("unload", text[i + 1])
 
+    # Store the LOADEDMODULES before trying to load the new module
+    loaded_modules_before = os.environ.get("LOADEDMODULES", "")
+
     # Load the module now that there are no conflicts
     # Some module systems use stdout and some use stderr
     module("load", mod)
+
+    # Check if the module was actually loaded by comparing LOADEDMODULES
+    loaded_modules_after = os.environ.get("LOADEDMODULES", "")
+
+    # If LOADEDMODULES didn't change, the module wasn't loaded
+    if loaded_modules_before == loaded_modules_after:
+        raise ModuleLoadError(mod, mod)
 
 
 def get_path_args_from_module_line(line):
@@ -237,3 +251,12 @@ def get_path_from_module_contents(text, module_name):
 
     # Unable to find path in module
     return None
+
+
+class ModuleLoadError(SpackError):
+    """Raised when a module cannot be loaded."""
+
+    def __init__(self, spec_or_id, module):
+        super().__init__(
+            f"Module specified for '{spec_or_id}' could not be loaded: {module}"
+        )

--- a/lib/spack/spack/util/module_cmd.py
+++ b/lib/spack/spack/util/module_cmd.py
@@ -114,7 +114,7 @@ def load_module(mod):
 
     # If LOADEDMODULES didn't change, the module wasn't loaded
     if loaded_modules_before == loaded_modules_after:
-        raise ModuleLoadError(mod, mod)
+        raise ModuleLoadError(mod)
 
 
 def get_path_args_from_module_line(line):
@@ -256,7 +256,5 @@ def get_path_from_module_contents(text, module_name):
 class ModuleLoadError(SpackError):
     """Raised when a module cannot be loaded."""
 
-    def __init__(self, spec_or_id, module):
-        super().__init__(
-            f"Module specified for '{spec_or_id}' could not be loaded: {module}"
-        )
+    def __init__(self, module):
+        super().__init__(f"Module '{module}' could not be loaded.")


### PR DESCRIPTION
Based on work from #21253 and reimplemented for modern Spack with claude code.

> Currently when loading modules from the modules list for a compiler, Spack ignores any errors, making it harder than necessary to figure out what's wrong when debugging issues like https://github.com/spack/spack/issues/18606, https://github.com/spack/spack/issues/10308, https://github.com/spack/spack/issues/17100 (and possible some others since the module loading is fuzzy and hence different compilers could be picked up). A simple call to avail before the load should return a non-empty list of matching available modules.
> This might break a couple of installations where the loading currently fails silently.

It's non-trivial to check that the subprocess succeeded at loading the module. We check by comparing the LOADEDMODULES env var before/after loading, instead of comparing the name to a loaded module name, to account for module name matching semantics.