### PR TITLE
solve.py: --show=facts,rules

### DIFF
--- a/lib/spack/spack/cmd/solve.py
+++ b/lib/spack/spack/cmd/solve.py
@@ -23,7 +23,7 @@ section = "developer"
 level = "long"
 
 #: output options
-show_options = ("asp", "opt", "output", "solutions")
+show_options = ("facts", "opt", "output", "solutions", "rules")
 
 
 def setup_parser(subparser: argparse.ArgumentParser) -> None:
@@ -33,11 +33,13 @@ def setup_parser(subparser: argparse.ArgumentParser) -> None:
         action="store",
         default="opt,solutions",
         help="select outputs\n\ncomma-separated list of:\n"
-        "  asp          asp program text\n"
+        "  facts        asp facts (problem instance)\n"
+        "  rules        asp rules (.lp files)\n"
         "  opt          optimization criteria for best model\n"
         "  output       raw clingo output\n"
         "  solutions    models found by asp program\n"
-        "  all          all of the above",
+        "  all          all of the above\n"
+        "  asp          alias for 'facts' (deprecated)",
     )
     subparser.add_argument(
         "--timers",
@@ -130,12 +132,14 @@ def solve(parser, args):
     # process output options
     show = re.split(r"\s*,\s*", args.show)
     if "all" in show:
-        show = show_options
+        show = list(show_options)
+    # 'asp' is a deprecated alias for 'facts'
+    show = ["facts" if s == "asp" else s for s in show]
     for d in show:
         if d not in show_options:
             raise ValueError(
                 "Invalid option for '--show': '%s'\nchoose from: (%s)"
-                % (d, ", ".join(show_options + ("all",)))
+                % (d, ", ".join(show_options + ("all", "asp")))
             )
 
     # Format required for the output (JSON, YAML or None)
@@ -151,8 +155,8 @@ def solve(parser, args):
         tty.die("spack solve requires at least one spec or an active environment")
 
     solver = asp.Solver()
-    output = sys.stdout if "asp" in show else None
-    setup_only = set(show) == {"asp"}
+    output = sys.stdout if ("facts" in show or "rules" in show) else None
+    setup_only = bool(show) and set(show) <= {"facts", "rules"}
     unify = spack.config.get("concretizer:unify")
     allow_deprecated = spack.config.get("config:deprecated", False)
     if unify == "when_possible":
@@ -162,6 +166,8 @@ def solve(parser, args):
                 out=output,
                 timers=args.timers,
                 stats=args.stats,
+                facts=("facts" in show),
+                rules=("rules" in show),
                 allow_deprecated=allow_deprecated,
             )
         ):
@@ -181,6 +187,8 @@ def solve(parser, args):
             timers=args.timers,
             stats=args.stats,
             setup_only=setup_only,
+            facts=("facts" in show),
+            rules=("rules" in show),
             allow_deprecated=allow_deprecated,
         )
         if not setup_only:
@@ -194,6 +202,8 @@ def solve(parser, args):
                 timers=args.timers,
                 stats=args.stats,
                 setup_only=setup_only,
+                facts=("facts" in show),
+                rules=("rules" in show),
                 allow_deprecated=allow_deprecated,
             )
             if not setup_only:

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -100,11 +100,15 @@ class OutputConfiguration(NamedTuple):
     out: Optional[io.IOBase]
     #: If True, stop after setup and don't solve
     setup_only: bool
+    #: If True, write the problem instance (facts) to out
+    facts: bool = True
+    #: If True, write the contents of the .lp rule files to out
+    rules: bool = False
 
 
 #: Default output configuration for a solve
 DEFAULT_OUTPUT_CONFIGURATION = OutputConfiguration(
-    timers=False, stats=False, out=None, setup_only=False
+    timers=False, stats=False, out=None, setup_only=False, facts=True, rules=False
 )
 
 
@@ -1106,16 +1110,11 @@ class PyclingoDriver:
         timer.stop("setup")
 
         timer.start("ordering")
-        # print the output with comments, etc. if the user asked
-        problem = problem_builder.asp_problem
-        if output.out is not None:
-            output.out.write("\n".join(problem))
+        # load control files to add to the input representation
+        control_file_paths = self._control_file_paths(control_files)
 
-        if output.setup_only:
-            return Result(specs), None, None
-
-        # strip the problem of comments and empty lines
-        problem = strip_asp_problem(problem)
+        # strip and order the problem so the output matches exactly what clingo receives
+        problem = strip_asp_problem(problem_builder.asp_problem)
         randomize = "SPACK_SOLVER_RANDOMIZATION" in os.environ
         if randomize:
             # create a shuffled copy -- useful for understanding performance variation
@@ -1123,11 +1122,23 @@ class PyclingoDriver:
         else:
             problem.sort()  # sort for deterministic output
 
+        if output.facts and output.out is not None:
+            if randomize:
+                output.out.write("\n".join(problem))
+            else:
+                output.out.write("\n".join(problem_builder.asp_problem))
+        if output.rules and output.out is not None:
+            for path in control_file_paths:
+                output.out.write(f"\n% ===== {os.path.basename(path)} =====\n")
+                with open(path, encoding="utf-8") as f:
+                    output.out.write(f.read())
+
+        if output.setup_only:
+            return Result(specs), None, None
+
         timer.stop("ordering")
 
         timer.start("cache-check")
-        # load control files to add to the input representation
-        control_file_paths = self._control_file_paths(control_files)
         cache_key = self._make_cache_key(problem, control_file_paths)
 
         result, concretization_stats = None, None
@@ -3961,6 +3972,8 @@ class Solver:
         stats: bool = False,
         tests: spack.concretize.TestsType = False,
         setup_only: bool = False,
+        facts: bool = True,
+        rules: bool = False,
         allow_deprecated: bool = False,
     ) -> Tuple[Result, Optional[spack.util.timer.Timer], Optional[Dict]]:
         """
@@ -3981,7 +3994,9 @@ class Solver:
         reusable_specs = self._check_input_and_extract_concrete_specs(specs)
         reusable_specs.extend(self.selector.reusable_specs(specs))
         setup = SpackSolverSetup(tests=tests)
-        output = OutputConfiguration(timers=timers, stats=stats, out=out, setup_only=setup_only)
+        output = OutputConfiguration(
+            timers=timers, stats=stats, out=out, setup_only=setup_only, facts=facts, rules=rules
+        )
 
         result = self.driver.solve(
             setup,
@@ -4010,6 +4025,8 @@ class Solver:
         timers: bool = False,
         stats: bool = False,
         tests: spack.concretize.TestsType = False,
+        facts: bool = True,
+        rules: bool = False,
         allow_deprecated: bool = False,
     ) -> Generator[Result, None, None]:
         """Solve for a stable model of specs in multiple rounds.
@@ -4037,7 +4054,9 @@ class Solver:
         setup.concretize_everything = False
 
         input_specs = specs
-        output = OutputConfiguration(timers=timers, stats=stats, out=out, setup_only=False)
+        output = OutputConfiguration(
+            timers=timers, stats=stats, out=out, setup_only=False, facts=facts, rules=rules
+        )
         while True:
             result, _, _ = self.driver.solve(
                 setup,


### PR DESCRIPTION
Currently you cannot run a single command that dumps both the facts
with the rules. This adds `spack solve --show=facts,rules` so you can
pick what you like to see. The old `--show=asp` maps to `--show=facts`.

Also, ensure that `SPACK_SOLVER_RANDOMIZATION` applies when dumping ASP
output.

