### PR TITLE
bootstrap env: cleanup environment lockfile on failure

### DIFF
--- a/lib/spack/spack/bootstrap/environment.py
+++ b/lib/spack/spack/bootstrap/environment.py
@@ -101,9 +101,16 @@ class BootstrapEnvironment(spack.environment.Environment):
                         if not spack.config.get("bootstrap:dev:enable_source", False)
                         else "auto"
                     )
-                    self.install_all(
-                        fail_fast=True, root_policy=fetch_policy, dependencies_policy=fetch_policy
-                    )
+                    try:
+                        self.install_all(
+                            fail_fast=True,
+                            root_policy=fetch_policy,
+                            dependencies_policy=fetch_policy,
+                        )
+                    except BaseException:
+                        # catch any exception as we always want to clean up
+                        self.environment_root().joinpath("spack.lock").unlink()
+                        raise
                     self.write(regenerate=True)
 
     def load(self) -> None:

--- a/lib/spack/spack/bootstrap/environment.py
+++ b/lib/spack/spack/bootstrap/environment.py
@@ -7,6 +7,7 @@ import contextlib
 import hashlib
 import os
 import pathlib
+import shutil
 import sys
 from typing import Iterable, List
 
@@ -109,7 +110,7 @@ class BootstrapEnvironment(spack.environment.Environment):
                         )
                     except BaseException:
                         # catch any exception as we always want to clean up
-                        self.environment_root().joinpath("spack.lock").unlink()
+                        shutil.rmtree(self.environment_root())
                         raise
                     self.write(regenerate=True)
 


### PR DESCRIPTION
If we fail to bootstrap the dev dependencies, cleanup the lockfile so we try again on a re-run.

Otherwise, the subsequent concretize command will return no specs, Spack assumes the env is installed, and tries to use the "installed" python, producing hard to trace errors.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
