### PR TITLE
commands: use parser.error() when possible

### DIFF
--- a/lib/spack/spack/cmd/__init__.py
+++ b/lib/spack/spack/cmd/__init__.py
@@ -639,29 +639,26 @@ def extant_file(f):
     return f
 
 
-def require_active_env(cmd_name):
-    """Used by commands to get the active environment
+def require_active_env(parser):
+    """Used by commands to get the active environment.
 
-    If an environment is not found, print an error message that says the calling
-    command *needs* an active environment.
+    If an environment is not found, calls ``parser.error()`` which prints usage and exits.
 
     Arguments:
-        cmd_name (str): name of calling command
+        parser: the subparser for the command (typically ``args.subparser``)
 
     Returns:
         (spack.environment.Environment): the active environment
     """
     env = ev.active_environment()
-
     if env:
         return env
-
-    tty.die(
-        "`spack %s` requires an environment" % cmd_name,
-        "activate an environment first:",
-        "    spack env activate ENV",
-        "or use:",
-        "    spack -e ENV %s ..." % cmd_name,
+    parser.error(
+        "requires an active environment\n"
+        "  activate an environment first:\n"
+        "      spack env activate ENV\n"
+        "  or use:\n"
+        "      spack -e ENV %s ..." % parser.prog.partition(" ")[2]
     )
 
 

--- a/lib/spack/spack/cmd/add.py
+++ b/lib/spack/spack/cmd/add.py
@@ -25,7 +25,7 @@ def setup_parser(subparser: argparse.ArgumentParser) -> None:
 
 
 def add(parser, args):
-    env = spack.cmd.require_active_env(cmd_name="add")
+    env = spack.cmd.require_active_env(args.subparser)
 
     with env.write_transaction():
         for spec in spack.cmd.parse_specs(args.specs):

--- a/lib/spack/spack/cmd/audit.py
+++ b/lib/spack/spack/cmd/audit.py
@@ -68,7 +68,7 @@ def packages(parser, args):
 def packages_https(parser, args):
     # Since packages takes a long time, --all is required without name
     if not args.check_all and not args.name:
-        tty.die("Please specify one or more packages to audit, or --all.")
+        args.subparser.error("please specify one or more packages to audit, or --all")
 
     pkgs = args.name or spack.repo.PATH.all_package_names()
     reports = spack.audit.run_group(args.subcommand, pkgs=pkgs)

--- a/lib/spack/spack/cmd/buildcache.py
+++ b/lib/spack/spack/cmd/buildcache.py
@@ -665,7 +665,7 @@ def download_fn(args):
     specs = _matching_specs(spack.cmd.parse_specs(args.spec))
 
     if len(specs) != 1:
-        tty.die("a single spec argument is required to download from a buildcache")
+        args.subparser.error("requires a single spec argument")
 
     spack.binary_distribution.download_single_spec(specs[0], args.path)
 
@@ -680,7 +680,7 @@ def save_specfile_fn(args):
     specs = spack.cmd.parse_specs(args.root_spec)
 
     if len(specs) != 1:
-        tty.die("a single spec argument is required to save specfile")
+        args.subparser.error("requires a single spec argument")
 
     root = specs[0]
 

--- a/lib/spack/spack/cmd/buildcache.py
+++ b/lib/spack/spack/cmd/buildcache.py
@@ -144,7 +144,7 @@ def setup_parser(subparser: argparse.ArgumentParser):
         "(can be specified multiple times, requires an active environment)",
     )
     arguments.add_common_arguments(push, ["specs", "jobs"])
-    push.set_defaults(func=push_fn)
+    push.set_defaults(func=push_fn, subparser=push)
 
     install = subparsers.add_parser("install", help=install_fn.__doc__)
     install.add_argument(
@@ -167,7 +167,7 @@ def setup_parser(subparser: argparse.ArgumentParser):
     )
 
     arguments.add_common_arguments(install, ["specs"])
-    install.set_defaults(func=install_fn)
+    install.set_defaults(func=install_fn, subparser=install)
 
     listcache = subparsers.add_parser("list", help=list_fn.__doc__)
     arguments.add_common_arguments(listcache, ["long", "very_long", "namespaces"])
@@ -185,7 +185,7 @@ def setup_parser(subparser: argparse.ArgumentParser):
         help="list specs for all available architectures instead of default platform and OS",
     )
     arguments.add_common_arguments(listcache, ["specs"])
-    listcache.set_defaults(func=list_fn)
+    listcache.set_defaults(func=list_fn, subparser=listcache)
 
     keys = subparsers.add_parser("keys", help=keys_fn.__doc__)
     keys.add_argument(
@@ -193,7 +193,7 @@ def setup_parser(subparser: argparse.ArgumentParser):
     )
     keys.add_argument("-t", "--trust", action="store_true", help="trust all downloaded keys")
     keys.add_argument("-f", "--force", action="store_true", help="force new download of keys")
-    keys.set_defaults(func=keys_fn)
+    keys.set_defaults(func=keys_fn, subparser=keys)
 
     # Check if binaries need to be rebuilt on remote mirror
     check = subparsers.add_parser("check", help=check_fn.__doc__)
@@ -219,7 +219,7 @@ def setup_parser(subparser: argparse.ArgumentParser):
 
     arguments.add_common_arguments(check, ["specs"])
 
-    check.set_defaults(func=check_fn)
+    check.set_defaults(func=check_fn, subparser=check)
 
     # Download tarball and specfile
     download = subparsers.add_parser("download", help=download_fn.__doc__)
@@ -231,7 +231,7 @@ def setup_parser(subparser: argparse.ArgumentParser):
         default=None,
         help="path to directory where tarball should be downloaded",
     )
-    download.set_defaults(func=download_fn)
+    download.set_defaults(func=download_fn, subparser=download)
 
     prune = subparsers.add_parser("prune", help=prune_fn.__doc__)
     prune.add_argument(
@@ -248,7 +248,7 @@ def setup_parser(subparser: argparse.ArgumentParser):
         action="store_true",
         help="do not actually delete anything from the buildcache, but log what would be deleted",
     )
-    prune.set_defaults(func=prune_fn)
+    prune.set_defaults(func=prune_fn, subparser=prune)
 
     # Given the root spec, save the yaml of the dependent spec to a file
     savespecfile = subparsers.add_parser("save-specfile", help=save_specfile_fn.__doc__)
@@ -263,7 +263,7 @@ def setup_parser(subparser: argparse.ArgumentParser):
     savespecfile.add_argument(
         "--specfile-dir", required=True, help="path to directory where spec yamls should be saved"
     )
-    savespecfile.set_defaults(func=save_specfile_fn)
+    savespecfile.set_defaults(func=save_specfile_fn, subparser=savespecfile)
 
     # Sync buildcache entries from one mirror to another
     sync = subparsers.add_parser("sync", help=sync_fn.__doc__)
@@ -298,7 +298,7 @@ def setup_parser(subparser: argparse.ArgumentParser):
         help="destination mirror name, path, or URL",
     )
 
-    sync.set_defaults(func=sync_fn)
+    sync.set_defaults(func=sync_fn, subparser=sync)
 
     # Check the validity of a buildcache
     check_index = subparsers.add_parser("check-index", help=check_index_fn.__doc__)
@@ -318,7 +318,7 @@ def setup_parser(subparser: argparse.ArgumentParser):
     check_index.add_argument(
         "mirror", type=arguments.mirror_name_or_url, help="mirror name, path, or URL"
     )
-    check_index.set_defaults(func=check_index_fn)
+    check_index.set_defaults(func=check_index_fn, subparser=check_index)
 
     # Update buildcache index without copying any additional packages
     update_index = subparsers.add_parser(
@@ -359,7 +359,7 @@ def setup_parser(subparser: argparse.ArgumentParser):
         help="if provided, key index will be updated as well as package index",
     )
     arguments.add_common_arguments(update_index, ["yes_to_all"])
-    update_index.set_defaults(func=update_index_fn)
+    update_index.set_defaults(func=update_index_fn, subparser=update_index)
 
     # Migrate a buildcache from layout_version 2 to version 3
     migrate = subparsers.add_parser("migrate", help=migrate_fn.__doc__)
@@ -380,7 +380,7 @@ def setup_parser(subparser: argparse.ArgumentParser):
     )
     arguments.add_common_arguments(migrate, ["yes_to_all"])
     # TODO: add -y argument to prompt if user really means to delete existing
-    migrate.set_defaults(func=migrate_fn)
+    migrate.set_defaults(func=migrate_fn, subparser=migrate)
 
 
 def _matching_specs(specs: List[Spec]) -> List[Spec]:
@@ -459,7 +459,7 @@ def push_fn(args):
         tty.die("--group and explicit specs are mutually exclusive")
 
     if args.groups:
-        env = spack.cmd.require_active_env(cmd_name="buildcache push")
+        env = spack.cmd.require_active_env(args.subparser)
         available_groups = env.manifest.groups()
         if any(g not in available_groups for g in args.groups):
             tty.die(
@@ -471,7 +471,7 @@ def push_fn(args):
     elif args.specs:
         roots = _matching_specs(spack.cmd.parse_specs(args.specs))
     else:
-        roots = spack.cmd.require_active_env(cmd_name="buildcache push").concrete_roots()
+        roots = spack.cmd.require_active_env(args.subparser).concrete_roots()
 
     mirror = args.mirror
     assert isinstance(mirror, spack.mirrors.mirror.Mirror)
@@ -628,7 +628,7 @@ def check_fn(args: argparse.Namespace):
     if specs_arg:
         specs = _matching_specs(spack.cmd.parse_specs(specs_arg))
     else:
-        specs = spack.cmd.require_active_env("buildcache check").all_specs()
+        specs = spack.cmd.require_active_env(args.subparser).all_specs()
 
     if not specs:
         tty.msg("No specs provided, exiting.")
@@ -795,7 +795,7 @@ def sync_fn(args):
     dest_mirror_url = dest_mirror.push_url
 
     # Get the active environment
-    env = spack.cmd.require_active_env(cmd_name="buildcache sync")
+    env = spack.cmd.require_active_env(args.subparser)
 
     tty.msg(
         "Syncing environment buildcache files from {0} to {1}".format(
@@ -892,6 +892,7 @@ def update_view(
     name: Optional[str] = None,
     update_keys: bool = False,
     yes_to_all: bool = False,
+    parser=None,
 ):
     """update a buildcache view index"""
     # OCI images do not support views.
@@ -951,7 +952,7 @@ def update_view(
             hashes.extend(env.all_hashes())
     else:
         # Get hashes in the current active environment
-        hashes = spack.cmd.require_active_env(cmd_name="buildcache update-view").all_hashes()
+        hashes = spack.cmd.require_active_env(parser).all_hashes()
 
     if not hashes:
         tty.warn("No specs found for view, creating an empty index")
@@ -1130,6 +1131,7 @@ def update_index_fn(args):
             name=args.name,
             update_keys=args.keys,
             yes_to_all=args.yes_to_all,
+            parser=args.subparser,
         )
     else:
         update_index(args.mirror, update_keys=args.keys, timer=t)

--- a/lib/spack/spack/cmd/buildcache.py
+++ b/lib/spack/spack/cmd/buildcache.py
@@ -456,7 +456,7 @@ def _specs_to_be_packaged(
 def push_fn(args):
     """create a binary package and push it to a mirror"""
     if args.specs and args.groups:
-        tty.die("--group and explicit specs are mutually exclusive")
+        args.subparser.error("--group and explicit specs are mutually exclusive")
 
     if args.groups:
         env = spack.cmd.require_active_env(args.subparser)
@@ -577,7 +577,7 @@ def push_fn(args):
 def install_fn(args):
     """install from a binary package"""
     if not args.specs:
-        tty.die("a spec argument is required to install from a buildcache")
+        args.subparser.error("a spec argument is required to install from a buildcache")
 
     query = spack.binary_distribution.BinaryCacheQuery(all_architectures=args.otherarch)
     matches = spack.store.find(args.specs, multiple=args.multiple, query_fn=query)
@@ -786,7 +786,7 @@ def sync_fn(args):
         return 0
 
     if args.src_mirror is None or args.dest_mirror is None:
-        tty.die("Provide mirrors to sync from and to.")
+        args.subparser.error("provide mirrors to sync from and to")
 
     src_mirror = args.src_mirror
     dest_mirror = args.dest_mirror

--- a/lib/spack/spack/cmd/buildcache.py
+++ b/lib/spack/spack/cmd/buildcache.py
@@ -892,7 +892,7 @@ def update_view(
     name: Optional[str] = None,
     update_keys: bool = False,
     yes_to_all: bool = False,
-    parser=None,
+    parser,
 ):
     """update a buildcache view index"""
     # OCI images do not support views.

--- a/lib/spack/spack/cmd/change.py
+++ b/lib/spack/spack/cmd/change.py
@@ -57,7 +57,7 @@ def change(parser, args):
     if args.list_name != "specs" and args.concrete_only:
         warnings.warn("'spack change --list-name' argument is ignored with '--concrete-only'")
 
-    env = spack.cmd.require_active_env(cmd_name="change")
+    env = spack.cmd.require_active_env(args.subparser)
 
     match_spec = None
     if args.match_spec:

--- a/lib/spack/spack/cmd/ci.py
+++ b/lib/spack/spack/cmd/ci.py
@@ -149,7 +149,7 @@ def setup_parser(subparser: argparse.ArgumentParser) -> None:
         help="Environment variables to forward from the generate environment "
         "to the generated jobs.",
     )
-    generate.set_defaults(func=ci_generate)
+    generate.set_defaults(func=ci_generate, subparser=generate)
 
     spack.cmd.common.arguments.add_concretizer_args(generate)
     spack.cmd.common.arguments.add_common_arguments(generate, ["jobs"])
@@ -159,7 +159,7 @@ def setup_parser(subparser: argparse.ArgumentParser) -> None:
     index = subparsers.add_parser(
         "rebuild-index", description=doc_dedented(ci_reindex), help=doc_first_line(ci_reindex)
     )
-    index.set_defaults(func=ci_reindex)
+    index.set_defaults(func=ci_reindex, subparser=index)
 
     # Handle steps of a ci build/rebuild
     rebuild = subparsers.add_parser(
@@ -192,7 +192,7 @@ def setup_parser(subparser: argparse.ArgumentParser) -> None:
         default=None,
         help="maximum time (in seconds) that tests are allowed to run",
     )
-    rebuild.set_defaults(func=ci_rebuild)
+    rebuild.set_defaults(func=ci_rebuild, subparser=rebuild)
     spack.cmd.common.arguments.add_common_arguments(rebuild, ["jobs"])
 
     # Facilitate reproduction of a failed CI build job
@@ -231,7 +231,7 @@ def setup_parser(subparser: argparse.ArgumentParser) -> None:
         "--gpg-url", help="URL to public GPG key for validating binary cache installs"
     )
 
-    reproduce.set_defaults(func=ci_reproduce)
+    reproduce.set_defaults(func=ci_reproduce, subparser=reproduce)
 
     # Verify checksums inside of ci workflows
     verify_versions = subparsers.add_parser(
@@ -241,7 +241,7 @@ def setup_parser(subparser: argparse.ArgumentParser) -> None:
     )
     verify_versions.add_argument("from_ref", help="git ref from which start looking at changes")
     verify_versions.add_argument("to_ref", help="git ref to end looking at changes")
-    verify_versions.set_defaults(func=ci_verify_versions)
+    verify_versions.set_defaults(func=ci_verify_versions, subparser=verify_versions)
 
 
 def ci_generate(args):
@@ -252,7 +252,7 @@ def ci_generate(args):
     before invoking this command. the value must be the CDash authorization token needed to create
     a build group and register all generated jobs under it
     """
-    env = spack.cmd.require_active_env(cmd_name="ci generate")
+    env = spack.cmd.require_active_env(args.subparser)
     spack_ci.generate_pipeline(env, args)
 
 
@@ -263,7 +263,7 @@ def ci_reindex(args):
     use the active, gitlab-enabled environment to rebuild the buildcache index for the associated
     mirror
     """
-    env = spack.cmd.require_active_env(cmd_name="ci rebuild-index")
+    env = spack.cmd.require_active_env(args.subparser)
     yaml_root = env.manifest[ev.TOP_LEVEL_KEY]
 
     if "mirrors" not in yaml_root or len(yaml_root["mirrors"].values()) < 1:
@@ -286,7 +286,7 @@ def ci_rebuild(args):
     """
     rebuild_timer = timer.Timer()
 
-    env = spack.cmd.require_active_env(cmd_name="ci rebuild")
+    env = spack.cmd.require_active_env(args.subparser)
 
     # Make sure the environment is "gitlab-enabled", or else there's nothing
     # to do.

--- a/lib/spack/spack/cmd/commands.py
+++ b/lib/spack/spack/cmd/commands.py
@@ -846,7 +846,7 @@ def _commands(parser: ArgumentParser, args: Namespace) -> None:
 
     # check header first so we don't open out files unnecessarily
     if args.header and not os.path.exists(args.header):
-        tty.die(f"No such file: '{args.header}'")
+        args.subparser.error(f"no such file: '{args.header}'")
 
     if args.update:
         tty.msg(f"Updating file: {args.update}")
@@ -884,7 +884,7 @@ def commands(parser: ArgumentParser, args: Namespace) -> None:
     """
     if args.update_completion:
         if args.format != "names" or any([args.aliases, args.update, args.header]):
-            tty.die("--update-completion can only be specified alone.")
+            args.subparser.error("--update-completion can only be specified alone.")
 
         # this runs the command multiple times with different arguments
         update_completion(parser, args)

--- a/lib/spack/spack/cmd/commands.py
+++ b/lib/spack/spack/cmd/commands.py
@@ -884,7 +884,7 @@ def commands(parser: ArgumentParser, args: Namespace) -> None:
     """
     if args.update_completion:
         if args.format != "names" or any([args.aliases, args.update, args.header]):
-            args.subparser.error("--update-completion can only be specified alone.")
+            args.subparser.error("--update-completion can only be specified alone")
 
         # this runs the command multiple times with different arguments
         update_completion(parser, args)

--- a/lib/spack/spack/cmd/concretize.py
+++ b/lib/spack/spack/cmd/concretize.py
@@ -31,7 +31,7 @@ def setup_parser(subparser: argparse.ArgumentParser) -> None:
 
 
 def concretize(parser, args):
-    env = spack.cmd.require_active_env(cmd_name="concretize")
+    env = spack.cmd.require_active_env(args.subparser)
 
     if args.test == "all":
         tests = True

--- a/lib/spack/spack/cmd/config.py
+++ b/lib/spack/spack/cmd/config.py
@@ -201,9 +201,9 @@ def _get_scope_and_section(args):
 
 def print_configuration(args, *, blame: bool) -> None:
     if args.scope and args.scope not in spack.config.existing_scope_names():
-        args.subparser.error(f"the argument --scope={args.scope} must refer to an existing scope.")
+        args.subparser.error(f"the argument --scope={args.scope} must refer to an existing scope")
     if args.scope and args.section is None:
-        args.subparser.error(f"the argument --scope={args.scope} requires specifying a section.")
+        args.subparser.error(f"the argument --scope={args.scope} requires specifying a section")
 
     group = getattr(args, "group", None)
     if group is not None:

--- a/lib/spack/spack/cmd/config.py
+++ b/lib/spack/spack/cmd/config.py
@@ -52,6 +52,7 @@ def setup_parser(subparser: argparse.ArgumentParser) -> None:
         default=None,
         help="show configuration as seen by this environment spec group (requires active env)",
     )
+    get_parser.set_defaults(subparser=get_parser)
 
     blame_parser = sp.add_parser(
         "blame", help="print configuration annotated with source file:line"
@@ -69,6 +70,7 @@ def setup_parser(subparser: argparse.ArgumentParser) -> None:
         default=None,
         help="show configuration as seen by this environment spec group (requires active env)",
     )
+    blame_parser.set_defaults(subparser=blame_parser)
 
     edit_parser = sp.add_parser("edit", help="edit configuration file")
     edit_parser.add_argument(
@@ -81,8 +83,10 @@ def setup_parser(subparser: argparse.ArgumentParser) -> None:
     edit_parser.add_argument(
         "--print-file", action="store_true", help="print the file name that would be edited"
     )
+    edit_parser.set_defaults(subparser=edit_parser)
 
-    sp.add_parser("list", help="list configuration sections")
+    list_parser = sp.add_parser("list", help="list configuration sections")
+    list_parser.set_defaults(subparser=list_parser)
 
     scopes_parser = sp.add_parser(
         "scopes", help="list defined scopes in descending order of precedence"
@@ -119,6 +123,7 @@ def setup_parser(subparser: argparse.ArgumentParser) -> None:
         nargs="?",
         choices=spack.config.SECTION_SCHEMAS,
     )
+    scopes_parser.set_defaults(subparser=scopes_parser)
 
     add_parser = sp.add_parser("add", help="add configuration parameters")
     add_parser.add_argument(
@@ -127,10 +132,12 @@ def setup_parser(subparser: argparse.ArgumentParser) -> None:
         help="colon-separated path to config that should be added, e.g. 'config:default:true'",
     )
     add_parser.add_argument("-f", "--file", help="file from which to set all config values")
+    add_parser.set_defaults(subparser=add_parser)
 
     change_parser = sp.add_parser("change", help="swap variants etc. on specs in config")
     change_parser.add_argument("path", help="colon-separated path to config section with specs")
     change_parser.add_argument("--match-spec", help="only change constraints that match this")
+    change_parser.set_defaults(subparser=change_parser)
 
     prefer_upstream_parser = sp.add_parser(
         "prefer-upstream", help="set package preferences from upstream"
@@ -142,12 +149,14 @@ def setup_parser(subparser: argparse.ArgumentParser) -> None:
         default=False,
         help="set packages preferences based on local installs, rather than upstream",
     )
+    prefer_upstream_parser.set_defaults(subparser=prefer_upstream_parser)
 
     remove_parser = sp.add_parser("remove", aliases=["rm"], help="remove configuration parameters")
     remove_parser.add_argument(
         "path",
         help="colon-separated path to config that should be removed, e.g. 'config:default:true'",
     )
+    remove_parser.set_defaults(subparser=remove_parser)
 
     # Make the add parser available later
     setattr(setup_parser, "add_parser", add_parser)
@@ -155,12 +164,14 @@ def setup_parser(subparser: argparse.ArgumentParser) -> None:
     update = sp.add_parser("update", help="update configuration files to the latest format")
     arguments.add_common_arguments(update, ["yes_to_all"])
     update.add_argument("section", help="section to update")
+    update.set_defaults(subparser=update)
 
     revert = sp.add_parser(
         "revert", help="revert configuration files to their state before update"
     )
     arguments.add_common_arguments(revert, ["yes_to_all"])
     revert.add_argument("section", help="section to update")
+    revert.set_defaults(subparser=revert)
 
 
 def _get_scope_and_section(args):
@@ -190,15 +201,16 @@ def _get_scope_and_section(args):
 
 def print_configuration(args, *, blame: bool) -> None:
     if args.scope and args.scope not in spack.config.existing_scope_names():
-        tty.die(f"the argument --scope={args.scope} must refer to an existing scope.")
+        args.subparser.error(f"the argument --scope={args.scope} must refer to an existing scope.")
     if args.scope and args.section is None:
-        tty.die(f"the argument --scope={args.scope} requires specifying a section.")
+        args.subparser.error(f"the argument --scope={args.scope} requires specifying a section.")
 
     group = getattr(args, "group", None)
     if group is not None:
         env = ev.active_environment()
         if env is None:
-            tty.die("the argument --group requires an active environment")
+            args.subparser.error("the argument --group requires an active environment")
+            return  # parser.error exits, but help mypy understand this is unreachable
         try:
             with env.config_override_for_group(group=group):
                 _print_configuration_helper(args, blame=blame)
@@ -282,7 +294,7 @@ def config_edit(args):
         # If we aren't editing a spack.yaml file, get config path from scope.
         scope, section = _get_scope_and_section(args)
         if not scope and not section:
-            tty.die("`spack config edit` requires a section argument or an active environment.")
+            args.subparser.error("requires a section argument or an active environment")
         config_file = spack.config.CONFIG.get_config_filename(scope, section)
 
     if args.print_file:

--- a/lib/spack/spack/cmd/deconcretize.py
+++ b/lib/spack/spack/cmd/deconcretize.py
@@ -93,8 +93,8 @@ def deconcretize_specs(args, specs):
 def deconcretize(parser, args):
     if not args.specs and not args.all:
         args.subparser.error(
-            "deconcretize requires at least one spec argument."
-            " Use `spack deconcretize --all` to deconcretize ALL specs."
+            "requires at least one spec argument\n"
+            "  use `spack deconcretize --all` to deconcretize ALL specs"
         )
 
     specs = spack.cmd.parse_specs(args.specs) if args.specs else [None]

--- a/lib/spack/spack/cmd/deconcretize.py
+++ b/lib/spack/spack/cmd/deconcretize.py
@@ -74,7 +74,7 @@ def get_deconcretize_list(
 
 
 def deconcretize_specs(args, specs):
-    env = spack.cmd.require_active_env(cmd_name="deconcretize")
+    env = spack.cmd.require_active_env(args.subparser)
 
     if args.specs:
         deconcretize_list = get_deconcretize_list(args, specs, env)
@@ -92,9 +92,9 @@ def deconcretize_specs(args, specs):
 
 def deconcretize(parser, args):
     if not args.specs and not args.all:
-        tty.die(
-            "deconcretize requires at least one spec argument.",
-            " Use `spack deconcretize --all` to deconcretize ALL specs.",
+        args.subparser.error(
+            "deconcretize requires at least one spec argument."
+            " Use `spack deconcretize --all` to deconcretize ALL specs."
         )
 
     specs = spack.cmd.parse_specs(args.specs) if args.specs else [None]

--- a/lib/spack/spack/cmd/dependencies.py
+++ b/lib/spack/spack/cmd/dependencies.py
@@ -49,7 +49,7 @@ def setup_parser(subparser: argparse.ArgumentParser) -> None:
 def dependencies(parser, args):
     specs = spack.cmd.parse_specs(args.spec)
     if len(specs) != 1:
-        args.subparser.error("takes only one spec.")
+        args.subparser.error("takes only one spec")
 
     if args.installed:
         env = ev.active_environment()

--- a/lib/spack/spack/cmd/dependencies.py
+++ b/lib/spack/spack/cmd/dependencies.py
@@ -49,7 +49,7 @@ def setup_parser(subparser: argparse.ArgumentParser) -> None:
 def dependencies(parser, args):
     specs = spack.cmd.parse_specs(args.spec)
     if len(specs) != 1:
-        tty.die("spack dependencies takes only one spec.")
+        args.subparser.error("takes only one spec.")
 
     if args.installed:
         env = ev.active_environment()

--- a/lib/spack/spack/cmd/dependents.py
+++ b/lib/spack/spack/cmd/dependents.py
@@ -87,7 +87,7 @@ def get_dependents(pkg_name, ideps, transitive=False, dependents=None):
 def dependents(parser, args):
     specs = spack.cmd.parse_specs(args.spec)
     if len(specs) != 1:
-        args.subparser.error("takes only one spec.")
+        args.subparser.error("takes only one spec")
 
     if args.installed:
         env = ev.active_environment()

--- a/lib/spack/spack/cmd/dependents.py
+++ b/lib/spack/spack/cmd/dependents.py
@@ -87,7 +87,7 @@ def get_dependents(pkg_name, ideps, transitive=False, dependents=None):
 def dependents(parser, args):
     specs = spack.cmd.parse_specs(args.spec)
     if len(specs) != 1:
-        tty.die("spack dependents takes only one spec.")
+        args.subparser.error("takes only one spec.")
 
     if args.installed:
         env = ev.active_environment()

--- a/lib/spack/spack/cmd/deprecate.py
+++ b/lib/spack/spack/cmd/deprecate.py
@@ -22,7 +22,6 @@ import spack.installer
 import spack.llnl.util.tty as tty
 import spack.store
 from spack.cmd.common import arguments
-from spack.error import SpackError
 from spack.llnl.util.filesystem import symlink
 
 from ..enums import InstallRecordStatus
@@ -94,7 +93,7 @@ def deprecate(parser, args):
     specs = spack.cmd.parse_specs(args.specs)
 
     if len(specs) != 2:
-        raise SpackError("spack deprecate requires exactly two specs")
+        args.subparser.error("requires exactly two specs")
 
     deprecate = spack.cmd.disambiguate_spec(
         specs[0],

--- a/lib/spack/spack/cmd/dev_build.py
+++ b/lib/spack/spack/cmd/dev_build.py
@@ -92,20 +92,19 @@ def setup_parser(subparser: argparse.ArgumentParser) -> None:
 
 def dev_build(self, args):
     if not args.spec:
-        tty.die("spack dev-build requires a package spec argument.")
+        args.subparser.error("requires a package spec argument")
 
     specs = spack.cmd.parse_specs(args.spec)
     if len(specs) > 1:
-        tty.die("spack dev-build only takes one spec.")
+        args.subparser.error("only takes one spec")
 
     spec = specs[0]
     if not spack.repo.PATH.exists(spec.name):
         raise spack.repo.UnknownPackageError(spec.name)
 
     if not spec.versions.concrete_range_as_version:
-        tty.die(
-            "spack dev-build spec must have a single, concrete version. "
-            "Did you forget a package version number?"
+        args.subparser.error(
+            "spec must have a single, concrete version. Did you forget a package version number?"
         )
 
     source_path = args.source_path

--- a/lib/spack/spack/cmd/develop.py
+++ b/lib/spack/spack/cmd/develop.py
@@ -215,7 +215,7 @@ def _dev_spec_generator(args, env):
     """
     if not args.spec:
         if args.clone is False:
-            raise SpackError("No spec provided to spack develop command")
+            args.subparser.error("no spec provided")
 
         for name, entry in env.dev_specs.items():
             path = entry.get("path", name)
@@ -227,7 +227,7 @@ def _dev_spec_generator(args, env):
     else:
         specs = spack.cmd.parse_specs(args.spec)
         if (args.path or args.build_directory) and len(specs) > 1:
-            raise SpackError(
+            args.subparser.error(
                 "spack develop requires at most one named spec when using the --path or"
                 " --build-directory arguments"
             )
@@ -252,7 +252,7 @@ def _dev_spec_generator(args, env):
 
 
 def develop(parser, args):
-    env = spack.cmd.require_active_env(cmd_name="develop")
+    env = spack.cmd.require_active_env(args.subparser)
 
     for spec, abspath in _dev_spec_generator(args, env):
         assure_concrete_spec(env, spec)

--- a/lib/spack/spack/cmd/develop.py
+++ b/lib/spack/spack/cmd/develop.py
@@ -228,8 +228,7 @@ def _dev_spec_generator(args, env):
         specs = spack.cmd.parse_specs(args.spec)
         if (args.path or args.build_directory) and len(specs) > 1:
             args.subparser.error(
-                "spack develop requires at most one named spec when using the --path or"
-                " --build-directory arguments"
+                "requires at most one named spec when using the --path or --build-directory arguments"
             )
 
         for spec in specs:

--- a/lib/spack/spack/cmd/develop.py
+++ b/lib/spack/spack/cmd/develop.py
@@ -228,7 +228,8 @@ def _dev_spec_generator(args, env):
         specs = spack.cmd.parse_specs(args.spec)
         if (args.path or args.build_directory) and len(specs) > 1:
             args.subparser.error(
-                "requires at most one named spec when using the --path or --build-directory arguments"
+                "requires at most one named spec when using the --path or --build-directory "
+                "arguments"
             )
 
         for spec in specs:

--- a/lib/spack/spack/cmd/diff.py
+++ b/lib/spack/spack/cmd/diff.py
@@ -209,7 +209,7 @@ def diff(parser, args):
     env = ev.active_environment()
 
     if len(args.specs) != 2:
-        tty.die("You must provide two specs to diff.")
+        args.subparser.error("you must provide two specs to diff")
 
     specs = []
     for spec in spack.cmd.parse_specs(args.specs):

--- a/lib/spack/spack/cmd/env.py
+++ b/lib/spack/spack/cmd/env.py
@@ -859,7 +859,7 @@ def env_loads_setup_parser(subparser):
 
 
 def env_loads(args):
-    env = spack.cmd.require_active_env(cmd_name="env loads")
+    env = spack.cmd.require_active_env(args.subparser)
 
     # Set the module types that have been selected
     module_type = args.module_type
@@ -1033,7 +1033,7 @@ def env_depfile_setup_parser(subparser):
 
 def env_depfile(args):
     # Currently only make is supported.
-    spack.cmd.require_active_env(cmd_name="env depfile")
+    spack.cmd.require_active_env(args.subparser)
 
     env = ev.active_environment()
 
@@ -1098,6 +1098,7 @@ def setup_parser(subparser: argparse.ArgumentParser) -> None:
             description=spack.cmd.doc_dedented(setup_parser_cmd),
             help=spack.cmd.doc_first_line(setup_parser_cmd),
         )
+        subsubparser.set_defaults(subparser=subsubparser)
         setup_parser_cmd(subsubparser)
 
 

--- a/lib/spack/spack/cmd/extensions.py
+++ b/lib/spack/spack/cmd/extensions.py
@@ -66,7 +66,7 @@ def extensions(parser, args):
     # Checks
     spec = cmd.parse_specs(args.spec)
     if len(spec) > 1:
-        tty.die("Can only list extensions for one package.")
+        args.subparser.error("can only list extensions for one package")
 
     env = ev.active_environment()
     spec = cmd.disambiguate_spec(spec[0], env)

--- a/lib/spack/spack/cmd/fetch.py
+++ b/lib/spack/spack/cmd/fetch.py
@@ -7,7 +7,6 @@ import argparse
 import spack.cmd
 import spack.config
 import spack.environment as ev
-import spack.llnl.util.tty as tty
 import spack.traverse
 from spack.cmd.common import arguments
 
@@ -54,9 +53,11 @@ def fetch(parser, args):
             else:
                 specs = env.all_specs()
             if specs == []:
-                tty.die("No uninstalled specs in environment. Did you run `spack concretize` yet?")
+                args.subparser.error(
+                    "no uninstalled specs in environment. Did you run `spack concretize` yet?"
+                )
         else:
-            tty.die("fetch requires at least one spec argument")
+            args.subparser.error("fetch requires at least one spec argument")
 
     if args.dependencies or args.missing:
         to_be_fetched = spack.traverse.traverse_nodes(specs, key=spack.traverse.by_dag_hash)

--- a/lib/spack/spack/cmd/fetch.py
+++ b/lib/spack/spack/cmd/fetch.py
@@ -57,7 +57,7 @@ def fetch(parser, args):
                     "no uninstalled specs in environment. Did you run `spack concretize` yet?"
                 )
         else:
-            args.subparser.error("fetch requires at least one spec argument")
+            args.subparser.error("requires at least one spec argument")
 
     if args.dependencies or args.missing:
         to_be_fetched = spack.traverse.traverse_nodes(specs, key=spack.traverse.by_dag_hash)

--- a/lib/spack/spack/cmd/find.py
+++ b/lib/spack/spack/cmd/find.py
@@ -189,10 +189,10 @@ def setup_parser(subparser: argparse.ArgumentParser) -> None:
 
 def query_arguments(args):
     if args.only_missing and (args.deprecated or args.missing):
-        raise RuntimeError("cannot use --only-missing with --deprecated, or --missing")
+        args.subparser.error("cannot use --only-missing with --deprecated, or --missing")
 
     if args.only_deprecated and (args.deprecated or args.missing):
-        raise RuntimeError("cannot use --only-deprecated with --deprecated, or --missing")
+        args.subparser.error("cannot use --only-deprecated with --deprecated, or --missing")
 
     installed = InstallRecordStatus.INSTALLED
     if args.only_missing:

--- a/lib/spack/spack/cmd/find.py
+++ b/lib/spack/spack/cmd/find.py
@@ -402,9 +402,9 @@ def find(parser, args):
     env = ev.active_environment()
 
     if not env and args.only_roots:
-        tty.die("-r / --only-roots requires an active environment")
+        args.subparser.error("-r / --only-roots requires an active environment")
     if not env and args.show_concretized:
-        tty.die("-c / --show-concretized requires an active environment")
+        args.subparser.error("-c / --show-concretized requires an active environment")
 
     try:
         results, concretized_but_not_installed = _find_query(args, env)

--- a/lib/spack/spack/cmd/gpg.py
+++ b/lib/spack/spack/cmd/gpg.py
@@ -26,16 +26,16 @@ def setup_parser(subparser: argparse.ArgumentParser) -> None:
     verify = subparsers.add_parser("verify", help=gpg_verify.__doc__)
     arguments.add_common_arguments(verify, ["installed_spec"])
     verify.add_argument("signature", type=str, nargs="?", help="the signature file")
-    verify.set_defaults(func=gpg_verify)
+    verify.set_defaults(func=gpg_verify, subparser=verify)
 
     trust = subparsers.add_parser("trust", help=gpg_trust.__doc__)
     trust.add_argument("keyfile", type=str, help="add a key to the trust store")
-    trust.set_defaults(func=gpg_trust)
+    trust.set_defaults(func=gpg_trust, subparser=trust)
 
     untrust = subparsers.add_parser("untrust", help=gpg_untrust.__doc__)
     untrust.add_argument("--signing", action="store_true", help="allow untrusting signing keys")
     untrust.add_argument("keys", nargs="+", type=str, help="remove keys from the trust store")
-    untrust.set_defaults(func=gpg_untrust)
+    untrust.set_defaults(func=gpg_untrust, subparser=untrust)
 
     sign = subparsers.add_parser("sign", help=gpg_sign.__doc__)
     sign.add_argument(
@@ -46,7 +46,7 @@ def setup_parser(subparser: argparse.ArgumentParser) -> None:
         "--clearsign", action="store_true", help="if specified, create a clearsign signature"
     )
     arguments.add_common_arguments(sign, ["installed_spec"])
-    sign.set_defaults(func=gpg_sign)
+    sign.set_defaults(func=gpg_sign, subparser=sign)
 
     create = subparsers.add_parser("create", help=gpg_create.__doc__)
     create.add_argument("name", type=str, help="the name to use for the new key")
@@ -71,18 +71,18 @@ def setup_parser(subparser: argparse.ArgumentParser) -> None:
         dest="secret",
         help="export the private key to a file",
     )
-    create.set_defaults(func=gpg_create)
+    create.set_defaults(func=gpg_create, subparser=create)
 
     list = subparsers.add_parser("list", help=gpg_list.__doc__)
     list.add_argument("--trusted", action="store_true", default=True, help="list trusted keys")
     list.add_argument(
         "--signing", action="store_true", help="list keys which may be used for signing"
     )
-    list.set_defaults(func=gpg_list)
+    list.set_defaults(func=gpg_list, subparser=list)
 
     init = subparsers.add_parser("init", help=gpg_init.__doc__)
     init.add_argument("--from", metavar="DIR", type=str, dest="import_dir", help=argparse.SUPPRESS)
-    init.set_defaults(func=gpg_init)
+    init.set_defaults(func=gpg_init, subparser=init)
 
     export = subparsers.add_parser("export", help=gpg_export.__doc__)
     export.add_argument("location", type=str, help="where to export keys")
@@ -90,7 +90,7 @@ def setup_parser(subparser: argparse.ArgumentParser) -> None:
         "keys", nargs="*", help="the keys to export (all public keys if unspecified)"
     )
     export.add_argument("--secret", action="store_true", help="export secret keys")
-    export.set_defaults(func=gpg_export)
+    export.set_defaults(func=gpg_export, subparser=export)
 
     publish = subparsers.add_parser("publish", help=gpg_publish.__doc__)
 
@@ -125,7 +125,7 @@ def setup_parser(subparser: argparse.ArgumentParser) -> None:
     publish.add_argument(
         "keys", nargs="*", help="keys to publish (all public keys if unspecified)"
     )
-    publish.set_defaults(func=gpg_publish)
+    publish.set_defaults(func=gpg_publish, subparser=publish)
 
 
 def gpg_create(args):

--- a/lib/spack/spack/cmd/graph.py
+++ b/lib/spack/spack/cmd/graph.py
@@ -57,10 +57,10 @@ in the lockfile.
 def graph(parser, args):
     env = ev.active_environment()
     if args.installed and env:
-        tty.die("cannot use --installed with an active environment")
+        args.subparser.error("cannot use --installed with an active environment")
 
     if args.color and not args.dot:
-        tty.die("the --color option can be used only with --dot")
+        args.subparser.error("the --color option can be used only with --dot")
 
     if args.installed:
         if not args.specs:

--- a/lib/spack/spack/cmd/info.py
+++ b/lib/spack/spack/cmd/info.py
@@ -639,9 +639,9 @@ def print_virtuals(pkg: PackageBase, args: Namespace) -> None:
 def info(parser: argparse.ArgumentParser, args: Namespace) -> None:
     specs = spack.cmd.parse_specs(args.spec)
     if len(specs) > 1:
-        tty.die(f"`spack info` requires exactly one spec. Parsed {len(specs)}")
+        args.subparser.error(f"requires exactly one spec, got {len(specs)}")
     if len(specs) == 0:
-        tty.die("`spack info` requires a spec.")
+        args.subparser.error("requires a spec")
 
     spec = specs[0]
     pkg_cls = spack.repo.PATH.get_pkg_class(spec.fullname)

--- a/lib/spack/spack/cmd/install.py
+++ b/lib/spack/spack/cmd/install.py
@@ -288,7 +288,7 @@ def _dump_log_on_error(e: InstallError):
 
 
 def _die_require_env(parser):
-    msg = "install requires a package argument or active environment"
+    msg = "requires a package argument or active environment"
     if "spack.yaml" in os.listdir(os.getcwd()):
         # There's a spack.yaml file in the working dir, the user may
         # have intended to use that
@@ -431,7 +431,7 @@ def install_without_active_env(args, install_kwargs, reporter):
     concrete_specs = concrete_specs_from_cli(args, install_kwargs)
 
     if len(concrete_specs) == 0:
-        tty.die("The `spack install` command requires a spec to install.")
+        args.subparser.error("requires a spec")
 
     if args.overwrite:
         require_user_confirmation_for_overwrite(concrete_specs, args)

--- a/lib/spack/spack/cmd/install.py
+++ b/lib/spack/spack/cmd/install.py
@@ -287,7 +287,7 @@ def _dump_log_on_error(e: InstallError):
             shutil.copyfileobj(log, sys.stderr)
 
 
-def _die_require_env():
+def _die_require_env(parser):
     msg = "install requires a package argument or active environment"
     if "spack.yaml" in os.listdir(os.getcwd()):
         # There's a spack.yaml file in the working dir, the user may
@@ -301,7 +301,7 @@ def _die_require_env():
             "  OR\n"
             "    spack --env . install"
         )
-    tty.die(msg)
+    parser.error(msg)
 
 
 def install(parser, args):
@@ -326,7 +326,7 @@ def install(parser, args):
     env = ev.active_environment()
 
     if not env and not args.spec:
-        _die_require_env()
+        _die_require_env(args.subparser)
 
     try:
         if env:

--- a/lib/spack/spack/cmd/location.py
+++ b/lib/spack/spack/cmd/location.py
@@ -104,7 +104,7 @@ def location(parser, args):
     if args.location_env is not False:
         if args.location_env is None:
             # Get current environment path
-            spack.cmd.require_active_env("location -e")
+            spack.cmd.require_active_env(args.subparser)
             path = ev.active_environment().path
         else:
             # Get path of requested environment
@@ -131,10 +131,10 @@ def location(parser, args):
     specs = spack.cmd.parse_specs(args.spec)
 
     if not specs:
-        tty.die("You must supply a spec.")
+        args.subparser.error("requires a spec")
 
     if len(specs) != 1:
-        tty.die("Too many specs.  Supply only one.")
+        args.subparser.error("too many specs, supply only one")
 
     # install_dir command matches against installed specs.
     if args.install_dir:

--- a/lib/spack/spack/cmd/log_parse.py
+++ b/lib/spack/spack/cmd/log_parse.py
@@ -7,7 +7,6 @@ import io
 import sys
 import warnings
 
-import spack.llnl.util.tty as tty
 from spack.util.log_parse import make_log_context, parse_log_events
 
 description = "filter errors and warnings from build logs"
@@ -67,7 +66,7 @@ def log_parse(parser, args):
     types = [s.strip() for s in args.show.split(",")]
     for e in types:
         if e not in event_types:
-            tty.die("Invalid event type: %s" % e)
+            args.subparser.error("invalid event type: %s" % e)
 
     events = []
     if "errors" in types:

--- a/lib/spack/spack/cmd/logs.py
+++ b/lib/spack/spack/cmd/logs.py
@@ -61,10 +61,10 @@ def logs(parser, args):
     specs = spack.cmd.parse_specs(args.spec)
 
     if not specs:
-        raise SpackError("You must supply a spec.")
+        args.subparser.error("requires a spec")
 
     if len(specs) != 1:
-        raise SpackError("Too many specs. Supply only one.")
+        args.subparser.error("too many specs, supply only one")
 
     concrete_spec = spack.cmd.matching_spec_from_env(specs[0])
 

--- a/lib/spack/spack/cmd/maintainers.py
+++ b/lib/spack/spack/cmd/maintainers.py
@@ -5,7 +5,6 @@
 import argparse
 from collections import defaultdict
 
-import spack.llnl.util.tty as tty
 import spack.llnl.util.tty.color as color
 import spack.repo
 from spack.llnl.util.tty.colify import colify
@@ -123,7 +122,7 @@ def maintainers(parser, args):
 
     if args.by_user:
         if not args.package_or_user:
-            tty.die("spack maintainers --by-user requires a user or --all")
+            args.subparser.error("--by-user requires a user or --all")
 
         packages = union_values(maintainers_to_packages(args.package_or_user))
         colify(packages)
@@ -131,7 +130,7 @@ def maintainers(parser, args):
 
     else:
         if not args.package_or_user:
-            tty.die("spack maintainers requires a package or --all")
+            args.subparser.error("requires a package or --all")
 
         users = union_values(packages_to_maintainers(args.package_or_user))
         colify(users)

--- a/lib/spack/spack/cmd/mirror.py
+++ b/lib/spack/spack/cmd/mirror.py
@@ -587,7 +587,7 @@ def versions_per_spec(args):
         try:
             num_versions = int(args.versions_per_spec)
         except ValueError:
-            raise SpackError(
+            args.subparser.error(
                 "'--versions-per-spec' must be a number or 'all', got '{0}'".format(
                     args.versions_per_spec
                 )
@@ -612,24 +612,24 @@ def process_mirror_stats(present, mirrored, error):
 def mirror_create(args):
     """create a directory to be used as a spack mirror, and fill it with package archives"""
     if args.file and args.all:
-        raise SpackError(
+        args.subparser.error(
             "cannot specify specs with a file if you chose to mirror all specs with '--all'"
         )
 
     if args.file and args.specs:
-        raise SpackError("cannot specify specs with a file AND on command line")
+        args.subparser.error("cannot specify specs with a file AND on command line")
 
     if not args.specs and not args.file and not args.all:
-        raise SpackError(
-            "no packages were specified.",
-            "To mirror all packages, use the '--all' option "
-            "(this will require significant time and space).",
+        args.subparser.error(
+            "no packages were specified."
+            " To mirror all packages, use the '--all' option"
+            " (this will require significant time and space)."
         )
 
     if args.versions_per_spec and args.all:
-        raise SpackError(
-            "cannot specify '--versions_per-spec' and '--all' together",
-            "The option '--all' already implies mirroring all versions for each package.",
+        args.subparser.error(
+            "cannot specify '--versions_per-spec' and '--all' together."
+            " The option '--all' already implies mirroring all versions for each package."
         )
 
     # When no directory is provided, the source dir is used

--- a/lib/spack/spack/cmd/mirror.py
+++ b/lib/spack/spack/cmd/mirror.py
@@ -621,15 +621,15 @@ def mirror_create(args):
 
     if not args.specs and not args.file and not args.all:
         args.subparser.error(
-            "no packages were specified."
-            " To mirror all packages, use the '--all' option"
-            " (this will require significant time and space)."
+            "no packages were specified\n"
+            "  to mirror all packages, use the '--all' option"
+            " (this will require significant time and space)"
         )
 
     if args.versions_per_spec and args.all:
         args.subparser.error(
-            "cannot specify '--versions_per-spec' and '--all' together."
-            " The option '--all' already implies mirroring all versions for each package."
+            "cannot specify '--versions_per-spec' and '--all' together\n"
+            "  '--all' already implies mirroring all versions for each package"
         )
 
     # When no directory is provided, the source dir is used

--- a/lib/spack/spack/cmd/patch.py
+++ b/lib/spack/spack/cmd/patch.py
@@ -26,7 +26,7 @@ def patch(parser, args):
     if not args.specs:
         env = ev.active_environment()
         if not env:
-            tty.die("`spack patch` requires a spec or an active environment")
+            args.subparser.error("requires a spec or an active environment")
         return _patch_env(env)
 
     if args.no_checksum:

--- a/lib/spack/spack/cmd/pkg.py
+++ b/lib/spack/spack/cmd/pkg.py
@@ -147,7 +147,7 @@ def pkg_source(args):
     """dump source code for a package"""
     specs = spack.cmd.parse_specs(args.spec, concretize=False)
     if len(specs) != 1:
-        tty.die("spack pkg source requires exactly one spec")
+        args.subparser.error("requires exactly one spec")
 
     spec = specs[0]
     filename = spack.repo.PATH.filename_for_package_name(spec.name)

--- a/lib/spack/spack/cmd/pkg.py
+++ b/lib/spack/spack/cmd/pkg.py
@@ -24,11 +24,13 @@ def setup_parser(subparser: argparse.ArgumentParser) -> None:
 
     add_parser = sp.add_parser("add", help=pkg_add.__doc__)
     arguments.add_common_arguments(add_parser, ["packages"])
+    add_parser.set_defaults(subparser=add_parser)
 
     list_parser = sp.add_parser("list", help=pkg_list.__doc__)
     list_parser.add_argument(
         "rev", default="HEAD", nargs="?", help="revision to list packages for"
     )
+    list_parser.set_defaults(subparser=list_parser)
 
     diff_parser = sp.add_parser("diff", help=pkg_diff.__doc__)
     diff_parser.add_argument(
@@ -37,12 +39,14 @@ def setup_parser(subparser: argparse.ArgumentParser) -> None:
     diff_parser.add_argument(
         "rev2", nargs="?", default="HEAD", help="revision to compare to rev1 (default is HEAD)"
     )
+    diff_parser.set_defaults(subparser=diff_parser)
 
     add_parser = sp.add_parser("added", help=pkg_added.__doc__)
     add_parser.add_argument("rev1", nargs="?", default="HEAD^", help="revision to compare against")
     add_parser.add_argument(
         "rev2", nargs="?", default="HEAD", help="revision to compare to rev1 (default is HEAD)"
     )
+    add_parser.set_defaults(subparser=add_parser)
 
     add_parser = sp.add_parser("changed", help=pkg_changed.__doc__)
     add_parser.add_argument("rev1", nargs="?", default="HEAD^", help="revision to compare against")
@@ -56,12 +60,14 @@ def setup_parser(subparser: argparse.ArgumentParser) -> None:
         default="C",
         help="types of changes to show (A: added, R: removed, C: changed); default is 'C'",
     )
+    add_parser.set_defaults(subparser=add_parser)
 
     rm_parser = sp.add_parser("removed", help=pkg_removed.__doc__)
     rm_parser.add_argument("rev1", nargs="?", default="HEAD^", help="revision to compare against")
     rm_parser.add_argument(
         "rev2", nargs="?", default="HEAD", help="revision to compare to rev1 (default is HEAD)"
     )
+    rm_parser.set_defaults(subparser=rm_parser)
 
     # explicitly add help for `spack pkg grep` with just `--help` and NOT `-h`. This is so
     # that the very commonly used -h (no filename) argument can be passed through to grep
@@ -70,6 +76,7 @@ def setup_parser(subparser: argparse.ArgumentParser) -> None:
         "grep_args", nargs=argparse.REMAINDER, default=None, help="arguments for grep"
     )
     grep_parser.add_argument("--help", action="help", help="show this help message and exit")
+    grep_parser.set_defaults(subparser=grep_parser)
 
     source_parser = sp.add_parser("source", help=pkg_source.__doc__)
     source_parser.add_argument(
@@ -80,9 +87,11 @@ def setup_parser(subparser: argparse.ArgumentParser) -> None:
         help="dump canonical source as used by package hash",
     )
     arguments.add_common_arguments(source_parser, ["spec"])
+    source_parser.set_defaults(subparser=source_parser)
 
     hash_parser = sp.add_parser("hash", help=pkg_hash.__doc__)
     arguments.add_common_arguments(hash_parser, ["spec"])
+    hash_parser.set_defaults(subparser=hash_parser)
 
 
 def pkg_add(args):
@@ -252,6 +261,6 @@ def pkg(parser, args, unknown_args):
     if args.pkg_command == "grep":
         return pkg_grep(args, unknown_args)
     elif unknown_args:
-        tty.die("unrecognized arguments: %s" % " ".join(unknown_args))
+        args.subparser.error("unrecognized arguments: %s" % " ".join(unknown_args))
     else:
         return action[args.pkg_command](args)

--- a/lib/spack/spack/cmd/python.py
+++ b/lib/spack/spack/cmd/python.py
@@ -71,11 +71,11 @@ def python(parser, args, unknown_args):
         return
 
     if unknown_args:
-        tty.die("Unknown arguments:", " ".join(unknown_args))
+        args.subparser.error("unrecognized arguments: %s" % " ".join(unknown_args))
 
     # Unexpected behavior from supplying both
     if args.python_command and args.python_args:
-        tty.die("You can only specify a command OR script, but not both.")
+        args.subparser.error("you can only specify a command OR script, but not both")
 
     # Ensure that spack.repo.PATH is initialized
     spack.repo.PATH.repos

--- a/lib/spack/spack/cmd/remove.py
+++ b/lib/spack/spack/cmd/remove.py
@@ -31,7 +31,7 @@ def setup_parser(subparser: argparse.ArgumentParser) -> None:
 
 
 def remove(parser, args):
-    env = spack.cmd.require_active_env(cmd_name="remove")
+    env = spack.cmd.require_active_env(args.subparser)
 
     with env.write_transaction():
         if args.all:

--- a/lib/spack/spack/cmd/restage.py
+++ b/lib/spack/spack/cmd/restage.py
@@ -5,7 +5,6 @@
 import argparse
 
 import spack.cmd
-import spack.llnl.util.tty as tty
 from spack.cmd.common import arguments
 
 description = "revert checked out package source code"
@@ -19,7 +18,7 @@ def setup_parser(subparser: argparse.ArgumentParser) -> None:
 
 def restage(parser, args):
     if not args.specs:
-        tty.die("spack restage requires at least one package spec.")
+        args.subparser.error("requires at least one package spec")
 
     specs = spack.cmd.parse_specs(args.specs, concretize=True)
     for spec in specs:

--- a/lib/spack/spack/cmd/solve.py
+++ b/lib/spack/spack/cmd/solve.py
@@ -148,7 +148,7 @@ def solve(parser, args):
     elif env:
         specs = list(env.user_specs)
     else:
-        tty.die("spack solve requires at least one spec or an active environment")
+        args.subparser.error("requires at least one spec or an active environment")
 
     solver = asp.Solver()
     output = sys.stdout if "asp" in show else None

--- a/lib/spack/spack/cmd/spec.py
+++ b/lib/spack/spack/cmd/spec.py
@@ -10,7 +10,6 @@ import spack.cmd
 import spack.environment as ev
 import spack.hash_types as ht
 import spack.llnl.util.lang as lang
-import spack.llnl.util.tty as tty
 import spack.package_base
 import spack.spec
 import spack.store
@@ -98,7 +97,7 @@ def spec(parser, args):
         env.concretize()
         concrete_specs = env.concrete_roots()
     else:
-        tty.die("spack spec requires at least one spec or an active environment")
+        args.subparser.error("requires at least one spec or an active environment")
 
     # With --yaml, --json, or --format, just print the raw specs to output
     if args.format:

--- a/lib/spack/spack/cmd/stage.py
+++ b/lib/spack/spack/cmd/stage.py
@@ -73,7 +73,7 @@ def stage(parser, args):
     if not args.specs:
         env = ev.active_environment()
         if not env:
-            tty.die("`spack stage` requires a spec or an active environment")
+            args.subparser.error("requires a spec or an active environment")
         return _stage_env(env, filter)
 
     specs = spack.cmd.parse_specs(args.specs, concretize=False)
@@ -84,7 +84,7 @@ def stage(parser, args):
 
     # prevent multiple specs from extracting in the same folder
     if len(specs) > 1 and custom_path:
-        tty.die("`--path` requires a single spec, but multiple were provided")
+        args.subparser.error("--path requires a single spec, but multiple were provided")
 
     specs = spack.cmd.matching_specs_from_env(specs)
     for spec in specs:

--- a/lib/spack/spack/cmd/tags.py
+++ b/lib/spack/spack/cmd/tags.py
@@ -60,7 +60,7 @@ def setup_parser(subparser: argparse.ArgumentParser) -> None:
 def tags(parser, args):
     # Disallow combining all option with (positional) tags to avoid confusion
     if args.all and args.tag:
-        tty.die("Use the '--all' option OR provide tag(s) on the command line")
+        args.subparser.error("use the '--all' option OR provide tag(s) on the command line")
 
     # Provide a nice, simple message if database is empty
     if args.installed and not spack.environment.installed_specs():

--- a/lib/spack/spack/cmd/undevelop.py
+++ b/lib/spack/spack/cmd/undevelop.py
@@ -49,7 +49,7 @@ def _update_config(specs_to_remove):
 def undevelop(parser, args):
     # TODO: when https://github.com/spack/spack/pull/35307 is merged,
     # an active env is not required if a scope is specified
-    env = spack.cmd.require_active_env(cmd_name="undevelop")
+    env = spack.cmd.require_active_env(args.subparser)
 
     if args.all:
         remove_specs = [spack.spec.Spec(s) for s in env.dev_specs]

--- a/lib/spack/spack/cmd/uninstall.py
+++ b/lib/spack/spack/cmd/uninstall.py
@@ -296,8 +296,8 @@ def uninstall_specs(args, specs):
 def uninstall(parser, args):
     if not args.specs and not args.all:
         args.subparser.error(
-            "uninstall requires at least one package argument.\n"
-            "  Use `spack uninstall --all` to uninstall ALL packages."
+            "requires at least one package argument\n"
+            "  use `spack uninstall --all` to uninstall ALL packages"
         )
 
     # [None] here handles the --all case by forcing all specs to be returned

--- a/lib/spack/spack/cmd/uninstall.py
+++ b/lib/spack/spack/cmd/uninstall.py
@@ -295,9 +295,9 @@ def uninstall_specs(args, specs):
 
 def uninstall(parser, args):
     if not args.specs and not args.all:
-        tty.die(
-            "uninstall requires at least one package argument.",
-            "  Use `spack uninstall --all` to uninstall ALL packages.",
+        args.subparser.error(
+            "uninstall requires at least one package argument.\n"
+            "  Use `spack uninstall --all` to uninstall ALL packages."
         )
 
     # [None] here handles the --all case by forcing all specs to be returned

--- a/lib/spack/spack/cmd/unload.py
+++ b/lib/spack/spack/cmd/unload.py
@@ -8,7 +8,6 @@ import sys
 
 import spack.cmd
 import spack.cmd.common
-import spack.error
 import spack.store
 import spack.user_environment as uenv
 from spack.cmd.common import arguments
@@ -68,7 +67,7 @@ def setup_parser(subparser: argparse.ArgumentParser) -> None:
 def unload(parser, args):
     """unload spack packages from the user environment"""
     if args.specs and args.all:
-        raise spack.error.SpackError(
+        args.subparser.error(
             "Cannot specify specs on command line when unloading all specs with '--all'"
         )
 

--- a/lib/spack/spack/cmd/unload.py
+++ b/lib/spack/spack/cmd/unload.py
@@ -68,7 +68,7 @@ def unload(parser, args):
     """unload spack packages from the user environment"""
     if args.specs and args.all:
         args.subparser.error(
-            "Cannot specify specs on command line when unloading all specs with '--all'"
+            "cannot specify specs on command line when unloading all specs with '--all'"
         )
 
     hashes = os.environ.get(uenv.spack_loaded_hashes_var, "").split(os.pathsep)

--- a/lib/spack/spack/cmd/verify.py
+++ b/lib/spack/spack/cmd/verify.py
@@ -20,28 +20,26 @@ description = "verify spack installations on disk"
 section = "admin"
 level = "long"
 
-MANIFEST_SUBPARSER: Optional[argparse.ArgumentParser] = None
-
 
 def setup_parser(subparser: argparse.ArgumentParser):
-    global MANIFEST_SUBPARSER
     sp = subparser.add_subparsers(metavar="SUBCOMMAND", dest="verify_command")
 
-    MANIFEST_SUBPARSER = sp.add_parser(
+    manifest_subparser = sp.add_parser(
         "manifest", help=verify_manifest.__doc__, description=verify_manifest.__doc__
     )
-    MANIFEST_SUBPARSER.add_argument(
+    manifest_subparser.set_defaults(subparser=manifest_subparser)
+    manifest_subparser.add_argument(
         "-l", "--local", action="store_true", help="verify only locally installed packages"
     )
-    MANIFEST_SUBPARSER.add_argument(
+    manifest_subparser.add_argument(
         "-j", "--json", action="store_true", help="output json-formatted errors"
     )
-    MANIFEST_SUBPARSER.add_argument("-a", "--all", action="store_true", help="verify all packages")
-    MANIFEST_SUBPARSER.add_argument(
+    manifest_subparser.add_argument("-a", "--all", action="store_true", help="verify all packages")
+    manifest_subparser.add_argument(
         "specs_or_files", nargs=argparse.REMAINDER, help="specs or files to verify"
     )
 
-    manifest_sp_type = MANIFEST_SUBPARSER.add_mutually_exclusive_group()
+    manifest_sp_type = manifest_subparser.add_mutually_exclusive_group()
     manifest_sp_type.add_argument(
         "-s",
         "--specs",
@@ -64,12 +62,14 @@ def setup_parser(subparser: argparse.ArgumentParser):
     libraries_subparser = sp.add_parser(
         "libraries", help=verify_libraries.__doc__, description=verify_libraries.__doc__
     )
+    libraries_subparser.set_defaults(subparser=libraries_subparser)
 
     arguments.add_common_arguments(libraries_subparser, ["constraint"])
 
     versions_subparser = sp.add_parser(
         "versions", help=verify_versions.__doc__, description=verify_versions.__doc__
     )
+    versions_subparser.set_defaults(subparser=versions_subparser)
     arguments.add_common_arguments(versions_subparser, ["constraint"])
 
 
@@ -186,7 +186,7 @@ def verify_manifest(args):
 
     if args.type == "files":
         if args.all:
-            MANIFEST_SUBPARSER.error("cannot use --all with --files")
+            args.subparser.error("cannot use --all with --files")
 
         for file in args.specs_or_files:
             results = spack.verify.check_file_manifest(file)
@@ -217,7 +217,7 @@ def verify_manifest(args):
         env = ev.active_environment()
         specs = list(map(lambda x: spack.cmd.disambiguate_spec(x, env, local=local), spec_args))
     else:
-        MANIFEST_SUBPARSER.error("use --all or specify specs to verify")
+        args.subparser.error("use --all or specify specs to verify")
 
     for spec in specs:
         tty.debug("Verifying package %s")

--- a/lib/spack/spack/main.py
+++ b/lib/spack/spack/main.py
@@ -369,6 +369,7 @@ class SpackArgumentParser(argparse.ArgumentParser):
                 help=module.description,
                 description=module.description,
             )
+            subparser.set_defaults(subparser=subparser)
             module.setup_parser(subparser)
 
         # return the callable function for the command
@@ -628,7 +629,7 @@ def _invoke_command(command, parser, args, unknown_args):
         return_val = command(parser, args, unknown_args)
     else:
         if unknown_args:
-            tty.die("unrecognized arguments: %s" % " ".join(unknown_args))
+            args.subparser.error("unrecognized arguments: %s" % " ".join(unknown_args))
         return_val = command(parser, args)
 
     # Allow commands to return and error code if they want

--- a/lib/spack/spack/test/cmd/audit.py
+++ b/lib/spack/spack/test/cmd/audit.py
@@ -42,7 +42,7 @@ def test_audit_packages_https(mutable_config, mock_packages, monkeypatch):
     # Without providing --all should fail
     audit("packages-https", fail_on_error=False)
     # The mock configuration has duplicate definitions of some compilers
-    assert audit.returncode == 1
+    assert audit.returncode == 2
 
     # This uses http and should fail
     audit("packages-https", "test-dependency", fail_on_error=False)

--- a/lib/spack/spack/test/cmd/audit.py
+++ b/lib/spack/spack/test/cmd/audit.py
@@ -41,7 +41,6 @@ def test_audit_packages_https(mutable_config, mock_packages, monkeypatch):
 
     # Without providing --all should fail
     audit("packages-https", fail_on_error=False)
-    # The mock configuration has duplicate definitions of some compilers
     assert audit.returncode == 2
 
     # This uses http and should fail

--- a/lib/spack/spack/test/cmd/config.py
+++ b/lib/spack/spack/test/cmd/config.py
@@ -755,7 +755,7 @@ def test_config_with_group_shows_override_packages(cmd_str, tmp_path, mutable_co
 def test_config_with_group_requires_active_environment(cmd_str, mutable_config):
     """Tests that using groups outside an environment should give a clear error."""
     output = config(cmd_str, "--group=mygroup", "packages", fail_on_error=False)
-    assert config.returncode != 0
+    assert config.returncode == 2
     assert "--group requires an active environment" in output
 
 
@@ -765,5 +765,5 @@ def test_config_with_unknown_group_gives_clear_error(cmd_str, tmp_path, mutable_
     (tmp_path / "spack.yaml").write_text("spack:\n  specs:\n  - zlib\n")
     with ev.Environment(str(tmp_path)):
         output = config(cmd_str, "--group=nonexistent", "packages", fail_on_error=False)
-    assert config.returncode != 0
+    assert config.returncode == 1
     assert "'nonexistent' not found in" in output

--- a/lib/spack/spack/test/cmd/create.py
+++ b/lib/spack/spack/test/cmd/create.py
@@ -150,7 +150,7 @@ def test_create_template_bad_name(mock_test_repo, name, expected):
     """Test template creation with bad name options."""
     output = create("--skip-editor", "-n", name, fail_on_error=False)
     assert expected in output
-    assert create.returncode != 0
+    assert create.returncode == 1
 
 
 def test_build_system_guesser_no_stage():

--- a/lib/spack/spack/test/cmd/dev_build.py
+++ b/lib/spack/spack/test/cmd/dev_build.py
@@ -161,7 +161,8 @@ def test_dev_build_fails_nonexistent_package_name(mock_packages):
 
 def test_dev_build_fails_no_version(mock_packages):
     output = dev_build("dev-build-test-install", fail_on_error=False)
-    assert "dev-build spec must have a single, concrete version" in output
+    assert "spec must have a single, concrete version" in output
+    assert dev_build.returncode != 0
 
 
 def test_dev_build_can_parse_path_with_at_symbol(tmp_path: pathlib.Path, install_mockery):

--- a/lib/spack/spack/test/cmd/dev_build.py
+++ b/lib/spack/spack/test/cmd/dev_build.py
@@ -162,7 +162,7 @@ def test_dev_build_fails_nonexistent_package_name(mock_packages):
 def test_dev_build_fails_no_version(mock_packages):
     output = dev_build("dev-build-test-install", fail_on_error=False)
     assert "spec must have a single, concrete version" in output
-    assert dev_build.returncode != 0
+    assert dev_build.returncode == 2
 
 
 def test_dev_build_can_parse_path_with_at_symbol(tmp_path: pathlib.Path, install_mockery):

--- a/lib/spack/spack/test/cmd/env.py
+++ b/lib/spack/spack/test/cmd/env.py
@@ -254,6 +254,12 @@ def template_combinatorial_env(tmp_path: pathlib.Path):
     """
 
 
+def test_add_requires_active_env():
+    """Test that spack add exits with code 2 when no environment is active."""
+    add("hdf5", fail_on_error=False)
+    assert add.returncode == 2
+
+
 def test_add():
     e = ev.create("test")
     e.add("mpileaks")

--- a/lib/spack/spack/test/cmd/location.py
+++ b/lib/spack/spack/test/cmd/location.py
@@ -71,14 +71,19 @@ def test_location_source_dir_missing():
 
 
 @pytest.mark.parametrize(
-    "options",
-    [([]), (["--source-dir", "mpileaks"]), (["--env", "missing-env"]), (["spec1", "spec2"])],
+    "options,expected_code",
+    [
+        ([], 2),
+        (["--source-dir", "mpileaks"], 1),
+        (["--env", "missing-env"], 1),
+        (["spec1", "spec2"], 2),
+    ],
 )
-def test_location_cmd_error(options):
+def test_location_cmd_error(options, expected_code):
     """Ensure the proper error is raised with problematic location options."""
     with pytest.raises(spack.main.SpackCommandError) as e:
         location(*options)
-    assert e.value.code != 0
+    assert e.value.code == expected_code
 
 
 def test_location_env_exists(mutable_mock_env_path):
@@ -141,7 +146,7 @@ def test_location_spec_errors(specs, expected):
     """Tests spack location with bad spec options."""
     output = location(*specs, fail_on_error=False)
     assert expected in output
-    assert location.returncode != 0
+    assert location.returncode == 2
 
 
 @pytest.mark.db

--- a/lib/spack/spack/test/cmd/location.py
+++ b/lib/spack/spack/test/cmd/location.py
@@ -78,7 +78,7 @@ def test_location_cmd_error(options):
     """Ensure the proper error is raised with problematic location options."""
     with pytest.raises(spack.main.SpackCommandError) as e:
         location(*options)
-    assert e.value.code == 1
+    assert e.value.code != 0
 
 
 def test_location_env_exists(mutable_mock_env_path):
@@ -135,12 +135,13 @@ def test_location_paths_options(option, expected):
 
 @pytest.mark.parametrize(
     "specs,expected",
-    [([], "You must supply a spec."), (["spec1", "spec2"], "Too many specs.  Supply only one.")],
+    [([], "requires a spec"), (["spec1", "spec2"], "too many specs, supply only one")],
 )
 def test_location_spec_errors(specs, expected):
     """Tests spack location with bad spec options."""
-    error = "==> Error: %s" % expected
-    assert location(*specs, fail_on_error=False).strip() == error
+    output = location(*specs, fail_on_error=False)
+    assert expected in output
+    assert location.returncode != 0
 
 
 @pytest.mark.db

--- a/lib/spack/spack/test/cmd/logs.py
+++ b/lib/spack/spack/test/cmd/logs.py
@@ -14,6 +14,7 @@ import pytest
 import spack.cmd.logs
 import spack.concretize
 import spack.error
+import spack.main
 import spack.spec
 from spack.main import SpackCommand
 
@@ -53,8 +54,9 @@ def test_logs_cmd_errors(install_mockery, mock_fetch, mock_archive, mock_package
     with pytest.raises(spack.error.SpackError, match="is not installed or staged"):
         logs("pkg-c")
 
-    with pytest.raises(spack.error.SpackError, match="Too many specs"):
+    with pytest.raises(spack.main.SpackCommandError) as e:
         logs("pkg-c mpi")
+    assert e.value.code != 0
 
     install("pkg-c")
     os.remove(spec.package.install_log_path)

--- a/lib/spack/spack/test/cmd/logs.py
+++ b/lib/spack/spack/test/cmd/logs.py
@@ -56,7 +56,7 @@ def test_logs_cmd_errors(install_mockery, mock_fetch, mock_archive, mock_package
 
     with pytest.raises(spack.main.SpackCommandError) as e:
         logs("pkg-c mpi")
-    assert e.value.code != 0
+    assert e.value.code == 2
 
     install("pkg-c")
     os.remove(spec.package.install_log_path)

--- a/lib/spack/spack/test/cmd/mirror.py
+++ b/lib/spack/spack/test/cmd/mirror.py
@@ -12,7 +12,6 @@ import spack.cmd.mirror
 import spack.concretize
 import spack.config
 import spack.environment as ev
-import spack.error
 import spack.mirrors.utils
 import spack.package_base
 import spack.spec
@@ -521,27 +520,19 @@ class TestMirrorCreate:
     @pytest.mark.parametrize(
         "cli_args,error_str",
         [
-            # Passed more than one among -f --all
+            (["create", "--file", "input.txt", "--all"], "cannot specify specs with a file if"),
+            (["create", "--file", "input.txt", "hdf5"], "cannot specify specs with a file AND"),
+            (["create"], "no packages were specified"),
             (
-                {"specs": None, "file": "input.txt", "all": True},
-                "cannot specify specs with a file if",
-            ),
-            (
-                {"specs": "hdf5", "file": "input.txt", "all": False},
-                "cannot specify specs with a file AND",
-            ),
-            ({"specs": None, "file": None, "all": False}, "no packages were specified"),
-            # Passed -n along with --all
-            (
-                {"specs": None, "file": None, "all": True, "versions_per_spec": 2},
+                ["create", "--all", "--versions-per-spec", "2"],
                 "cannot specify '--versions_per-spec'",
             ),
         ],
     )
     def test_error_conditions(self, cli_args, error_str):
-        args = MockMirrorArgs(**cli_args)
-        with pytest.raises(spack.error.SpackError, match=error_str):
-            spack.cmd.mirror.mirror_create(args)
+        output = mirror(*cli_args, fail_on_error=False)
+        assert error_str in output
+        assert mirror.returncode != 0
 
     @pytest.mark.parametrize(
         "cli_args,not_expected",

--- a/lib/spack/spack/test/cmd/mirror.py
+++ b/lib/spack/spack/test/cmd/mirror.py
@@ -532,7 +532,7 @@ class TestMirrorCreate:
     def test_error_conditions(self, cli_args, error_str):
         output = mirror(*cli_args, fail_on_error=False)
         assert error_str in output
-        assert mirror.returncode != 0
+        assert mirror.returncode == 2
 
     @pytest.mark.parametrize(
         "cli_args,not_expected",

--- a/lib/spack/spack/test/cmd/python.py
+++ b/lib/spack/spack/test/cmd/python.py
@@ -39,5 +39,5 @@ def test_python_with_module():
 
 def test_python_raises():
     out = python("--foobar", fail_on_error=False)
-    assert python.returncode != 0
+    assert python.returncode == 2
     assert "--foobar" in out

--- a/lib/spack/spack/test/cmd/python.py
+++ b/lib/spack/spack/test/cmd/python.py
@@ -39,4 +39,5 @@ def test_python_with_module():
 
 def test_python_raises():
     out = python("--foobar", fail_on_error=False)
-    assert "Error: Unknown arguments" in out
+    assert python.returncode != 0
+    assert "--foobar" in out

--- a/lib/spack/spack/test/cmd/spec.py
+++ b/lib/spack/spack/test/cmd/spec.py
@@ -140,7 +140,7 @@ def test_spec_deptypes_edges():
 def test_spec_returncode():
     with pytest.raises(SpackCommandError):
         spec()
-    assert spec.returncode != 0
+    assert spec.returncode == 2
 
 
 def test_spec_parse_error():

--- a/lib/spack/spack/test/cmd/spec.py
+++ b/lib/spack/spack/test/cmd/spec.py
@@ -140,7 +140,7 @@ def test_spec_deptypes_edges():
 def test_spec_returncode():
     with pytest.raises(SpackCommandError):
         spec()
-    assert spec.returncode == 1
+    assert spec.returncode != 0
 
 
 def test_spec_parse_error():

--- a/lib/spack/spack/test/cmd/style.py
+++ b/lib/spack/spack/test/cmd/style.py
@@ -155,7 +155,7 @@ def test_bad_root(tmp_path: pathlib.Path):
     """Ensure that `spack style` doesn't run on non-spack directories."""
     output = style("--root", str(tmp_path), fail_on_error=False)
     assert "This does not look like a valid spack root" in output
-    assert style.returncode != 0
+    assert style.returncode == 1
 
 
 @pytest.fixture
@@ -223,7 +223,7 @@ def test_external_root(external_style_root):
     output = style("--root-relative", "--root", str(tmp_path), fail_on_error=False)
 
     # make sure it failed
-    assert style.returncode != 0
+    assert style.returncode == 1
 
     # ruff-check error
     assert "Import block is un-sorted or un-formatted\n --> lib/spack/spack/dummy.py" in output
@@ -272,7 +272,7 @@ def test_style_with_errors(ruff_package_with_errors):
         "--tool", "ruff-check", "--root-relative", ruff_package_with_errors, fail_on_error=False
     )
     assert root_relative in output
-    assert style.returncode != 0
+    assert style.returncode == 1
     assert "spack style found errors" in output
 
 
@@ -280,7 +280,7 @@ def test_style_with_errors(ruff_package_with_errors):
 def test_style_with_ruff_format(ruff_package_with_errors):
     output = style("--tool", "ruff-format", ruff_package_with_errors, fail_on_error=False)
     assert "ruff-format found errors" in output
-    assert style.returncode != 0
+    assert style.returncode == 1
     assert "spack style found errors" in output
 
 


### PR DESCRIPTION
Exit codes now carry meaning:

* `1`: runtime "no" / "cannot" (package not found, install failure, etc.)
* `2`: invalid user input (wrong flags, bad argument combinations, missing required arguments); produced by `parser.error()`

To that end:

* Replace `tty.die` and `SpackError` with `parser.error` for command-line argument validation errors across all commands
* Replace `raise RuntimeError` with `parser.error` in `spack find` for conflicting `--only-missing`/`--deprecated`/`--missing` flags
* Inject the active subparser into the arguments namespace using `set_defaults(subparser=...)` to make it accessible to command functions
* Refactor `require_active_env` to accept a parser object instead of a command name string
* Adjust command error messages to align with standard argparse output formatting (lowercase, no repeated command name)
* Update CLI unit tests to assert specific exit codes (2 for bad input, 1 for runtime failures) rather than just non-zero