### PR TITLE
Filter develop dependencies from binary cache

### DIFF
--- a/lib/spack/spack/cmd/buildcache.py
+++ b/lib/spack/spack/cmd/buildcache.py
@@ -405,6 +405,25 @@ def _skip_no_redistribute_for_public(specs):
     return remaining_specs
 
 
+def _skip_develop_specs(specs):
+    remaining_specs = list()
+    removed_specs = list()
+    for spec in specs:
+        if spec.is_develop:
+            removed_specs.append(spec)
+        else:
+            remaining_specs.append(spec)
+    if removed_specs:
+        colified_output = tty.colify.colified(list(s.name for s in removed_specs), indent=4)
+        tty.info(
+            "The following specs will not be pushed to the binary cache"
+            " because they are develop specs:\n"
+            f"{colified_output}\n"
+            "Develop specs are excluded from binary caching by default."
+        )
+    return remaining_specs
+
+
 class PackagesAreNotInstalledError(spack.error.SpackError):
     """Raised when a list of specs is not installed but picked to be packaged."""
 
@@ -483,6 +502,8 @@ def push_fn(args):
 
     if not args.private:
         specs = _skip_no_redistribute_for_public(specs)
+
+    specs = _skip_develop_specs(specs)
 
     if len(specs) > 1:
         tty.info(f"Selected {len(specs)} specs to push to {push_url}")

--- a/lib/spack/spack/hooks/autopush.py
+++ b/lib/spack/spack/hooks/autopush.py
@@ -19,6 +19,10 @@ def post_install(spec, explicit):
     if pkg.installed_from_binary_cache:
         return
 
+    # Do nothing if spec is a develop spec
+    if spec.is_develop:
+        return
+
     # Push the package to all autopush mirrors
     for mirror in spack.mirrors.mirror.MirrorCollection(binary=True, autopush=True).values():
         signing_key = spack.binary_distribution.select_signing_key() if mirror.signed else None

--- a/lib/spack/spack/installer.py
+++ b/lib/spack/spack/installer.py
@@ -502,6 +502,13 @@ def _try_install_from_binary_cache(
         unsigned: if ``True`` or ``False`` override the mirror signature verification defaults
         timer: timer to keep track of binary install phases.
     """
+    # Skip develop specs -- they should always be built from source.
+    if pkg.spec.is_develop:
+        tty.debug(
+            f"Skipping binary cache for {package_id(pkg.spec)}: develop spec"
+        )
+        return False
+
     # Early exit if no binary mirrors are configured.
     if not spack.mirrors.mirror.MirrorCollection(binary=True):
         return False

--- a/lib/spack/spack/new_installer.py
+++ b/lib/spack/spack/new_installer.py
@@ -675,7 +675,8 @@ def _install(
         return
 
     # Try to install from buildcache, unless user asked for source only
-    if install_policy != "source_only":
+    # or this is a develop spec (which should always be built from source)
+    if install_policy != "source_only" and not spec.is_develop:
         if install_from_buildcache(mirrors, spec, unsigned, state_stream):
             spack.hooks.post_install(spec, explicit)
             return

--- a/lib/spack/spack/new_installer.py
+++ b/lib/spack/spack/new_installer.py
@@ -674,9 +674,12 @@ def _install(
         spack.hooks.post_install(spec, explicit)
         return
 
+    if spec.is_develop:
+        install_policy = "source_only"
+
     # Try to install from buildcache, unless user asked for source only
     # or this is a develop spec (which should always be built from source)
-    if install_policy != "source_only" and not spec.is_develop:
+    if install_policy != "source_only":
         if install_from_buildcache(mirrors, spec, unsigned, state_stream):
             spack.hooks.post_install(spec, explicit)
             return

--- a/lib/spack/spack/test/cmd/buildcache.py
+++ b/lib/spack/spack/test/cmd/buildcache.py
@@ -197,6 +197,52 @@ def test_buildcache_autopush(tmp_path: pathlib.Path, install_mockery, mock_fetch
     assert (mirror_autopush_dir / specs_dirs / manifest_file).exists()
 
 
+def test_buildcache_push_skips_develop_specs(
+    tmp_path: pathlib.Path, monkeypatch, default_mock_concretization, temporary_store
+):
+    """Test that develop specs (with dev_path) are excluded from buildcache push."""
+    spec = default_mock_concretization("dttop")
+    PackageInstaller([spec.package], explicit=True, fake=True).install()
+    slash_hash = f"/{spec.dag_hash()}"
+
+    class DontUpload(spack.binary_distribution.Uploader):
+        def __init__(self):
+            super().__init__(
+                spack.mirrors.mirror.Mirror.from_local_path(str(tmp_path)), False, False
+            )
+            self.pushed = []
+
+        def push(self, specs: List[spack.spec.Spec]):
+            self.pushed.extend(s.name for s in specs)
+            return [], []  # nothing skipped, nothing errored
+
+    uploader = DontUpload()
+    monkeypatch.setattr(
+        spack.binary_distribution, "make_uploader", lambda *args, **kwargs: uploader
+    )
+
+    # Monkeypatch is_develop to return True for the root spec
+    original_is_develop = type(spec).is_develop
+    monkeypatch.setattr(
+        type(spec), "is_develop", property(lambda self: self.name == "dttop")
+    )
+
+    buildcache("create", "--unsigned", "--only", "package", str(tmp_path), slash_hash)
+
+    # The develop spec should have been filtered out
+    assert "dttop" not in uploader.pushed
+
+
+def test_skip_develop_specs_filters_correctly():
+    """Unit test for _skip_develop_specs helper."""
+    normal_spec = spack.spec.Spec("foo@1.0")
+    develop_spec = spack.spec.Spec("bar@2.0 dev_path=/tmp/dev")
+
+    result = spack.cmd.buildcache._skip_develop_specs([normal_spec, develop_spec])
+    assert len(result) == 1
+    assert result[0].name == "foo"
+
+
 def test_buildcache_sync(
     mutable_mock_env_path,
     install_mockery,

--- a/lib/spack/spack/test/installer.py
+++ b/lib/spack/spack/test/installer.py
@@ -30,6 +30,7 @@ import spack.report
 import spack.spec
 import spack.store
 import spack.util.lock as lk
+import spack.variant
 from spack.main import SpackCommand
 from spack.test.conftest import RepoBuilder
 
@@ -201,6 +202,20 @@ def test_process_binary_cache_tarball_tar(install_mockery, monkeypatch, capfd):
 def test_try_install_from_binary_cache(install_mockery, mock_packages, monkeypatch):
     """Test return false when no match exists in the mirror"""
     spec = spack.concretize.concretize_one("mpich")
+    result = inst._try_install_from_binary_cache(spec.package, False, False)
+    assert not result
+
+
+def test_try_install_from_binary_cache_skips_develop(install_mockery, mock_packages, monkeypatch):
+    """Test that develop specs are skipped when trying to install from binary cache."""
+    spec = spack.concretize.concretize_one("trivial-install-test-package")
+    # Mark as develop spec
+    spec.variants["dev_path"] = spack.variant.VariantValue(
+        spack.variant.VariantType.SINGLE, "dev_path", ("/tmp/dev",), concrete=True
+    )
+    assert spec.is_develop
+
+    # Should return False without even checking mirrors
     result = inst._try_install_from_binary_cache(spec.package, False, False)
     assert not result
 


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
Add the behavior of filtering specs marked as 'develop' from being pushed to the binary cache. I think this should be the default behavior as the user typically does not want to pollute their binary cache with the code they are developing.

I have been using this patch for some weeks without any issue. The feature works with both the new and old installers, and supports `--autopush` too.

This feature could be enabled by a flag too it it makes more sense, or we could attach a new attribute to the mirror to enable/disable this behavior in environments.

This PR is a bit similar to https://github.com/spack/spack/pull/50099.