### PR TITLE
`$tempdir` - apply more constraints

### DIFF
--- a/lib/spack/spack/llnl/util/filesystem.py
+++ b/lib/spack/spack/llnl/util/filesystem.py
@@ -542,22 +542,8 @@ def get_owner_uid(path, err_msg=None) -> Union[str, int]:
      owning user.
 
     """
-    if not os.path.exists(path):
-        mkdirp(path, mode=stat.S_IRWXU)
-
-        p_stat = os.stat(path)
-        if p_stat.st_mode & stat.S_IRWXU != stat.S_IRWXU:
-            tty.error(
-                "Expected {0} to support mode {1}, but it is {2}".format(
-                    path, stat.S_IRWXU, p_stat.st_mode
-                )
-            )
-
-            raise OSError(errno.EACCES, err_msg.format(path, path) if err_msg else "")
-    else:
-        p_stat = os.stat(path)
-
     if sys.platform != "win32":
+        p_stat = os.lstat(path)
         owner_uid = p_stat.st_uid
     else:
         sid = win32security.GetFileSecurity(

--- a/lib/spack/spack/stage.py
+++ b/lib/spack/spack/stage.py
@@ -113,16 +113,28 @@ def create_stage_root(path: str) -> None:
     if user_node:
         user_paths.insert(0, user_node)
 
+    if user_paths:
+        mkdirp(user_paths[-1], mode=stat.S_IRWXU)
     for p in user_paths:
-        # Ensure access controls of subdirs from `$user` on down are
-        # restricted to the user.
-        owner_uid = get_owner_uid(p)
-        if user_uid != owner_uid:
-            tty.warn(
-                "Expected user {0} to own {1}, but it is owned by {2}".format(
-                    user_uid, p, owner_uid
+        if not sys.platform == "win32":
+            # Ensure access controls of subdirs from `$user` on down are
+            # restricted to the user.
+            owner_uid = get_owner_uid(p)
+            if user_uid != owner_uid:
+                raise OSError(
+                    errno.EACCES,
+                    f"Expected user {user_uid} to own {p}, but it is owned by {owner_uid}",
                 )
-            )
+
+            # And only the user should be able to write or read it
+            p_stat = os.lstat(p)
+            err_prefix = f"Cannot create stage root {path}:"
+            if not stat.S_ISDIR(p_stat.st_mode):
+                raise OSError(errno.ENOTDIR, f"{err_prefix} {p} is not a directory")
+            if (p_stat.st_mode & 0o777) != 0o700:
+                raise OSError(
+                    errno.EACCES, f"{err_prefix} {p} does not have {oct(0o700)} permissions"
+                )
 
     spack_src_subdir = os.path.join(path, _source_path_subdir)
     # When staging into a user-specified directory with `spack stage -p <PATH>`, we need

--- a/lib/spack/spack/stage.py
+++ b/lib/spack/spack/stage.py
@@ -7,6 +7,7 @@ import glob
 import hashlib
 import io
 import os
+import pathlib
 import shutil
 import stat
 import sys
@@ -174,7 +175,7 @@ def _resolve_paths(candidates):
     """
     temp_path = sup.canonicalize_path("$tempdir")
     user = sup.get_user()
-    tmp_has_usr = user in temp_path.split(os.path.sep)
+    tmp_has_usr = any(user in part for part in pathlib.Path(temp_path).parts)
 
     paths = []
     for path in candidates:

--- a/lib/spack/spack/test/config.py
+++ b/lib/spack/spack/test/config.py
@@ -456,7 +456,10 @@ def test_substitute_user_cache(mock_low_high_config):
 
 
 def test_substitute_tempdir(mock_low_high_config):
-    tempdir = tempfile.gettempdir()
+    if sys.platform == "win32":
+        tempdir = tempfile.gettempdir()
+    else:
+        tempdir = str(pathlib.Path(tempfile.gettempdir()) / f"spack-{spack_path.get_user()}")
     assert tempdir == spack_path.canonicalize_path("$tempdir")
     assert os.path.join(tempdir, "foo", "bar", "baz") == spack_path.canonicalize_path(
         os.path.join("$tempdir", "foo", "bar", "baz")

--- a/lib/spack/spack/test/stage.py
+++ b/lib/spack/spack/test/stage.py
@@ -735,7 +735,7 @@ class TestStage:
         assert spack.stage._resolve_paths([path_with_user]) == [path_with_user]
 
         canonicalized_tempdir = canonicalize_path("$tempdir")
-        temp_has_user = user in canonicalized_tempdir.split(os.sep)
+        temp_has_user = any(user in part for part in pathlib.Path(canonicalized_tempdir).parts)
         paths = [
             os.path.join("$tempdir", "stage"),
             os.path.join("$tempdir", "$user"),

--- a/lib/spack/spack/util/path.py
+++ b/lib/spack/spack/util/path.py
@@ -12,6 +12,7 @@ import getpass
 import os
 import pathlib
 import re
+import stat
 import subprocess
 import sys
 import tempfile
@@ -49,6 +50,55 @@ def get_user():
         return getpass.getuser()
 
 
+def get_tempdir():
+    """Get or create a per-user temporary directory for Spack.
+
+    We expect to be able to create a directory called ``spack-$user``
+    within the system-provided temporary directory that is owned
+    just by the user, and raise an error if we can't.
+
+    Returns:
+        str: Path to a secure temporary directory
+    """
+    system_tmp = tempfile.gettempdir()
+    if sys.platform == "win32":
+        return system_tmp
+
+    username = get_user()
+    system_tmp = pathlib.Path(system_tmp)
+    candidates = []
+    if username in system_tmp.parts:
+        candidates.append(os.path.join(system_tmp, "spack"))
+    candidates.append(os.path.join(system_tmp, f"spack-{username}"))
+    user_uid = os.getuid()
+
+    def make(path):
+        try:
+            os.mkdir(path, 0o700)
+        except FileExistsError:
+            stat_info = os.lstat(path)
+            if stat_info.st_uid != user_uid:
+                raise OSError(f"Intended Spack tempdir {path} not owned by {user_uid}")
+            if not stat.S_ISDIR(stat_info.st_mode):
+                raise OSError(f"{path} is not a directory")
+            if (stat_info.st_mode & 0o777) != 0o700:
+                raise OSError(
+                    f"Intended Spack tempdir {path} does not "
+                    f"have desired permissions {oct(stat_info.st_mode)}"
+                )
+
+        return path
+
+    for x in candidates[:-1]:
+        try:
+            return make(x)
+        except OSError as e:
+            tty.debug(f"tempdir candidate creation failed: {x}\n{str(e)}")
+            pass
+
+    return make(candidates[-1])
+
+
 # return value for replacements with no match
 NOMATCH = object()
 
@@ -65,7 +115,7 @@ def replacements():
     return {
         "spack": lambda: spack.paths.prefix,
         "user": lambda: get_user(),
-        "tempdir": lambda: tempfile.gettempdir(),
+        "tempdir": lambda: get_tempdir(),
         "user_cache_path": lambda: spack.paths.user_cache_path,
         "spack_instance_id": lambda: spack.paths.spack_instance_id,
         "architecture": lambda: arch,


### PR DESCRIPTION
Similar intention as https://github.com/spack/spack/pull/52330

This expects that if one asks for `$tempdir` , that Spack is allowed to create a directory called `spack-$user` in the tempdir root for just the user running Spack.
