### PR TITLE
typing: only import typing_extensions if needed

### DIFF
--- a/lib/spack/spack/bootstrap/_common.py
+++ b/lib/spack/spack/bootstrap/_common.py
@@ -14,7 +14,11 @@ import warnings
 from typing import Optional, Sequence, Union
 
 import spack.vendor.archspec.cpu
-from spack.vendor.typing_extensions import TypedDict
+
+if sys.version_info >= (3, 8):
+    from typing import TypedDict
+else:
+    from spack.vendor.typing_extensions import TypedDict
 
 import spack.llnl.util.filesystem as fs
 import spack.platforms

--- a/lib/spack/spack/deptypes.py
+++ b/lib/spack/spack/deptypes.py
@@ -3,9 +3,13 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 """Data structures that represent Spack's edge types."""
 
+import sys
 from typing import Iterable, List, Tuple, Union
 
-from spack.vendor.typing_extensions import Literal
+if sys.version_info >= (3, 8):
+    from typing import Literal
+else:
+    from spack.vendor.typing_extensions import Literal
 
 #: Type hint for the low-level dependency input (enum.Flag is too slow)
 DepFlag = int

--- a/lib/spack/spack/directives_meta.py
+++ b/lib/spack/spack/directives_meta.py
@@ -4,9 +4,13 @@
 
 import collections
 import functools
+import sys
 from typing import Any, Callable, Dict, List, Set, Tuple, Type, TypeVar, Union
 
-from spack.vendor.typing_extensions import ParamSpec
+if sys.version_info >= (3, 10):
+    from typing import ParamSpec
+else:
+    from spack.vendor.typing_extensions import ParamSpec
 
 import spack.error
 import spack.repo

--- a/lib/spack/spack/externals.py
+++ b/lib/spack/spack/externals.py
@@ -16,11 +16,15 @@ into the intermediate representation.
 """
 
 import re
+import sys
 import uuid
 import warnings
 from typing import Any, Callable, Dict, List, NamedTuple, Tuple, Union
 
-from spack.vendor.typing_extensions import TypedDict
+if sys.version_info >= (3, 8):
+    from typing import TypedDict
+else:
+    from spack.vendor.typing_extensions import TypedDict
 
 import spack.archspec
 import spack.deptypes

--- a/lib/spack/spack/filesystem_view.py
+++ b/lib/spack/spack/filesystem_view.py
@@ -12,7 +12,10 @@ import sys
 import tempfile
 from typing import Callable, Dict, List, Optional
 
-from spack.vendor.typing_extensions import Literal
+if sys.version_info >= (3, 8):
+    from typing import Literal
+else:
+    from spack.vendor.typing_extensions import Literal
 
 import spack.config
 import spack.directory_layout

--- a/lib/spack/spack/installer.py
+++ b/lib/spack/spack/installer.py
@@ -40,7 +40,10 @@ from collections import defaultdict
 from gzip import GzipFile
 from typing import TYPE_CHECKING, Dict, Iterator, List, Optional, Set, Tuple, Union
 
-from spack.vendor.typing_extensions import Literal
+if sys.version_info >= (3, 8):
+    from typing import Literal
+else:
+    from spack.vendor.typing_extensions import Literal
 
 import spack.binary_distribution as binary_distribution
 import spack.build_environment

--- a/lib/spack/spack/installer_dispatch.py
+++ b/lib/spack/spack/installer_dispatch.py
@@ -5,7 +5,10 @@
 import sys
 from typing import TYPE_CHECKING, List, Optional, Set, Union
 
-from spack.vendor.typing_extensions import Literal
+if sys.version_info >= (3, 8):
+    from typing import Literal
+else:
+    from spack.vendor.typing_extensions import Literal
 
 import spack.config
 import spack.traverse

--- a/lib/spack/spack/new_installer.py
+++ b/lib/spack/spack/new_installer.py
@@ -57,7 +57,10 @@ from typing import (
     Union,
 )
 
-from spack.vendor.typing_extensions import Literal
+if sys.version_info >= (3, 8):
+    from typing import Literal
+else:
+    from spack.vendor.typing_extensions import Literal
 
 import spack.binary_distribution
 import spack.build_environment

--- a/lib/spack/spack/package_base.py
+++ b/lib/spack/spack/package_base.py
@@ -21,7 +21,10 @@ import time
 import traceback
 from typing import Any, Callable, Dict, Iterable, List, Optional, Set, Tuple, Type, TypeVar, Union
 
-from spack.vendor.typing_extensions import Literal
+if sys.version_info >= (3, 8):
+    from typing import Literal
+else:
+    from spack.vendor.typing_extensions import Literal
 
 import spack.config
 import spack.dependency

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -58,6 +58,7 @@ import pathlib
 import platform
 import re
 import socket
+import sys
 import warnings
 from typing import (
     Any,
@@ -75,7 +76,11 @@ from typing import (
 )
 
 import spack.vendor.archspec.cpu
-from spack.vendor.typing_extensions import Literal
+
+if sys.version_info >= (3, 8):
+    from typing import Literal
+else:
+    from spack.vendor.typing_extensions import Literal
 
 import spack
 import spack.aliases

--- a/lib/spack/spack/traverse.py
+++ b/lib/spack/spack/traverse.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+import sys
 from collections import defaultdict, deque
 from typing import (
     TYPE_CHECKING,
@@ -18,7 +19,10 @@ from typing import (
     overload,
 )
 
-from spack.vendor.typing_extensions import Literal
+if sys.version_info >= (3, 8):
+    from typing import Literal
+else:
+    from spack.vendor.typing_extensions import Literal
 
 import spack.deptypes as dt
 

--- a/lib/spack/spack/util/executable.py
+++ b/lib/spack/spack/util/executable.py
@@ -11,7 +11,10 @@ import sys
 from pathlib import Path, PurePath
 from typing import BinaryIO, Callable, Dict, List, Optional, Sequence, Tuple, Type, Union, overload
 
-from spack.vendor.typing_extensions import Literal
+if sys.version_info >= (3, 8):
+    from typing import Literal
+else:
+    from spack.vendor.typing_extensions import Literal
 
 import spack.error
 import spack.llnl.util.tty as tty

--- a/lib/spack/spack/util/git.py
+++ b/lib/spack/spack/util/git.py
@@ -9,7 +9,10 @@ import shutil
 import sys
 from typing import List, Optional, overload
 
-from spack.vendor.typing_extensions import Literal
+if sys.version_info >= (3, 8):
+    from typing import Literal
+else:
+    from spack.vendor.typing_extensions import Literal
 
 import spack.llnl.util.filesystem as fs
 import spack.llnl.util.lang

--- a/lib/spack/spack/util/typing.py
+++ b/lib/spack/spack/util/typing.py
@@ -11,9 +11,13 @@ calls can be very expensive.
 
 """
 
+import sys
 from typing import TYPE_CHECKING, Any
 
-from spack.vendor.typing_extensions import Protocol
+if sys.version_info >= (3, 8):
+    from typing import Protocol
+else:
+    from spack.vendor.typing_extensions import Protocol
 
 if TYPE_CHECKING:
 

--- a/lib/spack/spack/util/web.py
+++ b/lib/spack/spack/util/web.py
@@ -24,7 +24,10 @@ from typing import IO, Callable, Dict, Iterable, List, Optional, Set, Tuple, Typ
 from urllib.error import HTTPError, URLError
 from urllib.request import HTTPDefaultErrorHandler, HTTPSHandler, Request, build_opener
 
-from spack.vendor.typing_extensions import ParamSpec
+if sys.version_info >= (3, 10):
+    from typing import ParamSpec
+else:
+    from spack.vendor.typing_extensions import ParamSpec
 
 import spack
 import spack.config


### PR DESCRIPTION
importing `typing_extensions` is redundant at runtime, so don't pay that cost.
