### PR TITLE
new_installer.py: support splicing

### DIFF
--- a/lib/spack/spack/installer_dispatch.py
+++ b/lib/spack/spack/installer_dispatch.py
@@ -9,7 +9,6 @@ from spack.vendor.typing_extensions import Literal
 
 import spack.config
 import spack.sandbox
-import spack.traverse
 
 if TYPE_CHECKING:
     import spack.installer
@@ -48,13 +47,6 @@ def create_installer(
         sys.platform == "win32" or spack.config.get("config:installer", "new") == "old"
     )
 
-    # Use the old installer if splicing is used.
-    if not use_old_installer:
-        specs = [pkg.spec for pkg in packages]
-        for s in spack.traverse.traverse_nodes(specs):
-            if s.build_spec is not s:
-                use_old_installer = True
-                break
     if spack.config.get("config:sandbox:enable", False):
         if use_old_installer:
             raise spack.sandbox.SandboxError(

--- a/lib/spack/spack/new_installer.py
+++ b/lib/spack/spack/new_installer.py
@@ -714,6 +714,20 @@ def _enable_sandbox(config: dict, spec: spack.spec.Spec, stage_path: str) -> Non
         raise spack.error.InstallError(f"Cannot enable build sandbox: {e}") from e
 
 
+def _rewire_no_db(spec: spack.spec.Spec, explicit: bool) -> None:
+    """Rewire a spliced spec from its build_spec prefix, without writing to the database."""
+    tmpdir = tempfile.mkdtemp()
+    try:
+        tarball = os.path.join(tmpdir, f"{spec.dag_hash()}.tar.gz")
+        spack.binary_distribution.create_tarball(spec.build_spec, tarball)
+        spack.hooks.pre_install(spec)
+        spack.binary_distribution.extract_buildcache_tarball(tarball, destination=spec.prefix)
+        spack.binary_distribution.relocate_package(spec)
+    finally:
+        shutil.rmtree(tmpdir, ignore_errors=True)
+    spack.hooks.post_install(spec, explicit)
+
+
 def _install(
     spec: spack.spec.Spec,
     explicit: bool,
@@ -753,6 +767,17 @@ def _install(
         elif install_policy == "cache_only":
             send_state("no binary available", state_stream)
             raise BinaryCacheMiss(f"No binary available for {spec}")
+
+    # Spliced spec: rewire from build_spec prefix, or trigger build_spec installation.
+    if spec.build_spec is not spec:
+        if install_policy == "source_only":
+            # Parent guarantees build_spec is available with a read lock.
+            send_state("rewiring", state_stream)
+            _rewire_no_db(spec, explicit)
+            return
+        # Binary cache was the only option; signal miss for force_source expansion.
+        send_state("no binary available", state_stream)
+        raise BinaryCacheMiss(f"No binary available for {spec}")
 
     unmodified_env = os.environ.copy()
     env_mods = spack.build_environment.setup_package(pkg, dirty=dirty)
@@ -1698,6 +1723,7 @@ class BuildGraph:
         overwrite_set: Optional[Set[str]] = None,
         tests: Union[bool, List[str], Set[str]] = False,
         explicit_set: Optional[Set[str]] = None,
+        has_mirrors: bool = True,
     ):
         """Construct a build graph from the given specs. This includes only packages that need to
         be installed. Installed packages are pruned from the graph, and build dependencies are only
@@ -1739,10 +1765,27 @@ class BuildGraph:
                     # If it needs to be marked explicit, keep it in the graph (don't prune).
                     if key not in explicit_set or record.explicit:
                         self.pruned.add(key)
-                elif install_policy == "source_only" or include_build_deps:
+                elif (
+                    install_policy == "source_only"
+                    or include_build_deps
+                    or (install_policy == "auto" and not has_mirrors)
+                ):
                     depflag |= dt.BUILD
 
-                dependencies = spec.dependencies(deptype=depflag)
+                dependencies = list(spec.dependencies(deptype=depflag))
+
+                # For spliced specs built from source, add build_spec as a pseudo-dependency
+                # so it gets built before the spliced spec.
+                if spec.build_spec is not spec and key not in self.pruned and (depflag & dt.BUILD):
+                    bs = spec.build_spec
+                    bh = bs.dag_hash()
+                    if bh not in self.pruned:
+                        _, bs_record = database.query_by_spec_hash(bh)
+                        if not (bs_record and bs_record.installed):
+                            dependencies.append(bs)
+                        else:
+                            self.done.add(bh)
+
                 self.parent_to_child[key] = {d.dag_hash() for d in dependencies}
 
                 # Enqueue new dependencies
@@ -1840,6 +1883,10 @@ class BuildGraph:
         for edge in spec.edges_to_dependencies(depflag=dt.BUILD):
             if (edge.depflag & base_deptypes) == 0:
                 unexpanded.append(edge.spec)
+        if dag_hash in self.force_source and spec.build_spec is not spec:
+            bh = spec.build_spec.dag_hash()
+            if bh not in self.nodes and bh not in self.done and bh not in self.pruned:
+                unexpanded.append(spec.build_spec)
         return unexpanded
 
     def expand_build_deps(
@@ -1922,6 +1969,8 @@ class ScheduleResult(NamedTuple):
     newly_installed: List[Tuple[str, spack.spec.Spec, spack.util.lock.Lock]]
     #: Actions to mark already installed specs explicit in the DB.
     to_mark_explicit: List[MarkExplicitAction]
+    #: Extra read locks to retain (e.g. on build_spec prefixes for spliced specs).
+    extra_read_locks: List[spack.util.lock.Lock]
 
 
 def schedule_builds(
@@ -1969,12 +2018,15 @@ def schedule_builds(
     to_start: List[Tuple[str, spack.util.lock.Lock]] = []
     newly_installed: List[Tuple[str, spack.spec.Spec, spack.util.lock.Lock]] = []
     to_mark_explicit: List[MarkExplicitAction] = []
+    extra_read_locks: List[spack.util.lock.Lock] = []
     blocked = True
 
     # Acquire the DB read lock non-blocking; hold it throughout the loop so the in-memory snapshot
     # stays consistent while we acquire per-spec prefix locks.
     if not db.lock.try_acquire_read():
-        return ScheduleResult(blocked, to_start, newly_installed, to_mark_explicit)
+        return ScheduleResult(
+            blocked, to_start, newly_installed, to_mark_explicit, extra_read_locks
+        )
 
     try:
         db._read()  # refresh in-memory snapshot under the read lock
@@ -2052,6 +2104,19 @@ def schedule_builds(
                         f"Cannot install {spec}: prefix {spec.prefix} already exists"
                     )
 
+            # For spliced specs, ensure a lock is held on build_spec to prevent concurrent
+            # uninstall while the child reads from it.
+            if spec.build_spec is not spec:
+                bs_lock = prefix_locker.lock(spec.build_spec)
+                # If the lock is already held (build_spec was built by us and its write lock
+                # is pending downgrade, or already downgraded to read), skip acquisition.
+                if not bs_lock._writes and not bs_lock._reads:
+                    if not bs_lock.try_acquire_read():
+                        lock.release_write()
+                        idx += 1
+                        continue
+                    extra_read_locks.append(bs_lock)
+
             # Acquire a jobserver token if needed. The first (implicit) job needs no token.
             if needs_jobserver_token and not jobserver.acquire(1):
                 lock.release_write()
@@ -2065,7 +2130,7 @@ def schedule_builds(
     finally:
         db.lock.release_read()
 
-    return ScheduleResult(blocked, to_start, newly_installed, to_mark_explicit)
+    return ScheduleResult(blocked, to_start, newly_installed, to_mark_explicit, extra_read_locks)
 
 
 def _node_to_roots(roots: List[spack.spec.Spec]) -> Dict[str, FrozenSet[str]]:
@@ -2396,12 +2461,7 @@ class PackageInstaller:
 
         specs = [pkg.spec for pkg in packages]
 
-        # No point trying cache when there are no binary mirrors configured.
-        if not spack.mirrors.mirror.MirrorCollection(binary=True):
-            if root_policy == "auto":
-                root_policy = "source_only"
-            if dependencies_policy == "auto":
-                dependencies_policy = "source_only"
+        self.has_mirrors = bool(spack.mirrors.mirror.MirrorCollection(binary=True))
         self.root_policy: InstallPolicy = root_policy
         self.dependencies_policy: InstallPolicy = dependencies_policy
         self.include_build_deps = include_build_deps
@@ -2434,6 +2494,7 @@ class PackageInstaller:
             self.overwrite,
             tests,
             self.explicit,
+            self.has_mirrors,
         )
 
         #: check what specs we could fetch from binaries (checks against cache, not remotely)
@@ -2443,7 +2504,9 @@ class PackageInstaller:
             pass
 
         self.binary_cache_for_spec = {
-            s.dag_hash(): spack.binary_distribution.BINARY_INDEX.find_by_hash(s.dag_hash())
+            s.dag_hash(): spack.binary_distribution.BINARY_INDEX.find_by_hash(
+                s.build_spec.dag_hash()
+            )
             for s in self.build_graph.nodes.values()
         }
         self.unsigned = unsigned
@@ -2800,8 +2863,13 @@ class PackageInstaller:
             return
         try:
             self.db._read()
+            dep_policy = (
+                "source_only"
+                if (self.dependencies_policy == "auto" and not self.has_mirrors)
+                else self.dependencies_policy
+            )
             newly_added = self.build_graph.expand_build_deps(
-                self.pending_expansions, self.pending_builds, self.db, self.dependencies_policy
+                self.pending_expansions, self.pending_builds, self.db, dep_policy
             )
             for h in newly_added:
                 self.binary_cache_for_spec[h] = (
@@ -2874,6 +2942,7 @@ class PackageInstaller:
         )
         blocked = result.blocked
         database_actions.extend(result.to_mark_explicit)
+        retained_read_locks.extend(result.extra_read_locks)
         # Specs installed by another process.
         for dag_hash, spec, lock in result.newly_installed:
             retained_read_locks.append(lock)
@@ -2889,6 +2958,8 @@ class PackageInstaller:
         if dag_hash in self.build_graph.force_source:
             return "source_only"
         policy = self.root_policy if is_root else self.dependencies_policy
+        if policy == "auto" and not self.has_mirrors:
+            return "source_only"
         if policy == "auto" and not self.include_build_deps:
             return "cache_only"
         return policy

--- a/lib/spack/spack/new_installer.py
+++ b/lib/spack/spack/new_installer.py
@@ -1969,8 +1969,6 @@ class ScheduleResult(NamedTuple):
     newly_installed: List[Tuple[str, spack.spec.Spec, spack.util.lock.Lock]]
     #: Actions to mark already installed specs explicit in the DB.
     to_mark_explicit: List[MarkExplicitAction]
-    #: Extra read locks to retain (e.g. on build_spec prefixes for spliced specs).
-    extra_read_locks: List[spack.util.lock.Lock]
 
 
 def schedule_builds(
@@ -2018,15 +2016,12 @@ def schedule_builds(
     to_start: List[Tuple[str, spack.util.lock.Lock]] = []
     newly_installed: List[Tuple[str, spack.spec.Spec, spack.util.lock.Lock]] = []
     to_mark_explicit: List[MarkExplicitAction] = []
-    extra_read_locks: List[spack.util.lock.Lock] = []
     blocked = True
 
     # Acquire the DB read lock non-blocking; hold it throughout the loop so the in-memory snapshot
     # stays consistent while we acquire per-spec prefix locks.
     if not db.lock.try_acquire_read():
-        return ScheduleResult(
-            blocked, to_start, newly_installed, to_mark_explicit, extra_read_locks
-        )
+        return ScheduleResult(blocked, to_start, newly_installed, to_mark_explicit)
 
     try:
         db._read()  # refresh in-memory snapshot under the read lock
@@ -2104,19 +2099,6 @@ def schedule_builds(
                         f"Cannot install {spec}: prefix {spec.prefix} already exists"
                     )
 
-            # For spliced specs, ensure a lock is held on build_spec to prevent concurrent
-            # uninstall while the child reads from it.
-            if spec.build_spec is not spec:
-                bs_lock = prefix_locker.lock(spec.build_spec)
-                # If the lock is already held (build_spec was built by us and its write lock
-                # is pending downgrade, or already downgraded to read), skip acquisition.
-                if not bs_lock._writes and not bs_lock._reads:
-                    if not bs_lock.try_acquire_read():
-                        lock.release_write()
-                        idx += 1
-                        continue
-                    extra_read_locks.append(bs_lock)
-
             # Acquire a jobserver token if needed. The first (implicit) job needs no token.
             if needs_jobserver_token and not jobserver.acquire(1):
                 lock.release_write()
@@ -2130,7 +2112,7 @@ def schedule_builds(
     finally:
         db.lock.release_read()
 
-    return ScheduleResult(blocked, to_start, newly_installed, to_mark_explicit, extra_read_locks)
+    return ScheduleResult(blocked, to_start, newly_installed, to_mark_explicit)
 
 
 def _node_to_roots(roots: List[spack.spec.Spec]) -> Dict[str, FrozenSet[str]]:
@@ -2942,7 +2924,6 @@ class PackageInstaller:
         )
         blocked = result.blocked
         database_actions.extend(result.to_mark_explicit)
-        retained_read_locks.extend(result.extra_read_locks)
         # Specs installed by another process.
         for dag_hash, spec, lock in result.newly_installed:
             retained_read_locks.append(lock)

--- a/lib/spack/spack/test/installer.py
+++ b/lib/spack/spack/test/installer.py
@@ -664,14 +664,16 @@ def test_rewire_task_no_tarball(default_mock_concretization, monkeypatch):
 
 
 @pytest.mark.parametrize("transitive", [True, False])
-def test_install_spliced(install_mockery, mock_fetch, monkeypatch, transitive):
+def test_install_spliced(install_mockery, mock_fetch, monkeypatch, transitive, installer_variant):
     """Test installing a spliced spec"""
     spec = spack.concretize.concretize_one("splice-t")
     dep = spack.concretize.concretize_one("splice-h+foo")
 
     # Do the splice.
     out = spec.splice(dep, transitive)
-    installer = create_installer([out], {"verbose": True, "fail_fast": True})
+    installer = spack.installer_dispatch.create_installer(
+        [out.package], verbose=True, fail_fast=True
+    )
     installer.install()
     for node in out.traverse():
         assert node.installed
@@ -679,19 +681,20 @@ def test_install_spliced(install_mockery, mock_fetch, monkeypatch, transitive):
 
 
 @pytest.mark.parametrize("transitive", [True, False])
-def test_install_spliced_build_spec_installed(install_mockery, mock_fetch, transitive):
+def test_install_spliced_build_spec_installed(
+    install_mockery, mock_fetch, transitive, installer_variant
+):
     """Test installing a spliced spec with the build spec already installed"""
     spec = spack.concretize.concretize_one("splice-t")
     dep = spack.concretize.concretize_one("splice-h+foo")
 
     # Do the splice.
     out = spec.splice(dep, transitive)
-    inst.PackageInstaller([out.build_spec.package]).install()
+    spack.installer_dispatch.create_installer([out.build_spec.package]).install()
 
-    installer = create_installer([out], {"verbose": True, "fail_fast": True})
-    installer._init_queue()
-    for _, task in installer.build_pq:
-        assert isinstance(task, inst.RewireTask if task.pkg.spec.spliced else inst.BuildTask)
+    installer = spack.installer_dispatch.create_installer(
+        [out.package], verbose=True, fail_fast=True
+    )
     installer.install()
     for node in out.traverse():
         assert node.installed
@@ -705,14 +708,22 @@ def test_install_spliced_build_spec_installed(install_mockery, mock_fetch, trans
     "root_str", ["splice-t^splice-h~foo", "splice-h~foo", "splice-vt^splice-a"]
 )
 def test_install_splice_root_from_binary(
-    mutable_mock_env_path, install_mockery, mock_fetch, temporary_mirror, transitive, root_str
+    mutable_mock_env_path,
+    install_mockery,
+    mock_fetch,
+    temporary_mirror,
+    transitive,
+    root_str,
+    installer_variant,
 ):
     """Test installing a spliced spec with the root available in binary cache"""
     # Test splicing and rewiring a spec with the same name, different hash.
     original_spec = spack.concretize.concretize_one(root_str)
     spec_to_splice = spack.concretize.concretize_one("splice-h+foo")
 
-    inst.PackageInstaller([original_spec.package, spec_to_splice.package]).install()
+    spack.installer_dispatch.create_installer(
+        [original_spec.package, spec_to_splice.package]
+    ).install()
 
     out = original_spec.splice(spec_to_splice, transitive)
 
@@ -729,7 +740,7 @@ def test_install_splice_root_from_binary(
     uninstall = SpackCommand("uninstall")
     uninstall("-ay")
 
-    inst.PackageInstaller([out.package], unsigned=True).install()
+    spack.installer_dispatch.create_installer([out.package], unsigned=True).install()
 
     assert len(spack.store.STORE.db.query()) == len(list(out.traverse()))
 
@@ -1390,17 +1401,6 @@ def test_print_install_test_log_failures(
     inst.print_install_test_log(pkg)
     out = capfd.readouterr()[0]
     assert "See test results at" in out
-
-
-def test_fallback_to_old_installer_for_splicing(monkeypatch, mock_packages, mutable_config):
-    """Test that the old installer is used for spliced specs (unsupported in the new installer)"""
-    mutable_config.set("config:installer", "new")
-    spec = spack.concretize.concretize_one("splice-t")
-    dep = spack.concretize.concretize_one("splice-h+foo")
-    out = spec.splice(dep)
-    assert isinstance(
-        spack.installer_dispatch.create_installer([out.package]), inst.PackageInstaller
-    )
 
 
 @pytest.mark.disable_clean_stage_check

--- a/lib/spack/spack/test/new_installer.py
+++ b/lib/spack/spack/test/new_installer.py
@@ -274,12 +274,12 @@ class TestPackageInstallerConstructor:
     def test_no_binary_mirrors_forces_source_only(
         self, temporary_store, mock_packages, mutable_config
     ):
-        """With no binary mirrors configured, auto is overridden to source_only."""
+        """With no binary mirrors configured, has_mirrors is False so auto resolves to
+        source_only at scheduling time."""
         spec = spack.spec.Spec("trivial-install-test-package")
         spec._mark_concrete()
         installer = PackageInstaller([spec.package], root_policy="auto")
-        assert installer.root_policy == "source_only"
-        assert installer.dependencies_policy == "source_only"
+        assert not installer.has_mirrors
 
     def test_no_binary_mirrors_preserves_cache_only(
         self, temporary_store, mock_packages, mutable_config


### PR DESCRIPTION
Two notes:

* Most of these code changes would have been redundant if `Spec.build_spec` was an ordinary build dependency, which I think is a missed opportunity. The existing splicing implementation treats it as a "ghost dependency" which means that more code has to be written to deal with the special case. I hope we can fix this in in a next release.
* Regarding locking: I believe there's an existing bug that I won't address in this PR. The installer invariant should be that if a package build starts we hold read locks on its dependencies. That's true for deps that were just installed, but I think it's skipped for those already installed. Since scheduling "build_spec" as just a build dep, I won't ad the ad-hoc code for locking, and it's also very unlikely that build_spec is locally installed anyways. Fixing this requires a bit more thought and a separate PR; keeping this one straightforward.

And a minor comment: I'm not sure how well the tests cover all possible uses of splicing, but improving that is not the scope of this PR.