### PR TITLE
Spack Style: Support `--repo`

### DIFF
--- a/lib/spack/spack/cmd/style.py
+++ b/lib/spack/spack/cmd/style.py
@@ -737,10 +737,11 @@ def style(parser, args):
 
     # run over package repositories
     if repos:
+        repo_tools = [x for x in tools_to_run if x != "mypy"]
         for repo in repos:
             repo_list = repo_file_dict[repo]
-            print_style_header_repo(repo_list, repo, tools_to_run)
-            for tool_name in tools_to_run:
+            print_style_header_repo(repo_list, repo, repo_tools)
+            for tool_name in repo_tools:
                 tool = tools[tool_name]
                 tty.msg(f"Running {tool.name} checks")
                 return_code |= tool.fun(repo_list, args, repo)

--- a/lib/spack/spack/cmd/style.py
+++ b/lib/spack/spack/cmd/style.py
@@ -6,9 +6,12 @@ import ast
 import os
 import re
 import sys
+from collections import defaultdict
 from pathlib import Path
 from typing import Dict, List, Optional, Set, Union
 
+import spack.llnl.util.filesystem as fsys
+import spack.llnl.util.lang as slang
 import spack.llnl.util.tty as tty
 import spack.llnl.util.tty.color as color
 import spack.paths
@@ -19,6 +22,7 @@ from spack.cmd.common.spec_strings import (
     _spec_str_default_handler,
     _spec_str_fix_handler,
 )
+from spack.error import SpackError
 from spack.llnl.util.filesystem import working_dir
 from spack.util.executable import Executable, which
 
@@ -40,6 +44,8 @@ mypy_ignores = [
     # doesn't exist in mypy 0.971 for Python 3.6
     "[annotation-unchecked]"
 ]
+
+DEFAULT_REPO = "builtin"
 
 
 #: decorator for adding tools to the list
@@ -70,6 +76,55 @@ class tool:
 tools: Dict[str, tool] = {}
 
 
+@slang.memoized
+def get_git() -> Executable:
+    return spack.util.git.git(required=True)
+
+
+def get_repo_default_ref(repo: spack.repo.Repo) -> str:
+    git = get_git()
+    with fsys.working_dir(repo.root):
+        full_default = git(
+            "rev-parse", "--abbrev-ref", "origin/HEAD", fail_on_error=False, output=str
+        )
+    if git.returncode != 0:
+        raise RuntimeError("This repo is not a git repository")
+    return "/".join(full_default.strip("\n").split("/")[1:])
+
+
+def get_repo_git_root(repo: spack.repo.Repo):
+    git = get_git()
+    with fsys.working_dir(repo.root):
+        git_root = git("rev-parse", "--show-toplevel", fail_on_error=False, output=str, error=str)
+    if git.returncode != 0:
+        raise RuntimeError(f"Encountered an error running git on {repo}: {git_root}")
+    return Path(git_root.strip("\n"))
+
+
+def is_relative_to(path: Path, root: Union[Path, str]):
+    try:
+        rel_path = path.relative_to(root)
+    except ValueError:
+        rel_path = None
+    return bool(rel_path)
+
+
+def changed_files_repo(
+    repo: spack.repo.Repo, untracked=True, all_files: bool = False, root=None, base=None
+) -> List[Path]:
+    """Get list of changed files in given repo
+
+    Arguments:
+        repo: repo object for which to determine changed files
+        untracked: include untracked packages
+        all_packages: include all package files
+    """
+    if not base:
+        base = get_repo_default_ref(repo)
+    file_root = get_repo_git_root(repo)
+    return changed_files(root=file_root, base=base, untracked=untracked, all_files=all_files)
+
+
 def changed_files(base="develop", untracked=True, all_files=False, root=None) -> List[Path]:
     """Get list of changed files in the Spack repository.
 
@@ -82,56 +137,63 @@ def changed_files(base="develop", untracked=True, all_files=False, root=None) ->
     if root is None:
         root = spack.paths.prefix
 
-    git = spack.util.git.git(required=True)
+    git = get_git()
 
-    # ensure base is in the repo
-    base_sha = git(
-        "rev-parse", "--quiet", "--verify", "--revs-only", base, fail_on_error=False, output=str
-    )
-    if git.returncode != 0:
-        tty.die(
-            "This repository does not have a '%s' revision." % base,
-            "spack style needs this branch to determine which files changed.",
-            "Ensure that '%s' exists, or specify files to check explicitly." % base,
+    with fsys.working_dir(root):
+        # ensure base is in the repo
+        base_sha = git(
+            "rev-parse",
+            "--quiet",
+            "--verify",
+            "--revs-only",
+            base,
+            fail_on_error=False,
+            output=str,
         )
+        if git.returncode != 0:
+            tty.die(
+                "This repository does not have a '%s' revision." % base,
+                "spack style needs this branch to determine which files changed.",
+                "Ensure that '%s' exists, or specify files to check explicitly." % base,
+            )
 
-    range = "{0}...".format(base_sha.strip())
+        range = "{0}...".format(base_sha.strip())
 
-    git_args = [
-        # Add changed files committed since branching off of develop
-        ["diff", "--name-only", "--diff-filter=ACMR", range],
-        # Add changed files that have been staged but not yet committed
-        ["diff", "--name-only", "--diff-filter=ACMR", "--cached"],
-        # Add changed files that are unstaged
-        ["diff", "--name-only", "--diff-filter=ACMR"],
-    ]
+        git_args = [
+            # Add changed files committed since branching off of develop
+            ["diff", "--name-only", "--diff-filter=ACMR", range],
+            # Add changed files that have been staged but not yet committed
+            ["diff", "--name-only", "--diff-filter=ACMR", "--cached"],
+            # Add changed files that are unstaged
+            ["diff", "--name-only", "--diff-filter=ACMR"],
+        ]
 
-    # Add new files that are untracked
-    if untracked:
-        git_args.append(["ls-files", "--exclude-standard", "--other"])
+        # Add new files that are untracked
+        if untracked:
+            git_args.append(["ls-files", "--exclude-standard", "--other"])
 
-    # add everything if the user asked for it
-    if all_files:
-        git_args.append(["ls-files", "--exclude-standard"])
+        # add everything if the user asked for it
+        if all_files:
+            git_args.append(["ls-files", "--exclude-standard"])
 
-    excludes = [os.path.realpath(os.path.join(root, f)) for f in exclude_paths]
-    changed = set()
+        excludes = [os.path.realpath(os.path.join(root, f)) for f in exclude_paths]
+        changed = set()
 
-    for arg_list in git_args:
-        files = git(*arg_list, output=str).split("\n")
+        for arg_list in git_args:
+            files = git(*arg_list, output=str).split("\n")
 
-        for f in files:
-            # Ignore non-Python files
-            if not (f.endswith(".py") or f == "bin/spack"):
-                continue
+            for f in files:
+                # Ignore non-Python files
+                if not (f.endswith(".py") or f == "bin/spack"):
+                    continue
 
-            # Ignore files in the exclude locations
-            if any(os.path.realpath(f).startswith(e) for e in excludes):
-                continue
+                # Ignore files in the exclude locations
+                if any(os.path.realpath(f).startswith(e) for e in excludes):
+                    continue
 
-            changed.add(Path(f))
+                changed.add(Path(f))
 
-    return sorted(changed)
+        return sorted(changed)
 
 
 def setup_parser(subparser: argparse.ArgumentParser) -> None:
@@ -195,6 +257,23 @@ def setup_parser(subparser: argparse.ArgumentParser) -> None:
         "v1.0 and v0.x. Example: spack style ``--spec-strings $(git ls-files)``. Note: must be "
         "used only on specs from spack v0.X.",
     )
+    repo_group = subparser.add_argument_group(
+        title="Repo", description="Options to configure style checks on Spack repositories"
+    )
+
+    repo_group.add_argument(
+        "--repo",
+        nargs="*",
+        help="repositories to perform style checks against, specified by namespace. "
+        "(default: builtin)",
+    )
+    repo_group.add_argument(
+        "--repo-only",
+        action="store_true",
+        default=False,
+        help="Runs style checks only against given repositories, specified by namespace, "
+        " not spack core. (default: builtin)",
+    )
 
     subparser.add_argument("files", nargs=argparse.REMAINDER, help="specific files to check")
 
@@ -204,6 +283,43 @@ def cwd_relative(path: Path, root: Union[Path, str], initial_working_dir: Path) 
     if path.is_absolute():
         return path
     return Path(os.path.relpath((root / path), initial_working_dir))
+
+
+def validate_repos(repos: List[str]) -> List[spack.repo.Repo]:
+    valid_repos = []
+    for repo in repos:
+        try:
+            pkg_repo = spack.repo.PATH.get_repo(repo)
+        except spack.repo.UnknownNamespaceError:
+            tty.debug(f"Unknown Namespace: {repo}. Skipping style checks on unknown repo")
+        else:
+            valid_repos.append(pkg_repo)
+    return valid_repos
+
+
+def repo_config_file(repo: spack.repo.Repo, *config_file_names: str):
+    repo_root = Path(repo.root)
+    for curr_dir in [repo_root, *repo_root.parents]:
+        config = next((curr_dir / x for x in config_file_names if (curr_dir / x).is_file()), None)
+        if config:
+            return str(config)
+    # fallback to core spack builtin config
+    try:
+        builtin = spack.repo.PATH.get_repo(DEFAULT_REPO)
+    except spack.repo.UnknownNamespaceError:
+        return None
+    return str(Path(builtin.root).parent.parent.parent / "pyproject.toml")
+
+
+def establish_configuration(args, *config_file_names, repo: Optional[spack.repo.Repo] = None):
+    config = os.path.join(spack.paths.prefix, "pyproject.toml")
+    root = args.root
+    working_dir = args.initial_working_dir
+    if repo:
+        config = repo_config_file(repo, *config_file_names) or config
+        working_dir = repo.root
+        root = repo.root
+    return root, working_dir, config
 
 
 def rewrite_and_print_output(
@@ -234,6 +350,17 @@ def rewrite_and_print_output(
         print(line)
 
 
+def print_style_header_repo(file_list: List[Path], repo: spack.repo.Repo, tools_to_run: List[str]):
+    tty.msg(
+        f"Running style checks on spack repository {repo}", "selected: " + ", ".join(tools_to_run)
+    )
+    # repo is always repo root relative
+    reporting = [os.path.relpath(file, repo.root) for file in file_list]
+    if reporting:
+        tty.msg(f"Modified files in repository: {repo}", *reporting)
+    sys.stdout.flush()
+
+
 def print_tool_result(tool, returncode):
     if returncode == 0:
         color.cprint("  @g{%s checks were clean}" % tool)
@@ -241,36 +368,42 @@ def print_tool_result(tool, returncode):
         color.cprint("  @r{%s found errors}" % tool)
 
 
+def setup_baseline_ruff_config(args, repo: Optional[spack.repo.Repo] = None):
+    root, working_dir, config = establish_configuration(
+        args, "pyproject.toml", "ruff.toml", ".ruff.toml", repo=repo
+    )
+    cmd_args = ["--quiet"]
+    if config:
+        cmd_args.extend(["--config", config])
+    return cmd_args, root, working_dir
+
+
 @tool("ruff-check", cmd="ruff")
-def ruff_check(file_list, args):
+def ruff_check(file_list, args, repo: Optional[spack.repo.Repo] = None):
     """Run the ruff-check command. Handles config and non generic ruff argument logic"""
-    cmd_args = ["--config", os.path.join(spack.paths.prefix, "pyproject.toml"), "--quiet"]
+    cmd_args, root, working_dir = setup_baseline_ruff_config(args, repo)
     if args.fix:
         cmd_args += ["--fix", "--no-unsafe-fixes"]
     else:
         cmd_args += ["--no-fix"]
-    return run_ruff(
-        file_list, "check", cmd_args, args.root, args.initial_working_dir, args.root_relative
-    )
+    return run_ruff(file_list, "check", cmd_args, root, working_dir, args.root_relative)
 
 
 @tool("ruff-format", cmd="ruff")
-def ruff_format(file_list, args):
+def ruff_format(file_list, args, repo: Optional[spack.repo.Repo] = None):
     """Run the ruff format command"""
-    cmd_args = ["--config", os.path.join(spack.paths.prefix, "pyproject.toml"), "--quiet"]
+    cmd_args, root, working_dir = setup_baseline_ruff_config(args, repo)
     if not args.fix:
         cmd_args += ["--check", "--diff"]
-    return run_ruff(
-        file_list, "format", cmd_args, args.root, args.initial_working_dir, args.root_relative
-    )
+    return run_ruff(file_list, "format", cmd_args, root, working_dir, args.root_relative)
 
 
 def run_ruff(
     file_list: List[Path],
     cmd: str,
     args: List[str],
-    root: Path,
-    working_dir: Path,
+    root: Union[Path, str],
+    working_dir: Union[Path, str],
     root_relative: bool,
 ):
     """Run the ruff tool"""
@@ -286,8 +419,9 @@ def run_ruff(
     replacement = "would reformat {0}"
 
     packed_args = (cmd,) + (*args,) + tuple(files)
-    output = ruff_cmd(*packed_args, fail_on_error=False, output=str, error=str)
-    returncode = ruff_cmd.returncode
+    with fsys.working_dir(str(root)):
+        output = ruff_cmd(*packed_args, fail_on_error=False, output=str, error=str)
+        returncode = ruff_cmd.returncode
     rewrite_and_print_output(output, root, working_dir, root_relative, pat, replacement)
 
     print_tool_result(f"ruff-{cmd}", returncode)
@@ -295,17 +429,14 @@ def run_ruff(
 
 
 @tool("mypy")
-def run_mypy(file_list, args):
+def run_mypy(file_list, args, repo: Optional[spack.repo.Repo] = None):
     mypy_cmd = tools["mypy"].executable
     if not mypy_cmd:
         tty.warn("Cannot execute requested tool: mypy\nCannot find tool")
         return -1
     # always run with config from running spack prefix
-    common_mypy_args = [
-        "--config-file",
-        os.path.join(spack.paths.prefix, "pyproject.toml"),
-        "--show-error-codes",
-    ]
+    root, working_dir, config = establish_configuration(args, "pyproject.toml", repo=repo)
+    common_mypy_args = ["--config-file", config, "--show-error-codes"]
     mypy_arg_sets = [common_mypy_args + ["--package", "spack", "--package", "llnl"]]
     if "SPACK_MYPY_CHECK_PACKAGES" in os.environ:
         mypy_arg_sets.append(
@@ -314,10 +445,11 @@ def run_mypy(file_list, args):
 
     returncode = 0
     for mypy_args in mypy_arg_sets:
-        output = mypy_cmd(*mypy_args, fail_on_error=False, output=str)
+        with fsys.working_dir(root):
+            output = mypy_cmd(*mypy_args, fail_on_error=False, output=str)
         returncode |= mypy_cmd.returncode
 
-        rewrite_and_print_output(output, args.root, args.initial_working_dir, args.root_relative)
+        rewrite_and_print_output(output, root, working_dir, args.root_relative)
 
     print_tool_result("mypy", returncode)
     return returncode
@@ -353,6 +485,7 @@ def _run_import_check(
     out=sys.stdout,
     base="develop",
     all=False,
+    repo: Optional[spack.repo.Repo] = None,
 ):
     if sys.version_info < (3, 9):
         print("import check requires Python 3.9 or later")
@@ -360,8 +493,14 @@ def _run_import_check(
 
     is_use = re.compile(r"(?<!from )(?<!import )spack\.[a-zA-Z0-9_\.]+")
 
+    get_changed_files = changed_files
+    changed_kwargs = {"root": root, "base": base, "all_files": all}
+    if repo:
+        get_changed_files = changed_files_repo
+        changed_kwargs["repo"] = repo
+
     exit_code = 0
-    files = file_list or changed_files(root=root, base=base, all_files=all)
+    files = file_list or get_changed_files(**changed_kwargs)
     for file in files:
         to_add: Set[str] = set()
         to_remove: List[str] = []
@@ -457,15 +596,24 @@ def _run_import_check(
 
 
 @tool("import", external=False)
-def run_import_check(file_list, args):
+def run_import_check(file_list, args, repo: Optional[spack.repo.Repo] = None):
+    root = args.root
+    working_dir = args.initial_working_dir
+    base = args.base
+    if repo:
+        repo_root = get_repo_git_root(repo)
+        root = repo_root
+        working_dir = repo_root
+        base = get_repo_default_ref(repo)
     exit_code = _run_import_check(
         file_list,
         fix=args.fix,
         root_relative=args.root_relative,
-        root=args.root,
-        working_dir=args.initial_working_dir,
-        base=args.base,
+        root=root,
+        working_dir=working_dir,
+        base=base,
         all=args.all,
+        repo=repo,
     )
     print_tool_result("import", exit_code)
     return exit_code
@@ -475,12 +623,12 @@ def print_style_header(file_list: List[Path], args, tools_to_run):
     tty.msg("Running style checks on spack", "selected: " + ", ".join(tools_to_run))
     # translate modified paths to cwd_relative if needed
     if file_list:
-        paths = file_list
         if not args.root_relative:
-            paths = [
-                cwd_relative(filename, args.root, args.initial_working_dir) for filename in paths
+            file_list = [
+                cwd_relative(filename, args.root, args.initial_working_dir)
+                for filename in file_list
             ]
-        tty.msg("Checking Files:", *[str(pth) for pth in paths])
+        tty.msg("Checking Files:", *[str(pth) for pth in file_list])
     sys.stdout.flush()
 
 
@@ -527,7 +675,17 @@ def style(parser, args):
     def prefix_relative(path: Union[Path, str]) -> Path:
         return Path(os.path.relpath(os.path.abspath(os.path.realpath(path)), args.root))
 
-    file_list = [prefix_relative(file) for file in args.files]
+    # determine repos to run style checks on
+    # if --repo is given but no repos are listed
+    # we fallback to builtin by default
+    repos = []
+    # args.repo is none if --repo is not supplied
+    # if supplied with no args, its []
+    # if supplied with args, [repo_name1, ...]
+    if args.repo is not None or args.repo_only:
+        repos = validate_repos(args.repo or ["builtin"])
+        if not repos:
+            raise SpackError("Style specified repos or repo-only but no repos were found.")
 
     # process --tool and --skip arguments
     selected = set(tool_names)
@@ -544,13 +702,46 @@ def style(parser, args):
     if missing_tools(tools_to_run):
         _bootstrap_dev_dependencies()
 
+    def find_repo_file(path, repos):
+        for repo in repos:
+            if is_relative_to(path, repo.root):
+                return (repo, path)
+        return ()
+
+    repo_file_dict = defaultdict(list)
+    core_file_list = []
+    for file in args.files:
+        repo_assoc = find_repo_file(file, repos)
+        if repo_assoc:
+            repo_file_dict[repo_assoc[0]].append(repo_assoc[1])
+        else:
+            core_file_list.append(prefix_relative(file))
+
     return_code = 0
-    with working_dir(str(args.root)):
-        print_style_header(file_list, args, tools_to_run)
-        for tool_name in tools_to_run:
-            tool = tools[tool_name]
-            tty.msg(f"Running {tool.name} checks")
-            return_code |= tool.fun(file_list, args)
+
+    if not args.repo_only:
+        # run over core spack
+        with working_dir(str(args.root)):
+            print_style_header(core_file_list, args, tools_to_run)
+            for tool_name in tools_to_run:
+                tool = tools[tool_name]
+                tty.msg(f"Running {tool.name} checks")
+                return_code |= tool.fun(core_file_list, args)
+    elif core_file_list:
+        tty.msg(
+            f"Repo only specified but files in core provided: Skipping {', '.join(core_file_list)}"
+        )
+
+    # run over package repositories
+    if repos:
+        for repo in repos:
+            repo_list = repo_file_dict[repo]
+            print_style_header_repo(repo_list, repo, tools_to_run)
+            for tool_name in tools_to_run:
+                tool = tools[tool_name]
+                tty.msg(f"Running {tool.name} checks")
+                return_code |= tool.fun(repo_list, args, repo)
+
     if return_code == 0:
         tty.msg(color.colorize("@*{spack style checks were clean}"))
     else:

--- a/lib/spack/spack/cmd/style.py
+++ b/lib/spack/spack/cmd/style.py
@@ -168,7 +168,12 @@ def changed_files_repo(
         if not base:
             base = get_repo_default_ref(repo)
         file_root = get_repo_git_root(repo) or repo.root
-        return [file_root / x for x in changed_files(root=file_root, base=base, untracked=untracked, all_files=all_files)]
+        return [
+            file_root / x
+            for x in changed_files(
+                root=file_root, base=base, untracked=untracked, all_files=all_files
+            )
+        ]
     except RuntimeError:
         return get_all_repo_py_files(repo)
 
@@ -312,8 +317,8 @@ def setup_parser(subparser: argparse.ArgumentParser) -> None:
     repo_group.add_argument(
         "--repo",
         nargs="*",
-        help="repositories to perform style checks against, specified by namespace, space separated. "
-        "(default: builtin)",
+        help="repositories to perform style checks against, specified by namespace,"
+        " space separated. (default: builtin)",
     )
     repo_group.add_argument(
         "--repo-only",
@@ -544,7 +549,6 @@ def _run_import_check(
         return 0
 
     is_use = re.compile(r"(?<!from )(?<!import )spack\.[a-zA-Z0-9_\.]+")
-    import pdb; pdb.set_trace()
     get_changed_files = changed_files
     changed_kwargs = {"root": root, "base": base, "all_files": all}
     if repo:

--- a/lib/spack/spack/cmd/style.py
+++ b/lib/spack/spack/cmd/style.py
@@ -122,6 +122,7 @@ def changed_files_repo(
                 root=str(root), base=base, untracked=untracked, all_files=all_files
             )
         ]
+    # Git failed, just return all the files
     except SystemExit:
         return get_all_repo_py_files(repo)
 
@@ -302,6 +303,7 @@ def repo_config_file(repo: spack.repo.Repo, *config_file_names: str):
         builtin = spack.repo.PATH.get_repo(DEFAULT_REPO)
     except spack.repo.UnknownNamespaceError:
         return None
+    # hardcode path to builtin config since we know where it is
     return str(Path(builtin.root).parent.parent.parent / "pyproject.toml")
 
 

--- a/lib/spack/spack/cmd/style.py
+++ b/lib/spack/spack/cmd/style.py
@@ -437,12 +437,15 @@ def run_mypy(file_list, args, repo: Optional[spack.repo.Repo] = None):
     # always run with config from running spack prefix
     root, working_dir, config = establish_configuration(args, "pyproject.toml", repo=repo)
     common_mypy_args = ["--config-file", config, "--show-error-codes"]
-    mypy_arg_sets = [common_mypy_args + ["--package", "spack", "--package", "llnl"]]
-    if "SPACK_MYPY_CHECK_PACKAGES" in os.environ:
-        mypy_arg_sets.append(
-            common_mypy_args + ["--package", "packages", "--disable-error-code", "no-redef"]
-        )
 
+    mypy_arg_sets = [common_mypy_args + ["--package", "spack", "--package", "llnl"]]
+    if repo:
+        repo_root = Path(repo.root)
+        spack_repo_index = repo_root.parts.index("spack_repo")
+        root = str(Path(*repo_root.parts[:spack_repo_index + 1]).parent)
+        mypy_arg_sets = [
+            common_mypy_args + ["--package", repo.full_namespace, "--disable-error-code", "no-redef"]
+        ]
     returncode = 0
     for mypy_args in mypy_arg_sets:
         with fsys.working_dir(root):

--- a/lib/spack/spack/cmd/style.py
+++ b/lib/spack/spack/cmd/style.py
@@ -500,7 +500,7 @@ def _run_import_check(
     get_changed_files = changed_files
     changed_kwargs = {"root": root, "base": base, "all_files": all}
     if repo:
-        get_changed_files = changed_files_repo
+        get_changed_files = changed_files_repo  # type: ignore
         changed_kwargs["repo"] = repo
 
     exit_code = 0

--- a/lib/spack/spack/cmd/style.py
+++ b/lib/spack/spack/cmd/style.py
@@ -83,13 +83,38 @@ def get_git() -> Executable:
 
 def get_repo_default_ref(repo: spack.repo.Repo) -> str:
     git = get_git()
+    full_default = ""
     with fsys.working_dir(repo.root):
-        full_default = git(
-            "rev-parse", "--abbrev-ref", "origin/HEAD", fail_on_error=False, output=str
+        res = git(
+            "rev-parse", "--abbrev-ref", "origin/HEAD", fail_on_error=False, output=str, error=str
         )
-    if git.returncode != 0:
-        raise RuntimeError("This repo is not a git repository")
-    return "/".join(full_default.strip("\n").split("/")[1:])
+        if git.returncode == 0 and res:
+            full_default = res.strip()
+
+        if git.returncode != 0 or not full_default or "origin/HEAD" in full_default:
+            ls_remote = git(
+                "ls-remote",
+                "--symref",
+                "origin",
+                "HEAD",
+                fail_on_error=False,
+                output=str,
+                error=str,
+            )
+            if git.returncode == 0 and ls_remote:
+                for line in ls_remote.splitlines():
+                    if line.startswith("ref:"):
+                        full_ref = line.split()[1]
+                        full_default = full_ref.split("/")[-1]
+                        break
+
+    if not full_default:
+        raise RuntimeError("Cannot determine default git ref")
+
+    if full_default.startswith("origin/"):
+        return full_default.replace("origin/", "", 1)
+
+    return full_default
 
 
 def get_repo_git_root(repo: spack.repo.Repo):
@@ -97,8 +122,28 @@ def get_repo_git_root(repo: spack.repo.Repo):
     with fsys.working_dir(repo.root):
         git_root = git("rev-parse", "--show-toplevel", fail_on_error=False, output=str, error=str)
     if git.returncode != 0:
-        raise RuntimeError(f"Encountered an error running git on {repo}: {git_root}")
+        tty.warn(f"Encountered an error running git on {repo}")
+        return None
     return Path(git_root.strip("\n"))
+
+
+def get_all_repo_py_files(repo: spack.repo.Repo):
+    """returns all python files in a given package repo"""
+    git = get_git()
+    with fsys.working_dir(repo.root):
+        all_files = git(
+            "ls-files",
+            "--cached",
+            "--others",
+            "--exclude-standard",
+            "*.py",
+            fail_on_error=False,
+            output=str,
+            error=str,
+        )
+    if git.returncode != 0:
+        raise RuntimeError(f"Encountered and error running git on {repo}")
+    return [repo.root / Path(x) for x in all_files.splitlines()]
 
 
 def is_relative_to(path: Path, root: Union[Path, str]):
@@ -119,10 +164,13 @@ def changed_files_repo(
         untracked: include untracked packages
         all_packages: include all package files
     """
-    if not base:
-        base = get_repo_default_ref(repo)
-    file_root = get_repo_git_root(repo)
-    return changed_files(root=file_root, base=base, untracked=untracked, all_files=all_files)
+    try:
+        if not base:
+            base = get_repo_default_ref(repo)
+        file_root = get_repo_git_root(repo) or repo.root
+        return changed_files(root=file_root, base=base, untracked=untracked, all_files=all_files)
+    except RuntimeError:
+        return get_all_repo_py_files(repo)
 
 
 def changed_files(base="develop", untracked=True, all_files=False, root=None) -> List[Path]:
@@ -264,7 +312,7 @@ def setup_parser(subparser: argparse.ArgumentParser) -> None:
     repo_group.add_argument(
         "--repo",
         nargs="*",
-        help="repositories to perform style checks against, specified by namespace. "
+        help="repositories to perform style checks against, specified by namespace, space separated. "
         "(default: builtin)",
     )
     repo_group.add_argument(
@@ -496,7 +544,7 @@ def _run_import_check(
         return 0
 
     is_use = re.compile(r"(?<!from )(?<!import )spack\.[a-zA-Z0-9_\.]+")
-
+    import pdb; pdb.set_trace()
     get_changed_files = changed_files
     changed_kwargs = {"root": root, "base": base, "all_files": all}
     if repo:
@@ -605,10 +653,10 @@ def run_import_check(file_list, args, repo: Optional[spack.repo.Repo] = None):
     working_dir = args.initial_working_dir
     base = args.base
     if repo:
-        repo_root = get_repo_git_root(repo)
+        repo_root = get_repo_git_root(repo) or Path(repo.root)
         root = repo_root
         working_dir = repo_root
-        base = get_repo_default_ref(repo)
+        base = ""
     exit_code = _run_import_check(
         file_list,
         fix=args.fix,

--- a/lib/spack/spack/cmd/style.py
+++ b/lib/spack/spack/cmd/style.py
@@ -118,7 +118,9 @@ def changed_files_repo(
     try:
         return [
             root / x
-            for x in changed_files(root=str(root), base=base, untracked=untracked, all_files=all_files)
+            for x in changed_files(
+                root=str(root), base=base, untracked=untracked, all_files=all_files
+            )
         ]
     except SystemExit:
         return get_all_repo_py_files(repo)

--- a/lib/spack/spack/cmd/style.py
+++ b/lib/spack/spack/cmd/style.py
@@ -168,7 +168,7 @@ def changed_files_repo(
         if not base:
             base = get_repo_default_ref(repo)
         file_root = get_repo_git_root(repo) or repo.root
-        return changed_files(root=file_root, base=base, untracked=untracked, all_files=all_files)
+        return [file_root / x for x in changed_files(root=file_root, base=base, untracked=untracked, all_files=all_files)]
     except RuntimeError:
         return get_all_repo_py_files(repo)
 

--- a/lib/spack/spack/cmd/style.py
+++ b/lib/spack/spack/cmd/style.py
@@ -6,7 +6,6 @@ import ast
 import os
 import re
 import sys
-from collections import defaultdict
 from pathlib import Path
 from typing import Dict, List, Optional, Set, Union
 
@@ -81,42 +80,6 @@ def get_git() -> Executable:
     return spack.util.git.git(required=True)
 
 
-def get_repo_default_ref(repo: spack.repo.Repo) -> str:
-    git = get_git()
-    full_default = ""
-    with fsys.working_dir(repo.root):
-        res = git(
-            "rev-parse", "--abbrev-ref", "origin/HEAD", fail_on_error=False, output=str, error=str
-        )
-        if git.returncode == 0 and res:
-            full_default = res.strip()
-
-        if git.returncode != 0 or not full_default or "origin/HEAD" in full_default:
-            ls_remote = git(
-                "ls-remote",
-                "--symref",
-                "origin",
-                "HEAD",
-                fail_on_error=False,
-                output=str,
-                error=str,
-            )
-            if git.returncode == 0 and ls_remote:
-                for line in ls_remote.splitlines():
-                    if line.startswith("ref:"):
-                        full_ref = line.split()[1]
-                        full_default = full_ref.split("/")[-1]
-                        break
-
-    if not full_default:
-        raise RuntimeError("Cannot determine default git ref")
-
-    if full_default.startswith("origin/"):
-        return full_default.replace("origin/", "", 1)
-
-    return full_default
-
-
 def get_repo_git_root(repo: spack.repo.Repo):
     git = get_git()
     with fsys.working_dir(repo.root):
@@ -129,21 +92,7 @@ def get_repo_git_root(repo: spack.repo.Repo):
 
 def get_all_repo_py_files(repo: spack.repo.Repo):
     """returns all python files in a given package repo"""
-    git = get_git()
-    with fsys.working_dir(repo.root):
-        all_files = git(
-            "ls-files",
-            "--cached",
-            "--others",
-            "--exclude-standard",
-            "*.py",
-            fail_on_error=False,
-            output=str,
-            error=str,
-        )
-    if git.returncode != 0:
-        raise RuntimeError(f"Encountered and error running git on {repo}")
-    return [repo.root / Path(x) for x in all_files.splitlines()]
+    return list(Path(repo.root).rglob("*.py"))
 
 
 def is_relative_to(path: Path, root: Union[Path, str]):
@@ -155,7 +104,7 @@ def is_relative_to(path: Path, root: Union[Path, str]):
 
 
 def changed_files_repo(
-    repo: spack.repo.Repo, untracked=True, all_files: bool = False, root=None, base=None
+    repo: spack.repo.Repo, untracked=True, all_files: bool = False, root=None, base="develop"
 ) -> List[Path]:
     """Get list of changed files in given repo
 
@@ -164,17 +113,14 @@ def changed_files_repo(
         untracked: include untracked packages
         all_packages: include all package files
     """
+    if not root:
+        root = get_repo_git_root(repo) or repo.root
     try:
-        if not base:
-            base = get_repo_default_ref(repo)
-        file_root = get_repo_git_root(repo) or repo.root
         return [
-            file_root / x
-            for x in changed_files(
-                root=file_root, base=base, untracked=untracked, all_files=all_files
-            )
+            root / x
+            for x in changed_files(root=str(root), base=base, untracked=untracked, all_files=all_files)
         ]
-    except RuntimeError:
+    except SystemExit:
         return get_all_repo_py_files(repo)
 
 
@@ -268,7 +214,8 @@ def setup_parser(subparser: argparse.ArgumentParser) -> None:
         "--root-relative",
         action="store_true",
         default=False,
-        help="print root-relative paths (default: cwd-relative)",
+        help="print root-relative paths (default: cwd-relative or repo-relative"
+        " if --repo is specified)",
     )
     subparser.add_argument(
         "-U",
@@ -286,7 +233,20 @@ def setup_parser(subparser: argparse.ArgumentParser) -> None:
         help="format automatically if possible (e.g., with isort, black)",
     )
     subparser.add_argument(
-        "--root", action="store", default=None, help="style check a different spack instance"
+        "--root",
+        action="store",
+        default=None,
+        help="style check a different spack or repo instance."
+        " If --repo is specified, --root should be the root of"
+        " the repo repository, not the repo root.",
+    )
+    subparser.add_argument(
+        "--repo",
+        nargs="?",
+        const="builtin",
+        default=None,
+        help="repositories to perform style checks against, specified by namespace."
+        " (default: builtin)",
     )
 
     tool_group = subparser.add_mutually_exclusive_group()
@@ -310,24 +270,6 @@ def setup_parser(subparser: argparse.ArgumentParser) -> None:
         "v1.0 and v0.x. Example: spack style ``--spec-strings $(git ls-files)``. Note: must be "
         "used only on specs from spack v0.X.",
     )
-    repo_group = subparser.add_argument_group(
-        title="Repo", description="Options to configure style checks on Spack repositories"
-    )
-
-    repo_group.add_argument(
-        "--repo",
-        nargs="*",
-        help="repositories to perform style checks against, specified by namespace,"
-        " space separated. (default: builtin)",
-    )
-    repo_group.add_argument(
-        "--repo-only",
-        action="store_true",
-        default=False,
-        help="Runs style checks only against given repositories, specified by namespace, "
-        " not spack core. (default: builtin)",
-    )
-
     subparser.add_argument("files", nargs=argparse.REMAINDER, help="specific files to check")
 
 
@@ -338,16 +280,13 @@ def cwd_relative(path: Path, root: Union[Path, str], initial_working_dir: Path) 
     return Path(os.path.relpath((root / path), initial_working_dir))
 
 
-def validate_repos(repos: List[str]) -> List[spack.repo.Repo]:
-    valid_repos = []
-    for repo in repos:
-        try:
-            pkg_repo = spack.repo.PATH.get_repo(repo)
-        except spack.repo.UnknownNamespaceError:
-            tty.debug(f"Unknown Namespace: {repo}. Skipping style checks on unknown repo")
-        else:
-            valid_repos.append(pkg_repo)
-    return valid_repos
+def validate_repo(repo: str) -> Optional[spack.repo.Repo]:
+    pkg_repo = None
+    try:
+        pkg_repo = spack.repo.PATH.get_repo(repo)
+    except spack.repo.UnknownNamespaceError:
+        tty.error(f"Unknown Namespace: {repo}. Skipping style checks on unknown repo")
+    return pkg_repo
 
 
 def repo_config_file(repo: spack.repo.Repo, *config_file_names: str):
@@ -653,21 +592,16 @@ def _run_import_check(
 
 @tool("import", external=False)
 def run_import_check(file_list, args, repo: Optional[spack.repo.Repo] = None):
-    root = args.root
     working_dir = args.initial_working_dir
-    base = args.base
     if repo:
-        repo_root = get_repo_git_root(repo) or Path(repo.root)
-        root = repo_root
-        working_dir = repo_root
-        base = ""
+        working_dir = args.root
     exit_code = _run_import_check(
         file_list,
         fix=args.fix,
         root_relative=args.root_relative,
-        root=root,
+        root=args.root,
         working_dir=working_dir,
-        base=base,
+        base=args.base,
         all=args.all,
         repo=repo,
     )
@@ -718,30 +652,39 @@ def style(parser, args):
     # save initial working directory for relativizing paths later
     args.initial_working_dir = Path.cwd()
 
-    # ensure that the config files we need actually exist in the spack prefix.
-    # assertions b/c users should not ever see these errors -- they're checked in CI.
-    assert (Path(spack.paths.prefix) / "pyproject.toml").is_file()
-
-    # validate spack root if the user provided one
-    args.root = Path(args.root).resolve() if args.root else Path(spack.paths.prefix)
-    spack_script = args.root / "bin" / "spack"
-    if not spack_script.exists():
-        tty.die("This does not look like a valid spack root.", "No such file: '%s'" % spack_script)
-
     def prefix_relative(path: Union[Path, str]) -> Path:
         return Path(os.path.relpath(os.path.abspath(os.path.realpath(path)), args.root))
 
-    # determine repos to run style checks on
+    # determine repo to run style checks on
     # if --repo is given but no repos are listed
     # we fallback to builtin by default
-    repos = []
     # args.repo is none if --repo is not supplied
     # if supplied with no args, its []
     # if supplied with args, [repo_name1, ...]
-    if args.repo is not None or args.repo_only:
-        repos = validate_repos(args.repo or ["builtin"])
-        if not repos:
-            raise SpackError("Style specified repos or repo-only but no repos were found.")
+    repo = None
+    if args.repo:
+        repo = validate_repo(args.repo or "builtin")
+        if not repo:
+            raise SpackError(f"Style specified repo: {args.repo} but no repo was found.")
+
+    # ensure that the config files we need actually exist in the spack prefix.
+    # assertions b/c users should not ever see these errors -- they're checked in CI.
+    assert (Path(spack.paths.prefix) / "pyproject.toml").is_file()
+    default_root_base = (
+        get_repo_git_root(repo) or Path(repo.root) if repo else Path(spack.paths.prefix)
+    )
+    # validate spack root if the user provided one
+    args.root = Path(args.root).resolve() if args.root else default_root_base
+
+    # no need to validate the repo, we already have by virtue of the repo object's construction
+    # we need to validate spack core repos though, since users can point to any directory
+    # with --root
+    if not repo:
+        spack_script = args.root / "bin" / "spack"
+        if not spack_script.exists():
+            tty.die(
+                "This does not look like a valid spack root.", "No such file: '%s'" % spack_script
+            )
 
     # process --tool and --skip arguments
     selected = set(tool_names)
@@ -758,46 +701,47 @@ def style(parser, args):
     if missing_tools(tools_to_run):
         _bootstrap_dev_dependencies()
 
-    def find_repo_file(path, repos):
-        for repo in repos:
-            if is_relative_to(path, repo.root):
-                return (repo, path)
-        return ()
-
-    repo_file_dict = defaultdict(list)
-    core_file_list = []
+    repo_files = []
+    core_files = []
     for file in args.files:
-        repo_assoc = find_repo_file(file, repos)
-        if repo_assoc:
-            repo_file_dict[repo_assoc[0]].append(repo_assoc[1])
+        file = Path(file)
+        if is_relative_to(file, args.root):
+            core_files.append(prefix_relative(file))
+        elif repo and is_relative_to(file, repo.root):
+            repo_files.append(file)
         else:
-            core_file_list.append(prefix_relative(file))
+            tty.warn(
+                f"File {file} is not in the spack root or specified repo,"
+                " linting as if it were core."
+            )
+            core_files.append(prefix_relative(file))
 
     return_code = 0
 
-    if not args.repo_only:
+    if not repo:
         # run over core spack
         with working_dir(str(args.root)):
-            print_style_header(core_file_list, args, tools_to_run)
+            print_style_header(core_files, args, tools_to_run)
             for tool_name in tools_to_run:
                 tool = tools[tool_name]
                 tty.msg(f"Running {tool.name} checks")
-                return_code |= tool.fun(core_file_list, args)
-    elif core_file_list:
-        tty.msg(
-            f"Repo only specified but files in core provided: Skipping {', '.join(core_file_list)}"
-        )
+                return_code |= tool.fun(core_files, args)
+    elif core_files:
+        tty.msg(f"Repo specified but files in core provided: Skipping {', '.join(core_files)}")
 
     # run over package repositories
-    if repos:
+    if repo:
         repo_tools = [x for x in tools_to_run if x != "mypy"]
-        for repo in repos:
-            repo_list = repo_file_dict[repo]
-            print_style_header_repo(repo_list, repo, repo_tools)
-            for tool_name in repo_tools:
-                tool = tools[tool_name]
-                tty.msg(f"Running {tool.name} checks")
-                return_code |= tool.fun(repo_list, args, repo)
+        print_style_header_repo(repo_files, repo, repo_tools)
+        for tool_name in repo_tools:
+            tool = tools[tool_name]
+            tty.msg(f"Running {tool.name} checks")
+            return_code |= tool.fun(repo_files, args, repo)
+    elif repo_files:
+        tty.msg(
+            "Files provided in repo specified but no repo provided:"
+            f" Skipping {', '.join(repo_files)}"
+        )
 
     if return_code == 0:
         tty.msg(color.colorize("@*{spack style checks were clean}"))

--- a/lib/spack/spack/cmd/style.py
+++ b/lib/spack/spack/cmd/style.py
@@ -442,9 +442,10 @@ def run_mypy(file_list, args, repo: Optional[spack.repo.Repo] = None):
     if repo:
         repo_root = Path(repo.root)
         spack_repo_index = repo_root.parts.index("spack_repo")
-        root = str(Path(*repo_root.parts[:spack_repo_index + 1]).parent)
+        root = str(Path(*repo_root.parts[: spack_repo_index + 1]).parent)
         mypy_arg_sets = [
-            common_mypy_args + ["--package", repo.full_namespace, "--disable-error-code", "no-redef"]
+            common_mypy_args
+            + ["--package", repo.full_namespace, "--disable-error-code", "no-redef"]
         ]
     returncode = 0
     for mypy_args in mypy_arg_sets:

--- a/lib/spack/spack/test/cmd/style.py
+++ b/lib/spack/spack/test/cmd/style.py
@@ -490,26 +490,4 @@ def test_repo_style(repo_builder: RepoBuilder, ruff_package_with_errors, externa
         bad_file_rel_path = os.path.relpath(bad_file, repo.root)
         assert bad_file_rel_path in output
         # check that we still ran on core
-        assert "lib/spack/spack/dummy.py" in output
-
-
-@pytest.mark.skipif(not RUFF, reason="ruff not installed")
-def test_repo_only_style(repo_builder: RepoBuilder, ruff_package_with_errors):
-    """Test repo only does not lint core changes"""
-    repo_builder.add_package("pkg-c")
-    repo_builder.add_package("pkg-b", dependencies=[("pkg-d", None, None), ("pkg-e", None, None)])
-    repo_builder.add_package("pkg-a", dependencies=[("pkg-b", None, None), ("pkg-c", None, None)])
-    with spack.repo.use_repositories(repo_builder.root) as repo_path:
-        repo = repo_path.get_repo(repo_builder.namespace)
-        repo_name = repo.namespace
-        repo_root = pathlib.Path(repo.root)
-        make_pyproject_config(repo_root)
-        bad_file = pathlib.Path(repo_builder._recipe_filename("bad_package"))
-        bad_file.parent.mkdir(parents=True)
-        bad_file.touch()
-        shutil.copy(ruff_package_with_errors, bad_file)
-        output = style("--repo-only", "--repo", repo_name, "-t", "ruff-check", fail_on_error=False)
-        bad_file_rel_path = os.path.relpath(bad_file, repo.root)
-        assert bad_file_rel_path in output
-        # check that we did not run on core
         assert "lib/spack/spack/dummy.py" not in output

--- a/lib/spack/spack/test/cmd/style.py
+++ b/lib/spack/spack/test/cmd/style.py
@@ -436,12 +436,12 @@ def test_changed_files_repo(git, repo_builder: RepoBuilder):
 
             (repo_root / "packages" / "repo_test_package").mkdir(parents=True, exist_ok=True)
             (repo_root / "packages" / "repo_test_package" / "package.py").touch()
-        assert repo_root / pathlib.Path("packages/repo_test_package/package.py") in changed_files_repo(
-            repo, base="HEAD"
-        )
-        assert repo_root / pathlib.Path("packages/repo_test_package/package.py") in changed_files_repo(
-            repo, base="main"
-        )
+        assert repo_root / pathlib.Path(
+            "packages/repo_test_package/package.py"
+        ) in changed_files_repo(repo, base="HEAD")
+        assert repo_root / pathlib.Path(
+            "packages/repo_test_package/package.py"
+        ) in changed_files_repo(repo, base="main")
 
 
 def test_changed_files_repo_no_git(repo_builder):
@@ -451,9 +451,9 @@ def test_changed_files_repo_no_git(repo_builder):
             repo_root = pathlib.Path(repo.root)
             (repo_root / "packages" / "repo_test_package").mkdir(parents=True, exist_ok=True)
             (repo_root / "packages" / "repo_test_package" / "package.py").touch()
-        assert repo_root / pathlib.Path("packages/repo_test_package/package.py") in changed_files_repo(
-            repo
-        )
+        assert repo_root / pathlib.Path(
+            "packages/repo_test_package/package.py"
+        ) in changed_files_repo(repo)
 
 
 def test_get_repo_config_file(repo_builder: RepoBuilder):

--- a/lib/spack/spack/test/cmd/style.py
+++ b/lib/spack/spack/test/cmd/style.py
@@ -15,8 +15,9 @@ import spack.cmd.style
 import spack.main
 import spack.paths
 import spack.repo
-from spack.cmd.style import _run_import_check, changed_files
+from spack.cmd.style import _run_import_check, changed_files, changed_files_repo
 from spack.llnl.util.filesystem import FileFilter, working_dir
+from spack.test.conftest import RepoBuilder
 from spack.util.executable import which
 
 #: directory with sample style files
@@ -81,6 +82,12 @@ def ruff_package_with_errors(scope="function"):
     yield tmp
 
 
+def make_pyproject_config(repo_root: pathlib.Path):
+    with working_dir(str(repo_root)):
+        (repo_root / "packages" / "repo_test_package").mkdir(parents=True, exist_ok=True)
+        (repo_root / "pyproject.toml").touch()
+
+
 def test_changed_files_from_git_rev_base(git, tmp_path: pathlib.Path):
     """Test arbitrary git ref as base."""
     with working_dir(str(tmp_path)):
@@ -92,13 +99,13 @@ def test_changed_files_from_git_rev_base(git, tmp_path: pathlib.Path):
 
         (tmp_path / "bin").mkdir(parents=True, exist_ok=True)
         (tmp_path / "bin" / "spack").touch()
-        assert changed_files(base="HEAD") == [pathlib.Path("bin/spack")]
-        assert changed_files(base="main") == [pathlib.Path("bin/spack")]
+        assert changed_files(base="HEAD", root=str(tmp_path)) == [pathlib.Path("bin/spack")]
+        assert changed_files(base="main", root=str(tmp_path)) == [pathlib.Path("bin/spack")]
 
         git("add", "bin/spack")
         git("commit", "--no-gpg-sign", "-m", "v1")
-        assert changed_files(base="HEAD") == []
-        assert changed_files(base="HEAD~") == [pathlib.Path("bin/spack")]
+        assert changed_files(base="HEAD", root=str(tmp_path)) == []
+        assert changed_files(base="HEAD~", root=str(tmp_path)) == [pathlib.Path("bin/spack")]
 
 
 def test_changed_no_base(git, tmp_path: pathlib.Path, capfd):
@@ -113,7 +120,7 @@ def test_changed_no_base(git, tmp_path: pathlib.Path, capfd):
         git("commit", "--no-gpg-sign", "-m", "initial commit")
 
         with pytest.raises(SystemExit):
-            changed_files(base="foobar")
+            changed_files(base="foobar", root=str(tmp_path))
 
         out, err = capfd.readouterr()
         assert "This repository does not have a 'foobar'" in err
@@ -414,3 +421,83 @@ def test_pkg_imports():
         is None
     )
     assert spack.cmd.style._module_part(pathlib.Path(spack.paths.prefix), "spack.pkg") is None
+
+
+def test_changed_files_repo(git, repo_builder: RepoBuilder):
+    with spack.repo.use_repositories(repo_builder.root) as repo_path:
+        repo = repo_path.get_repo(repo_builder.namespace)
+        with working_dir(repo.root):
+            repo_root = pathlib.Path(repo.root)
+            git("init")
+            git("checkout", "-b", "main")
+            git("config", "user.name", "test user")
+            git("config", "user.email", "test@user.com")
+            git("commit", "--no-gpg-sign", "--allow-empty", "-m", "initial commit")
+
+            (repo_root / "packages" / "repo_test_package").mkdir(parents=True, exist_ok=True)
+            (repo_root / "packages" / "repo_test_package" / "package.py").touch()
+        assert pathlib.Path("packages/repo_test_package/package.py") in changed_files_repo(
+            repo, base="HEAD"
+        )
+        assert pathlib.Path("packages/repo_test_package/package.py") in changed_files_repo(
+            repo, base="main"
+        )
+
+
+def test_get_repo_config_file(repo_builder: RepoBuilder):
+    repo_builder.add_package("pkg-c")
+    repo_builder.add_package("pkg-b", dependencies=[("pkg-d", None, None), ("pkg-e", None, None)])
+    repo_builder.add_package("pkg-a", dependencies=[("pkg-b", None, None), ("pkg-c", None, None)])
+    with spack.repo.use_repositories(repo_builder.root) as repo_path:
+        repo = repo_path.get_repo(repo_builder.namespace)
+        repo_root = pathlib.Path(repo.root)
+        make_pyproject_config(repo_root)
+        config_file = spack.cmd.style.repo_config_file(repo, "pyproject.toml")
+        assert config_file == str(repo_root / "pyproject.toml")
+
+
+@pytest.mark.skipif(not RUFF, reason="ruff not installed")
+def test_repo_style(repo_builder: RepoBuilder, ruff_package_with_errors, external_style_root):
+    tmp_path, _ = external_style_root
+    repo_builder.add_package("pkg-c")
+    repo_builder.add_package("pkg-b", dependencies=[("pkg-d", None, None), ("pkg-e", None, None)])
+    repo_builder.add_package("pkg-a", dependencies=[("pkg-b", None, None), ("pkg-c", None, None)])
+    with spack.repo.use_repositories(repo_builder.root) as repo_path:
+        repo = repo_path.get_repo(repo_builder.namespace)
+        repo_root = pathlib.Path(repo.root)
+        make_pyproject_config(repo_root)
+        repo_name = repo.namespace
+        bad_file = pathlib.Path(repo_builder._recipe_filename("bad_package"))
+        bad_file.parent.mkdir(parents=True)
+        bad_file.touch()
+        shutil.copy(ruff_package_with_errors, bad_file)
+        output = style(
+            "--root", str(tmp_path), "--repo", repo_name, "-t", "ruff-check", fail_on_error=False
+        )
+        # check that we ran on repo
+        bad_file_rel_path = os.path.relpath(bad_file, repo.root)
+        assert bad_file_rel_path in output
+        # check that we still ran on core
+        assert "lib/spack/spack/dummy.py" in output
+
+
+@pytest.mark.skipif(not RUFF, reason="ruff not installed")
+def test_repo_only_style(repo_builder: RepoBuilder, ruff_package_with_errors):
+    """Test repo only does not lint core changes"""
+    repo_builder.add_package("pkg-c")
+    repo_builder.add_package("pkg-b", dependencies=[("pkg-d", None, None), ("pkg-e", None, None)])
+    repo_builder.add_package("pkg-a", dependencies=[("pkg-b", None, None), ("pkg-c", None, None)])
+    with spack.repo.use_repositories(repo_builder.root) as repo_path:
+        repo = repo_path.get_repo(repo_builder.namespace)
+        repo_name = repo.namespace
+        repo_root = pathlib.Path(repo.root)
+        make_pyproject_config(repo_root)
+        bad_file = pathlib.Path(repo_builder._recipe_filename("bad_package"))
+        bad_file.parent.mkdir(parents=True)
+        bad_file.touch()
+        shutil.copy(ruff_package_with_errors, bad_file)
+        output = style("--repo-only", "--repo", repo_name, "-t", "ruff-check", fail_on_error=False)
+        bad_file_rel_path = os.path.relpath(bad_file, repo.root)
+        assert bad_file_rel_path in output
+        # check that we did not run on core
+        assert "lib/spack/spack/dummy.py" not in output

--- a/lib/spack/spack/test/cmd/style.py
+++ b/lib/spack/spack/test/cmd/style.py
@@ -436,11 +436,23 @@ def test_changed_files_repo(git, repo_builder: RepoBuilder):
 
             (repo_root / "packages" / "repo_test_package").mkdir(parents=True, exist_ok=True)
             (repo_root / "packages" / "repo_test_package" / "package.py").touch()
-        assert pathlib.Path("packages/repo_test_package/package.py") in changed_files_repo(
+        assert repo_root / pathlib.Path("packages/repo_test_package/package.py") in changed_files_repo(
             repo, base="HEAD"
         )
-        assert pathlib.Path("packages/repo_test_package/package.py") in changed_files_repo(
+        assert repo_root / pathlib.Path("packages/repo_test_package/package.py") in changed_files_repo(
             repo, base="main"
+        )
+
+
+def test_changed_files_repo_no_git(repo_builder):
+    with spack.repo.use_repositories(repo_builder.root) as repo_path:
+        repo = repo_path.get_repo(repo_builder.namespace)
+        with working_dir(repo.root):
+            repo_root = pathlib.Path(repo.root)
+            (repo_root / "packages" / "repo_test_package").mkdir(parents=True, exist_ok=True)
+            (repo_root / "packages" / "repo_test_package" / "package.py").touch()
+        assert repo_root / pathlib.Path("packages/repo_test_package/package.py") in changed_files_repo(
+            repo
         )
 
 

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -1947,7 +1947,7 @@ _spack_stage() {
 _spack_style() {
     if $list_options
     then
-        SPACK_COMPREPLY="-h --help -b --base -a --all -r --root-relative -U --no-untracked -f --fix --root -t --tool -s --skip --spec-strings --repo --repo-only"
+        SPACK_COMPREPLY="-h --help -b --base -a --all -r --root-relative -U --no-untracked -f --fix --root --repo -t --tool -s --skip --spec-strings"
     else
         SPACK_COMPREPLY=""
     fi

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -1947,7 +1947,7 @@ _spack_stage() {
 _spack_style() {
     if $list_options
     then
-        SPACK_COMPREPLY="-h --help -b --base -a --all -r --root-relative -U --no-untracked -f --fix --root -t --tool -s --skip --spec-strings"
+        SPACK_COMPREPLY="-h --help -b --base -a --all -r --root-relative -U --no-untracked -f --fix --root -t --tool -s --skip --spec-strings --repo --repo-only"
     else
         SPACK_COMPREPLY=""
     fi

--- a/share/spack/spack-completion.fish
+++ b/share/spack/spack-completion.fish
@@ -3102,7 +3102,7 @@ complete -c spack -n '__fish_spack_using_command stage' -l deprecated -f -a conf
 complete -c spack -n '__fish_spack_using_command stage' -l deprecated -d 'allow concretizer to select deprecated versions'
 
 # spack style
-set -g __fish_spack_optspecs_spack_style h/help b/base= a/all r/root-relative U/no-untracked f/fix root= t/tool= s/skip= spec-strings repo= repo-only
+set -g __fish_spack_optspecs_spack_style h/help b/base= a/all r/root-relative U/no-untracked f/fix root= repo= t/tool= s/skip= spec-strings
 
 complete -c spack -n '__fish_spack_using_command style' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command style' -s h -l help -d 'show this help message and exit'
@@ -3111,23 +3111,21 @@ complete -c spack -n '__fish_spack_using_command style' -s b -l base -r -d 'bran
 complete -c spack -n '__fish_spack_using_command style' -s a -l all -f -a all
 complete -c spack -n '__fish_spack_using_command style' -s a -l all -d 'check all files, not just changed files (applies only to Import Check)'
 complete -c spack -n '__fish_spack_using_command style' -s r -l root-relative -f -a root_relative
-complete -c spack -n '__fish_spack_using_command style' -s r -l root-relative -d 'print root-relative paths (default: cwd-relative)'
+complete -c spack -n '__fish_spack_using_command style' -s r -l root-relative -d 'print root-relative paths (default: cwd-relative or repo-relative if --repo is specified)'
 complete -c spack -n '__fish_spack_using_command style' -s U -l no-untracked -f -a untracked
 complete -c spack -n '__fish_spack_using_command style' -s U -l no-untracked -d 'exclude untracked files from checks'
 complete -c spack -n '__fish_spack_using_command style' -s f -l fix -f -a fix
 complete -c spack -n '__fish_spack_using_command style' -s f -l fix -d 'format automatically if possible (e.g., with isort, black)'
 complete -c spack -n '__fish_spack_using_command style' -l root -r -f -a root
-complete -c spack -n '__fish_spack_using_command style' -l root -r -d 'style check a different spack instance'
+complete -c spack -n '__fish_spack_using_command style' -l root -r -d 'style check a different spack or repo instance. If --repo is specified, --root should be the root of the repo repository, not the repo root.'
+complete -c spack -n '__fish_spack_using_command style' -l repo -r -f -a repo
+complete -c spack -n '__fish_spack_using_command style' -l repo -r -d 'repositories to perform style checks against, specified by namespace. (default: builtin)'
 complete -c spack -n '__fish_spack_using_command style' -s t -l tool -r -f -a tool
 complete -c spack -n '__fish_spack_using_command style' -s t -l tool -r -d 'specify which tools to run (default: import, ruff-format, ruff-check, mypy)'
 complete -c spack -n '__fish_spack_using_command style' -s s -l skip -r -f -a skip
 complete -c spack -n '__fish_spack_using_command style' -s s -l skip -r -d 'specify tools to skip (choose from import, ruff-format, ruff-check, mypy)'
 complete -c spack -n '__fish_spack_using_command style' -l spec-strings -f -a spec_strings
 complete -c spack -n '__fish_spack_using_command style' -l spec-strings -d 'upgrade spec strings in Python, JSON and YAML files for compatibility with Spack v1.0 and v0.x. Example: spack style ``--spec-strings $(git ls-files)``. Note: must be used only on specs from spack v0.X.'
-complete -c spack -n '__fish_spack_using_command style' -l repo -r -f -a repo
-complete -c spack -n '__fish_spack_using_command style' -l repo -r -d 'repositories to perform style checks against, specified by namespace. (default: builtin)'
-complete -c spack -n '__fish_spack_using_command style' -l repo-only -f -a repo_only
-complete -c spack -n '__fish_spack_using_command style' -l repo-only -d 'Runs style checks only against given repositories, specified by namespace,  not spack core. (default: builtin)'
 
 # spack tags
 set -g __fish_spack_optspecs_spack_tags h/help i/installed a/all

--- a/share/spack/spack-completion.fish
+++ b/share/spack/spack-completion.fish
@@ -3102,7 +3102,7 @@ complete -c spack -n '__fish_spack_using_command stage' -l deprecated -f -a conf
 complete -c spack -n '__fish_spack_using_command stage' -l deprecated -d 'allow concretizer to select deprecated versions'
 
 # spack style
-set -g __fish_spack_optspecs_spack_style h/help b/base= a/all r/root-relative U/no-untracked f/fix root= t/tool= s/skip= spec-strings
+set -g __fish_spack_optspecs_spack_style h/help b/base= a/all r/root-relative U/no-untracked f/fix root= t/tool= s/skip= spec-strings repo= repo-only
 
 complete -c spack -n '__fish_spack_using_command style' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command style' -s h -l help -d 'show this help message and exit'
@@ -3124,6 +3124,10 @@ complete -c spack -n '__fish_spack_using_command style' -s s -l skip -r -f -a sk
 complete -c spack -n '__fish_spack_using_command style' -s s -l skip -r -d 'specify tools to skip (choose from import, ruff-format, ruff-check, mypy)'
 complete -c spack -n '__fish_spack_using_command style' -l spec-strings -f -a spec_strings
 complete -c spack -n '__fish_spack_using_command style' -l spec-strings -d 'upgrade spec strings in Python, JSON and YAML files for compatibility with Spack v1.0 and v0.x. Example: spack style ``--spec-strings $(git ls-files)``. Note: must be used only on specs from spack v0.X.'
+complete -c spack -n '__fish_spack_using_command style' -l repo -r -f -a repo
+complete -c spack -n '__fish_spack_using_command style' -l repo -r -d 'repositories to perform style checks against, specified by namespace. (default: builtin)'
+complete -c spack -n '__fish_spack_using_command style' -l repo-only -f -a repo_only
+complete -c spack -n '__fish_spack_using_command style' -l repo-only -d 'Runs style checks only against given repositories, specified by namespace,  not spack core. (default: builtin)'
 
 # spack tags
 set -g __fish_spack_optspecs_spack_tags h/help i/installed a/all


### PR DESCRIPTION
Enables `spack style` to run on arbitrary package repositories.

Runs the `import` check, `ruff check` and `ruff format` on package repositories. Does not run `mypy`. 

Adds one argument to the `spack style` command:

`--repo` which optionally takes a repo to lint, specified by repo name. If no repo is provided, defaults to `builtin`.
Specifying `--repo` will only lint a repo, not core Spack.

Attempts to respect configuration files for ruff,ty whatever found in repo roots before falling back to using Spack's configuration for our style tools. 

Style config fallback with `--repo`:
* pyproject (or ruff specific) config in root of `--repo`
* pyproject in `builtin`
* Spack's pyproject

To do:

- [x] Restore functionality dropped in rebase
- [x] Add tests
- [x] Simplify, lint only one repo at a time, no simultaneous repo + core linting.