### PR TITLE
Error messages: empty range errors

### DIFF
--- a/lib/spack/spack/solver/error_messages.lp
+++ b/lib/spack/spack/solver/error_messages.lp
@@ -88,6 +88,8 @@ condition_cause(Condition2, ID2, Condition1, ID1) :-
 
 % More specific error message if the version cannot satisfy some constraint
 % Otherwise covered by `no_version_error` and `versions_conflict_error`.
+% When detailed version errors are disabled, this rule triggers for all version mismatches.
+% This fires only when version is NOT at a range boundary of ANY active constraint (XOR with the rules below).
 error(10000, "Cannot satisfy '{0}@{1}' (selected version {2} does not match)", Package, Constraint, Version, startcauses, ConstraintCause, CauseID)
   :- attr("node_version_satisfies", node(ID, Package), Constraint),
      pkg_fact(TriggerPkg, condition_effect(ConstraintCause, EffectID)),
@@ -95,16 +97,51 @@ error(10000, "Cannot satisfy '{0}@{1}' (selected version {2} does not match)", P
      condition_holds(ConstraintCause, node(CauseID, TriggerPkg)),
      attr("version", node(ID, Package), Version),
      not pkg_fact(Package, version_satisfies(Constraint, Version)),
-     choose_version(node(ID, Package), Version).
+     pkg_fact(Package, version_order(Version, VersionIdx)),
+     0 = #count { Constraint2, TriggerPkg2, ConstraintCause2, EffectID2, CauseID2, MaxIdx :
+       pkg_fact(TriggerPkg2, condition_effect(ConstraintCause2, EffectID2)),
+       imposed_constraint(EffectID2, "node_version_satisfies", Package, Constraint2),
+       condition_holds(ConstraintCause2, node(CauseID2, TriggerPkg2)),
+       pkg_fact(Package, version_range(Constraint2, VersionIdx, MaxIdx)) },
+     0 = #count { Constraint3, TriggerPkg3, ConstraintCause3, EffectID3, CauseID3, MinIdx :
+       pkg_fact(TriggerPkg3, condition_effect(ConstraintCause3, EffectID3)),
+       imposed_constraint(EffectID3, "node_version_satisfies", Package, Constraint3),
+       condition_holds(ConstraintCause3, node(CauseID3, TriggerPkg3)),
+       pkg_fact(Package, version_range(Constraint3, MinIdx, VersionIdx)) }.
 
-error(100, "Cannot satisfy '{0}@{1}' (version {2} does not match)", Package, Constraint, Version, startcauses, ConstraintCause, CauseID)
+% Preferred error: selected version is at the lower bound of active range constraint
+error(100, "Cannot satisfy '{0}@{1}' ({3} from {4})", Package, Constraint, Version, Constraint2, TriggerPkg2, startcauses, ConstraintCause, CauseID, ConstraintCause2, CauseID2)
   :- attr("node_version_satisfies", node(ID, Package), Constraint),
      pkg_fact(TriggerPkg, condition_effect(ConstraintCause, EffectID)),
      imposed_constraint(EffectID, "node_version_satisfies", Package, Constraint),
      condition_holds(ConstraintCause, node(CauseID, TriggerPkg)),
      attr("version", node(ID, Package), Version),
      not pkg_fact(Package, version_satisfies(Constraint, Version)),
-     not choose_version(node(ID, Package), Version).
+     pkg_fact(TriggerPkg2, condition_effect(ConstraintCause2, EffectID2)),
+     imposed_constraint(EffectID2, "node_version_satisfies", Package, Constraint2),
+     condition_holds(ConstraintCause2, node(CauseID2, TriggerPkg2)),
+     pkg_fact(Package, version_range(Constraint2, MinIdx, MaxIdx)),
+     pkg_fact(Package, version_order(Version, VersionIdx)),
+     VersionIdx == MinIdx.
+
+% Preferred error: selected version is at the upper bound of active range constraint
+% Interestingly, spack can choose this for a constraint like @2: if it picks the maximum version in the package.
+% this is not considered a bug: the point is that the range is enforced, and no version in that range was viable
+error(100, "Cannot satisfy '{0}@{1}' ({3} from {4})", Package, Constraint, Version, Constraint2, TriggerPkg2, startcauses, ConstraintCause, CauseID, ConstraintCause2, CauseID2)
+  :- attr("node_version_satisfies", node(ID, Package), Constraint),
+     pkg_fact(TriggerPkg, condition_effect(ConstraintCause, EffectID)),
+     imposed_constraint(EffectID, "node_version_satisfies", Package, Constraint),
+     condition_holds(ConstraintCause, node(CauseID, TriggerPkg)),
+     attr("version", node(ID, Package), Version),
+     not pkg_fact(Package, version_satisfies(Constraint, Version)),
+     pkg_fact(TriggerPkg2, condition_effect(ConstraintCause2, EffectID2)),
+     imposed_constraint(EffectID2, "node_version_satisfies", Package, Constraint2),
+     condition_holds(ConstraintCause2, node(CauseID2, TriggerPkg2)),
+     pkg_fact(Package, version_range(Constraint2, MinIdx, MaxIdx)),
+     pkg_fact(Package, version_order(Version, VersionIdx)),
+     VersionIdx == MaxIdx,
+     % avoid double reporting: prior statement will catch this
+     not MinIdx == MaxIdx.
 
 error(0, "Cannot satisfy '{0}@{1}' and '{0}@{2}'", Package, Constraint1, Constraint2, startcauses, Cause1, C1ID, Cause2, C2ID)
   :- attr("node_version_satisfies", node(ID, Package), Constraint1),
@@ -174,6 +211,7 @@ pkg_fact(Package, version_satisfies(Constraint, Version)) :-
 #show error/9.
 #show error/10.
 #show error/11.
+#show error/12.
 
 #show condition_cause/4.
 #show condition_reason/2.

--- a/lib/spack/spack/test/error_messages.py
+++ b/lib/spack/spack/test/error_messages.py
@@ -295,6 +295,57 @@ class T1(Package):
 )
 
 
+_pkgq4 = (
+    "q4",
+    """\
+class Q4(Package):
+    version("2.1")
+    version("2.0")
+
+    depends_on("q2")
+    depends_on("q3")
+""",
+)
+
+
+_pkgq3 = (
+    "q3",
+    """\
+class Q3(Package):
+    version("2.1")
+    version("2.0")
+
+    depends_on("q1@2:")
+""",
+)
+
+
+_pkgq2 = (
+    "q2",
+    """\
+class Q2(Package):
+    version("2.1")
+    version("2.0")
+
+    depends_on("q1@:1")
+""",
+)
+
+
+_pkgq1 = (
+    "q1",
+    """\
+class Q1(Package):
+    #version("2.1")
+    # if 2.0 is the max version, we can check double reporting
+    # of errors for a constraint like q1@2: (where lower bound == upper bound)
+    version("2.0")
+    version("1.1")
+    version("1.0")
+""",
+)
+
+
 all_pkgs = [
     _pkgx1,
     _pkgx2,
@@ -315,6 +366,10 @@ all_pkgs = [
     _pkgt2,
     _pkgt3,
     _pkgt4,
+    _pkgq1,
+    _pkgq2,
+    _pkgq3,
+    _pkgq4,
 ]
 
 
@@ -448,6 +503,13 @@ def test_diamond_with_pkg_conflict2(concretize_scope, test_repo):
 def test_version_range_null(concretize_scope, test_repo):
     with expect_failure_and_print():
         concretize_one("x2@3:4")
+
+
+def test_null_version_nonempty_union(concretize_scope, test_repo, working_env):
+    # Like prior test, but the version ranges individually are
+    # valid when applied as constraints
+    with expect_failure_and_print(should_mention=["q2", "q3", r":1", r"2:"]):
+        concretize_one("q4")
 
 
 # This error message is hard to follow: neither z2 or z3


### PR DESCRIPTION
Right now it seems like initial sanity checking has a reasonable error if a package declares versions like

```
version(1)
version(2)
version(3)
```

and a constraint requires `@4:5`, but if two constraint ranges are individually valid but have an empty intersection (e.g. `@:1` and `@3:`), the error message wasn't mentioning/chaining both.

## New approach

Prior work on concretization weighted against errors created by an arbitrary choice of version, instead preferring errors generated by conflicts with activated constraints. However, that logic didn't account for cases where a version range constraint was activated that conflicted with other version requirements (in those cases, the empty intersection would require a choice of version from the solver to generate an interesting error).

This work initially attempted to steer the solve by generating additional grounded facts (e.g. whether a selected version was a bound on a version range), but that slowed it down, so I then experimented with whether there was enough info for extracting a better message after the error is detected: this creates a preference *at error generation time* for reporting a version selection error as being part of an activated range bound.

More specifically, I started by generating facts in concretize.lp, and then moved all facts into error_messages.lp. If the solve happens to have generated an interesting error (a conflicting choice of version that is enforced by a constraint, vs. a totally arbitrary choice of version on the solver's part) we can report that by doing cause tracking on the two conflicting versions.

This seems to be sufficient for the unit test I added for this problem, although I doubt it would be sufficient to improve all such errors.

## Old approach in more detail (has since been rebased away)

This attempts to improve that by extending prior logic based on `choose_version`:

* It used to be that `choose_version` was a valve to allow the concretizer to pick a version when constraints did not apply one
* that was changed in https://github.com/spack/spack/commit/417913ac3f9b8d040ea94297620f1781eb948dc9 so everything has to choose_version
* that change was for optimization purposes, I undid it here to make it easier to reason about
* I allow bypassing `choose_version` for versions that are the minimum and maximum in a version_range, when that version range is applied as a constraint (i.e. when the constraint (a) is a version range and (b) enforced/triggered)

Seems to work for the reproducer test I added