### PR TITLE
main.py: deprecate --profile flags

### DIFF
--- a/lib/spack/docs/developer_guide.rst
+++ b/lib/spack/docs/developer_guide.rst
@@ -690,21 +690,12 @@ By running this command before and after the change, you can make sure that your
 Profiling
 ---------
 
-Spack has some limited built-in support for profiling, and can report statistics using standard Python timing tools.
-To use this feature, supply ``--profile`` to Spack on the command line, before any subcommands.
+To profile Spack, use Python's built-in `cProfile <https://docs.python.org/3/library/profile.html#module-cProfile>`_ module directly:
 
-.. _spack-p:
+.. code-block:: console
 
-``spack --profile``
-^^^^^^^^^^^^^^^^^^^
-
-``spack --profile`` output looks like this:
-
-.. command-output:: spack --profile graph hdf5
-   :ellipsis: 25
-
-The bottom of the output shows the most time-consuming functions, slowest on top.
-The profiling support is from Python's built-in tool, `cProfile <https://docs.python.org/3/library/profile.html#module-cProfile>`_.
+   $ python3 -m cProfile -s cumtime bin/spack find
+   $ python3 -m cProfile -o profile.out bin/spack find
 
 .. _releases:
 

--- a/lib/spack/spack/main.py
+++ b/lib/spack/spack/main.py
@@ -537,28 +537,12 @@ def make_argument_parser(**kwargs):
         help="do not use filesystem locking (unsafe)",
     )
 
-    profile = parser.add_argument_group("profiling")
-    profile.add_argument(
-        "-p",
-        "--profile",
-        action="store_true",
-        dest="spack_profile",
-        help="profile execution using cProfile",
+    debug.add_argument(
+        "-p", "--profile", action="store_true", dest="spack_profile", help=argparse.SUPPRESS
     )
-    profile.add_argument("--profile-file", default=None, help="Filename to save profile data to.")
-    profile.add_argument(
-        "--sorted-profile",
-        default=None,
-        metavar="STAT",
-        help="profile and sort by STAT, which can be: calls, ncalls,\n"
-        "cumtime, cumulative, filename, line, module",
-    )
-    profile.add_argument(
-        "--lines",
-        default=20,
-        action="store",
-        help="lines of profile output or 'all' (default: 20)",
-    )
+    debug.add_argument("--profile-file", default=None, help=argparse.SUPPRESS)
+    debug.add_argument("--sorted-profile", default=None, metavar="STAT", help=argparse.SUPPRESS)
+    debug.add_argument("--lines", default=20, action="store", help=argparse.SUPPRESS)
 
     return parser
 
@@ -1084,6 +1068,30 @@ def finish_parse_and_run(parser, cmd_name, main_args, env_format_error):
 
     # now we can actually execute the command.
     if main_args.spack_profile or main_args.sorted_profile or main_args.profile_file:
+        new_args = [sys.executable, "-m", "cProfile"]
+        if main_args.sorted_profile:
+            new_args.extend(["-s", main_args.sorted_profile])
+        if main_args.profile_file:
+            new_args.extend(["-o", main_args.profile_file])
+        new_args.append(spack.paths.spack_script)
+        skip_next = False
+        for arg in sys.argv[1:]:
+            if skip_next:
+                skip_next = False
+                continue
+            if arg in ("--sorted-profile", "--profile-file", "--lines"):
+                skip_next = True
+                continue
+            if arg.startswith(("--sorted-profile=", "--profile-file=", "--lines=")):
+                continue
+            if arg in ("--profile", "-p"):
+                continue
+            new_args.append(arg)
+        formatted_args = " ".join(shlex.quote(a) for a in new_args)
+        tty.warn(
+            "The --profile flag is deprecated and will be removed in Spack v1.3. "
+            f"Use `{formatted_args}` instead."
+        )
         _profile_wrapper(command, main_args, parser, args, unknown)
     elif main_args.pdb:
         new_args = [sys.executable, "-m", "pdb", spack.paths.spack_script]

--- a/share/spack/qa/run-unit-tests
+++ b/share/spack/qa/run-unit-tests
@@ -35,8 +35,6 @@ spack config get compilers
 bin/spack -h
 bin/spack help -a
 
-# Profile and print top 20 lines for a simple call to spack spec
-spack -p --lines 20 spec mpileaks%gcc
 $coverage_run $(which spack) bootstrap status --dev --optional
 
 # Check that we can import Spack packages directly as a first import

--- a/share/spack/spack-completion.fish
+++ b/share/spack/spack-completion.fish
@@ -471,13 +471,9 @@ complete -c spack -n '__fish_spack_using_command ' -s l -l enable-locks -d 'use 
 complete -c spack -n '__fish_spack_using_command ' -s L -l disable-locks -f -a locks
 complete -c spack -n '__fish_spack_using_command ' -s L -l disable-locks -d 'do not use filesystem locking (unsafe)'
 complete -c spack -n '__fish_spack_using_command ' -s p -l profile -f -a spack_profile
-complete -c spack -n '__fish_spack_using_command ' -s p -l profile -d 'profile execution using cProfile'
 complete -c spack -n '__fish_spack_using_command ' -l profile-file -r -f -a profile_file
-complete -c spack -n '__fish_spack_using_command ' -l profile-file -r -d 'Filename to save profile data to.'
 complete -c spack -n '__fish_spack_using_command ' -l sorted-profile -r -f -a sorted_profile
-complete -c spack -n '__fish_spack_using_command ' -l sorted-profile -r -d 'profile and sort by STAT, which can be: calls, ncalls,'
 complete -c spack -n '__fish_spack_using_command ' -l lines -r -f -a lines
-complete -c spack -n '__fish_spack_using_command ' -l lines -r -d 'lines of profile output or '"'"'all'"'"' (default: 20)'
 
 # spack add
 set -g __fish_spack_optspecs_spack_add h/help l/list-name=


### PR DESCRIPTION
Suppress `-p/--profile`, `--sorted-profile`, `--profile-file`, and
`--lines` from help output and print a deprecation warning with the
equivalent `python3 -m cProfile` command, mirroring the `--pdb`
deprecation pattern. Update docs to point users to `cProfile` directly.

* In the future, users will likely prefer [the sampling profiler][1] over
  cProfile
* With `spack --profile` we're missing profiling of anything that runs
  ahead of `main.py` as part of module imports.

[1]: https://docs.python.org/3.15/library/profiling.sampling.html