### PR TITLE
mirror.py: add type-hints and minor cleanup

### DIFF
--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -372,7 +372,7 @@ class BinaryCacheIndex:
             self.regenerate_spec_cache(clear_existing=clear_cache)
 
     def _fetch_mirror_index(
-        self, url: str, view: str, *, versions: List[int], cooldown: bool
+        self, url: str, view: Optional[str], *, versions: List[int], cooldown: bool
     ) -> _MirrorIndexResult:
         """Fetches the index of a mirror, using a highest-version first approach, and returning
         after the first success.

--- a/lib/spack/spack/mirrors/mirror.py
+++ b/lib/spack/spack/mirrors/mirror.py
@@ -480,6 +480,8 @@ class MirrorCollection(Mapping[str, Mirror]):
         return self._mirrors[item]
 
     def display(self) -> None:
+        if not self._mirrors:
+            return
         max_len = max(len(mirror.name) for mirror in self._mirrors.values())
         for mirror in self._mirrors.values():
             mirror.display(max_len)

--- a/lib/spack/spack/mirrors/mirror.py
+++ b/lib/spack/spack/mirrors/mirror.py
@@ -9,7 +9,6 @@ from typing import IO, Any, Dict, Iterator, List, Mapping, Optional, Tuple, Unio
 import spack.config
 import spack.llnl.util.tty as tty
 import spack.util.path
-import spack.util.spack_json as sjson
 import spack.util.spack_yaml as syaml
 import spack.util.url as url_util
 from spack.error import MirrorError
@@ -53,13 +52,6 @@ class Mirror:
         return Mirror(syaml.load(stream), name)
 
     @staticmethod
-    def from_json(stream: Union[str, IO[str]], name: Optional[str] = None) -> "Mirror":
-        try:
-            return Mirror(sjson.load(stream), name)
-        except Exception as e:
-            raise sjson.SpackJSONError("error parsing JSON mirror:", e) from e
-
-    @staticmethod
     def from_local_path(path: str) -> "Mirror":
         return Mirror(url_util.path_to_file_url(path))
 
@@ -83,18 +75,6 @@ class Mirror:
 
     def __repr__(self) -> str:
         return f"Mirror(name={self._name!r}, data={self._data!r})"
-
-    @overload
-    def to_json(self, stream: None = ...) -> str: ...
-
-    @overload
-    def to_json(self, stream: IO[str]) -> None: ...
-
-    def to_json(self, stream: Optional[IO[str]] = None) -> Optional[str]:
-        if stream is None:
-            return sjson.dumps(self.to_dict())
-        sjson.dump(self.to_dict(), stream)
-        return None
 
     @overload
     def to_yaml(self, stream: None = ...) -> str: ...
@@ -462,26 +442,6 @@ class MirrorCollection(Mapping[str, Mirror]):
         if not isinstance(other, MirrorCollection):
             return NotImplemented
         return self._mirrors == other._mirrors
-
-    @overload
-    def to_json(self, stream: None = ...) -> str: ...
-
-    @overload
-    def to_json(self, stream: IO[str]) -> None: ...
-
-    def to_json(self, stream: Optional[IO[str]] = None) -> Optional[str]:
-        if stream is None:
-            return sjson.dumps(self.to_dict(True))
-        sjson.dump(self.to_dict(True), stream)
-        return None
-
-    @staticmethod
-    def from_json(stream: Union[str, IO[str]]) -> "MirrorCollection":
-        try:
-            d = sjson.load(stream)
-            return MirrorCollection(d)
-        except Exception as e:
-            raise sjson.SpackJSONError("error parsing JSON mirror collection:", e) from e
 
     def to_dict(self, recursive: bool = False) -> Dict[str, Any]:
         return syaml.syaml_dict(

--- a/lib/spack/spack/mirrors/mirror.py
+++ b/lib/spack/spack/mirrors/mirror.py
@@ -105,7 +105,8 @@ class Mirror:
     def to_yaml(self, stream: Optional[IO[str]] = None) -> Optional[str]:
         return syaml.dump(self.to_dict(), stream)
 
-    def to_dict(self):
+    def to_dict(self) -> Union[str, dict]:
+        # Mirrors configured as a plain URL are stored as a string in the config schema
         return self._data
 
     def display(self, max_len: int = 0) -> None:
@@ -419,8 +420,8 @@ class MirrorCollection(Mapping[str, Mirror]):
 
     def __init__(
         self,
-        mirrors=None,
-        scope=None,
+        mirrors: Optional[Mapping[str, Any]] = None,
+        scope: Optional[str] = None,
         binary: Optional[bool] = None,
         source: Optional[bool] = None,
         autopush: Optional[bool] = None,
@@ -482,7 +483,7 @@ class MirrorCollection(Mapping[str, Mirror]):
         except Exception as e:
             raise sjson.SpackJSONError("error parsing JSON mirror collection:", e) from e
 
-    def to_dict(self, recursive=False):
+    def to_dict(self, recursive: bool = False) -> Dict[str, Any]:
         return syaml.syaml_dict(
             sorted(
                 ((k, (v.to_dict() if recursive else v)) for (k, v) in self._mirrors.items()),
@@ -491,7 +492,7 @@ class MirrorCollection(Mapping[str, Mirror]):
         )
 
     @staticmethod
-    def from_dict(d):
+    def from_dict(d: Mapping[str, Any]) -> "MirrorCollection":
         return MirrorCollection(d)
 
     def __getitem__(self, item: str) -> Mirror:

--- a/lib/spack/spack/mirrors/mirror.py
+++ b/lib/spack/spack/mirrors/mirror.py
@@ -137,12 +137,12 @@ class Mirror:
     @property
     def fetch_view(self) -> Optional[str]:
         """Get the fetch view"""
-        return self.get_view("fetch")
+        return self._get_value("view", direction="fetch")
 
     @property
     def push_view(self) -> Optional[str]:
         """Get the push view"""
-        return self.get_view("push")
+        return self._get_value("view", direction="push")
 
     def ensure_mirror_usable(self, direction: str = "push") -> None:
         access_pair = self._get_value("access_pair", direction)
@@ -337,9 +337,6 @@ class Mirror:
             raise ValueError(f"Mirror {self.name} has no URL configured")
 
         return _url_or_path_to_url(url)
-
-    def get_view(self, direction: str) -> Optional[str]:
-        return self._get_value("view", direction)
 
     def get_credentials(self, direction: str) -> Dict[str, Any]:
         """Get the mirror credentials from the mirror config

--- a/lib/spack/spack/mirrors/mirror.py
+++ b/lib/spack/spack/mirrors/mirror.py
@@ -4,7 +4,7 @@
 import operator
 import os
 import urllib.parse
-from typing import Any, Dict, List, Mapping, Optional, Tuple, Union
+from typing import IO, Any, Dict, Iterator, List, Mapping, Optional, Tuple, Union
 
 import spack.config
 import spack.llnl.util.tty as tty
@@ -44,7 +44,7 @@ class Mirror:
     to them. These two URLs are usually the same.
     """
 
-    def __init__(self, data: Union[str, dict], name: Optional[str] = None):
+    def __init__(self, data: Union[str, dict], name: Optional[str] = None) -> None:
         self._data = data
         self._name = name
 
@@ -60,11 +60,11 @@ class Mirror:
             raise sjson.SpackJSONError("error parsing JSON mirror:", e) from e
 
     @staticmethod
-    def from_local_path(path: str):
+    def from_local_path(path: str) -> "Mirror":
         return Mirror(url_util.path_to_file_url(path))
 
     @staticmethod
-    def from_url(url: str):
+    def from_url(url: str) -> "Mirror":
         """Create an anonymous mirror by URL. This method validates the URL."""
         if urllib.parse.urlparse(url).scheme not in supported_url_schemes:
             raise ValueError(
@@ -73,15 +73,15 @@ class Mirror:
             )
         return Mirror(url)
 
-    def __eq__(self, other):
+    def __eq__(self, other: object) -> bool:
         if not isinstance(other, Mirror):
             return NotImplemented
         return self._data == other._data and self._name == other._name
 
-    def __str__(self):
+    def __str__(self) -> str:
         return f"{self._name}: {self.push_url} {self.fetch_url}"
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return f"Mirror(name={self._name!r}, data={self._data!r})"
 
     def to_json(self, stream=None):
@@ -96,7 +96,7 @@ class Mirror:
     def to_dict(self):
         return self._data
 
-    def display(self, max_len=0):
+    def display(self, max_len: int = 0) -> None:
         fetch, push = self.fetch_url, self.push_url
         # don't print the same URL twice
         url = fetch if fetch == push else f"fetch: {fetch} push: {push}"
@@ -105,15 +105,15 @@ class Mirror:
         print(f"{self.name: <{max_len}} [{source}{binary}] {url}")
 
     @property
-    def name(self):
+    def name(self) -> str:
         return self._name or "<unnamed>"
 
     @property
-    def binary(self):
+    def binary(self) -> bool:
         return isinstance(self._data, str) or self._data.get("binary", True)
 
     @property
-    def source(self):
+    def source(self) -> bool:
         return isinstance(self._data, str) or self._data.get("source", True)
 
     @property
@@ -132,26 +132,26 @@ class Mirror:
         return self._data.get("autopush", False)
 
     @property
-    def fetch_url(self):
+    def fetch_url(self) -> str:
         """Get the valid, canonicalized fetch URL"""
         return self.get_url("fetch")
 
     @property
-    def push_url(self):
-        """Get the valid, canonicalized fetch URL"""
+    def push_url(self) -> str:
+        """Get the valid, canonicalized push URL"""
         return self.get_url("push")
 
     @property
-    def fetch_view(self):
-        """Get the valid, canonicalized fetch URL"""
+    def fetch_view(self) -> Optional[str]:
+        """Get the fetch view"""
         return self.get_view("fetch")
 
     @property
-    def push_view(self):
-        """Get the valid, canonicalized fetch URL"""
+    def push_view(self) -> Optional[str]:
+        """Get the push view"""
         return self.get_view("push")
 
-    def ensure_mirror_usable(self, direction: str = "push"):
+    def ensure_mirror_usable(self, direction: str = "push") -> None:
         access_pair = self._get_value("access_pair", direction)
         access_token_variable = self._get_value("access_token_variable", direction)
 
@@ -199,7 +199,7 @@ class Mirror:
 
         return supported_versions
 
-    def _update_connection_dict(self, current_data: dict, new_data: dict, top_level: bool):
+    def _update_connection_dict(self, current_data: dict, new_data: dict, top_level: bool) -> bool:
         # Only allow one to exist in the config
         if "access_token" in current_data and "access_token_variable" in new_data:
             current_data.pop("access_token")
@@ -239,7 +239,7 @@ class Mirror:
                 changed = True
         return changed
 
-    def update(self, data: dict, direction: Optional[str] = None) -> bool:
+    def update(self, data: Dict[str, Any], direction: Optional[str] = None) -> bool:
         """Modify the mirror with the given data. This takes care
         of expanding trivial mirror definitions by URL to something more
         rich with a dict if necessary
@@ -303,7 +303,7 @@ class Mirror:
 
         return self._update_connection_dict(self._data[direction], data, top_level=False)
 
-    def _get_value(self, attribute: str, direction: str):
+    def _get_value(self, attribute: str, direction: str) -> Any:
         """Returns the most specific value for a given attribute (either push/fetch or global)"""
         if direction not in ("fetch", "push"):
             raise ValueError(f"direction must be either 'fetch' or 'push', not {direction}")
@@ -345,7 +345,7 @@ class Mirror:
 
         return _url_or_path_to_url(url)
 
-    def get_view(self, direction: str):
+    def get_view(self, direction: str) -> Optional[str]:
         return self._get_value("view", direction)
 
     def get_credentials(self, direction: str) -> Dict[str, Any]:
@@ -447,7 +447,9 @@ class MirrorCollection(Mapping[str, Mirror]):
 
         self._mirrors = {m.name: m for m in mirrors if _filter(m)}
 
-    def __eq__(self, other):
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, MirrorCollection):
+            return NotImplemented
         return self._mirrors == other._mirrors
 
     def to_json(self, stream=None):
@@ -456,17 +458,17 @@ class MirrorCollection(Mapping[str, Mirror]):
         sjson.dump(self.to_dict(True), stream)
         return None
 
-    def to_yaml(self, stream=None):
+    def to_yaml(self, stream: Optional[IO[str]] = None) -> Optional[str]:
         return syaml.dump(self.to_dict(True), stream)
 
     # TODO: this isn't called anywhere
     @staticmethod
-    def from_yaml(stream, name=None):
+    def from_yaml(stream: Union[str, IO[str]], name: Optional[str] = None) -> "MirrorCollection":
         data = syaml.load(stream)
         return MirrorCollection(data)
 
     @staticmethod
-    def from_json(stream, name=None):
+    def from_json(stream: IO, name: Optional[str] = None) -> "MirrorCollection":
         try:
             d = sjson.load(stream)
             return MirrorCollection(d)
@@ -485,15 +487,15 @@ class MirrorCollection(Mapping[str, Mirror]):
     def from_dict(d):
         return MirrorCollection(d)
 
-    def __getitem__(self, item):
+    def __getitem__(self, item: str) -> Mirror:
         return self._mirrors[item]
 
-    def display(self):
+    def display(self) -> None:
         max_len = max(len(mirror.name) for mirror in self._mirrors.values())
         for mirror in self._mirrors.values():
             mirror.display(max_len)
 
-    def lookup(self, name_or_url):
+    def lookup(self, name_or_url: str) -> Mirror:
         """Looks up and returns a Mirror.
 
         If this MirrorCollection contains a named Mirror under the name
@@ -504,12 +506,12 @@ class MirrorCollection(Mapping[str, Mirror]):
         result = self.get(name_or_url)
 
         if result is None:
-            result = Mirror(fetch=name_or_url)
+            result = Mirror(name_or_url)
 
         return result
 
-    def __iter__(self):
+    def __iter__(self) -> Iterator[str]:
         return iter(self._mirrors)
 
-    def __len__(self):
+    def __len__(self) -> int:
         return len(self._mirrors)

--- a/lib/spack/spack/mirrors/mirror.py
+++ b/lib/spack/spack/mirrors/mirror.py
@@ -4,7 +4,7 @@
 import operator
 import os
 import urllib.parse
-from typing import IO, Any, Dict, Iterator, List, Mapping, Optional, Tuple, Union
+from typing import Any, Dict, Iterator, List, Mapping, Optional, Tuple, Union
 
 import spack.config
 import spack.llnl.util.tty as tty
@@ -457,7 +457,7 @@ class MirrorCollection(Mapping[str, Mirror]):
         return None
 
     @staticmethod
-    def from_json(stream: IO, name: Optional[str] = None) -> "MirrorCollection":
+    def from_json(stream) -> "MirrorCollection":
         try:
             d = sjson.load(stream)
             return MirrorCollection(d)

--- a/lib/spack/spack/mirrors/mirror.py
+++ b/lib/spack/spack/mirrors/mirror.py
@@ -458,15 +458,6 @@ class MirrorCollection(Mapping[str, Mirror]):
         sjson.dump(self.to_dict(True), stream)
         return None
 
-    def to_yaml(self, stream: Optional[IO[str]] = None) -> Optional[str]:
-        return syaml.dump(self.to_dict(True), stream)
-
-    # TODO: this isn't called anywhere
-    @staticmethod
-    def from_yaml(stream: Union[str, IO[str]], name: Optional[str] = None) -> "MirrorCollection":
-        data = syaml.load(stream)
-        return MirrorCollection(data)
-
     @staticmethod
     def from_json(stream: IO, name: Optional[str] = None) -> "MirrorCollection":
         try:

--- a/lib/spack/spack/mirrors/mirror.py
+++ b/lib/spack/spack/mirrors/mirror.py
@@ -4,7 +4,7 @@
 import operator
 import os
 import urllib.parse
-from typing import Any, Dict, Iterator, List, Mapping, Optional, Tuple, Union
+from typing import IO, Any, Dict, Iterator, List, Mapping, Optional, Tuple, Union, overload
 
 import spack.config
 import spack.llnl.util.tty as tty
@@ -49,11 +49,11 @@ class Mirror:
         self._name = name
 
     @staticmethod
-    def from_yaml(stream, name=None):
+    def from_yaml(stream: Union[str, IO[str]], name: Optional[str] = None) -> "Mirror":
         return Mirror(syaml.load(stream), name)
 
     @staticmethod
-    def from_json(stream, name=None):
+    def from_json(stream: Union[str, IO[str]], name: Optional[str] = None) -> "Mirror":
         try:
             return Mirror(sjson.load(stream), name)
         except Exception as e:
@@ -84,13 +84,25 @@ class Mirror:
     def __repr__(self) -> str:
         return f"Mirror(name={self._name!r}, data={self._data!r})"
 
-    def to_json(self, stream=None):
+    @overload
+    def to_json(self, stream: None = ...) -> str: ...
+
+    @overload
+    def to_json(self, stream: IO[str]) -> None: ...
+
+    def to_json(self, stream: Optional[IO[str]] = None) -> Optional[str]:
         if stream is None:
             return sjson.dumps(self.to_dict())
         sjson.dump(self.to_dict(), stream)
         return None
 
-    def to_yaml(self, stream=None):
+    @overload
+    def to_yaml(self, stream: None = ...) -> str: ...
+
+    @overload
+    def to_yaml(self, stream: IO[str]) -> None: ...
+
+    def to_yaml(self, stream: Optional[IO[str]] = None) -> Optional[str]:
         return syaml.dump(self.to_dict(), stream)
 
     def to_dict(self):
@@ -450,14 +462,20 @@ class MirrorCollection(Mapping[str, Mirror]):
             return NotImplemented
         return self._mirrors == other._mirrors
 
-    def to_json(self, stream=None):
+    @overload
+    def to_json(self, stream: None = ...) -> str: ...
+
+    @overload
+    def to_json(self, stream: IO[str]) -> None: ...
+
+    def to_json(self, stream: Optional[IO[str]] = None) -> Optional[str]:
         if stream is None:
             return sjson.dumps(self.to_dict(True))
         sjson.dump(self.to_dict(True), stream)
         return None
 
     @staticmethod
-    def from_json(stream) -> "MirrorCollection":
+    def from_json(stream: Union[str, IO[str]]) -> "MirrorCollection":
         try:
             d = sjson.load(stream)
             return MirrorCollection(d)

--- a/lib/spack/spack/mirrors/mirror.py
+++ b/lib/spack/spack/mirrors/mirror.py
@@ -382,9 +382,7 @@ class Mirror:
         tok = self._get_value("access_token_variable", direction)
         if tok:
             return os.environ.get(tok)
-        else:
-            return self._get_value("access_token", direction)
-        return None
+        return self._get_value("access_token", direction)
 
     def get_access_pair(self, direction: str) -> Optional[Tuple[str, str]]:
         pair = self._get_value("access_pair", direction)

--- a/lib/spack/spack/test/mirror.py
+++ b/lib/spack/spack/test/mirror.py
@@ -181,25 +181,11 @@ def test_invalid_json_mirror(invalid_json, error_message):
     ],
 )
 def test_roundtrip_mirror_collection(mirror_collection):
-    mirror_collection_yaml = mirror_collection.to_yaml()
-    assert (
-        spack.mirrors.mirror.MirrorCollection.from_yaml(mirror_collection_yaml)
-        == mirror_collection
-    )
     mirror_collection_json = mirror_collection.to_json()
     assert (
         spack.mirrors.mirror.MirrorCollection.from_json(mirror_collection_json)
         == mirror_collection
     )
-
-
-@pytest.mark.parametrize(
-    "invalid_yaml", ["playing_playlist: {{ action }} playlist {{ playlist_name }}"]
-)
-def test_invalid_yaml_mirror_collection(invalid_yaml):
-    with pytest.raises(SpackYAMLError, match="error parsing YAML") as e:
-        spack.mirrors.mirror.MirrorCollection.from_yaml(invalid_yaml)
-    assert invalid_yaml in str(e.value)
 
 
 @pytest.mark.parametrize("invalid_json, error_message", [("{13:", "Expecting property name")])

--- a/lib/spack/spack/test/mirror.py
+++ b/lib/spack/spack/test/mirror.py
@@ -18,7 +18,6 @@ import spack.mirrors.mirror
 import spack.mirrors.utils
 import spack.patch
 import spack.stage
-import spack.util.spack_json as sjson
 import spack.util.url as url_util
 from spack.cmd.common.arguments import mirror_name_or_url
 from spack.llnl.util.filesystem import resolve_link_target_relative_to_the_link, working_dir
@@ -146,8 +145,6 @@ def test_all_mirror(mock_git_repository, mock_svn_repository, mock_hg_repository
 def test_roundtrip_mirror(mirror: spack.mirrors.mirror.Mirror):
     mirror_yaml = mirror.to_yaml()
     assert spack.mirrors.mirror.Mirror.from_yaml(mirror_yaml) == mirror
-    mirror_json = mirror.to_json()
-    assert spack.mirrors.mirror.Mirror.from_json(mirror_json) == mirror
 
 
 @pytest.mark.parametrize(
@@ -157,44 +154,6 @@ def test_invalid_yaml_mirror(invalid_yaml):
     with pytest.raises(SpackYAMLError, match="error parsing YAML") as e:
         spack.mirrors.mirror.Mirror.from_yaml(invalid_yaml)
     assert invalid_yaml in str(e.value)
-
-
-@pytest.mark.parametrize("invalid_json, error_message", [("{13:", "Expecting property name")])
-def test_invalid_json_mirror(invalid_json, error_message):
-    with pytest.raises(sjson.SpackJSONError) as e:
-        spack.mirrors.mirror.Mirror.from_json(invalid_json)
-    exc_msg = str(e.value)
-    assert exc_msg.startswith("error parsing JSON mirror:")
-    assert error_message in exc_msg
-
-
-@pytest.mark.parametrize(
-    "mirror_collection",
-    [
-        spack.mirrors.mirror.MirrorCollection(
-            mirrors={
-                "example-mirror": spack.mirrors.mirror.Mirror(
-                    "https://example.com/fetch", "https://example.com/push"
-                ).to_dict()
-            }
-        )
-    ],
-)
-def test_roundtrip_mirror_collection(mirror_collection):
-    mirror_collection_json = mirror_collection.to_json()
-    assert (
-        spack.mirrors.mirror.MirrorCollection.from_json(mirror_collection_json)
-        == mirror_collection
-    )
-
-
-@pytest.mark.parametrize("invalid_json, error_message", [("{13:", "Expecting property name")])
-def test_invalid_json_mirror_collection(invalid_json, error_message):
-    with pytest.raises(sjson.SpackJSONError) as e:
-        spack.mirrors.mirror.MirrorCollection.from_json(invalid_json)
-    exc_msg = str(e.value)
-    assert exc_msg.startswith("error parsing JSON mirror collection:")
-    assert error_message in exc_msg
 
 
 def test_mirror_archive_paths_no_version(mock_packages, mock_archive):


### PR DESCRIPTION
This PR adds type-hints to classes and functions in `mirror.py`.

Besides that:
- Some dead code has been removed
- Some unused arguments have been removed
- A bug in `MirrorCollection.display` when there are no mirrors has been fixed

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
