### PR TITLE
Bugfix: Failed git include clean up destination dir

### DIFF
--- a/lib/spack/spack/config.py
+++ b/lib/spack/spack/config.py
@@ -34,8 +34,10 @@ import os
 import os.path
 import pathlib
 import re
+import shutil
 import sys
 import tempfile
+import warnings
 from collections import defaultdict
 from itertools import chain
 from typing import Any, Callable, Dict, Generator, List, Optional, Set, Tuple, Union, cast
@@ -163,7 +165,7 @@ class ConfigScope:
                 # Do not include duplicate scopes
                 for included_scope in included_scopes:
                     if any([included_scope.name == scope.name for scope in self._included_scopes]):
-                        tty.warn(f"Ignoring duplicate included scope: {included_scope.name}")
+                        warnings.warn(f"Ignoring duplicate included scope: {included_scope.name}")
                         continue
 
                     if included_scope not in self._included_scopes:
@@ -1357,6 +1359,9 @@ class GitIncludePaths(OptionalInclude):
             parent_scope: enclosing scope
 
         Returns: destination path if cloned or ``None``
+
+        Raises:
+            ConfigError: unable to create or clone the git repo
         """
         if self.fetched():
             tty.debug(f"Repository ({self.git}) already cloned to {self.destination}")
@@ -1367,17 +1372,12 @@ class GitIncludePaths(OptionalInclude):
         assert destination, f"{self} requires a local cache directory"
         tty.debug(f"Cloning {self.git} into {destination}")
 
-        with filesystem.working_dir(destination, create=True):
-            if not os.path.exists(".git"):
-                try:
+        try:
+            with filesystem.working_dir(destination, create=True):
+                if not os.path.exists(".git"):
                     tty.debug("Initializing the git repository")
                     spack.util.git.init_git_repo(self.git)
-                except spack.util.executable.ProcessError as e:
-                    raise spack.error.ConfigError(
-                        f"Unable to initialize repository ({self.git}) under {destination}: {e}"
-                    )
 
-            try:
                 if self.commit:
                     tty.debug(f"Pulling commit {self.commit}")
                     spack.util.git.pull_checkout_commit(self.commit)
@@ -1398,14 +1398,16 @@ class GitIncludePaths(OptionalInclude):
                 else:
                     raise spack.error.ConfigError(f"Missing or unsupported options in {self}")
 
-            except spack.util.executable.ProcessError as e:
-                raise spack.error.ConfigError(
-                    f"Unable to check out repository ({self}) in {destination}: {e}"
-                )
+        except spack.util.executable.ProcessError as e:
+            # Cleanup the destination if it exists
+            shutil.rmtree(destination, ignore_errors=True)
 
-            # only set the destination on successful clone/checkout
-            self.destination = destination
-            return self.destination
+            msg = f"Unable to check out repository ({self}) in {destination}: {e}"
+            raise spack.error.ConfigError(msg) from e
+
+        # only set the destination on successful clone/checkout
+        self.destination = destination
+        return self.destination
 
     def fetched(self) -> bool:
         return bool(self.destination) and os.path.exists(

--- a/lib/spack/spack/test/config.py
+++ b/lib/spack/spack/test/config.py
@@ -1990,7 +1990,7 @@ def test_included_path_git_errs(tmp_path: pathlib.Path, mock_low_high_config, mo
 
     monkeypatch.setattr(spack.util.git, "init_git_repo", _failing_init)
 
-    with pytest.raises(spack.error.ConfigError, match="Unable to initialize"):
+    with pytest.raises(spack.error.ConfigError, match="Unable to check out"):
         include.scopes(parent_scope)
 
     # fail in git config (so use default remote) *and* git checkout


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->

Fix cleanup after failed include.

Extracted from #52137