### PR TITLE
OCI Use the old binary layout in the spec metadata

### DIFF
--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -1560,7 +1560,9 @@ def _oci_push(
 
     def extra_config(spec: spack.spec.Spec):
         spec_dict = spec.to_dict(hash=ht.dag_hash)
-        spec_dict["buildcache_layout_version"] = CURRENT_BUILD_CACHE_LAYOUT_VERSION
+        spec_dict["buildcache_layout_version"] = (
+            2  # OCI Binary layout hasn't changed. Continue using v2
+        )
         spec_dict["binary_cache_checksum"] = {
             "hash_algorithm": "sha256",
             "hash": checksums[spec.dag_hash()].compressed_digest.digest,

--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -1560,9 +1560,7 @@ def _oci_push(
 
     def extra_config(spec: spack.spec.Spec):
         spec_dict = spec.to_dict(hash=ht.dag_hash)
-        spec_dict["buildcache_layout_version"] = (
-            2  # OCI Binary layout hasn't changed. Continue using v2
-        )
+        spec_dict["buildcache_layout_version"] = spack.mirrors.mirror.BINARY_MEDIA_TYPE_VERSION
         spec_dict["binary_cache_checksum"] = {
             "hash_algorithm": "sha256",
             "hash": checksums[spec.dag_hash()].compressed_digest.digest,

--- a/lib/spack/spack/mirrors/mirror.py
+++ b/lib/spack/spack/mirrors/mirror.py
@@ -18,7 +18,8 @@ from spack.oci.image import is_oci_url
 supported_url_schemes = ("file", "http", "https", "sftp", "ftp", "s3", "gs", "oci", "oci+http")
 
 #: The layout version spack can current install
-SUPPORTED_LAYOUT_VERSIONS = (3, 2)
+SUPPORTED_URL_LAYOUT_VERSIONS = (3, 2)
+BINARY_MEDIA_TYPE_VERSION = 2
 
 
 def _url_or_path_to_url(url_or_path: str) -> str:
@@ -179,17 +180,18 @@ class Mirror:
         # Only check the fetch configuration, the push configuration is whatever the latest
         # mirror version is which should support all configurable features.
 
-        # All configured mirrors support the latest version
-        supported_versions = [SUPPORTED_LAYOUT_VERSIONS[0]]
-        has_view = self.fetch_view is not None
-
         # Check if the mirror supports older layout versions
-        # OCI - Only return the newest version, the layout version is a dummy version since OCI
-        #       has its own layout.
+        # OCI - Return the tarball media type version, not the url layout version.
+        #       TODO: Clean up the distinction between these two versions
         # Views - Only versions >=3 support the views feature
-        if not is_oci_url(self.fetch_url) and not has_view:
-            supported_versions.extend(SUPPORTED_LAYOUT_VERSIONS[1:])
+        if is_oci_url(self.fetch_url):
+            return [BINARY_MEDIA_TYPE_VERSION]
 
+        # All configured mirrors support the latest version
+        supported_versions = [SUPPORTED_URL_LAYOUT_VERSIONS[0]]
+        has_view = self.fetch_view is not None
+        if not has_view:
+            supported_versions.extend(SUPPORTED_URL_LAYOUT_VERSIONS[1:])
         return supported_versions
 
     def _update_connection_dict(self, current_data: dict, new_data: dict, top_level: bool) -> bool:

--- a/lib/spack/spack/test/cmd/buildcache.py
+++ b/lib/spack/spack/test/cmd/buildcache.py
@@ -1044,7 +1044,7 @@ def read_specs_in_index(mirror_directory, view):
         database -> installs -> hashes...
     """
     mirror_metadata = spack.binary_distribution.MirrorMetadata(
-        f"file://{mirror_directory}", spack.mirrors.mirror.SUPPORTED_LAYOUT_VERSIONS[0], view
+        f"file://{mirror_directory}", spack.mirrors.mirror.SUPPORTED_URL_LAYOUT_VERSIONS[0], view
     )
     fetcher = spack.binary_distribution.DefaultIndexHandler(mirror_metadata, None)
     result = fetcher.conditional_fetch()

--- a/lib/spack/spack/url_buildcache.py
+++ b/lib/spack/spack/url_buildcache.py
@@ -32,6 +32,7 @@ import spack.util.crypto
 import spack.util.gpg
 import spack.util.url as url_util
 import spack.util.web as web_util
+from spack.mirrors.mirror import BINARY_MEDIA_TYPE_VERSION
 from spack.schema.url_buildcache_manifest import schema as buildcache_manifest_schema
 from spack.util.archive import ChecksumWriter
 from spack.util.crypto import hash_fun_for_algo
@@ -188,7 +189,7 @@ class URLBuildcacheEntry:
     LAYOUT_VERSION = 3
     BUILDCACHE_INDEX_MEDIATYPE = f"application/vnd.spack.db.v{spack.database._DB_VERSION}+json"
     SPEC_MEDIATYPE = f"application/vnd.spack.spec.v{spack.spec.SPECFILE_FORMAT_VERSION}+json"
-    TARBALL_MEDIATYPE = "application/vnd.spack.install.v2.tar+gzip"
+    TARBALL_MEDIATYPE = f"application/vnd.spack.install.v{BINARY_MEDIA_TYPE_VERSION}.tar+gzip"
     PUBLIC_KEY_MEDIATYPE = "application/pgp-keys"
     PUBLIC_KEY_INDEX_MEDIATYPE = "application/vnd.spack.keyindex.v1+json"
     BUILDCACHE_INDEX_FILE = "index.manifest.json"


### PR DESCRIPTION
OCI binary cache did not change for v3. Use the old layout version.

Currently OCI caches created with Spack >= v1.0 are not usable with Spack < v1.0. This is not because the binaries have changed, the binary contents of v1 caches should still be usable by v0.23. This change reverts the binary cache layout version _only_ for OCI caches so that the continue to be labeled as `v2` layout. This will make it possible for older Spack to read the OCI build cache binaries.

Note, this does not update the max allowed version for OCI build caches. Because the OCI build cache layout version has been v3 for a few versions the max allowed is left at `v3` to continue allowing users to read from their existing caches.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
