### PR TITLE
views: collapse unique subtrees in symlink case

### DIFF
--- a/lib/spack/docs/environments.rst
+++ b/lib/spack/docs/environments.rst
@@ -1107,6 +1107,7 @@ The root specs with their (transitive) link and run type dependencies will be pu
            all: "{name}/{version}-{compiler.name}"
          link: all
          link_type: symlink
+         link_dirs: true
 
 The default for the ``select`` and ``exclude`` values is to select everything and exclude nothing.
 The default projection is the default view projection (``{}``).
@@ -1117,6 +1118,13 @@ The ``link`` attribute allows the following values:
 #. ``link: roots`` include root specs without their dependencies.
 
 The ``link_type`` defaults to ``symlink`` but can also take the value of ``hardlink`` or ``copy``.
+
+.. versionadded:: 1.2
+
+   The ``link_dirs`` option controls whether directories are symlinked. This is the default
+   behavior in Spack v1.2 and later. This is an optimization that significantly reduces the time
+   to create views, and reduces the inode usage of the view. It only applies when ``link_type``
+   is set to ``symlink``. If you want to link only non-directory files, set ``link_dirs: false``.
 
 .. tip::
 

--- a/lib/spack/spack/environment/environment.py
+++ b/lib/spack/spack/environment/environment.py
@@ -705,6 +705,7 @@ class ViewDescriptor:
         exclude: Optional[List[str]] = None,
         link: str = default_view_link,
         link_type: fsv.LinkType = "symlink",
+        link_dirs: bool = True,
         groups: Optional[Union[str, List[str]]] = None,
     ) -> None:
         self.base = base_path
@@ -714,6 +715,7 @@ class ViewDescriptor:
         self.select = select or []
         self.exclude = exclude or []
         self.link_type: fsv.LinkType = fsv.canonicalize_link_type(link_type)
+        self.link_dirs: bool = link_type == "symlink" and link_dirs
         self.link = link
         if isinstance(groups, str):
             groups = [groups]
@@ -730,15 +732,15 @@ class ViewDescriptor:
         self.root = spack.util.path.canonicalize_path(new_path, default_wd=self.base)
 
     def __eq__(self, other: object) -> bool:
-        return isinstance(other, ViewDescriptor) and all(
-            [
-                self.root == other.root,
-                self.projections == other.projections,
-                self.select == other.select,
-                self.exclude == other.exclude,
-                self.link == other.link,
-                self.link_type == other.link_type,
-            ]
+        return (
+            isinstance(other, ViewDescriptor)
+            and self.root == other.root
+            and self.projections == other.projections
+            and self.select == other.select
+            and self.exclude == other.exclude
+            and self.link == other.link
+            and self.link_type == other.link_type
+            and self.link_dirs == other.link_dirs
         )
 
     def to_dict(self):
@@ -751,6 +753,8 @@ class ViewDescriptor:
             ret["exclude"] = self.exclude
         if self.link_type:
             ret["link_type"] = self.link_type
+        if self.link_dirs:
+            ret["link_dirs"] = self.link_dirs
         if self.link != default_view_link:
             ret["link"] = self.link
         return ret
@@ -765,6 +769,7 @@ class ViewDescriptor:
             exclude=d.get("exclude", []),
             link=d.get("link", default_view_link),
             link_type=d.get("link_type", "symlink"),
+            link_dirs=d.get("link_dirs", True),
             groups=d.get("group", None),
         )
 
@@ -829,6 +834,7 @@ class ViewDescriptor:
             ignore_conflicts=True,
             projections=self.projections,
             link_type=self.link_type,
+            link_dirs=self.link_dirs,
         )
 
     def __contains__(self, spec):

--- a/lib/spack/spack/filesystem_view.py
+++ b/lib/spack/spack/filesystem_view.py
@@ -3,7 +3,6 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 import functools as ft
-import itertools
 import os
 import re
 import shutil
@@ -39,8 +38,8 @@ from spack.llnl.util.link_tree import (
     DestinationMergeVisitor,
     LinkTree,
     MergeConflictSummary,
+    MultiPrefixMerger,
     SingleMergeConflictError,
-    SourceMergeVisitor,
 )
 from spack.llnl.util.tty.color import colorize
 
@@ -165,6 +164,7 @@ class FilesystemView:
         ignore_conflicts: bool = False,
         verbose: bool = False,
         link_type: LinkType = "symlink",
+        link_dirs: bool = False,
     ):
         """
         Initialize a filesystem view under the given ``root`` directory with
@@ -182,6 +182,7 @@ class FilesystemView:
         # Setup link function to include view
         self.link_type = link_type
         self._link = function_for_link_type(link_type)
+        self.link_dirs = link_dirs and link_type == "symlink"
 
     def link(self, src: str, dst: str, spec: Optional[spack.spec.Spec] = None) -> None:
         self._link(src, dst, self, spec)
@@ -714,13 +715,16 @@ class SimpleFilesystemView(FilesystemView):
         # Determine if the root is on a case-insensitive filesystem
         normalize_paths = is_folder_on_case_insensitive_filesystem(self._root)
 
-        visitor = SourceMergeVisitor(ignore=skip_list, normalize_paths=normalize_paths)
-
-        # Gather all the directories to be made and files to be linked
-        for spec in specs:
-            src_prefix = spec.package.view_source()
-            visitor.set_projection(self.get_relative_projection_for_spec(spec))
-            visit_directory_tree(src_prefix, visitor)
+        sources = [
+            (spec.package.view_source(), self.get_relative_projection_for_spec(spec))
+            for spec in specs
+        ]
+        visitor = MultiPrefixMerger(
+            sources,
+            ignore=skip_list,
+            normalize_paths=normalize_paths,
+            dir_symlink_optimization=self.link_dirs,
+        )
 
         # Check for conflicts in destination dir.
         visit_directory_tree(self._root, DestinationMergeVisitor(visitor))
@@ -754,21 +758,17 @@ class SimpleFilesystemView(FilesystemView):
         # Finally create the metadata dirs.
         self.link_metadata(specs)
 
-    def _source_merge_visitor_to_merge_map(self, visitor: SourceMergeVisitor):
+    def _source_merge_visitor_to_merge_map(self, visitor: MultiPrefixMerger):
         # For compatibility with add_files_to_view, we have to create a
         # merge_map of the form join(src_root, src_rel) => join(dst_root, dst_rel),
         # but our visitor.files format is dst_rel => (src_root, src_rel).
-        # We exploit that visitor.files is an ordered dict, and files per source
-        # prefix are contiguous.
-        source_root = lambda item: item[1][0]
-        per_source = itertools.groupby(visitor.files.items(), key=source_root)
-        return {
-            src_root: {
-                os.path.join(src_root, src_rel): os.path.join(self._root, dst_rel)
-                for dst_rel, (_, src_rel) in group
-            }
-            for src_root, group in per_source
-        }
+        merge_map: Dict[str, Dict[str, str]] = {}
+        for dst_rel, (src_root, src_rel) in visitor.files.items():
+            per_source = merge_map.get(src_root)
+            if per_source is None:
+                per_source = merge_map[src_root] = {}
+            per_source[os.path.join(src_root, src_rel)] = os.path.join(self._root, dst_rel)
+        return merge_map
 
     def relative_metadata_dir_for_spec(self, spec):
         return os.path.join(
@@ -778,15 +778,14 @@ class SimpleFilesystemView(FilesystemView):
         )
 
     def link_metadata(self, specs):
-        metadata_visitor = SourceMergeVisitor()
-
-        for spec in specs:
-            src_prefix = os.path.join(
-                spec.package.view_source(), spack.store.STORE.layout.metadata_dir
+        prefix_and_projection = [
+            (
+                os.path.join(spec.package.view_source(), spack.store.STORE.layout.metadata_dir),
+                self.relative_metadata_dir_for_spec(spec),
             )
-            proj = self.relative_metadata_dir_for_spec(spec)
-            metadata_visitor.set_projection(proj)
-            visit_directory_tree(src_prefix, metadata_visitor)
+            for spec in specs
+        ]
+        metadata_visitor = MultiPrefixMerger(prefix_and_projection)
 
         # Check for conflicts in destination dir.
         visit_directory_tree(self._root, DestinationMergeVisitor(metadata_visitor))

--- a/lib/spack/spack/llnl/util/link_tree.py
+++ b/lib/spack/spack/llnl/util/link_tree.py
@@ -7,7 +7,8 @@
 import filecmp
 import os
 import shutil
-from typing import Callable, Dict, List, Optional, Tuple
+from pathlib import Path
+from typing import Callable, Dict, List, Optional, Sequence, Tuple, Union
 
 import spack.llnl.util.filesystem as fs
 import spack.llnl.util.tty as tty
@@ -57,7 +58,7 @@ FileEntry = Tuple[int, str, str, bool]
 #: (index, src_root, rel_path)
 DirEntry = Tuple[int, str, str]
 
-PrefixAndProjection = Tuple[str, str]
+PrefixAndProjection = Union[Union[str, Path], Tuple[Union[str, Path], Union[str, Path]]]
 
 
 class MultiPrefixMerger:
@@ -66,14 +67,14 @@ class MultiPrefixMerger:
 
     def __init__(
         self,
-        sources: List[PrefixAndProjection],
+        sources: Sequence[PrefixAndProjection],
         ignore: Optional[Callable[[str], bool]] = None,
         normalize_paths: bool = False,
         dir_symlink_optimization: bool = False,
     ):
         """
         Args:
-            sources: list of (src_root, projection) pairs
+            sources: list of source directories, or tuples of (source directory, projection) pairs
             ignore: optional callable(rel_path) -> bool to skip entries
             normalize_paths: whether to normalize paths for case-insensitive filesystems
             dir_symlink_optimization: whether to enable directory-level symlink optimization
@@ -118,8 +119,12 @@ class MultiPrefixMerger:
 
         # Group sources by projection
         projection_groups: Dict[str, List[str]] = {}
-        for src_root, projection in sources:
-            projection_groups.setdefault(projection, []).append(src_root)
+        for src in sources:
+            if isinstance(src, tuple):
+                src_root, projection = src
+            else:
+                src_root, projection = src, ""
+            projection_groups.setdefault(str(projection), []).append(str(src_root))
 
         # Process each projection group
         for projection, roots in projection_groups.items():

--- a/lib/spack/spack/llnl/util/link_tree.py
+++ b/lib/spack/spack/llnl/util/link_tree.py
@@ -51,21 +51,40 @@ def _samefile(a: str, b: str):
         return False
 
 
-class SourceMergeVisitor(fs.BaseDirectoryVisitor):
-    """
-    Visitor that produces actions:
-    - An ordered list of directories to create in dst
-    - A list of files to link in dst
-    - A list of merge conflicts in dst/
-    """
+#: (index, src_root, rel_path, is_symlink)
+FileEntry = Tuple[int, str, str, bool]
+
+#: (index, src_root, rel_path)
+DirEntry = Tuple[int, str, str]
+
+PrefixAndProjection = Tuple[str, str]
+
+
+class MultiPrefixMerger:
+    """Class that takes multiple pairs of prefixes and projections, and produces a list of
+    directories to create, files to link, and conflicts when merging them together."""
 
     def __init__(
-        self, ignore: Optional[Callable[[str], bool]] = None, normalize_paths: bool = False
+        self,
+        sources: List[PrefixAndProjection],
+        ignore: Optional[Callable[[str], bool]] = None,
+        normalize_paths: bool = False,
+        dir_symlink_optimization: bool = False,
     ):
+        """
+        Args:
+            sources: list of (src_root, projection) pairs
+            ignore: optional callable(rel_path) -> bool to skip entries
+            normalize_paths: whether to normalize paths for case-insensitive filesystems
+            dir_symlink_optimization: whether to enable directory-level symlink optimization
+        """
         self.ignore = ignore if ignore is not None else lambda f: False
 
         # On case-insensitive filesystems, normalize paths to detect duplications
         self.normalize_paths = normalize_paths
+
+        #: Whether to symlink directories unique to one source
+        self._dir_symlink_optimization = dir_symlink_optimization
 
         # When mapping <src root> to <dst root>/<projection>, we need to prepend the <projection>
         # bit to the relative path in the destination dir.
@@ -96,6 +115,17 @@ class SourceMergeVisitor(fs.BaseDirectoryVisitor):
         # If the visitor is configured to normalize paths, keep a map of
         # normalized path to: original path, root directory + relative path
         self._files_normalized: Dict[str, Tuple[str, str, str]] = {}
+
+        # Group sources by projection
+        projection_groups: Dict[str, List[str]] = {}
+        for src_root, projection in sources:
+            projection_groups.setdefault(projection, []).append(src_root)
+
+        # Process each projection group
+        for projection, roots in projection_groups.items():
+            self.set_projection(projection)
+            active = [(i, root, "") for i, root in enumerate(roots)]
+            self._simultaneous_recurse(active, 0)
 
     def _in_directories(self, proj_rel_path: str) -> bool:
         """
@@ -150,14 +180,6 @@ class SourceMergeVisitor(fs.BaseDirectoryVisitor):
         else:
             return (proj_rel_path, *self.files[proj_rel_path])
 
-    def _del_file(self, proj_rel_path: str):
-        """
-        Remove a file from the list of files
-        """
-        del self.files[proj_rel_path]
-        if self.normalize_paths:
-            del self._files_normalized[proj_rel_path.lower()]
-
     def _add_file(self, proj_rel_path: str, root: str, rel_path: str):
         """
         Add a file to the list of files
@@ -166,113 +188,6 @@ class SourceMergeVisitor(fs.BaseDirectoryVisitor):
         self.files[proj_rel_path] = (root, rel_path)
         if self.normalize_paths:
             self._files_normalized[proj_rel_path.lower()] = (proj_rel_path, root, rel_path)
-
-    def before_visit_dir(self, root: str, rel_path: str, depth: int) -> bool:
-        """
-        Register a directory if dst / rel_path is not blocked by a file or ignored.
-        """
-        proj_rel_path = os.path.join(self.projection, rel_path)
-
-        if self.ignore(rel_path):
-            # Don't recurse when dir is ignored.
-            return False
-        elif self._in_files(proj_rel_path):
-            # A file-dir conflict is fatal except if they're the same file (symlinked dir).
-            src_a = os.path.join(*self._file(proj_rel_path))
-            src_b = os.path.join(root, rel_path)
-
-            if not _samefile(src_a, src_b):
-                self.fatal_conflicts.append(
-                    MergeConflict(dst=proj_rel_path, src_a=src_a, src_b=src_b)
-                )
-                return False
-
-            # Remove the link in favor of the dir.
-            existing_proj_rel_path, _, _ = self._file(proj_rel_path)
-            self._del_file(existing_proj_rel_path)
-            self._add_directory(proj_rel_path, root, rel_path)
-            return True
-        elif self._in_directories(proj_rel_path):
-            # No new directory, carry on.
-            return True
-        else:
-            # Register new directory.
-            self._add_directory(proj_rel_path, root, rel_path)
-            return True
-
-    def before_visit_symlinked_dir(self, root: str, rel_path: str, depth: int) -> bool:
-        """
-        Replace symlinked dirs with actual directories when possible in low depths,
-        otherwise handle it as a file (i.e. we link to the symlink).
-
-        Transforming symlinks into dirs makes it more likely we can merge directories,
-        e.g. when <prefix>/lib -> <prefix>/subdir/lib.
-
-        We only do this when the symlink is pointing into a subdirectory from the
-        symlink's directory, to avoid potential infinite recursion; and only at a
-        constant level of nesting, to avoid potential exponential blowups in file
-        duplication.
-        """
-        if self.ignore(rel_path):
-            return False
-
-        # Only follow symlinked dirs in <prefix>/**/**/*
-        if depth > 1:
-            handle_as_dir = False
-        else:
-            # Only follow symlinked dirs when pointing deeper
-            src = os.path.join(root, rel_path)
-            real_parent = os.path.realpath(os.path.dirname(src))
-            real_child = os.path.realpath(src)
-            handle_as_dir = real_child.startswith(real_parent)
-
-        if handle_as_dir:
-            return self.before_visit_dir(root, rel_path, depth)
-
-        self.visit_file(root, rel_path, depth, symlink=True)
-        return False
-
-    def visit_file(self, root: str, rel_path: str, depth: int, *, symlink: bool = False) -> None:
-        proj_rel_path = os.path.join(self.projection, rel_path)
-
-        if self.ignore(rel_path):
-            pass
-        elif self._in_directories(proj_rel_path):
-            # Can't create a file where a dir is, unless they are the same file (symlinked dir),
-            # in which case we simply drop the symlink in favor of the actual dir.
-            src_a = os.path.join(*self._directory(proj_rel_path))
-            src_b = os.path.join(root, rel_path)
-            if not symlink or not _samefile(src_a, src_b):
-                self.fatal_conflicts.append(
-                    MergeConflict(dst=proj_rel_path, src_a=src_a, src_b=src_b)
-                )
-        elif self._in_files(proj_rel_path):
-            # When two files project to the same path, they conflict iff they are distinct.
-            # If they are the same (i.e. one links to the other), register regular files rather
-            # than symlinks. The reason is that in copy-type views, we need a copy of the actual
-            # file, not the symlink.
-            src_a = os.path.join(*self._file(proj_rel_path))
-            src_b = os.path.join(root, rel_path)
-            if not _samefile(src_a, src_b):
-                # Distinct files produce a conflict.
-                self.file_conflicts.append(
-                    MergeConflict(dst=proj_rel_path, src_a=src_a, src_b=src_b)
-                )
-                return
-
-            if not symlink:
-                # Remove the link in favor of the actual file. The del is necessary to maintain the
-                # order of the files dict, which is grouped by root.
-                existing_proj_rel_path, _, _ = self._file(proj_rel_path)
-                self._del_file(existing_proj_rel_path)
-                self._add_file(proj_rel_path, root, rel_path)
-        else:
-            # Otherwise register this file to be linked.
-            self._add_file(proj_rel_path, root, rel_path)
-
-    def visit_symlinked_file(self, root: str, rel_path: str, depth: int) -> None:
-        # Treat symlinked files as ordinary files (without "dereferencing")
-        self.visit_file(root, rel_path, depth, symlink=True)
 
     def set_projection(self, projection: str) -> None:
         self.projection = os.path.normpath(projection)
@@ -300,9 +215,156 @@ class SourceMergeVisitor(fs.BaseDirectoryVisitor):
                     )
                 )
 
+    def _simultaneous_recurse(self, active: List[Tuple[int, str, str]], depth: int) -> None:
+        """Recursively scan active sources simultaneously.
+
+        Args:
+            depth: current depth from source root (for symlinked dir handling)
+            active: list of (index, src_root, rel_path) tuples that have this directory
+        """
+        # Mapping of normalized entry names to their corresponding directory and file entries
+        entry_map: Dict[str, Tuple[List[DirEntry], List[FileEntry]]] = {}
+
+        for idx, src_root, rel_path in active:
+            scan_path = os.path.join(src_root, rel_path) if rel_path else src_root
+            try:
+                scanner = os.scandir(scan_path)
+            except OSError:
+                continue  # skip if we cannot list directory entries.
+
+            with scanner:
+                for dir_entry in scanner:
+                    name = dir_entry.name
+                    child_rel = os.path.join(rel_path, name) if rel_path else name
+
+                    if self.ignore(child_rel):
+                        continue
+
+                    is_link = dir_entry.is_symlink()
+                    try:
+                        is_dir = dir_entry.is_dir(follow_symlinks=True)
+                    except OSError:
+                        is_dir = False  # broken symlink is not a dir.
+
+                    norm_name = name.lower() if self.normalize_paths else name
+                    dirs, files = entry_map.setdefault(norm_name, ([], []))
+
+                    if is_dir and not is_link:
+                        dirs.append((idx, src_root, child_rel))
+                    elif is_dir and is_link:
+                        if self._should_follow_symlinked_dir(src_root, child_rel, depth):
+                            dirs.append((idx, src_root, child_rel))
+                        else:
+                            files.append((idx, src_root, child_rel, True))
+                    else:
+                        files.append((idx, src_root, child_rel, is_link))
+
+        # Process collected entries in sorted order
+        for norm_name in sorted(entry_map):
+            dirs, files = entry_map[norm_name]
+
+            # When dirs and files project to the same path, we have a potential fatal conflict.
+            if dirs and files:
+                rel_path = dirs[0][2]
+                dir_proj = os.path.join(self.projection, rel_path) if self.projection else rel_path
+                conflicts = self._dir_file_conflicts(dir_proj, dirs, files)
+
+                if not conflicts:
+                    # all files were symlinks to a dir at the same projected location, ignore them.
+                    files.clear()
+                else:
+                    # actual dir-file conflicts we cannot resolve.
+                    self.fatal_conflicts.extend(conflicts)
+                    continue
+
+            # Note: no elif. We now have either files or dirs.
+            if files:
+                self._handle_files(files)
+            elif dirs and self._handle_dirs(dirs, depth):
+                self._simultaneous_recurse(dirs, depth + 1)
+
+    def _should_follow_symlinked_dir(self, src_root: str, rel_path: str, depth: int) -> bool:
+        """Determine if a symlinked directory should be followed (treated as real dir)
+        or treated as a file."""
+        if depth > 1:
+            return False
+        src = os.path.join(src_root, rel_path)
+        real_parent = os.path.realpath(os.path.dirname(src))
+        real_child = os.path.realpath(src)
+        return real_child.startswith(real_parent)
+
+    def _handle_files(self, files: List[FileEntry]) -> None:
+        """Handle file entries that all map to the same projected path."""
+        # In case of resolvable conflicts (conflicting files are links to the same file)
+        # the best candidate for the source is the non-symlink file.
+
+        _, root, rel_path, is_symlink = files[0]
+        dst = os.path.join(self.projection, rel_path) if self.projection else rel_path
+        for _, other_root, other_rel_path, other_is_symlink in files[1:]:
+            first_path = os.path.join(root, rel_path)
+            other_path = os.path.join(other_root, other_rel_path)
+            if not _samefile(first_path, other_path):
+                # two distinct files project to the same path; this is a conflict.
+                self.file_conflicts.append(
+                    MergeConflict(dst=dst, src_a=first_path, src_b=other_path)
+                )
+            elif not other_is_symlink and is_symlink:
+                # if they are the same, prefer the non-symlink as the source.
+                root, rel_path, is_symlink = other_root, other_rel_path, other_is_symlink
+                dst = os.path.join(self.projection, rel_path) if self.projection else rel_path
+
+        self._add_file(dst, root, rel_path)
+
+    def _handle_dirs(self, dirs: List[DirEntry], depth: int) -> bool:
+        """Handle directory entries that all map to the same projected path.
+
+        Returns True if the caller should recurse deeper into this directory.
+        """
+        _, src_root, rel_path = dirs[0]
+        proj_child = os.path.join(self.projection, rel_path) if self.projection else rel_path
+        if self._dir_symlink_optimization and depth > 0 and len(dirs) == 1:
+            # Unique subtree optimization: if this directory is unique to one source, and we're
+            # using symlinks, and we're not at the root level, we simply symlink the directory
+            # rather than creating it in the view and recursing into it.
+            self._add_file(proj_child, src_root, rel_path)
+            return False
+        else:
+            # Subtree optimization not possible, register make dirs operations and recurse.
+            self._add_directory(proj_child, src_root, rel_path)
+            return True
+
+    def _dir_file_conflicts(
+        self, proj_child_rel: str, dirs: List[DirEntry], files: List[FileEntry]
+    ) -> Optional[List[MergeConflict]]:
+        """Handle dir-file conflicts at the same projected path."""
+        # We drop all symlinks that resolve to any of the directories that project to the same path
+        # For example the symlink `<prefix a>/include -> <prefix b>/include` is a resolvable
+        # conflict as we just keep `<view>/include` in the view. Notice that this is a very rare
+        # occurrence.
+        remaining_files = [
+            os.path.join(file_root, file_rel_path)
+            for _, file_root, file_rel_path, is_sym in files
+            if not is_sym
+            or not any(
+                _samefile(
+                    os.path.join(file_root, file_rel_path), os.path.join(dir_root, dir_rel_path)
+                )
+                for _, dir_root, dir_rel_path in dirs
+            )
+        ]
+        if not remaining_files:
+            return None
+        # Use the first dir is the representative dir to register conflicts.
+        _, src_root, rel_path = dirs[0]
+        dir_src = os.path.join(src_root, rel_path)
+        return [
+            MergeConflict(dst=proj_child_rel, src_a=dir_src, src_b=file_path)
+            for file_path in remaining_files
+        ]
+
 
 class DestinationMergeVisitor(fs.BaseDirectoryVisitor):
-    """DestinationMergeVisitor takes a SourceMergeVisitor and:
+    """DestinationMergeVisitor takes a MultiPrefixMerger and:
 
     a. registers additional conflicts when merging to the destination prefix
     b. removes redundant mkdir operations when directories already exist in the destination prefix.
@@ -311,7 +373,7 @@ class DestinationMergeVisitor(fs.BaseDirectoryVisitor):
     directories in the sources directories.
     """
 
-    def __init__(self, source_merge_visitor: SourceMergeVisitor):
+    def __init__(self, source_merge_visitor: MultiPrefixMerger):
         self.src = source_merge_visitor
 
     def before_visit_dir(self, root: str, rel_path: str, depth: int) -> bool:

--- a/lib/spack/spack/schema/view.py
+++ b/lib/spack/spack/schema/view.py
@@ -63,6 +63,12 @@ properties: Dict[str, Any] = {
                             "description": "How files are linked in the view: 'symlink' "
                             "(default), 'hardlink', or 'copy'",
                         },
+                        "link_dirs": {
+                            "type": "boolean",
+                            "description": "Whether to link directories in the view, or only files"
+                            " (default: true, only applicable when link_type is 'symlink')",
+                            "default": True,
+                        },
                         "select": {
                             "type": "array",
                             "items": {"type": "string"},

--- a/lib/spack/spack/test/conftest.py
+++ b/lib/spack/spack/test/conftest.py
@@ -21,7 +21,7 @@ import tempfile
 import textwrap
 import xml.etree.ElementTree
 from pathlib import Path
-from typing import Callable, List, Optional, Tuple
+from typing import Callable, List, Optional, Tuple, Union
 
 import pytest
 
@@ -2582,3 +2582,34 @@ def installer_variant(request):
         pytest.skip("New installer not supported on Windows")
     with spack.config.override("config:installer", request.param):
         yield request.param
+
+
+class FsTree:
+    class symlink:
+        def __init__(self, target):
+            self.target = target
+
+    class file:
+        def __init__(self, content: Union[bytes, str] = b""):
+            self.content = content
+
+    class dir:
+        pass
+
+    def __init__(self, base_path: Path, layout: dict):
+        for rel_path, content in layout.items():
+            p = base_path / rel_path
+            p.parent.mkdir(parents=True, exist_ok=True)
+
+            assert isinstance(content, (self.symlink, self.file, self.dir))
+
+            if isinstance(content, self.dir):
+                p.mkdir(exist_ok=True)
+            elif isinstance(content, self.symlink):
+                p.symlink_to(content.target)
+            elif isinstance(content, self.file):
+                assert isinstance(content.content, (bytes, str))
+                if isinstance(content.content, bytes):
+                    p.write_bytes(content.content)
+                elif isinstance(content.content, str):
+                    p.write_text(content.content, encoding="utf-8")

--- a/lib/spack/spack/test/env.py
+++ b/lib/spack/spack/test/env.py
@@ -291,7 +291,12 @@ spack:
       link_type: symlink
 """,
             "./another-view",
-            {"root": "./another-view", "select": ["%gcc"], "link_type": "symlink"},
+            {
+                "root": "./another-view",
+                "select": ["%gcc"],
+                "link_type": "symlink",
+                "link_dirs": True,
+            },
         ),
         (
             """
@@ -305,7 +310,7 @@ spack:
       link_type: symlink
 """,
             True,
-            {"root": "./view-gcc", "select": ["%gcc"], "link_type": "symlink"},
+            {"root": "./view-gcc", "select": ["%gcc"], "link_type": "symlink", "link_dirs": True},
         ),
     ],
 )

--- a/lib/spack/spack/test/llnl/util/link_tree.py
+++ b/lib/spack/spack/test/llnl/util/link_tree.py
@@ -220,7 +220,7 @@ def test_source_merge_visitor_does_not_follow_symlinked_dirs_at_depth(tmp_path: 
         with open(j("a", "b", "c", "d", "file"), "wb"):
             pass
 
-    visitor = MultiPrefixMerger([(str(tmp_path), "")])
+    visitor = MultiPrefixMerger([tmp_path])
     assert [p for p in visitor.files.keys()] == [
         j("a", "b", "c", "d", "file"),
         j("a", "b", "c", "symlink_d"),  # treated as a file, not expanded
@@ -263,7 +263,7 @@ def test_source_merge_visitor_cant_be_cyclical(tmp_path: pathlib.Path):
         symlink(j("symlink_b"), j("a", "symlink_b_b"))
         symlink(j("..", "a"), j("b", "symlink_a"))
 
-    visitor = MultiPrefixMerger([(str(tmp_path), "")])
+    visitor = MultiPrefixMerger([tmp_path])
     assert [p for p in visitor.files.keys()] == [
         j("a", "symlink_b"),
         j("a", "symlink_b_b"),
@@ -296,7 +296,7 @@ def test_destination_merge_visitor_always_errors_on_symlinked_dirs(tmp_path: pat
             pass
         os.symlink("..", "example_b")
 
-    visitor = MultiPrefixMerger([(str(src_path), "")])
+    visitor = MultiPrefixMerger([src_path])
     visit_directory_tree(str(dst_path), DestinationMergeVisitor(visitor))
 
     assert visitor.fatal_conflicts
@@ -319,12 +319,12 @@ def test_destination_merge_visitor_file_dir_clashes(tmp_path: pathlib.Path):
         with open("example", "wb"):
             pass
 
-    a_to_b = MultiPrefixMerger([(str(a_path), "")])
+    a_to_b = MultiPrefixMerger([a_path])
     visit_directory_tree(str(b_path), DestinationMergeVisitor(a_to_b))
     assert a_to_b.fatal_conflicts
     assert a_to_b.fatal_conflicts[0].dst == "example"
 
-    b_to_a = MultiPrefixMerger([(str(b_path), "")])
+    b_to_a = MultiPrefixMerger([b_path])
     visit_directory_tree(str(a_path), DestinationMergeVisitor(b_to_a))
     assert b_to_a.fatal_conflicts
     assert b_to_a.fatal_conflicts[0].dst == "example"
@@ -352,18 +352,12 @@ def test_source_merge_visitor_handles_same_file_gracefully(
     (tmp_path / "b" / "bar").write_bytes(b"hello")
 
     visitor_1 = MultiPrefixMerger(
-        [
-            (str(tmp_path / "a"), str(tmp_path / "view")),
-            (str(tmp_path / "b"), str(tmp_path / "view")),
-        ],
+        [(tmp_path / "a", tmp_path / "view"), (tmp_path / "b", tmp_path / "view")],
         normalize_paths=normalize,
     )
 
     visitor_2 = MultiPrefixMerger(
-        [
-            (str(tmp_path / "b"), str(tmp_path / "view")),
-            (str(tmp_path / "a"), str(tmp_path / "view")),
-        ],
+        [(tmp_path / "b", tmp_path / "view"), (tmp_path / "a", tmp_path / "view")],
         normalize_paths=normalize,
     )
 
@@ -391,10 +385,7 @@ def test_source_merge_visitor_deals_with_dangling_symlinks(tmp_path: pathlib.Pat
     (tmp_path / "dir_b" / "file").write_bytes(b"data")
 
     visitor = MultiPrefixMerger(
-        [
-            (str(tmp_path / "dir_a"), str(tmp_path / "view")),
-            (str(tmp_path / "dir_b"), str(tmp_path / "view")),
-        ]
+        [(tmp_path / "dir_a", tmp_path / "view"), (tmp_path / "dir_b", tmp_path / "view")]
     )
 
     # Check that a conflict was registered.
@@ -415,9 +406,7 @@ def test_source_visitor_file_file(tmp_path: pathlib.Path, normalize: bool):
     (tmp_path / "a" / "file").write_bytes(b"")
     (tmp_path / "b" / "FILE").write_bytes(b"")
 
-    v = MultiPrefixMerger(
-        [(str(tmp_path / "a"), ""), (str(tmp_path / "b"), "")], normalize_paths=normalize
-    )
+    v = MultiPrefixMerger([tmp_path / "a", tmp_path / "b"], normalize_paths=normalize)
 
     if normalize:
         assert len(v.files) == 1
@@ -438,12 +427,8 @@ def test_source_visitor_file_dir(tmp_path: pathlib.Path, normalize: bool):
     (tmp_path / "a" / "file").write_bytes(b"")
     (tmp_path / "b").mkdir()
     (tmp_path / "b" / "FILE").mkdir()
-    v1 = MultiPrefixMerger(
-        [(str(tmp_path / "a"), ""), (str(tmp_path / "b"), "")], normalize_paths=normalize
-    )
-    v2 = MultiPrefixMerger(
-        [(str(tmp_path / "b"), ""), (str(tmp_path / "a"), "")], normalize_paths=normalize
-    )
+    v1 = MultiPrefixMerger([tmp_path / "a", tmp_path / "b"], normalize_paths=normalize)
+    v2 = MultiPrefixMerger([tmp_path / "b", tmp_path / "a"], normalize_paths=normalize)
 
     assert not v1.file_conflicts and not v2.file_conflicts
 
@@ -463,9 +448,7 @@ def test_source_visitor_dir_dir(tmp_path: pathlib.Path, normalize: bool):
     (tmp_path / "a" / "dir").mkdir()
     (tmp_path / "b").mkdir()
     (tmp_path / "b" / "DIR").mkdir()
-    v = MultiPrefixMerger(
-        [(str(tmp_path / "a"), ""), (str(tmp_path / "b"), "")], normalize_paths=normalize
-    )
+    v = MultiPrefixMerger([tmp_path / "a", tmp_path / "b"], normalize_paths=normalize)
 
     assert not v.files
     assert not v.fatal_conflicts
@@ -486,7 +469,7 @@ def test_dst_visitor_file_file(tmp_path: pathlib.Path, normalize: bool):
     (tmp_path / "a" / "file").write_bytes(b"")
     (tmp_path / "b" / "FILE").write_bytes(b"")
 
-    src = MultiPrefixMerger([(str(tmp_path / "a"), "")], normalize_paths=normalize)
+    src = MultiPrefixMerger([tmp_path / "a"], normalize_paths=normalize)
     visit_directory_tree(str(tmp_path / "b"), DestinationMergeVisitor(src))
 
     assert len(src.files) == 1
@@ -507,9 +490,9 @@ def test_dst_visitor_file_dir(tmp_path: pathlib.Path, normalize: bool):
     (tmp_path / "a" / "file").write_bytes(b"")
     (tmp_path / "b").mkdir()
     (tmp_path / "b" / "FILE").mkdir()
-    src1 = MultiPrefixMerger([(str(tmp_path / "a"), "")], normalize_paths=normalize)
+    src1 = MultiPrefixMerger([tmp_path / "a"], normalize_paths=normalize)
     visit_directory_tree(str(tmp_path / "b"), DestinationMergeVisitor(src1))
-    src2 = MultiPrefixMerger([(str(tmp_path / "b"), "")], normalize_paths=normalize)
+    src2 = MultiPrefixMerger([tmp_path / "b"], normalize_paths=normalize)
     visit_directory_tree(str(tmp_path / "a"), DestinationMergeVisitor(src2))
 
     assert len(src1.files) == 1
@@ -554,9 +537,7 @@ def test_unique_subdir_optimization(tmp_path: pathlib.Path):
         },
     )
 
-    visitor = MultiPrefixMerger(
-        sources=[(str(src_a), ""), (str(src_b), "")], dir_symlink_optimization=True
-    )
+    visitor = MultiPrefixMerger(sources=[src_a, src_b], dir_symlink_optimization=True)
 
     assert not visitor.fatal_conflicts
     assert not visitor.file_conflicts
@@ -601,9 +582,7 @@ def test_unique_subdir_optimization_disabled(tmp_path: pathlib.Path):
 
     FsTree(tmp_path, {"a/lib/a/liba.so": FsTree.file(b"a"), "b/lib/b/libb.so": FsTree.file(b"b")})
 
-    visitor = MultiPrefixMerger(
-        sources=[(str(src_a), ""), (str(src_b), "")], dir_symlink_optimization=False
-    )
+    visitor = MultiPrefixMerger(sources=[src_a, src_b], dir_symlink_optimization=False)
 
     assert not visitor.fatal_conflicts
     assert not visitor.file_conflicts
@@ -626,7 +605,7 @@ def test_projection_dirs_created(tmp_path: pathlib.Path):
 
     FsTree(tmp_path, {"a/file.txt": FsTree.file(b"a")})
 
-    visitor = MultiPrefixMerger(sources=[(str(src_a), "proj/sub")], dir_symlink_optimization=True)
+    visitor = MultiPrefixMerger(sources=[(src_a, "proj/sub")], dir_symlink_optimization=True)
 
     assert "proj" in visitor.directories
     assert os.path.join("proj", "sub") in visitor.directories

--- a/lib/spack/spack/test/llnl/util/link_tree.py
+++ b/lib/spack/spack/test/llnl/util/link_tree.py
@@ -20,6 +20,7 @@ from spack.llnl.util.filesystem import (
     working_dir,
 )
 from spack.llnl.util.link_tree import DestinationMergeVisitor, LinkTree, MultiPrefixMerger
+from spack.test.conftest import FsTree
 
 
 @pytest.fixture
@@ -535,30 +536,23 @@ def test_unique_subdir_optimization(tmp_path: pathlib.Path):
     src_a = tmp_path / "a"
     src_b = tmp_path / "b"
 
-    # shared dir: lib (exists in both) -- depth 0, shared
-    (src_a / "lib").mkdir(parents=True)
-    (src_a / "lib" / "liba.so").write_bytes(b"a")
-    (src_b / "lib").mkdir(parents=True)
-    (src_b / "lib" / "libb.so").write_bytes(b"b")
-
-    # shared dir: share (exists in both) -- depth 0, shared
-    # but unique subdirs at depth 1
-    (src_a / "share").mkdir()
-    (src_a / "share" / "app_a").mkdir()
-    (src_a / "share" / "app_a" / "data.txt").write_bytes(b"a")
-    (src_a / "share" / "app_a" / "sub").mkdir()
-    (src_a / "share" / "app_a" / "sub" / "deep.txt").write_bytes(b"deep")
-    (src_b / "share").mkdir()
-    (src_b / "share" / "app_b").mkdir()
-    (src_b / "share" / "app_b" / "info.txt").write_bytes(b"b")
-
-    # unique dir: include (only in a) -- depth 0, unique but NOT collapsed
-    (src_a / "include").mkdir()
-    (src_a / "include" / "a.h").write_bytes(b"a")
-
-    # unique dir: bin (only in b) -- depth 0, unique but NOT collapsed
-    (src_b / "bin").mkdir()
-    (src_b / "bin" / "prog").write_bytes(b"p")
+    FsTree(
+        tmp_path,
+        {
+            # shared dir: lib (exists in both) -- depth 0, shared
+            "a/lib/liba.so": FsTree.file(b"a"),
+            "b/lib/libb.so": FsTree.file(b"b"),
+            # shared dir: share (exists in both) -- depth 0, shared
+            # but unique subdirs at depth 1
+            "a/share/app_a/data.txt": FsTree.file(b"a"),
+            "a/share/app_a/sub/deep.txt": FsTree.file(b"deep"),
+            "b/share/app_b/info.txt": FsTree.file(b"b"),
+            # unique dir: include (only in a) -- depth 0, unique but NOT collapsed
+            "a/include/a.h": FsTree.file(b"a"),
+            # unique dir: bin (only in b) -- depth 0, unique but NOT collapsed
+            "b/bin/prog": FsTree.file(b"p"),
+        },
+    )
 
     visitor = MultiPrefixMerger(
         sources=[(str(src_a), ""), (str(src_b), "")], dir_symlink_optimization=True
@@ -605,10 +599,7 @@ def test_unique_subdir_optimization_disabled(tmp_path: pathlib.Path):
     src_a = tmp_path / "a"
     src_b = tmp_path / "b"
 
-    (src_a / "lib" / "a").mkdir(parents=True)
-    (src_a / "lib" / "a" / "liba.so").write_bytes(b"a")
-    (src_b / "lib" / "b").mkdir(parents=True)
-    (src_b / "lib" / "b" / "libb.so").write_bytes(b"b")
+    FsTree(tmp_path, {"a/lib/a/liba.so": FsTree.file(b"a"), "b/lib/b/libb.so": FsTree.file(b"b")})
 
     visitor = MultiPrefixMerger(
         sources=[(str(src_a), ""), (str(src_b), "")], dir_symlink_optimization=False
@@ -632,8 +623,8 @@ def test_unique_subdir_optimization_disabled(tmp_path: pathlib.Path):
 def test_projection_dirs_created(tmp_path: pathlib.Path):
     """Projection directories should be registered."""
     src_a = tmp_path / "a"
-    (src_a).mkdir()
-    (src_a / "file.txt").write_bytes(b"a")
+
+    FsTree(tmp_path, {"a/file.txt": FsTree.file(b"a")})
 
     visitor = MultiPrefixMerger(sources=[(str(src_a), "proj/sub")], dir_symlink_optimization=True)
 

--- a/lib/spack/spack/test/llnl/util/link_tree.py
+++ b/lib/spack/spack/test/llnl/util/link_tree.py
@@ -19,7 +19,7 @@ from spack.llnl.util.filesystem import (
     visit_directory_tree,
     working_dir,
 )
-from spack.llnl.util.link_tree import DestinationMergeVisitor, LinkTree, SourceMergeVisitor
+from spack.llnl.util.link_tree import DestinationMergeVisitor, LinkTree, MultiPrefixMerger
 
 
 @pytest.fixture
@@ -219,8 +219,7 @@ def test_source_merge_visitor_does_not_follow_symlinked_dirs_at_depth(tmp_path: 
         with open(j("a", "b", "c", "d", "file"), "wb"):
             pass
 
-    visitor = SourceMergeVisitor()
-    visit_directory_tree(str(tmp_path), visitor)
+    visitor = MultiPrefixMerger([(str(tmp_path), "")])
     assert [p for p in visitor.files.keys()] == [
         j("a", "b", "c", "d", "file"),
         j("a", "b", "c", "symlink_d"),  # treated as a file, not expanded
@@ -263,8 +262,7 @@ def test_source_merge_visitor_cant_be_cyclical(tmp_path: pathlib.Path):
         symlink(j("symlink_b"), j("a", "symlink_b_b"))
         symlink(j("..", "a"), j("b", "symlink_a"))
 
-    visitor = SourceMergeVisitor()
-    visit_directory_tree(str(tmp_path), visitor)
+    visitor = MultiPrefixMerger([(str(tmp_path), "")])
     assert [p for p in visitor.files.keys()] == [
         j("a", "symlink_b"),
         j("a", "symlink_b_b"),
@@ -297,8 +295,7 @@ def test_destination_merge_visitor_always_errors_on_symlinked_dirs(tmp_path: pat
             pass
         os.symlink("..", "example_b")
 
-    visitor = SourceMergeVisitor()
-    visit_directory_tree(str(src_path), visitor)
+    visitor = MultiPrefixMerger([(str(src_path), "")])
     visit_directory_tree(str(dst_path), DestinationMergeVisitor(visitor))
 
     assert visitor.fatal_conflicts
@@ -321,14 +318,12 @@ def test_destination_merge_visitor_file_dir_clashes(tmp_path: pathlib.Path):
         with open("example", "wb"):
             pass
 
-    a_to_b = SourceMergeVisitor()
-    visit_directory_tree(str(a_path), a_to_b)
+    a_to_b = MultiPrefixMerger([(str(a_path), "")])
     visit_directory_tree(str(b_path), DestinationMergeVisitor(a_to_b))
     assert a_to_b.fatal_conflicts
     assert a_to_b.fatal_conflicts[0].dst == "example"
 
-    b_to_a = SourceMergeVisitor()
-    visit_directory_tree(str(b_path), b_to_a)
+    b_to_a = MultiPrefixMerger([(str(b_path), "")])
     visit_directory_tree(str(a_path), DestinationMergeVisitor(b_to_a))
     assert b_to_a.fatal_conflicts
     assert b_to_a.fatal_conflicts[0].dst == "example"
@@ -355,15 +350,21 @@ def test_source_merge_visitor_handles_same_file_gracefully(
     (tmp_path / "b" / u("dir")).symlink_to(tmp_path / "a" / "dir")
     (tmp_path / "b" / "bar").write_bytes(b"hello")
 
-    visitor_1 = SourceMergeVisitor(normalize_paths=normalize)
-    visitor_1.set_projection(str(tmp_path / "view"))
-    for p in ("a", "b"):
-        visit_directory_tree(str(tmp_path / p), visitor_1)
+    visitor_1 = MultiPrefixMerger(
+        [
+            (str(tmp_path / "a"), str(tmp_path / "view")),
+            (str(tmp_path / "b"), str(tmp_path / "view")),
+        ],
+        normalize_paths=normalize,
+    )
 
-    visitor_2 = SourceMergeVisitor(normalize_paths=normalize)
-    visitor_2.set_projection(str(tmp_path / "view"))
-    for p in ("b", "a"):
-        visit_directory_tree(str(tmp_path / p), visitor_2)
+    visitor_2 = MultiPrefixMerger(
+        [
+            (str(tmp_path / "b"), str(tmp_path / "view")),
+            (str(tmp_path / "a"), str(tmp_path / "view")),
+        ],
+        normalize_paths=normalize,
+    )
 
     assert not visitor_1.file_conflicts and not visitor_2.file_conflicts
     assert not visitor_1.fatal_conflicts and not visitor_2.fatal_conflicts
@@ -388,11 +389,12 @@ def test_source_merge_visitor_deals_with_dangling_symlinks(tmp_path: pathlib.Pat
     (tmp_path / "dir_b").mkdir()
     (tmp_path / "dir_b" / "file").write_bytes(b"data")
 
-    visitor = SourceMergeVisitor()
-    visitor.set_projection(str(tmp_path / "view"))
-
-    visit_directory_tree(str(tmp_path / "dir_a"), visitor)
-    visit_directory_tree(str(tmp_path / "dir_b"), visitor)
+    visitor = MultiPrefixMerger(
+        [
+            (str(tmp_path / "dir_a"), str(tmp_path / "view")),
+            (str(tmp_path / "dir_b"), str(tmp_path / "view")),
+        ]
+    )
 
     # Check that a conflict was registered.
     assert len(visitor.file_conflicts) == 1
@@ -412,9 +414,9 @@ def test_source_visitor_file_file(tmp_path: pathlib.Path, normalize: bool):
     (tmp_path / "a" / "file").write_bytes(b"")
     (tmp_path / "b" / "FILE").write_bytes(b"")
 
-    v = SourceMergeVisitor(normalize_paths=normalize)
-    for p in ("a", "b"):
-        visit_directory_tree(str(tmp_path / p), v)
+    v = MultiPrefixMerger(
+        [(str(tmp_path / "a"), ""), (str(tmp_path / "b"), "")], normalize_paths=normalize
+    )
 
     if normalize:
         assert len(v.files) == 1
@@ -435,12 +437,12 @@ def test_source_visitor_file_dir(tmp_path: pathlib.Path, normalize: bool):
     (tmp_path / "a" / "file").write_bytes(b"")
     (tmp_path / "b").mkdir()
     (tmp_path / "b" / "FILE").mkdir()
-    v1 = SourceMergeVisitor(normalize_paths=normalize)
-    for p in ("a", "b"):
-        visit_directory_tree(str(tmp_path / p), v1)
-    v2 = SourceMergeVisitor(normalize_paths=normalize)
-    for p in ("b", "a"):
-        visit_directory_tree(str(tmp_path / p), v2)
+    v1 = MultiPrefixMerger(
+        [(str(tmp_path / "a"), ""), (str(tmp_path / "b"), "")], normalize_paths=normalize
+    )
+    v2 = MultiPrefixMerger(
+        [(str(tmp_path / "b"), ""), (str(tmp_path / "a"), "")], normalize_paths=normalize
+    )
 
     assert not v1.file_conflicts and not v2.file_conflicts
 
@@ -460,9 +462,9 @@ def test_source_visitor_dir_dir(tmp_path: pathlib.Path, normalize: bool):
     (tmp_path / "a" / "dir").mkdir()
     (tmp_path / "b").mkdir()
     (tmp_path / "b" / "DIR").mkdir()
-    v = SourceMergeVisitor(normalize_paths=normalize)
-    for p in ("a", "b"):
-        visit_directory_tree(str(tmp_path / p), v)
+    v = MultiPrefixMerger(
+        [(str(tmp_path / "a"), ""), (str(tmp_path / "b"), "")], normalize_paths=normalize
+    )
 
     assert not v.files
     assert not v.fatal_conflicts
@@ -483,8 +485,7 @@ def test_dst_visitor_file_file(tmp_path: pathlib.Path, normalize: bool):
     (tmp_path / "a" / "file").write_bytes(b"")
     (tmp_path / "b" / "FILE").write_bytes(b"")
 
-    src = SourceMergeVisitor(normalize_paths=normalize)
-    visit_directory_tree(str(tmp_path / "a"), src)
+    src = MultiPrefixMerger([(str(tmp_path / "a"), "")], normalize_paths=normalize)
     visit_directory_tree(str(tmp_path / "b"), DestinationMergeVisitor(src))
 
     assert len(src.files) == 1
@@ -505,11 +506,9 @@ def test_dst_visitor_file_dir(tmp_path: pathlib.Path, normalize: bool):
     (tmp_path / "a" / "file").write_bytes(b"")
     (tmp_path / "b").mkdir()
     (tmp_path / "b" / "FILE").mkdir()
-    src1 = SourceMergeVisitor(normalize_paths=normalize)
-    visit_directory_tree(str(tmp_path / "a"), src1)
+    src1 = MultiPrefixMerger([(str(tmp_path / "a"), "")], normalize_paths=normalize)
     visit_directory_tree(str(tmp_path / "b"), DestinationMergeVisitor(src1))
-    src2 = SourceMergeVisitor(normalize_paths=normalize)
-    visit_directory_tree(str(tmp_path / "b"), src2)
+    src2 = MultiPrefixMerger([(str(tmp_path / "b"), "")], normalize_paths=normalize)
     visit_directory_tree(str(tmp_path / "a"), DestinationMergeVisitor(src2))
 
     assert len(src1.files) == 1
@@ -527,3 +526,117 @@ def test_dst_visitor_file_dir(tmp_path: pathlib.Path, normalize: bool):
     else:
         assert not src1.fatal_conflicts and not src2.fatal_conflicts
         assert not src1.file_conflicts and not src2.file_conflicts
+
+
+def test_unique_subdir_optimization(tmp_path: pathlib.Path):
+    """A subdirectory at depth > 0 unique to one prefix should be registered as a single file
+    entry (to be symlinked as a directory) in symlink mode, not recursed into. Top-level (depth 0)
+    dirs are always recursed into."""
+    src_a = tmp_path / "a"
+    src_b = tmp_path / "b"
+
+    # shared dir: lib (exists in both) -- depth 0, shared
+    (src_a / "lib").mkdir(parents=True)
+    (src_a / "lib" / "liba.so").write_bytes(b"a")
+    (src_b / "lib").mkdir(parents=True)
+    (src_b / "lib" / "libb.so").write_bytes(b"b")
+
+    # shared dir: share (exists in both) -- depth 0, shared
+    # but unique subdirs at depth 1
+    (src_a / "share").mkdir()
+    (src_a / "share" / "app_a").mkdir()
+    (src_a / "share" / "app_a" / "data.txt").write_bytes(b"a")
+    (src_a / "share" / "app_a" / "sub").mkdir()
+    (src_a / "share" / "app_a" / "sub" / "deep.txt").write_bytes(b"deep")
+    (src_b / "share").mkdir()
+    (src_b / "share" / "app_b").mkdir()
+    (src_b / "share" / "app_b" / "info.txt").write_bytes(b"b")
+
+    # unique dir: include (only in a) -- depth 0, unique but NOT collapsed
+    (src_a / "include").mkdir()
+    (src_a / "include" / "a.h").write_bytes(b"a")
+
+    # unique dir: bin (only in b) -- depth 0, unique but NOT collapsed
+    (src_b / "bin").mkdir()
+    (src_b / "bin" / "prog").write_bytes(b"p")
+
+    visitor = MultiPrefixMerger(
+        sources=[(str(src_a), ""), (str(src_b), "")], dir_symlink_optimization=True
+    )
+
+    assert not visitor.fatal_conflicts
+    assert not visitor.file_conflicts
+
+    # depth 0 unique dirs should be recursed into (directories), not collapsed
+    assert "include" in visitor.directories
+    assert "include" not in visitor.files
+    assert os.path.join("include", "a.h") in visitor.files
+    assert "bin" in visitor.directories
+    assert "bin" not in visitor.files
+    assert os.path.join("bin", "prog") in visitor.files
+
+    # "lib" should be a directory (shared), with individual files inside
+    assert "lib" in visitor.directories
+    assert os.path.join("lib", "liba.so") in visitor.files
+    assert os.path.join("lib", "libb.so") in visitor.files
+
+    # depth 1 unique subdirs under shared parent should be collapsed (dir-level symlinks)
+    assert "share" in visitor.directories
+    assert os.path.join("share", "app_a") in visitor.files
+    assert visitor.files[os.path.join("share", "app_a")] == (
+        str(src_a),
+        os.path.join("share", "app_a"),
+    )
+    assert os.path.join("share", "app_b") in visitor.files
+    assert visitor.files[os.path.join("share", "app_b")] == (
+        str(src_b),
+        os.path.join("share", "app_b"),
+    )
+
+    # Subdirs of collapsed dirs should NOT appear in directories
+    assert os.path.join("share", "app_a") not in visitor.directories
+    assert os.path.join("share", "app_a", "sub") not in visitor.directories
+    assert os.path.join("share", "app_b") not in visitor.directories
+
+
+def test_unique_subdir_optimization_disabled(tmp_path: pathlib.Path):
+    """For hardlink/copy views, unique subdirs should NOT be dir-level symlinks;
+    individual files should be registered instead."""
+    src_a = tmp_path / "a"
+    src_b = tmp_path / "b"
+
+    (src_a / "lib" / "a").mkdir(parents=True)
+    (src_a / "lib" / "a" / "liba.so").write_bytes(b"a")
+    (src_b / "lib" / "b").mkdir(parents=True)
+    (src_b / "lib" / "b" / "libb.so").write_bytes(b"b")
+
+    visitor = MultiPrefixMerger(
+        sources=[(str(src_a), ""), (str(src_b), "")], dir_symlink_optimization=False
+    )
+
+    assert not visitor.fatal_conflicts
+    assert not visitor.file_conflicts
+
+    # Check that all files are there
+    assert "lib" in visitor.directories
+    assert os.path.join("lib", "a") in visitor.directories
+    assert os.path.join("lib", "b") in visitor.directories
+    assert os.path.join("lib", "a", "liba.so") in visitor.files
+    assert os.path.join("lib", "b", "libb.so") in visitor.files
+
+    # No dirs are symlinked.
+    assert os.path.join("lib", "a") not in visitor.files
+    assert os.path.join("lib", "b") not in visitor.files
+
+
+def test_projection_dirs_created(tmp_path: pathlib.Path):
+    """Projection directories should be registered."""
+    src_a = tmp_path / "a"
+    (src_a).mkdir()
+    (src_a / "file.txt").write_bytes(b"a")
+
+    visitor = MultiPrefixMerger(sources=[(str(src_a), "proj/sub")], dir_symlink_optimization=True)
+
+    assert "proj" in visitor.directories
+    assert os.path.join("proj", "sub") in visitor.directories
+    assert os.path.join("proj", "sub", "file.txt") in visitor.files

--- a/lib/spack/spack/test/views.py
+++ b/lib/spack/spack/test/views.py
@@ -66,3 +66,99 @@ def test_view_with_spec_not_contributing_files(mock_packages, tmp_path: pathlib.
     view.add_specs(a, b)
     assert os.path.lexists(os.path.join(view_dir, "file"))
     assert os.path.lexists(os.path.join(view_dir, "subdir", "file"))
+
+
+def test_view_unique_subdir_becomes_dir_symlink(mock_packages, tmp_path: pathlib.Path):
+    """With link_dirs=True, if a directory is only contributed to by a single spec, the view
+    should create a symlink to that directory instead of linking individual files."""
+    view_dir = str(tmp_path / "view")
+    os.mkdir(view_dir)
+
+    layout = DirectoryLayout(view_dir)
+    view = SimpleFilesystemView(view_dir, layout, link_type="symlink", link_dirs=True)
+
+    a = Spec("pkg-a")
+    b = Spec("pkg-b")
+    a.set_prefix(str(tmp_path / "a"))
+    b.set_prefix(str(tmp_path / "b"))
+    a._mark_concrete()
+    b._mark_concrete()
+
+    # Create directory structures with .spack metadata
+    os.makedirs(os.path.join(a.prefix, ".spack"))
+    os.makedirs(os.path.join(b.prefix, ".spack"))
+
+    # Shared dir: lib (in both)
+    os.makedirs(os.path.join(a.prefix, "lib"))
+    os.makedirs(os.path.join(b.prefix, "lib"))
+    with open(os.path.join(a.prefix, "lib", "liba.so"), "w", encoding="utf-8") as f:
+        f.write("a")
+    with open(os.path.join(b.prefix, "lib", "libb.so"), "w", encoding="utf-8") as f:
+        f.write("b")
+
+    # Unique dir: include (only in a) with nested content
+    os.makedirs(os.path.join(a.prefix, "include", "a"))
+    with open(os.path.join(a.prefix, "include", "a", "a.h"), "w", encoding="utf-8") as f:
+        f.write("header_a")
+
+    # Unique dir but at depth 0, not deep enough to be symlinked.
+    os.makedirs(os.path.join(a.prefix, "bin"))
+    with open(os.path.join(a.prefix, "bin", "a"), "w", encoding="utf-8") as f:
+        f.write("binary_a")
+
+    # Unique dir: bin (only in b)
+    os.makedirs(os.path.join(b.prefix, "include", "b"))
+    with open(os.path.join(b.prefix, "include", "b", "b.h"), "w", encoding="utf-8") as f:
+        f.write("header_b")
+
+    view.add_specs(a, b)
+
+    # Shared dir "lib" should be a real directory with individual file symlinks
+    lib_dir = os.path.join(view_dir, "lib")
+    assert os.path.isdir(lib_dir) and not os.path.islink(lib_dir)
+    assert os.path.islink(os.path.join(lib_dir, "liba.so"))
+    assert os.path.islink(os.path.join(lib_dir, "libb.so"))
+
+    # Unique dir "include/a" should be a directory symlink
+    include_link = os.path.join(view_dir, "include", "a")
+    assert os.path.islink(include_link)
+    assert os.path.isdir(include_link)
+    assert os.path.isfile(os.path.join(include_link, "a.h"))
+
+    # Unique dir "include/b" should be a directory symlink pointing to b's include
+    include_b_link = os.path.join(view_dir, "include", "b")
+    assert os.path.islink(include_b_link)
+    assert os.path.isdir(include_b_link)
+    assert os.path.isfile(os.path.join(include_b_link, "b.h"))
+
+    # Unique dir "bin/" is too shallow to be symlinked, so should be an actual dir.
+    assert os.path.islink(os.path.join(view_dir, "bin")) is False
+    assert os.path.isdir(os.path.join(view_dir, "bin"))
+    assert os.path.islink(os.path.join(view_dir, "bin", "a"))
+
+
+def test_view_no_dir_symlinks(mock_packages, tmp_path: pathlib.Path):
+    """With link_dirs=False, no directies are symlinked."""
+    view_dir = str(tmp_path / "view")
+    os.mkdir(view_dir)
+
+    layout = DirectoryLayout(view_dir)
+    view = SimpleFilesystemView(view_dir, layout, link_type="symlink", link_dirs=False)
+
+    a = Spec("pkg-a")
+    a.set_prefix(str(tmp_path / "a"))
+    a._mark_concrete()
+
+    os.makedirs(os.path.join(a.prefix, ".spack"))
+    os.makedirs(os.path.join(a.prefix, "include", "a"))
+    with open(os.path.join(a.prefix, "include", "a", "a.h"), "w", encoding="utf-8") as f:
+        f.write("header")
+
+    view.add_specs(a)
+
+    # "include/a" should be a real directory, not a symlink
+    include_dir = os.path.join(view_dir, "include", "a")
+    assert os.path.isdir(include_dir) and not os.path.islink(include_dir)
+    # File should be a symlink.
+    ah_path = os.path.join(include_dir, "a.h")
+    assert os.path.islink(ah_path)

--- a/lib/spack/spack/test/views.py
+++ b/lib/spack/spack/test/views.py
@@ -12,6 +12,7 @@ from spack.directory_layout import DirectoryLayout
 from spack.filesystem_view import SimpleFilesystemView, YamlFilesystemView
 from spack.installer import PackageInstaller
 from spack.spec import Spec
+from spack.test.conftest import FsTree
 
 
 def test_remove_extensions_ordered(install_mockery, mock_fetch, tmp_path: pathlib.Path):
@@ -84,32 +85,22 @@ def test_view_unique_subdir_becomes_dir_symlink(mock_packages, tmp_path: pathlib
     a._mark_concrete()
     b._mark_concrete()
 
-    # Create directory structures with .spack metadata
-    os.makedirs(os.path.join(a.prefix, ".spack"))
-    os.makedirs(os.path.join(b.prefix, ".spack"))
-
-    # Shared dir: lib (in both)
-    os.makedirs(os.path.join(a.prefix, "lib"))
-    os.makedirs(os.path.join(b.prefix, "lib"))
-    with open(os.path.join(a.prefix, "lib", "liba.so"), "w", encoding="utf-8") as f:
-        f.write("a")
-    with open(os.path.join(b.prefix, "lib", "libb.so"), "w", encoding="utf-8") as f:
-        f.write("b")
-
-    # Unique dir: include (only in a) with nested content
-    os.makedirs(os.path.join(a.prefix, "include", "a"))
-    with open(os.path.join(a.prefix, "include", "a", "a.h"), "w", encoding="utf-8") as f:
-        f.write("header_a")
-
-    # Unique dir but at depth 0, not deep enough to be symlinked.
-    os.makedirs(os.path.join(a.prefix, "bin"))
-    with open(os.path.join(a.prefix, "bin", "a"), "w", encoding="utf-8") as f:
-        f.write("binary_a")
-
-    # Unique dir: bin (only in b)
-    os.makedirs(os.path.join(b.prefix, "include", "b"))
-    with open(os.path.join(b.prefix, "include", "b", "b.h"), "w", encoding="utf-8") as f:
-        f.write("header_b")
+    FsTree(
+        tmp_path,
+        {
+            # metadata dirs for both
+            "a/.spack": FsTree.dir(),
+            "b/.spack": FsTree.dir(),
+            # shared dir "lib" with different files in each
+            "a/lib/liba.so": FsTree.file(),
+            "b/lib/libb.so": FsTree.file(),
+            # unique dir "include/a" and "include/b" with nested content
+            "a/include/a/a.h": FsTree.file(),
+            "b/include/b/b.h": FsTree.file(),
+            # unique dir "bin" but at depth 0, so not deep enough to be symlinked
+            "a/bin/a": FsTree.file(),
+        },
+    )
 
     view.add_specs(a, b)
 
@@ -149,10 +140,7 @@ def test_view_no_dir_symlinks(mock_packages, tmp_path: pathlib.Path):
     a.set_prefix(str(tmp_path / "a"))
     a._mark_concrete()
 
-    os.makedirs(os.path.join(a.prefix, ".spack"))
-    os.makedirs(os.path.join(a.prefix, "include", "a"))
-    with open(os.path.join(a.prefix, "include", "a", "a.h"), "w", encoding="utf-8") as f:
-        f.write("header")
+    FsTree(tmp_path, {"a/.spack": FsTree.dir(), "a/include/a/a.h": FsTree.file("header")})
 
     view.add_specs(a)
 


### PR DESCRIPTION
Closes #51741

When a subdir is unique to a single spec's prefix, do not symlink each
file recursively but just symlink the dir.

Using simultaneous DFS on all prefixes this avoids many filesystem
operations.

Tried it on `py-black` with default views config.

Before:

```
% time     seconds  usecs/call     calls    errors syscall
------ ----------- ----------- --------- --------- ------------------
 81.21    0.445178          28     15610           symlink
  5.64    0.030944          26      1183           mkdir
  2.96    0.016201           5      3231           getdents64
  ...
------ ----------- ----------- --------- --------- ------------------
100.00    0.548202          14     36978      1647 total
```

After:

```
% time     seconds  usecs/call     calls    errors syscall
------ ----------- ----------- --------- --------- ------------------
 42.61    0.055549          23      2410           symlink
 10.51    0.013707          22       599           mkdir
  7.16    0.009340           4      2061           getdents64
  ...
------ ----------- ----------- --------- --------- ------------------
100.00    0.130372           6     20138      1645 total
```

So an 84% reduction in symlinks, 50% reduction in mkdirs, and 36% reduction in reading dir contents.

It's enabled by default, you can opt out with `view:<name>:link_dirs:false`.