### PR TITLE
Fix check for unaffected pruning

### DIFF
--- a/lib/spack/spack/ci/__init__.py
+++ b/lib/spack/spack/ci/__init__.py
@@ -152,7 +152,7 @@ def stack_changed(env_path: str) -> bool:
     if git_dir is None:
         return False
 
-    rel_env_path = os.path.relpath(env_path, git_dir)
+    rel_env_path = spack.util.path.convert_to_posix_path(os.path.relpath(env_path, git_dir))
     stack_paths = [rel_env_path]
 
     # Get the gitlab pipeline config from the CI variable. GitLab documents
@@ -165,7 +165,7 @@ def stack_changed(env_path: str) -> bool:
             ci_config_path = os.path.relpath(ci_config_path, git_dir)
         else:
             ci_config_path = os.path.normpath(ci_config_path)
-        stack_paths.append(ci_config_path)
+        stack_paths.append(spack.util.path.convert_to_posix_path(ci_config_path))
 
     with fs.working_dir(git_dir):
         diff = git(

--- a/lib/spack/spack/ci/__init__.py
+++ b/lib/spack/spack/ci/__init__.py
@@ -129,6 +129,16 @@ def filter_added_checksums(
     return list(added_checksums - removed_checksums)
 
 
+def _stack_path_matches(candidate: str, changed_path: str) -> bool:
+    """Return True if ``changed_path`` (posix-separated, as reported by git) is exactly
+    ``candidate`` or lives underneath it. ``candidate == "."`` (the git root itself)
+    matches any path."""
+    candidate = candidate.rstrip("/")
+    if candidate in ("", "."):
+        return True
+    return changed_path == candidate or changed_path.startswith(candidate + "/")
+
+
 def stack_changed(env_path: str) -> bool:
     """Given an environment manifest path, return whether or not the stack was changed.
     Returns True iff the environment manifest changed between the provided revisions (or
@@ -172,7 +182,7 @@ def stack_changed(env_path: str) -> bool:
             return False
 
         for path in diff.split():
-            if any(p in path for p in stack_paths):
+            if any(_stack_path_matches(p, path) for p in stack_paths):
                 tty.debug(f"env represented by {rel_env_path} changed")
                 tty.debug(f"touched file: {path}")
                 return True

--- a/lib/spack/spack/ci/__init__.py
+++ b/lib/spack/spack/ci/__init__.py
@@ -143,6 +143,13 @@ def stack_changed(env_path: str) -> bool:
         return False
 
     rel_env_path = os.path.relpath(env_path, git_dir)
+    stack_paths = [rel_env_path]
+
+    # Get the gitlab pipeline config from the CI variable
+    ci_config_path = os.environ.get("CI_CONFIG_PATH")
+    if ci_config_path:
+        ci_config_path = os.path.relpath(ci_config_path, git_dir)
+        stack_paths.append(ci_config_path)
 
     with fs.working_dir(git_dir):
         diff = git(
@@ -159,7 +166,7 @@ def stack_changed(env_path: str) -> bool:
             return False
 
         for path in diff.split():
-            if ".gitlab-ci.yml" in path or rel_env_path in path:
+            if any(p in path for p in stack_paths):
                 tty.debug(f"env represented by {rel_env_path} changed")
                 tty.debug(f"touched file: {path}")
                 return True

--- a/lib/spack/spack/ci/__init__.py
+++ b/lib/spack/spack/ci/__init__.py
@@ -142,6 +142,8 @@ def stack_changed(env_path: str) -> bool:
     if git_dir is None:
         return False
 
+    rel_env_path = os.path.relpath(env_path, git_dir)
+
     with fs.working_dir(git_dir):
         diff = git(
             "diff",
@@ -157,8 +159,8 @@ def stack_changed(env_path: str) -> bool:
             return False
 
         for path in diff.split():
-            if ".gitlab-ci.yml" in path or path in env_path:
-                tty.debug(f"env represented by {env_path} changed")
+            if ".gitlab-ci.yml" in path or rel_env_path in path:
+                tty.debug(f"env represented by {rel_env_path} changed")
                 tty.debug(f"touched file: {path}")
                 return True
     return False

--- a/lib/spack/spack/ci/__init__.py
+++ b/lib/spack/spack/ci/__init__.py
@@ -145,10 +145,16 @@ def stack_changed(env_path: str) -> bool:
     rel_env_path = os.path.relpath(env_path, git_dir)
     stack_paths = [rel_env_path]
 
-    # Get the gitlab pipeline config from the CI variable
+    # Get the gitlab pipeline config from the CI variable. GitLab documents
+    # CI_CONFIG_PATH as already being relative to the project root, so only
+    # convert it with relpath (which is resolved against the current working
+    # directory, not git_dir) when it was given as an absolute path.
     ci_config_path = os.environ.get("CI_CONFIG_PATH")
     if ci_config_path:
-        ci_config_path = os.path.relpath(ci_config_path, git_dir)
+        if os.path.isabs(ci_config_path):
+            ci_config_path = os.path.relpath(ci_config_path, git_dir)
+        else:
+            ci_config_path = os.path.normpath(ci_config_path)
         stack_paths.append(ci_config_path)
 
     with fs.working_dir(git_dir):

--- a/lib/spack/spack/test/ci.py
+++ b/lib/spack/spack/test/ci.py
@@ -93,7 +93,7 @@ def test_filter_added_checksums_new_checksum(mock_git_package_changes):
         "86993903527d9b12fc543335c19c1d33a93797b3d4d37648b5addae83679ecd8": Version("2.0.0"),
     }
 
-    with fs.working_dir(repo.packages_path):
+    with fs.working_dir(repo.root):
         assert ci.filter_added_checksums(
             checksum_versions.keys(), filename, from_ref=commits[-2], to_ref=commits[-3]
         ) == ["3f6576971397b379d4205ae5451ff5a68edf6c103b2f03c4188ed7075fbb5f04"]
@@ -110,7 +110,7 @@ def test_filter_added_checksums_new_commit(mock_git_package_changes):
         "86993903527d9b12fc543335c19c1d33a93797b3d4d37648b5addae83679ecd8": Version("2.0.0"),
     }
 
-    with fs.working_dir(repo.packages_path):
+    with fs.working_dir(repo.root):
         assert ci.filter_added_checksums(
             checksum_versions, filename, from_ref=commits[-3], to_ref=commits[-4]
         ) == ["74253725f884e2424a0dd8ae3f69896d5377f325"]

--- a/lib/spack/spack/test/ci.py
+++ b/lib/spack/spack/test/ci.py
@@ -32,6 +32,57 @@ def repro_dir(tmp_path: pathlib.Path):
         yield result
 
 
+@pytest.fixture(scope="function")
+def mock_git_repo(git, tmp_path: pathlib.Path):
+    """Create a mock git repo with two commits, the last one creating
+    a .gitlab-ci.yml"""
+
+    repo_path = str(tmp_path / "mockspackrepo")
+    fs.mkdirp(repo_path)
+
+    with fs.working_dir(repo_path):
+        git("init")
+
+        git("config", "--local", "user.email", "testing@spack.io")
+        git("config", "--local", "user.name", "Spack Testing")
+
+        # This path is used to satisfy git root detection and detection of environment changed
+        path_to_env = os.path.sep.join(("no", "such", "env", "path", "spack.yaml"))
+        os.makedirs(os.path.dirname(path_to_env))
+        with open(path_to_env, "w", encoding="utf-8") as f:
+            f.write(
+                """
+spack:
+    specs:
+    - a
+"""
+            )
+
+        git("add", path_to_env)
+
+        with open("README.md", "w", encoding="utf-8") as f:
+            f.write("# Introduction")
+
+        # initial commit with README
+        git("add", "README.md")
+        git("-c", "commit.gpgsign=false", "commit", "-m", "initial commit")
+
+        with open(".gitlab-ci.yml", "w", encoding="utf-8") as f:
+            f.write(
+                """
+testjob:
+    script:
+        - echo "success"
+            """
+            )
+
+        # second commit, adding a .gitlab-ci.yml
+        git("add", ".gitlab-ci.yml")
+        git("-c", "commit.gpgsign=false", "commit", "-m", "add a .gitlab-ci.yml")
+
+        yield repo_path
+
+
 def test_filter_added_checksums_new_checksum(mock_git_package_changes):
     repo, filename, commits = mock_git_package_changes
 

--- a/lib/spack/spack/test/ci.py
+++ b/lib/spack/spack/test/ci.py
@@ -672,3 +672,61 @@ def test_ci_stack_changed(git, mock_git_package_changes, monkeypatch):
         commit("Update stack env")
 
     assert ci.stack_changed(stack_env)
+
+
+@pytest.mark.parametrize(
+    "candidate,changed_path,expected",
+    [
+        ("env", "env/spack.yaml", True),
+        ("env", "env", True),
+        ("env", "environments/spack.yaml", False),
+        (".gitlab-ci.yml", ".gitlab-ci.yml", True),
+        (".gitlab-ci.yml", ".gitlab-ci.yml.bak", False),
+        (".", "anything/at/all", True),
+        ("", "anything/at/all", True),
+    ],
+)
+def test_stack_path_matches(candidate, changed_path, expected):
+    assert ci._stack_path_matches(candidate, changed_path) is expected
+
+
+def test_ci_stack_changed_outside_git_repo(tmp_path):
+    """Verify that stack_changed() returns False (and doesn't raise)
+    when the environment is outside a git repository."""
+    assert ci.stack_changed(str(tmp_path / "spack.yaml")) is False
+
+
+def test_ci_stack_changed_initial_commit(mock_git_repo, git):
+    """Verify that stack_changed() returns False (and doesn't raise)
+    on a repo's initial commit."""
+    with fs.working_dir(mock_git_repo):
+        first_commit = git("rev-list", "--max-parents=0", "HEAD", output=str).strip()
+        git("checkout", first_commit)
+
+    fake_env_path = os.path.join(mock_git_repo, os.path.sep.join(("no", "such", "env", "path")))
+    assert ci.stack_changed(fake_env_path) is False
+
+
+def test_ci_stack_changed_relative_ci_config_path(git, mock_git_package_changes, monkeypatch):
+    """Verify that a relative path to CI_CONFIG_PATH is usable as-is
+    without going through os.path.relpath."""
+    repo, filename, commits = mock_git_package_changes
+    stack_env = os.path.join(repo.root, "env", "spack.yaml")
+
+    monkeypatch.setenv("CI_CONFIG_PATH", os.path.join(".ci", "pipeline.yml"))
+    assert not ci.stack_changed(stack_env)
+
+    with fs.working_dir(repo.root):
+        with open(os.path.join(".ci", "pipeline.yml"), "a", encoding="utf-8") as fd:
+            fd.write("another_job: { script: [echo 'Hello'] }")
+        git("add", os.path.join(".ci", "pipeline.yml"))
+        git(
+            "commit",
+            "--no-gpg-sign",
+            "--date",
+            "2020-01-%02d 12:0:00 +0300" % len(commits),
+            "-am",
+            "Update pipeline.yml",
+        )
+
+    assert ci.stack_changed(stack_env)

--- a/lib/spack/spack/test/ci.py
+++ b/lib/spack/spack/test/ci.py
@@ -44,7 +44,7 @@ def test_filter_added_checksums_new_checksum(mock_git_package_changes):
 
     with fs.working_dir(repo.packages_path):
         assert ci.filter_added_checksums(
-            checksum_versions.keys(), filename, from_ref=commits[-1], to_ref=commits[-2]
+            checksum_versions.keys(), filename, from_ref=commits[-2], to_ref=commits[-3]
         ) == ["3f6576971397b379d4205ae5451ff5a68edf6c103b2f03c4188ed7075fbb5f04"]
 
 
@@ -61,7 +61,7 @@ def test_filter_added_checksums_new_commit(mock_git_package_changes):
 
     with fs.working_dir(repo.packages_path):
         assert ci.filter_added_checksums(
-            checksum_versions, filename, from_ref=commits[-2], to_ref=commits[-3]
+            checksum_versions, filename, from_ref=commits[-3], to_ref=commits[-4]
         ) == ["74253725f884e2424a0dd8ae3f69896d5377f325"]
 
 
@@ -565,3 +565,48 @@ def test_ci_skipped_report(tmp_path: pathlib.Path, config, monkeypatch):
             elif reason in line:
                 have[1] += 1
         assert all(count == 1 for count in have)
+
+
+def test_ci_stack_changed(git, mock_git_package_changes):
+    repo, filename, commits = mock_git_package_changes
+
+    stack_env = os.path.join(repo.root, "env", "spack.yaml")
+
+    # The changes to CI and the env are both the first commit
+    # No change should be detected
+    assert not ci.stack_changed(stack_env)
+
+    # Setting the path to the CI config with non-default name should
+    os.environ["CI_CONFIG_PATH"] = os.path.join(repo.root, ".ci", "pipeline.yml")
+    assert not ci.stack_changed(stack_env)
+
+    def commit(message, commit_counter=len(commits)):
+        git(
+            "commit",
+            "--no-gpg-sign",
+            "--date",
+            "2020-01-%02d 12:0:00 +0300" % commit_counter,
+            "-am",
+            message,
+        )
+        commit_counter += 1
+
+    # Edit the pipeline.yml
+    with fs.working_dir(repo.root):
+        with open(os.path.join(".ci", "pipeline.yml"), "a", encoding="utf-8") as fd:
+            fd.write("another_job: { script: [echo 'Hello'] }")
+        git("add", os.path.join(".ci", "pipeline.yml"))
+        commit("Update pipeline.yml")
+
+    assert ci.stack_changed(stack_env)
+
+    # Edit the stack env
+    with fs.working_dir(repo.root):
+        git("reset", "--hard", "HEAD~")
+        with open(os.path.join("env", "spack.yaml"), "w", encoding="utf-8") as fd:
+            fd.write("spack: { specs: [ 'zlib'] }")
+
+        git("add", os.path.join("env", "spack.yaml"))
+        commit("Update stack env")
+
+    assert ci.stack_changed(stack_env)

--- a/lib/spack/spack/test/ci.py
+++ b/lib/spack/spack/test/ci.py
@@ -567,6 +567,17 @@ def test_ci_skipped_report(tmp_path: pathlib.Path, config, monkeypatch):
         assert all(count == 1 for count in have)
 
 
+def test_ci_get_stack_changed_no_env(mock_git_repo, monkeypatch):
+    """Test that we can detect the change to .gitlab-ci.yml in a
+    mock spack git repo."""
+    os.environ["CI_CONFIG_PATH"] = os.path.join(mock_git_repo, ".gitlab-ci.yml")
+    monkeypatch.setattr(spack.paths, "prefix", mock_git_repo)
+    fake_env_path = os.path.join(
+        spack.paths.prefix, os.path.sep.join(("no", "such", "env", "path"))
+    )
+    assert ci.stack_changed(fake_env_path) is True
+
+
 def test_ci_stack_changed(git, mock_git_package_changes):
     repo, filename, commits = mock_git_package_changes
 

--- a/lib/spack/spack/test/ci.py
+++ b/lib/spack/spack/test/ci.py
@@ -621,7 +621,7 @@ def test_ci_skipped_report(tmp_path: pathlib.Path, config, monkeypatch):
 def test_ci_get_stack_changed_no_env(mock_git_repo, monkeypatch):
     """Test that we can detect the change to .gitlab-ci.yml in a
     mock spack git repo."""
-    os.environ["CI_CONFIG_PATH"] = os.path.join(mock_git_repo, ".gitlab-ci.yml")
+    monkeypatch.setenv("CI_CONFIG_PATH", os.path.join(mock_git_repo, ".gitlab-ci.yml"))
     monkeypatch.setattr(spack.paths, "prefix", mock_git_repo)
     fake_env_path = os.path.join(
         spack.paths.prefix, os.path.sep.join(("no", "such", "env", "path"))
@@ -629,7 +629,7 @@ def test_ci_get_stack_changed_no_env(mock_git_repo, monkeypatch):
     assert ci.stack_changed(fake_env_path) is True
 
 
-def test_ci_stack_changed(git, mock_git_package_changes):
+def test_ci_stack_changed(git, mock_git_package_changes, monkeypatch):
     repo, filename, commits = mock_git_package_changes
 
     stack_env = os.path.join(repo.root, "env", "spack.yaml")
@@ -639,7 +639,7 @@ def test_ci_stack_changed(git, mock_git_package_changes):
     assert not ci.stack_changed(stack_env)
 
     # Setting the path to the CI config with non-default name should
-    os.environ["CI_CONFIG_PATH"] = os.path.join(repo.root, ".ci", "pipeline.yml")
+    monkeypatch.setenv("CI_CONFIG_PATH", os.path.join(repo.root, ".ci", "pipeline.yml"))
     assert not ci.stack_changed(stack_env)
 
     def commit(message, commit_counter=len(commits)):

--- a/lib/spack/spack/test/cmd/ci.py
+++ b/lib/spack/spack/test/cmd/ci.py
@@ -1132,17 +1132,6 @@ spack:
             assert concrete_spec.dag_hash() + " callpath" in output
 
 
-def test_ci_get_stack_changed(mock_git_repo, monkeypatch):
-    """Test that we can detect the change to .gitlab-ci.yml in a
-    mock spack git repo."""
-    os.environ["CI_CONFIG_PATH"] = os.path.join(mock_git_repo, ".gitlab-ci.yml")
-    monkeypatch.setattr(spack.paths, "prefix", mock_git_repo)
-    fake_env_path = os.path.join(
-        spack.paths.prefix, os.path.sep.join(("no", "such", "env", "path"))
-    )
-    assert ci.stack_changed(fake_env_path) is True
-
-
 def test_ci_generate_prune_untouched(
     ci_generate_test, monkeypatch, tmp_path: pathlib.Path, repo_builder: RepoBuilder
 ):

--- a/lib/spack/spack/test/cmd/ci.py
+++ b/lib/spack/spack/test/cmd/ci.py
@@ -1135,6 +1135,7 @@ spack:
 def test_ci_get_stack_changed(mock_git_repo, monkeypatch):
     """Test that we can detect the change to .gitlab-ci.yml in a
     mock spack git repo."""
+    os.environ["CI_CONFIG_PATH"] = os.path.join(mock_git_repo, ".gitlab-ci.yml")
     monkeypatch.setattr(spack.paths, "prefix", mock_git_repo)
     fake_env_path = os.path.join(
         spack.paths.prefix, os.path.sep.join(("no", "such", "env", "path"))
@@ -2287,9 +2288,10 @@ def test_ci_verify_versions_valid(
     with spack.repo.use_repositories(repo):
         monkeypatch.setattr(spack.repo, "builtin_repo", lambda: repo)
 
-        out = ci_cmd("verify-versions", commits[-1], commits[-3])
+        out = ci_cmd("verify-versions", commits[-2], commits[-4])
         assert "Validated diff-test@2.1.5" in out
         assert "Validated diff-test@2.1.6" in out
+        assert "Validated diff-test@2.1.7" not in out
 
 
 def test_ci_verify_versions_invalid(
@@ -2303,9 +2305,10 @@ def test_ci_verify_versions_invalid(
     with spack.repo.use_repositories(repo):
         monkeypatch.setattr(spack.repo, "builtin_repo", lambda: repo)
 
-        out = ci_cmd("verify-versions", commits[-1], commits[-3], fail_on_error=False)
+        out = ci_cmd("verify-versions", commits[-2], commits[-4], fail_on_error=False)
         assert "Invalid checksum found diff-test@2.1.5" in out
         assert "Invalid commit for diff-test@2.1.6" in out
+        assert "diff-test@2.1.7" not in out
 
 
 def test_ci_verify_versions_standard_duplicates(
@@ -2318,8 +2321,9 @@ def test_ci_verify_versions_standard_duplicates(
     with spack.repo.use_repositories(repo):
         monkeypatch.setattr(spack.repo, "builtin_repo", lambda: repo)
 
-        out = ci_cmd("verify-versions", commits[-3], commits[-4], fail_on_error=False)
-        print(f"'{out}'")
+        out = ci_cmd("verify-versions", commits[-4], commits[-5], fail_on_error=False)
+        assert "Validated diff-test@2.1.5" not in out
+        assert "Validated diff-test@2.1.6" not in out
         assert "Validated diff-test@2.1.7" in out
         assert "Invalid checksum found diff-test@2.1.8" in out
 
@@ -2332,5 +2336,5 @@ def test_ci_verify_versions_manual_package(monkeypatch, mock_packages, mock_git_
         pkg_class = repos.get_pkg_class("diff-test")
         monkeypatch.setattr(pkg_class, "manual_download", True)
 
-        out = ci_cmd("verify-versions", commits[-1], commits[-2])
+        out = ci_cmd("verify-versions", commits[-2], commits[-3])
         assert "Skipping manual download package: diff-test" in out

--- a/lib/spack/spack/test/cmd/repo.py
+++ b/lib/spack/spack/test/cmd/repo.py
@@ -970,10 +970,10 @@ def test_repo_show_version_updates_success(mock_git_package_changes):
 
     with spack.repo.use_repositories(test_repo):
         # commits are ordered from newest to oldest after reversal
-        # commits[-2] = add v2.1.5, commits[-4] = add v2.1.7 and v2.1.8
+        # commits[-3] = add v2.1.5, commits[-5] = add v2.1.7 and v2.1.8
         # Find versions added between these commits
         # Includes v2.1.6 (git version), v2.1.7, and v2.1.8 (sha256 versions)
-        output = repo("show-version-updates", test_repo.root, commits[-2], commits[-4])
+        output = repo("show-version-updates", test_repo.root, commits[-3], commits[-5])
 
         # Verify all three versions are included
         assert "diff-test@" in output
@@ -1004,8 +1004,8 @@ def test_repo_show_version_updates_excludes_manual_packages(monkeypatch, mock_gi
             "show-version-updates",
             "--no-manual-packages",
             test_repo.root,
-            commits[-2],
-            commits[-4],
+            commits[-3],
+            commits[-5],
         )
 
         # Package should be excluded
@@ -1029,8 +1029,8 @@ def test_repo_show_version_updates_excludes_non_redistributable(
             "show-version-updates",
             "--only-redistributable",
             test_repo.root,
-            commits[-2],
-            commits[-4],
+            commits[-3],
+            commits[-5],
         )
 
         # Package should be excluded
@@ -1043,10 +1043,10 @@ def test_repo_show_version_updates_excludes_git_versions(mock_git_package_change
     test_repo, _, commits = mock_git_package_changes
 
     with spack.repo.use_repositories(test_repo):
-        # commits[-3] = add v2.1.6 (git version), commits[-4] = add v2.1.7 and v2.1.8 (sha256)
+        # commits[-4] = add v2.1.6 (git version), commits[-5] = add v2.1.7 and v2.1.8 (sha256)
         # Without --no-git-versions, v2.1.6 would be included
         output = repo(
-            "show-version-updates", "--no-git-versions", test_repo.root, commits[-3], commits[-4]
+            "show-version-updates", "--no-git-versions", test_repo.root, commits[-4], commits[-5]
         )
 
         # v2.1.6 (git version) should be excluded
@@ -1072,7 +1072,7 @@ def test_repo_show_version_updates_excludes_deprecated(monkeypatch, mock_git_pac
 
         # Run show-version-updates with --no-deprecated flag
         output = repo(
-            "show-version-updates", "--no-deprecated", test_repo.root, commits[-2], commits[-4]
+            "show-version-updates", "--no-deprecated", test_repo.root, commits[-3], commits[-5]
         )
 
         # v2.1.7 (deprecated) should be excluded

--- a/lib/spack/spack/test/conftest.py
+++ b/lib/spack/spack/test/conftest.py
@@ -66,6 +66,7 @@ import spack.util.lang
 import spack.util.lock
 import spack.util.naming
 import spack.util.parallel
+import spack.util.path
 import spack.util.spack_yaml as syaml
 import spack.util.tty.color
 import spack.util.url as url_util
@@ -352,6 +353,12 @@ def _mock_git_package_changes_template(git, tmp_path_factory: pytest.TempPathFac
 
         # The commits are ordered with the last commit first in the list
         commits = list(reversed(commits))
+
+    # Make filename relative to the git repo root (repo.root) and use POSIX path
+    # separators since that's what git reports.
+    filename = spack.util.path.convert_to_posix_path(
+        os.path.relpath(os.path.join(repo.packages_path, filename), repo.root)
+    )
 
     return root, repo_path, filename, commits
 

--- a/lib/spack/spack/test/conftest.py
+++ b/lib/spack/spack/test/conftest.py
@@ -295,17 +295,35 @@ def _mock_git_package_changes_template(git, tmp_path_factory: pytest.TempPathFac
         )
         commit_counter += 1
 
-    with working_dir(repo.packages_path):
+    def latest_commit():
+        return git("rev-list", "-n1", "HEAD", output=str, error=str).strip()
+
+    commits = []
+
+    # Create an environment and Gitlab CI config to mimic spack-packages, living
+    # alongside the packages subdirectory in the same git repo.
+    with working_dir(repo.root):
         git("init")
 
         git("config", "user.name", "Spack")
         git("config", "user.email", "spack@spack.io")
 
-        commits = []
+        env_dir = "env"
+        os.makedirs(env_dir)
+        with open(os.path.join(env_dir, "spack.yaml"), "w", encoding="utf-8") as fd:
+            fd.write("spack: {}")
 
-        def latest_commit():
-            return git("rev-list", "-n1", "HEAD", output=str, error=str).strip()
+        ci_dir = ".ci"
+        os.makedirs(ci_dir)
+        with open(os.path.join(ci_dir, "pipeline.yml"), "w", encoding="utf-8") as fd:
+            fd.write("some_job: { script: [echo 'Hello'] }")
 
+        git("add", "env/spack.yaml")
+        git("add", ".ci/pipeline.yml")
+        commit("ci: add stack")
+        commits.append(latest_commit())
+
+    with working_dir(repo.packages_path):
         os.makedirs(os.path.dirname(filename))
 
         # add diff-test as a new package to the repository
@@ -353,8 +371,12 @@ def mock_git_package_changes(
        o diff-test: add v2.1.5 (from source tarball)
        |
        o diff-test: new package (testing multiple added versions)
+       |
+       o ci: add stack
 
-    The repo consists of a single package.py file for DiffTest.
+    The repo consists of a single package.py file for DiffTest, plus an
+    ``env/spack.yaml`` environment and a ``.ci/pipeline.yml`` to mimic the
+    structure of spack-packages for testing ``stack_changed``.
 
     Important attributes of the repo for test coverage are: multiple package
     versions are added with some coming from a tarball and some from git refs.

--- a/lib/spack/spack/test/util/git.py
+++ b/lib/spack/spack/test/util/git.py
@@ -27,7 +27,7 @@ def test_git_not_found(monkeypatch):
 def test_modified_files(mock_git_package_changes):
     repo, filename, commits = mock_git_package_changes
 
-    with working_dir(repo.packages_path):
+    with working_dir(repo.root):
         files = spack.util.git.get_modified_files(from_ref="HEAD~1", to_ref="HEAD")
         assert len(files) == 1
         assert files[0] == filename


### PR DESCRIPTION
Check for changes to the environment using the relative path to the environment from the `git_dir`.
Use the CI variable `CI_CONFIG_PATH` to determine Gitlab CI config if it exists at all.