### PR TITLE
Allow disabling develop package reference stage links via config.

### DIFF
--- a/lib/spack/spack/package_base.py
+++ b/lib/spack/spack/package_base.py
@@ -1211,7 +1211,10 @@ class PackageBase(WindowsRPath, PackageViewMixin, metaclass=PackageMeta):
             link_format = spack.config.get("config:develop_stage_link")
             if not link_format:
                 link_format = "build-{arch}-{hash:7}"
-            stage_link = self.spec.format_path(link_format)
+            if link_format == "None":
+                stage_link = None
+            else:
+                stage_link = self.spec.format_path(link_format)
             source_stage = stg.DevelopStage(
                 stg.compute_stage_name(self.spec), dev_path, stage_link
             )

--- a/lib/spack/spack/schema/config.py
+++ b/lib/spack/spack/schema/config.py
@@ -89,7 +89,8 @@ properties: Dict[str, Any] = {
             },
             "develop_stage_link": {
                 "type": "string",
-                "description": "Name for development spec build stage directories",
+                "description": "Name for development spec build stage directories. Setting to "
+                "None will disable develop stage links.",
             },
             "test_stage": {
                 "type": "string",

--- a/lib/spack/spack/stage.py
+++ b/lib/spack/spack/stage.py
@@ -974,13 +974,16 @@ class DevelopStage(AbstractStage):
         self._source_path = dev_path
 
         # The path of a link that will point to this stage
-        if os.path.isabs(reference_link):
-            link_path = reference_link
+        if reference_link:
+            if os.path.isabs(reference_link):
+                link_path = reference_link
+            else:
+                link_path = os.path.join(self._source_path, reference_link)
+            if not os.path.isdir(os.path.dirname(link_path)):
+                raise StageError(f"The directory containing {link_path} must exist")
+            self.reference_link = link_path
         else:
-            link_path = os.path.join(self._source_path, reference_link)
-        if not os.path.isdir(os.path.dirname(link_path)):
-            raise StageError(f"The directory containing {link_path} must exist")
-        self.reference_link = link_path
+            self.reference_link = None
 
     @property
     def source_path(self):
@@ -1007,10 +1010,11 @@ class DevelopStage(AbstractStage):
 
     def create(self):
         super().create()
-        try:
-            symlink(self.path, self.reference_link)
-        except (AlreadyExistsError, FileExistsError):
-            pass
+        if self.reference_link:
+            try:
+                symlink(self.path, self.reference_link)
+            except (AlreadyExistsError, FileExistsError):
+                pass
 
     def destroy(self):
         # Destroy all files, but do not follow symlinks
@@ -1018,10 +1022,11 @@ class DevelopStage(AbstractStage):
             shutil.rmtree(self.path)
         except FileNotFoundError:
             pass
-        try:
-            os.remove(self.reference_link)
-        except FileNotFoundError:
-            pass
+        if self.reference_link:
+            try:
+                os.remove(self.reference_link)
+            except FileNotFoundError:
+                pass
         self.created = False
 
     def restage(self):

--- a/lib/spack/spack/test/stage.py
+++ b/lib/spack/spack/test/stage.py
@@ -871,6 +871,21 @@ class TestDevelopStage:
         srctree2 = _create_tree_from_dir_recursive(srcdir)
         assert srctree2 == devtree
 
+    def test_develop_stage_without_reference_link(self, develop_path, tmp_build_stage_dir):
+        """Check that develop stages can be created without creating a reference link"""
+        devtree, srcdir = develop_path
+        stage = DevelopStage("test-stage", srcdir, reference_link=None)
+        stage.create()
+        srctree1 = _create_tree_from_dir_recursive(stage.source_path)
+        assert srctree1 == devtree
+
+        stage.destroy()
+        # Make sure destroying the stage doesn't change anything
+        # about the path
+        assert not os.path.exists(stage.path)
+        srctree2 = _create_tree_from_dir_recursive(srcdir)
+        assert srctree2 == devtree
+
 
 def test_stage_create_replace_path(tmp_build_stage_dir):
     """Ensure stage creation replaces a non-directory path."""


### PR DESCRIPTION
By setting the existing config:develop_stage_link option to "None".

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
