### PR TITLE
new_installer.py: keep logs on failure

### DIFF
--- a/lib/spack/spack/new_installer.py
+++ b/lib/spack/spack/new_installer.py
@@ -2543,10 +2543,11 @@ class PackageInstaller:
         except Exception as e:
             spack.llnl.util.tty.debug(f"[{__name__}]: Failed to finalize reports: {e}]")
 
-        # Clean up temp log files now that reports have consumed them.
+        # Clean up temp log files of successful builds now that reports have consumed them.
         if not self.keep_stage:
-            for log_path in self.log_paths.values():
-                if log_path == os.devnull:
+            failed_hashes = {s.dag_hash() for s in failures}
+            for dag_hash, log_path in self.log_paths.items():
+                if log_path == os.devnull or dag_hash in failed_hashes:
                     continue
                 try:
                     os.unlink(log_path)

--- a/lib/spack/spack/test/installer.py
+++ b/lib/spack/spack/test/installer.py
@@ -1401,3 +1401,13 @@ def test_fallback_to_old_installer_for_splicing(monkeypatch, mock_packages, muta
     assert isinstance(
         spack.installer_dispatch.create_installer([out.package]), inst.PackageInstaller
     )
+
+
+@pytest.mark.disable_clean_stage_check
+def test_log_files_preserved_on_error(install_mockery, mock_fetch, installer_variant):
+    """Test that the log file is preserved when an install error occurs."""
+    pkg = spack.concretize.concretize_one("build-error").package
+    installer = spack.installer_dispatch.create_installer([pkg])
+    with pytest.raises(spack.error.InstallError):
+        installer.install()
+    assert os.path.exists(pkg.log_path)


### PR DESCRIPTION
Regressed in #52236, and it seems there was no test for it.