### PR TITLE
Simplify `BinaryCacheIndex.update` + some fixes

### DIFF
--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -417,22 +417,20 @@ class BinaryCacheIndex:
     ) -> Tuple[bool, bool]:
         items_to_remove = []
         clear, regenerate = False, not self._mirrors_for_spec
-        for cache_key in self._local_index_cache:
-            meta = MirrorMetadata.from_string(cache_key)
+
+        for local_index_key in self._local_index_cache:
+            meta = MirrorMetadata.from_string(local_index_key)
             if meta.version not in supported_mirror_versions.get((meta.url, meta.view), ()):
-                items_to_remove.append(
-                    {
-                        "url": cache_key,
-                        "cache_key": self._local_index_cache[cache_key]["index_path"],
-                    }
-                )
-                if meta in self._last_fetch_times:
-                    del self._last_fetch_times[meta]
+                index_file_key = self._local_index_cache[local_index_key]["index_path"]
+                items_to_remove.append((local_index_key, index_file_key, meta))
                 clear, regenerate = True, True
 
-        for item in items_to_remove:
-            self._index_file_cache.remove(item["cache_key"])
-            del self._local_index_cache[item["url"]]
+        for local_index_key, index_file_key, meta in items_to_remove:
+            if meta in self._last_fetch_times:
+                del self._last_fetch_times[meta]
+            self._index_file_cache.remove(index_file_key)
+            del self._local_index_cache[local_index_key]
+
         return clear, regenerate
 
     def _fetch_and_cache_index(self, mirror_metadata: MirrorMetadata, cache_entry={}):

--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -34,6 +34,7 @@ from typing import (
     Iterable,
     List,
     Mapping,
+    NamedTuple,
     Optional,
     Set,
     Tuple,
@@ -155,6 +156,13 @@ class FetchCacheError(Exception):
             err = errors[0]
             self.message = "{0}: {1}".format(err.__class__.__name__, str(err))
         super().__init__(self.message)
+
+
+class _MirrorIndexResult(NamedTuple):
+    succeeded: bool
+    regenerate: bool
+    had_cache_entry: bool
+    error: Optional[Exception]
 
 
 class BinaryCacheIndex:
@@ -324,60 +332,85 @@ class BinaryCacheIndex:
         # If we have a cached index for a mirror which is no longer configured, remove it
         clear_cache, regenerate_cache = self._remove_stale_cache_entries(supported_mirror_versions)
 
-        ttl = spack.config.CONFIG.get("config:binary_index_ttl", 600)
-        fetch_errors: List[Exception] = []
-        all_methods_failed = True
-        now = time.time()
-
+        # Fetch or update the other indexes
+        errors, all_failed = [], True
         for (url, view), versions in supported_mirror_versions.items():
-            for version in versions:
-                meta = MirrorMetadata(url, version, view)
-                cache_entry = self._local_index_cache.get(str(meta))
+            result = self._fetch_mirror_index(url, view, versions=versions, cooldown=with_cooldown)
+            if result.error:
+                errors.append(result.error)
 
-                if cache_entry is not None:
-                    in_cooldown = (
-                        with_cooldown
-                        and ttl > 0
-                        and meta in self._last_fetch_times
-                        and now - self._last_fetch_times[meta][0] < ttl
-                    )
-                    if in_cooldown:
-                        if self._last_fetch_times[meta][1]:
-                            all_methods_failed = False
-                        break
+            if result.succeeded:
+                all_failed = False
 
-                try:
-                    needs_regen = self._fetch_and_cache_index(meta, cache_entry=cache_entry or {})
-                    self._last_fetch_times[meta] = (now, True)
-                    all_methods_failed = False
-                except FetchIndexError as e:
-                    fetch_errors.append(e)
-                    self._last_fetch_times[meta] = (now, False)
-                    break
-                except BuildcacheIndexNotExists:
-                    self._last_fetch_times[meta] = (now, False)
-                    # Binary caches are not required to have an index
-                    all_methods_failed = False
-                    continue
-
-                regenerate_cache |= needs_regen
-                # A new mirror only needs regeneration, not clearing of existing entries.
-                clear_cache |= needs_regen and cache_entry is not None
-                break
+            regenerate_cache |= result.regenerate
+            clear_cache |= result.regenerate and result.had_cache_entry
 
         self._write_local_index_cache()
 
-        if supported_mirror_versions and all_methods_failed:
-            raise FetchCacheError(fetch_errors)
+        if supported_mirror_versions and all_failed:
+            raise FetchCacheError(errors)
 
-        if fetch_errors:
+        if errors:
             warnings.warn(
                 "The following issues were ignored while updating the indices of binary caches:\n"
-                + str(FetchCacheError(fetch_errors))
+                + str(FetchCacheError(errors))
             )
 
         if regenerate_cache:
             self.regenerate_spec_cache(clear_existing=clear_cache)
+
+    def _fetch_mirror_index(
+        self, url: str, view: str, *, versions: List[int], cooldown: bool
+    ) -> _MirrorIndexResult:
+        """Fetches the index of a mirror, using a highest-version first approach, and returning
+        after the first success.
+        """
+        now = time.time()
+        ttl = spack.config.CONFIG.get_config("config").get("binary_index_ttl", 600)
+        for version in versions:
+            meta = MirrorMetadata(url, version, view)
+            cache_entry = self._local_index_cache.get(str(meta))
+
+            if cache_entry is not None and (
+                # Cache entry in cooldown
+                cooldown
+                and ttl > 0
+                and meta in self._last_fetch_times
+                and now - self._last_fetch_times[meta][0] < ttl
+            ):
+                return _MirrorIndexResult(
+                    succeeded=self._last_fetch_times[meta][1],
+                    regenerate=False,
+                    had_cache_entry=True,
+                    error=None,
+                )
+
+            try:
+                regenerate = self._fetch_and_cache_index(meta, cache_entry=cache_entry or {})
+                self._last_fetch_times[meta] = (now, True)
+                return _MirrorIndexResult(
+                    succeeded=True,
+                    regenerate=regenerate,
+                    had_cache_entry=cache_entry is not None,
+                    error=None,
+                )
+            except FetchIndexError as e:
+                self._last_fetch_times[meta] = (now, False)
+                return _MirrorIndexResult(
+                    succeeded=False,
+                    regenerate=False,
+                    had_cache_entry=cache_entry is not None,
+                    error=e,
+                )
+            except BuildcacheIndexNotExists:
+                # Try next lower layout version
+                self._last_fetch_times[meta] = (now, False)
+                continue
+
+        # All versions reported no index found. This is not a failure
+        return _MirrorIndexResult(
+            succeeded=True, regenerate=False, had_cache_entry=False, error=None
+        )
 
     def _remove_stale_cache_entries(
         self, supported_mirror_versions: Dict[Tuple[str, Any], List[int]]

--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -26,7 +26,20 @@ import urllib.request
 import warnings
 from collections import defaultdict
 from contextlib import closing
-from typing import IO, Callable, Dict, Iterable, List, Mapping, Optional, Set, Tuple, Union, cast
+from typing import (
+    IO,
+    Any,
+    Callable,
+    Dict,
+    Iterable,
+    List,
+    Mapping,
+    Optional,
+    Set,
+    Tuple,
+    Union,
+    cast,
+)
 
 import spack.caches
 import spack.config
@@ -302,140 +315,92 @@ class BinaryCacheIndex:
         from each configured mirror and stored locally (both in memory and
         on disk under ``_index_cache_root``)."""
         self._init_local_index_cache()
-        configured_mirrors = [
-            MirrorMetadata(m.fetch_url, layout_version, m.fetch_view)
+
+        supported_mirror_versions = {
+            (m.fetch_url, m.fetch_view): m.supported_layout_versions
             for m in spack.mirrors.mirror.MirrorCollection(binary=True).values()
-            for layout_version in m.supported_layout_versions
-        ]
-        items_to_remove = []
-        spec_cache_clear_needed = False
-        spec_cache_regenerate_needed = not self._mirrors_for_spec
+        }
 
-        # First compare the mirror urls currently present in the cache to the
-        # configured mirrors.  If we have a cached index for a mirror which is
-        # no longer configured, we should remove it from the cache.  For any
-        # cached indices corresponding to currently configured mirrors, we need
-        # to check if the cache is still good, or needs to be updated.
-        # Finally, if there are configured mirrors for which we don't have a
-        # cache entry, we need to fetch and cache the indices from those
-        # mirrors.
+        # If we have a cached index for a mirror which is no longer configured, remove it
+        clear_cache, regenerate_cache = self._remove_stale_cache_entries(supported_mirror_versions)
 
-        # If, during this process, we find that any mirrors for which we
-        # already have entries have either been removed, or their index
-        # hash has changed, then our concrete spec cache (_mirrors_for_spec)
-        # likely has entries that need to be removed, so we will clear it
-        # and regenerate that data structure.
-
-        # If, during this process, we find that there are new mirrors for
-        # which do not yet have an entry in our index cache, then we simply
-        # need to regenerate the concrete spec cache, but do not need to
-        # clear it first.
-
-        # Otherwise the concrete spec cache should not need to be updated at
-        # all.
-
+        ttl = spack.config.CONFIG.get("config:binary_index_ttl", 600)
         fetch_errors: List[Exception] = []
         all_methods_failed = True
-        ttl = spack.config.get("config:binary_index_ttl", 600)
         now = time.time()
 
-        for local_index_cache_key in self._local_index_cache:
-            urlAndVersion = MirrorMetadata.from_string(local_index_cache_key)
-            cached_mirror_url = urlAndVersion.url
-            cache_entry = self._local_index_cache[local_index_cache_key]
-            cached_index_path = cache_entry["index_path"]
-            if urlAndVersion in configured_mirrors:
-                # Only do a fetch if the last fetch was longer than TTL ago
-                if (
-                    with_cooldown
-                    and ttl > 0
-                    and cached_mirror_url in self._last_fetch_times
-                    and now - self._last_fetch_times[urlAndVersion][0] < ttl
-                ):
-                    # We're in the cooldown period, don't try to fetch again
-                    # If the fetch succeeded last time, consider this update a success, otherwise
-                    # re-report the error here
-                    if self._last_fetch_times[urlAndVersion][1]:
-                        all_methods_failed = False
-                else:
-                    # May need to fetch the index and update the local caches
-                    needs_regen = False
-                    try:
-                        needs_regen = self._fetch_and_cache_index(
-                            urlAndVersion, cache_entry=cache_entry
-                        )
-                        self._last_fetch_times[urlAndVersion] = (now, True)
-                        all_methods_failed = False
-                    except FetchIndexError as e:
-                        fetch_errors.append(e)
-                        self._last_fetch_times[urlAndVersion] = (now, False)
-                    except BuildcacheIndexNotExists:
-                        self._last_fetch_times[urlAndVersion] = (now, False)
-                        # Binary caches are not required to have an index, don't raise
-                        # if it doesn't exist.
-                        all_methods_failed = False
+        for (url, view), versions in supported_mirror_versions.items():
+            for version in versions:
+                meta = MirrorMetadata(url, version, view)
+                cache_entry = self._local_index_cache.get(str(meta))
 
-                    # The need to regenerate implies a need to clear as well.
-                    spec_cache_clear_needed |= needs_regen
-                    spec_cache_regenerate_needed |= needs_regen
-            else:
-                # No longer have this mirror, cached index should be removed
-                items_to_remove.append(
-                    {
-                        "url": local_index_cache_key,
-                        "cache_key": os.path.join(self._index_cache_root, cached_index_path),
-                    }
-                )
-                if urlAndVersion in self._last_fetch_times:
-                    del self._last_fetch_times[urlAndVersion]
-                spec_cache_clear_needed = True
-                spec_cache_regenerate_needed = True
+                if cache_entry is not None:
+                    in_cooldown = (
+                        with_cooldown
+                        and ttl > 0
+                        and meta in self._last_fetch_times
+                        and now - self._last_fetch_times[meta][0] < ttl
+                    )
+                    if in_cooldown:
+                        if self._last_fetch_times[meta][1]:
+                            all_methods_failed = False
+                        break
 
-        # Clean up items to be removed, identified above
-        for item in items_to_remove:
-            url = item["url"]
-            cache_key = item["cache_key"]
-            self._index_file_cache.remove(cache_key)
-            del self._local_index_cache[url]
+                try:
+                    needs_regen = self._fetch_and_cache_index(meta, cache_entry=cache_entry or {})
+                    self._last_fetch_times[meta] = (now, True)
+                    all_methods_failed = False
+                except FetchIndexError as e:
+                    fetch_errors.append(e)
+                    self._last_fetch_times[meta] = (now, False)
+                    break
+                except BuildcacheIndexNotExists:
+                    self._last_fetch_times[meta] = (now, False)
+                    # Binary caches are not required to have an index
+                    all_methods_failed = False
+                    continue
 
-        # Iterate the configured mirrors now.  Any mirror urls we do not
-        # already have in our cache must be fetched, stored, and represented
-        # locally.
-        for urlAndVersion in configured_mirrors:
-            if str(urlAndVersion) in self._local_index_cache:
-                continue
-
-            # Need to fetch the index and update the local caches
-            needs_regen = False
-            try:
-                needs_regen = self._fetch_and_cache_index(urlAndVersion)
-                self._last_fetch_times[urlAndVersion] = (now, True)
-                all_methods_failed = False
-            except FetchIndexError as e:
-                fetch_errors.append(e)
-                self._last_fetch_times[urlAndVersion] = (now, False)
-            except BuildcacheIndexNotExists:
-                self._last_fetch_times[urlAndVersion] = (now, False)
-                # Binary caches are not required to have an index, don't raise
-                # if it doesn't exist.
-                all_methods_failed = False
-
-            # Generally speaking, a new mirror wouldn't imply the need to
-            # clear the spec cache, so leave it as is.
-            if needs_regen:
-                spec_cache_regenerate_needed = True
+                regenerate_cache |= needs_regen
+                # A new mirror only needs regeneration, not clearing of existing entries.
+                clear_cache |= needs_regen and cache_entry is not None
+                break
 
         self._write_local_index_cache()
 
-        if configured_mirrors and all_methods_failed:
+        if supported_mirror_versions and all_methods_failed:
             raise FetchCacheError(fetch_errors)
+
         if fetch_errors:
             warnings.warn(
                 "The following issues were ignored while updating the indices of binary caches:\n"
                 + str(FetchCacheError(fetch_errors))
             )
-        if spec_cache_regenerate_needed:
-            self.regenerate_spec_cache(clear_existing=spec_cache_clear_needed)
+
+        if regenerate_cache:
+            self.regenerate_spec_cache(clear_existing=clear_cache)
+
+    def _remove_stale_cache_entries(
+        self, supported_mirror_versions: Dict[Tuple[str, Any], List[int]]
+    ) -> Tuple[bool, bool]:
+        items_to_remove = []
+        clear, regenerate = False, not self._mirrors_for_spec
+        for cache_key in list(self._local_index_cache.keys()):
+            meta = MirrorMetadata.from_string(cache_key)
+            if meta.version not in supported_mirror_versions.get((meta.url, meta.view), ()):
+                items_to_remove.append(
+                    {
+                        "url": cache_key,
+                        "cache_key": self._local_index_cache[cache_key]["index_path"],
+                    }
+                )
+                if meta in self._last_fetch_times:
+                    del self._last_fetch_times[meta]
+                clear, regenerate = True, True
+
+        for item in items_to_remove:
+            self._index_file_cache.remove(item["cache_key"])
+            del self._local_index_cache[item["url"]]
+        return clear, regenerate
 
     def _fetch_and_cache_index(self, mirror_metadata: MirrorMetadata, cache_entry={}):
         """Fetch a buildcache index file from a remote mirror and cache it.

--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -165,6 +165,11 @@ class _MirrorIndexResult(NamedTuple):
     error: Optional[Exception]
 
 
+class _LastFetch(NamedTuple):
+    time: float
+    succeeded: bool
+
+
 class BinaryCacheIndex:
     """
     The BinaryCacheIndex tracks what specs are available on (usually remote)
@@ -199,7 +204,7 @@ class BinaryCacheIndex:
 
         # mapping from mirror urls to the time.time() of the last index fetch and a bool indicating
         # whether the fetch succeeded or not.
-        self._last_fetch_times: Dict[MirrorMetadata, Tuple[float, bool]] = {}
+        self._last_fetch_times: Dict[MirrorMetadata, _LastFetch] = {}
 
         #: Dictionary mapping DAG hashes of specs to Spec objects
         self._known_specs: Dict[str, spack.spec.Spec] = {}
@@ -376,10 +381,10 @@ class BinaryCacheIndex:
                 cooldown
                 and ttl > 0
                 and meta in self._last_fetch_times
-                and now - self._last_fetch_times[meta][0] < ttl
+                and now - self._last_fetch_times[meta].time < ttl
             ):
                 return _MirrorIndexResult(
-                    succeeded=self._last_fetch_times[meta][1],
+                    succeeded=self._last_fetch_times[meta].succeeded,
                     regenerate=False,
                     had_cache_entry=True,
                     error=None,
@@ -387,7 +392,7 @@ class BinaryCacheIndex:
 
             try:
                 regenerate = self._fetch_and_cache_index(meta, cache_entry=cache_entry or {})
-                self._last_fetch_times[meta] = (now, True)
+                self._last_fetch_times[meta] = _LastFetch(time=now, succeeded=True)
                 return _MirrorIndexResult(
                     succeeded=True,
                     regenerate=regenerate,
@@ -395,7 +400,7 @@ class BinaryCacheIndex:
                     error=None,
                 )
             except FetchIndexError as e:
-                self._last_fetch_times[meta] = (now, False)
+                self._last_fetch_times[meta] = _LastFetch(time=now, succeeded=False)
                 return _MirrorIndexResult(
                     succeeded=False,
                     regenerate=False,
@@ -404,7 +409,7 @@ class BinaryCacheIndex:
                 )
             except BuildcacheIndexNotExists:
                 # Try next lower layout version
-                self._last_fetch_times[meta] = (now, False)
+                self._last_fetch_times[meta] = _LastFetch(time=now, succeeded=False)
                 continue
 
         # All versions reported no index found. This is not a failure

--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -413,6 +413,7 @@ class BinaryCacheIndex:
                 continue
 
         # All versions reported no index found. This is not a failure
+        warnings.warn(f"the mirror at {url} cannot be used in concretization (no index found)")
         return _MirrorIndexResult(
             succeeded=True, regenerate=False, had_cache_entry=False, error=None
         )

--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -417,7 +417,7 @@ class BinaryCacheIndex:
     ) -> Tuple[bool, bool]:
         items_to_remove = []
         clear, regenerate = False, not self._mirrors_for_spec
-        for cache_key in list(self._local_index_cache.keys()):
+        for cache_key in self._local_index_cache:
             meta = MirrorMetadata.from_string(cache_key)
             if meta.version not in supported_mirror_versions.get((meta.url, meta.view), ()):
                 items_to_remove.append(

--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -111,6 +111,7 @@ from .url_buildcache import (
     get_url_buildcache_class,
     get_valid_spec_file,
 )
+from .vendor.typing_extensions import TypedDict
 
 
 class BuildCacheDatabase(spack.database.Database):
@@ -170,6 +171,12 @@ class _LastFetch(NamedTuple):
     succeeded: bool
 
 
+class _LocalIndexCache(TypedDict, total=False):
+    index_hash: str
+    index_path: str
+    etag: str
+
+
 class BinaryCacheIndex:
     """
     The BinaryCacheIndex tracks what specs are available on (usually remote)
@@ -196,7 +203,7 @@ class BinaryCacheIndex:
         self._index_file_cache_initialized = False
 
         # stores a map of mirror URL and version layout to index hash and cache key (index path)
-        self._local_index_cache: dict[str, dict] = {}
+        self._local_index_cache: dict[str, _LocalIndexCache] = {}
 
         # hashes of remote indices already ingested into the concrete spec
         # cache (_mirrors_for_spec)

--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -369,8 +369,7 @@ class BinaryCacheIndex:
                     except FetchIndexError as e:
                         fetch_errors.append(e)
                         self._last_fetch_times[urlAndVersion] = (now, False)
-                    except BuildcacheIndexNotExists as e:
-                        fetch_errors.append(e)
+                    except BuildcacheIndexNotExists:
                         self._last_fetch_times[urlAndVersion] = (now, False)
                         # Binary caches are not required to have an index, don't raise
                         # if it doesn't exist.
@@ -415,8 +414,7 @@ class BinaryCacheIndex:
             except FetchIndexError as e:
                 fetch_errors.append(e)
                 self._last_fetch_times[urlAndVersion] = (now, False)
-            except BuildcacheIndexNotExists as e:
-                fetch_errors.append(e)
+            except BuildcacheIndexNotExists:
                 self._last_fetch_times[urlAndVersion] = (now, False)
                 # Binary caches are not required to have an index, don't raise
                 # if it doesn't exist.
@@ -432,9 +430,9 @@ class BinaryCacheIndex:
         if configured_mirrors and all_methods_failed:
             raise FetchCacheError(fetch_errors)
         if fetch_errors:
-            tty.warn(
-                "The following issues were ignored while updating the indices of binary caches",
-                FetchCacheError(fetch_errors),
+            warnings.warn(
+                "The following issues were ignored while updating the indices of binary caches:\n"
+                + str(FetchCacheError(fetch_errors))
             )
         if spec_cache_regenerate_needed:
             self.regenerate_spec_cache(clear_existing=spec_cache_clear_needed)

--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -432,8 +432,7 @@ class BinaryCacheIndex:
                 clear, regenerate = True, True
 
         for local_index_key, index_file_key, meta in items_to_remove:
-            if meta in self._last_fetch_times:
-                del self._last_fetch_times[meta]
+            self._last_fetch_times.pop(meta, None)
             self._index_file_cache.remove(index_file_key)
             del self._local_index_cache[local_index_key]
 

--- a/lib/spack/spack/test/binary_distribution.py
+++ b/lib/spack/spack/test/binary_distribution.py
@@ -1488,3 +1488,20 @@ def test_mirror_metadata_with_view():
 
     with pytest.raises(spack.url_buildcache.MirrorMetadataError, match="Malformed string"):
         spack.binary_distribution.MirrorMetadata.from_string("https://dummy.io/__v3%asdf__@aview")
+
+
+def test_update_warns_on_mirror_with_no_index(monkeypatch, tmp_path: pathlib.Path, mutable_config):
+    """Tests that BinaryCacheIndex.update() warns when a mirror has no index for any supported
+    layout version.
+    """
+    mirror_url = url_util.path_to_file_url(str(tmp_path / "mirror_dir"))
+    spack.config.set("mirrors", {"test": mirror_url})
+
+    def no_index(*args, **kwargs):
+        raise spack.binary_distribution.BuildcacheIndexNotExists("no index")
+
+    binary_index = spack.binary_distribution.BinaryCacheIndex(str(tmp_path / "index_cache"))
+    monkeypatch.setattr(binary_index, "_fetch_and_cache_index", no_index)
+
+    with pytest.warns(UserWarning, match="cannot be used in concretization"):
+        binary_index.update()

--- a/lib/spack/spack/test/binary_distribution.py
+++ b/lib/spack/spack/test/binary_distribution.py
@@ -1488,35 +1488,3 @@ def test_mirror_metadata_with_view():
 
     with pytest.raises(spack.url_buildcache.MirrorMetadataError, match="Malformed string"):
         spack.binary_distribution.MirrorMetadata.from_string("https://dummy.io/__v3%asdf__@aview")
-
-
-@pytest.mark.usefixtures("install_mockery", "mock_packages", "mock_fetch")
-@pytest.mark.regression("52341")
-def test_no_warning_for_missing_v2_index_on_v3_mirror(
-    recwarn, monkeypatch, tmp_path: pathlib.Path, mutable_config
-):
-    """Tests that a v3-only mirror doesn't trigger a warning when Spack checks for a v2 index."""
-    index_cache_root = str(tmp_path / "index_cache")
-    monkeypatch.setattr(
-        spack.binary_distribution,
-        "BINARY_INDEX",
-        spack.binary_distribution.BinaryCacheIndex(index_cache_root),
-    )
-
-    mirror_dir = tmp_path / "mirror_dir"
-    mirror_url = url_util.path_to_file_url(str(mirror_dir))
-    mutable_config.set("mirrors", {"test": mirror_url})
-
-    # Create the cache
-    s = spack.concretize.concretize_one("libdwarf")
-    install_cmd("--fake", "--no-cache", s.name)
-    buildcache_cmd("push", "-u", str(mirror_dir), s.name)
-    buildcache_cmd("update-index", str(mirror_dir))
-
-    # Read the v3 cache
-    spack.binary_distribution.BINARY_INDEX = spack.binary_distribution.BinaryCacheIndex(
-        index_cache_root
-    )
-    buildcache_cmd("list", "-al")
-
-    assert not any("issues were ignored" in str(w.message) for w in recwarn.list)

--- a/lib/spack/spack/test/binary_distribution.py
+++ b/lib/spack/spack/test/binary_distribution.py
@@ -1488,3 +1488,35 @@ def test_mirror_metadata_with_view():
 
     with pytest.raises(spack.url_buildcache.MirrorMetadataError, match="Malformed string"):
         spack.binary_distribution.MirrorMetadata.from_string("https://dummy.io/__v3%asdf__@aview")
+
+
+@pytest.mark.usefixtures("install_mockery", "mock_packages", "mock_fetch")
+@pytest.mark.regression("52341")
+def test_no_warning_for_missing_v2_index_on_v3_mirror(
+    recwarn, monkeypatch, tmp_path: pathlib.Path, mutable_config
+):
+    """Tests that a v3-only mirror doesn't trigger a warning when Spack checks for a v2 index."""
+    index_cache_root = str(tmp_path / "index_cache")
+    monkeypatch.setattr(
+        spack.binary_distribution,
+        "BINARY_INDEX",
+        spack.binary_distribution.BinaryCacheIndex(index_cache_root),
+    )
+
+    mirror_dir = tmp_path / "mirror_dir"
+    mirror_url = url_util.path_to_file_url(str(mirror_dir))
+    mutable_config.set("mirrors", {"test": mirror_url})
+
+    # Create the cache
+    s = spack.concretize.concretize_one("libdwarf")
+    install_cmd("--fake", "--no-cache", s.name)
+    buildcache_cmd("push", "-u", str(mirror_dir), s.name)
+    buildcache_cmd("update-index", str(mirror_dir))
+
+    # Read the v3 cache
+    spack.binary_distribution.BINARY_INDEX = spack.binary_distribution.BinaryCacheIndex(
+        index_cache_root
+    )
+    buildcache_cmd("list", "-al")
+
+    assert not any("issues were ignored" in str(w.message) for w in recwarn.list)

--- a/lib/spack/spack/url_buildcache.py
+++ b/lib/spack/spack/url_buildcache.py
@@ -1380,7 +1380,7 @@ class MirrorMetadata:
         return hash((self.url, self.version, self.view))
 
     @classmethod
-    def from_string(cls, s: str):
+    def from_string(cls, s: str) -> "MirrorMetadata":
         m = re.match(r"^(.*)__v([0-9]+)(?:__(.*))?$", s)
         if not m:
             raise MirrorMetadataError(f"Malformed string {s}")


### PR DESCRIPTION
depends #52343

Modifications:
1. Extract stale cache removal into its own method.
2. Unify two loops over existing mirrors already in cache and existing mirrors not in cache, sharing an identical body, with a single loop that doesn't check if a mirror is or is not in cache.
3. Fix a locking bug for stale cache removal, which resulted in the wrong path for a lock being computed.[^1]
4. Fix a bug introduced in #48713 that made cooldown effectively dead code.[^2]
5. Add a warning when a mirror doesn't have an index that it cannot be used in concretization


[^1]: `FileCache.remove` expects a relative path, but gets an absolute one. Using an absolute path instead makes the removal work, but the lock computes a different offset.

[^2]: `cached_mirror_url in self._last_fetch_times` is always False, since the item is a `str` and the keys are `MirrorMetadata`
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
