### PR TITLE
Cut prefixes at the LAST instance of bin/lib

### DIFF
--- a/lib/spack/spack/detection/common.py
+++ b/lib/spack/spack/detection/common.py
@@ -147,6 +147,15 @@ def _convert_to_iterable(single_val_or_multiple):
         return [x]
 
 
+def prefix_before_last(path: pathlib.PurePath, names: Tuple[str, ...]) -> Optional[str]:
+    """Parent of the innermost component whose lowercased name is in names, or None."""
+    while path.name:
+        if path.name.lower() in names:
+            return str(path.parent) if path.parent.name else ""
+        path = path.parent
+    return None
+
+
 def executable_prefix(executable_dir: str) -> str:
     """Given a directory where an executable is found, guess the prefix
     (i.e. the "root" directory of that installation) and return it.
@@ -159,13 +168,8 @@ def executable_prefix(executable_dir: str) -> str:
     # prefix
     assert os.path.isdir(executable_dir)
 
-    components = executable_dir.split(os.sep)
-    # convert to lower to match Bin, BIN, bin
-    lowered_components = executable_dir.lower().split(os.sep)
-    if "bin" not in lowered_components:
-        return executable_dir
-    idx = max(i for i, comp in enumerate(lowered_components) if comp == "bin")
-    return os.sep.join(components[:idx])
+    prefix = prefix_before_last(pathlib.PurePath(executable_dir), ("bin",))
+    return executable_dir if prefix is None else prefix
 
 
 def library_prefix(library_dir: str) -> str:
@@ -180,20 +184,9 @@ def library_prefix(library_dir: str) -> str:
     # to get a Spack-compatible prefix
     assert os.path.isdir(library_dir)
 
-    components = library_dir.split(os.sep)
-    # convert to lowercase to match lib, LIB, Lib, etc.
-    lowered_components = library_dir.lower().split(os.sep)
-    if "lib64" in lowered_components:
-        idx = max(i for i, comp in enumerate(lowered_components) if comp == "lib64")
-        return os.sep.join(components[:idx])
-    elif "lib" in lowered_components:
-        idx = max(i for i, comp in enumerate(lowered_components) if comp == "lib")
-        return os.sep.join(components[:idx])
-    elif sys.platform == "win32" and "bin" in lowered_components:
-        idx = max(i for i, comp in enumerate(lowered_components) if comp == "bin")
-        return os.sep.join(components[:idx])
-    else:
-        return library_dir
+    names = ("lib", "lib64", "bin") if sys.platform == "win32" else ("lib", "lib64")
+    prefix = prefix_before_last(pathlib.PurePath(library_dir), names)
+    return library_dir if prefix is None else prefix
 
 
 def update_configuration(

--- a/lib/spack/spack/detection/common.py
+++ b/lib/spack/spack/detection/common.py
@@ -164,7 +164,7 @@ def executable_prefix(executable_dir: str) -> str:
     lowered_components = executable_dir.lower().split(os.sep)
     if "bin" not in lowered_components:
         return executable_dir
-    idx = lowered_components.index("bin")
+    idx = max(i for i, comp in enumerate(lowered_components) if comp == "bin")
     return os.sep.join(components[:idx])
 
 
@@ -184,13 +184,13 @@ def library_prefix(library_dir: str) -> str:
     # convert to lowercase to match lib, LIB, Lib, etc.
     lowered_components = library_dir.lower().split(os.sep)
     if "lib64" in lowered_components:
-        idx = lowered_components.index("lib64")
+       idx = max(i for i, comp in enumerate(lowered_components) if comp == "lib64")
         return os.sep.join(components[:idx])
     elif "lib" in lowered_components:
-        idx = lowered_components.index("lib")
+        idx = max(i for i, comp in enumerate(lowered_components) if comp == "lib")
         return os.sep.join(components[:idx])
     elif sys.platform == "win32" and "bin" in lowered_components:
-        idx = lowered_components.index("bin")
+        idx = max(i for i, comp in enumerate(lowered_components) if comp == "bin")
         return os.sep.join(components[:idx])
     else:
         return library_dir

--- a/lib/spack/spack/detection/common.py
+++ b/lib/spack/spack/detection/common.py
@@ -183,8 +183,8 @@ def library_prefix(library_dir: str) -> str:
     components = library_dir.split(os.sep)
     # convert to lowercase to match lib, LIB, Lib, etc.
     lowered_components = library_dir.lower().split(os.sep)
-    if "lib64" in lowered_components:
-       idx = max(i for i, comp in enumerate(lowered_components) if comp == "lib64")
+   if "lib64" in lowered_components:
+        idx = max(i for i, comp in enumerate(lowered_components) if comp == "lib64")
         return os.sep.join(components[:idx])
     elif "lib" in lowered_components:
         idx = max(i for i, comp in enumerate(lowered_components) if comp == "lib")

--- a/lib/spack/spack/detection/common.py
+++ b/lib/spack/spack/detection/common.py
@@ -183,7 +183,7 @@ def library_prefix(library_dir: str) -> str:
     components = library_dir.split(os.sep)
     # convert to lowercase to match lib, LIB, Lib, etc.
     lowered_components = library_dir.lower().split(os.sep)
-   if "lib64" in lowered_components:
+    if "lib64" in lowered_components:
         idx = max(i for i, comp in enumerate(lowered_components) if comp == "lib64")
         return os.sep.join(components[:idx])
     elif "lib" in lowered_components:

--- a/lib/spack/spack/test/detection.py
+++ b/lib/spack/spack/test/detection.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 import collections
 import pathlib
+import sys
 
 import spack.detection
 import spack.detection.common
@@ -88,7 +89,7 @@ def test_detect_specs_deduplicates_across_prefixes(tmp_path, monkeypatch, mock_p
     assert len(detected) == 1
 
 
-def test_prefix_cuts_at_last_bin_or_lib(tmp_path: pathlib.Path):
+def test_prefix_cuts_at_last_bin_or_lib(tmp_path: pathlib.Path, monkeypatch):
     """Prefixes should be cut at the LAST occurrence
     of bin/lib/lib64, not the first, so nested paths like .../bin/gcc/bin don't
     produce a garbage prefix."""
@@ -120,3 +121,10 @@ def test_prefix_cuts_at_last_bin_or_lib(tmp_path: pathlib.Path):
     nested_lib64.mkdir(parents=True)
     expected_lib64 = str(tmp_path / "lib64" / "foo")
     assert spack.detection.common.library_prefix(str(nested_lib64)) == expected_lib64
+
+    # on win32, library_prefix falls back to cutting at "bin" if no lib/lib64 found
+    monkeypatch.setattr(sys, "platform", "win32")
+    nested_win_bin = tmp_path / "winbin" / "foo" / "bin"
+    nested_win_bin.mkdir(parents=True)
+    expected_win_bin = str(tmp_path / "winbin" / "foo")
+    assert spack.detection.common.library_prefix(str(nested_win_bin)) == expected_win_bin

--- a/lib/spack/spack/test/detection.py
+++ b/lib/spack/spack/test/detection.py
@@ -91,7 +91,7 @@ def test_detect_specs_deduplicates_across_prefixes(tmp_path, monkeypatch, mock_p
     assert len(detected) == 1
 
 
-def test_prefix_cuts_at_last_bin_or_lib(tmp_path: pathlib.Path, monkeypatch):
+def test_prefix_cuts_at_last_bin_or_lib(tmp_path: pathlib.Path):
     """Prefixes should be cut at the LAST occurrence
     of bin/lib/lib64, not the first, so nested paths like .../bin/gcc/bin don't
     produce a garbage prefix."""
@@ -131,7 +131,7 @@ def test_prefix_cuts_at_last_bin_or_lib(tmp_path: pathlib.Path, monkeypatch):
 
 
 def test_prefix_before_last_supports_windows_paths():
-    path = pathlib.PureWindowsPath(r"C:\\Apps\\Lib64\\foo\\LIB")
+    path = pathlib.PureWindowsPath(r"C:\Apps\Lib64\foo\LIB")
     assert (
         spack.detection.common.prefix_before_last(path, ("lib", "lib64")) == r"C:\Apps\Lib64\foo"
     )

--- a/lib/spack/spack/test/detection.py
+++ b/lib/spack/spack/test/detection.py
@@ -5,6 +5,8 @@ import collections
 import pathlib
 import sys
 
+import pytest
+
 import spack.detection
 import spack.detection.common
 import spack.detection.path
@@ -122,8 +124,22 @@ def test_prefix_cuts_at_last_bin_or_lib(tmp_path: pathlib.Path, monkeypatch):
     expected_lib64 = str(tmp_path / "lib64" / "foo")
     assert spack.detection.common.library_prefix(str(nested_lib64)) == expected_lib64
 
-    # on win32, library_prefix falls back to cutting at "bin" if no lib/lib64 found
-    monkeypatch.setattr(sys, "platform", "win32")
+    # the innermost recognized component wins, regardless of its name
+    mixed_lib = tmp_path / "lib64" / "foo" / "lib"
+    mixed_lib.mkdir(parents=True)
+    assert spack.detection.common.library_prefix(str(mixed_lib)) == str(
+        tmp_path / "lib64" / "foo"
+    )
+
+
+def test_prefix_before_last_supports_windows_paths():
+    path = pathlib.PureWindowsPath(r"C:\\Apps\\Lib64\\foo\\LIB")
+    assert spack.detection.common.prefix_before_last(path, ("lib", "lib64")) == r"C:\Apps\Lib64\foo"
+
+
+@pytest.mark.skipif(sys.platform != "win32", reason="Skip Windows paths on not Windows")
+def test_library_prefix_cuts_at_bin_on_windows(tmp_path: pathlib.Path):
+    """On Windows, library prefixes fall back to cutting at the last bin directory."""
     nested_win_bin = tmp_path / "winbin" / "foo" / "bin"
     nested_win_bin.mkdir(parents=True)
     expected_win_bin = str(tmp_path / "winbin" / "foo")

--- a/lib/spack/spack/test/detection.py
+++ b/lib/spack/spack/test/detection.py
@@ -86,3 +86,36 @@ def test_detect_specs_deduplicates_across_prefixes(tmp_path, monkeypatch, mock_p
 
     # Both prefixes produce cmake@3.17.1; only the first should be kept.
     assert len(detected) == 1
+
+def test_prefix_cuts_at_last_bin_or_lib(tmp_path: pathlib.Path):
+    """Prefixes should be cut at the LAST occurrence
+    of bin/lib/lib64, not the first, so nested paths like .../bin/gcc/bin don't
+    produce a garbage prefix."""
+
+    # nested bin: only the last "bin" should be cut
+    nested_bin = tmp_path / "bin" / "gcc" / "bin"
+    nested_bin.mkdir(parents=True)
+    expected_bin = str(tmp_path / "bin" / "gcc")
+    assert spack.detection.common.executable_prefix(str(nested_bin)) == expected_bin
+
+    # simple, single "bin"
+    simple_bin = tmp_path / "simple" / "bin"
+    simple_bin.mkdir(parents=True)
+    assert spack.detection.common.executable_prefix(str(simple_bin)) == str(tmp_path / "simple")
+
+    # no "bin" component at all
+    no_bin = tmp_path / "opt" / "gcc"
+    no_bin.mkdir(parents=True)
+    assert spack.detection.common.executable_prefix(str(no_bin)) == str(no_bin)
+
+    # nested lib: only the last "lib" should be cut
+    nested_lib = tmp_path / "lib" / "foo" / "lib"
+    nested_lib.mkdir(parents=True)
+    expected_lib = str(tmp_path / "lib" / "foo")
+    assert spack.detection.common.library_prefix(str(nested_lib)) == expected_lib
+
+    # nested lib64: only the last "lib64" should be cut
+    nested_lib64 = tmp_path / "lib64" / "foo" / "lib64"
+    nested_lib64.mkdir(parents=True)
+    expected_lib64 = str(tmp_path / "lib64" / "foo")
+    assert spack.detection.common.library_prefix(str(nested_lib64)) == expected_lib64

--- a/lib/spack/spack/test/detection.py
+++ b/lib/spack/spack/test/detection.py
@@ -87,6 +87,7 @@ def test_detect_specs_deduplicates_across_prefixes(tmp_path, monkeypatch, mock_p
     # Both prefixes produce cmake@3.17.1; only the first should be kept.
     assert len(detected) == 1
 
+
 def test_prefix_cuts_at_last_bin_or_lib(tmp_path: pathlib.Path):
     """Prefixes should be cut at the LAST occurrence
     of bin/lib/lib64, not the first, so nested paths like .../bin/gcc/bin don't

--- a/lib/spack/spack/test/detection.py
+++ b/lib/spack/spack/test/detection.py
@@ -127,14 +127,14 @@ def test_prefix_cuts_at_last_bin_or_lib(tmp_path: pathlib.Path, monkeypatch):
     # the innermost recognized component wins, regardless of its name
     mixed_lib = tmp_path / "lib64" / "foo" / "lib"
     mixed_lib.mkdir(parents=True)
-    assert spack.detection.common.library_prefix(str(mixed_lib)) == str(
-        tmp_path / "lib64" / "foo"
-    )
+    assert spack.detection.common.library_prefix(str(mixed_lib)) == str(tmp_path / "lib64" / "foo")
 
 
 def test_prefix_before_last_supports_windows_paths():
     path = pathlib.PureWindowsPath(r"C:\\Apps\\Lib64\\foo\\LIB")
-    assert spack.detection.common.prefix_before_last(path, ("lib", "lib64")) == r"C:\Apps\Lib64\foo"
+    assert (
+        spack.detection.common.prefix_before_last(path, ("lib", "lib64")) == r"C:\Apps\Lib64\foo"
+    )
 
 
 @pytest.mark.skipif(sys.platform != "win32", reason="Skip Windows paths on not Windows")


### PR DESCRIPTION
Without this a path like /home/user/bin/gcc/bin/etc will set the prefix as /home/user... which is bad.  See: https://github.com/spack/spack/issues/52278

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
