### PR TITLE
solver: pre-check if unknown virtuals are in the input specs

### DIFF
--- a/lib/spack/spack/error.py
+++ b/lib/spack/spack/error.py
@@ -116,6 +116,10 @@ class SpecError(SpackError):
     """Superclass for all errors that occur while constructing specs."""
 
 
+class InvalidVirtualOnEdgeError(SpecError):
+    """Raised when an edge requires a virtual that does not exist in the repository."""
+
+
 class UnsatisfiableSpecError(SpecError):
     """
     Raised when a spec conflicts with package constraints.

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -3917,6 +3917,8 @@ class Solver:
     def _check_input_and_extract_concrete_specs(
         specs: Sequence[spack.spec.Spec],
     ) -> List[spack.spec.Spec]:
+        _check_unknown_virtuals_in_input_specs(specs)
+
         reusable: List[spack.spec.Spec] = []
         analyzer = create_graph_analyzer()
         for root in specs:
@@ -4065,6 +4067,33 @@ class Solver:
         self._conc_cache.cleanup()
 
 
+class _SkipConcreteVisitor(traverse.BaseVisitor):
+    """Visitor that trims edges between two concrete nodes."""
+
+    def neighbors(self, item):
+        if item.edge.spec.concrete:
+            return []
+        return super().neighbors(item)
+
+
+def _check_unknown_virtuals_in_input_specs(specs: Sequence[spack.spec.Spec]) -> None:
+    """Raise InvalidVirtualOnEdgeError if any edge in *specs* requires an unknown virtual."""
+    errors = []
+    for root in specs:
+        root_edges = traverse.with_artificial_edges([root])
+        visitor = traverse.CoverNodesVisitor(_SkipConcreteVisitor())
+        for edge in traverse.traverse_depth_first_edges_generator(root_edges, visitor):
+            for virtual in edge.virtuals:
+                if not spack.repo.PATH.is_virtual(virtual):
+                    errors.append(f"'{virtual}' in '{root}' is not a known virtual package")
+    if not errors:
+        return
+    if len(errors) == 1:
+        raise InvalidVirtualOnEdgeError(errors[0])
+    details = "\n".join(f"    {idx}. {msg}" for idx, msg in enumerate(errors, 1))
+    raise InvalidVirtualOnEdgeError(f"unknown virtuals have been found in input specs:\n{details}")
+
+
 class UnsatisfiableSpecError(spack.error.UnsatisfiableSpecError):
     """There was an issue with the spec that was requested (i.e. a user error)."""
 
@@ -4143,3 +4172,7 @@ class InvalidVersionError(spack.error.SpackError):
 
 class InvalidDependencyError(spack.error.SpackError):
     """Raised when an explicit dependency is not a possible dependency."""
+
+
+class InvalidVirtualOnEdgeError(spack.error.SpackError):
+    """Raised when an edge requires a virtual that does not exist in the repository."""

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -4082,7 +4082,7 @@ def _check_unknown_virtuals_in_input_specs(specs: Sequence[spack.spec.Spec]) -> 
     for root in specs:
         root_edges = traverse.with_artificial_edges([root])
         visitor = traverse.CoverNodesVisitor(_SkipConcreteVisitor())
-        for edge in traverse.traverse_depth_first_edges_generator(root_edges, visitor):
+        for edge in traverse.traverse_breadth_first_edges_generator(root_edges, visitor):
             for virtual in edge.virtuals:
                 if not spack.repo.PATH.is_virtual(virtual):
                     errors.append(f"'{virtual}' in '{root}' is not a known virtual package")

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -4077,7 +4077,7 @@ class _SkipConcreteVisitor(traverse.BaseVisitor):
 
 
 def _check_unknown_virtuals_in_input_specs(specs: Sequence[spack.spec.Spec]) -> None:
-    """Raise InvalidVirtualOnEdgeError if any edge in *specs* requires an unknown virtual."""
+    """Raise if any edge in *specs* requires a virtual that does not exist in the repository."""
     errors = []
     for root in specs:
         root_edges = traverse.with_artificial_edges([root])
@@ -4089,9 +4089,11 @@ def _check_unknown_virtuals_in_input_specs(specs: Sequence[spack.spec.Spec]) -> 
     if not errors:
         return
     if len(errors) == 1:
-        raise InvalidVirtualOnEdgeError(errors[0])
+        raise spack.error.InvalidVirtualOnEdgeError(errors[0])
     details = "\n".join(f"    {idx}. {msg}" for idx, msg in enumerate(errors, 1))
-    raise InvalidVirtualOnEdgeError(f"unknown virtuals have been found in input specs:\n{details}")
+    raise spack.error.InvalidVirtualOnEdgeError(
+        f"unknown virtuals have been found in input specs:\n{details}"
+    )
 
 
 class UnsatisfiableSpecError(spack.error.UnsatisfiableSpecError):
@@ -4172,7 +4174,3 @@ class InvalidVersionError(spack.error.SpackError):
 
 class InvalidDependencyError(spack.error.SpackError):
     """Raised when an explicit dependency is not a possible dependency."""
-
-
-class InvalidVirtualOnEdgeError(spack.error.SpackError):
-    """Raised when an edge requires a virtual that does not exist in the repository."""

--- a/lib/spack/spack/solver/requirements.py
+++ b/lib/spack/spack/solver/requirements.py
@@ -26,6 +26,24 @@ def _mark_str(raw) -> str:
     return f"{mark.name}:{mark.line + 1}: " if mark else ""
 
 
+def _check_unknown_virtuals_on_edges(raw_strs: List[str], specs: List["spack.spec.Spec"]) -> None:
+    """Raise SpecError if any edge in *specs* requires a virtual that does not exist."""
+    errors = []
+    for raw, spec in zip(raw_strs, specs):
+        for edge in spack.traverse.traverse_edges([spec], root=False):
+            for virtual in edge.virtuals:
+                if not spack.repo.PATH.is_virtual(virtual):
+                    errors.append(
+                        f"{_mark_str(raw)}'{virtual}' in '{raw}' is not a known virtual package"
+                    )
+    if not errors:
+        return
+    if len(errors) == 1:
+        raise spack.error.SpecError(errors[0])
+    details = "\n".join(f"    {idx}. {msg}" for idx, msg in enumerate(errors, 1))
+    raise spack.error.SpecError(f"unknown virtuals have been detected in requirements:\n{details}")
+
+
 def _check_unknown_targets(
     raw_strs: List[str], specs: List["spack.spec.Spec"], *, always_warn: bool = False
 ) -> None:
@@ -316,6 +334,7 @@ class RequirementParser:
                     for constraint in raw_strs
                 ]
                 _check_unknown_targets(raw_strs, constraints)
+                _check_unknown_virtuals_on_edges(raw_strs, constraints)
                 when_str = requirement.get("when")
                 when = self._parse_and_expand(when_str) if when_str else spack.spec.Spec()
 

--- a/lib/spack/spack/solver/requirements.py
+++ b/lib/spack/spack/solver/requirements.py
@@ -27,7 +27,7 @@ def _mark_str(raw) -> str:
 
 
 def _check_unknown_virtuals_on_edges(raw_strs: List[str], specs: List["spack.spec.Spec"]) -> None:
-    """Raise SpecError if any edge in *specs* requires a virtual that does not exist."""
+    """Raise if any edge in *specs* requires a virtual that does not exist in the repository."""
     errors = []
     for raw, spec in zip(raw_strs, specs):
         for edge in spack.traverse.traverse_edges([spec], root=False):
@@ -39,9 +39,11 @@ def _check_unknown_virtuals_on_edges(raw_strs: List[str], specs: List["spack.spe
     if not errors:
         return
     if len(errors) == 1:
-        raise spack.error.SpecError(errors[0])
+        raise spack.error.InvalidVirtualOnEdgeError(errors[0])
     details = "\n".join(f"    {idx}. {msg}" for idx, msg in enumerate(errors, 1))
-    raise spack.error.SpecError(f"unknown virtuals have been detected in requirements:\n{details}")
+    raise spack.error.InvalidVirtualOnEdgeError(
+        f"unknown virtuals have been detected in requirements:\n{details}"
+    )
 
 
 def _check_unknown_targets(

--- a/lib/spack/spack/test/concretization/errors.py
+++ b/lib/spack/spack/test/concretization/errors.py
@@ -174,6 +174,19 @@ def assert_actionable_error(exc_info, *required_part: str) -> None:
             ["mvapich2", "file_systems", "the value 'auto' is mutually exclusive"],
             id="variant_disjoint_sets",
         ),
+        # "fortan" is not a known virtual (typo of "fortran"). The error must name the
+        # unknown virtual and quote the originating spec, and must not be a generic internal error.
+        pytest.param(
+            "zlib %c,cxx,fortan=gcc",
+            ["fortan", "zlib %c,cxx,fortan=gcc", "not a known virtual"],
+            id="unknown_virtual_on_edge",
+        ),
+        # Two unknown virtuals on the same edge: both must appear in the single error raised.
+        pytest.param(
+            "zlib %c,fortan,cxxxx=gcc",
+            ["fortan", "cxxxx", "zlib %c,cxxxx,fortan=gcc"],
+            id="two_unknown_virtuals_on_edge",
+        ),
     ],
 )
 def test_input_spec_driven_errors(
@@ -224,6 +237,22 @@ def test_input_spec_driven_errors(
             "libelf%gcc",
             ["libelf"],
             id="requirement_unsatisfied_generic",
+        ),
+        # A `require:` entry names a virtual that does not exist. The error must name the
+        # unknown virtual and quote the originating spec so the user can find and fix the
+        # config entry.
+        pytest.param(
+            {"packages:zlib": {"require": ["%[virtuals=fortan]gcc"]}},
+            "zlib",
+            ["fortan", "%[virtuals=fortan]gcc"],
+            id="unknown_virtual_in_requirement",
+        ),
+        # Two unknown virtuals in a single requirement spec: both must appear in the error.
+        pytest.param(
+            {"packages:zlib": {"require": ["%[virtuals=fortan,cxxxx]gcc"]}},
+            "zlib",
+            ["fortan", "cxxxx", "%[virtuals=fortan,cxxxx]gcc"],
+            id="two_unknown_virtuals_in_requirement",
         ),
     ],
 )


### PR DESCRIPTION
fixes #51364
closes #51323

Error early with a clear message if unknown virtuals are in the input specs or in a requirement.

**Example**
<img width="1266" height="185" alt="Screenshot from 2026-04-18 16-15-39" src="https://github.com/user-attachments/assets/3c94f7e9-bb38-4032-a04e-57bc4cc027de" />


<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
