### PR TITLE
add command `spack location --view`

### DIFF
--- a/lib/spack/spack/cmd/location.py
+++ b/lib/spack/spack/cmd/location.py
@@ -79,6 +79,16 @@ def setup_parser(subparser: argparse.ArgumentParser) -> None:
         default=False,
         help="location of the named or current environment",
     )
+    directories.add_argument(
+        "-v",
+        "--view",
+        action="store",
+        nargs="?",
+        metavar="name",
+        dest="location_view",
+        default=False,
+        help="location of the named or active environment view",
+    )
 
     subparser.add_argument(
         "--first",
@@ -112,6 +122,22 @@ def location(parser, args):
                 tty.die("no such environment: '%s'" % args.location_env)
             path = ev.root(args.location_env)
         print(path)
+        return
+
+    # no -v corresponds to False, -v without arg to None, -v name to the string name.
+    if args.location_view is not False:
+        env = spack.cmd.require_active_env("location -v")
+        view_name = args.location_view
+        if view_name is None:
+            # get active view name
+            view_name = os.getenv(ev.spack_env_view_var)
+            if view_name is None:
+                tty.die("no active view in the current environment")
+        # print the view location
+        if env.has_view(view_name):
+            print(f"{env.views[view_name].root}\n")
+        else:
+            tty.die("no such view in the current environment: '%s'" % view_name)
         return
 
     if args.repo is not False:

--- a/lib/spack/spack/test/cmd/location.py
+++ b/lib/spack/spack/test/cmd/location.py
@@ -104,6 +104,80 @@ def test_location_env_missing():
     assert out == error
 
 
+def test_location_active_view(mutable_mock_env_path, monkeypatch):
+    """Tests spack location --view for the active view."""
+    mutable_mock_env_path.mkdir()
+    view_path = os.path.abspath(mutable_mock_env_path / "path" / "to" / "view")
+    spack_yaml = mutable_mock_env_path / ev.manifest_name
+    spack_yaml.write_text(
+        f"""spack:
+      specs: []
+      view:
+        viewname:
+          root: {view_path}
+      concretizer:
+        unify: True
+    """
+    )
+    e = ev.Environment(mutable_mock_env_path)
+    monkeypatch.setenv(ev.spack_env_view_var, "viewname")
+    with e:
+        assert location("--view").strip() == view_path
+
+
+def test_location_no_active_view(mutable_mock_env_path):
+    """Tests spack location --env without active view."""
+    mutable_mock_env_path.mkdir()
+    view_path = os.path.abspath(mutable_mock_env_path / "path" / "to" / "view")
+    spack_yaml = mutable_mock_env_path / ev.manifest_name
+    spack_yaml.write_text(
+        f"""spack:
+      specs: []
+      view:
+        viewname:
+          root: {view_path}
+      concretizer:
+        unify: True
+    """
+    )
+    e = ev.Environment(mutable_mock_env_path)
+    error = "==> Error: no active view in the current environment"
+    with e:
+        out = location("--view", fail_on_error=False).strip()
+        assert out == error
+
+
+def test_location_view_exists(mutable_mock_env_path):
+    """Tests spack location --view <name> for an existing view."""
+    mutable_mock_env_path.mkdir()
+    view_path = os.path.abspath(mutable_mock_env_path / "path" / "to" / "view")
+    spack_yaml = mutable_mock_env_path / ev.manifest_name
+    spack_yaml.write_text(
+        f"""spack:
+      specs: []
+      view:
+        viewname:
+          root: {view_path}
+      concretizer:
+        unify: True
+    """
+    )
+    e = ev.Environment(mutable_mock_env_path)
+    with e:
+        assert location("--view", "viewname").strip() == view_path
+
+
+def test_location_view_missing(mutable_mock_env_path):
+    """Tests spack location --env <view> with missing view."""
+    e = ev.create("example", with_view=True)
+    e.write()
+    missing_view_name = "missing-view"
+    error = "==> Error: no such view in the current environment: '%s'" % missing_view_name
+    with e:
+        out = location("--view", missing_view_name, fail_on_error=False).strip()
+        assert out == error
+
+
 @pytest.mark.db
 @pytest.mark.not_on_windows("Broken on Windows")
 def test_location_install_dir(mock_spec):

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -677,7 +677,7 @@ _spack_buildcache_migrate() {
 _spack_cd() {
     if $list_options
     then
-        SPACK_COMPREPLY="-h --help -m --module-dir -r --spack-root -i --install-dir -p --package-dir --repo --packages -P -s --stage-dir -S --stages -c --source-dir -b --build-dir -e --env --first"
+        SPACK_COMPREPLY="-h --help -m --module-dir -r --spack-root -i --install-dir -p --package-dir --repo --packages -P -s --stage-dir -S --stages -c --source-dir -b --build-dir -e --env -v --view --first"
     else
         _all_packages
     fi
@@ -1406,7 +1406,7 @@ _spack_load() {
 _spack_location() {
     if $list_options
     then
-        SPACK_COMPREPLY="-h --help -m --module-dir -r --spack-root -i --install-dir -p --package-dir --repo --packages -P -s --stage-dir -S --stages -c --source-dir -b --build-dir -e --env --first"
+        SPACK_COMPREPLY="-h --help -m --module-dir -r --spack-root -i --install-dir -p --package-dir --repo --packages -P -s --stage-dir -S --stages -c --source-dir -b --build-dir -e --env -v --view --first"
     else
         _all_packages
     fi

--- a/share/spack/spack-completion.fish
+++ b/share/spack/spack-completion.fish
@@ -921,7 +921,7 @@ complete -c spack -n '__fish_spack_using_command buildcache migrate' -s y -l yes
 complete -c spack -n '__fish_spack_using_command buildcache migrate' -s y -l yes-to-all -d 'assume "yes" is the answer to every confirmation request'
 
 # spack cd
-set -g __fish_spack_optspecs_spack_cd h/help m/module-dir r/spack-root i/install-dir p/package-dir repo= s/stage-dir S/stages c/source-dir b/build-dir e/env= first
+set -g __fish_spack_optspecs_spack_cd h/help m/module-dir r/spack-root i/install-dir p/package-dir repo= s/stage-dir S/stages c/source-dir b/build-dir e/env= v/view= first
 complete -c spack -n '__fish_spack_using_command_pos_remainder 0 cd' -f -k -a '(__fish_spack_specs)'
 complete -c spack -n '__fish_spack_using_command cd' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command cd' -s h -l help -d 'show this help message and exit'
@@ -945,6 +945,8 @@ complete -c spack -n '__fish_spack_using_command cd' -s b -l build-dir -f -a bui
 complete -c spack -n '__fish_spack_using_command cd' -s b -l build-dir -d 'build directory for a spec (requires it to be staged first)'
 complete -c spack -n '__fish_spack_using_command cd' -s e -l env -r -f -a location_env
 complete -c spack -n '__fish_spack_using_command cd' -s e -l env -r -d 'location of the named or current environment'
+complete -c spack -n '__fish_spack_using_command cd' -s v -l view -r -f -a location_view
+complete -c spack -n '__fish_spack_using_command cd' -s v -l view -r -d 'location of the named or active environment view'
 complete -c spack -n '__fish_spack_using_command cd' -l first -f -a find_first
 complete -c spack -n '__fish_spack_using_command cd' -l first -d 'use the first match if multiple packages match the spec'
 
@@ -2260,7 +2262,7 @@ complete -c spack -n '__fish_spack_using_command load' -l list -f -a list
 complete -c spack -n '__fish_spack_using_command load' -l list -d 'show loaded packages: same as ``spack find --loaded``'
 
 # spack location
-set -g __fish_spack_optspecs_spack_location h/help m/module-dir r/spack-root i/install-dir p/package-dir repo= s/stage-dir S/stages c/source-dir b/build-dir e/env= first
+set -g __fish_spack_optspecs_spack_location h/help m/module-dir r/spack-root i/install-dir p/package-dir repo= s/stage-dir S/stages c/source-dir b/build-dir e/env= v/view= first
 complete -c spack -n '__fish_spack_using_command_pos_remainder 0 location' -f -k -a '(__fish_spack_specs)'
 complete -c spack -n '__fish_spack_using_command location' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command location' -s h -l help -d 'show this help message and exit'
@@ -2284,6 +2286,8 @@ complete -c spack -n '__fish_spack_using_command location' -s b -l build-dir -f 
 complete -c spack -n '__fish_spack_using_command location' -s b -l build-dir -d 'build directory for a spec (requires it to be staged first)'
 complete -c spack -n '__fish_spack_using_command location' -s e -l env -r -f -a location_env
 complete -c spack -n '__fish_spack_using_command location' -s e -l env -r -d 'location of the named or current environment'
+complete -c spack -n '__fish_spack_using_command location' -s v -l view -r -f -a location_view
+complete -c spack -n '__fish_spack_using_command location' -s v -l view -r -d 'location of the named or active environment view'
 complete -c spack -n '__fish_spack_using_command location' -l first -f -a find_first
 complete -c spack -n '__fish_spack_using_command location' -l first -d 'use the first match if multiple packages match the spec'
 


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->

Based on an answer by @becker33 to my question in slack.

In environments with multiple views, the path to the currently active view is not always obvious. This PR adds the command `spack env view show` to make the view path easier to use in scripts (and also maybe to help users find the path).

example:
```
> spack env activate <env>
> spack env view show
```
might produce output:
```
/path/to/env/.spack_env/view
```