### PR TITLE
Graceful variant deprecation

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,6 @@
+## Package API v2.5
+- `spack.package.variant` directive: added `deprecated=` parameter.
+
 ## Package API v2.4
 - Added the `%%` sigil to spec syntax, to propagate compiler preferences.
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 ## Package API v2.5
-- `spack.package.variant` directive: added `deprecated=` parameter.
+- `spack.package.variant` directive: added `deprecated=` and `substitutions=` parameters.
+- Added `hip-lang` and `cuda-lang` as valid languages for the concretizer
 
 ## Package API v2.4
 - Added the `%%` sigil to spec syntax, to propagate compiler preferences.

--- a/lib/spack/docs/package_api.rst
+++ b/lib/spack/docs/package_api.rst
@@ -37,6 +37,10 @@ Spack version |spack_version| supports package repositories with a Package API v
 Changelog
 ---------
 
+**v2.5** *(Spack v1.2.0)*
+
+* The :func:`~spack.package.variant` directive now supports the ``deprecated=`` parameter for graceful variant deprecation.
+
 **v2.4** *(Spack v1.0.3)*
 
 * The ``%%`` operator can be used on input specs to set propagated preferences, which is particularly useful for ``unify: false`` environments.

--- a/lib/spack/docs/packaging_guide_creation.rst
+++ b/lib/spack/docs/packaging_guide_creation.rst
@@ -1630,6 +1630,69 @@ The default for this variant, when it is present, is always ``True``, regardless
 This allows packages to override variants in packages or build system classes from which they inherit, by modifying the variant values without modifying the ``when`` clause.
 It also allows a package to implement ``or`` semantics for a variant ``when`` clause by duplicating the variant definition.
 
+Deprecating Variants
+^^^^^^^^^^^^^^^^^^^^
+
+.. versionadded:: 1.2
+
+When a variant needs to be renamed or removed, the ``deprecated`` parameter provides a graceful migration path.
+Users who still reference the old variant in CLI commands, environments, or ``packages.yaml`` will see a warning instead of a hard error.
+The old variant is automatically translated or removed before concretization.
+
+To simply remove a variant that is no longer needed:
+
+.. code-block:: python
+
+   class Foo(Package):
+       ...
+       variant("old_flag", default=True, deprecated=True)
+       ...
+
+Any reference to ``old_flag`` (e.g., ``foo+old_flag``) will be silently dropped with a warning message.
+
+To rename a variant or map old values to new ones, pass a dictionary that maps old variant settings to replacement spec constraints:
+
+.. code-block:: python
+
+   class Foo(Package):
+       ...
+       variant("shared", default=True, deprecated={
+           "+shared": "libs=shared",
+           "~shared": "libs=static",
+       })
+       variant("libs", default="shared", values=("shared", "static"), multi=False)
+       ...
+
+With this definition, ``foo+shared`` is automatically rewritten to ``foo libs=shared``, and ``foo~shared`` becomes ``foo libs=static``.
+If the deprecated variant was set with propagation (e.g., ``foo ++shared``), propagation carries over to the replacement.
+
+Multi-valued variants can also be mapped:
+
+.. code-block:: python
+
+   class Foo(Package):
+       ...
+       variant("old_backends", default="none", values=("a", "b", "none"), multi=True,
+               deprecated={
+                   "old_backends=a": "backends=alpha",
+                   "old_backends=b": "backends=beta",
+               })
+       variant("backends", default="none", values=("alpha", "beta", "none"), multi=True)
+       ...
+
+Here ``foo old_backends=a,b`` becomes ``foo backends=alpha,beta``.
+
+.. note::
+
+   The ``deprecated`` parameter cannot be combined with ``when``.
+   Deprecated variants are always unconditional.
+
+.. note::
+
+   Deprecated variants are not substituted in package recipes.
+   The state of a repository must be self-consistent at all times.
+   Variant deprecation is just a way to gracefully migrate user configuration or scripts.
+
 .. _dependencies:
 
 Dependencies

--- a/lib/spack/docs/packaging_guide_creation.rst
+++ b/lib/spack/docs/packaging_guide_creation.rst
@@ -1650,13 +1650,13 @@ To simply remove a variant that is no longer needed:
 
 Any reference to ``old_flag`` (e.g., ``foo+old_flag``) will be silently dropped with a warning message.
 
-To rename a variant or map old values to new ones, pass a dictionary that maps old variant settings to replacement spec constraints:
+To rename a variant or map old values to new ones, set ``deprecated=True`` and pass a ``substitutions`` dictionary that maps old variant settings to replacement spec constraints:
 
 .. code-block:: python
 
    class Foo(Package):
        ...
-       variant("shared", default=True, deprecated={
+       variant("shared", default=True, deprecated=True, substitutions={
            "+shared": "libs=shared",
            "~shared": "libs=static",
        })
@@ -1673,7 +1673,7 @@ Multi-valued variants can also be mapped:
    class Foo(Package):
        ...
        variant("old_backends", default="none", values=("a", "b", "none"), multi=True,
-               deprecated={
+               deprecated=True, substitutions={
                    "old_backends=a": "backends=alpha",
                    "old_backends=b": "backends=beta",
                })
@@ -1686,6 +1686,7 @@ Here ``foo old_backends=a,b`` becomes ``foo backends=alpha,beta``.
 
    The ``deprecated`` parameter cannot be combined with ``when``.
    Deprecated variants are always unconditional.
+   Passing ``substitutions`` without ``deprecated=True`` raises a ``DirectiveError``.
 
 .. note::
 

--- a/lib/spack/spack/__init__.py
+++ b/lib/spack/spack/__init__.py
@@ -19,7 +19,7 @@ spack_version = __version__
 #: version is incremented when the package API is extended in a backwards-compatible way. The major
 #: version is incremented upon breaking changes. This version is changed independently from the
 #: Spack version.
-package_api_version = (2, 4)
+package_api_version = (2, 5)
 
 #: The minimum Package API version that this version of Spack is compatible with. This should
 #: always be a tuple of the form ``(major, 0)``, since compatibility with vX.Y implies

--- a/lib/spack/spack/cmd/__init__.py
+++ b/lib/spack/spack/cmd/__init__.py
@@ -29,6 +29,7 @@ import spack.traverse as traverse
 import spack.user_environment as uenv
 import spack.util.spack_json as sjson
 import spack.util.spack_yaml as syaml
+import spack.variant
 from spack.llnl.util.filesystem import join_path
 from spack.llnl.util.lang import attr_setdefault, index_by
 from spack.llnl.util.tty.colify import colify
@@ -184,6 +185,8 @@ def parse_specs(
 
     toolchains = spack.config.CONFIG.get("toolchains", {})
     specs = spack.spec_parser.parse(arg_string, toolchains=toolchains)
+    for spec in specs:
+        spack.variant.expand_deprecated_variants(spec, origin="on the command line")
     if not concretize:
         return specs
 

--- a/lib/spack/spack/directives.py
+++ b/lib/spack/spack/directives.py
@@ -46,7 +46,7 @@ import os
 import re
 import warnings
 from functools import partial
-from typing import Any, Callable, List, Optional, Tuple, Type, Union
+from typing import Any, Callable, Dict, List, Optional, Tuple, Type, Union
 
 import spack.deptypes as dt
 import spack.error
@@ -661,7 +661,8 @@ def variant(
     validator: Optional[Callable[[str, str, Tuple[Any, ...]], None]] = None,
     when: Optional[Union[str, bool]] = None,
     sticky: bool = False,
-    deprecated: Union[bool, dict] = False,
+    deprecated: bool = False,
+    substitutions: Optional[Dict[str, str]] = None,
 ):
     """Declare a variant for a package.
 
@@ -681,8 +682,11 @@ def variant(
         when: Optional condition on which the variant applies
         sticky: The variant should not be changed by the concretizer to find a valid concrete spec
         deprecated: If ``False`` the variant is normal. If ``True``, the variant is accepted but
-            silently dropped before concretization. If a ``dict``, each key is a condition and each
-            value is the replacement constraint to apply when the condition matches.
+            dropped before concretization (with a warning), optionally replacing it with the
+            constraints in ``substitutions``.
+        substitutions: Optional mapping of old variant conditions to replacement spec constraints.
+            Each key is a condition string (e.g. ``"+shared"``) and each value is the replacement
+            constraint (e.g. ``"libs=shared"``). Only valid when ``deprecated=True``.
 
     Raises:
         spack.directives_meta.DirectiveError: If arguments passed to the directive are invalid
@@ -698,6 +702,7 @@ def variant(
         when=when,
         sticky=sticky,
         deprecated=deprecated,
+        substitutions=substitutions,
     )
 
 
@@ -716,11 +721,16 @@ def _execute_variant(
     validator: Optional[Callable[[str, str, Tuple[Any, ...]], None]],
     when: Optional[Union[str, bool]],
     sticky: bool,
-    deprecated: Union[bool, dict] = False,
+    deprecated: bool = False,
+    substitutions: Optional[Dict[str, str]] = None,
 ):
+    if substitutions is not None and not deprecated:
+        raise DirectiveError(
+            f"variant '{name}' in {pkg.name}: 'substitutions' requires 'deprecated=True'"
+        )
     # Handle deprecated variants early — they bypass all normal variant logic
-    if deprecated is not False:
-        _handle_deprecated_variant(pkg, name=name, when=when, deprecated=deprecated)
+    if deprecated:
+        _handle_deprecated_variant(pkg, name=name, when=when, substitutions=substitutions)
         return
 
     # This validation can be removed at runtime and enforced with an audit in Spack v1.0.
@@ -816,24 +826,25 @@ def _execute_variant(
 
 
 def _handle_deprecated_variant(
-    pkg: "Type[PackageBase]", *, name: str, when: Any, deprecated: Union[bool, dict]
+    pkg: "Type[PackageBase]",
+    *,
+    name: str,
+    when: Any,
+    substitutions: Optional[Dict[str, str]] = None,
 ) -> None:
     if when is not None:
         raise DirectiveError(
             f"variant '{name}' in {pkg.name}: 'deprecated' and 'when' cannot be combined"
         )
-    if deprecated is True:
+    if substitutions is None:
         pkg.deprecated_variants[name] = spack.variant.DeprecatedVariant(name)
-    elif isinstance(deprecated, dict):
-        if not all(isinstance(k, str) and isinstance(v, str) for k, v in deprecated.items()):
-            raise DirectiveError(
-                f"variant '{name}' in {pkg.name}: deprecated mapping keys and values "
-                f"must be strings"
-            )
-        pkg.deprecated_variants[name] = spack.variant.DeprecatedVariant(name, mapping=deprecated)
     else:
-        raise DirectiveError(
-            f"variant '{name}' in {pkg.name}: 'deprecated' must be True or a dict"
+        if not all(isinstance(k, str) and isinstance(v, str) for k, v in substitutions.items()):
+            raise DirectiveError(
+                f"variant '{name}' in {pkg.name}: substitutions keys and values must be strings"
+            )
+        pkg.deprecated_variants[name] = spack.variant.DeprecatedVariant(
+            name, mapping=substitutions
         )
 
 

--- a/lib/spack/spack/directives.py
+++ b/lib/spack/spack/directives.py
@@ -728,9 +728,9 @@ def _execute_variant(
         raise DirectiveError(
             f"variant '{name}' in {pkg.name}: 'substitutions' requires 'deprecated=True'"
         )
-    # Handle deprecated variants early — they bypass all normal variant logic
+    # Handle deprecated variants early - they bypass all normal variant logic
     if deprecated:
-        _handle_deprecated_variant(pkg, name=name, when=when, substitutions=substitutions)
+        _handle_deprecated_variant(pkg, name=name, substitutions=substitutions)
         return
 
     # This validation can be removed at runtime and enforced with an audit in Spack v1.0.
@@ -826,17 +826,8 @@ def _execute_variant(
 
 
 def _handle_deprecated_variant(
-    pkg: "Type[PackageBase]",
-    *,
-    name: str,
-    when: Any,
-    substitutions: Optional[Dict[str, str]] = None,
+    pkg: "Type[PackageBase]", *, name: str, substitutions: Optional[Dict[str, str]] = None
 ) -> None:
-    if when is not None:
-        warnings.warn(
-            f"variant '{name}' in {pkg.name}: 'deprecated' and 'when' are used together; "
-            f"the 'when' condition is ignored for deprecated variants"
-        )
     if substitutions is None:
         pkg.deprecated_variants[name] = spack.variant.DeprecatedVariant(name)
     else:

--- a/lib/spack/spack/directives.py
+++ b/lib/spack/spack/directives.py
@@ -733,6 +733,12 @@ def _execute_variant(
         _handle_deprecated_variant(pkg, name=name, substitutions=substitutions)
         return
 
+    if name in pkg.deprecated_variants:
+        raise DirectiveError(
+            f"variant '{name}' in {pkg.name}: cannot define a non-deprecated variant "
+            "with the same name as a deprecated variant"
+        )
+
     # This validation can be removed at runtime and enforced with an audit in Spack v1.0.
     # For now it's a warning to let people migrate faster.
     if not (
@@ -828,6 +834,11 @@ def _execute_variant(
 def _handle_deprecated_variant(
     pkg: "Type[PackageBase]", *, name: str, substitutions: Optional[Dict[str, str]] = None
 ) -> None:
+    if any(name in d for d in pkg.variants.values()):
+        raise DirectiveError(
+            f"variant '{name}' in {pkg.name}: cannot deprecate a variant "
+            "that is also defined as non-deprecated"
+        )
     if substitutions is None:
         pkg.deprecated_variants[name] = spack.variant.DeprecatedVariant(name)
     else:

--- a/lib/spack/spack/directives.py
+++ b/lib/spack/spack/directives.py
@@ -833,8 +833,9 @@ def _handle_deprecated_variant(
     substitutions: Optional[Dict[str, str]] = None,
 ) -> None:
     if when is not None:
-        raise DirectiveError(
-            f"variant '{name}' in {pkg.name}: 'deprecated' and 'when' cannot be combined"
+        warnings.warn(
+            f"variant '{name}' in {pkg.name}: 'deprecated' and 'when' are used together; "
+            f"the 'when' condition is ignored for deprecated variants"
         )
     if substitutions is None:
         pkg.deprecated_variants[name] = spack.variant.DeprecatedVariant(name)

--- a/lib/spack/spack/directives.py
+++ b/lib/spack/spack/directives.py
@@ -59,6 +59,7 @@ import spack.util.crypto
 import spack.variant
 from spack.dependency import Dependency
 from spack.directives_meta import DirectiveError, directive, get_spec
+from spack.package_base import PackageBase
 from spack.resource import Resource
 from spack.spec import EMPTY_SPEC
 from spack.version import StandardVersion, VersionChecksumError, VersionError
@@ -650,7 +651,7 @@ def conditional(*values: Union[str, bool], when: Optional[WhenType] = None):
     )
 
 
-@directive("variants")
+@directive(("variants", "deprecated_variants"))
 def variant(
     name: str,
     default: Optional[Union[bool, str, Tuple[str, ...]]] = None,
@@ -660,6 +661,7 @@ def variant(
     validator: Optional[Callable[[str, str, Tuple[Any, ...]], None]] = None,
     when: Optional[Union[str, bool]] = None,
     sticky: bool = False,
+    deprecated: Union[bool, dict] = False,
 ):
     """Declare a variant for a package.
 
@@ -678,6 +680,9 @@ def variant(
             if the group doesn't meet the additional constraints
         when: Optional condition on which the variant applies
         sticky: The variant should not be changed by the concretizer to find a valid concrete spec
+        deprecated: If ``False`` the variant is normal. If ``True``, the variant is accepted but
+            silently dropped before concretization. If a ``dict``, each key is a condition and each
+            value is the replacement constraint to apply when the condition matches.
 
     Raises:
         spack.directives_meta.DirectiveError: If arguments passed to the directive are invalid
@@ -692,6 +697,7 @@ def variant(
         validator=validator,
         when=when,
         sticky=sticky,
+        deprecated=deprecated,
     )
 
 
@@ -710,7 +716,12 @@ def _execute_variant(
     validator: Optional[Callable[[str, str, Tuple[Any, ...]], None]],
     when: Optional[Union[str, bool]],
     sticky: bool,
+    deprecated: Union[bool, dict] = False,
 ):
+    # Handle deprecated variants early — they bypass all normal variant logic
+    if deprecated is not False:
+        _handle_deprecated_variant(pkg, name=name, when=when, deprecated=deprecated)
+        return
 
     # This validation can be removed at runtime and enforced with an audit in Spack v1.0.
     # For now it's a warning to let people migrate faster.
@@ -802,6 +813,28 @@ def _execute_variant(
         sticky=sticky,
         precedence=pkg.num_variant_definitions(),
     )
+
+
+def _handle_deprecated_variant(
+    pkg: "Type[PackageBase]", *, name: str, when: Any, deprecated: Union[bool, dict]
+) -> None:
+    if when is not None:
+        raise DirectiveError(
+            f"variant '{name}' in {pkg.name}: 'deprecated' and 'when' cannot be combined"
+        )
+    if deprecated is True:
+        pkg.deprecated_variants[name] = spack.variant.DeprecatedVariant(name)
+    elif isinstance(deprecated, dict):
+        if not all(isinstance(k, str) and isinstance(v, str) for k, v in deprecated.items()):
+            raise DirectiveError(
+                f"variant '{name}' in {pkg.name}: deprecated mapping keys and values "
+                f"must be strings"
+            )
+        pkg.deprecated_variants[name] = spack.variant.DeprecatedVariant(name, mapping=deprecated)
+    else:
+        raise DirectiveError(
+            f"variant '{name}' in {pkg.name}: 'deprecated' must be True or a dict"
+        )
 
 
 @directive("resources")

--- a/lib/spack/spack/environment/list.py
+++ b/lib/spack/spack/environment/list.py
@@ -57,6 +57,9 @@ class SpecList:
                     spec.constrain(const)
                 if self._toolchains:
                     expand_toolchains(spec, self._toolchains)
+                spack.variant.expand_deprecated_variants(
+                    spec, origin="in the environment spec list"
+                )
                 specs.append(spec)
             self._specs = specs
 

--- a/lib/spack/spack/package_base.py
+++ b/lib/spack/spack/package_base.py
@@ -569,6 +569,8 @@ class PackageBase(WindowsRPath, PackageViewMixin, metaclass=PackageMeta):
     patches: Dict[spack.spec.Spec, List[spack.patch.Patch]]
     #: Class level dictionary populated by :func:`~spack.directives.variant` directives
     variants: Dict[spack.spec.Spec, Dict[str, spack.variant.Variant]]
+    #: Class level dictionary populated by :func:`~spack.directives.variant` directives
+    deprecated_variants: Dict[str, spack.variant.DeprecatedVariant]
     #: Class level dictionary populated by :func:`~spack.directives.license` directives
     licenses: Dict[spack.spec.Spec, str]
     #: Class level dictionary populated by :func:`~spack.directives.can_splice` directives

--- a/lib/spack/spack/solver/requirements.py
+++ b/lib/spack/spack/solver/requirements.py
@@ -15,6 +15,7 @@ import spack.spec
 import spack.spec_parser
 import spack.traverse
 import spack.util.spack_yaml
+import spack.variant
 from spack.enums import PropagationPolicy
 from spack.llnl.util import tty
 from spack.util.spack_yaml import get_mark_from_yaml_data
@@ -153,10 +154,17 @@ class RequirementParser:
         self.toolchains = configuration.get_config("toolchains")
         self._warned_compiler_all: set = set()
 
-    def _parse_and_expand(self, string: str, *, named: bool = False) -> spack.spec.Spec:
+    def _parse_and_expand(
+        self, string: str, *, named: bool = False, pkg_name: Optional[str] = None
+    ) -> spack.spec.Spec:
         result = parse_spec_from_yaml_string(string, named=named)
         if self.toolchains:
             spack.spec_parser.expand_toolchains(result, self.toolchains)
+        mark = get_mark_from_yaml_data(string)
+        origin = "packages.yaml"
+        if mark and mark.name:
+            origin = f"{mark.name}:{mark.line:d}" if mark.line is not None else mark.name
+        spack.variant.expand_deprecated_variants(result, origin=f"in {origin}", pkg_name=pkg_name)
         return result
 
     def rules(self, pkg: spack.package_base.PackageBase) -> List[RequirementRule]:
@@ -232,7 +240,7 @@ class RequirementParser:
             if kind == RequirementKind.DEFAULT:
                 # Warn about %gcc type of preferences under `all`.
                 self._maybe_warn_compiler_in_all(item, "prefer")
-            spec, condition, msg = self._parse_prefer_conflict_item(item)
+            spec, condition, msg = self._parse_prefer_conflict_item(item, pkg_name=pkg_name)
             result.append(
                 preference(pkg_name, constraint=spec, condition=condition, kind=kind, message=msg)
             )
@@ -247,20 +255,20 @@ class RequirementParser:
     ) -> List[RequirementRule]:
         result = []
         for item in conflicts:
-            spec, condition, msg = self._parse_prefer_conflict_item(item)
+            spec, condition, msg = self._parse_prefer_conflict_item(item, pkg_name=pkg_name)
             result.append(
                 conflict(pkg_name, constraint=spec, condition=condition, kind=kind, message=msg)
             )
         return result
 
-    def _parse_prefer_conflict_item(self, item):
+    def _parse_prefer_conflict_item(self, item, *, pkg_name: Optional[str] = None):
         # The item is either a string or an object with at least a "spec" attribute
         if isinstance(item, str):
-            spec = self._parse_and_expand(item)
+            spec = self._parse_and_expand(item, pkg_name=pkg_name)
             condition = spack.spec.Spec()
             message = None
         else:
-            spec = self._parse_and_expand(item["spec"])
+            spec = self._parse_and_expand(item["spec"], pkg_name=pkg_name)
             condition = spack.spec.Spec(item.get("when"))
             message = item.get("message")
         raw_key = item if isinstance(item, str) else item.get("spec", item)
@@ -312,12 +320,18 @@ class RequirementParser:
                 # validate specs from YAML first, and fail with line numbers if parsing fails.
                 raw_strs = list(constraints)
                 constraints = [
-                    self._parse_and_expand(constraint, named=kind == RequirementKind.VIRTUAL)
+                    self._parse_and_expand(
+                        constraint, named=kind == RequirementKind.VIRTUAL, pkg_name=pkg_name
+                    )
                     for constraint in raw_strs
                 ]
                 _check_unknown_targets(raw_strs, constraints)
                 when_str = requirement.get("when")
-                when = self._parse_and_expand(when_str) if when_str else spack.spec.Spec()
+                when = (
+                    self._parse_and_expand(when_str, pkg_name=pkg_name)
+                    if when_str
+                    else spack.spec.Spec()
+                )
 
                 constraints = [
                     x

--- a/lib/spack/spack/test/cmd/init_py_functions.py
+++ b/lib/spack/spack/test/cmd/init_py_functions.py
@@ -5,6 +5,7 @@ import pathlib
 
 import pytest
 
+import spack.cmd
 import spack.config
 import spack.environment as ev
 import spack.error
@@ -138,3 +139,13 @@ def test_special_cases_concretization_matching_specs_from_env(
         else:
             # assertion error from monkeypatch above if test fails
             matching_specs_from_env(specs)
+
+
+def test_cli_parse_specs_expands_deprecated(mock_packages, config):
+    """Tests that spack.cmd.parse_specs expands deprecated variants from CLI args."""
+    specs = spack.cmd.parse_specs(["deprecated-variant-pkg+shared"])
+    assert len(specs) == 1
+    spec = specs[0]
+    assert "shared" not in spec.variants
+    assert "libs" in spec.variants
+    assert "shared" in spec.variants["libs"].values

--- a/lib/spack/spack/test/directives.py
+++ b/lib/spack/spack/test/directives.py
@@ -301,13 +301,12 @@ def _fake_pkg():
     return type("FakePkg", (), {"name": "fake", "deprecated_variants": {}})()
 
 
-def test_deprecated_with_when_raises(mock_packages):
-    """Tests that using 'deprecated=' and 'when=' together raises an error."""
-    with pytest.raises(
-        spack.directives.DirectiveError, match="'deprecated' and 'when' cannot be combined"
-    ):
+def test_deprecated_with_when_warns(mock_packages):
+    """Tests that using 'deprecated=' and 'when=' together issues a warning."""
+    pkg = _fake_pkg()
+    with pytest.warns(UserWarning, match="'when' condition is ignored for deprecated variants"):
         spack.directives._execute_variant(
-            _fake_pkg(),
+            pkg,
             name="bad",
             default=True,
             description="",
@@ -319,6 +318,7 @@ def test_deprecated_with_when_raises(mock_packages):
             deprecated=True,
             substitutions=None,
         )
+    assert "bad" in pkg.deprecated_variants
 
 
 def test_substitutions_without_deprecated_raises():

--- a/lib/spack/spack/test/directives.py
+++ b/lib/spack/spack/test/directives.py
@@ -301,26 +301,6 @@ def _fake_pkg():
     return type("FakePkg", (), {"name": "fake", "deprecated_variants": {}})()
 
 
-def test_deprecated_with_when_warns(mock_packages):
-    """Tests that using 'deprecated=' and 'when=' together issues a warning."""
-    pkg = _fake_pkg()
-    with pytest.warns(UserWarning, match="'when' condition is ignored for deprecated variants"):
-        spack.directives._execute_variant(
-            pkg,
-            name="bad",
-            default=True,
-            description="",
-            values=None,
-            multi=None,
-            validator=None,
-            when="+foo",
-            sticky=False,
-            deprecated=True,
-            substitutions=None,
-        )
-    assert "bad" in pkg.deprecated_variants
-
-
 def test_substitutions_without_deprecated_raises():
     """Tests that passing 'substitutions' without 'deprecated=True' raises an error."""
     with pytest.raises(

--- a/lib/spack/spack/test/directives.py
+++ b/lib/spack/spack/test/directives.py
@@ -226,9 +226,10 @@ def test_directives_meta_combine_when():
 
 def test_directive_descriptor_init():
     # when `pkg.variants` is initialized, only the `variant` directive should run
+    # `deprecated_variants` is also initialized since `variant` manages both dicts
     variants = DirectiveDictDescriptor("variants")
     assert variants.directives_to_run == ["variant"]
-    assert variants.dicts_to_init == ["variants"]
+    assert variants.dicts_to_init == ["deprecated_variants", "variants"]
 
     # when `pkg.dependencies` is initialized, `depends_on` and `extends` should run, and also
     # `pkg.extendees` should be initialized
@@ -294,3 +295,22 @@ def test_patched_dependencies_sets_class_attribute():
 
     assert DoesNotPatchDependencies._patches_dependencies is False
     assert DoesNotPatchDependencies.patches  # type: ignore
+
+
+def test_deprecated_with_when_raises(mock_packages):
+    """Tests that using 'deprecated=' and 'when=' together raises an error."""
+    with pytest.raises(
+        spack.directives.DirectiveError, match="'deprecated' and 'when' cannot be combined"
+    ):
+        spack.directives._execute_variant(
+            type("FakePkg", (), {"name": "fake", "deprecated_variants": {}})(),
+            name="bad",
+            default=True,
+            description="",
+            values=None,
+            multi=None,
+            validator=None,
+            when="+foo",
+            sticky=False,
+            deprecated=True,
+        )

--- a/lib/spack/spack/test/directives.py
+++ b/lib/spack/spack/test/directives.py
@@ -9,6 +9,7 @@ import spack.concretize
 import spack.directives
 import spack.repo
 import spack.spec
+import spack.variant
 import spack.version
 from spack.directives import _make_when_spec, depends_on, extends, patch
 from spack.directives_meta import DirectiveDictDescriptor, DirectiveMeta
@@ -298,7 +299,7 @@ def test_patched_dependencies_sets_class_attribute():
 
 
 def _fake_pkg():
-    return type("FakePkg", (), {"name": "fake", "deprecated_variants": {}})()
+    return type("FakePkg", (), {"name": "fake", "deprecated_variants": {}, "variants": {}})()
 
 
 def test_substitutions_without_deprecated_raises():
@@ -338,4 +339,36 @@ def test_deprecated_substitutions_invalid_types_raises():
             sticky=False,
             deprecated=True,
             substitutions={"+bad": 42},  # type: ignore[dict-item]
+        )
+
+
+def test_deprecated_variant_conflicts_with_normal_raises():
+    """Tests that deprecating a variant already defined as non-deprecated raises an error."""
+    fake = _fake_pkg()
+    # Simulate a normal variant already present for "shared"
+    fake.variants["always"] = {"shared": object()}
+    with pytest.raises(spack.directives.DirectiveError, match="cannot deprecate a variant"):
+        spack.directives._handle_deprecated_variant(fake, name="shared")
+
+
+def test_normal_variant_conflicts_with_deprecated_raises():
+    """Tests that defining a non-deprecated variant with the same name as a deprecated one raises
+    an error.
+    """
+    fake = _fake_pkg()
+    # Simulate a deprecated variant already present for "shared"
+    fake.deprecated_variants["shared"] = spack.variant.DeprecatedVariant("shared")
+    with pytest.raises(
+        spack.directives.DirectiveError, match="cannot define a non-deprecated variant"
+    ):
+        spack.directives._execute_variant(
+            fake,
+            name="shared",
+            default=True,
+            description="",
+            values=None,
+            multi=None,
+            validator=None,
+            when=None,
+            sticky=False,
         )

--- a/lib/spack/spack/test/directives.py
+++ b/lib/spack/spack/test/directives.py
@@ -297,13 +297,17 @@ def test_patched_dependencies_sets_class_attribute():
     assert DoesNotPatchDependencies.patches  # type: ignore
 
 
+def _fake_pkg():
+    return type("FakePkg", (), {"name": "fake", "deprecated_variants": {}})()
+
+
 def test_deprecated_with_when_raises(mock_packages):
     """Tests that using 'deprecated=' and 'when=' together raises an error."""
     with pytest.raises(
         spack.directives.DirectiveError, match="'deprecated' and 'when' cannot be combined"
     ):
         spack.directives._execute_variant(
-            type("FakePkg", (), {"name": "fake", "deprecated_variants": {}})(),
+            _fake_pkg(),
             name="bad",
             default=True,
             description="",
@@ -313,4 +317,45 @@ def test_deprecated_with_when_raises(mock_packages):
             when="+foo",
             sticky=False,
             deprecated=True,
+            substitutions=None,
+        )
+
+
+def test_substitutions_without_deprecated_raises():
+    """Tests that passing 'substitutions' without 'deprecated=True' raises an error."""
+    with pytest.raises(
+        spack.directives.DirectiveError, match="'substitutions' requires 'deprecated=True'"
+    ):
+        spack.directives._execute_variant(
+            _fake_pkg(),
+            name="bad",
+            default=True,
+            description="",
+            values=None,
+            multi=None,
+            validator=None,
+            when=None,
+            sticky=False,
+            deprecated=False,
+            substitutions={"+bad": "good=val"},
+        )
+
+
+def test_deprecated_substitutions_invalid_types_raises():
+    """Tests that non-string keys or values in 'substitutions' raise an error."""
+    with pytest.raises(
+        spack.directives.DirectiveError, match="substitutions keys and values must be strings"
+    ):
+        spack.directives._execute_variant(
+            _fake_pkg(),
+            name="bad",
+            default=True,
+            description="",
+            values=None,
+            multi=None,
+            validator=None,
+            when=None,
+            sticky=False,
+            deprecated=True,
+            substitutions={"+bad": 42},  # type: ignore[dict-item]
         )

--- a/lib/spack/spack/test/spec_semantics.py
+++ b/lib/spack/spack/test/spec_semantics.py
@@ -1115,6 +1115,8 @@ class TestSpecSemantics:
 
         class Pkg:
             name = "PKG"
+            deprecated_variants: dict = {}
+            variants: dict = {}
 
         # We can't use names that are reserved by Spack
         fn = variant("patches")

--- a/lib/spack/spack/test/variant.py
+++ b/lib/spack/spack/test/variant.py
@@ -9,7 +9,9 @@ import spack.concretize
 import spack.error
 import spack.repo
 import spack.spec
+import spack.util.spack_yaml as syaml
 import spack.variant
+from spack.concretize import concretize_one
 from spack.spec import Spec, VariantMap
 from spack.variant import (
     BoolValuedVariant,
@@ -339,6 +341,89 @@ class TestBoolValuedVariant:
         a = BoolValuedVariant("foo", False)
         expected = ("foo", False)
         assert a.yaml_entry() == expected
+
+
+@pytest.mark.usefixtures("mock_packages")
+class TestDeprecatedVariant:
+    def test_deprecated_variants_stored_separately(self, mock_packages):
+        """Tests that deprecated variants are stored in a separate dictionary and return false
+        true a "has_variant" check.
+        """
+        pkg_cls = mock_packages.get_pkg_class("deprecated-variant-pkg")
+
+        assert "old_flag" in pkg_cls.deprecated_variants
+        assert "shared" in pkg_cls.deprecated_variants
+        assert "old_backends" in pkg_cls.deprecated_variants
+
+        assert not pkg_cls.has_variant("old_flag")
+        assert not pkg_cls.has_variant("shared")
+        assert not pkg_cls.has_variant("old_backends")
+        assert pkg_cls.has_variant("libs")
+        assert pkg_cls.has_variant("backends")
+
+    def test_deprecated_true_removal(self):
+        """Tests that variants using 'deprecated=True' are removed on deprecated variants
+        expansion.
+        """
+        spec = spack.spec.Spec("deprecated-variant-pkg+old_flag")
+        assert "old_flag" in spec.variants
+
+        spack.variant.expand_deprecated_variants(spec)
+        assert "old_flag" not in spec.variants
+
+    @pytest.mark.parametrize(
+        "deprecated,substitute",
+        [
+            # Bool variants
+            ("+shared", "libs=shared"),
+            ("~shared", "libs=static"),
+            # Multi-value variants
+            ("old_backends=a,b", "backends=alpha,beta"),
+        ],
+    )
+    def test_deprecated_mapping(self, deprecated, substitute):
+        """Tests mapping of deprecated variants to new variants."""
+        spec = spack.spec.Spec(f"deprecated-variant-pkg {deprecated}")
+        assert spec.satisfies(deprecated)
+        assert not spec.satisfies(substitute)
+
+        spack.variant.expand_deprecated_variants(spec)
+        assert not spec.satisfies(deprecated)
+        assert spec.satisfies(substitute)
+
+    def test_deprecated_propagation(self):
+        """Tests that propagation carries over from deprecated variant to replacement."""
+        spec = spack.spec.Spec("deprecated-variant-pkg ++shared")
+        assert spec.variants["shared"].propagate is True
+        assert "libs" not in spec.variants
+
+        spack.variant.expand_deprecated_variants(spec)
+        assert spec.variants["libs"].propagate is True
+        assert "shared" not in spec.variants
+
+    def test_deprecated_noop_when_no_deprecated_variants_set(self):
+        """Tests that expansion is a no when no deprecated variants are present on the spec"""
+        spec = spack.spec.Spec("deprecated-variant-pkg libs=static")
+        expanded_spec = spec.copy()
+        spack.variant.expand_deprecated_variants(expanded_spec)
+        assert spec == expanded_spec
+
+    @pytest.mark.parametrize("attr_name", ["prefer", "require"])
+    def test_config_parse_specs_expands_deprecated(self, mutable_config, attr_name):
+        """Tests that we can expand deprecated variants from config"""
+        packages_yaml = syaml.load_config(
+            f"""
+    packages:
+      deprecated-variant-pkg:
+        {attr_name}:
+        - +shared
+    """
+        )
+        mutable_config.set("packages", packages_yaml["packages"])
+
+        s = concretize_one("deprecated-variant-pkg")
+        assert s.satisfies("libs:=shared")
+        assert "shared" not in s.variants
 
 
 def test_from_node_dict():

--- a/lib/spack/spack/test/variant.py
+++ b/lib/spack/spack/test/variant.py
@@ -361,6 +361,16 @@ class TestDeprecatedVariant:
         assert pkg_cls.has_variant("libs")
         assert pkg_cls.has_variant("backends")
 
+    def test_deprecated_mapping_stored_correctly(self, mock_packages):
+        """Tests that 'substitutions' is stored as 'mapping' in DeprecatedVariant."""
+        pkg_cls = mock_packages.get_pkg_class("deprecated-variant-pkg")
+
+        assert pkg_cls.deprecated_variants["old_flag"].mapping is None
+        assert pkg_cls.deprecated_variants["shared"].mapping == {
+            "+shared": "libs=shared",
+            "~shared": "libs=static",
+        }
+
     def test_deprecated_true_removal(self):
         """Tests that variants using 'deprecated=True' are removed on deprecated variants
         expansion.

--- a/lib/spack/spack/variant.py
+++ b/lib/spack/spack/variant.py
@@ -11,11 +11,13 @@ import enum
 import functools
 import inspect
 import itertools
+import warnings
 from typing import (
     TYPE_CHECKING,
     Any,
     Callable,
     Collection,
+    Dict,
     Iterable,
     List,
     Optional,
@@ -28,6 +30,7 @@ from typing import (
 import spack.error
 import spack.llnl.util.lang as lang
 import spack.llnl.util.tty.color
+import spack.repo
 import spack.spec_parser
 
 if TYPE_CHECKING:
@@ -810,6 +813,107 @@ def prevalidate_variant_value(
 
 class ConditionalVariantValues(lang.TypedMutableSequence):
     """A list, just with a different type"""
+
+
+class DeprecatedVariant:
+    """A variant that has been deprecated. Deprecated variants are accepted when parsing but
+    removed or substituted before concretization.
+    """
+
+    __slots__ = ("name", "mapping")
+
+    name: str
+    mapping: Optional[Dict[str, str]]
+
+    def __init__(self, name: str, mapping: Optional[Dict[str, str]] = None):
+        """
+        Args:
+            name: name of the deprecated variant
+            mapping:  if ``None`` the variant is simply dropped. If ``mapping`` is a dict, each key
+                is a condition and each value is a replacement. When the user's value satisfies a
+                key, the corresponding replacement constraint is applied.
+        """
+        self.name = name
+        self.mapping = mapping
+
+
+def _parse_spec_no_deprecated_expansion(text: str) -> "spack.spec.Spec":
+    """Parse a spec string without triggering deprecated variant expansion."""
+    parser = spack.spec_parser.SpecParser(text)
+    result = parser.next_spec()
+    if result is None:
+        raise InvalidVariantValueError(f"expected a single spec, but got none: {text}")
+    return result
+
+
+def expand_deprecated_variants(
+    spec: "spack.spec.Spec", *, origin: str = "the input spec", pkg_name: Optional[str] = None
+) -> None:
+    """Expand deprecated variants on every node of *spec* in-place.
+
+    For each node in the spec DAG, look up the package class and check whether any of the node's
+    variants are deprecated. Deprecated variants are removed and, if a mapping is provided,
+    replaced with the corresponding new constraints.
+
+    Warnings are emitted for every substitution or removal.
+
+    Args:
+        spec: the spec to expand in-place
+        origin: human-readable description of where the spec came from, used in warning messages
+        pkg_name: optional package name override, used when the spec is an anonymous constraint
+            (e.g. ``+shared`` from packages.yaml) but the target package is known from context
+    """
+    for node in list(spec.traverse()):
+        name = node.name or pkg_name
+        if not name:
+            continue
+
+        try:
+            pkg_cls = spack.repo.PATH.get_pkg_class(name)
+        except spack.repo.UnknownPackageError:
+            continue
+
+        deprecated = getattr(pkg_cls, "deprecated_variants", None)
+        if not deprecated:
+            continue
+
+        for dv_name, dv in list(deprecated.items()):
+            if dv_name not in node.variants:
+                continue
+
+            old_variant = node.variants[dv_name]
+            propagate = old_variant.propagate
+            header = f"variant '{dv_name}' of package '{name}' is deprecated"
+
+            # Easy case: just remove the variant
+            if dv.mapping is None:
+                del node.variants[dv_name]
+                warnings.warn(f"{header}: remove '{old_variant}' {origin}")
+                continue
+
+            # More complicated: map each match to a replacement
+            replacements = []
+            for key, replacement in dv.mapping.items():
+                key_spec = _parse_spec_no_deprecated_expansion(f"{name} {key}")
+                key_vv = key_spec.variants[dv_name]
+                if old_variant.satisfies(key_vv):
+                    replacements.append(replacement)
+
+            # Remove the deprecated variant
+            del node.variants[dv_name]
+
+            # Apply each replacement constraint
+            for repl in replacements:
+                repl_spec = _parse_spec_no_deprecated_expansion(f"{name} {repl}")
+                # Carry over propagation from the original variant
+                if propagate:
+                    for vv in repl_spec.variants.values():
+                        vv.propagate = True
+                node.constrain(repl_spec)
+
+            warnings.warn(
+                f"{header}. Substitute '{old_variant}' {origin} with '{', '.join(replacements)}'"
+            )
 
 
 class DuplicateVariantError(spack.error.SpecError):

--- a/lib/spack/spack/variant.py
+++ b/lib/spack/spack/variant.py
@@ -837,15 +837,6 @@ class DeprecatedVariant:
         self.mapping = mapping
 
 
-def _parse_spec_no_deprecated_expansion(text: str) -> "spack.spec.Spec":
-    """Parse a spec string without triggering deprecated variant expansion."""
-    parser = spack.spec_parser.SpecParser(text)
-    result = parser.next_spec()
-    if result is None:
-        raise InvalidVariantValueError(f"expected a single spec, but got none: {text}")
-    return result
-
-
 def expand_deprecated_variants(
     spec: "spack.spec.Spec", *, origin: str = "the input spec", pkg_name: Optional[str] = None
 ) -> None:
@@ -863,7 +854,7 @@ def expand_deprecated_variants(
         pkg_name: optional package name override, used when the spec is an anonymous constraint
             (e.g. ``+shared`` from packages.yaml) but the target package is known from context
     """
-    for node in list(spec.traverse()):
+    for node in spec.traverse():
         name = node.name or pkg_name
         if not name:
             continue
@@ -877,7 +868,7 @@ def expand_deprecated_variants(
         if not deprecated:
             continue
 
-        for dv_name, dv in list(deprecated.items()):
+        for dv_name, dv in deprecated.items():
             if dv_name not in node.variants:
                 continue
 
@@ -894,7 +885,7 @@ def expand_deprecated_variants(
             # More complicated: map each match to a replacement
             replacements = []
             for key, replacement in dv.mapping.items():
-                key_spec = _parse_spec_no_deprecated_expansion(f"{name} {key}")
+                key_spec = spack.spec_parser.parse_one_or_raise(f"{name} {key}")
                 key_vv = key_spec.variants[dv_name]
                 if old_variant.satisfies(key_vv):
                     replacements.append(replacement)
@@ -904,7 +895,7 @@ def expand_deprecated_variants(
 
             # Apply each replacement constraint
             for repl in replacements:
-                repl_spec = _parse_spec_no_deprecated_expansion(f"{name} {repl}")
+                repl_spec = spack.spec_parser.parse_one_or_raise(f"{name} {repl}")
                 # Carry over propagation from the original variant
                 if propagate:
                     for vv in repl_spec.variants.values():

--- a/var/spack/test_repos/spack_repo/builtin_mock/packages/deprecated_variant_pkg/package.py
+++ b/var/spack/test_repos/spack_repo/builtin_mock/packages/deprecated_variant_pkg/package.py
@@ -1,0 +1,37 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class DeprecatedVariantPkg(Package):
+    homepage = "http://www.example.com"
+    url = "http://www.example.com/deprecated-variant-pkg-1.0.tar.gz"
+
+    version("1.0", sha256="abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890")
+
+    # Case 1: deprecated=True (just remove)
+    variant("old_flag", default=True, deprecated=True)
+
+    # Case 2: bool variant with mapping
+    variant(
+        "shared", default=True, deprecated={"+shared": "libs=shared", "~shared": "libs=static"}
+    )
+
+    # The replacement variant for shared
+    variant("libs", default="shared", values=("shared", "static"), multi=False)
+
+    # Case 3: multi-valued variant with per-value mapping
+    variant(
+        "old_backends",
+        default="none",
+        values=("a", "b", "c", "none"),
+        multi=True,
+        deprecated={
+            "old_backends=a": "backends=alpha",
+            "old_backends=b": "backends=beta",
+            "old_backends=c": "backends=gamma",
+        },
+    )
+    variant("backends", default="none", values=("alpha", "beta", "gamma", "none"), multi=True)

--- a/var/spack/test_repos/spack_repo/builtin_mock/packages/deprecated_variant_pkg/package.py
+++ b/var/spack/test_repos/spack_repo/builtin_mock/packages/deprecated_variant_pkg/package.py
@@ -16,7 +16,10 @@ class DeprecatedVariantPkg(Package):
 
     # Case 2: bool variant with mapping
     variant(
-        "shared", default=True, deprecated={"+shared": "libs=shared", "~shared": "libs=static"}
+        "shared",
+        default=True,
+        deprecated=True,
+        substitutions={"+shared": "libs=shared", "~shared": "libs=static"},
     )
 
     # The replacement variant for shared
@@ -28,7 +31,8 @@ class DeprecatedVariantPkg(Package):
         default="none",
         values=("a", "b", "c", "none"),
         multi=True,
-        deprecated={
+        deprecated=True,
+        substitutions={
             "old_backends=a": "backends=alpha",
             "old_backends=b": "backends=beta",
             "old_backends=c": "backends=gamma",


### PR DESCRIPTION
fixes #38829

When a package needs to rename or remove a variant, users who have the old variant in CLI commands, environment files, or `packages.yaml` currently get hard errors. 

This feature makes the transition from old variant to new variant less painful.  Old variants are transformed or removed before being used for concretization, and a warning is emitted pointing users to the source of the deprecated usage.

### Changes

The `deprecated` and `substitutions` parameters have been added to the `variant()` directive for graceful variant deprecation:
  - `deprecated=True` marks the variant as deprecated
  - `substitutions={mapping}` (optional) translates old variant values to new constraints (e.g., `+shared` -> `libs=shared`)

Expansion happens at CLI parsing, environment spec lists, and `packages.yaml` requirements. 

The warning message includes provenance, which can be either `command line`, or `packages.yaml` with file path and line number, or environment spec list.

### Usage in packages

```python       
# Simple removal
variant("old_flag", ..., deprecated=True)

# Mapping
variant("shared", ..., deprecated=True, substitutions={"+shared": "libs=shared", "~shared": "libs=static"})
variant("libs", default="shared", values=("shared", "static"), multi=True)
```

### Example

This example stems from the following diff:
```diff
diff --git a/repos/spack_repo/builtin/packages/openblas/package.py b/repos/spack_repo/builtin/packages/openblas/package.py
index fa4ae8ec90..790b4e436a 100644
--- a/repos/spack_repo/builtin/packages/openblas/package.py
+++ b/repos/spack_repo/builtin/packages/openblas/package.py
@@ -111,7 +111,8 @@ class Openblas(CMakePackage, MakefilePackage):
 
     variant("ilp64", default=False, description="Force 64-bit Fortran native integers")
     variant("pic", default=True, description="Build position independent code")
-    variant("shared", default=True, description="Build shared libraries")
+    variant("shared", default=True, description="Build shared libraries", deprecated=True, substitutions={"+shared": "libs=shared", "~shared": "libs=static"})
+    variant("libs", default="shared", multi=True, values=("shared", "static"), description="Build shared libraries")
     variant(
         "dynamic_dispatch",
         default=True,
```

<img width="3191" height="298" alt="2026-03-20_10-41" src="https://github.com/user-attachments/assets/d7b89137-b4f9-48ea-ace9-1d0ef98846a6" />

### Not implemented here

Deprecated variants are not expanded in directives etc. to avoid slowing down / complicate each and every parse. Currently we catch inconsistencies in CI using audits:
```
$ spack audit packages cepgen
PKG-DIRECTIVES: 1 issue found
1. cepgen: wrong variant used for dependency in 'depends_on()'
    No such variant 'shared' in package openblas
    in /home/culpo/spack-packages/repos/spack_repo/builtin/packages/cepgen/package.py
```
which should be sufficient.
