### PR TITLE
Fix Windows tar

### DIFF
--- a/lib/spack/spack/test/util/compression.py
+++ b/lib/spack/spack/test/util/compression.py
@@ -128,53 +128,59 @@ def test_file_type_check_does_not_advance_stream(tmp_path: pathlib.Path, ext):
         assert f.tell() == 0
 
 
-class TestConvertToMsysPath:
-    def test_windows_path_with_backslashes(self):
-        result = compression._convert_to_msys_path("C:\\Users\\test\\file.tar")
-        if sys.platform == "win32":
-            assert result == "/c/Users/test/file.tar"
-        else:
-            assert result == "C:\\Users\\test\\file.tar"
+def test_convert_to_msys_path_windows_backslashes():
+    result = compression._convert_to_msys_path("C:\\Users\\test\\file.tar")
+    if sys.platform == "win32":
+        assert result == "/c/Users/test/file.tar"
+    else:
+        assert result == "C:\\Users\\test\\file.tar"
 
-    def test_windows_path_with_forward_slashes(self):
-        result = compression._convert_to_msys_path("C:/Users/test/file.tar")
-        if sys.platform == "win32":
-            assert result == "/c/Users/test/file.tar"
-        else:
-            assert result == "C:/Users/test/file.tar"
 
-    def test_different_drive_letters(self):
-        d_result = compression._convert_to_msys_path("D:\\data\\archive.tar.gz")
-        e_result = compression._convert_to_msys_path("E:/temp/file.tar")
-        if sys.platform == "win32":
-            assert d_result == "/d/data/archive.tar.gz"
-            assert e_result == "/e/temp/file.tar"
-        else:
-            assert d_result == "D:\\data\\archive.tar.gz"
-            assert e_result == "E:/temp/file.tar"
+def test_convert_to_msys_path_windows_forward_slashes():
+    result = compression._convert_to_msys_path("C:/Users/test/file.tar")
+    if sys.platform == "win32":
+        assert result == "/c/Users/test/file.tar"
+    else:
+        assert result == "C:/Users/test/file.tar"
 
-    def test_uppercase_drive_letter(self):
-        result = compression._convert_to_msys_path("C:\\Path\\To\\File.tar")
-        if sys.platform == "win32":
-            assert result == "/c/Path/To/File.tar"
-        else:
-            assert result == "C:\\Path\\To\\File.tar"
 
-    def test_relative_path_without_drive(self):
-        result = compression._convert_to_msys_path("relative/path/file.tar")
-        assert result == "relative/path/file.tar"
+def test_convert_to_msys_path_different_drive_letters():
+    d_result = compression._convert_to_msys_path("D:\\data\\archive.tar.gz")
+    e_result = compression._convert_to_msys_path("E:/temp/file.tar")
+    if sys.platform == "win32":
+        assert d_result == "/d/data/archive.tar.gz"
+        assert e_result == "/e/temp/file.tar"
+    else:
+        assert d_result == "D:\\data\\archive.tar.gz"
+        assert e_result == "E:/temp/file.tar"
 
-    def test_unix_style_absolute_path(self):
-        result = compression._convert_to_msys_path("/unix/path/file.tar")
-        assert result == "/unix/path/file.tar"
 
-    def test_empty_string(self):
-        result = compression._convert_to_msys_path("")
-        assert result == ""
+def test_convert_to_msys_path_uppercase_drive_letter():
+    result = compression._convert_to_msys_path("C:\\Path\\To\\File.tar")
+    if sys.platform == "win32":
+        assert result == "/c/Path/To/File.tar"
+    else:
+        assert result == "C:\\Path\\To\\File.tar"
 
-    def test_single_drive_letter(self):
-        result = compression._convert_to_msys_path("C:")
-        if sys.platform == "win32":
-            assert result == "/c"
-        else:
-            assert result == "C:"
+
+def test_convert_to_msys_path_relative_path():
+    result = compression._convert_to_msys_path("relative/path/file.tar")
+    assert result == "relative/path/file.tar"
+
+
+def test_convert_to_msys_path_unix_absolute_path():
+    result = compression._convert_to_msys_path("/unix/path/file.tar")
+    assert result == "/unix/path/file.tar"
+
+
+def test_convert_to_msys_path_empty_string():
+    result = compression._convert_to_msys_path("")
+    assert result == ""
+
+
+def test_convert_to_msys_path_single_drive_letter():
+    result = compression._convert_to_msys_path("C:")
+    if sys.platform == "win32":
+        assert result == "/c"
+    else:
+        assert result == "C:"

--- a/lib/spack/spack/test/util/compression.py
+++ b/lib/spack/spack/test/util/compression.py
@@ -125,3 +125,41 @@ def test_file_type_check_does_not_advance_stream(tmp_path: pathlib.Path, ext):
         computed_ext = compression.extension_from_magic_numbers_by_stream(f, decompress=True)
         assert computed_ext == f"tar.{ext}"
         assert f.tell() == 0
+
+
+@pytest.mark.skipif(os.name != "nt", reason="MSYS path conversion only on Windows")
+class TestConvertToMsysPath:
+    def test_windows_path_with_backslashes(self):
+        result = compression._convert_to_msys_path("C:\\Users\\test\\file.tar")
+        assert result == "/c/Users/test/file.tar"
+
+    def test_windows_path_with_forward_slashes(self):
+        result = compression._convert_to_msys_path("C:/Users/test/file.tar")
+        assert result == "/c/Users/test/file.tar"
+
+    def test_different_drive_letters(self):
+        assert compression._convert_to_msys_path("D:\\data\\archive.tar.gz") == "/d/data/archive.tar.gz"
+        assert compression._convert_to_msys_path("E:/temp/file.tar") == "/e/temp/file.tar"
+
+    def test_uppercase_drive_letter(self):
+        result = compression._convert_to_msys_path("C:\\Path\\To\\File.tar")
+        assert result == "/c/Path/To/File.tar"
+
+    def test_relative_path_without_drive(self):
+        result = compression._convert_to_msys_path("relative/path/file.tar")
+        assert result == "relative/path/file.tar"
+
+    def test_empty_string(self):
+        result = compression._convert_to_msys_path("")
+        assert result == ""
+
+    def test_single_drive_letter(self):
+        result = compression._convert_to_msys_path("C:")
+        assert result == "/c"
+
+
+@pytest.mark.skipif(os.name == "nt", reason="Test non-Windows behavior")
+def test_convert_to_msys_path_returns_unchanged_on_unix():
+    original = "/unix/style/path"
+    result = compression._convert_to_msys_path(original)
+    assert result == original

--- a/lib/spack/spack/test/util/compression.py
+++ b/lib/spack/spack/test/util/compression.py
@@ -6,6 +6,7 @@ import io
 import os
 import pathlib
 import shutil
+import sys
 import tarfile
 from itertools import product
 
@@ -127,27 +128,45 @@ def test_file_type_check_does_not_advance_stream(tmp_path: pathlib.Path, ext):
         assert f.tell() == 0
 
 
-@pytest.mark.skipif(os.name != "nt", reason="MSYS path conversion only on Windows")
 class TestConvertToMsysPath:
     def test_windows_path_with_backslashes(self):
         result = compression._convert_to_msys_path("C:\\Users\\test\\file.tar")
-        assert result == "/c/Users/test/file.tar"
+        if sys.platform == "win32":
+            assert result == "/c/Users/test/file.tar"
+        else:
+            assert result == "C:\\Users\\test\\file.tar"
 
     def test_windows_path_with_forward_slashes(self):
         result = compression._convert_to_msys_path("C:/Users/test/file.tar")
-        assert result == "/c/Users/test/file.tar"
+        if sys.platform == "win32":
+            assert result == "/c/Users/test/file.tar"
+        else:
+            assert result == "C:/Users/test/file.tar"
 
     def test_different_drive_letters(self):
-        assert compression._convert_to_msys_path("D:\\data\\archive.tar.gz") == "/d/data/archive.tar.gz"
-        assert compression._convert_to_msys_path("E:/temp/file.tar") == "/e/temp/file.tar"
+        d_result = compression._convert_to_msys_path("D:\\data\\archive.tar.gz")
+        e_result = compression._convert_to_msys_path("E:/temp/file.tar")
+        if sys.platform == "win32":
+            assert d_result == "/d/data/archive.tar.gz"
+            assert e_result == "/e/temp/file.tar"
+        else:
+            assert d_result == "D:\\data\\archive.tar.gz"
+            assert e_result == "E:/temp/file.tar"
 
     def test_uppercase_drive_letter(self):
         result = compression._convert_to_msys_path("C:\\Path\\To\\File.tar")
-        assert result == "/c/Path/To/File.tar"
+        if sys.platform == "win32":
+            assert result == "/c/Path/To/File.tar"
+        else:
+            assert result == "C:\\Path\\To\\File.tar"
 
     def test_relative_path_without_drive(self):
         result = compression._convert_to_msys_path("relative/path/file.tar")
         assert result == "relative/path/file.tar"
+
+    def test_unix_style_absolute_path(self):
+        result = compression._convert_to_msys_path("/unix/path/file.tar")
+        assert result == "/unix/path/file.tar"
 
     def test_empty_string(self):
         result = compression._convert_to_msys_path("")
@@ -155,11 +174,7 @@ class TestConvertToMsysPath:
 
     def test_single_drive_letter(self):
         result = compression._convert_to_msys_path("C:")
-        assert result == "/c"
-
-
-@pytest.mark.skipif(os.name == "nt", reason="Test non-Windows behavior")
-def test_convert_to_msys_path_returns_unchanged_on_unix():
-    original = "/unix/style/path"
-    result = compression._convert_to_msys_path(original)
-    assert result == original
+        if sys.platform == "win32":
+            assert result == "/c"
+        else:
+            assert result == "C:"

--- a/lib/spack/spack/util/compression.py
+++ b/lib/spack/spack/util/compression.py
@@ -12,6 +12,7 @@ from typing import Any, BinaryIO, Callable, Dict, List, Optional
 
 import spack.llnl.url
 from spack.error import SpackError
+from spack.llnl.path import convert_to_posix_path
 from spack.llnl.util import tty
 from spack.util.executable import CommandNotFoundError, which
 
@@ -39,6 +40,29 @@ except ImportError:
     LZMA_SUPPORTED = False
 
 
+def _convert_to_msys_path(path: str) -> str:
+    """Convert Windows path to MSYS2/Cygwin format for Git for Windows tar.
+
+    Converts C:\\path\\to\\file or C:/path/to/file to /c/path/to/file
+
+    Args:
+        path: Windows-style path
+
+    Returns:
+        MSYS2-style path, or original path if not Windows
+    """
+    if sys.platform != "win32":
+        return path
+
+    path = convert_to_posix_path(path)
+
+    if len(path) >= 2 and path[1] == ':':
+        drive = path[0].lower()
+        return f"/{drive}{path[2:]}"
+
+    return path
+
+
 def _system_untar(archive_file: str, remove_archive_file: bool = False) -> str:
     """Returns path to unarchived tar file. Untars archive via system tar.
 
@@ -61,7 +85,7 @@ def _system_untar(archive_file: str, remove_archive_file: bool = False) -> str:
     # than where they are extracted. In certain cases like rootless containers, setting original
     # ownership is known to fail, so we need to disable it.
     tar.add_default_arg("-oxf")
-    tar(archive_file)
+    tar(_convert_to_msys_path(archive_file))
     if remove_archive_file:
         # remove input file to prevent two stage
         # extractions from being treated as exploding

--- a/lib/spack/spack/util/compression.py
+++ b/lib/spack/spack/util/compression.py
@@ -41,7 +41,7 @@ except ImportError:
 
 
 def _convert_to_msys_path(path: str) -> str:
-    """Convert Windows path to MSYS2/Cygwin format for Git for Windows tar.
+    """Convert Windows path to MSYS2 format for Git for Windows tar.
 
     Converts C:\\path\\to\\file or C:/path/to/file to /c/path/to/file
 
@@ -53,13 +53,10 @@ def _convert_to_msys_path(path: str) -> str:
     """
     if sys.platform != "win32":
         return path
-
     path = convert_to_posix_path(path)
-
     if len(path) >= 2 and path[1] == ':':
         drive = path[0].lower()
         return f"/{drive}{path[2:]}"
-
     return path
 
 


### PR DESCRIPTION
# Context
I am planning to contribute Windows package builds, but untar-ing requires transforming Windows paths to the Unix-style.

# Changes
- Added a function to `lib/spack/spack/util/compress.py` that wraps `spack.llnl.path.convert_to_posix_path`. The new function keeps `_system_untar` in `compress.py` largely unchanged and free of mention of Windows.
