### PR TITLE
sbang: install ahead of time

### DIFF
--- a/lib/spack/spack/hooks/sbang.py
+++ b/lib/spack/spack/hooks/sbang.py
@@ -2,7 +2,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-import filecmp
 import os
 import re
 import shutil
@@ -11,13 +10,8 @@ import sys
 import tempfile
 
 import spack.error
-import spack.llnl.util.filesystem as fs
 import spack.llnl.util.tty as tty
-import spack.package_prefs
-import spack.paths
-import spack.spec
 import spack.store
-from spack.util.socket import _gethostname
 
 #: OS-imposed character limit for shebang line: 127 for Linux; 511 for Mac.
 #: Different Linux distributions have different limits, but 127 is the
@@ -38,11 +32,6 @@ else:
     except Exception:
         # ignore any error a sane default is set already
         pass
-
-#: Groupdb does not exist on Windows, prevent imports
-#: on supported systems
-if sys.platform != "win32":
-    import grp
 
 #: Spack itself also limits the shebang line to at most 4KB, which should be plenty.
 spack_shebang_limit = 4096
@@ -189,50 +178,6 @@ def filter_shebangs_in_directory(directory, filenames=None):
             tty.debug("Patched overlong shebang in %s" % path)
 
 
-def install_sbang():
-    """Ensure that ``sbang`` is installed in the root of Spack's install_tree.
-
-    This is the shortest known publicly accessible path, and installing
-    ``sbang`` here ensures that users can access the script and that
-    ``sbang`` itself is in a short path.
-    """
-    # copy in a new version of sbang if it differs from what's in spack
-    sbang_path = sbang_install_path()
-    if os.path.exists(sbang_path) and filecmp.cmp(spack.paths.sbang_script, sbang_path):
-        return
-
-    # make $install_tree/bin
-    sbang_bin_dir = os.path.dirname(sbang_path)
-    fs.mkdirp(sbang_bin_dir)
-
-    # get permissions for bin dir from configuration files
-    group_name = spack.package_prefs.get_package_group(spack.spec.Spec("all"))
-    config_mode = spack.package_prefs.get_package_dir_permissions(spack.spec.Spec("all"))
-
-    if group_name:
-        os.chmod(sbang_bin_dir, config_mode)  # Use package directory permissions
-    else:
-        fs.set_install_permissions(sbang_bin_dir)
-
-    # set group on sbang_bin_dir if not already set (only if set in configuration)
-    # TODO: after we drop python2 support, use shutil.chown to avoid gid lookups that
-    # can fail for remote groups
-    if group_name and os.stat(sbang_bin_dir).st_gid != grp.getgrnam(group_name).gr_gid:
-        os.chown(sbang_bin_dir, os.stat(sbang_bin_dir).st_uid, grp.getgrnam(group_name).gr_gid)
-
-    # copy over the fresh copy of `sbang`
-    sbang_tmp_path = os.path.join(sbang_bin_dir, f".sbang.{_gethostname()}.{os.getpid()}.tmp")
-    shutil.copy(spack.paths.sbang_script, sbang_tmp_path)
-
-    # set permissions on `sbang` (including group if set in configuration)
-    os.chmod(sbang_tmp_path, config_mode)
-    if group_name:
-        os.chown(sbang_tmp_path, os.stat(sbang_tmp_path).st_uid, grp.getgrnam(group_name).gr_gid)
-
-    # Finally, move the new `sbang` into place atomically
-    os.rename(sbang_tmp_path, sbang_path)
-
-
 def post_install(spec, explicit=None):
     """This hook edits scripts so that they call /bin/bash
     $spack_prefix/bin/sbang instead of something longer than the
@@ -243,8 +188,6 @@ def post_install(spec, explicit=None):
     if spec.external:
         tty.debug("SKIP: shebang filtering [external package]")
         return
-
-    install_sbang()
 
     for directory, _, filenames in os.walk(spec.prefix):
         filter_shebangs_in_directory(directory, filenames)

--- a/lib/spack/spack/installer.py
+++ b/lib/spack/spack/installer.py
@@ -2461,6 +2461,7 @@ class PackageInstaller:
 
         """
 
+        spack.store.STORE.install_sbang()
         self._init_queue()
         failed_build_requests = []
         install_status = InstallStatus(len(self.build_pq))

--- a/lib/spack/spack/new_installer.py
+++ b/lib/spack/spack/new_installer.py
@@ -2445,6 +2445,7 @@ class PackageInstaller:
         self._installer()
 
     def _installer(self) -> None:
+        spack.store.STORE.install_sbang()
         jobserver = JobServer(self.jobs)
         selector = selectors.DefaultSelector()
 

--- a/lib/spack/spack/store.py
+++ b/lib/spack/spack/store.py
@@ -17,9 +17,13 @@ debugging easier.
 """
 
 import contextlib
+import filecmp
 import os
 import pathlib
 import re
+import secrets
+import shutil
+import sys
 import uuid
 from typing import Any, Callable, Dict, Generator, List, Optional, Tuple, Union, cast
 
@@ -28,9 +32,11 @@ import spack.database
 import spack.directory_layout
 import spack.error
 import spack.llnl.util.lang
+import spack.package_prefs
 import spack.paths
 import spack.spec
 import spack.util.path
+from spack.llnl.util import filesystem as fs
 from spack.llnl.util import tty
 
 #: default installation root, relative to the Spack install path
@@ -193,6 +199,58 @@ class Store:
     def reindex(self) -> None:
         """Convenience function to reindex the store DB with its own layout."""
         return self.db.reindex()
+
+    def install_sbang(self) -> None:
+        """Install the sbang script in this store's bin directory.
+
+        sbang is a short shell script that Spack prepends to scripts with shebangs that are too
+        long for the OS. It must live in the store so its path is short enough to fit on a
+        shebang line.
+        """
+
+        if sys.platform == "win32":
+            return
+
+        import grp  # unix only, hence the import here
+
+        sbang_path = os.path.join(self.unpadded_root, "bin", "sbang")
+        try:
+            if filecmp.cmp(sbang_path, spack.paths.sbang_script):
+                return  # installed and up to date
+        except FileNotFoundError:
+            pass
+
+        bin_dir = os.path.dirname(sbang_path)
+        os.makedirs(bin_dir, exist_ok=True)
+
+        all_spec = spack.spec.Spec("all")
+        group_name = spack.package_prefs.get_package_group(all_spec)
+        config_mode = spack.package_prefs.get_package_dir_permissions(all_spec)
+        gid = grp.getgrnam(group_name).gr_gid if group_name else -1
+
+        if group_name:
+            os.chmod(bin_dir, config_mode)
+            os.chown(bin_dir, -1, gid)
+        else:
+            fs.set_install_permissions(bin_dir)
+
+        sbang_tmp_path = os.path.join(bin_dir, f".sbang.{secrets.token_hex(8)}.tmp")
+        # Open a randomized temporary file with O_EXCL to error on races. Outside the try-except
+        # to ensure we don't delete a file created by another process in the except block.
+        sbang_tmp_file = open(sbang_tmp_path, "xb")
+        try:
+            with open(spack.paths.sbang_script, "rb") as src, sbang_tmp_file as dst:
+                shutil.copyfileobj(src, dst)
+                os.fchmod(dst.fileno(), config_mode | 0o111)  # ensure executable
+                if group_name:
+                    os.fchown(dst.fileno(), -1, gid)
+            os.rename(sbang_tmp_path, sbang_path)
+        except BaseException:
+            try:
+                os.unlink(sbang_tmp_path)
+            except OSError:
+                pass
+            raise
 
     def __reduce__(self):
         return Store, (

--- a/lib/spack/spack/test/sbang.py
+++ b/lib/spack/spack/test/sbang.py
@@ -333,7 +333,7 @@ def run_test_install_sbang(group):
     assert sbang_path.startswith(spack.store.STORE.unpadded_root)
     assert not os.path.exists(sbang_bin_dir)
 
-    sbang.install_sbang()
+    spack.store.STORE.install_sbang()
     check_sbang_installation(group)
 
     # put an invalid file in for sbang
@@ -341,11 +341,11 @@ def run_test_install_sbang(group):
     with open(sbang_path, "w", encoding="utf-8") as f:
         f.write("foo")
 
-    sbang.install_sbang()
+    spack.store.STORE.install_sbang()
     check_sbang_installation(group)
 
     # install again and make sure sbang is still fine
-    sbang.install_sbang()
+    spack.store.STORE.install_sbang()
     check_sbang_installation(group)
 
 


### PR DESCRIPTION
Move the responsibility for installing `sbang` from the post-install
hook to the installer. This ensures that sbang is present before the
build begins, eliminates unnecessary races to install it in parallel in
the build sub-processes, and allows the build subprocesses to run with
more restricted write access, necessary for sandboxing.

Other than that:

* Use O_EXCL to prevent race conditions where multiple processes create
  a temporary file in `$store/bin`
* Use fchmod/fchown to eliminate TOCTOU
* Due to use of fd, we now have to chmod with 0o111 to make sbang
  executable.
* Eliminate a few redundant syscalls.
