### PR TITLE
fix: don't map prefix to view root for pkgs excluded from view

### DIFF
--- a/lib/spack/spack/test/cmd/env.py
+++ b/lib/spack/spack/test/cmd/env.py
@@ -1201,6 +1201,44 @@ packages:
         assert str(fake_bin) in env_variables["PATH"]
 
 
+def test_env_excluded_spec_run_env_not_remapped_to_view(
+    tmp_path: pathlib.Path, mock_fetch, mock_packages, install_mockery
+):
+    """Ensure setup_run_environment paths for specs excluded from a view
+    are not incorrectly remapped to the view root."""
+    view_root = tmp_path / "view"
+    manifest_dir = tmp_path / "environment"
+    manifest_dir.mkdir(parents=True, exist_ok=False)
+    manifest_file = manifest_dir / ev.manifest_name
+    manifest_file.write_text(
+        f"""\
+spack:
+  specs:
+  - sets-path-in-run-env
+  view:
+    default:
+      root: {view_root}
+      exclude: [sets-path-in-run-env]
+"""
+    )
+
+    e = ev.create("test", manifest_file)
+    e.concretize()
+    e.install_all(fake=True)
+    e.write()
+
+    env_mod = spack.util.environment.EnvironmentModifications()
+    e.add_view_to_env(env_mod, "default")
+    env_variables: Dict[str, str] = {}
+    env_mod.apply_modifications(env_variables)
+
+    pkg_spec = next(s for s in e.concrete_roots() if s.name == "sets-path-in-run-env")
+    expected = str(pkg_spec.prefix.share.join("my-data"))
+
+    # The env var must retain the install-prefix path
+    assert env_variables.get("SETS_PATH_IN_RUN_ENV_DIR") == expected
+
+
 def test_init_with_file_and_remove(tmp_path: pathlib.Path, monkeypatch):
     """Ensure a user can remove from any position in the spack.yaml file."""
     path = tmp_path / "spack.yaml"

--- a/lib/spack/spack/user_environment.py
+++ b/lib/spack/spack/user_environment.py
@@ -68,7 +68,9 @@ def project_env_mods(
 ) -> None:
     """Given a list of environment modifications, project paths changes to the view."""
     prefix_to_prefix = {
-        str(s.prefix): view.get_projection_for_spec(s) for s in specs if not s.external
+        str(s.prefix): view.get_projection_for_spec(s)
+        for s in specs
+        if not s.external and s in view
     }
     # Avoid empty regex if all external
     if not prefix_to_prefix:

--- a/lib/spack/spack/user_environment.py
+++ b/lib/spack/spack/user_environment.py
@@ -72,7 +72,7 @@ def project_env_mods(
         for s in specs
         if not s.external and s in view
     }
-    # Avoid empty regex if all external
+    # Avoid empty regex if mapping empty
     if not prefix_to_prefix:
         return
     prefix_regex = re.compile("|".join(re.escape(p) for p in prefix_to_prefix.keys()))

--- a/var/spack/test_repos/spack_repo/builtin_mock/packages/sets_path_in_run_env/package.py
+++ b/var/spack/test_repos/spack_repo/builtin_mock/packages/sets_path_in_run_env/package.py
@@ -1,0 +1,26 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack_repo.builtin_mock.build_systems.generic import Package
+
+from spack.package import *
+
+
+class SetsPathInRunEnv(Package):
+    """Package that sets a prefix-based path env var in setup_run_environment.
+
+    Used to test that view path projection does not remap env vars for specs
+    that are excluded from the target view.
+    """
+
+    homepage = "http://www.example.com"
+    url = "http://www.example.com/a-1.0.tar.gz"
+
+    version("1.0", md5="0123456789abcdef0123456789abcdef")
+
+    def setup_run_environment(self, env: EnvironmentModifications) -> None:
+        env.set("SETS_PATH_IN_RUN_ENV_DIR", self.prefix.share.join("my-data"))
+
+    def install(self, spec, prefix):
+        mkdirp(prefix.bin)


### PR DESCRIPTION
This PR fixes an issue where `setup_run_environment` maps self.prefix to the view root even when the package is explicitly excluded from the path. In those cases, the prefix is not mapped to the view root and continues to point to the install_root prefix.