### PR TITLE
download cache: fix race

### DIFF
--- a/lib/spack/spack/caches.py
+++ b/lib/spack/spack/caches.py
@@ -51,7 +51,7 @@ def _fetch_cache():
     return spack.fetch_strategy.FsCache(path)
 
 
-class MirrorCache(spack.fetch_strategy._FilesystemCache):
+class MirrorCache(spack.fetch_strategy.FsCacheBase):
     def __init__(self, root, skip_unstable_versions):
         super().__init__(root)
         self.skip_unstable_versions = skip_unstable_versions

--- a/lib/spack/spack/caches.py
+++ b/lib/spack/spack/caches.py
@@ -4,7 +4,6 @@
 
 """Caches used by Spack to store data"""
 
-import os
 from typing import cast
 
 import spack.config
@@ -13,7 +12,6 @@ import spack.llnl.util.lang
 import spack.paths
 import spack.util.file_cache
 import spack.util.path
-from spack.llnl.util.filesystem import mkdirp
 
 
 def misc_cache_location():
@@ -53,19 +51,17 @@ def _fetch_cache():
     return spack.fetch_strategy.FsCache(path)
 
 
-class MirrorCache:
+class MirrorCache(spack.fetch_strategy._FilesystemCache):
     def __init__(self, root, skip_unstable_versions):
-        self.root = os.path.abspath(root)
+        super().__init__(root)
         self.skip_unstable_versions = skip_unstable_versions
 
     def store(self, fetcher, relative_dest):
-        """Fetch and relocate the fetcher's target into our mirror cache."""
+        """Fetch and relocate the fetcher's target into our mirror cache.
 
-        # Note this will archive package sources even if they would not
-        # normally be cached (e.g. the current tip of an hg/git branch)
-        dst = os.path.join(self.root, relative_dest)
-        mkdirp(os.path.dirname(dst))
-        fetcher.archive(dst)
+        Note: archives package sources even if not normally cached (e.g. tip of hg/git branch).
+        """
+        super().store(fetcher, relative_dest)
 
 
 #: Spack's local cache for downloaded source archives

--- a/lib/spack/spack/fetch_strategy.py
+++ b/lib/spack/spack/fetch_strategy.py
@@ -1761,7 +1761,7 @@ def from_list_url(pkg):
             tty.msg("Could not determine url from list_url.")
 
 
-class _FilesystemCache:
+class FsCacheBase:
     def __init__(self, root):
         self.root = os.path.abspath(root)
 
@@ -1783,7 +1783,7 @@ class _FilesystemCache:
             raise
 
 
-class FsCache(_FilesystemCache):
+class FsCache(FsCacheBase):
     def store(self, fetcher, relative_dest):
         # skip fetchers that aren't cachable
         if not fetcher.cachable:

--- a/lib/spack/spack/fetch_strategy.py
+++ b/lib/spack/spack/fetch_strategy.py
@@ -32,6 +32,7 @@ import hashlib
 import http.client
 import os
 import re
+import secrets
 import shutil
 import sys
 import time
@@ -1760,10 +1761,29 @@ def from_list_url(pkg):
             tty.msg("Could not determine url from list_url.")
 
 
-class FsCache:
+class _FilesystemCache:
     def __init__(self, root):
         self.root = os.path.abspath(root)
 
+    def store(self, fetcher, relative_dest):
+        dst = os.path.join(self.root, relative_dest)
+        mkdirp(os.path.dirname(dst))
+        tmp = os.path.join(
+            os.path.dirname(dst), ".tmp." + secrets.token_hex(6) + "." + os.path.basename(dst)
+        )
+        open(tmp, "xb").close()
+        try:
+            fetcher.archive(tmp)
+            os.replace(tmp, dst)
+        except BaseException:
+            try:
+                os.unlink(tmp)
+            except OSError:
+                pass
+            raise
+
+
+class FsCache(_FilesystemCache):
     def store(self, fetcher, relative_dest):
         # skip fetchers that aren't cachable
         if not fetcher.cachable:
@@ -1773,9 +1793,7 @@ class FsCache:
         if isinstance(fetcher, CacheURLFetchStrategy):
             return
 
-        dst = os.path.join(self.root, relative_dest)
-        mkdirp(os.path.dirname(dst))
-        fetcher.archive(dst)
+        super().store(fetcher, relative_dest)
 
     def fetcher(self, target_path: str, digest: Optional[str], **kwargs) -> CacheURLFetchStrategy:
         path = os.path.join(self.root, target_path)

--- a/lib/spack/spack/test/mirror.py
+++ b/lib/spack/spack/test/mirror.py
@@ -218,6 +218,27 @@ class MockFetcher:
             pass
 
 
+def test_cache_store_atomic_on_failure(tmp_path: pathlib.Path):
+    """A failed archive() must not leave a partial file at the final destination."""
+
+    class FailingFetcher:
+        cachable = True
+
+        @staticmethod
+        def archive(dst):
+            with open(dst, "wb") as f:
+                f.write(b"partial")
+            raise RuntimeError("simulated failure mid-archive")
+
+    for cache in [
+        spack.caches.MirrorCache(root=str(tmp_path), skip_unstable_versions=False),
+        spack.fetch_strategy.FsCache(str(tmp_path)),
+    ]:
+        with pytest.raises(RuntimeError, match="simulated failure"):
+            cache.store(FailingFetcher(), "pkg/pkg-1.0.tar.gz")
+        assert not (tmp_path / "pkg" / "pkg-1.0.tar.gz").exists()
+
+
 @pytest.mark.regression("14067")
 def test_mirror_layout_make_alias(tmp_path: pathlib.Path):
     """Confirm that the cosmetic symlink created in the mirror cache (which may


### PR DESCRIPTION
If two builds `foo/hash1` and `foo/hash2` cache sources at the same
time, there's a race, resulting in a broken archive. This is
particularly bad for git sources where we ~can't~ don't do source verification

This fix does not rule out races entirely, but does give an exclusive
temporary file to write to, followed by a rename.

