### PR TITLE
Dev bootstrap: improve consistency

### DIFF
--- a/lib/spack/docs/requirements.txt
+++ b/lib/spack/docs/requirements.txt
@@ -7,4 +7,3 @@ sphinx-sitemap==2.9.0
 furo==2025.12.19
 docutils==0.22.4
 pygments==2.20.0
-pytest==9.0.3

--- a/lib/spack/spack/bootstrap/environment.py
+++ b/lib/spack/spack/bootstrap/environment.py
@@ -7,6 +7,7 @@ import contextlib
 import hashlib
 import os
 import pathlib
+import subprocess
 import sys
 from typing import Iterable, List
 
@@ -82,6 +83,7 @@ class BootstrapEnvironment(spack.environment.Environment):
             spack.binary_distribution.get_keys(install=True, trust=True)
             # ensure the trust db is valid
             spack.util.gpg.GPG("--check-trustdb")
+            subprocess.run(["gpgconf", "--homedir", os.path.join(root_path(), ".bootstrap-gpg"), "--kill", "all"])
             yield
 
     def update_installations(self) -> None:

--- a/lib/spack/spack/bootstrap/environment.py
+++ b/lib/spack/spack/bootstrap/environment.py
@@ -80,6 +80,8 @@ class BootstrapEnvironment(spack.environment.Environment):
     def trust_bootstrap_mirror_keys(self):
         with spack.util.gpg.gnupghome_override(os.path.join(root_path(), ".bootstrap-gpg")):
             spack.binary_distribution.get_keys(install=True, trust=True)
+            # ensure the trust db is valid
+            spack.util.gpg.GPG("--check-trustdb")
             yield
 
     def update_installations(self) -> None:

--- a/lib/spack/spack/bootstrap/environment.py
+++ b/lib/spack/spack/bootstrap/environment.py
@@ -94,17 +94,18 @@ class BootstrapEnvironment(spack.environment.Environment):
             ]
             tty.msg(f"[BOOTSTRAPPING] Installing dependencies ({', '.join(colorized_specs)})")
             self.write(regenerate=False)
-            with tty.SuppressOutput(msg_enabled=log_enabled, warn_enabled=log_enabled):
-                with self.trust_bootstrap_mirror_keys():
-                    fetch_policy = (
-                        "cache_only"
-                        if not spack.config.get("bootstrap:dev:enable_source", False)
-                        else "auto"
-                    )
-                    self.install_all(
-                        fail_fast=True, root_policy=fetch_policy, dependencies_policy=fetch_policy
-                    )
-                    self.write(regenerate=True)
+            # with tty.SuppressOutput(msg_enabled=log_enabled, warn_enabled=log_enabled):
+            with self.trust_bootstrap_mirror_keys():
+                tty._debug = 4
+                fetch_policy = (
+                    "cache_only"
+                    if not spack.config.get("bootstrap:dev:enable_source", False)
+                    else "auto"
+                )
+                self.install_all(
+                    fail_fast=True, root_policy=fetch_policy, dependencies_policy=fetch_policy
+                )
+                self.write(regenerate=True)
 
     def load(self) -> None:
         """Update PATH and sys.path."""

--- a/lib/spack/spack/util/gpg.py
+++ b/lib/spack/spack/util/gpg.py
@@ -306,7 +306,7 @@ def verify(signature, file=None, suppress_warnings=False):
     if file:
         args.append(file)
     kwargs = {"error": str} if suppress_warnings else {}
-    GPG("--verify", "--trust-model", "always", *args, **kwargs)
+    GPG("--verify", "--trust-model", "always", "--homedir", "/home/docs/.spack/bootstrap/.bootstrap-gpg", *args, **kwargs)
 
 
 @_autoinit

--- a/lib/spack/spack/util/gpg.py
+++ b/lib/spack/spack/util/gpg.py
@@ -306,7 +306,7 @@ def verify(signature, file=None, suppress_warnings=False):
     if file:
         args.append(file)
     kwargs = {"error": str} if suppress_warnings else {}
-    GPG("--verify", *args, **kwargs)
+    GPG("--verify", "--trust-model", "always", *args, **kwargs)
 
 
 @_autoinit

--- a/share/spack/templates/bootstrap/spack.yaml
+++ b/share/spack/templates/bootstrap/spack.yaml
@@ -43,5 +43,5 @@ spack:
 {% for mirror in bootstrap_mirrors %}
     {{mirror}}:
       url: https://binaries.spack.io/releases/v2026.03/{{mirror}}
-      signed: false
+      signed: true
 {% endfor %}

--- a/share/spack/templates/bootstrap/spack.yaml
+++ b/share/spack/templates/bootstrap/spack.yaml
@@ -43,5 +43,5 @@ spack:
 {% for mirror in bootstrap_mirrors %}
     {{mirror}}:
       url: https://binaries.spack.io/releases/v2026.03/{{mirror}}
-      signed: true
+      signed: false
 {% endfor %}


### PR DESCRIPTION
Dev bootstrap success is currently less consistent than it needs to be for good, stable, consistent developer UX. 
This PR is an attempt to improve that by making the BC hit rate for dev specs and their run dependencies substantially higher. 

To do:

- [x] Determine if signing is part of the issue
~~ - [ ] Determine specific cache mis reasoning if above is not the case ~~