### PR TITLE
spec: replace highlight callbacks with style-based callbacks

### DIFF
--- a/lib/spack/spack/cmd/spec.py
+++ b/lib/spack/spack/cmd/spec.py
@@ -178,10 +178,10 @@ def spec(parser, args):
         "show_types": args.types,
         "status_fn": status_fn,
         "hashes": args.long or args.very_long,
-        "highlight_version_fn": (
+        "version_style_fn": (
             spack.package_base.non_preferred_version if args.non_defaults else None
         ),
-        "highlight_variant_fn": (
+        "variant_style_fn": (
             spack.package_base.non_default_variant if args.non_defaults else None
         ),
     }

--- a/lib/spack/spack/enums.py
+++ b/lib/spack/spack/enums.py
@@ -54,3 +54,12 @@ class Context(enum.Enum):
         elif s == "test":
             return Context.TEST
         raise ValueError(f"context should be one of 'build', 'run', 'test', got {s}")
+
+
+class PartStyle(enum.Enum):
+    """Style to apply when formatting a part of a Spec string"""
+
+    NORMAL = "normal"
+    HIGHLIGHT = "highlight"
+    DIM = "dim"
+    HIDDEN = "hidden"

--- a/lib/spack/spack/environment/environment.py
+++ b/lib/spack/spack/environment/environment.py
@@ -2959,10 +2959,10 @@ def display_specs(
         hashes=True,
         hashlen=7,
         status_fn=status_fn if status_fn is not None else spack.store.STORE.db.install_status,
-        highlight_version_fn=(
+        version_style_fn=(
             spack.package_base.non_preferred_version if highlight_non_defaults else None
         ),
-        highlight_variant_fn=(
+        variant_style_fn=(
             spack.package_base.non_default_variant if highlight_non_defaults else None
         ),
         key=traverse.by_dag_hash,

--- a/lib/spack/spack/package_base.py
+++ b/lib/spack/spack/package_base.py
@@ -27,6 +27,7 @@ import spack.config
 import spack.dependency
 import spack.deptypes as dt
 import spack.directives_meta
+import spack.enums
 import spack.error
 import spack.fetch_strategy as fs
 import spack.hooks
@@ -2608,25 +2609,35 @@ def preferred_version(
     return version
 
 
-def non_preferred_version(node: spack.spec.Spec) -> bool:
-    """Returns True if the spec version is not the preferred one, according to the package.py"""
+def non_preferred_version(node: spack.spec.Spec) -> spack.enums.PartStyle:
+    """Returns :attr:`~spack.enums.PartStyle.HIGHLIGHT` if the spec version is not the preferred
+    one according to package.py, :attr:`~spack.enums.PartStyle.NORMAL` otherwise.
+    """
     if not node.versions.concrete:
-        return False
+        return spack.enums.PartStyle.NORMAL
 
     try:
-        return node.version != preferred_version(node.package)
+        is_preferred = node.version == preferred_version(node.package)
     except ValueError:
-        return False
+        return spack.enums.PartStyle.NORMAL
+
+    return spack.enums.PartStyle.NORMAL if is_preferred else spack.enums.PartStyle.HIGHLIGHT
 
 
-def non_default_variant(node: spack.spec.Spec, variant_name: str) -> bool:
-    """Returns True if the variant in the spec has a non-default value."""
+def non_default_variant(node: spack.spec.Spec, variant_name: str) -> spack.enums.PartStyle:
+    """Return :attr:`~spack.enums.PartStyle.HIGHLIGHT` if the variant has a non-default value,
+    :attr:`~spack.enums.PartStyle.NORMAL` otherwise.
+
+    Intended for use as ``variant_style_fn`` in :meth:`~spack.spec.Spec.format`.
+    """
     try:
         default_variant = node.package.get_variant(variant_name).make_default()
-        return not node.satisfies(str(default_variant))
+        is_non_default = not node.satisfies(str(default_variant))
     except ValueError:
-        # This is the case for special variants like "patches" etc.
-        return False
+        # Special variants like "patches" have no meaningful default.
+        return spack.enums.PartStyle.NORMAL
+
+    return spack.enums.PartStyle.HIGHLIGHT if is_non_default else spack.enums.PartStyle.NORMAL
 
 
 def sort_by_pkg_preference(

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -84,6 +84,7 @@ import spack
 import spack.aliases
 import spack.compilers.flags
 import spack.deptypes as dt
+import spack.enums
 import spack.error
 import spack.hash_types as ht
 import spack.patch
@@ -164,6 +165,12 @@ ARCHITECTURE_COLOR = "@m"  #: color for highlighting architectures
 VARIANT_COLOR = "@B"  #: color for highlighting variants
 HASH_COLOR = "@K"  #: color for highlighting package hashes
 HIGHLIGHT_COLOR = "@_R"  #: color for highlighting spec parts on demand
+DIM_COLOR = "@K"  #: color for dimmed (grey-out) spec parts
+#: Maps PartStyle to a color override; NORMAL is absent so .get(style, default) preserves default
+_STYLE_COLOR_MAP = {
+    spack.enums.PartStyle.HIGHLIGHT: HIGHLIGHT_COLOR,
+    spack.enums.PartStyle.DIM: DIM_COLOR,
+}
 
 #: Default format for Spec.format(). This format can be round-tripped, so that:
 #:     Spec(Spec("string").format()) == Spec("string)"
@@ -1325,8 +1332,9 @@ def tree(
     status_fn: Optional[Callable[["Spec"], InstallStatus]] = None,
     prefix: Optional[Callable[["Spec"], str]] = None,
     key: Callable[["Spec"], Any] = id,
-    highlight_version_fn: Optional[Callable[["Spec"], bool]] = None,
-    highlight_variant_fn: Optional[Callable[["Spec", str], bool]] = None,
+    version_style_fn: Optional[Callable[["Spec"], spack.enums.PartStyle]] = None,
+    variant_style_fn: Optional[Callable[["Spec", str], spack.enums.PartStyle]] = None,
+    architecture_style_fn: Optional[Callable[["Spec", str], spack.enums.PartStyle]] = None,
 ) -> str:
     """Prints out specs and their dependencies, tree-formatted with indentation.
 
@@ -1349,10 +1357,11 @@ def tree(
             installation status
         prefix: optional callable that takes a node as an argument and return its
             installation prefix
-        highlight_version_fn: optional callable that returns true on nodes where the version
-            needs to be highlighted
-        highlight_variant_fn: optional callable that returns true on variants that need
-            to be highlighted
+        version_style_fn: optional callable ``(node) -> PartStyle`` controlling version rendering
+        variant_style_fn: optional callable ``(node, key) -> PartStyle`` controlling variant
+            rendering
+        architecture_style_fn: optional callable ``(node, part) -> PartStyle`` controlling
+            architecture part rendering
     """
     out = ""
 
@@ -1412,8 +1421,9 @@ def tree(
             node.format(
                 format,
                 color=color,
-                highlight_version_fn=highlight_version_fn,
-                highlight_variant_fn=highlight_variant_fn,
+                version_style_fn=version_style_fn,
+                variant_style_fn=variant_style_fn,
+                architecture_style_fn=architecture_style_fn,
             )
             + "\n"
         )
@@ -4015,8 +4025,9 @@ class Spec:
         format_string: str = DEFAULT_FORMAT,
         color: Optional[bool] = False,
         *,
-        highlight_version_fn: Optional[Callable[["Spec"], bool]] = None,
-        highlight_variant_fn: Optional[Callable[["Spec", str], bool]] = None,
+        version_style_fn: Optional[Callable[["Spec"], spack.enums.PartStyle]] = None,
+        variant_style_fn: Optional[Callable[["Spec", str], spack.enums.PartStyle]] = None,
+        architecture_style_fn: Optional[Callable[["Spec", str], spack.enums.PartStyle]] = None,
     ) -> str:
         r"""Prints out attributes of a spec according to a format string.
 
@@ -4097,13 +4108,23 @@ class Spec:
         Args:
             format_string: string containing the format to be expanded
             color: True for colorized result; False for no color; None for auto color.
-            highlight_version_fn: optional callable that returns true on nodes where the version
-                needs to be highlighted
-            highlight_variant_fn: optional callable that returns true on variants that need
-                to be highlighted
+            version_style_fn: optional callable ``(node) -> PartStyle`` controlling how the
+                version part is rendered. ``HIGHLIGHT`` uses highlight color, ``DIM`` uses
+                grey-out color, ``HIDDEN`` suppresses the part entirely.
+            variant_style_fn: optional callable ``(node, key) -> PartStyle`` controlling how
+                each individual variant is rendered.
+            architecture_style_fn: optional callable ``(node, part) -> PartStyle`` controlling
+                how architecture parts are rendered. ``part`` is one of ``"platform"``,
+                ``"os"``, ``"target"``, or ``"architecture"`` for the whole ArchSpec.
         """
-        # Fast path for the common case: default format with no color
-        if format_string == DEFAULT_FORMAT and color is False:
+        # Fast path for the common case: default format with no color and no style callbacks
+        if (
+            format_string == DEFAULT_FORMAT
+            and color is False
+            and version_style_fn is None
+            and variant_style_fn is None
+            and architecture_style_fn is None
+        ):
             return self._format_default()
 
         ensure_modern_format_string(format_string)
@@ -4118,7 +4139,7 @@ class Spec:
             return clr.colorize(f"{color_fmt}{sigil}{clr.cescape(string)}@.", color=color)
 
         def format_attribute(match_object: Match) -> str:
-            (esc, sig, dep, hash, hash_len, attribute, close_brace, unmatched_close_brace) = (
+            esc, sig, dep, hash, hash_len, attribute, close_brace, unmatched_close_brace = (
                 match_object.groups()
             )
             if esc:
@@ -4148,7 +4169,6 @@ class Spec:
 
             attribute = attribute.lower()
             parts = attribute.split(".")
-            assert parts
 
             # check that the sigil is valid for the attribute.
             if not sig:
@@ -4210,47 +4230,51 @@ class Spec:
                     # not printing anything
                     return ""
 
-            # Set color codes for various attributes
-            color = None
-            if "architecture" in parts:
-                color = ARCHITECTURE_COLOR
-            elif "variants" in parts or sig.endswith("="):
-                color = VARIANT_COLOR
+            is_version_part = "version" in parts or "versions" in parts
+            is_arch_part = "architecture" in parts
+            is_variant_part = "variants" in parts
+
+            color_code = None
+            if is_arch_part:
+                color_code = ARCHITECTURE_COLOR
+            elif is_variant_part or sig.endswith("="):
+                color_code = VARIANT_COLOR
             elif any(c in parts for c in ("compiler", "compilers", "compiler_flags")):
-                color = COMPILER_COLOR
-            elif "version" in parts or "versions" in parts:
-                color = VERSION_COLOR
-                if highlight_version_fn and highlight_version_fn(current_node):
-                    color = HIGHLIGHT_COLOR
+                color_code = COMPILER_COLOR
+            elif is_version_part:
+                color_code = VERSION_COLOR
 
-            # return empty string if the value of the attribute is None.
-            if current is None:
-                return ""
+            if version_style_fn and is_version_part:
+                style = version_style_fn(current_node)
+                if style == spack.enums.PartStyle.HIDDEN:
+                    return ""
+                color_code = _STYLE_COLOR_MAP.get(style, color_code)
 
-            # Override the color for single variants, if need be
-            if color and highlight_variant_fn and isinstance(current, VariantMap):
+            if architecture_style_fn and is_arch_part:
+                style = architecture_style_fn(current_node, parts[-1])
+                if style == spack.enums.PartStyle.HIDDEN:
+                    return ""
+                color_code = _STYLE_COLOR_MAP.get(style, color_code)
+
+            if variant_style_fn and is_variant_part and isinstance(current, VariantMap):
                 bool_keys, kv_keys = current.partition_keys()
+                key_and_prefix = [(k, "") for k in bool_keys] + [(k, " ") for k in kv_keys]
                 result = ""
-
-                for key in bool_keys:
-                    current_color = color
-                    if highlight_variant_fn(current_node, key):
-                        current_color = HIGHLIGHT_COLOR
-
-                    result += safe_color(sig, str(current[key]), current_color)
-
-                for key in kv_keys:
-                    current_color = color
-                    if highlight_variant_fn(current_node, key):
-                        current_color = HIGHLIGHT_COLOR
-
-                    # Don't highlight the space before the key/value pair
-                    result += " " + safe_color(sig, f"{current[key]}", current_color)
-
+                for key, prefix in key_and_prefix:
+                    style = variant_style_fn(current_node, key)
+                    if style == spack.enums.PartStyle.HIDDEN:
+                        continue
+                    key_color: Optional[str] = _STYLE_COLOR_MAP.get(style, color_code)
+                    result += prefix + safe_color(sig, str(current[key]), key_color)
                 return result
 
-            # return colored output
-            return safe_color(sig, str(current), color)
+            if variant_style_fn and is_variant_part and not isinstance(current, VariantMap):
+                style = variant_style_fn(current_node, parts[-1])
+                if style == spack.enums.PartStyle.HIDDEN:
+                    return ""
+                color_code = _STYLE_COLOR_MAP.get(style, color_code)
+
+            return safe_color(sig, str(current), color_code)
 
         return SPEC_FORMAT_RE.sub(format_attribute, format_string).strip()
 
@@ -4492,8 +4516,9 @@ class Spec:
         status_fn: Optional[Callable[["Spec"], InstallStatus]] = None,
         prefix: Optional[Callable[["Spec"], str]] = None,
         key=id,
-        highlight_version_fn: Optional[Callable[["Spec"], bool]] = None,
-        highlight_variant_fn: Optional[Callable[["Spec", str], bool]] = None,
+        version_style_fn: Optional[Callable[["Spec"], spack.enums.PartStyle]] = None,
+        variant_style_fn: Optional[Callable[["Spec", str], spack.enums.PartStyle]] = None,
+        architecture_style_fn: Optional[Callable[["Spec", str], spack.enums.PartStyle]] = None,
     ) -> str:
         """Prints out this spec and its dependencies, tree-formatted with indentation.
 
@@ -4517,10 +4542,12 @@ class Spec:
                 installation status
             prefix: optional callable that takes a node as an argument and return its
                 installation prefix
-            highlight_version_fn: optional callable that returns true on nodes where the version
-                needs to be highlighted
-            highlight_variant_fn: optional callable that returns true on variants that need
-                to be highlighted
+            version_style_fn: optional callable ``(node) -> PartStyle`` controlling version
+                rendering
+            variant_style_fn: optional callable ``(node, key) -> PartStyle`` controlling variant
+                rendering
+            architecture_style_fn: optional callable ``(node, part) -> PartStyle`` controlling
+                architecture part rendering
         """
         return tree(
             [self],
@@ -4538,8 +4565,9 @@ class Spec:
             status_fn=status_fn,
             prefix=prefix,
             key=key,
-            highlight_version_fn=highlight_version_fn,
-            highlight_variant_fn=highlight_variant_fn,
+            version_style_fn=version_style_fn,
+            variant_style_fn=variant_style_fn,
+            architecture_style_fn=architecture_style_fn,
         )
 
     def __repr__(self):

--- a/lib/spack/spack/test/spec_format.py
+++ b/lib/spack/spack/test/spec_format.py
@@ -1,0 +1,200 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+"""Tests formatting of spec strings"""
+
+from spack.enums import PartStyle
+from spack.spec import DIM_COLOR, HIGHLIGHT_COLOR, VARIANT_COLOR, VERSION_COLOR
+from spack.util.tty.color import colorize
+
+
+def _always_version(style):
+    """Returns a version_style_fn that always returns *style*."""
+    return lambda node: style
+
+
+def _always_variant(style):
+    """Returns a variant_style_fn that always returns *style* for every key."""
+    return lambda node, key: style
+
+
+def _always_arch(style):
+    """Returns an architecture_style_fn that always returns *style*."""
+    return lambda node, part: style
+
+
+def _variant_key(target_key, match_style, other_style=PartStyle.NORMAL):
+    """Returns a variant_style_fn that returns *match_style* for *target_key*."""
+    return lambda node, key: match_style if key == target_key else other_style
+
+
+def test_version_style_hidden(default_mock_concretization):
+    """Tests that HIDDEN suppresses the version entirely."""
+    s = default_mock_concretization("mpileaks@2.3")
+    result = s.format("{@version}", version_style_fn=_always_version(PartStyle.HIDDEN))
+    assert result == ""
+
+    result = s.format("{name}{@version}", version_style_fn=_always_version(PartStyle.HIDDEN))
+    assert result == "mpileaks"
+
+
+def test_version_style_highlight(default_mock_concretization):
+    """Tests that HIGHLIGHT applies HIGHLIGHT_COLOR to the version"""
+    s = default_mock_concretization("mpileaks@2.3")
+    result = s.format(
+        "{name}{@version}", color=True, version_style_fn=_always_version(PartStyle.HIGHLIGHT)
+    )
+    expected = colorize(f"mpileaks{HIGHLIGHT_COLOR}@@{s.version}@.", color=True)
+    assert result == expected
+
+
+def test_version_style_dim(default_mock_concretization):
+    """Tests that DIM applies DIM_COLOR to the version."""
+    s = default_mock_concretization("mpileaks@2.3")
+    result = s.format(
+        "{name}{@version}", color=True, version_style_fn=_always_version(PartStyle.DIM)
+    )
+    expected = colorize(f"mpileaks{DIM_COLOR}@@{s.version}@.", color=True)
+    assert result == expected
+
+
+def test_version_style_normal_uses_default_color(default_mock_concretization):
+    """Tests that NORMAL keeps the default VERSION_COLOR."""
+    s = default_mock_concretization("mpileaks@2.3")
+    result = s.format(
+        "{name}{@version}", color=True, version_style_fn=_always_version(PartStyle.NORMAL)
+    )
+    expected = colorize(f"mpileaks{VERSION_COLOR}@@{s.version}@.", color=True)
+    assert result == expected
+
+
+def test_single_variant_style_hidden(default_mock_concretization):
+    """Tests that HIDDEN on a single variant suppresses it."""
+    s = default_mock_concretization("mpileaks+debug")
+    result = s.format("{name}{variants.debug}", variant_style_fn=_always_variant(PartStyle.HIDDEN))
+    assert result == "mpileaks"
+
+
+def test_single_variant_style_highlight(default_mock_concretization):
+    """Tests that HIGHLIGHT on a single variant applies HIGHLIGHT_COLOR."""
+    s = default_mock_concretization("mpileaks+debug")
+    result = s.format(
+        "{name}{variants.debug}", color=True, variant_style_fn=_always_variant(PartStyle.HIGHLIGHT)
+    )
+    expected = colorize(f"mpileaks{HIGHLIGHT_COLOR}{s.variants['debug']}@.", color=True)
+    assert result == expected
+
+
+def test_single_variant_style_dim(default_mock_concretization):
+    """Tests that DIM on a single variant applies DIM_COLOR."""
+    s = default_mock_concretization("mpileaks+debug")
+    result = s.format(
+        "{name}{variants.debug}", color=True, variant_style_fn=_always_variant(PartStyle.DIM)
+    )
+    expected = colorize(f"mpileaks{DIM_COLOR}{s.variants['debug']}@.", color=True)
+    assert result == expected
+
+
+def test_single_variant_style_normal_uses_variant_color(default_mock_concretization):
+    """Tests that NORMAL keeps the default VARIANT_COLOR."""
+    s = default_mock_concretization("mpileaks+debug")
+    result = s.format(
+        "{variants.debug}", color=True, variant_style_fn=_always_variant(PartStyle.NORMAL)
+    )
+    expected = colorize(f"{VARIANT_COLOR}{s.variants['debug']}@.", color=True)
+    assert result == expected
+
+
+def test_all_variants_some_hidden(default_mock_concretization):
+    """Tests that HIDDEN for a specific key removes it from the output."""
+    s = default_mock_concretization("mpileaks+debug")
+    result = s.format("{variants}", variant_style_fn=_variant_key("debug", PartStyle.HIDDEN))
+    assert "+debug" not in result
+    assert "~debug" not in result
+
+
+def test_all_variants_mixed_styles(default_mock_concretization):
+    """Tests that different keys can have different styles."""
+    s = default_mock_concretization("mpileaks+debug")
+    result = s.format(
+        "{variants}",
+        color=True,
+        variant_style_fn=_variant_key("debug", PartStyle.HIGHLIGHT, PartStyle.DIM),
+    )
+    highlighted = colorize(f"{HIGHLIGHT_COLOR}+debug@.", color=True)
+    assert highlighted in result
+    dimmed_shared = colorize(f"{DIM_COLOR}+shared@.", color=True)
+    assert dimmed_shared in result
+
+
+def test_all_variants_all_hidden(default_mock_concretization):
+    """Tests that all variants HIDDEN leads to the empty string."""
+    s = default_mock_concretization("mpileaks+debug")
+    result = s.format("{variants}", variant_style_fn=_always_variant(PartStyle.HIDDEN))
+    assert result == ""
+
+
+def test_architecture_platform_hidden(default_mock_concretization):
+    """Tests that HIDDEN for 'platform' suppresses the platform part."""
+    s = default_mock_concretization("mpileaks")
+    result = s.format(
+        "{name}{ platform=architecture.platform}",
+        architecture_style_fn=_always_arch(PartStyle.HIDDEN),
+    )
+    assert result == "mpileaks"
+
+
+def test_architecture_os_hidden(default_mock_concretization):
+    """Tests that HIDDEN for 'os' suppresses the os part."""
+    s = default_mock_concretization("mpileaks")
+    result = s.format(
+        "{name}{ os=architecture.os}", architecture_style_fn=_always_arch(PartStyle.HIDDEN)
+    )
+    assert result == "mpileaks"
+
+
+def test_architecture_target_hidden(default_mock_concretization):
+    """Tests that HIDDEN for 'target' suppresses the target part."""
+    s = default_mock_concretization("mpileaks")
+    result = s.format(
+        "{name}{ target=architecture.target}", architecture_style_fn=_always_arch(PartStyle.HIDDEN)
+    )
+    assert result == "mpileaks"
+
+
+def test_architecture_target_highlight(default_mock_concretization):
+    """Tests that HIGHLIGHT for 'target' applies HIGHLIGHT_COLOR."""
+    s = default_mock_concretization("mpileaks")
+    result = s.format(
+        "{ target=architecture.target}",
+        color=True,
+        architecture_style_fn=_always_arch(PartStyle.HIGHLIGHT),
+    )
+    expected = colorize(f"{HIGHLIGHT_COLOR} target={s.architecture.target}@.", color=True)
+    assert result == expected
+
+
+def test_architecture_os_dim(default_mock_concretization):
+    """Tests that DIM for 'os' applies DIM_COLOR."""
+    s = default_mock_concretization("mpileaks")
+    result = s.format(
+        "{ os=architecture.os}", color=True, architecture_style_fn=_always_arch(PartStyle.DIM)
+    )
+    expected = colorize(f"{DIM_COLOR} os={s.architecture.os}@.", color=True)
+    assert result == expected
+
+
+def test_architecture_style_fn_receives_correct_part(default_mock_concretization):
+    """Tests that architecture_style_fn receives the correct sub-part name."""
+    s = default_mock_concretization("mpileaks")
+    received_parts = []
+
+    def record_part(node, part):
+        received_parts.append(part)
+        return PartStyle.NORMAL
+
+    s.format(
+        "{ platform=architecture.platform}{ os=architecture.os}{ target=architecture.target}",
+        architecture_style_fn=record_part,
+    )
+    assert received_parts == ["platform", "os", "target"]

--- a/lib/spack/spack/test/spec_semantics.py
+++ b/lib/spack/spack/test/spec_semantics.py
@@ -2582,10 +2582,11 @@ def test_highlighting_spec_parts(spec_str, expected_fmt, default_mock_concretiza
     """Tests correct highlighting of non-default versions and variants"""
     s = default_mock_concretization(spec_str)
     expected = colorize(expected_fmt, color=True)
+
     colorized_str = s.format(
         color=True,
-        highlight_version_fn=spack.package_base.non_preferred_version,
-        highlight_variant_fn=spack.package_base.non_default_variant,
+        version_style_fn=spack.package_base.non_preferred_version,
+        variant_style_fn=spack.package_base.non_default_variant,
     )
     assert expected in colorized_str
 


### PR DESCRIPTION
Replace the `highlight_version_fn` and `highlight_variant_fn` parameters of `Spec.format()` returning a Boolean with three style callbacks that return the `PartStyle` enum.

This enum can currently take four values:
1. NORMAL
2. HIGHLIGHT
3. DIM
4. HIDDEN

HIGHLIGHT currently renders that spec part in red. DIM renders the part in grey-out color. HIDDEN suppresses it entirely from the output.

**Notes**
- This change will be useful to any future PR that deals with formatting specs (e.g. a `spack env diff` command that can compare two lockfiles)
- Technically this change breaks the package API, but I would avoid maintaining backward compatibility on an essentially internal method of specs

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
