### PR TITLE
build(deps): bump CI dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,7 +7,9 @@ updates:
 
   - package-ecosystem: "pip"
     directories:
-     - "/.github/workflows/requirements/*"
+     - "/.github/workflows/requirements/coverage"
+     - "/.github/workflows/requirements/style"
+     - "/.github/workflows/requirements/unit_tests"
      - "/lib/spack/docs"
     schedule:
       interval: "daily"

--- a/.github/workflows/bootstrap.yml
+++ b/.github/workflows/bootstrap.yml
@@ -199,7 +199,7 @@ jobs:
           dnf install -y \
               bzip2 curl gcc-c++ gcc gcc-gfortran git gnupg2 gzip \
               make patch python3.11 tcl unzip which xz
-    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
     - name: Setup repo and non-root user
       run: |
           git --version

--- a/.github/workflows/bootstrap.yml
+++ b/.github/workflows/bootstrap.yml
@@ -199,7 +199,7 @@ jobs:
           dnf install -y \
               bzip2 curl gcc-c++ gcc gcc-gfortran git gnupg2 gzip \
               make patch python3.11 tcl unzip which xz
-    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
     - name: Setup repo and non-root user
       run: |
           git --version

--- a/.github/workflows/import-check.yaml
+++ b/.github/workflows/import-check.yaml
@@ -9,7 +9,7 @@ jobs:
     continue-on-error: true
     runs-on: ubuntu-latest
     steps:
-    - uses: julia-actions/setup-julia@4a12c5f801ca5ef0458bba44687563ef276522dd # v2.7
+    - uses: julia-actions/setup-julia@4a12c5f801ca5ef0458bba44687563ef276522dd # v3.0.0
       with:
         version: '1.10'
     - uses: julia-actions/cache@9a93c5fb3e9c1c20b60fc80a478cae53e38618a4 # v3.0.2

--- a/.github/workflows/import-check.yaml
+++ b/.github/workflows/import-check.yaml
@@ -9,7 +9,7 @@ jobs:
     continue-on-error: true
     runs-on: ubuntu-latest
     steps:
-    - uses: julia-actions/setup-julia@4c0cb0fce8556fdb04a90347310e5db8b1f98fb9 # v2.7
+    - uses: julia-actions/setup-julia@4a12c5f801ca5ef0458bba44687563ef276522dd # v2.7
       with:
         version: '1.10'
     - uses: julia-actions/cache@9a93c5fb3e9c1c20b60fc80a478cae53e38618a4 # v3.0.2

--- a/.github/workflows/requirements/style/requirements.txt
+++ b/.github/workflows/requirements/style/requirements.txt
@@ -8,4 +8,4 @@ pylint==4.0.5
 docutils==0.22.4
 ruamel.yaml==0.19.1
 slotscheck==0.19.1
-ruff==0.15.7
+ruff==0.15.11

--- a/.github/workflows/requirements/unit_tests/requirements.txt
+++ b/.github/workflows/requirements/unit_tests/requirements.txt
@@ -3,4 +3,3 @@ pytest-cov==7.1.0
 pytest-xdist==3.8.0
 coverage[toml]<=7.11.0
 clingo==5.8.0
-click==8.3.2

--- a/.github/workflows/requirements/unit_tests/requirements.txt
+++ b/.github/workflows/requirements/unit_tests/requirements.txt
@@ -1,4 +1,4 @@
-pytest==9.0.2
+pytest==9.0.3
 pytest-cov==7.1.0
 pytest-xdist==3.3.1
 coverage[toml]<=7.11.0

--- a/.github/workflows/requirements/unit_tests/requirements.txt
+++ b/.github/workflows/requirements/unit_tests/requirements.txt
@@ -3,4 +3,4 @@ pytest-cov==7.1.0
 pytest-xdist==3.3.1
 coverage[toml]<=7.11.0
 clingo==5.8.0
-click==8.1.7
+click==8.3.2

--- a/.github/workflows/requirements/unit_tests/requirements.txt
+++ b/.github/workflows/requirements/unit_tests/requirements.txt
@@ -1,6 +1,6 @@
 pytest==9.0.3
 pytest-cov==7.1.0
-pytest-xdist==3.3.1
+pytest-xdist==3.8.0
 coverage[toml]<=7.11.0
 clingo==5.8.0
 click==8.3.2


### PR DESCRIPTION
Combines the following dependabot PRs:

- #52314 bump click from 8.1.7 to 8.3.2 in unit_tests
- #52313 bump pytest from 9.0.2 to 9.0.3 in unit_tests
- #52312 bump pytest-xdist from 3.3.1 to 3.8.0 in unit_tests
- #52311 bump ruff from 0.15.7 to 0.15.11 in style
- #52306 bump actions/checkout from 4.2.2 to 6.0.2
- #52305 bump julia-actions/setup-julia from 2.7.0 to 3.0.0

Supersedes #52310, #52309, #52308, #52307 (duplicates targeting the same files).