### PR TITLE
reporters: use stage log file in new installer

### DIFF
--- a/lib/spack/spack/new_installer.py
+++ b/lib/spack/spack/new_installer.py
@@ -581,13 +581,6 @@ def worker_function(
             except Exception:
                 pass  # don't fail the build just because log compression failed
 
-        # Remove the uncompressed log file from the stage dir on successful install.
-        if not keep_stage:
-            try:
-                os.unlink(log_path)
-            except OSError:
-                pass
-
     sys.exit(exit_code)
 
 
@@ -1956,18 +1949,21 @@ class ReportData:
         record.start()
         self.build_records[spec.dag_hash()] = record
 
-    def finish_record(self, spec: spack.spec.Spec, exitcode: int) -> None:
+    def finish_record(
+        self, spec: spack.spec.Spec, exitcode: int, log_path: Optional[str] = None
+    ) -> None:
         """Mark the InstallRecord for a spec as succeeded or failed."""
         record = self.build_records.get(spec.dag_hash())
         if record is None or spec.external:
             return
         if exitcode == 0:
-            record.succeed()
+            record.succeed(log_path)
         else:
             record.fail(
                 spack.error.InstallError(
                     f"Installation of {spec.name} failed; see log for details"
-                )
+                ),
+                log_path,
             )
 
     def finalize(
@@ -2016,7 +2012,9 @@ class NullReportData(ReportData):
     def start_record(self, spec: spack.spec.Spec) -> None:
         pass
 
-    def finish_record(self, spec: spack.spec.Spec, exitcode: int) -> None:
+    def finish_record(
+        self, spec: spack.spec.Spec, exitcode: int, log_path: Optional[str] = None
+    ) -> None:
         pass
 
     def finalize(
@@ -2533,6 +2531,16 @@ class PackageInstaller:
         except Exception as e:
             spack.llnl.util.tty.debug(f"[{__name__}]: Failed to finalize reports: {e}]")
 
+        # Clean up temp log files now that reports have consumed them.
+        if not self.keep_stage:
+            for log_path in self.log_paths.values():
+                if log_path == os.devnull:
+                    continue
+                try:
+                    os.unlink(log_path)
+                except OSError:
+                    pass
+
         if failures:
             for s in failures:
                 build_info = self.build_status.builds[s.dag_hash()]
@@ -2563,7 +2571,7 @@ class PackageInstaller:
             build.cleanup(selector)
             exitcode = build.proc.exitcode
             assert exitcode is not None, "Finished build should have exit code set"
-            self.report_data.finish_record(build.spec, exitcode)
+            self.report_data.finish_record(build.spec, exitcode, build.log_path)
             if exitcode == 0:
                 # Add successful builds for database insertion (after a short delay)
                 database_actions.append(build)

--- a/lib/spack/spack/report.py
+++ b/lib/spack/spack/report.py
@@ -7,6 +7,7 @@ import gzip
 import os
 import time
 import traceback
+from typing import Optional
 
 import spack.error
 
@@ -98,7 +99,11 @@ class SpecRecord(Record):
         self.elapsed_time = 0.0
         self.message = msg
 
-    def fail(self, exc):
+    def fetch_log(self, log_path: Optional[str] = None) -> str:
+        """Fetch the log for this spec record. Subclasses should override."""
+        return ""
+
+    def fail(self, exc, log_path: Optional[str] = None):
         """Record failure based on exception type
 
         Errors wrapped by spack.error.InstallError are "failures"
@@ -112,14 +117,14 @@ class SpecRecord(Record):
             self.result = "error"
             self.message = str(exc) or "Unknown error"
             self.exception = traceback.format_exc()
-        self.stdout = self.fetch_log() + self.message
+        self.stdout = self.fetch_log(log_path) + self.message
         assert self._start_time, "Start time is None"
         self.elapsed_time = time.time() - self._start_time
 
-    def succeed(self):
+    def succeed(self, log_path: Optional[str] = None):
         """Record success for this spec"""
         self.result = "success"
-        self.stdout = self.fetch_log()
+        self.stdout = self.fetch_log(log_path)
         assert self._start_time, "Start time is None"
         self.elapsed_time = time.time() - self._start_time
 
@@ -131,10 +136,12 @@ class InstallRecord(SpecRecord):
         super().__init__(spec)
         self.installed_from_binary_cache = None
 
-    def fetch_log(self):
-        """Install log comes from install prefix on success, or stage dir on failure."""
+    def fetch_log(self, log_path: Optional[str] = None) -> str:
+        """Install log comes from log_path if provided, install prefix, or stage dir."""
         try:
-            if os.path.exists(self._package.install_log_path):
+            if log_path and os.path.exists(log_path):
+                stream = open(log_path, encoding="utf-8", errors="replace")
+            elif os.path.exists(self._package.install_log_path):
                 stream = gzip.open(
                     self._package.install_log_path, "rt", encoding="utf-8", errors="replace"
                 )
@@ -145,8 +152,8 @@ class InstallRecord(SpecRecord):
         except OSError:
             return f"Cannot open log for {self._spec.cshort_spec}"
 
-    def succeed(self):
-        super().succeed()
+    def succeed(self, log_path: Optional[str] = None):
+        super().succeed(log_path)
         self.installed_from_binary_cache = self._package.installed_from_binary_cache
 
 
@@ -158,10 +165,10 @@ class NullInstallRecord(InstallRecord):
     def start(self) -> None:
         pass
 
-    def succeed(self) -> None:
+    def succeed(self, log_path: Optional[str] = None) -> None:
         pass
 
-    def fail(self, exc) -> None:
+    def fail(self, exc, log_path: Optional[str] = None) -> None:
         pass
 
     def skip(self, msg: str = "") -> None:
@@ -193,7 +200,7 @@ class TestRecord(SpecRecord):
         super().__init__(spec)
         self.directory = directory
 
-    def fetch_log(self):
+    def fetch_log(self, log_path: Optional[str] = None) -> str:
         """Get output from test log"""
         log_file = os.path.join(self.directory, self._package.test_suite.test_log_name(self._spec))
         try:


### PR DESCRIPTION
Closes #52063

The new installer runs every build (including buildcache installs) in a
subprocess capturing output to a temp log file. Pass that `log_path` to the
reporter so it reads the actual install log rather than the historical build
log from the install prefix.

The child process no longer deletes the temp log file; cleanup is now done by
the parent after `report_data.finalize()` has consumed the logs.

