### PR TITLE
new_installer.py: use tty.color.colorize for coloring

### DIFF
--- a/lib/spack/spack/installer/ui.py
+++ b/lib/spack/spack/installer/ui.py
@@ -691,4 +691,4 @@ class TerminalUI(InstallerUI):
             else (now - build_info.start_time)
         )
         if elapsed > 0:
-            yield f"{self.color.BLACK.bright} {pretty_duration(elapsed)}{self.color.RESET}"
+            yield f"{self.color.BLACK.bright} ({pretty_duration(elapsed)}){self.color.RESET}"

--- a/lib/spack/spack/installer/ui.py
+++ b/lib/spack/spack/installer/ui.py
@@ -15,7 +15,7 @@ import time
 from typing import Callable, Dict, Generator, List, NamedTuple, Optional, Union, cast
 
 import spack.config
-import spack.util.tty.color as tty_color
+import spack.util.tty.color as coloring
 from spack.util.lang import pretty_duration
 from spack.util.log_parse import make_log_context, parse_log_events
 from spack.util.path import padding_filter, padding_filter_bytes
@@ -215,10 +215,11 @@ class TerminalUI(InstallerUI):
         self.terminal_size_changed: bool = True
         self.get_time = get_time
         self.is_tty = is_tty if is_tty is not None else stdout.isatty()
-        if color is not None:
-            self.color = color
-        else:
-            self.color = tty_color.get_color_when(stdout)
+
+        if color is None:
+            color = coloring.get_color_when(stdout)
+        self.color = coloring.get_colors(color)
+
         #: Verbose mode only applies to non-TTY where we want to track a single build log.
         self.verbose = verbose and not self.is_tty
         self.filter_padding = filter_padding
@@ -362,7 +363,7 @@ class TerminalUI(InstallerUI):
         self.tracked_build_id = new_build_id
 
         # @@ to escape @, @c for cyan, @. for reset
-        version_str = tty_color.colorize(f"@c@@{new_build.version}@.", color=self.color)
+        version_str = f"{self.color.CYAN}@{new_build.version}{self.color.RESET}"
         prefix = "" if self.log_ends_with_newline else "\n"
 
         if new_build.state == "failed":
@@ -539,10 +540,6 @@ class TerminalUI(InstallerUI):
         self.total_lines = 0
 
         if not finalize:
-            bold = "@*"
-            reset = "@."
-            cyan = "@c"
-
             if self.actual_jobs != self.target_jobs:
                 jobs_str = f"{self.actual_jobs}=>{self.target_jobs}"
             else:
@@ -555,17 +552,17 @@ class TerminalUI(InstallerUI):
                 # Need {{}} for Progress because {bold} otherwise consumes one additional character
                 self._println(
                     buffer,
-                    tty_color.colorize(
-                        f"{bold}{{Progress:}}{reset} {self.completed}/{self.total}"
-                        f"  {cyan}+{reset}/{cyan}-{reset}: "
-                        f"{jobs_str} jobs"
-                        f"  {cyan}/{reset}: filter  {cyan}v{reset}: logs"
-                        f"  {cyan}n{reset}/{cyan}p{reset}: next/prev",
-                        color=self.color,
-                    ),
+                    f"{self.color.BOLD}{{Progress:}}{self.color.RESET} {self.completed}/{self.total}"
+                    f"  {self.color.CYAN}+{self.color.RESET}/{self.color.CYAN}-{self.color.RESET}: "
+                    f"{jobs_str} jobs"
+                    f"  {self.color.CYAN}/{self.color.RESET}: filter  {self.color.CYAN}v{self.color.RESET}: logs"
+                    f"  {self.color.CYAN}n{self.color.RESET}/{self.color.CYAN}p{self.color.RESET}: next/prev",
                 )
             else:
-                self._println(buffer, f"{bold}Progress:{reset} {self.completed}/{self.total}")
+                self._println(
+                    buffer,
+                    f"{self.color.BOLD}Progress:{self.color.RESET} {self.completed}/{self.total}",
+                )
 
         if self.blocked and not has_unfinished:
             self._println(buffer, "Waiting for other Spack install process...")
@@ -639,7 +636,7 @@ class TerminalUI(InstallerUI):
         line_width = 0
         for component in self._generate_line_components(build_info, now=now):
             if max_width > 0:
-                line_width += tty_color.clen(component)
+                line_width += coloring.clen(component)
                 if line_width > max_width:
                     break
             buffer.write(component)
@@ -649,16 +646,6 @@ class TerminalUI(InstallerUI):
     ) -> Generator[str, None, None]:
         """Yield formatted line components for a package. Escape sequences are yielded as separate
         strings so they do not contribute to the line width."""
-        cyan = "@c"
-        green = "@g"
-        grey = "@K"
-        red = "@r"
-        white = "@W"
-        reset = "@."
-
-        def colorize(string):
-            return tty_color.colorize(string, color=self.color)
-
         if build_info.external:
             indicator = "[e]"
         elif build_info.state == "finished":
@@ -671,19 +658,20 @@ class TerminalUI(InstallerUI):
             indicator = f"[{SPINNER_CHARS[self.spinner_index]}]"
 
         if build_info.state == "failed":
-            color_code = red
+            color_code = self.color.RED
         elif build_info.state == "finished":
-            color_code = green
+            color_code = self.color.GREEN
         else:
             color_code = ""
 
-        yield colorize(f"{color_code}{indicator}{reset}")
+        yield f"{color_code}{indicator}{self.color.RESET}"
         yield " "
-        yield colorize(f"{grey}{build_info.hash}{reset}")
+        yield f"{self.color.BLACK.bright}{build_info.hash}{self.color.RESET}"
         yield " "
         # Package name in bold white if explicit, default otherwise
-        yield colorize(f"{white if build_info.explicit else ''}{build_info.name}{reset}")
-        yield colorize(f"{cyan}@@{build_info.version}{reset}")  # @@ escapes @
+        name_color = self.color.WHITE.bright if build_info.explicit else ""
+        yield f"{name_color}{build_info.name}{self.color.RESET}"
+        yield f"{self.color.CYAN}@{build_info.version}{self.color.RESET}"
 
         # progress or state
         if build_info.progress_percent is not None:
@@ -706,4 +694,4 @@ class TerminalUI(InstallerUI):
             else (now - build_info.start_time)
         )
         if elapsed > 0:
-            yield colorize(f"{grey} ({pretty_duration(elapsed)}){reset}")
+            yield f"{self.color.BLACK.bright} {pretty_duration(elapsed)}{self.color.RESET}"

--- a/lib/spack/spack/installer/ui.py
+++ b/lib/spack/spack/installer/ui.py
@@ -362,7 +362,6 @@ class TerminalUI(InstallerUI):
 
         self.tracked_build_id = new_build_id
 
-        # @@ to escape @, @c for cyan, @. for reset
         version_str = f"{self.color.CYAN}@{new_build.version}{self.color.RESET}"
         prefix = "" if self.log_ends_with_newline else "\n"
 
@@ -555,7 +554,6 @@ class TerminalUI(InstallerUI):
                 " next/prev"
             )
             if coloring.clen(long_header) < max_width:
-                # Need {{}} for Progress because {bold} otherwise consumes one additional character
                 self._println(buffer, long_header)
             else:
                 self._println(

--- a/lib/spack/spack/installer/ui.py
+++ b/lib/spack/spack/installer/ui.py
@@ -544,20 +544,19 @@ class TerminalUI(InstallerUI):
                 jobs_str = f"{self.actual_jobs}=>{self.target_jobs}"
             else:
                 jobs_str = str(self.target_jobs)
-            long_header_len = len(
-                f"Progress: {self.completed}/{self.total}  +/-: {jobs_str} jobs"
-                "  /: filter  v: logs  n/p: next/prev"
+
+            long_header = (
+                f"{self.color.BOLD}Progress:{self.color.RESET} {self.completed}/{self.total}"
+                f"  {self.color.CYAN}+{self.color.RESET}/{self.color.CYAN}-{self.color.RESET}: "
+                f"{jobs_str} jobs"
+                f"  {self.color.CYAN}/{self.color.RESET}: filter"
+                f"  {self.color.CYAN}v{self.color.RESET}: logs"
+                f"  {self.color.CYAN}n{self.color.RESET}/{self.color.CYAN}p{self.color.RESET}:"
+                " next/prev"
             )
-            if long_header_len < max_width:
+            if coloring.clen(long_header) < max_width:
                 # Need {{}} for Progress because {bold} otherwise consumes one additional character
-                self._println(
-                    buffer,
-                    f"{self.color.BOLD}{{Progress:}}{self.color.RESET} {self.completed}/{self.total}"
-                    f"  {self.color.CYAN}+{self.color.RESET}/{self.color.CYAN}-{self.color.RESET}: "
-                    f"{jobs_str} jobs"
-                    f"  {self.color.CYAN}/{self.color.RESET}: filter  {self.color.CYAN}v{self.color.RESET}: logs"
-                    f"  {self.color.CYAN}n{self.color.RESET}/{self.color.CYAN}p{self.color.RESET}: next/prev",
-                )
+                self._println(buffer, long_header)
             else:
                 self._println(
                     buffer,

--- a/lib/spack/spack/installer/ui.py
+++ b/lib/spack/spack/installer/ui.py
@@ -15,7 +15,7 @@ import time
 from typing import Callable, Dict, Generator, List, NamedTuple, Optional, Union, cast
 
 import spack.config
-import spack.util.tty.color
+import spack.util.tty.color as tty_color
 from spack.util.lang import pretty_duration
 from spack.util.log_parse import make_log_context, parse_log_events
 from spack.util.path import padding_filter, padding_filter_bytes
@@ -215,14 +215,10 @@ class TerminalUI(InstallerUI):
         self.terminal_size_changed: bool = True
         self.get_time = get_time
         self.is_tty = is_tty if is_tty is not None else stdout.isatty()
-        if color is None:
-            color = spack.util.tty.color.get_color_when(stdout)
-        # ANSI escape codes used for rendering; empty strings when color is disabled.
-        if color:
-            self.red, self.green, self.cyan = "\033[31m", "\033[32m", "\033[0;36m"
-            self.gray, self.bold, self.reset = "\033[0;90m", "\033[1m", "\033[0m"
+        if color is not None:
+            self.color = color
         else:
-            self.red = self.green = self.cyan = self.gray = self.bold = self.reset = ""
+            self.color = tty_color.get_color_when(stdout)
         #: Verbose mode only applies to non-TTY where we want to track a single build log.
         self.verbose = verbose and not self.is_tty
         self.filter_padding = filter_padding
@@ -365,7 +361,8 @@ class TerminalUI(InstallerUI):
 
         self.tracked_build_id = new_build_id
 
-        version_str = f"{self.cyan}@{new_build.version}{self.reset}"
+        # @@ to escape @, @c for cyan, @. for reset
+        version_str = tty_color.colorize(f"@c@@{new_build.version}@.", color=self.color)
         prefix = "" if self.log_ends_with_newline else "\n"
 
         if new_build.state == "failed":
@@ -542,20 +539,31 @@ class TerminalUI(InstallerUI):
         self.total_lines = 0
 
         if not finalize:
+            bold = "@*"
+            reset = "@."
+            cyan = "@c"
+
             if self.actual_jobs != self.target_jobs:
                 jobs_str = f"{self.actual_jobs}=>{self.target_jobs}"
             else:
                 jobs_str = str(self.target_jobs)
-            bold, reset, cyan = self.bold, self.reset, self.cyan
-            long_header = (
-                f"{bold}Progress:{reset} {self.completed}/{self.total}"
-                f"  {cyan}+{reset}/{cyan}-{reset}: "
-                f"{jobs_str} jobs"
-                f"  {cyan}/{reset}: filter  {cyan}v{reset}: logs"
-                f"  {cyan}n{reset}/{cyan}p{reset}: next/prev"
+            long_header_len = len(
+                f"Progress: {self.completed}/{self.total}  +/-: {jobs_str} jobs"
+                "  /: filter  v: logs  n/p: next/prev"
             )
-            if spack.util.tty.color.clen(long_header) < max_width:
-                self._println(buffer, long_header)
+            if long_header_len < max_width:
+                # Need {{}} for Progress because {bold} otherwise consumes one additional character
+                self._println(
+                    buffer,
+                    tty_color.colorize(
+                        f"{bold}{{Progress:}}{reset} {self.completed}/{self.total}"
+                        f"  {cyan}+{reset}/{cyan}-{reset}: "
+                        f"{jobs_str} jobs"
+                        f"  {cyan}/{reset}: filter  {cyan}v{reset}: logs"
+                        f"  {cyan}n{reset}/{cyan}p{reset}: next/prev",
+                        color=self.color,
+                    ),
+                )
             else:
                 self._println(buffer, f"{bold}Progress:{reset} {self.completed}/{self.total}")
 
@@ -630,9 +638,8 @@ class TerminalUI(InstallerUI):
         """Print a single build line to the buffer, truncating to max_width (if > 0)."""
         line_width = 0
         for component in self._generate_line_components(build_info, now=now):
-            # ANSI escape sequence(s), does not contribute to width
-            if not component.startswith("\033") and max_width > 0:
-                line_width += len(component)
+            if max_width > 0:
+                line_width += tty_color.clen(component)
                 if line_width > max_width:
                     break
             buffer.write(component)
@@ -642,6 +649,16 @@ class TerminalUI(InstallerUI):
     ) -> Generator[str, None, None]:
         """Yield formatted line components for a package. Escape sequences are yielded as separate
         strings so they do not contribute to the line width."""
+        cyan = "@c"
+        green = "@g"
+        grey = "@K"
+        red = "@r"
+        white = "@W"
+        reset = "@."
+
+        def colorize(string):
+            return tty_color.colorize(string, color=self.color)
+
         if build_info.external:
             indicator = "[e]"
         elif build_info.state == "finished":
@@ -653,32 +670,20 @@ class TerminalUI(InstallerUI):
         else:
             indicator = f"[{SPINNER_CHARS[self.spinner_index]}]"
 
-        gray, reset = self.gray, self.reset
-
         if build_info.state == "failed":
-            yield self.red
+            color_code = red
         elif build_info.state == "finished":
-            yield self.green
-
-        yield indicator
-        yield reset
-        yield " "
-        yield gray
-        yield build_info.hash
-        yield reset
-        yield " "
-
-        # Package name in bold if explicit, default otherwise
-        if build_info.explicit:
-            yield self.bold
-            yield build_info.name
-            yield reset
+            color_code = green
         else:
-            yield build_info.name
+            color_code = ""
 
-        yield self.cyan
-        yield f"@{build_info.version}"
-        yield reset
+        yield colorize(f"{color_code}{indicator}{reset}")
+        yield " "
+        yield colorize(f"{grey}{build_info.hash}{reset}")
+        yield " "
+        # Package name in bold white if explicit, default otherwise
+        yield colorize(f"{white if build_info.explicit else ''}{build_info.name}{reset}")
+        yield colorize(f"{cyan}@@{build_info.version}{reset}")  # @@ escapes @
 
         # progress or state
         if build_info.progress_percent is not None:
@@ -701,6 +706,4 @@ class TerminalUI(InstallerUI):
             else (now - build_info.start_time)
         )
         if elapsed > 0:
-            yield gray
-            yield f" ({pretty_duration(elapsed)})"
-            yield reset
+            yield colorize(f"{grey} ({pretty_duration(elapsed)}){reset}")

--- a/lib/spack/spack/installer/ui.py
+++ b/lib/spack/spack/installer/ui.py
@@ -665,8 +665,8 @@ class TerminalUI(InstallerUI):
         yield " "
         yield f"{self.color.BLACK.bright}{build_info.hash}{self.color.RESET}"
         yield " "
-        # Package name in bold white if explicit, default otherwise
-        name_color = self.color.WHITE.bright if build_info.explicit else ""
+        # Package name in bold if explicit, default otherwise
+        name_color = self.color.BOLD if build_info.explicit else ""
         yield f"{name_color}{build_info.name}{self.color.RESET}"
         yield f"{self.color.CYAN}@{build_info.version}{self.color.RESET}"
 

--- a/lib/spack/spack/installer/ui.py
+++ b/lib/spack/spack/installer/ui.py
@@ -663,7 +663,7 @@ class TerminalUI(InstallerUI):
 
         yield f"{color_code}{indicator}{self.color.RESET}"
         yield " "
-        yield f"{self.color.BLACK.bright}{build_info.hash}{self.color.RESET}"
+        yield f"{self.color.BLACK_BRIGHT}{build_info.hash}{self.color.RESET}"
         yield " "
         # Package name in bold if explicit, default otherwise
         name_color = self.color.BOLD if build_info.explicit else ""
@@ -691,4 +691,4 @@ class TerminalUI(InstallerUI):
             else (now - build_info.start_time)
         )
         if elapsed > 0:
-            yield f"{self.color.BLACK.bright} ({pretty_duration(elapsed)}){self.color.RESET}"
+            yield f"{self.color.BLACK_BRIGHT} ({pretty_duration(elapsed)}){self.color.RESET}"

--- a/lib/spack/spack/installer/ui.py
+++ b/lib/spack/spack/installer/ui.py
@@ -641,8 +641,7 @@ class TerminalUI(InstallerUI):
     def _generate_line_components(
         self, build_info: BuildInfo, static: bool = False, now: float = 0.0
     ) -> Generator[str, None, None]:
-        """Yield formatted line components for a package. Escape sequences are yielded as separate
-        strings so they do not contribute to the line width."""
+        """Yield formatted line components for a package."""
         if build_info.external:
             indicator = "[e]"
         elif build_info.state == "finished":

--- a/lib/spack/spack/test/installer/ui.py
+++ b/lib/spack/spack/test/installer/ui.py
@@ -11,6 +11,7 @@ from typing import List, Optional, Tuple
 import pytest
 
 import spack.installer.ui as inst
+import spack.util.tty.color
 from spack.installer.base import StdinReader
 from spack.installer.ui import TerminalUI
 
@@ -1406,7 +1407,8 @@ class TestTerminalUIColor:
         on_build_added(tui, "pkg")
         tui.on_state_changed("pkg", "finished")
         # green indicator, reset, dark-gray hash
-        assert stdout.getvalue().startswith("\033[32m[+]\033[0m \033[0;90m")
+        expected = spack.util.tty.color.colorize("@g[+]@. @K", color=True)
+        assert stdout.getvalue().startswith(expected)
 
     def test_non_tty_failed_color_true_emits_red(self):
         """color=True in non-TTY mode: failed line has per-component ANSI colors."""
@@ -1414,7 +1416,8 @@ class TestTerminalUIColor:
         on_build_added(tui, "pkg")
         tui.on_state_changed("pkg", "failed")
         # red indicator, reset, dark-gray hash
-        assert stdout.getvalue().startswith("\033[31m[x]\033[0m \033[0;90m")
+        expected = spack.util.tty.color.colorize("@r[x]@. @K", color=True)
+        assert stdout.getvalue().startswith(expected)
 
     def test_non_tty_finished_color_false_no_ansi(self):
         """color=False in non-TTY mode: finished line has no ANSI escape codes."""

--- a/lib/spack/spack/util/tty/color.py
+++ b/lib/spack/spack/util/tty/color.py
@@ -105,6 +105,8 @@ class Style(str):
 
 
 class Color(str):
+    bright: str
+
     def __new__(cls, normal_code: int):
         instance = super().__new__(cls, f"\033[0;{normal_code}m")
         instance.bright = f"\033[0;{normal_code + 60}m"
@@ -112,6 +114,8 @@ class Color(str):
 
 
 class NullColor(str):
+    bright: str
+
     def __new__(cls):
         instance = super().__new__(cls, "")
         instance.bright = ""

--- a/lib/spack/spack/util/tty/color.py
+++ b/lib/spack/spack/util/tty/color.py
@@ -99,36 +99,31 @@ colors = {
 }  # white
 
 
-class Style:
-    def __init__(self, style_code: int):
-        self.style = f"\033[{style_code}m"
-
-    def __repr__(self):
-        return self.style
+class Style(str):
+    def __new__(cls, style_code: int):
+        return super().__new__(cls, f"\033[{style_code}m")
 
 
-class Color:
-    def __init__(self, normal_code: int):
-        self.normal = f"\033[0;{normal_code}m"
-        self.bright = f"\033[0;{normal_code + 60}m"
-
-    def __repr__(self):
-        return self.normal
+class Color(str):
+    def __new__(cls, normal_code: int):
+        instance = super().__new__(cls, f"\033[0;{normal_code}m")
+        instance.bright = f"\033[0;{normal_code + 60}m"
+        return instance
 
 
-class NullColor:
-    bright = ""
-
-    def __repr__(self):
-        return ""
+class NullColor(str):
+    def __new__(cls):
+        instance = super().__new__(cls, "")
+        instance.bright = ""
+        return instance
 
 
 def get_colors(color: Optional[bool] = None):
     active = get_color_when() if color is None else color
-    return COLORS_ACTIVE() if active else COLORS_INACTIVE()
+    return ColorsActive if active else ColorsInactive
 
 
-class COLORS_ACTIVE:
+class ColorsActive:
     BLACK = Color(30)
     RED = Color(31)
     GREEN = Color(32)
@@ -144,18 +139,9 @@ class COLORS_ACTIVE:
     RESET = "\033[0m"
 
 
-class COLORS_INACTIVE:
-    BLACK = NullColor()
-    RED = NullColor()
-    GREEN = NullColor()
-    YELLOW = NullColor()
-    BLUE = NullColor()
-    MAGENTA = NullColor()
-    CYAN = NullColor()
-    WHITE = NullColor()
-    BOLD = NullColor()
-    UNDERLINE = NullColor()
-    RESET = NullColor()
+class ColorsInactive:
+    BLACK = RED = GREEN = YELLOW = BLUE = MAGENTA = CYAN = WHITE = NullColor()
+    BOLD = UNDERLINE = RESET = ""
 
 
 # Regex to be used for color formatting

--- a/lib/spack/spack/util/tty/color.py
+++ b/lib/spack/spack/util/tty/color.py
@@ -98,6 +98,66 @@ colors = {
     "W": 97,
 }  # white
 
+
+class Style:
+    def __init__(self, style_code: int):
+        self.style = f"\033[{style_code}m"
+
+    def __repr__(self):
+        return self.style
+
+
+class Color:
+    def __init__(self, normal_code: int):
+        self.normal = f"\033[0;{normal_code}m"
+        self.bright = f"\033[0;{normal_code + 60}m"
+
+    def __repr__(self):
+        return self.normal
+
+
+class NullColor:
+    bright = ""
+
+    def __repr__(self):
+        return ""
+
+
+def get_colors(color: Optional[bool] = None):
+    active = get_color_when() if color is None else color
+    return COLORS_ACTIVE() if active else COLORS_INACTIVE()
+
+
+class COLORS_ACTIVE:
+    BLACK = Color(30)
+    RED = Color(31)
+    GREEN = Color(32)
+    YELLOW = Color(33)
+    BLUE = Color(34)
+    MAGENTA = Color(35)
+    CYAN = Color(36)
+    WHITE = Color(37)
+
+    BOLD = Style(1)
+    UNDERLINE = Style(4)
+
+    RESET = "\033[0m"
+
+
+class COLORS_INACTIVE:
+    BLACK = NullColor()
+    RED = NullColor()
+    GREEN = NullColor()
+    YELLOW = NullColor()
+    BLUE = NullColor()
+    MAGENTA = NullColor()
+    CYAN = NullColor()
+    WHITE = NullColor()
+    BOLD = NullColor()
+    UNDERLINE = NullColor()
+    RESET = NullColor()
+
+
 # Regex to be used for color formatting
 COLOR_RE = re.compile(r"@(?:(@)|(\.)|([*_])?([a-zA-Z])?(?:{((?:[^}]|}})*)})?)")
 

--- a/lib/spack/spack/util/tty/color.py
+++ b/lib/spack/spack/util/tty/color.py
@@ -99,52 +99,40 @@ colors = {
 }  # white
 
 
-class Style(str):
-    def __new__(cls, style_code: int):
-        return super().__new__(cls, f"\033[{style_code}m")
-
-
-class Color(str):
-    bright: str
-
-    def __new__(cls, normal_code: int):
-        instance = super().__new__(cls, f"\033[0;{normal_code}m")
-        instance.bright = f"\033[0;{normal_code + 60}m"
-        return instance
-
-
-class NullColor(str):
-    bright: str
-
-    def __new__(cls):
-        instance = super().__new__(cls, "")
-        instance.bright = ""
-        return instance
-
-
 def get_colors(color: Optional[bool] = None):
     active = get_color_when() if color is None else color
     return ColorsActive if active else ColorsInactive
 
 
 class ColorsActive:
-    BLACK = Color(30)
-    RED = Color(31)
-    GREEN = Color(32)
-    YELLOW = Color(33)
-    BLUE = Color(34)
-    MAGENTA = Color(35)
-    CYAN = Color(36)
-    WHITE = Color(37)
+    BLACK =  "\033[0;30m"
+    RED = "\033[0;31m"
+    GREEN = "\033[0;32m"
+    YELLOW = "\033[0;33m"
+    BLUE = "\033[0;34m"
+    MAGENTA = "\033[0;35m"
+    CYAN = "\033[0;36m"
+    WHITE = "\033[0;37m"
 
-    BOLD = Style(1)
-    UNDERLINE = Style(4)
+    BLACK_BRIGHT =  "\033[0;90m"
+    RED_BRIGHT = "\033[0;91m"
+    GREEN_BRIGHT = "\033[0;92m"
+    YELLOW_BRIGHT = "\033[0;93m"
+    BLUE_BRIGHT = "\033[0;94m"
+    MAGENTA_BRIGHT = "\033[0;95m"
+    CYAN_BRIGHT = "\033[0;96m"
+    WHITE_BRIGHT = "\033[0;97m"
+
+    BOLD = "\033[1m"
+    UNDERLINE = "\033[4m"
 
     RESET = "\033[0m"
 
 
 class ColorsInactive:
-    BLACK = RED = GREEN = YELLOW = BLUE = MAGENTA = CYAN = WHITE = NullColor()
+    BLACK = RED = GREEN = YELLOW = BLUE = MAGENTA = CYAN = WHITE = ""
+    BLACK_BRIGHT = RED_BRIGHT = GREEN_BRIGHT = YELLOW_BRIGHT = ""
+    BLUE_BRIGHT = MAGENTA_BRIGHT = CYAN_BRIGHT = WHITE_BRIGHT = ""
     BOLD = UNDERLINE = RESET = ""
 
 
@@ -472,12 +460,10 @@ class ColorStream:
         self._color = color
 
     def write(self, string: str, *, raw: bool = False) -> None:
-        raw_write = getattr(self._stream, "write")
-
         color = self._color
         if self._color is None:
             if raw:
                 color = True
             else:
                 color = get_color_when(self._stream)
-        raw_write(colorize(string, color=color))
+        self._stream.write(colorize(string, color=color))

--- a/lib/spack/spack/util/tty/color.py
+++ b/lib/spack/spack/util/tty/color.py
@@ -105,7 +105,7 @@ def get_colors(color: Optional[bool] = None):
 
 
 class ColorsActive:
-    BLACK =  "\033[0;30m"
+    BLACK = "\033[0;30m"
     RED = "\033[0;31m"
     GREEN = "\033[0;32m"
     YELLOW = "\033[0;33m"
@@ -114,7 +114,7 @@ class ColorsActive:
     CYAN = "\033[0;36m"
     WHITE = "\033[0;37m"
 
-    BLACK_BRIGHT =  "\033[0;90m"
+    BLACK_BRIGHT = "\033[0;90m"
     RED_BRIGHT = "\033[0;91m"
     GREEN_BRIGHT = "\033[0;92m"
     YELLOW_BRIGHT = "\033[0;93m"


### PR DESCRIPTION
Removes ad-hoc coloring logic in favor of the centralized module that already exists.