### PR TITLE
Split `sjson.dump` to avoid ambiguous type-hints

### DIFF
--- a/lib/spack/spack/cmd/diff.py
+++ b/lib/spack/spack/cmd/diff.py
@@ -228,7 +228,7 @@ def diff(parser, args):
     attributes = args.attribute or ["all"]
 
     if args.dump_json:
-        print(sjson.dump(c))
+        print(sjson.dumps(c))
     else:
         tty.warn("This interface is subject to change.\n")
         print_difference(c, attributes)

--- a/lib/spack/spack/environment/environment.py
+++ b/lib/spack/spack/environment/environment.py
@@ -791,7 +791,7 @@ class ViewDescriptor:
                 ("specs", [(spec.dag_hash(), spec.prefix) for spec in sorted(specs)]),
             ]
         )
-        contents = sjson.dump(d)
+        contents = sjson.dumps(d)
         return spack.util.hash.b32_hash(contents)
 
     def get_projection_for_spec(self, spec):

--- a/lib/spack/spack/install_test.py
+++ b/lib/spack/spack/install_test.py
@@ -858,8 +858,7 @@ class TestSuite:
     def content_hash(self) -> str:
         """The hash used to uniquely identify the test suite."""
         if not self._hash:
-            json_text = sjson.dump(self.to_dict())
-            assert json_text is not None, f"{__name__} unexpected value for 'json_text'"
+            json_text = sjson.dumps(self.to_dict())
             sha = hashlib.sha1(json_text.encode("utf-8"))
             b32_hash = base64.b32encode(sha.digest()).lower()
             b32_hash = b32_hash.decode("utf-8")

--- a/lib/spack/spack/mirrors/mirror.py
+++ b/lib/spack/spack/mirrors/mirror.py
@@ -85,7 +85,10 @@ class Mirror:
         return f"Mirror(name={self._name!r}, data={self._data!r})"
 
     def to_json(self, stream=None):
-        return sjson.dump(self.to_dict(), stream)
+        if stream is None:
+            return sjson.dumps(self.to_dict())
+        sjson.dump(self.to_dict(), stream)
+        return None
 
     def to_yaml(self, stream=None):
         return syaml.dump(self.to_dict(), stream)
@@ -448,7 +451,10 @@ class MirrorCollection(Mapping[str, Mirror]):
         return self._mirrors == other._mirrors
 
     def to_json(self, stream=None):
-        return sjson.dump(self.to_dict(True), stream)
+        if stream is None:
+            return sjson.dumps(self.to_dict(True))
+        sjson.dump(self.to_dict(True), stream)
+        return None
 
     def to_yaml(self, stream=None):
         return syaml.dump(self.to_dict(True), stream)

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -2628,7 +2628,10 @@ class Spec:
         return syaml.dump(self.to_dict(hash), stream=stream, default_flow_style=False)
 
     def to_json(self, stream=None, *, hash=ht.dag_hash, pretty=False):
-        return sjson.dump(self.to_dict(hash), stream=stream, pretty=pretty)
+        if stream is None:
+            return sjson.dumps(self.to_dict(hash), pretty=pretty)
+        sjson.dump(self.to_dict(hash), stream, pretty=pretty)
+        return None
 
     @staticmethod
     def from_specfile(path):

--- a/lib/spack/spack/test/spec_yaml.py
+++ b/lib/spack/spack/test/spec_yaml.py
@@ -186,8 +186,8 @@ def test_ordered_read_not_required_for_consistent_dag_hash(
     # Dump to YAML and JSON
     yaml_string = syaml.dump(spec_dict, default_flow_style=False)
     yaml_string_rev = syaml.dump(spec_dict_rev, default_flow_style=False)
-    json_string = sjson.dump(spec_dict)
-    json_string_rev = sjson.dump(spec_dict_rev)
+    json_string = sjson.dumps(spec_dict)
+    json_string_rev = sjson.dumps(spec_dict_rev)
 
     # spec yaml is ordered like the spec dict
     assert yaml_string == spec_yaml

--- a/lib/spack/spack/util/spack_json.py
+++ b/lib/spack/spack/util/spack_json.py
@@ -13,6 +13,7 @@ __all__ = ["load", "dump", "dumps", "SpackJSONError"]
 
 _DEFAULT_SEPARATORS = (",", ":")
 _DEFAULT_INDENT = None
+_PRETTY_SEPARATORS = (", ", ": ")
 _PRETTY_INDENT = "  "
 
 
@@ -26,13 +27,15 @@ def load(stream: Any) -> Dict:
 def dump(data: Any, stream: IO[str], pretty: bool = False) -> None:
     """Wrapper around json.dump with different default arguments"""
     indent = _PRETTY_INDENT if pretty else _DEFAULT_INDENT
-    json.dump(data, stream, separators=_DEFAULT_SEPARATORS, indent=indent)
+    separators = _PRETTY_SEPARATORS if pretty else _DEFAULT_SEPARATORS
+    json.dump(data, stream, separators=separators, indent=indent)
 
 
 def dumps(data: Any, pretty: bool = False) -> str:
     """Wrapper around json.dumps with different default arguments"""
     indent = _PRETTY_INDENT if pretty else _DEFAULT_INDENT
-    return json.dumps(data, separators=_DEFAULT_SEPARATORS, indent=indent)
+    separators = _PRETTY_SEPARATORS if pretty else _DEFAULT_SEPARATORS
+    return json.dumps(data, separators=separators, indent=indent)
 
 
 class SpackJSONError(spack.error.SpackError):

--- a/lib/spack/spack/util/spack_json.py
+++ b/lib/spack/spack/util/spack_json.py
@@ -5,14 +5,15 @@
 """Simple wrapper around JSON to guarantee consistent use of load/dump."""
 
 import json
-from typing import IO, Any, Dict  # noqa: F401
+from typing import IO, Any, Dict
 
 import spack.error
 
 __all__ = ["load", "dump", "dumps", "SpackJSONError"]
 
-_json_dump_args = {"indent": None, "separators": (",", ":")}
-_pretty_dump_args = {"indent": "  ", "separators": (", ", ": ")}
+_DEFAULT_SEPARATORS = (",", ":")
+_DEFAULT_INDENT = None
+_PRETTY_INDENT = "  "
 
 
 def load(stream: Any) -> Dict:
@@ -22,16 +23,16 @@ def load(stream: Any) -> Dict:
     return json.load(stream)
 
 
-def dump(data: Dict, stream: IO, pretty: bool = False) -> None:
+def dump(data: Any, stream: IO[str], pretty: bool = False) -> None:
     """Wrapper around json.dump with different default arguments"""
-    dump_args = _pretty_dump_args if pretty else _json_dump_args
-    json.dump(data, stream, **dump_args)
+    indent = _PRETTY_INDENT if pretty else _DEFAULT_INDENT
+    json.dump(data, stream, separators=_DEFAULT_SEPARATORS, indent=indent)
 
 
-def dumps(data: Dict, pretty: bool = False) -> str:
+def dumps(data: Any, pretty: bool = False) -> str:
     """Wrapper around json.dumps with different default arguments"""
-    dump_args = _pretty_dump_args if pretty else _json_dump_args
-    return json.dumps(data, **dump_args)
+    indent = _PRETTY_INDENT if pretty else _DEFAULT_INDENT
+    return json.dumps(data, separators=_DEFAULT_SEPARATORS, indent=indent)
 
 
 class SpackJSONError(spack.error.SpackError):

--- a/lib/spack/spack/util/spack_json.py
+++ b/lib/spack/spack/util/spack_json.py
@@ -5,11 +5,11 @@
 """Simple wrapper around JSON to guarantee consistent use of load/dump."""
 
 import json
-from typing import Any, Dict, Optional
+from typing import IO, Any, Dict  # noqa: F401
 
 import spack.error
 
-__all__ = ["load", "dump", "SpackJSONError"]
+__all__ = ["load", "dump", "dumps", "SpackJSONError"]
 
 _json_dump_args = {"indent": None, "separators": (",", ":")}
 _pretty_dump_args = {"indent": "  ", "separators": (", ", ": ")}
@@ -22,13 +22,16 @@ def load(stream: Any) -> Dict:
     return json.load(stream)
 
 
-def dump(data: Dict, stream: Optional[Any] = None, pretty: bool = False) -> Optional[str]:
-    """Dump JSON with a reasonable amount of indentation and separation."""
+def dump(data: Dict, stream: IO, pretty: bool = False) -> None:
+    """Wrapper around json.dump with different default arguments"""
     dump_args = _pretty_dump_args if pretty else _json_dump_args
-    if stream is None:
-        return json.dumps(data, **dump_args)  # type: ignore[arg-type]
-    json.dump(data, stream, **dump_args)  # type: ignore[arg-type]
-    return None
+    json.dump(data, stream, **dump_args)
+
+
+def dumps(data: Dict, pretty: bool = False) -> str:
+    """Wrapper around json.dumps with different default arguments"""
+    dump_args = _pretty_dump_args if pretty else _json_dump_args
+    return json.dumps(data, **dump_args)
 
 
 class SpackJSONError(spack.error.SpackError):

--- a/lib/spack/spack/util/timer.py
+++ b/lib/spack/spack/util/timer.py
@@ -181,7 +181,7 @@ class Timer(BaseTimer):
         if extra_attributes:
             data.update(extra_attributes)
         if out:
-            out.write(sjson.dump(data))
+            out.write(sjson.dumps(data))
         else:
             return data
 

--- a/lib/spack/spack/verify.py
+++ b/lib/spack/spack/verify.py
@@ -193,7 +193,7 @@ class VerificationResults:
         return bool(self.errors)
 
     def json_string(self):
-        return sjson.dump(self.errors)
+        return sjson.dumps(self.errors)
 
     def __str__(self):
         res = ""


### PR DESCRIPTION
Now there are two functions, which are wrappers around `json.dump` and `json.dumps`. The return type is clear, and only one of them accepts a stream.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
