### PR TITLE
Support Mirrors with Index Views in Spack CI

### DIFF
--- a/lib/spack/docs/pipelines.rst
+++ b/lib/spack/docs/pipelines.rst
@@ -704,3 +704,15 @@ Optional.
 Only needed if you want ``spack ci rebuild`` to trust the key you store in this variable, in which case, it will subsequently be used to sign and verify binary packages (when installing or creating build caches).
 You could also have already trusted a key Spack knows about, or if no key is present anywhere, Spack will install specs using ``--no-check-signature`` and create build caches using ``-u`` (for unsigned binaries).
 
+``SPACK_CI_BUILDCACHE_VIEW``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Optional.
+Only needed when using a ``buildcache-destination`` mirror that points at a build cache view.
+This option affects the behavior the ``reindex`` job (:ref:`rebuild_index`) can have the values ``force`` or ``append`` which mirror behavior described by ref:`cmd-spack-buildcache-update-view`.
+The default option is ``append`` because that is what is used by the Spack build farm.
+
+.. warning::
+
+   Using the ``append`` option with build cache index views is a non-atomic operation.
+   It is up to the CI maintainer to ensure that concurrent writes to the build cache are handled appropriately.

--- a/lib/spack/docs/pipelines.rst
+++ b/lib/spack/docs/pipelines.rst
@@ -709,7 +709,8 @@ You could also have already trusted a key Spack knows about, or if no key is pre
 
 Optional.
 Only needed when using a ``buildcache-destination`` mirror that points at a build cache view.
-This option affects the behavior the ``reindex`` job (:ref:`rebuild_index`) can have the values ``force`` or ``append`` which mirror behavior described by ref:`cmd-spack-buildcache-update-view`.
+This option affects the behavior of the ``reindex`` job (:ref:`rebuild_index`) and can have the values ``force`` or ``append``.
+The behavior of each option is described in more detail by :ref:`cmd-spack-buildcache-update-view`.
 The default option is ``append`` because that is what is used by the Spack build farm.
 
 .. warning::

--- a/lib/spack/spack/ci/__init__.py
+++ b/lib/spack/spack/ci/__init__.py
@@ -254,7 +254,7 @@ def create_already_built_pruner(check_index_only: bool = True) -> PrunerCallback
         if not spec_locations:
             return RebuildDecision(True, "not found anywhere")
 
-        urls = ",".join(f"{loc.url}@v{loc.version}" for loc in spec_locations)
+        urls = ",".join(f"{loc:_url@v_version? (view: _view)}" for loc in spec_locations)
         message = f"up-to-date [{urls}]"
         return RebuildDecision(False, message)
 

--- a/lib/spack/spack/ci/common.py
+++ b/lib/spack/spack/ci/common.py
@@ -601,7 +601,7 @@ class SpackCIConfig:
             option = os.environ.get("SPACK_CI_BUILDCACHE_VIEW", "append")
             if option == "append":
                 # Running this in CI relies on a guarentee from the calling context that there is
-                # only a single writter or the build cache view doesn't require a complete view
+                # only a single writer or the build cache view doesn't require a complete view
                 # after each append.
                 tty.warn("Using --append to update buildcache-destination mirror index view")
                 update_index_extra_args.extend(["-y", "--append"])

--- a/lib/spack/spack/ci/common.py
+++ b/lib/spack/spack/ci/common.py
@@ -617,7 +617,7 @@ class SpackCIConfig:
                 "reindex-job": {
                     "script:": [
                         "spack env activate --without-view {env_dir}",
-                        "spack buildcache -v update-index --keys "
+                        "spack -v buildcache update-index --keys "
                         + f"{' '.join(update_index_extra_args)} buildcache-destination",
                     ]
                 }

--- a/lib/spack/spack/ci/common.py
+++ b/lib/spack/spack/ci/common.py
@@ -570,7 +570,12 @@ class SpackCIConfig:
 
     # Generate IR from the configs
     def generate_ir(self):
-        """Generate the IR from the Spack CI configurations."""
+        """Generate the IR from the Spack CI configurations.
+
+        Generate makes use of special strings that need to be expanded by python format.
+
+            env_dir: The concrete environment directory used in downstream jobs
+        """
 
         jobs = self.ir["jobs"]
 
@@ -579,8 +584,7 @@ class SpackCIConfig:
             {
                 "build-job": {
                     "script": [
-                        "cd {env_dir}",
-                        "spack env activate --without-view .",
+                        "spack env activate --without-view {env_dir}",
                         "spack spec /$SPACK_JOB_SPEC_DAG_HASH",
                         "spack ci rebuild",
                     ]
@@ -589,18 +593,33 @@ class SpackCIConfig:
             {"noop-job": {"script": ['echo "All specs already up to date, nothing to rebuild."']}},
         ]
 
+        pipeline_mirrors = spack.mirrors.mirror.MirrorCollection(binary=True)
+        buildcache_destination = pipeline_mirrors["buildcache-destination"]
+        update_index_extra_args = []
+        if buildcache_destination.push_view:
+            update_index_extra_args.extend(["--name", buildcache_destination.push_view])
+            option = os.environ.get("SPACK_CI_BUILDCACHE_VIEW", "append")
+            if option == "append":
+                # Running this in CI relies on a guarentee from the calling context that there is
+                # only a single writter or the build cache view doesn't require a complete view
+                # after each append.
+                tty.warn("Using --append to update buildcache-destination mirror index view")
+                update_index_extra_args.extend(["-y", "--append"])
+            elif option == "force":
+                update_index_extra_args.append("--force")
+            else:
+                raise SpackCIError(f"Unrecognized value: SPACK_CI_BUILDCACHE_VIEW={option}")
+
         # Job overrides
         overrides = [
             # Reindex script
             {
                 "reindex-job": {
-                    "script:": ["spack -v buildcache update-index --keys {index_target_mirror}"]
-                }
-            },
-            # Cleanup script
-            {
-                "cleanup-job": {
-                    "script:": ["spack -d mirror destroy {mirror_prefix}/$CI_PIPELINE_ID"]
+                    "script:": [
+                        "spack env activate --without-view {env_dir}",
+                        "spack buildcache -v update-index --keys "
+                        + f"{' '.join(update_index_extra_args)} buildcache-destination",
+                    ]
                 }
             },
             # Add signing job tags

--- a/lib/spack/spack/ci/gitlab.py
+++ b/lib/spack/spack/ci/gitlab.py
@@ -112,7 +112,7 @@ def generate_gitlab_yaml(pipeline: PipelineDag, spack_ci: SpackCIConfig, options
     generate_job_name = os.environ.get("CI_JOB_NAME", "job-does-not-exist")
     generate_pipeline_id = os.environ.get("CI_PIPELINE_ID", "pipeline-does-not-exist")
     artifacts_root = pathlib.Path(options.artifacts_root)
-    if artifacts_root.is_relative_to(ci_project_dir):
+    if ci_project_dir == artifacts_root or ci_project_dir in artifacts_root.parents:
         artifacts_root = artifacts_root.relative_to(ci_project_dir)
     pipeline_artifacts_dir = (ci_project_dir / artifacts_root).absolute().resolve()
     output_file = options.output_file

--- a/lib/spack/spack/ci/gitlab.py
+++ b/lib/spack/spack/ci/gitlab.py
@@ -195,7 +195,7 @@ def generate_gitlab_yaml(pipeline: PipelineDag, spack_ci: SpackCIConfig, options
     rel_user_artifacts_dir = os.path.relpath(user_artifacts_dir, ci_project_dir)
 
     def main_script_replacements(cmd):
-        return cmd.replace("{env_dir}", rel_concrete_env_dir)
+        return cmd.replace("{env_dir}", shlex.quote(rel_concrete_env_dir))
 
     output_object = {}
     job_id = 0
@@ -378,21 +378,35 @@ def generate_gitlab_yaml(pipeline: PipelineDag, spack_ci: SpackCIConfig, options
             output_object["sign-pkgs"] = signing_job
 
         if options.rebuild_index:
+            # Create a dummy job that runs as the stage before reindex.
+            # This job will be used to ensure reindex doesn't run until
+            # the other build jobs complete.
+            stage_names.append("stage-wait")
+            wait_job = spack_ci_ir["jobs"]["noop"]["attributes"]
+            wait_job["stage"] = "stage-wait"
+            wait_job["retry"] = 0
+            wait_job["when"] = "always"
+            wait_job["script"] = ["echo 'Open the pod bay doors HAL'"]
+            wait_job["dependencies"] = []
+
+            output_object["wait-for-build-jobs"] = wait_job
+
             # Add a final job to regenerate the index
             stage_names.append("stage-rebuild-index")
             final_job = spack_ci_ir["jobs"]["reindex"]["attributes"]
 
             final_job["stage"] = "stage-rebuild-index"
-            target_mirror = options.buildcache_destination.push_url
-            final_job["script"] = unpack_script(
-                final_job["script"],
-                op=lambda cmd: cmd.replace("{index_target_mirror}", target_mirror),
-            )
+            final_job["script"] = unpack_script(final_job["script"], op=main_script_replacements)
 
             final_job["when"] = "always"
             final_job["retry"] = service_job_retries
             final_job["interruptible"] = True
-            final_job["dependencies"] = []
+            # update-index needs to download generate artifacts
+            # it also needs to wait until all of the other stages complete.
+            final_job["needs"] = [
+                {"job": generate_job_name, "pipeline": f"{generate_pipeline_id}"},
+                "wait-for-build-jobs",
+            ]
 
             output_object["rebuild-index"] = final_job
 

--- a/lib/spack/spack/ci/gitlab.py
+++ b/lib/spack/spack/ci/gitlab.py
@@ -3,6 +3,8 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 import copy
 import os
+import pathlib
+import shlex
 import shutil
 import urllib
 from typing import List, Optional
@@ -104,13 +106,15 @@ def generate_gitlab_yaml(pipeline: PipelineDag, spack_ci: SpackCIConfig, options
         spack_ci: An object containing the configured attributes of all jobs in the pipeline
         options: An object containing all the pipeline options gathered from yaml, env, etc...
     """
-    ci_project_dir = os.environ.get("CI_PROJECT_DIR") or os.getcwd()
+    ci_project_dir = (
+        pathlib.Path(os.environ.get("CI_PROJECT_DIR") or os.getcwd()).absolute().resolve()
+    )
     generate_job_name = os.environ.get("CI_JOB_NAME", "job-does-not-exist")
     generate_pipeline_id = os.environ.get("CI_PIPELINE_ID", "pipeline-does-not-exist")
-    artifacts_root = options.artifacts_root
-    if artifacts_root.startswith(ci_project_dir):
-        artifacts_root = os.path.relpath(artifacts_root, ci_project_dir)
-    pipeline_artifacts_dir = os.path.join(ci_project_dir, artifacts_root)
+    artifacts_root = pathlib.Path(options.artifacts_root)
+    if artifacts_root.is_relative_to(ci_project_dir):
+        artifacts_root = artifacts_root.relative_to(ci_project_dir)
+    pipeline_artifacts_dir = (ci_project_dir / artifacts_root).absolute().resolve()
     output_file = options.output_file
 
     if not output_file:
@@ -123,18 +127,18 @@ def generate_gitlab_yaml(pipeline: PipelineDag, spack_ci: SpackCIConfig, options
 
     spack_ci_ir = spack_ci.generate_ir()
 
-    concrete_env_dir = os.path.join(pipeline_artifacts_dir, "concrete_environment")
+    concrete_env_dir = pipeline_artifacts_dir / "concrete_environment"
 
     # Now that we've added the mirrors we know about, they should be properly
     # reflected in the environment manifest file, so copy that into the
     # concrete environment directory, along with the spack.lock file.
-    if not os.path.exists(concrete_env_dir):
-        os.makedirs(concrete_env_dir)
+    if not concrete_env_dir.exists():
+        concrete_env_dir.mkdir(parents=True)
 
     # Copy the manifest and handle relative included paths
-    with open(options.env.manifest_path, "r", encoding="utf-8") as fin, open(
-        os.path.join(concrete_env_dir, "spack.yaml"), "w", encoding="utf-8"
-    ) as fout:
+    with open(options.env.manifest_path, "r", encoding="utf-8") as fin, (
+        concrete_env_dir / "spack.yaml"
+    ).open("w", encoding="utf-8") as fout:
         data = syaml.load(fin)
         if "spack" not in data:
             raise spack.config.ConfigSectionError(
@@ -172,15 +176,15 @@ def generate_gitlab_yaml(pipeline: PipelineDag, spack_ci: SpackCIConfig, options
 
             data["spack"]["include"] = fixed_includes
 
-            os.makedirs(concrete_env_dir, exist_ok=True)
+            concrete_env_dir.mkdir(parents=True, exist_ok=True)
         syaml.dump(data, fout)
 
-    shutil.copyfile(options.env.lock_path, os.path.join(concrete_env_dir, "spack.lock"))
+    shutil.copyfile(options.env.lock_path, str(concrete_env_dir / "spack.lock"))
 
-    job_log_dir = os.path.join(pipeline_artifacts_dir, "logs")
-    job_repro_dir = os.path.join(pipeline_artifacts_dir, "reproduction")
-    job_test_dir = os.path.join(pipeline_artifacts_dir, "tests")
-    user_artifacts_dir = os.path.join(pipeline_artifacts_dir, "user_data")
+    job_log_dir = pipeline_artifacts_dir / "logs"
+    job_repro_dir = pipeline_artifacts_dir / "reproduction"
+    job_test_dir = pipeline_artifacts_dir / "tests"
+    user_artifacts_dir = pipeline_artifacts_dir / "user_data"
 
     # We communicate relative paths to the downstream jobs to avoid issues in
     # situations where the CI_PROJECT_DIR varies between the pipeline
@@ -188,14 +192,14 @@ def generate_gitlab_yaml(pipeline: PipelineDag, spack_ci: SpackCIConfig, options
     # checks out the project into a runner-specific directory, for example,
     # and different runners are picked for generate and rebuild jobs.
 
-    rel_concrete_env_dir = os.path.relpath(concrete_env_dir, ci_project_dir)
-    rel_job_log_dir = os.path.relpath(job_log_dir, ci_project_dir)
-    rel_job_repro_dir = os.path.relpath(job_repro_dir, ci_project_dir)
-    rel_job_test_dir = os.path.relpath(job_test_dir, ci_project_dir)
-    rel_user_artifacts_dir = os.path.relpath(user_artifacts_dir, ci_project_dir)
+    rel_concrete_env_dir = concrete_env_dir.relative_to(ci_project_dir)
+    rel_job_log_dir = job_log_dir.relative_to(ci_project_dir)
+    rel_job_repro_dir = job_repro_dir.relative_to(ci_project_dir)
+    rel_job_test_dir = job_test_dir.relative_to(ci_project_dir)
+    rel_user_artifacts_dir = user_artifacts_dir.relative_to(ci_project_dir)
 
     def main_script_replacements(cmd):
-        return cmd.replace("{env_dir}", shlex.quote(rel_concrete_env_dir))
+        return cmd.replace("{env_dir}", shlex.quote(rel_concrete_env_dir.as_posix()))
 
     output_object = {}
     job_id = 0
@@ -278,10 +282,10 @@ def generate_gitlab_yaml(pipeline: PipelineDag, spack_ci: SpackCIConfig, options
                 {
                     "when": "always",
                     "paths": [
-                        rel_job_log_dir,
-                        rel_job_repro_dir,
-                        rel_job_test_dir,
-                        rel_user_artifacts_dir,
+                        rel_job_log_dir.as_posix(),
+                        rel_job_repro_dir.as_posix(),
+                        rel_job_test_dir.as_posix(),
+                        rel_user_artifacts_dir.as_posix(),
                     ],
                 },
             )
@@ -314,8 +318,8 @@ def generate_gitlab_yaml(pipeline: PipelineDag, spack_ci: SpackCIConfig, options
     # the only purpose is to specify a list of sources and destinations for
     # everything that should be copied.
     distinguish_stack = options.stack_name if options.stack_name else "rebuilt"
-    manifest_path = os.path.join(
-        pipeline_artifacts_dir, "specs_to_copy", f"copy_{distinguish_stack}_specs.json"
+    manifest_path = (
+        pipeline_artifacts_dir / "specs_to_copy" / f"copy_{distinguish_stack}_specs.json"
     )
     maybe_generate_manifest(pipeline, options, manifest_path)
 
@@ -421,13 +425,13 @@ def generate_gitlab_yaml(pipeline: PipelineDag, spack_ci: SpackCIConfig, options
         rebuild_everything = not options.prune_up_to_date and not options.prune_untouched
 
         output_object["variables"] = {
-            "SPACK_ARTIFACTS_ROOT": artifacts_root,
-            "SPACK_CONCRETE_ENV_DIR": rel_concrete_env_dir,
+            "SPACK_ARTIFACTS_ROOT": artifacts_root.as_posix(),
+            "SPACK_CONCRETE_ENV_DIR": rel_concrete_env_dir.as_posix(),
             "SPACK_VERSION": spack_version,
             "SPACK_CHECKOUT_VERSION": version_to_clone,
-            "SPACK_JOB_LOG_DIR": rel_job_log_dir,
-            "SPACK_JOB_REPRO_DIR": rel_job_repro_dir,
-            "SPACK_JOB_TEST_DIR": rel_job_test_dir,
+            "SPACK_JOB_LOG_DIR": rel_job_log_dir.as_posix(),
+            "SPACK_JOB_REPRO_DIR": rel_job_repro_dir.as_posix(),
+            "SPACK_JOB_TEST_DIR": rel_job_test_dir.as_posix(),
             "SPACK_PIPELINE_TYPE": options.pipeline_type.name if options.pipeline_type else "None",
             "SPACK_CI_STACK_NAME": os.environ.get("SPACK_CI_STACK_NAME", "None"),
             "SPACK_REBUILD_CHECK_UP_TO_DATE": str(options.prune_up_to_date),

--- a/lib/spack/spack/ci/gitlab.py
+++ b/lib/spack/spack/ci/gitlab.py
@@ -154,10 +154,10 @@ def generate_gitlab_yaml(pipeline: PipelineDag, spack_ci: SpackCIConfig, options
             if parsed.scheme not in file_schemes:
                 return path
 
-            if os.path.isabs(expanded_path):
+            if os.path.isabs(parsed.path):
                 return path
             abs_path = path_util.canonicalize_path(path, orig_root)
-            return os.path.relpath(abs_path, start=new_root)
+            return pathlib.Path(os.path.relpath(abs_path, new_root)).as_posix()
 
         # If there are no includes, just copy
         if "include" in data["spack"]:

--- a/lib/spack/spack/cmd/blame.py
+++ b/lib/spack/spack/cmd/blame.py
@@ -159,8 +159,7 @@ def package_repo_root(path: Union[str, pathlib.Path]) -> Optional[pathlib.Path]:
             if (repo_dest / ".git").exists():
                 prefix = repo_dest
 
-                # TODO: replace check with `is_relative_to` once supported
-                if prefix and str(path).startswith(str(prefix)):
+                if prefix == path or prefix in path.parents:
                     return prefix
 
         # Handle the local repository case, making sure it's a spack repository.
@@ -169,8 +168,7 @@ def package_repo_root(path: Union[str, pathlib.Path]) -> Optional[pathlib.Path]:
             if "spack_repo" in repo_path.parts:
                 prefix = git_prefix(repo_path)
 
-                # TODO: replace check with `is_relative_to` once supported
-                if prefix and str(path).startswith(str(prefix)):
+                if prefix == path or prefix in path.parents:
                     return prefix
 
     return None

--- a/lib/spack/spack/package_base.py
+++ b/lib/spack/spack/package_base.py
@@ -2447,7 +2447,11 @@ class WindowsSimulatedRPath:
                 new_pth = pathlib.Path(pth).parent
             else:
                 new_pth = pathlib.Path(pth)
-            path_is_in_prefix = new_pth.is_relative_to(self.base_modification_prefix)
+
+            path_is_in_prefix = (
+                self.base_modification_prefix == new_pth
+                or self.base_modification_prefix in new_pth.parents
+            )
             if not path_is_in_prefix:
                 raise RuntimeError(
                     f"Attempting to generate rpath symlink out of rpath context:\

--- a/lib/spack/spack/test/binary_distribution.py
+++ b/lib/spack/spack/test/binary_distribution.py
@@ -1483,6 +1483,54 @@ def test_mirror_metadata():
         spack.binary_distribution.MirrorMetadata.from_string("https://dummy.io/__v3@@4")
 
 
+def mirror_metadata_check_format(data, fmt, result):
+    assert fmt.format(data) == result.format(data)
+
+
+def test_mirror_metadata_format():
+    mirror_metadata = spack.binary_distribution.MirrorMetadata("https://dummy.io/__v3", 3)
+
+    # Check pass-through formatting
+    mirror_metadata_check_format(mirror_metadata, "{0:_url}", "{0.url}")
+    mirror_metadata_check_format(mirror_metadata, "{0:_version}", "{0.version}")
+    mirror_metadata_check_format(mirror_metadata, "{0:_view}", "{0.view}")
+
+    # Empty view
+    mirror_metadata_check_format(mirror_metadata, "{0:?_view}", "")
+    mirror_metadata_check_format(
+        mirror_metadata, "{0:_url?^_view^_version?^_version}", "{0.url}^{0.version}"
+    )
+    mirror_metadata_check_format(
+        mirror_metadata,
+        "{0:_url?^_view^_version?^_version?^_view^_version?^_url}",
+        "{0.url}^{0.version}^{0.url}",
+    )
+
+
+def test_mirror_metadata_format_with_view():
+    mirror_metadata = spack.binary_distribution.MirrorMetadata(
+        "https://dummy.io/__v3__@aview", 3, "aview"
+    )
+
+    # Check pass-through formatting
+    mirror_metadata_check_format(mirror_metadata, "{0:_url}", "{0.url}")
+    mirror_metadata_check_format(mirror_metadata, "{0:_version}", "{0.version}")
+    mirror_metadata_check_format(mirror_metadata, "{0:_view}", "{0.view}")
+
+    # View exists
+    mirror_metadata_check_format(mirror_metadata, "{0:?_view}", "{0.view}")
+    mirror_metadata_check_format(
+        mirror_metadata,
+        "{0:_url?^_view^_version?^_version}",
+        "{0.url}^{0.view}^{0.version}^{0.version}",
+    )
+    mirror_metadata_check_format(
+        mirror_metadata,
+        "{0:_url?^_view^_version?^_version?^_view^_version?^_url}",
+        "{0.url}^{0.view}^{0.version}^{0.version}^{0.view}^{0.version}^{0.url}",
+    )
+
+
 def test_mirror_metadata_with_view():
     mirror_metadata = spack.binary_distribution.MirrorMetadata(
         "https://dummy.io/__v3__@aview", 3, "aview"

--- a/lib/spack/spack/test/binary_distribution.py
+++ b/lib/spack/spack/test/binary_distribution.py
@@ -1494,6 +1494,7 @@ def test_mirror_metadata_format():
     mirror_metadata_check_format(mirror_metadata, "{0:_url}", "{0.url}")
     mirror_metadata_check_format(mirror_metadata, "{0:_version}", "{0.version}")
     mirror_metadata_check_format(mirror_metadata, "{0:_view}", "{0.view}")
+    mirror_metadata_check_format(mirror_metadata, "{0}", "{0.url}@{0.version}")
 
     # Empty view
     mirror_metadata_check_format(mirror_metadata, "{0:?_view}", "")
@@ -1516,6 +1517,7 @@ def test_mirror_metadata_format_with_view():
     mirror_metadata_check_format(mirror_metadata, "{0:_url}", "{0.url}")
     mirror_metadata_check_format(mirror_metadata, "{0:_version}", "{0.version}")
     mirror_metadata_check_format(mirror_metadata, "{0:_view}", "{0.view}")
+    mirror_metadata_check_format(mirror_metadata, "{0}", "{0.url}@{0.version}-{0.view}")
 
     # View exists
     mirror_metadata_check_format(mirror_metadata, "{0:?_view}", "{0.view}")

--- a/lib/spack/spack/test/cmd/ci.py
+++ b/lib/spack/spack/test/cmd/ci.py
@@ -119,22 +119,31 @@ def ci_generate_test(
     Additional positional arguments will be added to the 'spack generate' call.
     """
 
-    def _func(spack_yaml_content, *args, fail_on_error=True):
-        spack_yaml = tmp_path / "spack.yaml"
-        spack_yaml.write_text(spack_yaml_content)
-        ev.create("test", init_file=spack_yaml, with_view=False)
-        outputfile = tmp_path / ".gitlab-ci.yml"
-        with ev.read("test"):
-            output = ci_cmd(
-                "generate", "--output-file", str(outputfile), *args, fail_on_error=fail_on_error
-            )
+    def _func(spack_yaml_content, *args, fail_on_error=True, raise_on_error=True):
+        try:
+            spack_yaml = tmp_path / "spack.yaml"
+            spack_yaml.write_text(spack_yaml_content)
+            ev.create("test", init_file=spack_yaml, with_view=False)
+            outputfile = tmp_path / ".gitlab-ci.yml"
+            with ev.read("test"):
+                output = ci_cmd(
+                    "generate",
+                    "--output-file",
+                    str(outputfile),
+                    *args,
+                    fail_on_error=fail_on_error,
+                )
 
-        return spack_yaml, outputfile, output
+            return spack_yaml, outputfile, output
+        except ci.SpackCIError as e:
+            if raise_on_error:
+                raise e
+            return None, None, e
 
     return _func
 
 
-@pytest.mark.parametrize("with_view", (False, True, "append", "force"))
+@pytest.mark.parametrize("with_view", (False, True, "append", "force", "invalid_view_mode"))
 def test_ci_generate_with_env(
     ci_generate_test, tmp_path: pathlib.Path, mock_binary_index, with_view
 ):
@@ -148,7 +157,7 @@ def test_ci_generate_with_env(
         if isinstance(with_view, str):
             os.environ["SPACK_CI_BUILDCACHE_VIEW"] = with_view
 
-    spack_yaml, outputfile, _ = ci_generate_test(
+    spack_yaml, outputfile, output = ci_generate_test(
         f"""\
 spack:
   definitions:
@@ -194,7 +203,14 @@ spack:
 """,
         "--artifacts-root",
         str(tmp_path / "my_artifacts_root"),
+        raise_on_error=False,
     )
+
+    if with_view == "invalid_view_mode":
+        assert isinstance(output, ci.SpackCIError)
+        assert "SPACK_CI_BUILDCACHE_VIEW=invalid_view_mode" in str(output)
+        return
+
     yaml_contents = syaml.load(outputfile.read_text())
 
     assert "workflow" in yaml_contents

--- a/lib/spack/spack/test/cmd/ci.py
+++ b/lib/spack/spack/test/cmd/ci.py
@@ -201,7 +201,8 @@ spack:
     assert "rebuild-index" in yaml_contents
     rebuild_job = yaml_contents["rebuild-index"]
     assert (
-        rebuild_job["script"][1] == "spack -v buildcache update-index --keys  buildcache-destination"
+        rebuild_job["script"][1]
+        == "spack -v buildcache update-index --keys  buildcache-destination"
     )
     assert rebuild_job["custom_attribute"] == "custom!"
 

--- a/lib/spack/spack/test/cmd/ci.py
+++ b/lib/spack/spack/test/cmd/ci.py
@@ -193,15 +193,15 @@ spack:
     assert yaml_contents["workflow"]["rules"] == [{"when": "always"}]
 
     assert "stages" in yaml_contents
-    assert len(yaml_contents["stages"]) == 6
+    assert len(yaml_contents["stages"]) == 7
     assert yaml_contents["stages"][0] == "stage-0"
-    assert yaml_contents["stages"][5] == "stage-rebuild-index"
+    assert yaml_contents["stages"][5] == "stage-wait"
+    assert yaml_contents["stages"][6] == "stage-rebuild-index"
 
     assert "rebuild-index" in yaml_contents
     rebuild_job = yaml_contents["rebuild-index"]
     assert (
-        rebuild_job["script"][0]
-        == f"spack -v buildcache update-index --keys {mirror_url.as_uri()}"
+        rebuild_job["script"][1] == "spack -v buildcache update-index --keys  buildcache-destination"
     )
     assert rebuild_job["custom_attribute"] == "custom!"
 
@@ -333,12 +333,11 @@ spack:
             "git checkout ${SPACK_REF}",
             "popd",
         ]
-        assert ci_obj["script"][1].startswith("cd ")
-        ci_obj["script"][1] = "cd ENV"
+        assert ci_obj["script"][1].startswith("spack env activate --without-view ")
+        ci_obj["script"][1] = "spack env activate --without-view ENV"
         assert ci_obj["script"] == [
             "spack -d ci rebuild",
-            "cd ENV",
-            "spack env activate --without-view .",
+            "spack env activate --without-view ENV",
             "spack spec /$SPACK_JOB_SPEC_DAG_HASH",
             "spack ci rebuild",
         ]
@@ -1681,7 +1680,8 @@ spack:
     with open(tmp_path / ".gitlab-ci.yml", encoding="utf-8") as f:
         pipeline_doc = syaml.load(f)
         assert fst not in pipeline_doc["rebuild-index"]["script"][0]
-        assert snd in pipeline_doc["rebuild-index"]["script"][0]
+        assert "env activate" in pipeline_doc["rebuild-index"]["script"][0]
+        assert "buildcache-destination" in pipeline_doc["rebuild-index"]["script"][1]
 
 
 def dynamic_mapping_setup(tmp_path: pathlib.Path):
@@ -1862,11 +1862,13 @@ spack:
     # Make sure there are only two jobs and two stages
     stages = pipeline_doc["stages"]
     copy_stage = "copy"
+    wait_stage = "stage-wait"
     rebuild_index_stage = "stage-rebuild-index"
 
-    assert len(stages) == 2
+    assert len(stages) == 3
     assert stages[0] == copy_stage
-    assert stages[1] == rebuild_index_stage
+    assert stages[1] == wait_stage
+    assert stages[2] == rebuild_index_stage
 
     rebuild_index_job = pipeline_doc["rebuild-index"]
     assert rebuild_index_job["stage"] == rebuild_index_stage

--- a/lib/spack/spack/test/cmd/ci.py
+++ b/lib/spack/spack/test/cmd/ci.py
@@ -134,11 +134,20 @@ def ci_generate_test(
     return _func
 
 
-def test_ci_generate_with_env(ci_generate_test, tmp_path: pathlib.Path, mock_binary_index):
+@pytest.mark.parametrize("with_view", (False, True, "append", "force"))
+def test_ci_generate_with_env(
+    ci_generate_test, tmp_path: pathlib.Path, mock_binary_index, with_view
+):
     """Make sure we can get a .gitlab-ci.yml from an environment file
     which has the gitlab-ci, cdash, and mirrors sections.
     """
     mirror_url = tmp_path / "ci-mirror"
+    mirror_config = {"url": str(mirror_url)}
+    if with_view:
+        mirror_config["view"] = "someview"
+        if isinstance(with_view, str):
+            os.environ["SPACK_CI_BUILDCACHE_VIEW"] = with_view
+
     spack_yaml, outputfile, _ = ci_generate_test(
         f"""\
 spack:
@@ -155,7 +164,7 @@ spack:
     - matrix:
       - [$old-gcc-pkgs]
   mirrors:
-    buildcache-destination: {mirror_url}
+    buildcache-destination: {mirror_config}
   ci:
     pipeline-gen:
     - submapping:
@@ -200,9 +209,18 @@ spack:
 
     assert "rebuild-index" in yaml_contents
     rebuild_job = yaml_contents["rebuild-index"]
+    # Handle view parameter
+    if isinstance(with_view, bool):
+        with_view = "append" if with_view else ""
+
+    if with_view == "append":
+        with_view = "--name someview -y --append"
+    elif with_view == "force":
+        with_view = "--name someview --force"
+
     assert (
         rebuild_job["script"][1]
-        == "spack -v buildcache update-index --keys  buildcache-destination"
+        == f"spack -v buildcache update-index --keys {with_view} buildcache-destination"
     )
     assert rebuild_job["custom_attribute"] == "custom!"
 

--- a/lib/spack/spack/url_buildcache.py
+++ b/lib/spack/spack/url_buildcache.py
@@ -1396,14 +1396,19 @@ class MirrorMetadata:
         """
         if not format_spec:
             format_spec = "_url@_version?-_view"
-        out = format_spec.replace("_url", self.url)
-        out = out.replace("_version", str(self.version))
-        out = out.replace("_view", str(self.view))
-        parts = out.split("?")
+
+        formatted = []
+        parts = format_spec.split("?")
+        for p in parts:
+            formatted.append(
+                p.replace("_url", self.url)
+                .replace("_version", str(self.version))
+                .replace("_view", str(self.view))
+            )
         if self.view:
-            return "".join(parts)
+            return "".join(formatted)
         else:
-            return "".join(parts[0::2])
+            return "".join(formatted[0::2])
 
     @classmethod
     def from_string(cls, s: str) -> "MirrorMetadata":

--- a/lib/spack/spack/url_buildcache.py
+++ b/lib/spack/spack/url_buildcache.py
@@ -1395,8 +1395,7 @@ class MirrorMetadata:
                 https://my-mirror.com/prefix^my-view@v3
         """
         if not format_spec:
-            format_spec = "_url@v3?-_view"
-            return
+            format_spec = "_url@_version?-_view"
         out = format_spec.replace("_url", self.url)
         out = out.replace("_version", str(self.version))
         out = out.replace("_view", str(self.view))

--- a/lib/spack/spack/url_buildcache.py
+++ b/lib/spack/spack/url_buildcache.py
@@ -1365,10 +1365,7 @@ class MirrorMetadata:
         self.view = view
 
     def __str__(self):
-        s = f"{self.url}__v{self.version}"
-        if self.view:
-            s += f"__{self.view}"
-        return s
+        return f"{self:_url__v_version?___view}"
 
     def __eq__(self, other):
         if not isinstance(other, MirrorMetadata):
@@ -1377,6 +1374,37 @@ class MirrorMetadata:
 
     def __hash__(self):
         return hash((self.url, self.version, self.view))
+
+    def __format__(self, format_spec):
+        """Format the mirror metadata
+
+        Format Spec:
+            _url:     metadata.url
+            _version: metadata.version
+            _view:    metadata.view
+            ?:        delimiter to wrap conditional printing based on optional view
+
+        Example
+
+            f"{meta_data:_url?^_view?@v_version}"
+
+            Expansion without a view:
+                https://my-mirror.com/prefix@v3
+
+            Expansion with a view:
+                https://my-mirror.com/prefix^my-view@v3
+        """
+        if not format_spec:
+            format_spec = "_url@v3?-_view"
+            return
+        out = format_spec.replace("_url", self.url)
+        out = out.replace("_version", str(self.version))
+        out = out.replace("_view", str(self.view))
+        parts = out.split("?")
+        if self.view:
+            return "".join(parts)
+        else:
+            return "".join(parts[0::2])
 
     @classmethod
     def from_string(cls, s: str) -> "MirrorMetadata":


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->

Allow controlling the reindex behavior when using index views in CI.

* Add new option to select binary cache index view behavior
  (append/overried)
* Add new variable `SPACK_CI_BUILDCACHE_VIEW`
* Apply quoting around expanded paths passed to CI

Tertiary changes
* Formatting for MirrorMetadata with views
   * Views are optional metadata. Provide a way to conditionally format
mirror metadata to print view information if it exists.
* Remove unused CI cleanup job

    * The default cleanup job was using gitlab specific variables and
variables that were unexpanded by gitlab CI. Drop this as it is related
to a long since removed legacy feature "artfacts-buildcache" which has
been deprecated and removed for a few years.