### PR TITLE
Bump the package API version to v2.5

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,6 @@
+## Package API v2.5
+- Added `cuda-lang` and `hip-lang` as language virtuals (analogous to `c`, `cxx`, `fortran`).
+
 ## Package API v2.4
 - Added the `%%` sigil to spec syntax, to propagate compiler preferences.
 

--- a/lib/spack/docs/package_api.rst
+++ b/lib/spack/docs/package_api.rst
@@ -37,6 +37,11 @@ Spack version |spack_version| supports package repositories with a Package API v
 Changelog
 ---------
 
+**v2.5** *(Spack v1.2.0)*
+
+* Added ``cuda-lang`` and ``hip-lang`` as language virtuals, analogous to ``c``, ``cxx``, and ``fortran``.
+  Packages that use CUDA or HIP can now declare explicit language dependencies on these virtuals.
+
 **v2.4** *(Spack v1.0.3)*
 
 * The ``%%`` operator can be used on input specs to set propagated preferences, which is particularly useful for ``unify: false`` environments.

--- a/lib/spack/spack/__init__.py
+++ b/lib/spack/spack/__init__.py
@@ -19,7 +19,7 @@ spack_version = __version__
 #: version is incremented when the package API is extended in a backwards-compatible way. The major
 #: version is incremented upon breaking changes. This version is changed independently from the
 #: Spack version.
-package_api_version = (2, 4)
+package_api_version = (2, 5)
 
 #: The minimum Package API version that this version of Spack is compatible with. This should
 #: always be a tuple of the form ``(major, 0)``, since compatibility with vX.Y implies


### PR DESCRIPTION
This change includes adding hip-lang and cuda-lang, and was overlooked in #52145

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
