### PR TITLE
Spack managing its own reified environment

### DIFF
--- a/lib/spack/spack/bootstrap/_common.py
+++ b/lib/spack/spack/bootstrap/_common.py
@@ -23,7 +23,7 @@ import spack.util.environment
 import spack.util.executable
 from spack.llnl.util import tty
 
-from .config import spec_for_current_python
+from .config import abi_spec_for_current_python
 
 
 class QueryInfo(TypedDict, total=False):
@@ -54,7 +54,7 @@ def _try_import_from_store(
     # If it is a string assume it's one of the root specs by this module
     if isinstance(query_spec, str):
         # We have to run as part of this python interpreter
-        query_spec += " ^" + spec_for_current_python()
+        query_spec += " ^" + abi_spec_for_current_python()
 
     installed_specs = spack.store.STORE.db.query(query_spec, installed=True)
 

--- a/lib/spack/spack/bootstrap/base_env.py
+++ b/lib/spack/spack/bootstrap/base_env.py
@@ -1,0 +1,201 @@
+from spack.bootstrap.config import abi_spec_for_current_python, store_path
+from typing import Optional
+import json
+from spack.installer import log
+from spack.spec import ArchSpec, Spec, FlagMap
+import spack.deptypes as dt
+import sys
+from spack.store import use_store
+import spack.vendor.archspec.cpu as ascpu
+import spack.platforms
+from spack.bootstrap.config import root_path
+import hashlib
+import spack.environment
+import spack.tengine
+from pathlib import Path
+from spack.detection import by_path
+import spack.environment.shell
+import sys
+import os
+import spack.llnl.util.tty as tty
+from spack.spec import Spec, parse_with_version_concrete
+import spack.platforms
+import spack.binary_distribution
+import spack.config
+from spack.llnl.util.lang import Singleton
+_SPACK_SPACK_ENV_VAR = "SPACK_SPACK_ENV"
+def _init_env():
+    sse =SpackSpackEnvironment(os.environ.get(_SPACK_SPACK_ENV_VAR, None))
+    sse.setup()
+    return sse
+SPACK_SPACK_ENV = Singleton(_init_env)
+_RUNNING_PYTHON_SPEC = None
+def detect_running_python_external() -> Spec:
+    global _RUNNING_PYTHON_SPEC
+    if _RUNNING_PYTHON_SPEC is None:
+        tty.debug("Attempting to detect spec for currently executing python interpreter")
+        detected = by_path(['python'], path_hints=[sys.exec_prefix])
+        if "python" in detected:
+            detected_python = detected["python"][0]
+            detected_python.external_path = sys.exec_prefix
+            detected_python.namespace = "builtin"
+            detected_python._set_architecture(
+                platform=str(spack.platforms.host()),
+                os=str(spack.platforms.host().default_os),
+                target=str(ascpu.host().family)
+            )
+            for flag_type in FlagMap.valid_compiler_flags():
+                detected_python.compiler_flags[flag_type] = []
+            tty.debug(f"Detected: {detected_python.long_spec}")
+            _RUNNING_PYTHON_SPEC = detected_python
+        else:
+            raise Exception("Detection for current python failed")
+    return _RUNNING_PYTHON_SPEC
+
+def refresh_system_path():
+    '''
+    sys.path is derived at startup, when we edit the venv we reload it
+    '''
+    import importlib
+    importlib.invalidate_caches()
+    
+def spec_for_current_python_venv() -> Spec:
+    if _SPACK_SPACK_ENV_VAR in os.environ:
+        venv_spec = SPACK_SPACK_ENV.matching_spec(Spec("python-venv"))
+        assert venv_spec is not None
+    else:
+        venv_spec = Spec("python-venv@=1.0")
+        venv_spec.namespace = "builtin"
+        venv_spec.architecture = ArchSpec.default_arch()
+        venv_spec.add_dependency_edge(
+            parse_with_version_concrete(detect_running_python_external()),
+            virtuals=(),
+            direct=True,
+            depflag=(dt.BUILD | dt.RUN)
+        )
+        for flag_type in FlagMap.valid_compiler_flags():
+            venv_spec.compiler_flags[flag_type] = []
+        venv_spec._finalize_concretization()
+    return venv_spec
+
+def reexec_spack_under_venv():
+    tty.info("Attempting to re-execute spack ")
+    if _SPACK_SPACK_ENV_VAR not in os.environ:
+        new_env = dict(os.environ)
+        new_spack_python = SPACK_SPACK_ENV.python_interpreter
+        for d in SPACK_SPACK_ENV.view_root.iterdir():
+            print(d)
+        assert SPACK_SPACK_ENV.python_interpreter.exists(), "interpreter should exist"
+        tty.info(f"Setting new spack python to: {new_spack_python}")
+        new_env["SPACK_PYTHON"] = str(new_spack_python)
+        new_env[_SPACK_SPACK_ENV_VAR] = str(SPACK_SPACK_ENV.env_path)
+        os.execvpe(sys.argv[0], sys.argv, env=new_env)
+    else:
+        tty.info("Already executing under the base environment")
+    
+
+def spack_in_env() -> bool:
+    return _SPACK_SPACK_ENV_VAR in os.environ
+
+class SpackSpackEnvironment(spack.environment.Environment):
+    def __init__(self, env_path = None) -> None:
+        self._env_path = Path(env_path) if env_path is not None else None
+        self._spack_yaml_path = None
+        self._spack_lock_path = None
+        self._view_root = None
+        self._python_interpreter = None
+        if not self.spack_yaml_path.exists():
+            self._write_spack_yaml_file()
+        super().__init__(self.env_path)
+    def setup(self):
+        if not self.spack_lock_path.exists():
+            with self.write_transaction():
+                tty.info("Locking base Spack environment to current python interpreter")
+                self.add_concrete_spec(
+                    Spec("python-venv"),
+                    spec_for_current_python_venv()
+                )
+                self.install_all()
+                self.write(regenerate=True)
+    def add_concrete_spec(
+            self,
+            spec: Spec,
+            concrete: Spec,
+            *,
+            new: bool = True,
+            group: Optional[str] = None
+    ):
+        self.add(spec)
+        return super().add_concrete_spec(spec, concrete, new=new, group=group)
+
+                
+    @property
+    def env_path(self) -> Path:
+        if self._env_path is None:
+            bootstrap_root = Path(root_path())
+            python_part = abi_spec_for_current_python().replace("@", "")
+            arch_part = ascpu.host().family
+            interpreter_part = hashlib.md5(sys.exec_prefix.encode()).hexdigest()[:5]
+            environment_dir = f"venv-{python_part}-{arch_part}-{interpreter_part}"
+            self._env_path = Path(bootstrap_root / "environments" / environment_dir)
+        return self._env_path
+    
+    @property
+    def spack_yaml_path(self) -> Path:
+        if self._spack_yaml_path is None:
+            self._spack_yaml_path = self.env_path / "spack.yaml"
+        return self._spack_yaml_path
+    
+    @property
+    def spack_lock_path(self) -> Path:
+        if self._spack_lock_path is None:
+            self._spack_lock_path = self.env_path / "spack.lock"
+        return self._spack_lock_path
+    
+    def _write_spack_yaml_file(self):
+        tty.info(f"Creating base Spack environment at: {self.env_path}")
+        temp_env = spack.tengine.make_environment()
+        template = temp_env.get_template("spack_spack_env/spack.yaml")
+        context = {
+            "environment_path": self.env_path,
+            "python_spec": f"{abi_spec_for_current_python()}+ctypes",
+            "python_prefix": sys.exec_prefix
+        }
+        self.env_path.mkdir(parents=True, exist_ok=True)
+        self.spack_yaml_path.write_text(template.render(context), encoding="utf-8")
+        
+    @property
+    def view_root(self) -> Path:
+        """Location of the view"""
+        if self._view_root is None:
+            self._view_root = self.env_path / ".spack-env" / "view"
+        return self._view_root
+
+    @property
+    def python_interpreter(self) -> Path:
+        if self._python_interpreter is None:
+            self._python_interpreter = self.view_root / "bin" / "python"
+        return self._python_interpreter
+    
+    def load(self):
+        env_mods = spack.environment.shell.activate(self)
+        # We don't want this environment to interfere with the user active environment
+        env_mods.drop(spack.environment.spack_env_var)
+        env_mods.drop(spack.environment.spack_env_view_var)
+        if os.environ.get("SPACK_PYTHON", None) != str(self.python_interpreter):
+            env_mods.set("SPACK_PYTHON", str(self.python_interpreter))
+        refresh_system_path()
+        env_mods.apply_modifications()
+
+
+
+def _splice_in_python_venv_from_buildcache(pkg_hash: str):
+    tty.debug(f'Fetching spec for {pkg_hash}')
+    full_candidate_spec = (
+        spack.binary_distribution.BINARY_INDEX._known_specs[pkg_hash]
+    )
+    tty.debug(f'Got {full_candidate_spec.long_spec}')
+    return full_candidate_spec.splice(
+        spec_for_current_python_venv()
+    )
+

--- a/lib/spack/spack/bootstrap/clingo.py
+++ b/lib/spack/spack/bootstrap/clingo.py
@@ -25,7 +25,7 @@ import spack.spec
 import spack.traverse
 import spack.version
 
-from .config import spec_for_current_python
+from .config import abi_spec_for_current_python
 
 
 def _select_best_version(
@@ -204,7 +204,7 @@ class ClingoBootstrapConcretizer:
 
     def python_external_spec(self) -> "spack.spec.Spec":
         """Python external spec corresponding to the current running interpreter"""
-        result = spack.spec.Spec(spec_for_current_python(), external_path=sys.exec_prefix)
+        result = spack.spec.Spec(abi_spec_for_current_python(), external_path=sys.exec_prefix)
         return self._external_spec(result)
 
     def libc_external_spec(self) -> "spack.spec.Spec":

--- a/lib/spack/spack/bootstrap/config.py
+++ b/lib/spack/spack/bootstrap/config.py
@@ -27,7 +27,7 @@ def is_bootstrapping() -> bool:
     return _REF_COUNT > 0
 
 
-def spec_for_current_python() -> str:
+def abi_spec_for_current_python() -> str:
     """For bootstrapping purposes we are just interested in the Python
     minor version (all patches are ABI compatible with the same minor).
 
@@ -64,7 +64,7 @@ def spack_python_interpreter() -> Generator:
     available.
     """
     python_prefix = sys.exec_prefix
-    external_python = spec_for_current_python()
+    external_python = abi_spec_for_current_python()
 
     entry = {
         "buildable": False,

--- a/lib/spack/spack/bootstrap/core.py
+++ b/lib/spack/spack/bootstrap/core.py
@@ -57,7 +57,7 @@ from ._common import (
 )
 from .clingo import ClingoBootstrapConcretizer
 from .config import spack_python_interpreter, abi_spec_for_current_python
-
+from .base_env import SPACK_SPACK_ENV, _splice_in_python_venv_from_buildcache
 #: Name of the file containing metadata about the bootstrapping source
 METADATA_YAML_FILENAME = "metadata.yaml"
 
@@ -218,7 +218,7 @@ class BuildcacheBootstrapper(Bootstrapper):
 
                 if python_spec is not None and not abstract_spec.intersects(f"^{python_spec}"):
                     continue
-
+                    
                 for _, pkg_hash, pkg_sha256 in item["binaries"]:
                     self._install_by_hash(pkg_hash, pkg_sha256, bincache_platform)
 
@@ -236,7 +236,7 @@ class BuildcacheBootstrapper(Bootstrapper):
 
         tty.debug(f"Bootstrapping {module} from pre-built binaries")
         abstract_spec, bincache_platform = self._spec_and_platform(
-            abstract_spec_str + " ^" + abi_spec_for_current_python()
+           abstract_spec_str + " ^" + abi_spec_for_current_python()
         )
         data = self._read_metadata(module)
         return self._install_and_test(abstract_spec, bincache_platform, data, test_fn)
@@ -253,6 +253,51 @@ class BuildcacheBootstrapper(Bootstrapper):
         data = self._read_metadata(abstract_spec.name)
         return self._install_and_test(abstract_spec, bincache_platform, data, test_fn)
 
+@bootstrapper(bootstrapper_type="buildcache")
+class BinarySpackSpackEnvBootstrapper(Bootstrapper):
+    def try_import(self, module: str, abstract_spec_str: str) -> bool:
+        if _python_import(module):
+            tty.debug(f'Able to avoid bootstrap for {module} by importing')
+            return True
+        with open(os.path.join(self.metadata_dir, f"{module}.json")) as f:
+            bincache_metadata = json.load(f)
+        abstract_spec = spack.spec.Spec(
+            abstract_spec_str + f" ^{abi_spec_for_current_python()}"
+        )
+        with spack.config.override(self.mirror_scope):
+            spack.binary_distribution.BINARY_INDEX.regenerate_spec_cache()
+            spack.binary_distribution.update_cache_and_get_specs()
+            for item in bincache_metadata['verified']:
+                candidate_abstract = spack.spec.Spec(item['spec'])
+                if not abstract_spec.intersects(candidate_abstract):
+                    continue
+                candidate_concrete = None
+                for (name, pkg_hash, shasum) in item['binaries']:
+                    if name == candidate_abstract.name:
+                        candidate_concrete = _splice_in_python_venv_from_buildcache(pkg_hash)
+                        tty.debug(f'Got spliced spec: {candidate_concrete}')
+                        SPACK_SPACK_ENV.add_concrete_spec(
+                            abstract_spec,
+                            candidate_concrete
+                        )
+                        tty.debug(f'Added spliced spec to environment')
+                        SPACK_SPACK_ENV.install_all()
+                        SPACK_SPACK_ENV.write(regenerate=True)
+                        SPACK_SPACK_ENV.load()
+                        print(sys.path)
+                        if _python_import(module):
+                            tty.debug(f'Able to import module {module} after bootstrapping')
+                            return True
+                        else:
+                            tty.debug(f'Unable to import module {module} after bootstrapping')
+                        return False
+                if candidate_concrete is None:
+                    tty.debug(f"Unable to find concrete spec for candidate {abstract_spec}")
+                    
+
+        
+    def try_search_path(self, executables: tuple[str], abstract_spec_str: str) -> bool:
+        pass
 
 @bootstrapper(bootstrapper_type="install")
 class SourceBootstrapper(Bootstrapper):

--- a/lib/spack/spack/bootstrap/core.py
+++ b/lib/spack/spack/bootstrap/core.py
@@ -56,7 +56,7 @@ from ._common import (
     _try_import_from_store,
 )
 from .clingo import ClingoBootstrapConcretizer
-from .config import spack_python_interpreter, spec_for_current_python
+from .config import spack_python_interpreter, abi_spec_for_current_python
 
 #: Name of the file containing metadata about the bootstrapping source
 METADATA_YAML_FILENAME = "metadata.yaml"
@@ -236,7 +236,7 @@ class BuildcacheBootstrapper(Bootstrapper):
 
         tty.debug(f"Bootstrapping {module} from pre-built binaries")
         abstract_spec, bincache_platform = self._spec_and_platform(
-            abstract_spec_str + " ^" + spec_for_current_python()
+            abstract_spec_str + " ^" + abi_spec_for_current_python()
         )
         data = self._read_metadata(module)
         return self._install_and_test(abstract_spec, bincache_platform, data, test_fn)
@@ -282,7 +282,7 @@ class SourceBootstrapper(Bootstrapper):
                 concrete_spec = bootstrapper.concretize()
             else:
                 abstract_spec = spack.spec.Spec(
-                    abstract_spec_str + " ^" + spec_for_current_python()
+                    abstract_spec_str + " ^" + abi_spec_for_current_python()
                 )
                 concrete_spec = spack.concretize.concretize_one(abstract_spec)
 

--- a/lib/spack/spack/bootstrap/environment.py
+++ b/lib/spack/spack/bootstrap/environment.py
@@ -17,7 +17,7 @@ import spack.util.path
 from spack.llnl.util import tty
 
 from ._common import _root_spec
-from .config import root_path, spec_for_current_python, store_path
+from .config import root_path, abi_spec_for_current_python, store_path
 from .core import _add_externals_if_missing
 
 
@@ -49,7 +49,7 @@ class BootstrapEnvironment(spack.environment.Environment):
     def environment_root(cls) -> pathlib.Path:
         """Environment root directory"""
         bootstrap_root_path = root_path()
-        python_part = spec_for_current_python().replace("@", "")
+        python_part = abi_spec_for_current_python().replace("@", "")
         arch_part = spack.vendor.archspec.cpu.host().family
         interpreter_part = hashlib.md5(sys.exec_prefix.encode()).hexdigest()[:5]
         environment_dir = f"{python_part}-{arch_part}-{interpreter_part}"
@@ -109,7 +109,7 @@ class BootstrapEnvironment(spack.environment.Environment):
         env = spack.tengine.make_environment()
         template = env.get_template("bootstrap/spack.yaml")
         context = {
-            "python_spec": f"{spec_for_current_python()}+ctypes",
+            "python_spec": f"{abi_spec_for_current_python()}+ctypes",
             "python_prefix": sys.exec_prefix,
             "architecture": spack.vendor.archspec.cpu.host().family,
             "environment_path": self.environment_root(),

--- a/lib/spack/spack/cmd/bootstrap.py
+++ b/lib/spack/spack/cmd/bootstrap.py
@@ -310,7 +310,7 @@ def _status(args):
         sections.append("develop")
 
     header = "@*b{{Spack v{0} - {1}}}".format(
-        spack.spack_version, spack.bootstrap.config.spec_for_current_python()
+        spack.spack_version, spack.bootstrap.config.abi_spec_for_current_python()
     )
     print(spack.llnl.util.tty.color.colorize(header))
     print()

--- a/lib/spack/spack/main.py
+++ b/lib/spack/spack/main.py
@@ -28,6 +28,7 @@ from typing import Any, List, Optional, Set, Tuple
 import spack.vendor.archspec.cpu
 
 import spack
+import spack.bootstrap.base_env as base_env
 import spack.cmd
 import spack.config
 import spack.environment
@@ -46,6 +47,7 @@ import spack.store
 import spack.util.debug
 import spack.util.environment
 import spack.util.lock
+
 
 from .enums import ConfigScopePriority
 
@@ -425,6 +427,11 @@ def make_argument_parser(**kwargs):
     )
     general.add_argument(
         "-b", "--bootstrap", action="store_true", help="use bootstrap config, store, and externals"
+    )
+    general.add_argument(
+        "--venv",
+        action="store_true",
+        help="have spack run under a spack environment"
     )
     general.add_argument(
         "-V", "--version", action="store_true", help="show version number and exit"
@@ -1060,6 +1067,7 @@ def _main(argv=None):
         parser.print_help()
         return 1
 
+    
     # Try to load the particular command the caller asked for.
     cmd_name = args.command[0]
     cmd_name, args.command = resolve_alias(cmd_name, args.command)
@@ -1068,7 +1076,18 @@ def _main(argv=None):
     # bootstrap context needs to include parsing the command, b/c things
     # like `ConstraintAction` and `ConfigSetAction` happen at parse time.
     bootstrap_context = spack.llnl.util.lang.nullcontext()
+    if args.venv and not base_env.spack_in_env():
+        tty.info('Re-executing Spack under a Spack environment')
+        base_env.reexec_spack_under_venv()
+    if base_env.spack_in_env():
+        tty.info('Spack is executing under a Spack environment')
+        tty.info(f'SPACK_SPACK_ENV: {os.environ.get(base_env._SPACK_SPACK_ENV_VAR)}')
+        tty.info(f'SPACK_PYTHON: {os.environ.get("SPACK_PYTHON")}')
+        tty.info(f'sys.executable: {sys.executable}')
+        tty.info(f'PYTHONPATH: {os.environ.get("PYTHONPATH")}')
+    
     if args.bootstrap:
+    
         import spack.bootstrap as bootstrap  # avoid circular imports
 
         bootstrap_context = bootstrap.ensure_bootstrap_configuration()

--- a/lib/spack/spack/new_installer.py
+++ b/lib/spack/spack/new_installer.py
@@ -2175,7 +2175,10 @@ class PackageInstaller:
         #: check what specs we could fetch from binaries (checks against cache, not remotely)
         spack.binary_distribution.BINARY_INDEX.update()
         self.binary_cache_for_spec = {
-            s.dag_hash(): spack.binary_distribution.BINARY_INDEX.find_by_hash(s.dag_hash())
+            s.dag_hash(): (
+                spack.binary_distribution.BINARY_INDEX.find_by_hash(s.dag_hash())
+                + spack.binary_distribution.BINARY_INDEX.find_by_hash(s.build_spec.dag_hash())
+            )
             for s in self.build_graph.nodes.values()
         }
         self.unsigned = unsigned

--- a/share/spack/templates/spack_spack_env/spack.yaml
+++ b/share/spack/templates/spack_spack_env/spack.yaml
@@ -1,0 +1,15 @@
+spack:
+  specs:
+    - python-venv
+    
+  view: true
+  packages:
+    python:
+      buildable: false
+      externals:
+        - spec: "{{ python_spec }}"
+          prefix: "{{ python_prefix }}"
+
+  concretizer:
+    reuse: false
+    unify: true


### PR DESCRIPTION
*TL;DR*: Have Spack execute under its own managed Spack environment. This will provide an extension point for boostrapping python and having Spack extensions provide external dependencies. 
# Overview
Spack itself has a number of dependencies:
- python
- git 
- clingo
- patchelf
- dev tools, linters, pytest etc

In particular, dependencies that provide python libraries need to unified with the python platform that spack itself is running on. This makes it tricky for extensions to provide a consistent platform, since they have an implicit dependency on Spack's own environment. This PR works towards reifying Spack's runtime environment as a Spack environment itself. This will require a few moving parts:
1. Cooperation from the Spack entry-point to rexecute Spack under the same environment, even if started from another python instance (prototyped)
2. Bootstrapping to augment this environment when dependencies are added (prototyped for binary clingo, others to come)
3. Added config to control which python is used initially, where this env lives, whether to enable it by default, etc. (not yet implemented)
4. The ability to bootstrap Python itself to use in this environment, so Spack can build the exact python it would like to run on. This will probably be multi-stage (not yet implemented). 
5. Some work on plugins/extensions to extend the base Spack environment (not yet implemented)

# Example 

Currently, the following two commands work:
1. `spack --venv commands`: This creates the new environment and re-executes Spack under it. 
2. `spack --venv spec zlib`: This creates the new environment, re-executes Spack under it, bootstraps Clingo into that environment, and then works like you would expect. 