### PR TITLE
log parser: `tail -n` like support

### DIFF
--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -1654,7 +1654,7 @@ def _make_child_error(msg, module, name, traceback, log, log_type, context):
 
 
 def write_log_summary(out, log_type, log, last=None):
-    errors, warnings = parse_log_events(log)
+    errors, warnings, _ = parse_log_events(log)
     nerr = len(errors)
     nwar = len(warnings)
 

--- a/lib/spack/spack/cmd/log_parse.py
+++ b/lib/spack/spack/cmd/log_parse.py
@@ -47,6 +47,7 @@ def setup_parser(subparser: argparse.ArgumentParser) -> None:
     subparser.add_argument(
         "-t",
         "--tail",
+        metavar="LINES",
         action="store",
         type=int,
         default=0,

--- a/lib/spack/spack/cmd/log_parse.py
+++ b/lib/spack/spack/cmd/log_parse.py
@@ -44,6 +44,14 @@ def setup_parser(subparser: argparse.ArgumentParser) -> None:
     subparser.add_argument(
         "-j", "--jobs", action="store", type=int, default=None, help=argparse.SUPPRESS
     )
+    subparser.add_argument(
+        "-t",
+        "--tail",
+        action="store",
+        type=int,
+        default=0,
+        help="number of trailing log lines to show (0 to disable)",
+    )
 
     subparser.add_argument("file", help="a log file containing build output, or - for stdin")
 
@@ -60,7 +68,9 @@ def log_parse(parser, args):
     if args.jobs is not None:
         warnings.warn("The --jobs option is deprecated and will be removed in Spack v1.3")
 
-    log_errors, log_warnings = parse_log_events(input, args.context, args.profile)
+    log_errors, log_warnings, tail = parse_log_events(
+        input, args.context, args.profile, tail=args.tail
+    )
     if args.profile:
         return
 
@@ -76,5 +86,8 @@ def log_parse(parser, args):
     if "warnings" in types:
         events.extend(log_warnings)
         print("%d warnings" % len(log_warnings))
+
+    if tail:
+        events.append(tail)
 
     print(make_log_context(events), end="")

--- a/lib/spack/spack/new_installer.py
+++ b/lib/spack/spack/new_installer.py
@@ -83,6 +83,7 @@ import spack.util.lock
 from spack.installer import _do_fake_install, dump_packages
 from spack.llnl.util.lang import pretty_duration
 from spack.llnl.util.tty.log import _is_background_tty, ignore_signal
+from spack.util.log_parse import make_log_context, parse_log_events
 from spack.util.path import padding_filter, padding_filter_bytes
 
 if TYPE_CHECKING:
@@ -1358,13 +1359,12 @@ class BuildStatus:
         build_info = self.builds[build_id]
         if not build_info.log_path or not os.path.exists(build_info.log_path):
             return
-        buf = io.StringIO()
-        spack.build_environment.write_log_summary(
-            buf, f"{build_info.name}@{build_info.version} build", build_info.log_path
-        )
-        summary = buf.getvalue()
-        if summary:
-            build_info.log_summary = summary
+        errors, warnings, tail_event = parse_log_events(build_info.log_path, tail=20)
+        events = [*errors, *warnings]
+        if tail_event is not None:
+            events.append(tail_event)
+        if events:
+            build_info.log_summary = make_log_context(events)
 
     def update_progress(self, build_id: str, current: int, total: int) -> None:
         """Update the progress of a package and mark the display as dirty."""

--- a/lib/spack/spack/reporters/cdash.py
+++ b/lib/spack/spack/reporters/cdash.py
@@ -203,7 +203,7 @@ class CDash(Reporter):
         for phase in phases_encountered:
             report_data[phase]["endtime"] = self.endtime
             report_data[phase]["log"] = "\n".join(report_data[phase]["loglines"])
-            errors, warnings = parse_log_events(report_data[phase]["loglines"])
+            errors, warnings, _ = parse_log_events(report_data[phase]["loglines"])
 
             # Convert errors to warnings if the package reported success.
             if package["result"] == "success":

--- a/lib/spack/spack/test/util/log_parser.py
+++ b/lib/spack/spack/test/util/log_parser.py
@@ -7,7 +7,7 @@ import pathlib
 import re
 
 from spack.llnl.util.tty.color import color_when
-from spack.util.ctest_log_parser import CTestLogParser, _optimize_regexes
+from spack.util.ctest_log_parser import CTestLogParser, LogEvent, _optimize_regexes
 from spack.util.log_parse import make_log_context
 
 
@@ -32,7 +32,7 @@ configure: error: cannot run C compiled programs.                           E
         )
 
     parser = CTestLogParser()
-    errors, warnings = parser.parse(str(log_file))
+    errors, warnings, _ = parser.parse(str(log_file))
 
     assert len(errors) == 4
     assert all(e.text.endswith("E") for e in errors)
@@ -49,7 +49,7 @@ def test_log_parser_stream():
         "/var/tmp/build/foo.py:60: warning: some weird warning              W\n"
     )
     parser = CTestLogParser()
-    errors, warnings = parser.parse(log)
+    errors, warnings, _ = parser.parse(log)
 
     assert len(errors) == 1
     assert errors[0].text.endswith("E")
@@ -65,7 +65,7 @@ def test_log_parser_preserves_leading_whitespace():
         "            ^\n"
     )
     parser = CTestLogParser()
-    errors, _ = parser.parse(log, context=6)
+    errors, _, _ = parser.parse(log, context=6)
 
     assert len(errors) == 1
     assert errors[0].post_context[0] == "    int y = x + 1;"
@@ -84,7 +84,7 @@ def test_make_log_context_merges_overlapping_events(tmp_path: pathlib.Path):
     log_file.write_text("".join(lines))
 
     parser = CTestLogParser()
-    errors, warnings = parser.parse(str(log_file), context=3)
+    errors, warnings, _ = parser.parse(str(log_file), context=3)
 
     log_events = sorted([*errors, *warnings], key=lambda e: e.line_no)
     output = make_log_context(log_events)
@@ -108,7 +108,7 @@ def test_make_log_context_warning_in_error_context_keeps_yellow(tmp_path: pathli
     log_file.write_text("".join(lines))
 
     parser = CTestLogParser()
-    errors, warnings = parser.parse(str(log_file), context=3)
+    errors, warnings, _ = parser.parse(str(log_file), context=3)
 
     assert len(errors) == len(warnings) == 1
 
@@ -127,8 +127,55 @@ def test_log_parser_non_utf8_bytes(tmp_path: pathlib.Path):
     log_file = tmp_path / "log.bin"
     log_file.write_bytes(b"checking things...\nerror: \x80\xff something broke\ndone\n")
     parser = CTestLogParser()
-    errors, _ = parser.parse(str(log_file))
+    errors, _, _ = parser.parse(str(log_file))
     assert len(errors) == 1
+
+
+def test_tail_renders_as_plain_context():
+    """A LogEvent should render all lines as plain context with no highlighting."""
+    lines = ["tail line 1", "tail line 2", "tail line 3"]
+    section = LogEvent(text=lines[-1], line_no=100, pre_context=lines[:-1])
+
+    with color_when(False):
+        output = make_log_context([section])
+
+    assert "-- lines 98 to 100 --" in output
+    # All lines should be plain context (indented with two spaces, no "> " prefix)
+    assert "  tail line 1\n" in output
+    assert "  tail line 2\n" in output
+    assert "  tail line 3\n" in output
+    assert "> " not in output
+
+
+def test_tail_overlapping_with_error():
+    """Tail lines overlapping with an error's context should not be duplicated."""
+    log = io.StringIO("line 1\nline 2\nline 3\nerror: something broke\nline 5\nline 6\nline 7\n")
+    parser = CTestLogParser()
+    errors, _, tail = parser.parse(log, context=2, tail=3)
+    assert len(errors) == 1
+    assert tail is not None
+
+    with color_when(False):
+        output = make_log_context([*errors, tail])
+
+    # "line 5" and "line 6" appear in both the error context and the tail,
+    # but should only appear once in the output
+    assert output.count("line 5") == 1
+    assert output.count("line 6") == 1
+    assert output.count("line 7") == 1
+
+
+def test_tail_only():
+    """A LogEvent with no errors/warnings renders correctly."""
+    lines = ["final line 1", "final line 2"]
+    section = LogEvent(text=lines[-1], line_no=51, pre_context=lines[:-1])
+
+    with color_when(False):
+        output = make_log_context([section])
+
+    assert "-- lines 50 to 51 --" in output
+    assert "  final line 1\n" in output
+    assert "  final line 2\n" in output
 
 
 class TestOptimizeRegexes:

--- a/lib/spack/spack/util/ctest_log_parser.py
+++ b/lib/spack/spack/util/ctest_log_parser.py
@@ -74,7 +74,7 @@ import math
 import re
 import time
 from collections import deque
-from typing import Dict, List, TextIO, Tuple, Union
+from typing import Dict, List, Optional, TextIO, Tuple, Union
 
 _error_matches = [
     "^FAIL: ",
@@ -328,7 +328,7 @@ def _profile_match(matches, exceptions, line, match_times, exc_times):
         return True
 
 
-def _parse(stream, profile, context):
+def _parse(stream, profile, context, tail=0):
 
     error_matches = [re.compile(r) for r in _optimize_regexes(_error_matches)]
     error_exceptions = [re.compile(r) for r in _optimize_regexes(_error_exceptions)]
@@ -350,12 +350,14 @@ def _parse(stream, profile, context):
     errors = []
     warnings = []
     # rolling window of recent lines
-    pre_context = deque(maxlen=context)
+    pre_context = deque(maxlen=max(context, tail))
     # list of (event, remaining_post_context_lines)
     pending_events: List[Tuple[LogEvent, int]] = []
 
+    last_line_no = 0
     for i, line in enumerate(stream):
         rstripped_line = line.rstrip()
+        last_line_no = i + 1
 
         # feed this line into every event still collecting post_context
         if pending_events:
@@ -379,7 +381,7 @@ def _parse(stream, profile, context):
             pre_context.append(rstripped_line)
             continue
 
-        event.pre_context = list(pre_context)
+        event.pre_context = list(pre_context)[-context:] if context else []
         event.post_context = []
 
         # get file/line number for the event, if possible
@@ -405,7 +407,14 @@ def _parse(stream, profile, context):
         else:
             warnings.append(event)
 
-    return errors, warnings, timings
+    # build tail section from the last N lines of the log, if requested
+    if tail > 0 and last_line_no > 0:
+        lines = list(pre_context)[-tail:]
+        tail_event = LogEvent(text=lines[-1], line_no=last_line_no, pre_context=lines[:-1])
+    else:
+        tail_event = None
+
+    return errors, warnings, tail_event, timings
 
 
 class CTestLogParser:
@@ -436,20 +445,22 @@ class CTestLogParser:
             index += 1
 
     def parse(
-        self, stream: Union[str, TextIO], context: int = 6
-    ) -> Tuple[List[BuildError], List[BuildWarning]]:
+        self, stream: Union[str, TextIO], context: int = 6, tail: int = 0
+    ) -> Tuple[List[BuildError], List[BuildWarning], Optional[LogEvent]]:
         """Parse a log file by searching each line for errors and warnings.
 
         Args:
             stream: filename or stream to read from
             context: lines of context to extract around each log event
+            tail: if > 0, also return a :class:`LogEvent` with the last ``tail`` lines
 
         Returns:
-            two lists containing :class:`BuildError` and :class:`BuildWarning` objects.
+            two lists containing :class:`BuildError` and :class:`BuildWarning` objects,
+            plus an optional :class:`LogEvent` for the tail (None when ``tail=0``).
         """
         if isinstance(stream, str):
             with open(stream, encoding="utf-8", errors="replace") as f:
-                return self.parse(f, context)
+                return self.parse(f, context, tail)
 
-        errors, warnings, self.timings = _parse(stream, self.profile, context)
-        return errors, warnings
+        errors, warnings, tail_event, self.timings = _parse(stream, self.profile, context, tail)
+        return errors, warnings, tail_event

--- a/lib/spack/spack/util/log_parse.py
+++ b/lib/spack/spack/util/log_parse.py
@@ -3,25 +3,29 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 import io
-from typing import List, TextIO, Union
+from typing import List, TextIO, Tuple, Union
 
 from spack.llnl.util.tty.color import cescape, colorize
-from spack.util.ctest_log_parser import CTestLogParser, LogEvent
+from spack.util.ctest_log_parser import BuildError, BuildWarning, CTestLogParser, LogEvent
 
 __all__ = ["parse_log_events", "make_log_context"]
 
 
-def parse_log_events(stream: Union[str, TextIO], context: int = 6, profile: bool = False):
-    """Extract interesting events from a log file as a list of LogEvent.
+def parse_log_events(
+    stream: Union[str, TextIO], context: int = 6, profile: bool = False, tail: int = 0
+) -> Tuple[List[BuildError], List[BuildWarning], Union[LogEvent, None]]:
+    """Extract interesting events from a log file.
 
     Args:
         stream: build log name or file object
         context: lines of context to extract around each log event
         profile: print out profile information for parsing
+        tail: if > 0, also return the last ``tail`` lines
 
     Returns:
         two lists containing :class:`~spack.util.ctest_log_parser.BuildError` and
-        :class:`~spack.util.ctest_log_parser.BuildWarning` objects.
+        :class:`~spack.util.ctest_log_parser.BuildWarning` objects, plus an optional
+        :class:`~spack.util.ctest_log_parser.LogEvent` for the tail (None when ``tail=0``).
 
     This is a wrapper around :class:`~spack.util.ctest_log_parser.CTestLogParser` that
     lazily constructs a single ``CTestLogParser`` object.  This ensures
@@ -32,7 +36,7 @@ def parse_log_events(stream: Union[str, TextIO], context: int = 6, profile: bool
         parser = CTestLogParser(profile=profile)
         setattr(parse_log_events, "ctest_parser", parser)
 
-    result = parser.parse(stream, context)
+    result = parser.parse(stream, context, tail)
     if profile:
         parser.print_timings()
     return result
@@ -54,7 +58,7 @@ def make_log_context(log_events: List[LogEvent]) -> str:
     Parses the log file for lines containing errors, and prints them out with context.
     Errors are highlighted in red and warnings in yellow. Events are sorted by line number.
     """
-    event_colors = {e.line_no: e.color for e in log_events}
+    event_colors = {e.line_no: e.color for e in log_events if e.color}
     log_events = sorted(log_events, key=lambda e: e.line_no)
 
     out = io.StringIO()

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -1415,7 +1415,7 @@ _spack_location() {
 _spack_log_parse() {
     if $list_options
     then
-        SPACK_COMPREPLY="-h --help --show -c --context -p --profile -w --width -j --jobs"
+        SPACK_COMPREPLY="-h --help --show -c --context -p --profile -w --width -j --jobs -t --tail"
     else
         SPACK_COMPREPLY=""
     fi

--- a/share/spack/spack-completion.fish
+++ b/share/spack/spack-completion.fish
@@ -2284,7 +2284,7 @@ complete -c spack -n '__fish_spack_using_command location' -l first -f -a find_f
 complete -c spack -n '__fish_spack_using_command location' -l first -d 'use the first match if multiple packages match the spec'
 
 # spack log-parse
-set -g __fish_spack_optspecs_spack_log_parse h/help show= c/context= p/profile w/width= j/jobs=
+set -g __fish_spack_optspecs_spack_log_parse h/help show= c/context= p/profile w/width= j/jobs= t/tail=
 
 complete -c spack -n '__fish_spack_using_command log-parse' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command log-parse' -s h -l help -d 'show this help message and exit'
@@ -2296,6 +2296,8 @@ complete -c spack -n '__fish_spack_using_command log-parse' -s p -l profile -f -
 complete -c spack -n '__fish_spack_using_command log-parse' -s p -l profile -d 'print out a profile of time spent in regexes during parse'
 complete -c spack -n '__fish_spack_using_command log-parse' -s w -l width -r -f -a width
 complete -c spack -n '__fish_spack_using_command log-parse' -s j -l jobs -r -f -a jobs
+complete -c spack -n '__fish_spack_using_command log-parse' -s t -l tail -r -f -a tail
+complete -c spack -n '__fish_spack_using_command log-parse' -s t -l tail -r -d 'number of trailing log lines to show (0 to disable)'
 
 # spack logs
 set -g __fish_spack_optspecs_spack_logs h/help


### PR DESCRIPTION
The log parser doesn't catch everything, and worst case the summary on build failure is empty. That's annoying for people using the new installer.

The simplest fix is to include the last 20 lines of the log. I think that's useful whether the log parser detected errors/warnings or not.

* The new installer call path is affected only; old installer remains as is
* In the new installer, the duplicate header is dropped (one from new installer "log summary", one from write_log_summary)
* The flag `spack log-parse --tail` is added.
