### PR TITLE
Make SpecLocker, environments and caches respect `--disable-locks` 

### DIFF
--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -196,7 +196,9 @@ class BinaryIndexCache:
         self._index_contents_key = "contents.json"
 
         # a FileCache instance storing copies of remote binary cache indices
-        self._index_file_cache: file_cache.FileCache = file_cache.FileCache(self._index_cache_root)
+        self._index_file_cache: file_cache.FileCache = file_cache.FileCache(
+            self._index_cache_root, enable_lock=spack.config.get("config:locks", True)
+        )
         self._index_file_cache_initialized = False
 
         # stores a map of mirror URL and version layout to index hash and cache key (index path)

--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -197,7 +197,7 @@ class BinaryIndexCache:
 
         # a FileCache instance storing copies of remote binary cache indices
         self._index_file_cache: file_cache.FileCache = file_cache.FileCache(
-            self._index_cache_root, enable_lock=spack.config.get("config:locks", True)
+            self._index_cache_root, enable_lock=spack.config.CONFIG.get("config:locks", True)
         )
         self._index_file_cache_initialized = False
 

--- a/lib/spack/spack/caches.py
+++ b/lib/spack/spack/caches.py
@@ -25,7 +25,9 @@ def misc_cache_location():
 
 def _misc_cache():
     path = misc_cache_location()
-    return spack.util.file_cache.FileCache(path)
+    return spack.util.file_cache.FileCache(
+        path, enable_lock=spack.config.get("config:locks", True)
+    )
 
 
 #: Spack's cache for small data

--- a/lib/spack/spack/caches.py
+++ b/lib/spack/spack/caches.py
@@ -26,7 +26,7 @@ def misc_cache_location():
 def _misc_cache():
     path = misc_cache_location()
     return spack.util.file_cache.FileCache(
-        path, enable_lock=spack.config.get("config:locks", True)
+        path, enable_lock=spack.config.CONFIG.get("config:locks", True)
     )
 
 

--- a/lib/spack/spack/database.py
+++ b/lib/spack/spack/database.py
@@ -279,8 +279,8 @@ class LockConfiguration(NamedTuple):
     """
 
     enable: bool
-    database_timeout: Optional[int]
-    package_timeout: Optional[int]
+    database_timeout: Optional[float]
+    package_timeout: Optional[float]
 
 
 #: Configure a database to avoid using locks
@@ -332,16 +332,10 @@ def failures_lock_path(root_dir: Union[str, pathlib.Path]) -> pathlib.Path:
 class SpecLocker:
     """Manages acquiring and releasing read or write locks on concrete specs."""
 
-    def __init__(
-        self,
-        lock_path: Union[str, pathlib.Path],
-        default_timeout: Optional[float],
-        *,
-        enable: bool = True,
-    ):
+    def __init__(self, lock_path: Union[str, pathlib.Path], lock_cfg: LockConfiguration):
         self.lock_path = pathlib.Path(lock_path)
-        self.default_timeout = default_timeout
-        self._enable = enable
+        self.default_timeout = lock_cfg.package_timeout
+        self._enable = lock_cfg.enable
 
         # Maps (spec.dag_hash(), spec.name) to the corresponding lock object
         self.locks: Dict[Tuple[str, str], lk.Lock] = {}
@@ -436,19 +430,11 @@ class FailureTracker:
     #: File for locking particular concrete spec hashes
     locker: SpecLocker
 
-    def __init__(
-        self,
-        root_dir: Union[str, pathlib.Path],
-        default_timeout: Optional[float],
-        *,
-        enable: bool = True,
-    ):
+    def __init__(self, root_dir: Union[str, pathlib.Path], lock_cfg: LockConfiguration):
         #: Ensure a persistent location for dealing with parallel installation
         #: failures (e.g., across near-concurrent processes).
         self.dir = pathlib.Path(root_dir) / _DB_DIRNAME / "failures"
-        self.locker = SpecLocker(
-            failures_lock_path(root_dir), default_timeout=default_timeout, enable=enable
-        )
+        self.locker = SpecLocker(failures_lock_path(root_dir), lock_cfg=lock_cfg)
 
     def _ensure_parent_directories(self) -> None:
         """Ensure that parent directories of the FailureTracker exist.

--- a/lib/spack/spack/database.py
+++ b/lib/spack/spack/database.py
@@ -436,11 +436,19 @@ class FailureTracker:
     #: File for locking particular concrete spec hashes
     locker: SpecLocker
 
-    def __init__(self, root_dir: Union[str, pathlib.Path], default_timeout: Optional[float]):
+    def __init__(
+        self,
+        root_dir: Union[str, pathlib.Path],
+        default_timeout: Optional[float],
+        *,
+        enable: bool = True,
+    ):
         #: Ensure a persistent location for dealing with parallel installation
         #: failures (e.g., across near-concurrent processes).
         self.dir = pathlib.Path(root_dir) / _DB_DIRNAME / "failures"
-        self.locker = SpecLocker(failures_lock_path(root_dir), default_timeout=default_timeout)
+        self.locker = SpecLocker(
+            failures_lock_path(root_dir), default_timeout=default_timeout, enable=enable
+        )
 
     def _ensure_parent_directories(self) -> None:
         """Ensure that parent directories of the FailureTracker exist.

--- a/lib/spack/spack/database.py
+++ b/lib/spack/spack/database.py
@@ -332,9 +332,16 @@ def failures_lock_path(root_dir: Union[str, pathlib.Path]) -> pathlib.Path:
 class SpecLocker:
     """Manages acquiring and releasing read or write locks on concrete specs."""
 
-    def __init__(self, lock_path: Union[str, pathlib.Path], default_timeout: Optional[float]):
+    def __init__(
+        self,
+        lock_path: Union[str, pathlib.Path],
+        default_timeout: Optional[float],
+        *,
+        enable: bool = True,
+    ):
         self.lock_path = pathlib.Path(lock_path)
         self.default_timeout = default_timeout
+        self._enable = enable
 
         # Maps (spec.dag_hash(), spec.name) to the corresponding lock object
         self.locks: Dict[Tuple[str, str], lk.Lock] = {}
@@ -369,6 +376,7 @@ class SpecLocker:
             length=1,
             default_timeout=timeout,
             desc=spec.name,
+            enable=self._enable,
         )
 
     def has_lock(self, spec: "spack.spec.Spec") -> bool:

--- a/lib/spack/spack/environment/environment.py
+++ b/lib/spack/spack/environment/environment.py
@@ -1072,9 +1072,8 @@ class Environment:
         self.name = environment_name(self.path)
         self.env_subdir_path = env_subdir_path(self.path)
 
-        self.txlock = lk.Lock(
-            self._transaction_lock_path, enable=spack.config.get("config:locks", True)
-        )
+        self._lock_enabled = spack.config.CONFIG.get("config:locks", True)
+        self.txlock = lk.Lock(self._transaction_lock_path, enable=self._lock_enabled)
 
         self._unify = None
         self.views: Dict[str, ViewDescriptor] = {}
@@ -1148,9 +1147,7 @@ class Environment:
 
     def __setstate__(self, state):
         self.__dict__.update(state)
-        self.txlock = lk.Lock(
-            self._transaction_lock_path, enable=spack.config.get("config:locks", True)
-        )
+        self.txlock = lk.Lock(self._transaction_lock_path, enable=self._lock_enabled)
         self._repo = None
 
     def _re_read(self):

--- a/lib/spack/spack/environment/environment.py
+++ b/lib/spack/spack/environment/environment.py
@@ -1072,7 +1072,9 @@ class Environment:
         self.name = environment_name(self.path)
         self.env_subdir_path = env_subdir_path(self.path)
 
-        self.txlock = lk.Lock(self._transaction_lock_path)
+        self.txlock = lk.Lock(
+            self._transaction_lock_path, enable=spack.config.get("config:locks", True)
+        )
 
         self._unify = None
         self.views: Dict[str, ViewDescriptor] = {}
@@ -1146,7 +1148,9 @@ class Environment:
 
     def __setstate__(self, state):
         self.__dict__.update(state)
-        self.txlock = lk.Lock(self._transaction_lock_path)
+        self.txlock = lk.Lock(
+            self._transaction_lock_path, enable=spack.config.get("config:locks", True)
+        )
         self._repo = None
 
     def _re_read(self):

--- a/lib/spack/spack/environment/environment.py
+++ b/lib/spack/spack/environment/environment.py
@@ -1072,8 +1072,8 @@ class Environment:
         self.name = environment_name(self.path)
         self.env_subdir_path = env_subdir_path(self.path)
 
-        self._lock_enabled = spack.config.CONFIG.get("config:locks", True)
-        self.txlock = lk.Lock(self._transaction_lock_path, enable=self._lock_enabled)
+        lock_enabled = spack.config.CONFIG.get("config:locks", True)
+        self.txlock = lk.Lock(self._transaction_lock_path, enable=lock_enabled)
 
         self._unify = None
         self.views: Dict[str, ViewDescriptor] = {}
@@ -1139,6 +1139,7 @@ class Environment:
 
     def __getstate__(self):
         state = self.__dict__.copy()
+        state["_txlock_enabled"] = self.txlock.enabled
         state.pop("txlock", None)
         state.pop("_repo", None)
         state.pop("repo_token", None)
@@ -1146,8 +1147,9 @@ class Environment:
         return state
 
     def __setstate__(self, state):
+        lock_enabled = state.pop("_txlock_enabled")
         self.__dict__.update(state)
-        self.txlock = lk.Lock(self._transaction_lock_path, enable=self._lock_enabled)
+        self.txlock = lk.Lock(self._transaction_lock_path, enable=lock_enabled)
         self._repo = None
 
     def _re_read(self):

--- a/lib/spack/spack/repo.py
+++ b/lib/spack/spack/repo.py
@@ -74,7 +74,8 @@ SPACK_REPO_INDEX_FILE_NAME = "spack-repo-index.yaml"
 def package_repository_lock() -> spack.util.lock.Lock:
     """Lock for process safety when cloning remote package repositories"""
     return spack.util.lock.Lock(
-        os.path.join(spack.paths.user_cache_path, "package-repository.lock")
+        os.path.join(spack.paths.user_cache_path, "package-repository.lock"),
+        enable=spack.config.get("config:locks", True),
     )
 
 

--- a/lib/spack/spack/repo.py
+++ b/lib/spack/spack/repo.py
@@ -75,7 +75,7 @@ def package_repository_lock() -> spack.util.lock.Lock:
     """Lock for process safety when cloning remote package repositories"""
     return spack.util.lock.Lock(
         os.path.join(spack.paths.user_cache_path, "package-repository.lock"),
-        enable=spack.config.get("config:locks", True),
+        enable=spack.config.CONFIG.get("config:locks", True),
     )
 
 

--- a/lib/spack/spack/stage.py
+++ b/lib/spack/spack/stage.py
@@ -271,7 +271,7 @@ class AbstractStage(abc.ABC):
                 start=lock_id,
                 length=1,
                 desc=self.name,
-                enable=spack.config.get("config:locks", True),
+                enable=spack.config.CONFIG.get("config:locks", True),
             )
         return self._lock
 

--- a/lib/spack/spack/stage.py
+++ b/lib/spack/spack/stage.py
@@ -267,7 +267,11 @@ class AbstractStage(abc.ABC):
             lock_id = prefix_bits(sha1, bit_length(sys.maxsize))
             stage_lock_path = os.path.join(get_stage_root(), ".lock")
             self._lock = spack.util.lock.Lock(
-                stage_lock_path, start=lock_id, length=1, desc=self.name
+                stage_lock_path,
+                start=lock_id,
+                length=1,
+                desc=self.name,
+                enable=spack.config.get("config:locks", True),
             )
         return self._lock
 

--- a/lib/spack/spack/store.py
+++ b/lib/spack/spack/store.py
@@ -201,7 +201,9 @@ class Store:
         tty.debug("PACKAGE LOCK TIMEOUT: {0}".format(str(timeout_format_str)))
 
         self.prefix_locker = spack.database.SpecLocker(
-            spack.database.prefix_lock_path(root), default_timeout=lock_cfg.package_timeout
+            spack.database.prefix_lock_path(root),
+            default_timeout=lock_cfg.package_timeout,
+            enable=lock_cfg.enable,
         )
         self.failure_tracker = spack.database.FailureTracker(
             self.root, default_timeout=lock_cfg.package_timeout

--- a/lib/spack/spack/store.py
+++ b/lib/spack/spack/store.py
@@ -206,7 +206,7 @@ class Store:
             enable=lock_cfg.enable,
         )
         self.failure_tracker = spack.database.FailureTracker(
-            self.root, default_timeout=lock_cfg.package_timeout
+            self.root, default_timeout=lock_cfg.package_timeout, enable=lock_cfg.enable
         )
 
     def has_padding(self) -> bool:

--- a/lib/spack/spack/store.py
+++ b/lib/spack/spack/store.py
@@ -201,13 +201,9 @@ class Store:
         tty.debug("PACKAGE LOCK TIMEOUT: {0}".format(str(timeout_format_str)))
 
         self.prefix_locker = spack.database.SpecLocker(
-            spack.database.prefix_lock_path(root),
-            default_timeout=lock_cfg.package_timeout,
-            enable=lock_cfg.enable,
+            spack.database.prefix_lock_path(root), lock_cfg=lock_cfg
         )
-        self.failure_tracker = spack.database.FailureTracker(
-            self.root, default_timeout=lock_cfg.package_timeout, enable=lock_cfg.enable
-        )
+        self.failure_tracker = spack.database.FailureTracker(self.root, lock_cfg=lock_cfg)
 
     def has_padding(self) -> bool:
         """Returns True if the store layout includes path padding."""

--- a/lib/spack/spack/test/env.py
+++ b/lib/spack/spack/test/env.py
@@ -2170,3 +2170,22 @@ def test_unified_environment_with_mixed_compilers_and_fortran(tmp_path, config):
     assert mpich.satisfies("%fortran=gcc")
     assert openblas.satisfies("%c,fortran=gcc")
     assert mpich["fortran"].dag_hash() == openblas["fortran"].dag_hash()
+
+
+@pytest.mark.parametrize("enable_locks", [True, False])
+def test_environment_pickle_preserves_lock_state(enable_locks, tmp_path: pathlib.Path):
+    """Tests that an environment round-trips through pickle with its lock-enable state intact."""
+    with spack.config.override("config:locks", enable_locks):
+        env = ev.create_in_dir(tmp_path)
+    assert env._lock_enabled is enable_locks
+
+    blob = pickle.dumps(env)
+
+    # Flip the global config, then unpickle: the restored environment must keep the value
+    # that was pickled, not the (now different) global one.
+    with spack.config.override("config:locks", not enable_locks):
+        restored = pickle.loads(blob)
+
+    assert restored._lock_enabled is enable_locks
+    # The rebuilt transaction lock must reflect the pickled state, not the flipped global.
+    assert type(restored.txlock.backend) is type(env.txlock.backend)

--- a/lib/spack/spack/test/env.py
+++ b/lib/spack/spack/test/env.py
@@ -2177,15 +2177,13 @@ def test_environment_pickle_preserves_lock_state(enable_locks, tmp_path: pathlib
     """Tests that an environment round-trips through pickle with its lock-enable state intact."""
     with spack.config.override("config:locks", enable_locks):
         env = ev.create_in_dir(tmp_path)
-    assert env._lock_enabled is enable_locks
+    original_enabled = env.txlock.enabled
 
     blob = pickle.dumps(env)
 
-    # Flip the global config, then unpickle: the restored environment must keep the value
+    # Flip the global config, then unpickle: the rebuilt transaction lock must keep the state
     # that was pickled, not the (now different) global one.
     with spack.config.override("config:locks", not enable_locks):
         restored = pickle.loads(blob)
 
-    assert restored._lock_enabled is enable_locks
-    # The rebuilt transaction lock must reflect the pickled state, not the flipped global.
-    assert type(restored.txlock.backend) is type(env.txlock.backend)
+    assert restored.txlock.enabled == original_enabled

--- a/lib/spack/spack/test/old_installer.py
+++ b/lib/spack/spack/test/old_installer.py
@@ -483,7 +483,12 @@ def test_dump_packages_deps_errs(install_mockery, tmp_path: pathlib.Path, monkey
 
 def test_clear_failures_success(tmp_path: pathlib.Path):
     """Test the clear_failures happy path."""
-    failures = spack.database.FailureTracker(str(tmp_path), default_timeout=0.1)
+    failures = spack.database.FailureTracker(
+        str(tmp_path),
+        lock_cfg=spack.database.LockConfiguration(
+            enable=True, database_timeout=None, package_timeout=0.1
+        ),
+    )
 
     spec = spack.spec.Spec("pkg-a")
     spec._mark_concrete()
@@ -511,7 +516,12 @@ def test_clear_failures_success(tmp_path: pathlib.Path):
 @pytest.mark.skipif(fs.getuid() == 0, reason="user is root")
 def test_clear_failures_errs(tmp_path: pathlib.Path, capfd):
     """Test the clear_failures exception paths."""
-    failures = spack.database.FailureTracker(str(tmp_path), default_timeout=0.1)
+    failures = spack.database.FailureTracker(
+        str(tmp_path),
+        lock_cfg=spack.database.LockConfiguration(
+            enable=True, database_timeout=None, package_timeout=0.1
+        ),
+    )
     spec = spack.spec.Spec("pkg-a")
     spec._mark_concrete()
     failures.mark(spec)

--- a/lib/spack/spack/util/file_cache.py
+++ b/lib/spack/spack/util/file_cache.py
@@ -96,7 +96,7 @@ class FileCache:
 
     """
 
-    def __init__(self, root: Union[str, pathlib.Path], timeout=120):
+    def __init__(self, root: Union[str, pathlib.Path], timeout=120, *, enable_lock: bool = True):
         """Create a file cache object.
 
         This will create the cache directory if it does not exist yet.
@@ -107,6 +107,8 @@ class FileCache:
             timeout: when there is contention among multiple Spack processes
                 for cache files, this specifies how long Spack should wait
                 before assuming that there is a deadlock.
+
+            enable_lock: if False, all lock operations are no-ops.
         """
         if isinstance(root, str):
             root = pathlib.Path(root)
@@ -116,6 +118,7 @@ class FileCache:
         self.lock_path = self.root / ".lock"
         self._locks: Dict[str, Lock] = {}
         self.lock_timeout = timeout
+        self._enable_lock = enable_lock
 
     def destroy(self):
         """Remove all files under the cache root."""
@@ -149,6 +152,7 @@ class FileCache:
                 length=length,
                 default_timeout=self.lock_timeout,
                 desc=f"key:{key_str}",
+                enable=self._enable_lock,
             )
         return self._locks[key_str]
 

--- a/lib/spack/spack/util/lock.py
+++ b/lib/spack/spack/util/lock.py
@@ -430,6 +430,11 @@ class Lock:
         else:
             self.backend = DummyBackend()
 
+    @property
+    def enabled(self) -> bool:
+        """True if this lock actually takes OS locks (False for the no-op backend)."""
+        return not isinstance(self.backend, DummyBackend)
+
     @staticmethod
     def _poll_interval_generator(
         _wait_times: Optional[Tuple[float, float, float]] = None,


### PR DESCRIPTION
closes #52724
refers #52251

Modifications:
- Forward the lock_cfg.enable parameter from the Store to SpecLocker
- Make environments `txlock` respect the `config:locks` parameter
- Make file caches respect the `config:locks` parameter

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
