### PR TITLE
gcs.py: fix up cert error on gcs fetch

### DIFF
--- a/lib/spack/spack/test/gcs_fetch.py
+++ b/lib/spack/spack/test/gcs_fetch.py
@@ -2,10 +2,14 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+import os
 import pathlib
+
+import pytest
 
 import spack.fetch_strategy
 import spack.stage
+import spack.util.gcs
 
 
 def test_gcsfetchstrategy_downloaded(tmp_path: pathlib.Path):
@@ -20,3 +24,24 @@ def test_gcsfetchstrategy_downloaded(tmp_path: pathlib.Path):
     fetcher = Archived_GCSFS(url="gs://example/gcs.tar.gz")
     with spack.stage.Stage(fetcher, path=str(tmp_path)):
         fetcher.fetch()
+
+
+class GCSTestImportError(Exception):
+    pass
+
+
+def test_gcs_client_env_var(monkeypatch, working_env):
+    """Ensure gcs_client sets GCE_METADATA_MTLS_MODE to none."""
+
+    def mock_try_gcs_import():
+        raise GCSTestImportError("Custom GCS import error for testing")
+
+    monkeypatch.setattr(spack.util.gcs, "try_gcs_import", mock_try_gcs_import)
+
+    if "GCE_METADATA_MTLS_MODE" in os.environ:
+        del os.environ["GCE_METADATA_MTLS_MODE"]
+
+    with pytest.raises(GCSTestImportError):
+        spack.util.gcs.gcs_client()
+
+    assert os.environ.get("GCE_METADATA_MTLS_MODE") == "none"

--- a/lib/spack/spack/util/gcs.py
+++ b/lib/spack/spack/util/gcs.py
@@ -18,14 +18,12 @@ from urllib.request import BaseHandler
 from spack.util import tty
 
 
-def gcs_client():
-    """Create a GCS client
-    Creates an authenticated GCS client to access GCS buckets and blobs
-    """
-
+def try_gcs_import():
     try:
         import google.auth
         from google.cloud import storage
+
+        return google.auth, storage
     except ImportError as ex:
         tty.error(
             "{0}, google-cloud-storage python module is missing.".format(ex)
@@ -33,7 +31,21 @@ def gcs_client():
         )
         sys.exit(1)
 
-    storage_credentials, storage_project = google.auth.default()
+
+def gcs_client():
+    """Create a GCS client
+    Creates an authenticated GCS client to access GCS buckets and blobs
+    """
+    # Disable GCE mTLS for the metadata server to avoid cert errors
+    # thrown by google-auth when accessing GCS buckets. The mTLS change was introduced in
+    # https://github.com/googleapis/google-auth-library-python/pull/1856.
+    # This change reverts back to using the http endpoint, which was the default behavior
+    # before this (erroneous) change.
+    os.environ.setdefault("GCE_METADATA_MTLS_MODE", "none")
+
+    google_auth, storage = try_gcs_import()
+
+    storage_credentials, storage_project = google_auth.default()
     storage_client = storage.Client(storage_project, storage_credentials)
     return storage_client
 

--- a/lib/spack/spack/util/gcs.py
+++ b/lib/spack/spack/util/gcs.py
@@ -18,14 +18,12 @@ from urllib.request import BaseHandler
 import spack.llnl.util.tty as tty
 
 
-def gcs_client():
-    """Create a GCS client
-    Creates an authenticated GCS client to access GCS buckets and blobs
-    """
-
+def try_gcs_import():
     try:
         import google.auth
         from google.cloud import storage
+
+        return google.auth, storage
     except ImportError as ex:
         tty.error(
             "{0}, google-cloud-storage python module is missing.".format(ex)
@@ -33,7 +31,21 @@ def gcs_client():
         )
         sys.exit(1)
 
-    storage_credentials, storage_project = google.auth.default()
+
+def gcs_client():
+    """Create a GCS client
+    Creates an authenticated GCS client to access GCS buckets and blobs
+    """
+    # Disable GCE mTLS for the metadata server to avoid cert errors
+    # thrown by google-auth when accessing GCS buckets. The mTLS change was introduced in
+    # https://github.com/googleapis/google-auth-library-python/pull/1856.
+    # This change reverts back to using the http endpoint, which was the default behavior
+    # before this (erroneous) change.
+    os.environ.setdefault("GCE_METADATA_MTLS_MODE", "none")
+
+    google_auth, storage = try_gcs_import()
+
+    storage_credentials, storage_project = google_auth.default()
     storage_client = storage.Client(storage_project, storage_credentials)
     return storage_client
 


### PR DESCRIPTION
When running with newer `google-auth` lib (https://github.com/googleapis/google-auth-library-python/pull/1856), the default behavior is to access the https endpoint of the metadata server. This is causing cert errors like the following:

```
// The spack installation comes with a build-cache hosted on a gcs bucket
spack install ior@3.2.1 +lustre ^openmpi@5.0.8 fabrics=ucx ^ucx@1.20.0 +verbs +rdmacm +rc +ud +thread_multiple

==> Error: Failed to retrieve https://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/?recursive=true from the Google Compute Engine metadata service. Compute Engine Metadata server unavailable. Last exception: HTTPSConnectionPool(host='metadata.google.internal', port=443): Max retries exceeded with url: /computeMetadata/v1/instance/service-accounts/default/?recursive=true (Caused by SSLError(SSLCertVerificationError(1, '[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: unable to get local issuer certificate (_ssl.c:1004)')))
```

This PR adds the `GCE_METADATA_MTLS_MODE` env-var to avoid accessing the https endpoint.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
