### PR TITLE
externals: fix parsing single-valued variants

### DIFF
--- a/lib/spack/spack/externals.py
+++ b/lib/spack/spack/externals.py
@@ -120,10 +120,9 @@ def complete_variants_and_architecture(node: spack.spec.Spec) -> None:
                     and len(node.variants[name].values) == 1
                 ):
                     # Spec parsing defaults to MULTI for non-boolean variants. Correct the type
-                    # using the package definition, preserving the user-specified value and flags.
+                    # using the package definition, preserving the user-specified value.
                     existing = node.variants[name]
                     corrected = vdef.make_variant(*existing.values)
-                    corrected.propagate = existing.propagate
                     node.variants.substitute(corrected)
             changed = True
 

--- a/lib/spack/spack/externals.py
+++ b/lib/spack/spack/externals.py
@@ -115,6 +115,16 @@ def complete_variants_and_architecture(node: spack.spec.Spec) -> None:
                 if name not in node.variants:
                     # Cannot use Spec.constrain, because we lose information on the variant type
                     node.variants[name] = vdef.make_default()
+                elif (
+                    node.variants[name].type != vdef.variant_type
+                    and len(node.variants[name].values) == 1
+                ):
+                    # Spec parsing defaults to MULTI for non-boolean variants. Correct the type
+                    # using the package definition, preserving the user-specified value and flags.
+                    existing = node.variants[name]
+                    corrected = vdef.make_variant(*existing.values)
+                    corrected.propagate = existing.propagate
+                    node.variants.substitute(corrected)
             changed = True
 
 

--- a/lib/spack/spack/test/externals.py
+++ b/lib/spack/spack/test/externals.py
@@ -340,3 +340,35 @@ def test_external_node_completion(
     # Assert all nodes have the namespace set
     for node in spack.traverse.traverse_nodes(parser.all_specs()):
         assert node.namespace is not None
+
+
+@pytest.mark.regression("52179")
+def test_external_spec_single_valued_variant_type_is_corrected():
+    """Tests that an external spec string including a single-valued variant is parsed correctly."""
+    externals_dict = [
+        {"spec": "dual-cmake-autotools@1.0 build_system=autotools", "prefix": "/usr/dual"}
+    ]
+    parser = ExternalSpecsParser(externals_dict, complete_node=complete_variants_and_architecture)
+    specs = parser.all_specs()
+    assert len(specs) == 1
+    spec = specs[0]
+
+    # Single-valued variants return the value, not a tuple of values
+    build_system_value = spec.variants["build_system"].value
+    assert build_system_value == "autotools", (
+        f"Expected 'autotools' but got {build_system_value!r} "
+        f"(type: {type(build_system_value).__name__})"
+    )
+
+
+@pytest.mark.regression("52179")
+def test_external_spec_multi_valued_variant_is_not_changed():
+    """Tests that multi-valued variants in external specs are preserved as they are, even if the
+    definition in package.py says otherwise.
+    """
+    # Package.py prescribes a single-valued variant in this case
+    externals_dict = [{"spec": "variant-values@1.0 v=foo,bar", "prefix": "/usr/variant-values"}]
+    parser = ExternalSpecsParser(externals_dict, complete_node=complete_variants_and_architecture)
+    specs = parser.all_specs()
+    assert len(specs) == 1
+    assert specs[0].variants["v"].value == ("bar", "foo")


### PR DESCRIPTION
fixes #52179

When an external spec string like is parsed from `packages.yaml`, `VariantValue.from_string_or_bool` creates either Boolean variants or multi-valued variants.

For the `build_system` variants this is an issue because `.value` returns a single value for single-valued variants and a tuple for multi-valued variants.

Here we fix the issue by using the definition in the `package.py` file to instantiate the correct type when possible

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
