### PR TITLE
Windows Shells: Allow bin/spack to work as expected

### DIFF
--- a/bin/spack.bat
+++ b/bin/spack.bat
@@ -12,6 +12,13 @@
 ::    . /path/to/spack/install/spack_cmd.bat
 ::
 @echo off
+:: We're directly invoking this script
+:: compute spack_root from this
+if "%SPACK_ROOT%" =="" (
+    pushd %~dp0..
+    set SPACK_ROOT=%CD%
+    popd
+)
 
 set spack="%SPACK_ROOT%\bin\spack"
 

--- a/bin/spack.ps1
+++ b/bin/spack.ps1
@@ -125,8 +125,18 @@ function Invoke-SpackLoad {
     }
 }
 
+function Set-SpackRoot {
+    if ([string]::IsNullOrEmpty($Env:SPACK_ROOT)) {
+        Push-Location $PSScriptRoot/..
+        $Env:SPACK_ROOT = $PWD.Path
+        Pop-Location
+    }
+}
+
+Set-SpackRoot
 
 $SpackCMD_params, $SpackSubCommand, $SpackSubCommandArgs = Read-SpackArgs $args
+
 
 if (Compare-CommonArgs $SpackCMD_params) {
     python "$Env:SPACK_ROOT/bin/spack" $SpackCMD_params $SpackSubCommand $SpackSubCommandArgs


### PR DESCRIPTION
Previously scripts assumed you were working in an established spack shell. This allows them to be invoked directly like bin/spack (or bin\spack for cmd)


edit to see if gitlab picks up the PR now

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
