### PR TITLE
darwin: use forkserver when using new installer

### DIFF
--- a/lib/spack/spack/main.py
+++ b/lib/spack/spack/main.py
@@ -1122,6 +1122,14 @@ def main(argv=None):
             the executable name. If None, parses from sys.argv.
 
     """
+    if (
+        sys.platform == "darwin"
+        and multiprocessing.get_start_method(allow_none=True) is None
+        and spack.config.get("config:installer") == "new"
+    ):
+        # Forkserver is significantly faster than spawn. This has to be configured once and early
+        # in the process.
+        multiprocessing.set_start_method("forkserver")
     # When using the forkserver start method, preload the following modules to improve startup
     # time of child processes.
     multiprocessing.set_forkserver_preload(["spack.main", "spack.package", "spack.new_installer"])


### PR DESCRIPTION
Forkserver improves subprocess startup time compared to spawn, and should be fork-safe.

Using `spack install --fake`, which measures mostly latency, I see the following:

From 2.961s to 1.136s on my macbook.

I believe this should be safe, given that we don't create threads or SSL context objects at import time, etc.