### PR TITLE
new_installer.py: schedule build deps dynamically

### DIFF
--- a/lib/spack/spack/new_installer.py
+++ b/lib/spack/spack/new_installer.py
@@ -70,6 +70,7 @@ import spack.hooks
 import spack.llnl.util.filesystem as fs
 import spack.llnl.util.tty
 import spack.llnl.util.tty.color
+import spack.mirrors.mirror
 import spack.paths
 import spack.report
 import spack.spec
@@ -117,6 +118,13 @@ OVERWRITE_GARBAGE_SUFFIX = ".garbage"
 #: Exit code used by the child process to signal that the build was stopped at a phase boundary
 EXIT_STOPPED_AT_PHASE = 3
 
+#: Exit code used by the child process to signal a binary cache miss (no source fallback)
+EXIT_BUILD_CACHE_MISS = 4
+
+
+class BinaryCacheMiss(spack.error.SpackError):
+    pass
+
 
 class DatabaseAction:
     """Base class for objects that need to be persisted to the database."""
@@ -128,13 +136,13 @@ class DatabaseAction:
 
     def save_to_db(self, db: spack.database.Database) -> None: ...
 
-    def release_lock(self) -> None:
+    def release_prefix_lock(self) -> None:
         if self.prefix_lock is not None:
             try:
                 self.prefix_lock.release_write()
             except Exception:
                 pass
-            self.prefix_lock = None
+        self.prefix_lock = None
 
 
 class MarkExplicitAction(DatabaseAction):
@@ -225,7 +233,7 @@ def tee(control_r: int, log_r: int, log_path: str, parent_w: int) -> None:
     selector.register(control_r, selectors.EVENT_READ)
 
     try:
-        with open(log_path, "wb") as log_file, open(parent_w, "wb", closefd=False) as parent:
+        with open(log_path, "ab") as log_file, open(parent_w, "wb", closefd=False) as parent:
             while True:
                 for key, _ in selector.select():
                     if key.fd == log_r:
@@ -396,8 +404,9 @@ class PrefixPivoter:
             return
 
         # Failure handling:
-        if self.keep_prefix:
-            # Leave the failed prefix in place, discard the backup
+        if self.keep_prefix and not issubclass(exc_type, BinaryCacheMiss):
+            # Leave the failed prefix in place, discard the backup. Except for binary cache misses,
+            # which is a scheduling failure and not a build failure.
             if self.tmp_prefix is not None:
                 self._rmtree_ignore_errors(self.tmp_prefix)
         elif self.tmp_prefix is not None:
@@ -565,6 +574,8 @@ def worker_function(
     except ProcessError as e:
         print(e, file=sys.stderr)
         exit_code = 1
+    except BinaryCacheMiss:
+        exit_code = EXIT_BUILD_CACHE_MISS
     except BaseException:
         traceback.print_exc(limit=-4)
         exit_code = 1
@@ -695,9 +706,8 @@ def _install(
             spack.hooks.post_install(spec, explicit)
             return
         elif install_policy == "cache_only":
-            # Binary required but not available
             send_state("no binary available", state_stream)
-            raise spack.error.InstallError(f"No binary available for {spec}")
+            raise BinaryCacheMiss(f"No binary available for {spec}")
 
     unmodified_env = os.environ.copy()
     env_mods = spack.build_environment.setup_package(pkg, dirty=dirty)
@@ -933,6 +943,7 @@ def start_build(
     install_source: bool,
     run_tests: bool,
     jobserver: JobServer,
+    log_path: str,
     stop_before: Optional[str] = None,
     stop_at: Optional[str] = None,
 ) -> ChildInfo:
@@ -947,17 +958,6 @@ def start_build(
     gmake = next(iter(spec.dependencies("gmake")), None)
     makeflags = jobserver.makeflags(gmake)
     fifo = "--jobserver-auth=fifo:" in makeflags
-
-    # TODO: remove once external specs do not create a build process
-    if spec.external:
-        log_path = os.devnull
-    else:
-        log_fd, log_path = tempfile.mkstemp(
-            prefix=f"spack-stage-{spec.name}-{spec.version}-{spec.dag_hash()}-",
-            suffix=".log",
-            dir=spack.stage.get_stage_root(),
-        )
-        os.close(log_fd)  # child will open it
 
     proc = Process(
         target=worker_function,
@@ -1116,7 +1116,7 @@ class BuildInfo:
         self.duration: Optional[float] = None
         self.progress_percent: Optional[int] = None
         self.control_w_conn = control_w_conn
-        self.log_path: Optional[str] = log_path
+        self.log_path = log_path
         self.log_summary: Optional[str] = None
 
 
@@ -1196,6 +1196,15 @@ class BuildStatus:
                 os.write(control_w_conn.fileno(), b"1")
             except OSError:
                 pass
+
+    def remove_build(self, build_id: str) -> None:
+        """Remove a build from the display (e.g. after a binary cache miss before retry)."""
+        self.builds.pop(build_id, None)
+        if self.tracked_build_id == build_id:
+            self.tracked_build_id = ""
+            if not self.overview_mode:
+                self.overview_mode = True
+        self.dirty = True
 
     def toggle(self) -> None:
         """Toggle between overview mode and following a specific build."""
@@ -1650,9 +1659,13 @@ class BuildGraph:
         overwrite_set = overwrite_set or set()
         explicit_set = explicit_set or set()
         self.pruned: Set[str] = set()
+        self.done: Set[str] = set()
+        self.force_source: Set[str] = set()
         stack: List[Tuple[spack.spec.Spec, InstallPolicy]] = [
             (s, root_policy) for s in self.nodes.values()
         ]
+
+        self.tests = tests
 
         with database.read_transaction():
             # Set the install prefix for each spec based on the db record or store layout
@@ -1668,23 +1681,18 @@ class BuildGraph:
                 spec, install_policy = stack.pop()
                 key = spec.dag_hash()
                 _, record = database.query_by_spec_hash(key)
+                depflag = self._base_deptypes(spec)
 
                 # Conditionally include build dependencies. Don't prune installed specs
                 # that need to be marked explicit so they flow through the DB write path.
                 if record and record.installed and key not in overwrite_set:
-                    # Installed spec only needs link/run deps traversed.
-                    dependencies = spec.dependencies(deptype=dt.LINK | dt.RUN)
                     # If it needs to be marked explicit, keep it in the graph (don't prune).
-                    if not (key in explicit_set and not record.explicit):
+                    if key not in explicit_set or record.explicit:
                         self.pruned.add(key)
-                elif install_policy == "cache_only" and not include_build_deps:
-                    dependencies = spec.dependencies(deptype=dt.LINK | dt.RUN)
-                else:
-                    deptype = dt.BUILD | dt.LINK | dt.RUN
-                    if tests is True or (tests and spec.name in tests):
-                        deptype |= dt.TEST
-                    dependencies = spec.dependencies(deptype=deptype)
+                elif install_policy == "source_only" or include_build_deps:
+                    depflag |= dt.BUILD
 
+                dependencies = spec.dependencies(deptype=depflag)
                 self.parent_to_child[key] = {d.dag_hash() for d in dependencies}
 
                 # Enqueue new dependencies
@@ -1738,6 +1746,15 @@ class BuildGraph:
                     "installed"
                 )
 
+    def _base_deptypes(self, spec: spack.spec.Spec) -> dt.DepFlag:
+        """Returns the dependency types that are always eagerly traversed. These are LINK, RUN, and
+        conditionally TEST, but excludes BUILD. Build deps are deferred until after a build cache
+        miss."""
+        deptypes = dt.LINK | dt.RUN
+        if self.tests is True or (self.tests and spec.name in self.tests):
+            deptypes |= dt.TEST
+        return deptypes
+
     def enqueue_parents(self, dag_hash: str, pending_builds: List[str]) -> None:
         """After a spec is installed, remove it from the graph and enqueue any parents that are
         now ready to install.
@@ -1746,6 +1763,7 @@ class BuildGraph:
             dag_hash: The dag_hash of the spec that was just installed
             pending_builds: List to append parent specs that are ready to build
         """
+        self.done.add(dag_hash)
         # Remove node and edges from the node in the build graph
         self.parent_to_child.pop(dag_hash, None)
         self.nodes.pop(dag_hash, None)
@@ -1760,6 +1778,85 @@ class BuildGraph:
             children.remove(dag_hash)
             if not children:
                 pending_builds.append(parent)
+
+    def has_unexpanded_build_deps(self, dag_hash: str) -> bool:
+        return bool(self.get_unexpanded_build_deps(dag_hash))
+
+    def get_unexpanded_build_deps(self, dag_hash: str) -> List["spack.spec.Spec"]:
+        """Returns a list of unprocessed build deps for a spec."""
+        spec = self.nodes[dag_hash]
+        base_deptypes = self._base_deptypes(spec)
+        unexpanded = []
+        for edge in spec.edges_to_dependencies(depflag=dt.BUILD):
+            if (edge.depflag & base_deptypes) == 0:
+                unexpanded.append(edge.spec)
+        return unexpanded
+
+    def expand_build_deps(
+        self,
+        spec_hashes: List[str],
+        pending_builds: List[str],
+        database: "spack.database.Database",
+        dependencies_policy: InstallPolicy = "auto",
+    ) -> List[str]:
+        """Expand build dependencies for a list of specs after binary cache misses.
+
+        Adds the spec's build deps and their transitive runtime deps to the graph. When
+        ``dependencies_policy`` is ``"source_only"``, build deps of newly added specs are included
+        immediately. Installed deps are skipped without adding edges.
+
+        The caller must hold the database read lock and have called ``db._read()``.
+
+        Returns the list of newly added dag hashes."""
+        # Seed with tuples of (parent_hash, dep) for each to-be-expanded build dep
+        stack = [(h, dep) for h in spec_hashes for dep in self.get_unexpanded_build_deps(h)]
+        newly_added: List[str] = []
+
+        while stack:
+            parent_hash, dep = stack.pop()
+            dep_hash = dep.dag_hash()
+
+            # Skip installed deps
+            if dep_hash in self.pruned or dep_hash in self.done:
+                continue
+
+            # If already in the graph (e.g. overwrite build in progress), add edge but don't
+            # re-add node. This must be checked before the DB installed check, because an
+            # overwrite build is installed in the DB but not yet done.
+            if dep_hash in self.nodes:
+                self.parent_to_child.setdefault(parent_hash, set()).add(dep_hash)
+                self.child_to_parent.setdefault(dep_hash, set()).add(parent_hash)
+                continue
+
+            _, record = database.query_by_spec_hash(dep_hash)
+            if record and record.installed:
+                self.done.add(dep_hash)
+                continue
+
+            # Add forward/reverse edge
+            self.parent_to_child.setdefault(parent_hash, set()).add(dep_hash)
+            self.child_to_parent.setdefault(dep_hash, set()).add(parent_hash)
+
+            # New node: add to graph and recurse into its link/run/test deps
+            self.nodes[dep_hash] = dep
+            self.parent_to_child.setdefault(dep_hash, set())
+            newly_added.append(dep_hash)
+
+            deptype = self._base_deptypes(dep)
+            if dependencies_policy == "source_only":
+                deptype |= dt.BUILD
+            for child in dep.dependencies(deptype=deptype):
+                stack.append((dep_hash, child))
+
+        # Enqueue nodes that are ready (no uninstalled children)
+        for h in newly_added:
+            if not self.parent_to_child[h]:
+                pending_builds.append(h)
+        for dag_hash in spec_hashes:
+            if not self.parent_to_child[dag_hash]:
+                pending_builds.append(dag_hash)
+
+        return newly_added
 
 
 class ScheduleResult(NamedTuple):
@@ -2249,6 +2346,12 @@ class PackageInstaller:
 
         specs = [pkg.spec for pkg in packages]
 
+        # No point trying cache when there are no binary mirrors configured.
+        if not spack.mirrors.mirror.MirrorCollection(binary=True):
+            if root_policy == "auto":
+                root_policy = "source_only"
+            if dependencies_policy == "auto":
+                dependencies_policy = "source_only"
         self.root_policy: InstallPolicy = root_policy
         self.dependencies_policy: InstallPolicy = dependencies_policy
         self.include_build_deps = include_build_deps
@@ -2304,6 +2407,9 @@ class PackageInstaller:
         self.pending_builds = [
             parent for parent, children in self.build_graph.parent_to_child.items() if not children
         ]
+
+        #: specs awaiting build-dep expansion (deferred until DB read lock is available)
+        self.pending_expansions: List[str] = []
 
         self.verbose = verbose
         self.running_builds: Dict[int, ChildInfo] = {}
@@ -2372,7 +2478,12 @@ class PackageInstaller:
                 )
                 self.build_status.set_blocked(blocked and not self.running_builds)
 
-            while self.pending_builds or self.running_builds or database_actions:
+            while (
+                self.pending_builds
+                or self.running_builds
+                or database_actions
+                or self.pending_expansions
+            ):
                 # Monitor the jobserver when we have pending builds, capacity, and at least one
                 # spec is not locked by another process. Also listen if the target parallelism is
                 # reduced.
@@ -2429,9 +2540,10 @@ class PackageInstaller:
                         jobserver.maybe_discard_tokens()
                         self.build_status.set_jobs(jobserver.num_jobs, jobserver.target_jobs)
 
-                if finished_pids:
-                    self._handle_finished_builds(
-                        finished_pids, selector, jobserver, database_actions, failures
+                current_time = time.monotonic()
+                for pid in finished_pids:
+                    self._handle_finished_build(
+                        pid, current_time, jobserver, selector, failures, database_actions
                     )
 
                 if failures and self.fail_fast:
@@ -2468,12 +2580,18 @@ class PackageInstaller:
                 if (
                     database_actions
                     and (
-                        time.monotonic() >= self.next_database_write
+                        current_time >= self.next_database_write
                         or not (self.pending_builds or self.running_builds)
                     )
                     and self._save_to_db(database_actions, retained_read_locks)
                 ):
                     database_actions.clear()
+
+                # Try to expand build deps for cache-miss specs. This requires a read lock on the
+                # database, meaning that it can take several iterations of the event loop in case
+                # of contention with other processes.
+                if self.pending_expansions:
+                    self._try_expand_build_deps()
 
                 # Try to schedule more builds, acquiring per-spec locks and jobserver tokens.
                 if self.capacity and self.pending_builds:
@@ -2521,7 +2639,7 @@ class PackageInstaller:
             # Release all held locks best-effort, so that one failure does not prevent the others
             # from being released.
             for child in self.running_builds.values():
-                child.release_lock()
+                child.release_prefix_lock()
 
             for lock in retained_read_locks:
                 try:
@@ -2529,7 +2647,7 @@ class PackageInstaller:
                 except Exception:
                     pass
             for action in database_actions:
-                action.release_lock()
+                action.release_prefix_lock()
 
             try:
                 self.build_status.overview_mode = True
@@ -2569,45 +2687,81 @@ class PackageInstaller:
                 "The following packages failed to install:\n" + "\n".join(lines)
             )
 
-    def _handle_finished_builds(
+    def _handle_finished_build(
         self,
-        finished_pids: List[int],
-        selector: selectors.BaseSelector,
+        pid: int,
+        current_time: float,
         jobserver: JobServer,
-        database_actions: List[DatabaseAction],
+        selector: selectors.BaseSelector,
         failures: List[spack.spec.Spec],
+        database_actions: List[DatabaseAction],
     ) -> None:
-        """Handle builds that finished since the last event loop iteration."""
-        current_time = time.monotonic()
-        for pid in finished_pids:
-            build = self.running_builds.pop(pid)
-            self.capacity += 1
-            jobserver.release()
-            self.build_status.set_jobs(jobserver.num_jobs, jobserver.target_jobs)
-            self._drain_child_output(build, selector)
-            self._drain_child_state(build, selector)
-            build.cleanup(selector)
-            exitcode = build.proc.exitcode
-            assert exitcode is not None, "Finished build should have exit code set"
-            self.report_data.finish_record(build.spec, exitcode, build.log_path)
-            if exitcode == 0:
-                # Add successful builds for database insertion (after a short delay)
-                database_actions.append(build)
-                self.build_graph.enqueue_parents(build.spec.dag_hash(), self.pending_builds)
-                self.next_database_write = current_time + DATABASE_WRITE_INTERVAL
-                self.build_status.update_state(build.spec.dag_hash(), "finished")
-            elif exitcode == EXIT_STOPPED_AT_PHASE:
-                # Partial build: neither failure nor success. Should not be persisted in
-                # the database, but also not treated as a failure in the UI. Just release
-                # locks and move on.
-                build.release_lock()
-            elif not self.fail_fast or not failures:
-                # In fail-fast mode, only record the first failure. Subsequent failures may
-                # be a consequence of us terminating other builds, and should not be
-                # reported as failures in the UI.
-                failures.append(build.spec)
-                self.build_status.update_state(build.spec.dag_hash(), "failed")
-                self.build_status.parse_log_summary(build.spec.dag_hash())
+        """Handle a build that has finished. Remove from running_builds; release jobserver token;
+        update UI state; defer database insertion if successful; possibly reschedule if failed with
+        cache miss; register failures."""
+        build = self.running_builds.pop(pid)
+        dag_hash = build.spec.dag_hash()
+        self.capacity += 1
+        jobserver.release()
+        self.build_status.set_jobs(jobserver.num_jobs, jobserver.target_jobs)
+        self._drain_child_output(build, selector)
+        self._drain_child_state(build, selector)
+        build.cleanup(selector)
+        exitcode = build.proc.exitcode
+        assert exitcode is not None, "Finished build should have exit code set"
+        self.report_data.finish_record(build.spec, exitcode, build.log_path)
+
+        if exitcode == 0:
+            # Schedule successful builds for batched database insertion. We don't release the
+            # prefix lock here; that strictly happens after a successful db write.
+            database_actions.append(build)
+            self.build_graph.enqueue_parents(dag_hash, self.pending_builds)
+            self.next_database_write = current_time + DATABASE_WRITE_INTERVAL
+            self.build_status.update_state(dag_hash, "finished")
+            return
+
+        # When we don't have to do a db write, we can release the lock immediately.
+        build.release_prefix_lock()
+
+        is_root = dag_hash in self.build_graph.roots
+        user_policy = self.root_policy if is_root else self.dependencies_policy
+
+        if exitcode == EXIT_BUILD_CACHE_MISS and user_policy == "auto":
+            # Check if we can reschedule this as a source build after a build cache miss. If so,
+            # return early without recording a failure.
+            self.build_graph.force_source.add(dag_hash)
+            self.build_status.remove_build(dag_hash)
+            if self.build_graph.has_unexpanded_build_deps(dag_hash):
+                self.pending_expansions.append(dag_hash)
+            else:
+                self.pending_builds.append(dag_hash)
+        elif exitcode == EXIT_STOPPED_AT_PHASE:
+            pass  # the user requested early stopping; don't treat as failure
+        elif not failures or not self.fail_fast:
+            # Record a failure. In fail-fast mode, only record the first failure; subsequent
+            # failures may be a consequence of us terminating other builds.
+            failures.append(build.spec)
+            self.build_status.update_state(dag_hash, "failed")
+            self.build_status.parse_log_summary(dag_hash)
+
+    def _try_expand_build_deps(self) -> None:
+        """Try to expand build deps for specs with cache misses. Non-blocking: returns immediately
+        if the DB read lock is unavailable."""
+        if not self.db.lock.try_acquire_read():
+            return
+        try:
+            self.db._read()
+            newly_added = self.build_graph.expand_build_deps(
+                self.pending_expansions, self.pending_builds, self.db, self.dependencies_policy
+            )
+            for h in newly_added:
+                self.binary_cache_for_spec[h] = (
+                    spack.binary_distribution.BINARY_INDEX.find_by_hash(h)
+                )
+            self.build_status.total += len(newly_added)
+            self.pending_expansions.clear()
+        finally:
+            self.db.lock.release_read()
 
     def _save_to_db(
         self,
@@ -2682,6 +2836,14 @@ class PackageInstaller:
             self._start(selector, jobserver, dag_hash, lock)
         return blocked
 
+    def _install_policy(self, dag_hash: str, is_root: bool) -> InstallPolicy:
+        if dag_hash in self.build_graph.force_source:
+            return "source_only"
+        policy = self.root_policy if is_root else self.dependencies_policy
+        if policy == "auto" and not self.include_build_deps:
+            return "cache_only"
+        return policy
+
     def _start(
         self,
         selector: selectors.BaseSelector,
@@ -2696,12 +2858,25 @@ class PackageInstaller:
         tests = self.tests
         run_tests = tests is True or bool(tests and spec.name in tests)
         is_root = dag_hash in self.build_graph.roots
+        # Both possible sub-processes (cache install, source build) append to the same log file.
+        if dag_hash not in self.log_paths:
+            if spec.external:
+                self.log_paths[dag_hash] = os.devnull
+            else:
+                log_fd, log_path = tempfile.mkstemp(
+                    prefix=f"spack-stage-{spec.name}-{spec.version}-{spec.dag_hash()}-",
+                    suffix=".log",
+                    dir=spack.stage.get_stage_root(),
+                )
+                os.close(log_fd)
+                self.log_paths[dag_hash] = log_path
+
         child_info = start_build(
             spec,
             explicit=explicit,
             mirrors=self.binary_cache_for_spec[dag_hash],
             unsigned=self.unsigned,
-            install_policy=self.root_policy if is_root else self.dependencies_policy,
+            install_policy=self._install_policy(dag_hash, is_root),
             dirty=self.dirty,
             # keep_stage/restage logic taken from installer.py
             keep_stage=self.keep_stage or is_develop,
@@ -2712,10 +2887,10 @@ class PackageInstaller:
             install_source=self.install_source,
             run_tests=run_tests,
             jobserver=jobserver,
+            log_path=self.log_paths[dag_hash],
             stop_before=self.stop_before if is_root else None,
             stop_at=self.stop_at if is_root else None,
         )
-        self.log_paths[dag_hash] = child_info.log_path
         child_info.prefix_lock = prefix_lock
         pid = child_info.proc.pid
         assert type(pid) is int

--- a/lib/spack/spack/new_installer.py
+++ b/lib/spack/spack/new_installer.py
@@ -115,15 +115,14 @@ OVERWRITE_BACKUP_SUFFIX = ".old"
 #: Suffix for temporary cleanup during failed install
 OVERWRITE_GARBAGE_SUFFIX = ".garbage"
 
-#: Exit code used by the child process to signal that the build was stopped at a phase boundary
-EXIT_STOPPED_AT_PHASE = 3
 
-#: Exit code used by the child process to signal a binary cache miss (no source fallback)
-EXIT_BUILD_CACHE_MISS = 4
-
-
-class BinaryCacheMiss(spack.error.SpackError):
-    pass
+class ExitCode:
+    SUCCESS = 0
+    BUILD_ERROR = 1
+    #: Exit code used by the child process to signal that the build was stopped at a phase boundary
+    STOPPED_AT_PHASE = 3
+    #: Exit code used by the child process to signal a binary cache miss (no source fallback)
+    BUILD_CACHE_MISS = 4
 
 
 class DatabaseAction:
@@ -546,7 +545,7 @@ def worker_function(
 
     # Use closedfd=false because of the connection objects. Use line buffering.
     state_stream = os.fdopen(state.fileno(), "w", buffering=1, closefd=False)
-    exit_code = 0
+    exit_code = ExitCode.SUCCESS
 
     try:
         with PrefixPivoter(spec.prefix, keep_prefix):
@@ -570,20 +569,20 @@ def worker_function(
                 stop_at,
             )
     except spack.error.StopPhase:
-        exit_code = EXIT_STOPPED_AT_PHASE
+        exit_code = ExitCode.STOPPED_AT_PHASE
     except ProcessError as e:
         print(e, file=sys.stderr)
-        exit_code = 1
+        exit_code = ExitCode.BUILD_ERROR
     except BinaryCacheMiss:
-        exit_code = EXIT_BUILD_CACHE_MISS
+        exit_code = ExitCode.BUILD_CACHE_MISS
     except BaseException:
         traceback.print_exc(limit=-4)
-        exit_code = 1
+        exit_code = ExitCode.BUILD_ERROR
     finally:
         tee.close()
         state_stream.close()
 
-    if exit_code == 0:
+    if exit_code == ExitCode.SUCCESS:
         # Try to install the compressed log file
         if not os.path.lexists(spec.package.install_log_path):
             try:
@@ -2726,7 +2725,7 @@ class PackageInstaller:
         is_root = dag_hash in self.build_graph.roots
         user_policy = self.root_policy if is_root else self.dependencies_policy
 
-        if exitcode == EXIT_BUILD_CACHE_MISS and user_policy == "auto":
+        if exitcode == ExitCode.BUILD_CACHE_MISS and user_policy == "auto":
             # Check if we can reschedule this as a source build after a build cache miss. If so,
             # return early without recording a failure.
             self.build_graph.force_source.add(dag_hash)
@@ -2735,7 +2734,7 @@ class PackageInstaller:
                 self.pending_expansions.append(dag_hash)
             else:
                 self.pending_builds.append(dag_hash)
-        elif exitcode == EXIT_STOPPED_AT_PHASE:
+        elif exitcode == ExitCode.STOPPED_AT_PHASE:
             pass  # the user requested early stopping; don't treat as failure
         elif not failures or not self.fail_fast:
             # Record a failure. In fail-fast mode, only record the first failure; subsequent
@@ -2988,3 +2987,7 @@ class PackageInstaller:
                 )
             elif "installed_from_binary_cache" in message:
                 child_info.spec.package.installed_from_binary_cache = True
+
+
+class BinaryCacheMiss(spack.error.SpackError):
+    pass

--- a/lib/spack/spack/new_installer.py
+++ b/lib/spack/spack/new_installer.py
@@ -2725,7 +2725,9 @@ class PackageInstaller:
         is_root = dag_hash in self.build_graph.roots
         user_policy = self.root_policy if is_root else self.dependencies_policy
 
-        if exitcode == ExitCode.BUILD_CACHE_MISS and user_policy == "auto":
+        if exitcode == ExitCode.STOPPED_AT_PHASE:
+            return  # the user requested early stopping; don't treat as failure
+        elif exitcode == ExitCode.BUILD_CACHE_MISS and user_policy == "auto":
             # Check if we can reschedule this as a source build after a build cache miss. If so,
             # return early without recording a failure.
             self.build_graph.force_source.add(dag_hash)
@@ -2734,8 +2736,6 @@ class PackageInstaller:
                 self.pending_expansions.append(dag_hash)
             else:
                 self.pending_builds.append(dag_hash)
-        elif exitcode == ExitCode.STOPPED_AT_PHASE:
-            pass  # the user requested early stopping; don't treat as failure
         elif not failures or not self.fail_fast:
             # Record a failure. In fail-fast mode, only record the first failure; subsequent
             # failures may be a consequence of us terminating other builds.

--- a/lib/spack/spack/new_installer.py
+++ b/lib/spack/spack/new_installer.py
@@ -2067,7 +2067,7 @@ class ReportData:
         record = self.build_records.get(spec.dag_hash())
         if record is None or spec.external:
             return
-        if exitcode == 0:
+        if exitcode == ExitCode.SUCCESS:
             record.succeed(log_path)
         else:
             record.fail(
@@ -2710,7 +2710,7 @@ class PackageInstaller:
         assert exitcode is not None, "Finished build should have exit code set"
         self.report_data.finish_record(build.spec, exitcode, build.log_path)
 
-        if exitcode == 0:
+        if exitcode == ExitCode.SUCCESS:
             # Schedule successful builds for batched database insertion. We don't release the
             # prefix lock here; that strictly happens after a successful db write.
             database_actions.append(build)

--- a/lib/spack/spack/test/cmd/install.py
+++ b/lib/spack/spack/test/cmd/install.py
@@ -681,21 +681,27 @@ def test_build_warning_output(mock_fetch, install_mockery):
     assert "foo.c:89: warning: some weird warning!" in e.value.long_message
 
 
-def test_cache_only_fails(mock_fetch, install_mockery):
+@pytest.mark.disable_clean_stage_check  # new installer keeps a log for build cache installs
+def test_cache_only_fails(mock_fetch, install_mockery, installer_variant):
     # libelf from cache fails to install, which automatically removes the
     # the libdwarf build task
     out = install("--cache-only", "libdwarf", fail_on_error=False)
+    assert isinstance(install.error, spack.error.InstallError)
+    assert not spack.store.STORE.db.query_local("libdwarf")
+    assert not spack.store.STORE.db.query_local("libelf")
 
-    assert "Failed to install gcc-runtime" in out
-    assert "Skipping build of libdwarf" in out
-    assert "was not installed" in out
+    if installer_variant == "old":
+        assert "Failed to install gcc-runtime" in out
+        assert "Skipping build of libdwarf" in out
+        assert "was not installed" in out
 
-    # Check that failure prefix locks are still cached
-    failed_packages = [
-        pkg_name for dag_hash, pkg_name in spack.store.STORE.failure_tracker.locker.locks.keys()
-    ]
-    assert "libelf" in failed_packages
-    assert "libdwarf" in failed_packages
+        # Check that failure prefix locks are still cached
+        failed_packages = [
+            pkg_name
+            for dag_hash, pkg_name in spack.store.STORE.failure_tracker.locker.locks.keys()
+        ]
+        assert "libelf" in failed_packages
+        assert "libdwarf" in failed_packages
 
 
 def test_install_only_dependencies(mock_fetch, install_mockery, installer_variant):

--- a/lib/spack/spack/test/installer_build_graph.py
+++ b/lib/spack/spack/test/installer_build_graph.py
@@ -688,3 +688,173 @@ class TestBuildGraphTestDeps:
         assert root.dag_hash() in graph.nodes
         # build-only dep should NOT be pulled in since root is already installed.
         assert specs_with_build_deps["build_dep"].dag_hash() not in graph.nodes
+
+
+class TestExpandBuildDeps:
+    """Tests for BuildGraph.expand_build_deps after a binary cache miss."""
+
+    def _make_graph(self, specs, root, temporary_store):
+        """Helper to create a BuildGraph with include_build_deps=False (auto policy)."""
+        return BuildGraph(
+            specs=[specs[root]],
+            root_policy="auto",
+            dependencies_policy="auto",
+            include_build_deps=False,
+            install_package=True,
+            install_deps=True,
+            database=temporary_store.db,
+        )
+
+    def _expand(self, graph, dag_hash, pending, db, tests=False):
+        """Call expand_build_deps under the DB read lock (as the real caller would)."""
+        with db.read_transaction():
+            return graph.expand_build_deps([dag_hash], pending, db, tests)
+
+    def test_expand_build_deps_adds_missing_deps(self, temporary_store: Store):
+        """A --build--> C --link--> D, A --link--> B.
+        Initial graph (auto, no build deps): A, B.
+        After expand: C, D added. D is leaf -> in pending_builds."""
+        specs = create_dag(
+            nodes=["a", "b", "c", "d"],
+            edges=[("a", "b", "link"), ("a", "c", "build"), ("c", "d", "link")],
+        )
+        graph = self._make_graph(specs, "a", temporary_store)
+        assert specs["c"].dag_hash() not in graph.nodes
+        assert specs["d"].dag_hash() not in graph.nodes
+
+        pending: List[str] = []
+        newly_added = self._expand(graph, specs["a"].dag_hash(), pending, temporary_store.db)
+
+        assert specs["c"].dag_hash() in newly_added
+        assert specs["d"].dag_hash() in newly_added
+        assert specs["c"].dag_hash() in graph.nodes
+        assert specs["d"].dag_hash() in graph.nodes
+        # D is a leaf (no children), so it should be enqueued
+        assert specs["d"].dag_hash() in pending
+        # C waits on D, so it should NOT be enqueued
+        assert specs["c"].dag_hash() not in pending
+
+    def test_expand_build_deps_shared_dep_already_in_graph(self, temporary_store: Store):
+        """A --link--> B, A --build--> C --link--> B.
+        Initial graph: A, B. After expand: C added with edge C->B."""
+        specs = create_dag(
+            nodes=["a", "b", "c"],
+            edges=[("a", "b", "link"), ("a", "c", "build"), ("c", "b", "link")],
+        )
+        graph = self._make_graph(specs, "a", temporary_store)
+        assert specs["b"].dag_hash() in graph.nodes
+        assert specs["c"].dag_hash() not in graph.nodes
+
+        pending: List[str] = []
+        newly_added = self._expand(graph, specs["a"].dag_hash(), pending, temporary_store.db)
+
+        assert specs["c"].dag_hash() in newly_added
+        # C depends on B, so C->B edge should exist
+        assert specs["b"].dag_hash() in graph.parent_to_child[specs["c"].dag_hash()]
+        # B should list C as a parent
+        assert specs["c"].dag_hash() in graph.child_to_parent[specs["b"].dag_hash()]
+        # C waits on B, so not in pending
+        assert specs["c"].dag_hash() not in pending
+
+    def test_expand_build_deps_skips_installed_in_db(self, temporary_store: Store):
+        """A --build--> C --link--> D. D installed in DB.
+        After expand: C added, D NOT added. No edge C->D. C in pending."""
+        specs = create_dag(nodes=["a", "c", "d"], edges=[("a", "c", "build"), ("c", "d", "link")])
+        install_spec_in_db(specs["d"], temporary_store)
+        graph = self._make_graph(specs, "a", temporary_store)
+
+        pending: List[str] = []
+        newly_added = self._expand(graph, specs["a"].dag_hash(), pending, temporary_store.db)
+
+        assert specs["c"].dag_hash() in newly_added
+        assert specs["d"].dag_hash() not in newly_added
+        assert specs["d"].dag_hash() not in graph.nodes
+        # No edge from C to D (installed dep)
+        assert specs["d"].dag_hash() not in graph.parent_to_child.get(specs["c"].dag_hash(), set())
+        # C has no uninstalled children, so it should be enqueued
+        assert specs["c"].dag_hash() in pending
+
+    def test_expand_build_deps_skips_installed_in_session(self, temporary_store: Store):
+        """Same as above, but D in graph.done instead of DB."""
+        specs = create_dag(nodes=["a", "c", "d"], edges=[("a", "c", "build"), ("c", "d", "link")])
+        graph = self._make_graph(specs, "a", temporary_store)
+        graph.done.add(specs["d"].dag_hash())
+
+        pending: List[str] = []
+        newly_added = self._expand(graph, specs["a"].dag_hash(), pending, temporary_store.db)
+
+        assert specs["c"].dag_hash() in newly_added
+        assert specs["d"].dag_hash() not in newly_added
+        assert specs["d"].dag_hash() not in graph.nodes
+        assert specs["c"].dag_hash() in pending
+
+    def test_expand_build_deps_reenqueues_original_when_all_deps_installed(
+        self, temporary_store: Store
+    ):
+        """A --build--> C. C installed in DB.
+        After expand: C NOT added. A re-enqueued (no uninstalled children)."""
+        specs = create_dag(nodes=["a", "c"], edges=[("a", "c", "build")])
+        install_spec_in_db(specs["c"], temporary_store)
+        graph = self._make_graph(specs, "a", temporary_store)
+
+        pending: List[str] = []
+        newly_added = self._expand(graph, specs["a"].dag_hash(), pending, temporary_store.db)
+
+        assert len(newly_added) == 0
+        assert specs["a"].dag_hash() in pending
+
+    def test_expand_build_deps_no_deadlock_on_installed_dep(self, temporary_store: Store):
+        """A --build--> C --link--> D. D installed in DB.
+        No edge C->D in parent_to_child. C in pending."""
+        specs = create_dag(nodes=["a", "c", "d"], edges=[("a", "c", "build"), ("c", "d", "link")])
+        install_spec_in_db(specs["d"], temporary_store)
+        graph = self._make_graph(specs, "a", temporary_store)
+
+        pending: List[str] = []
+        self._expand(graph, specs["a"].dag_hash(), pending, temporary_store.db)
+
+        # No edge from C to D: installed deps get no edge, otherwise C is never scheduled
+        assert specs["d"].dag_hash() not in graph.parent_to_child.get(specs["c"].dag_hash(), set())
+        assert specs["c"].dag_hash() in pending
+
+    def test_has_unexpanded_build_deps_true(self, temporary_store: Store):
+        """A --build--> C, A --link--> B. With include_build_deps=False, C is not in the graph,
+        so has_unexpanded_build_deps returns True."""
+        specs = create_dag(nodes=["a", "b", "c"], edges=[("a", "b", "link"), ("a", "c", "build")])
+        graph = self._make_graph(specs, "a", temporary_store)
+        assert graph.has_unexpanded_build_deps(specs["a"].dag_hash())
+
+    def test_has_unexpanded_build_deps_false_shared(self, temporary_store: Store):
+        """A --(build,link)--> B. B is already in graph as link dep,
+        so has_unexpanded_build_deps returns False."""
+        specs = create_dag(nodes=["a", "b"], edges=[("a", "b", ("build", "link"))])
+        graph = self._make_graph(specs, "a", temporary_store)
+        assert not graph.has_unexpanded_build_deps(specs["a"].dag_hash())
+
+    def test_expand_build_deps_does_not_mark_in_graph_spec_as_done(self, temporary_store: Store):
+        """A --link--> B, A --link--> C, B --build--> C.
+        C is in the graph (link dep of A) and installed in DB (simulating an overwrite build
+        in progress). Expanding B's build deps should add edge B->C and NOT mark C as done."""
+        specs = create_dag(
+            nodes=["a", "b", "c"],
+            edges=[("a", "b", "link"), ("a", "c", "link"), ("b", "c", "build")],
+        )
+        graph = self._make_graph(specs, "a", temporary_store)
+        # C should be in graph as a link dep of A
+        assert specs["c"].dag_hash() in graph.nodes
+
+        # Simulate overwrite: install C in DB after graph creation
+        install_spec_in_db(specs["c"], temporary_store)
+
+        pending: List[str] = []
+        self._expand(graph, specs["b"].dag_hash(), pending, temporary_store.db)
+
+        c_hash = specs["c"].dag_hash()
+        b_hash = specs["b"].dag_hash()
+        # C must NOT be marked as done (it's still being overwrite-built)
+        assert c_hash not in graph.done
+        # Edge B->C must exist
+        assert c_hash in graph.parent_to_child[b_hash]
+        assert b_hash in graph.child_to_parent[c_hash]
+        # B should NOT be in pending (it still waits on C)
+        assert b_hash not in pending

--- a/lib/spack/spack/test/installer_tui.py
+++ b/lib/spack/spack/test/installer_tui.py
@@ -179,6 +179,30 @@ class TestBasicStateManagement:
         assert status.completed == 1
         assert status.builds[build_id].finished_time == fake_time[0] + inst.CLEANUP_TIMEOUT
 
+    def test_remove_build(self):
+        """Test that remove_build removes the build from the display."""
+        status, _, _ = create_build_status(total=2)
+        specs = add_mock_builds(status, 2)
+        build_id = specs[0].dag_hash()
+
+        status.dirty = False
+        status.remove_build(build_id)
+        assert build_id not in status.builds
+        assert len(status.builds) == 1
+        assert status.dirty is True
+
+    def test_remove_build_resets_tracked(self):
+        """Test that removing the tracked build resets tracking to overview mode."""
+        status, _, _ = create_build_status(total=1)
+        (spec,) = add_mock_builds(status, 1)
+        build_id = spec.dag_hash()
+
+        status.tracked_build_id = build_id
+        status.overview_mode = False
+        status.remove_build(build_id)
+        assert status.tracked_build_id == ""
+        assert status.overview_mode is True
+
     def test_parse_log_summary(self, tmp_path):
         """Test that parse_log_summary parses the build log and stores the summary."""
         status, _, _ = create_build_status()

--- a/lib/spack/spack/test/new_installer.py
+++ b/lib/spack/spack/test/new_installer.py
@@ -15,6 +15,8 @@ if sys.platform == "win32":
 import spack.spec
 from spack.new_installer import (
     OVERWRITE_GARBAGE_SUFFIX,
+    BinaryCacheMiss,
+    BuildGraph,
     JobServer,
     PackageInstaller,
     PrefixPivoter,
@@ -162,6 +164,19 @@ class TestPrefixPivoter:
         # Nothing should remain
         assert len(list(tmp_path.iterdir())) == 0
 
+    def test_binary_cache_miss_with_keep_prefix_and_existing_prefix_restores_original(
+        self, tmp_path: pathlib.Path, existing_prefix: pathlib.Path
+    ):
+        """BinaryCacheMiss bypasses keep_prefix: original prefix is restored."""
+        with pytest.raises(BinaryCacheMiss), PrefixPivoter(str(existing_prefix), keep_prefix=True):
+            existing_prefix.mkdir()
+            (existing_prefix / "partial_file").write_text("partial content")
+            raise BinaryCacheMiss("cache miss")
+
+        assert (existing_prefix / "old_file").read_text() == "old content"
+        assert not (existing_prefix / "partial_file").exists()
+        assert len(list(tmp_path.iterdir())) == 1
+
 
 class FailingPrefixPivoter(PrefixPivoter):
     """Test subclass that can simulate filesystem failures."""
@@ -255,6 +270,28 @@ class TestPackageInstallerConstructor:
         spec = spack.spec.Spec("trivial-install-test-package")
         spec._mark_concrete()
         assert PackageInstaller([spec.package]).capacity == 1
+
+    def test_no_binary_mirrors_forces_source_only(
+        self, temporary_store, mock_packages, mutable_config
+    ):
+        """With no binary mirrors configured, auto is overridden to source_only."""
+        spec = spack.spec.Spec("trivial-install-test-package")
+        spec._mark_concrete()
+        installer = PackageInstaller([spec.package], root_policy="auto")
+        assert installer.root_policy == "source_only"
+        assert installer.dependencies_policy == "source_only"
+
+    def test_no_binary_mirrors_preserves_cache_only(
+        self, temporary_store, mock_packages, mutable_config
+    ):
+        """Without binary mirrors, an explicit cache_only shouldn't turn into source_only."""
+        spec = spack.spec.Spec("trivial-install-test-package")
+        spec._mark_concrete()
+        installer = PackageInstaller(
+            [spec.package], root_policy="cache_only", dependencies_policy="cache_only"
+        )
+        assert installer.root_policy == "cache_only"
+        assert installer.dependencies_policy == "cache_only"
 
 
 class _FakeBuildGraph:
@@ -622,3 +659,56 @@ def test_nodes_to_roots_shared_dependency():
     assert node_to_roots[a.dag_hash()] == frozenset([a.dag_hash()])
     assert node_to_roots[b.dag_hash()] == frozenset([b.dag_hash()])
     assert node_to_roots[c.dag_hash()] == frozenset([a.dag_hash(), b.dag_hash()])
+
+
+def test_expand_build_deps_source_only_includes_nested_build_deps(temporary_store):
+    """When dependencies_policy is source_only, expand_build_deps must include BUILD deps of
+    dynamically added specs, not just LINK|RUN. Otherwise those specs attempt to build from source
+    without their build tools in the graph."""
+    # root --[build]--> build_tool --[build]--> nested_build_tool
+    #                              --[link]-->  lib_dep
+    specs = create_dag(
+        nodes=["root", "build_tool", "nested_build_tool", "lib_dep"],
+        edges=[
+            ("root", "build_tool", "build"),
+            ("build_tool", "nested_build_tool", "build"),
+            ("build_tool", "lib_dep", "link"),
+        ],
+    )
+    root = specs["root"]
+    for s in specs.values():
+        s._mark_concrete()
+
+    # Construct a BuildGraph with root_policy="auto" so root's build deps are deferred.
+    bg = BuildGraph(
+        specs=[root],
+        root_policy="auto",
+        dependencies_policy="source_only",
+        include_build_deps=False,
+        install_package=True,
+        install_deps=True,
+        database=temporary_store.db,
+    )
+
+    # The initial graph should contain only root (build deps deferred for "auto" policy).
+    assert root.dag_hash() in bg.nodes
+    assert specs["build_tool"].dag_hash() not in bg.nodes
+
+    # Simulate a cache miss: expand build deps for root.
+    pending = []
+    with temporary_store.db.read_transaction():
+        newly_added = bg.expand_build_deps(
+            [root.dag_hash()], pending, temporary_store.db, dependencies_policy="source_only"
+        )
+
+    added_hashes = set(newly_added)
+
+    # build_tool must be added (direct BUILD dep of root)
+    assert specs["build_tool"].dag_hash() in added_hashes
+
+    # lib_dep must be added (LINK dep of build_tool)
+    assert specs["lib_dep"].dag_hash() in added_hashes
+
+    # nested_build_tool must also be added (BUILD dep of build_tool). This is the bug: without the
+    # fix, expand_build_deps only traverses LINK|RUN, so nested_build_tool is missing.
+    assert specs["nested_build_tool"].dag_hash() in added_hashes


### PR DESCRIPTION
Instead of scheduling the full dependency DAG up front, the installer
initially schedules only the link/run sub-DAG. Each spec is attempted
from the binary cache first. On a cache miss, pure build dependencies
are scheduled. This repeats recursively, so build deps are only
installed when they are actually needed.

There is no overhead for users who don't have binary mirrors configured.