### PR TITLE
file_cache.py: use str key

### DIFF
--- a/lib/spack/spack/util/file_cache.py
+++ b/lib/spack/spack/util/file_cache.py
@@ -114,7 +114,7 @@ class FileCache:
         self.root.mkdir(parents=True, exist_ok=True)
 
         self.lock_path = self.root / ".lock"
-        self._locks: Dict[Union[pathlib.Path, str], Lock] = {}
+        self._locks: Dict[str, Lock] = {}
         self.lock_timeout = timeout
 
     def destroy(self):


### PR DESCRIPTION
Allowing `Path | str` is a mistake, since they can be distinct but map to the same file, meaning there could be two lock instances for the same entry.

