### PR TITLE
add extended coloration output for package descriptions

### DIFF
--- a/etc/spack/defaults/base/config.yaml
+++ b/etc/spack/defaults/base/config.yaml
@@ -250,3 +250,6 @@ config:
     concretise: concretize
     containerise: containerize
     rm: remove
+
+  indent_offset: 4
+  max_width: 0

--- a/lib/spack/spack/cmd/info.py
+++ b/lib/spack/spack/cmd/info.py
@@ -9,10 +9,11 @@ import shutil
 import sys
 import textwrap
 from argparse import Namespace
-from typing import Any, Callable, Dict, Iterable, List, Optional, TextIO, Tuple
+from typing import Any, Callable, Dict, Iterable, Iterator, List, Optional, TextIO, Tuple
 
 import spack.builder
 import spack.cmd
+import spack.config
 import spack.dependency
 import spack.deptypes as dt
 import spack.fetch_strategy as fs
@@ -94,6 +95,24 @@ def padder(str_list: Iterable, extra: int = 0) -> Callable:
 def setup_parser(subparser: argparse.ArgumentParser) -> None:
     subparser.add_argument(
         "-a", "--all", action="store_true", default=False, help="output all package information"
+    )
+    subparser.add_argument(
+        "-n",
+        "--name-only",
+        action="store_true",
+        default=False,
+        help="Disable all machine-readable information.\n"
+        "Print out only the package's docstring, homepage, and\n"
+        "other semantic information intended for a human audience.",
+    )
+    subparser.add_argument(
+        "-e",
+        "--extended",
+        action="store_true",
+        default=False,
+        help="Include the full package docstring.\n"
+        "Typically only the first line of the package docstring is printed.\n"
+        "This includes the rest of the docstring, for expansive text on each package's purpose.",
     )
 
     by = subparser.add_mutually_exclusive_group()
@@ -186,7 +205,7 @@ def print_dependencies(pkg: PackageBase, args: Namespace) -> None:
     print_definitions(pkg, "Dependencies", pkg.dependencies, DependencyFormatter(), args.by_name)
 
 
-def print_dependency_suggestion(pkg: PackageBase) -> None:
+def print_dependency_suggestion(pkg: PackageBase, args: Namespace) -> None:
     variant_counts = count_bool_variant_conditions(pkg.dependencies)
     big_variants = [
         (name, val)
@@ -636,6 +655,45 @@ def print_virtuals(pkg: PackageBase, args: Namespace) -> None:
         color.cprint("    None")
 
 
+def print_sections(args: Namespace) -> Iterator[Callable[[PackageBase, Namespace], None]]:
+    """Output optional information in the expected order.
+
+    --name-only restricts the info we print, but otherwise respects the same arguments.
+    --all will unconditionally print every optional piece of data.
+    """
+    if args.name_only:
+        if args.all or args.maintainers:
+            yield print_maintainers
+        yield print_licenses
+        return
+
+    if args.all or args.maintainers:
+        yield print_maintainers
+    if args.all or args.namespace:
+        yield print_namespace
+    if args.all or args.detectable:
+        yield print_detectable
+    if args.all or args.tags:
+        yield print_tags
+    if args.all or not args.no_versions:
+        yield print_versions
+    if args.all or not args.no_variants:
+        yield print_variants
+    if args.all or args.phases:
+        yield print_phases
+    if args.all or not args.no_dependencies:
+        yield print_dependencies
+    if args.all or args.virtuals:
+        yield print_virtuals
+    if args.all or args.tests:
+        yield print_tests
+    yield print_licenses
+
+    yield print_dependency_suggestion
+
+    return
+
+
 def info(parser: argparse.ArgumentParser, args: Namespace) -> None:
     specs = spack.cmd.parse_specs(args.spec)
     if len(specs) > 1:
@@ -655,7 +713,15 @@ def info(parser: argparse.ArgumentParser, args: Namespace) -> None:
     color.cprint("")
     color.cprint(section_title("Description:"))
     if pkg.__doc__:
-        color.cprint(color.cescape(pkg.format_doc(indent=4)))
+        color.cprint(
+            color.cescape(
+                pkg.format_doc(
+                    indent=spack.config.get("config:indent_offset"),
+                    extended=args.extended,
+                    max_width=tty.TerminalWidth.configured(),
+                )
+            )
+        )
     else:
         color.cprint("    None")
 
@@ -663,23 +729,7 @@ def info(parser: argparse.ArgumentParser, args: Namespace) -> None:
         color.cprint(section_title("Homepage: ") + str(pkg.homepage))
 
     # Now output optional information in expected order
-    sections = [
-        (args.all or args.maintainers, print_maintainers),
-        (args.all or args.namespace, print_namespace),
-        (args.all or args.detectable, print_detectable),
-        (args.all or args.tags, print_tags),
-        (args.all or not args.no_versions, print_versions),
-        (args.all or not args.no_variants, print_variants),
-        (args.all or args.phases, print_phases),
-        (args.all or not args.no_dependencies, print_dependencies),
-        (args.all or args.virtuals, print_virtuals),
-        (args.all or args.tests, print_tests),
-        (True, print_licenses),
-    ]
-    for print_it, func in sections:
-        if print_it:
-            func(pkg, args)
-
-    print_dependency_suggestion(pkg)
-
-    color.cprint("")
+    for func in print_sections(args):
+        func(pkg, args)
+    # print_licenses() is always printed, and always at the end.
+    # It will conclude with two trailing newlines, as a result of print_definitions().

--- a/lib/spack/spack/cmd/list.py
+++ b/lib/spack/spack/cmd/list.py
@@ -253,6 +253,9 @@ def version_json(pkg_names, out):
     out.write("\n]\n")
 
 
+# TODO(cosmicexplorer):
+# - unify the styling from spack.llnl.util.tty.color across terminal and HTML output!
+# - caching, asynchrony, and parallelism could fix this!
 @formatter
 def html(pkg_names, out):
     """Print out information on all packages in Sphinx HTML.

--- a/lib/spack/spack/llnl/util/tty/__init__.py
+++ b/lib/spack/spack/llnl/util/tty/__init__.py
@@ -11,7 +11,12 @@ import textwrap
 import traceback
 from datetime import datetime
 from types import TracebackType
-from typing import IO, Callable, Iterator, NoReturn, Optional, Type, Union
+from typing import IO, TYPE_CHECKING, Callable, Iterator, NoReturn, Optional, Type, Union
+
+if TYPE_CHECKING:
+    from typing_extensions import Self
+
+from spack.util.lang import memoized
 
 from .color import cescape, clen, cprint, cwrite
 
@@ -282,19 +287,90 @@ def get_yes_or_no(prompt: str, default: Optional[bool] = None) -> Optional[bool]
     return result
 
 
-def hline(label: Optional[str] = None, *, char: str = "-", max_width: int = 64) -> None:
+class TerminalWidth(int):
+    MIN_WIDTH = 10
+
+    def __new__(cls, *args, **kwargs):
+        ret = super().__new__(cls, *args, **kwargs)
+        if ret <= cls.MIN_WIDTH:
+            raise ValueError(
+                f"selected terminal width must be at least {cls.MIN_WIDTH} columns wide "
+                f"(was: {ret})"
+            )
+        return ret
+
+    @classmethod
+    @memoized
+    def _default(cls) -> Self:
+        return cls(72)
+
+    @classmethod
+    @memoized
+    def _as_introspected(cls) -> Optional[Self]:
+        """Query the stdlib facilities for the width of the encompassing terminal, if available."""
+        cols = shutil.get_terminal_size().columns
+        if cols:
+            return cls(cols)
+        return None
+
+    @classmethod
+    def _as_configured(cls) -> Optional[Self]:
+        # May return 0 (the default), which we convert to a None.
+        import spack.config
+
+        width = spack.config.get("config:max_width")
+        if width:
+            return cls(width)
+        return None
+
+    @classmethod
+    def configured(cls, default: Optional[Self] = None) -> Self:
+        configured = cls._as_configured()
+        if configured is not None:
+            return configured
+        introspected = cls._as_introspected()
+        if introspected is not None:
+            return introspected
+        return default or cls._default
+
+    @memoized
+    def limit_to(self, within_range: Self) -> Self:
+        if self <= within_range:
+            return self
+        return within_range
+
+    def reduce_by(self, n: int) -> Self:
+        """Reduce the current width by some amount."""
+        if n < 0:
+            raise ValueError(f"cannot reduce a terminal width by a negative (got: {n})")
+        # This will raise ValueError if < the min width.
+        return self.__class__(self - n)
+
+    @classmethod
+    @memoized
+    def _hline_max_width(cls) -> Self:
+        return cls(64)
+
+    @classmethod
+    def convert_or_default(cls, default: Self, max_width: Optional[int] = None) -> Self:
+        if max_width is None:
+            return default
+        return cls(max_width)
+
+
+def hline(
+    label: Optional[str] = None, *, char: str = "-", max_width: Optional[int] = None
+) -> None:
     """Draw a labeled horizontal line.
 
     Args:
         char: char to draw the line with
         max_width: maximum width of the line
     """
-    cols = shutil.get_terminal_size().columns
-    if not cols:
-        cols = max_width
-    else:
-        cols -= 2
-    cols = min(max_width, cols)
+    max_width = TerminalWidth.convert_or_default(
+        default=TerminalWidth._hline_max_width(), max_width=max_width
+    )
+    cols = TerminalWidth.configured().reduce_by(2).limit_to(max_width)
 
     label = str(label)
     prefix = char * 2 + " "

--- a/lib/spack/spack/llnl/util/tty/color.py
+++ b/lib/spack/spack/llnl/util/tty/color.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 """
-This file implements an expression syntax, similar to ``printf``, for adding
+This file implements an expression syntax, similar to ``texinfo``, for adding
 ANSI colors to text.
 
 See :func:`colorize`, :func:`cwrite`, and :func:`cprint` for routines that can
@@ -27,29 +27,41 @@ Expression      Meaning
 ``@R``          Turn on bright red coloring
 ``@*{foo}``     Bold foo, but don't change text color
 ``@_{bar}``     Underline bar, but don't change text color
-``@*b``         Turn on bold, blue text
-``@_B``         Turn on bright blue text with an underline
+``@/{baz}``     Italicize baz, but don't change text color.
+``@~{qux}``     Strikethrough qux, but don't change text color.
+``@*b``         Turn on bold, blue text.
+``@_B``         Turn on bright blue text with an underline.
+``@/B``         Turn on bright blue text in italics.
+``@~B``         Turn on bright blue text with a strikethrough.
 ``@.``          Revert to plain formatting
 ``@*g{green}``  Print out 'green' in bold, green text, then reset to plain.
 ``@*ggreen@.``  Print out 'green' in bold, green text, then reset to plain.
 ==============  ============================================================
+The final example is intended to demonstrate the behavior of {...} as a grouping operator,
+reminiscent of its use in texinfo, and not to perform any form of quoting function.
 
 The syntax consists of:
 
 ==========  =====================================================
 color-expr  ``'@' [style] color-code '{' text '}' | '@.' | '@@'``
-style       ``'*' | '_'``
+style       ``'*' | '_' | '/' | '~'``
 color-code  ``[krgybmcwKRGYBMCW]``
 text        ``.*``
 ==========  =====================================================
 
-``@`` indicates the start of a color expression.  It can be followed
-by an optional ``*`` or ``_`` that indicates whether the font should be bold or
-underlined.  If ``*`` or ``_`` is not provided, the text will be plain.  Then
-an optional color code is supplied.  This can be ``[krgybmcw]`` or ``[KRGYBMCW]``,
+``@`` indicates the start of a formatting expression.  It may be followed by an optional ``*``,
+``_``, ``/``, or ``~``, which indicates styling that modifies the *shape* of the font, such as bold
+or underline effects. The subsequent character is the color code to be applied.
+This can be ``[krgybmcw]`` or ``[KRGYBMCW]``,
 where the letters map to  ``black(k)``, ``red(r)``, ``green(g)``, ``yellow(y)``, ``blue(b)``,
-``magenta(m)``, ``cyan(c)``, and ``white(w)``.  Lowercase letters denote normal ANSI
-colors and capital letters denote bright ANSI colors.
+``magenta(m)``, ``cyan(c)``, and ``white(w)``.
+
+The lowercase ASCII alphabet is translated to ANSI color sequences as above, while the
+corresponding uppercase ASCII character denotes a "bright" version of the indicated color.
+
+The user and their terminal are always able to translate these codes into their own preferred
+palette, but we also make sure to provide appropriate config flags to disable this styling, so that
+we can ensure Spack's text output remains robust and independent of this configurable formatting.
 
 Finally, the color expression can be followed by text enclosed in ``{}``.  If
 braces are present, only the text in braces is colored.  If the braces are
@@ -76,7 +88,18 @@ class ColorParseError(Exception):
 
 
 # Text styles for ansi codes
-styles = {"*": "1", "_": "4", None: "0"}  # bold  # underline  # plain
+styles = {
+    # bold
+    "*": "1",
+    # italics
+    "/": "3",
+    # underline
+    "_": "4",
+    # strikethrough
+    "~": "9",
+    # reset
+    None: "0",
+}
 
 # Dim and bright ansi colors
 colors = {
@@ -99,7 +122,7 @@ colors = {
 }  # white
 
 # Regex to be used for color formatting
-COLOR_RE = re.compile(r"@(?:(@)|(\.)|([*_])?([a-zA-Z])?(?:{((?:[^}]|}})*)})?)")
+COLOR_RE = re.compile(r"@(?:(@)|(\.)|([*_/~])?([a-zA-Z])?(?:{((?:[^}]|}})*)})?)")
 
 # Mapping from color arguments to values for tty.set_color
 color_when_values = {"always": True, "auto": None, "never": False}

--- a/lib/spack/spack/main.py
+++ b/lib/spack/spack/main.py
@@ -186,6 +186,19 @@ class SpackHelpFormatter(argparse.RawTextHelpFormatter):
             first_newline = result.index("\n")
             header, rest = result[:first_newline], result[first_newline:]
 
+        if rest:
+            textwrap.wrap(
+                "".join(rest),
+                initial_indent="",
+                subsequent_indent=help_position * " ",
+                width=tty.TerminalWidth.configured(),
+            )
+
+        # FIXME(cosmicexplorer): each time we use an f-string it eagerly generates a robust
+        #                        debuggable log output, only to immediately drop the result.
+        #                        We can create an API that delays serialization until given an
+        #                        output stream.
+        # tty.debug(f'prog {prog!r} removed from help formatter {self!r}')
         return color.colorize(f"@c{{{color.cescape(header)}}}{color.cescape(rest)}")
 
     def add_arguments(self, actions):

--- a/lib/spack/spack/package_base.py
+++ b/lib/spack/spack/package_base.py
@@ -10,7 +10,6 @@ import errno
 import functools
 import glob
 import hashlib
-import io
 import itertools
 import os
 import pathlib
@@ -53,6 +52,7 @@ import spack.variant
 from spack.compilers.adaptor import DeprecatedCompiler
 from spack.error import InstallError, NoURLError, PackageError
 from spack.filesystem_view import YamlFilesystemView
+from spack.llnl.util.tty.color import colorize
 from spack.resource import Resource
 from spack.util.filesystem import AlreadyExistsError, find_all_shared_libraries, islink, symlink
 from spack.util.lang import ClassProperty, classproperty, dedupe, memoized
@@ -2272,20 +2272,75 @@ class PackageBase(WindowsRPath, PackageViewMixin, metaclass=PackageMeta):
         """Removes the package's build stage and source tarball."""
         self.stage.destroy()
 
+    @classproperty
+    def docstring_uses_rich_text(cls):
+        # Default to false--this is a new and breaking way to interpret text, so let users opt in.
+        return False
+
+    @classproperty
+    def docstring_has_extended_text(cls):
+        # Default to false--this is a new and breaking way to interpret text, so let users opt in.
+        return False
+
+    _until_first_break = re.compile(r"^(.*?)(?=$|\n\n)", flags=re.DOTALL)
+    _spacing = re.compile(r"\s+")
+
     @classmethod
     def format_doc(cls, **kwargs):
-        """Wrap doc string at 72 characters and format nicely"""
+        """Wrap doc string and format nicely!"""
         indent = kwargs.get("indent", 0)
+        extended = kwargs.get("extended", False)
+        max_width = tty.TerminalWidth.convert_or_default(
+            default=tty.TerminalWidth._default(), max_width=kwargs.get("max_width", None)
+        )
 
-        if not cls.__doc__:
+        # We perform several transformations upon this string depending upon kwarg values.
+        doc = cls.__doc__
+        if not doc:
             return ""
 
-        doc = re.sub(r"\s+", " ", cls.__doc__)
-        lines = textwrap.wrap(doc, 72)
-        results = io.StringIO()
-        for line in lines:
-            results.write((" " * indent) + line + "\n")
-        return results.getvalue()
+        # If the docstring opts into this "extended" mechanism, then use it to limit the text
+        # we print.
+        if cls.docstring_has_extended_text:
+            if not extended:
+                doc = cls._until_first_break.match(cls.__doc__).group(0)
+                doc = cls._spacing.sub(" ", doc)
+            # If "extended" *is* selected, then we preserve newlines and other spacing in
+            # the output.
+        else:
+            # Otherwise, we perform the previous behavior, which coalesces all forms of spacing.
+            doc = cls._spacing.sub(" ", doc)
+
+        # If the docstring opts into using coloration, we perform that process on the
+        # coalesced version.
+        if cls.docstring_uses_rich_text:
+            doc = colorize(doc)
+
+        # The textwrap.wrap() method supports its own indentation. Use those arguments with our
+        # given prefix.
+        prefix = " " * indent
+        # Wrap to the specified width.
+        if cls.docstring_has_extended_text and extended:
+            sections = doc.split("\n\n")
+
+            lines_by_section = []
+            for section in sections:
+                # import pdb; pdb.set_trace()
+                lines = textwrap.wrap(
+                    section, width=max_width, initial_indent=prefix, subsequent_indent=prefix
+                )
+                lines_by_section.append("\n".join(lines))
+            joined_lines = "\n\n".join(lines_by_section)
+        else:
+            lines = textwrap.wrap(
+                doc, width=max_width, initial_indent=prefix, subsequent_indent=prefix
+            )
+            joined_lines = "\n".join(lines)
+
+        if joined_lines:
+            return joined_lines + "\n"
+        else:
+            return ""
 
     @property
     def all_urls(self) -> List[str]:

--- a/lib/spack/spack/schema/config.py
+++ b/lib/spack/spack/schema/config.py
@@ -228,6 +228,21 @@ properties: Dict[str, Any] = {
                 "description": "A mapping of aliases that can be used to define new "
                 "Spack commands",
             },
+            "indent_offset": {
+                "type": "integer",
+                "minimum": 0,
+                "description": "The number of ASCII space (0x20) characters used to prefix "
+                "every line of structured output, increasing linearly with the level of "
+                "hierarchical nesting.",
+            },
+            "max_width": {
+                "type": "integer",
+                "minimum": 0,
+                "description": "How many monospace characters may be written to the "
+                "terminal in sequence before writing an ASCII newline (0xa) "
+                "as part of a context-specific word-wrapping processto limit "
+                "the terminal column width necessary to convey the output.",
+            },
             "installer": {
                 "type": "string",
                 "enum": ["old", "new"],


### PR DESCRIPTION
This is a proposal for extended package description output!

The two big changes for package maintainers are:
1. Opt-in coloration in the terminal for `spack info`!
2. Opt-in "extended" description, which allows for a shorter and a longer output as needed.

The changes for users are:
1. The "indent offset" (the degree `spack info` indents inner sections) is now a config value.
2. The "max width" (the amount of terminal columns used for `spack info`) is now a config value.
3. The `-n|--name-only` argument was added to limit `spack info` output to the documentation string and license.
4. The `-e|--extended` argument was added to trigger the "extended" output, for packages which opt in to this new method.

Crucially, word wrapping was previously handled in two separate code paths--this unifies them and makes them user-selectable.

Finally, for decorated documentation:
1. Adds italicized sections with the `/` metacharacter.
2. Adds underlined sections with the `_` metacharacter.

These new decorations can be used to bedazzle packages:

```diff
diff --git a/repos/spack_repo/builtin/packages/coreutils/package.py b/repos/spack_repo/builtin/packages/coreutils/package.py
index 5c47ca0fb0b..63e2f0d9938 100644
--- a/repos/spack_repo/builtin/packages/coreutils/package.py
+++ b/repos/spack_repo/builtin/packages/coreutils/package.py
@@ -4,26 +4,34 @@
 
 import re
 
 from spack_repo.builtin.build_systems.autotools import AutotoolsPackage
 from spack_repo.builtin.build_systems.gnu import GNUMirrorPackage
 
 from spack.package import *
 
 
 class Coreutils(AutotoolsPackage, GNUMirrorPackage):
-    """The GNU Core Utilities are the basic file, shell and text
-    manipulation utilities of the GNU operating system.  These are
-    the core utilities which are expected to exist on every
-    operating system.
+    """The GNU Core Utilities are the @_y{basic} file, shell and text
+    manipulation utilities of the GNU operating system.
+
+    While many operating systems have programs with these names,
+    most of the programs in this package have significant advantages over their Unix
+    counterparts, such as greater speed, additional options, and fewer
+    arbitrary limits.
+
+    These are the @/r{core} utilities which are a necessary component of every operating system.
     """
+    docstring_uses_rich_text = True
+    docstring_has_extended_text = True
 
+    git = "git://git.sv.gnu.org/coreutils"
     homepage = "https://www.gnu.org/software/coreutils/"
     gnu_mirror_path = "coreutils/coreutils-8.26.tar.xz"
 
     tags = ["core-packages"]
 
     executables = [r"^(?:ck|md5|b2|sha256|sha384|sha512)sum$"]
 
     license("GPL-3.0-or-later")
 
     version("9.10", sha256="16535a9adf0b10037364e2d612aad3d9f4eca3a344949ced74d12faf4bd51d25")
```

This produces the following output:
<img width="1173" height="533" alt="spack-coreutils" src="https://github.com/user-attachments/assets/f978699e-6592-4d8e-8ac4-bea17ccc8879" />

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
