### PR TITLE
Optional remote includes should not raise an error

### DIFF
--- a/lib/spack/spack/config.py
+++ b/lib/spack/spack/config.py
@@ -1380,20 +1380,12 @@ class GitIncludePaths(OptionalInclude):
         assert destination, f"{self} requires a local cache directory"
         tty.debug(f"Cloning {self.git} into {destination}")
 
-        with filesystem.working_dir(destination, create=True):
-            if not os.path.exists(".git"):
-                try:
+        try:
+            with filesystem.working_dir(destination, create=True):
+                if not os.path.exists(".git"):
                     tty.debug("Initializing the git repository")
                     spack.util.git.init_git_repo(self.git)
-                except spack.util.executable.ProcessError as e:
-                    msg = f"Unable to initialize repository ({self.git}) under {destination}: {e}"
-                    if self.optional:
-                        warnings.warn(msg)
-                        return None
-                    else:
-                        raise spack.error.ConfigError(msg)
 
-            try:
                 if self.commit:
                     tty.debug(f"Pulling commit {self.commit}")
                     spack.util.git.pull_checkout_commit(self.commit)
@@ -1414,21 +1406,20 @@ class GitIncludePaths(OptionalInclude):
                 else:
                     raise spack.error.ConfigError(f"Missing or unsupported options in {self}")
 
-            except spack.util.executable.ProcessError as e:
-                # Cleanup the destination if it exists
-                if os.path.exists(destination):
-                    shutil.rmtree(destination)
+        except spack.util.executable.ProcessError as e:
+            # Cleanup the destination if it exists
+            shutil.rmtree(destination, ignore_errors=True)
 
-                msg = f"Unable to check out repository ({self}) in {destination}: {e}"
-                if self.optional:
-                    warnings.warn(msg)
-                    return None
-                else:
-                    raise spack.error.ConfigError(msg)
+            msg = f"Unable to check out repository ({self}) in {destination}: {e}"
+            if self.optional:
+                warnings.warn(msg)
+                return None
+            else:
+                raise spack.error.ConfigError(msg)
 
-            # only set the destination on successful clone/checkout
-            self.destination = destination
-            return self.destination
+        # only set the destination on successful clone/checkout
+        self.destination = destination
+        return self.destination
 
     def fetched(self) -> bool:
         return bool(self.destination) and os.path.exists(

--- a/lib/spack/spack/config.py
+++ b/lib/spack/spack/config.py
@@ -1389,6 +1389,7 @@ class GitIncludePaths(OptionalInclude):
                     msg = f"Unable to initialize repository ({self.git}) under {destination}: {e}"
                     if self.optional:
                         warnings.warn(msg)
+                        return None
                     else:
                         raise spack.error.ConfigError(msg)
 
@@ -1414,13 +1415,16 @@ class GitIncludePaths(OptionalInclude):
                     raise spack.error.ConfigError(f"Missing or unsupported options in {self}")
 
             except spack.util.executable.ProcessError as e:
+                # Cleanup the destination if it exists
+                if os.path.exists(destination):
+                    shutil.rmtree(destination)
+
                 msg = f"Unable to check out repository ({self}) in {destination}: {e}"
                 if self.optional:
                     warnings.warn(msg)
+                    return None
                 else:
                     raise spack.error.ConfigError(msg)
-                # Cleanup the destination if it exists
-                shutil.rmtree(destination)
 
             # only set the destination on successful clone/checkout
             self.destination = destination
@@ -1455,6 +1459,8 @@ class GitIncludePaths(OptionalInclude):
 
         destination = self._clone(parent_scope)
         if not destination:
+            if self.optional:
+                return []
             raise spack.error.ConfigError(f"Unable to cache the include: {self}")
 
         scopes: List[ConfigScope] = []

--- a/lib/spack/spack/config.py
+++ b/lib/spack/spack/config.py
@@ -37,6 +37,7 @@ import re
 import shutil
 import sys
 import tempfile
+import warnings
 from collections import defaultdict
 from itertools import chain
 from typing import Any, Callable, Dict, Generator, List, Optional, Set, Tuple, Union, cast
@@ -164,7 +165,7 @@ class ConfigScope:
                 # Do not include duplicate scopes
                 for included_scope in included_scopes:
                     if any([included_scope.name == scope.name for scope in self._included_scopes]):
-                        tty.warn(f"Ignoring duplicate included scope: {included_scope.name}")
+                        warnings.warn(f"Ignoring duplicate included scope: {included_scope.name}")
                         continue
 
                     if included_scope not in self._included_scopes:
@@ -1292,12 +1293,12 @@ class IncludePath(OptionalInclude):
         try:
             config_path = rfc_util.local_path(self.path, self.sha256, base)
         except spack.error.FetchError as e:
-            tty.debug(f"Failed to fetch include at {self.path}: {e}")
+            warnings.warn(f"Failed to fetch include at {self.path}: {e}")
             if self.optional:
                 return []
 
             # If this is not an optional include, fail early for this error
-            raise spack.error.ConfigFileError("Failed to include non-optional config") from e
+            raise ConfigFileError("Failed to include non-optional config") from e
 
         self.destination = config_path
 
@@ -1366,6 +1367,9 @@ class GitIncludePaths(OptionalInclude):
             parent_scope: enclosing scope
 
         Returns: destination path if cloned or ``None``
+
+        Raises:
+            ConfigError: unable to create or clone the git repo
         """
         if self.fetched():
             tty.debug(f"Repository ({self.git}) already cloned to {self.destination}")
@@ -1384,7 +1388,7 @@ class GitIncludePaths(OptionalInclude):
                 except spack.util.executable.ProcessError as e:
                     msg = f"Unable to initialize repository ({self.git}) under {destination}: {e}"
                     if self.optional:
-                        tty.warn(msg)
+                        warnings.warn(msg)
                     else:
                         raise spack.error.ConfigError(msg)
 
@@ -1412,7 +1416,7 @@ class GitIncludePaths(OptionalInclude):
             except spack.util.executable.ProcessError as e:
                 msg = f"Unable to check out repository ({self}) in {destination}: {e}"
                 if self.optional:
-                    tty.warn(msg)
+                    warnings.warn(msg)
                 else:
                     raise spack.error.ConfigError(msg)
                 # Cleanup the destination if it exists

--- a/lib/spack/spack/config.py
+++ b/lib/spack/spack/config.py
@@ -34,6 +34,7 @@ import os
 import os.path
 import pathlib
 import re
+import shutil
 import sys
 import tempfile
 from collections import defaultdict
@@ -1288,8 +1289,16 @@ class IncludePath(OptionalInclude):
         # path for a local (or remote) file.
         tty.debug(f"Local base directory for {self.path} is {base}")
 
-        config_path = rfc_util.local_path(self.path, self.sha256, base)
-        assert config_path
+        try:
+            config_path = rfc_util.local_path(self.path, self.sha256, base)
+        except spack.error.FetchError as e:
+            tty.debug(f"Failed to fetch include at {self.path}: {e}")
+            if self.optional:
+                return []
+
+            # If this is not an optional include, fail early for this error
+            raise spack.error.ConfigFileError("Failed to include non-optional config") from e
+
         self.destination = config_path
 
         scope = self._scope(self.path, self.destination, parent_scope)
@@ -1373,9 +1382,11 @@ class GitIncludePaths(OptionalInclude):
                     tty.debug("Initializing the git repository")
                     spack.util.git.init_git_repo(self.git)
                 except spack.util.executable.ProcessError as e:
-                    raise spack.error.ConfigError(
-                        f"Unable to initialize repository ({self.git}) under {destination}: {e}"
-                    )
+                    msg = f"Unable to initialize repository ({self.git}) under {destination}: {e}"
+                    if self.optional:
+                        tty.warn(msg)
+                    else:
+                        raise spack.error.ConfigError(msg)
 
             try:
                 if self.commit:
@@ -1399,9 +1410,13 @@ class GitIncludePaths(OptionalInclude):
                     raise spack.error.ConfigError(f"Missing or unsupported options in {self}")
 
             except spack.util.executable.ProcessError as e:
-                raise spack.error.ConfigError(
-                    f"Unable to check out repository ({self}) in {destination}: {e}"
-                )
+                msg = f"Unable to check out repository ({self}) in {destination}: {e}"
+                if self.optional:
+                    tty.warn(msg)
+                else:
+                    raise spack.error.ConfigError(msg)
+                # Cleanup the destination if it exists
+                shutil.rmtree(destination)
 
             # only set the destination on successful clone/checkout
             self.destination = destination

--- a/lib/spack/spack/config.py
+++ b/lib/spack/spack/config.py
@@ -1293,7 +1293,7 @@ class IncludePath(OptionalInclude):
         try:
             config_path = rfc_util.local_path(self.path, self.sha256, base)
         except spack.error.FetchError as e:
-            warnings.warn(f"Failed to fetch include at {self.path}: {e}")
+            tty.debug(f"Failed to fetch include at {self.path}: {e}")
             if self.optional:
                 return []
 
@@ -1412,7 +1412,7 @@ class GitIncludePaths(OptionalInclude):
 
             msg = f"Unable to check out repository ({self}) in {destination}: {e}"
             if self.optional:
-                warnings.warn(msg)
+                tty.debug(msg)
                 return None
             else:
                 raise spack.error.ConfigError(msg)

--- a/lib/spack/spack/test/config.py
+++ b/lib/spack/spack/test/config.py
@@ -1990,7 +1990,7 @@ def test_included_path_git_errs(tmp_path: pathlib.Path, mock_low_high_config, mo
 
     monkeypatch.setattr(spack.util.git, "init_git_repo", _failing_init)
 
-    with pytest.raises(spack.error.ConfigError, match="Unable to initialize"):
+    with pytest.raises(spack.error.ConfigError, match="Unable to check out"):
         include.scopes(parent_scope)
 
     # fail in git config (so use default remote) *and* git checkout

--- a/lib/spack/spack/test/config.py
+++ b/lib/spack/spack/test/config.py
@@ -2016,6 +2016,59 @@ def test_included_path_git_errs(tmp_path: pathlib.Path, mock_low_high_config, mo
         include.scopes(parent_scope)
 
 
+def test_included_path_git_optional_quiet_errs(
+    tmp_path: pathlib.Path, mock_low_high_config, monkeypatch
+):
+    monkeypatch.setattr(spack.paths, "user_cache_path", str(tmp_path))
+
+    paths = ["concretizer.yaml"]
+    entry = {
+        "git": "https://example.com/linux/configs.git",
+        "branch": "develop",
+        "paths": paths,
+        "when": 'platform == "test"',
+        "optional": True,
+    }
+    include = spack.config.included_path(entry)
+    parent_scope = mock_low_high_config.scopes["low"]
+
+    # fail to initialize the repository
+    def _failing_init(*args, **kwargs):
+        raise spack.util.executable.ProcessError("mock init repo failure")
+
+    monkeypatch.setattr(spack.util.git, "init_git_repo", _failing_init)
+
+    # No error
+    scopes = include.scopes(parent_scope)
+    assert len(scopes) == len(paths)
+    assert all(s.name == "low:" + p for s, p in zip(scopes, paths))
+
+    # fail in git config (so use default remote) *and* git checkout
+    def _init_repo(*args, **kwargs):
+        fs.mkdirp(fs.join_path(include.destination, ".git"))
+
+    class MockIncludeGit(spack.util.executable.Executable):
+        def __init__(self, required: bool):
+            pass
+
+        def __call__(self, *args, **kwargs) -> str:  # type: ignore
+            raise spack.util.executable.ProcessError("mock git failure")
+
+    monkeypatch.setattr(spack.util.git, "init_git_repo", _init_repo)
+    monkeypatch.setattr(spack.util.git, "git", MockIncludeGit)
+
+    scopes = include.scopes(parent_scope)
+    assert len(scopes) == len(paths)
+    assert all(s.name == "low:" + p for s, p in zip(scopes, paths))
+
+    # set up invalid option failure
+    include.branch = ""  # type: ignore[union-attr]
+
+    scopes = include.scopes(parent_scope)
+    assert len(scopes) == len(paths)
+    assert all(s.name == "low:" + p for s, p in zip(scopes, paths))
+
+
 def test_missing_include_scope_list(mock_missing_dir_include_scopes):
     """Tests that an included scope with a non existent file/directory
     is still listed as a scope under spack.config.CONFIG.scopes"""

--- a/lib/spack/spack/test/config.py
+++ b/lib/spack/spack/test/config.py
@@ -2040,8 +2040,7 @@ def test_included_path_git_optional_quiet_errs(
 
     # No error
     scopes = include.scopes(parent_scope)
-    assert len(scopes) == len(paths)
-    assert all(s.name == "low:" + p for s, p in zip(scopes, paths))
+    assert len(scopes) == 0
 
     # fail in git config (so use default remote) *and* git checkout
     def _init_repo(*args, **kwargs):
@@ -2058,15 +2057,12 @@ def test_included_path_git_optional_quiet_errs(
     monkeypatch.setattr(spack.util.git, "git", MockIncludeGit)
 
     scopes = include.scopes(parent_scope)
-    assert len(scopes) == len(paths)
-    assert all(s.name == "low:" + p for s, p in zip(scopes, paths))
+    assert len(scopes) == 0
 
     # set up invalid option failure
     include.branch = ""  # type: ignore[union-attr]
-
-    scopes = include.scopes(parent_scope)
-    assert len(scopes) == len(paths)
-    assert all(s.name == "low:" + p for s, p in zip(scopes, paths))
+    with pytest.raises(spack.error.ConfigError):
+        _ = include.scopes(parent_scope)
 
 
 def test_missing_include_scope_list(mock_missing_dir_include_scopes):


### PR DESCRIPTION
Setting optional should make failures to setup a configuration include a non-fatal. This allows for running with included remote configs on isolated systems or pointing at private repos.

Instead of a hard error, the errors are converted to warnings when the included config is optional.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
