### PR TITLE
Don't display spurious warnings for buildcaches

### DIFF
--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -369,8 +369,7 @@ class BinaryCacheIndex:
                     except FetchIndexError as e:
                         fetch_errors.append(e)
                         self._last_fetch_times[urlAndVersion] = (now, False)
-                    except BuildcacheIndexNotExists as e:
-                        fetch_errors.append(e)
+                    except BuildcacheIndexNotExists:
                         self._last_fetch_times[urlAndVersion] = (now, False)
                         # Binary caches are not required to have an index, don't raise
                         # if it doesn't exist.
@@ -415,8 +414,7 @@ class BinaryCacheIndex:
             except FetchIndexError as e:
                 fetch_errors.append(e)
                 self._last_fetch_times[urlAndVersion] = (now, False)
-            except BuildcacheIndexNotExists as e:
-                fetch_errors.append(e)
+            except BuildcacheIndexNotExists:
                 self._last_fetch_times[urlAndVersion] = (now, False)
                 # Binary caches are not required to have an index, don't raise
                 # if it doesn't exist.
@@ -432,9 +430,9 @@ class BinaryCacheIndex:
         if configured_mirrors and all_methods_failed:
             raise FetchCacheError(fetch_errors)
         if fetch_errors:
-            tty.warn(
-                "The following issues were ignored while updating the indices of binary caches",
-                FetchCacheError(fetch_errors),
+            warnings.warn(
+                "The following issues were ignored while updating the indices of binary caches:\n"
+                + str(FetchCacheError(fetch_errors))
             )
         if spec_cache_regenerate_needed:
             self.regenerate_spec_cache(clear_existing=spec_cache_clear_needed)

--- a/lib/spack/spack/test/binary_distribution.py
+++ b/lib/spack/spack/test/binary_distribution.py
@@ -1488,35 +1488,3 @@ def test_mirror_metadata_with_view():
 
     with pytest.raises(spack.url_buildcache.MirrorMetadataError, match="Malformed string"):
         spack.binary_distribution.MirrorMetadata.from_string("https://dummy.io/__v3%asdf__@aview")
-
-
-@pytest.mark.usefixtures("install_mockery", "mock_packages", "mock_fetch")
-@pytest.mark.regression("52341")
-def test_no_warning_for_missing_v2_index_on_v3_mirror(
-    recwarn, monkeypatch, tmp_path: pathlib.Path, mutable_config
-):
-    """Tests that a v3-only mirror doesn't trigger a warning when Spack checks for a v2 index."""
-    index_cache_root = str(tmp_path / "index_cache")
-    monkeypatch.setattr(
-        spack.binary_distribution,
-        "BINARY_INDEX",
-        spack.binary_distribution.BinaryCacheIndex(index_cache_root),
-    )
-
-    mirror_dir = tmp_path / "mirror_dir"
-    mirror_url = url_util.path_to_file_url(str(mirror_dir))
-    mutable_config.set("mirrors", {"test": mirror_url})
-
-    # Create the cache
-    s = spack.concretize.concretize_one("libdwarf")
-    install_cmd("--fake", "--no-cache", s.name)
-    buildcache_cmd("push", "-u", str(mirror_dir), s.name)
-    buildcache_cmd("update-index", str(mirror_dir))
-
-    # Read the v3 cache
-    spack.binary_distribution.BINARY_INDEX = spack.binary_distribution.BinaryCacheIndex(
-        index_cache_root
-    )
-    buildcache_cmd("list", "-al")
-
-    assert not any("issues were ignored" in str(w.message) for w in recwarn.list)

--- a/lib/spack/spack/test/binary_distribution.py
+++ b/lib/spack/spack/test/binary_distribution.py
@@ -1488,3 +1488,35 @@ def test_mirror_metadata_with_view():
 
     with pytest.raises(spack.url_buildcache.MirrorMetadataError, match="Malformed string"):
         spack.binary_distribution.MirrorMetadata.from_string("https://dummy.io/__v3%asdf__@aview")
+
+
+@pytest.mark.usefixtures("install_mockery", "mock_packages", "mock_fetch")
+@pytest.mark.regression("52341")
+def test_no_warning_for_missing_v2_index_on_v3_mirror(
+    recwarn, monkeypatch, tmp_path: pathlib.Path, mutable_config
+):
+    """Tests that a v3-only mirror doesn't trigger a warning when Spack checks for a v2 index."""
+    index_cache_root = str(tmp_path / "index_cache")
+    monkeypatch.setattr(
+        spack.binary_distribution,
+        "BINARY_INDEX",
+        spack.binary_distribution.BinaryCacheIndex(index_cache_root),
+    )
+
+    mirror_dir = tmp_path / "mirror_dir"
+    mirror_url = url_util.path_to_file_url(str(mirror_dir))
+    mutable_config.set("mirrors", {"test": mirror_url})
+
+    # Create the cache
+    s = spack.concretize.concretize_one("libdwarf")
+    install_cmd("--fake", "--no-cache", s.name)
+    buildcache_cmd("push", "-u", str(mirror_dir), s.name)
+    buildcache_cmd("update-index", str(mirror_dir))
+
+    # Read the v3 cache
+    spack.binary_distribution.BINARY_INDEX = spack.binary_distribution.BinaryCacheIndex(
+        index_cache_root
+    )
+    buildcache_cmd("list", "-al")
+
+    assert not any("issues were ignored" in str(w.message) for w in recwarn.list)


### PR DESCRIPTION
fixes #52341 

Currently, when buildchache indexes do not exist, we emit a loud warning to the user. This warning is spurious most of the times, since we search unconditionally for both the v3 index and the v2 index (if the v3 index is found, the v2 index is not). Comments hint that:
```python
# Binary caches are not required to have an index, don't raise
# if it doesn't exist.
```
so here we stop emitting a loud warning in case an index is not found.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
