### PR TITLE
Include/exclude specs from binary caches (mirrors)

### DIFF
--- a/lib/spack/docs/binary_caches.rst
+++ b/lib/spack/docs/binary_caches.rst
@@ -324,10 +324,11 @@ The ``mirrors.yaml`` has to be edited directly to specify select and exclude pat
    mirrors:
      <name>:
        url: <url>
-       select: []
-       exclude: [python@3.14, ^mpich]
-
-This configuration includes all specs, except ``python@3.14`` and those that depend on ``mpich``.
+       select:
+       - "%gcc"  # include only specs that depend on gcc
+       exclude:
+       - "dev_path=*"  # except development specs
+       - "^mpich"  # and any spec that depends on mpich
 
 
 Relocation

--- a/lib/spack/docs/binary_caches.rst
+++ b/lib/spack/docs/binary_caches.rst
@@ -315,6 +315,7 @@ Including and Excluding Specs in Build Caches
 .. versionadded:: 1.2
 
 When pushing to or fetching from a build cache, you can specify include and exclude patterns in the mirror configuration to control which specs are included in or excluded from the build cache.
+If a spec satisfies an include and exclude filter then the exclusion wins.
 By default, all specs are included and none are excluded.
 
 The ``mirrors.yaml`` has to be edited directly to specify include and exclude patterns:

--- a/lib/spack/docs/binary_caches.rst
+++ b/lib/spack/docs/binary_caches.rst
@@ -308,6 +308,28 @@ Alternatively, you can edit the ``mirrors.yaml`` configuration file directly:
 
 See also :ref:`mirrors`.
 
+
+Including and Excluding Specs in Build Caches
+---------------------------------------------
+
+.. versionadded:: 1.2
+
+When pushing to a build cache, you can specify select and exclude patterns in the mirror configuration to control which specs are included in or excluded from the build cache.
+By default, all specs are included and none are excluded.
+
+The ``mirrors.yaml`` has to be edited directly to specify select and exclude patterns:
+
+.. code-block:: yaml
+
+   mirrors:
+     <name>:
+       url: <url>
+       select: []
+       exclude: [python@3.14, ^mpich]
+
+This configuration includes all specs, except ``python@3.14`` and those that depend on ``mpich``.
+
+
 Relocation
 ----------
 

--- a/lib/spack/docs/binary_caches.rst
+++ b/lib/spack/docs/binary_caches.rst
@@ -314,7 +314,7 @@ Including and Excluding Specs in Build Caches
 
 .. versionadded:: 1.2
 
-When pushing to a build cache, you can specify select and exclude patterns in the mirror configuration to control which specs are included in or excluded from the build cache.
+When pushing to or fetching from a build cache, you can specify select and exclude patterns in the mirror configuration to control which specs are included in or excluded from the build cache.
 By default, all specs are included and none are excluded.
 
 The ``mirrors.yaml`` has to be edited directly to specify select and exclude patterns:

--- a/lib/spack/docs/binary_caches.rst
+++ b/lib/spack/docs/binary_caches.rst
@@ -314,19 +314,19 @@ Including and Excluding Specs in Build Caches
 
 .. versionadded:: 1.2
 
-When pushing to or fetching from a build cache, you can specify select and exclude patterns in the mirror configuration to control which specs are included in or excluded from the build cache.
+When pushing to or fetching from a build cache, you can specify include and exclude patterns in the mirror configuration to control which specs are included in or excluded from the build cache.
 By default, all specs are included and none are excluded.
 
-The ``mirrors.yaml`` has to be edited directly to specify select and exclude patterns:
+The ``mirrors.yaml`` has to be edited directly to specify include and exclude patterns:
 
 .. code-block:: yaml
 
    mirrors:
      <name>:
        url: <url>
-       select:
+       include_binary:
        - "%gcc"  # include only specs that depend on gcc
-       exclude:
+       exclude_binary:
        - "dev_path=*"  # except development specs
        - "^mpich"  # and any spec that depends on mpich
 

--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -1750,7 +1750,12 @@ def download_tarball(
                 return mirror, layout_version
         return spack.mirrors.mirror.Mirror(url), layout_version
 
-    mirrors = [fetch_url_to_mirror(mirror_metadata) for mirror_metadata in urls_and_versions]
+    mirrors = [
+        (mirror, layout_version)
+        for mirror_metadata in urls_and_versions
+        for mirror, layout_version in [fetch_url_to_mirror(mirror_metadata)]
+        if mirror.matches(spec)
+    ]
 
     for mirror, layout_version in mirrors:
         # Override mirror's default if

--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -1754,7 +1754,7 @@ def download_tarball(
         (mirror, layout_version)
         for mirror_metadata in urls_and_versions
         for mirror, layout_version in [fetch_url_to_mirror(mirror_metadata)]
-        if mirror.matches(spec, direction="fetch")
+        if mirror.matches_binary(spec, direction="fetch")
     ]
 
     for mirror, layout_version in mirrors:

--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -1754,7 +1754,7 @@ def download_tarball(
         (mirror, layout_version)
         for mirror_metadata in urls_and_versions
         for mirror, layout_version in [fetch_url_to_mirror(mirror_metadata)]
-        if mirror.matches(spec)
+        if mirror.matches(spec, direction="fetch")
     ]
 
     for mirror, layout_version in mirrors:

--- a/lib/spack/spack/cmd/buildcache.py
+++ b/lib/spack/spack/cmd/buildcache.py
@@ -420,6 +420,27 @@ def _skip_no_redistribute_for_public(specs):
     return remaining_specs
 
 
+def _filter_specs_for_push(specs, mirror):
+    """Filter specs based on mirror select/exclude patterns."""
+    remaining_specs = list()
+    removed_specs = list()
+
+    for spec in specs:
+        if mirror.matches(spec):
+            remaining_specs.append(spec)
+        else:
+            removed_specs.append(spec)
+
+    if removed_specs:
+        colified_output = tty.colify.colified(list(s.name for s in removed_specs), indent=4)
+        tty.info(
+            "The following specs will not be pushed to the binary cache"
+            " because they match exclude patterns:\n"
+            f"{colified_output}"
+        )
+    return remaining_specs
+
+
 class PackagesAreNotInstalledError(spack.error.SpackError):
     """Raised when a list of specs is not installed but picked to be packaged."""
 
@@ -511,6 +532,8 @@ def push_fn(args):
 
     if not args.private:
         specs = _skip_no_redistribute_for_public(specs)
+
+    specs = _filter_specs_for_push(specs, mirror)
 
     if len(specs) > 1:
         tty.info(f"Selected {len(specs)} specs to push to {push_url}")

--- a/lib/spack/spack/cmd/buildcache.py
+++ b/lib/spack/spack/cmd/buildcache.py
@@ -17,7 +17,6 @@ import spack.config
 import spack.deptypes as dt
 import spack.environment as ev
 import spack.error
-import spack.llnl.util.tty as tty
 import spack.mirrors.mirror
 import spack.oci.image
 import spack.oci.oci
@@ -32,7 +31,9 @@ from spack.binary_distribution import BINARY_INDEX
 from spack.cmd import display_specs
 from spack.cmd.common import arguments
 from spack.llnl.string import plural
+from spack.llnl.util import tty
 from spack.llnl.util.lang import elide_list, stable_partition
+from spack.llnl.util.tty import colify
 from spack.spec import Spec, save_dependency_specfiles
 
 from ..buildcache_migrate import migrate
@@ -401,16 +402,16 @@ def _format_spec(spec: Spec) -> str:
     return spec.cformat("{name}{@version}{/hash:7}")
 
 
-def _skip_no_redistribute_for_public(specs):
-    remaining_specs = list()
-    removed_specs = list()
+def _skip_no_redistribute_for_public(specs: List[Spec]) -> List[Spec]:
+    remaining_specs: List[Spec] = []
+    removed_specs: List[Spec] = []
     for spec in specs:
         if spec.package.redistribute_binary:
             remaining_specs.append(spec)
         else:
             removed_specs.append(spec)
     if removed_specs:
-        colified_output = tty.colify.colified(list(s.name for s in removed_specs), indent=4)
+        colified_output = colify.colified(list(s.name for s in removed_specs), indent=4)
         tty.debug(
             "The following specs will not be added to the binary cache"
             " because they cannot be redistributed:\n"
@@ -420,10 +421,10 @@ def _skip_no_redistribute_for_public(specs):
     return remaining_specs
 
 
-def _filter_specs_for_push(specs, mirror):
+def _filter_specs_for_push(specs: List[Spec], mirror: spack.mirrors.mirror.Mirror) -> List[Spec]:
     """Filter specs based on mirror select/exclude patterns."""
-    remaining_specs = list()
-    removed_specs = list()
+    remaining_specs: List[Spec] = []
+    removed_specs: List[Spec] = []
 
     for spec in specs:
         if mirror.matches(spec):
@@ -432,8 +433,8 @@ def _filter_specs_for_push(specs, mirror):
             removed_specs.append(spec)
 
     if removed_specs:
-        colified_output = tty.colify.colified(list(s.name for s in removed_specs), indent=4)
-        tty.info(
+        colified_output = colify.colified(list(s.name for s in removed_specs), indent=4)
+        tty.debug(
             "The following specs will not be pushed to the binary cache"
             " because they match exclude patterns:\n"
             f"{colified_output}"

--- a/lib/spack/spack/cmd/buildcache.py
+++ b/lib/spack/spack/cmd/buildcache.py
@@ -411,7 +411,7 @@ def _skip_no_redistribute_for_public(specs: List[Spec]) -> List[Spec]:
         else:
             removed_specs.append(spec)
     if removed_specs:
-        colified_output = colify.colified(list(s.name for s in removed_specs), indent=4)
+        colified_output = colify.colified([s.name for s in removed_specs], indent=4)
         tty.debug(
             "The following specs will not be added to the binary cache"
             " because they cannot be redistributed:\n"
@@ -433,7 +433,7 @@ def _filter_specs_for_push(specs: List[Spec], mirror: spack.mirrors.mirror.Mirro
             removed_specs.append(spec)
 
     if removed_specs:
-        colified_output = colify.colified(list(s.name for s in removed_specs), indent=4)
+        colified_output = colify.colified([s.name for s in removed_specs], indent=4)
         tty.debug(
             "The following specs will not be pushed to the binary cache"
             " because they match exclude patterns:\n"

--- a/lib/spack/spack/cmd/buildcache.py
+++ b/lib/spack/spack/cmd/buildcache.py
@@ -427,7 +427,7 @@ def _filter_specs_for_push(specs: List[Spec], mirror: spack.mirrors.mirror.Mirro
     removed_specs: List[Spec] = []
 
     for spec in specs:
-        if mirror.matches(spec):
+        if mirror.matches(spec, direction="push"):
             remaining_specs.append(spec)
         else:
             removed_specs.append(spec)

--- a/lib/spack/spack/cmd/buildcache.py
+++ b/lib/spack/spack/cmd/buildcache.py
@@ -422,12 +422,12 @@ def _skip_no_redistribute_for_public(specs: List[Spec]) -> List[Spec]:
 
 
 def _filter_specs_for_push(specs: List[Spec], mirror: spack.mirrors.mirror.Mirror) -> List[Spec]:
-    """Filter specs based on mirror select/exclude patterns."""
+    """Filter specs based on mirror include/exclude buildcache patterns."""
     remaining_specs: List[Spec] = []
     removed_specs: List[Spec] = []
 
     for spec in specs:
-        if mirror.matches(spec, direction="push"):
+        if mirror.matches_binary(spec, direction="push"):
             remaining_specs.append(spec)
         else:
             removed_specs.append(spec)
@@ -436,7 +436,7 @@ def _filter_specs_for_push(specs: List[Spec], mirror: spack.mirrors.mirror.Mirro
         colified_output = colify.colified([s.name for s in removed_specs], indent=4)
         tty.debug(
             "The following specs will not be pushed to the binary cache"
-            " because they do not match the mirror's select/exclude filters:\n"
+            " because they do not match the mirror's include/exclude filters:\n"
             f"{colified_output}"
         )
     return remaining_specs

--- a/lib/spack/spack/cmd/buildcache.py
+++ b/lib/spack/spack/cmd/buildcache.py
@@ -436,7 +436,7 @@ def _filter_specs_for_push(specs: List[Spec], mirror: spack.mirrors.mirror.Mirro
         colified_output = colify.colified([s.name for s in removed_specs], indent=4)
         tty.debug(
             "The following specs will not be pushed to the binary cache"
-            " because they match exclude patterns:\n"
+            " because they do not match the mirror's select/exclude filters:\n"
             f"{colified_output}"
         )
     return remaining_specs

--- a/lib/spack/spack/hooks/autopush.py
+++ b/lib/spack/spack/hooks/autopush.py
@@ -23,8 +23,7 @@ def post_install(spec, explicit):
     for mirror in spack.mirrors.mirror.MirrorCollection(binary=True, autopush=True).values():
         if not mirror.matches(spec):
             tty.debug(
-                f"{spec.name}: Skipped push to '{mirror.name}' "
-                f"due to select/exclude filters"
+                f"{spec.name}: Skipped push to '{mirror.name}' due to select/exclude filters"
             )
             continue
 

--- a/lib/spack/spack/hooks/autopush.py
+++ b/lib/spack/spack/hooks/autopush.py
@@ -21,6 +21,13 @@ def post_install(spec, explicit):
 
     # Push the package to all autopush mirrors
     for mirror in spack.mirrors.mirror.MirrorCollection(binary=True, autopush=True).values():
+        if not mirror.matches(spec):
+            tty.debug(
+                f"{spec.name}: Skipped push to '{mirror.name}' "
+                f"due to select/exclude filters"
+            )
+            continue
+
         signing_key = spack.binary_distribution.select_signing_key() if mirror.signed else None
         with spack.binary_distribution.make_uploader(
             mirror=mirror, force=True, signing_key=signing_key

--- a/lib/spack/spack/hooks/autopush.py
+++ b/lib/spack/spack/hooks/autopush.py
@@ -21,7 +21,7 @@ def post_install(spec, explicit):
 
     # Push the package to all autopush mirrors
     for mirror in spack.mirrors.mirror.MirrorCollection(binary=True, autopush=True).values():
-        if not mirror.matches(spec):
+        if not mirror.matches(spec, direction="push"):
             tty.debug(
                 f"{spec.name}: Skipped push to '{mirror.name}' due to select/exclude filters"
             )

--- a/lib/spack/spack/hooks/autopush.py
+++ b/lib/spack/spack/hooks/autopush.py
@@ -21,9 +21,9 @@ def post_install(spec, explicit):
 
     # Push the package to all autopush mirrors
     for mirror in spack.mirrors.mirror.MirrorCollection(binary=True, autopush=True).values():
-        if not mirror.matches(spec, direction="push"):
+        if not mirror.matches_binary(spec, direction="push"):
             tty.debug(
-                f"{spec.name}: Skipped push to '{mirror.name}' due to select/exclude filters"
+                f"{spec.name}: Skipped push to '{mirror.name}' due to include/exclude filters"
             )
             continue
 

--- a/lib/spack/spack/installer.py
+++ b/lib/spack/spack/installer.py
@@ -497,7 +497,7 @@ def _try_install_from_binary_cache(
     """
     # Early exit if no binary mirror accepts this spec (select/exclude filters).
     if not any(
-        m.matches(pkg.spec, direction="fetch")
+        m.matches_binary(pkg.spec, direction="fetch")
         for m in spack.mirrors.mirror.MirrorCollection(binary=True).values()
     ):
         return False

--- a/lib/spack/spack/installer.py
+++ b/lib/spack/spack/installer.py
@@ -497,7 +497,7 @@ def _try_install_from_binary_cache(
     """
     # Early exit if no binary mirror accepts this spec (select/exclude filters).
     if not any(
-        m.matches(pkg.spec) for m in spack.mirrors.mirror.MirrorCollection(binary=True).values()
+        m.matches(pkg.spec, direction="fetch") for m in spack.mirrors.mirror.MirrorCollection(binary=True).values()
     ):
         return False
 

--- a/lib/spack/spack/installer.py
+++ b/lib/spack/spack/installer.py
@@ -497,7 +497,8 @@ def _try_install_from_binary_cache(
     """
     # Early exit if no binary mirror accepts this spec (select/exclude filters).
     if not any(
-        m.matches(pkg.spec, direction="fetch") for m in spack.mirrors.mirror.MirrorCollection(binary=True).values()
+        m.matches(pkg.spec, direction="fetch")
+        for m in spack.mirrors.mirror.MirrorCollection(binary=True).values()
     ):
         return False
 

--- a/lib/spack/spack/installer.py
+++ b/lib/spack/spack/installer.py
@@ -495,8 +495,11 @@ def _try_install_from_binary_cache(
         unsigned: if ``True`` or ``False`` override the mirror signature verification defaults
         timer: timer to keep track of binary install phases.
     """
-    # Early exit if no binary mirrors are configured.
-    if not spack.mirrors.mirror.MirrorCollection(binary=True):
+    # Early exit if no binary mirror accepts this spec (select/exclude filters).
+    if not any(
+        m.matches(pkg.spec)
+        for m in spack.mirrors.mirror.MirrorCollection(binary=True).values()
+    ):
         return False
 
     tty.debug(f"Searching for binary cache of {package_id(pkg.spec)}")

--- a/lib/spack/spack/installer.py
+++ b/lib/spack/spack/installer.py
@@ -497,8 +497,7 @@ def _try_install_from_binary_cache(
     """
     # Early exit if no binary mirror accepts this spec (select/exclude filters).
     if not any(
-        m.matches(pkg.spec)
-        for m in spack.mirrors.mirror.MirrorCollection(binary=True).values()
+        m.matches(pkg.spec) for m in spack.mirrors.mirror.MirrorCollection(binary=True).values()
     ):
         return False
 

--- a/lib/spack/spack/mirrors/mirror.py
+++ b/lib/spack/spack/mirrors/mirror.py
@@ -155,21 +155,15 @@ class Mirror:
             return False
         return self._data.get("autopush", False)
 
-    @property
-    def select(self) -> List[str]:
-        if isinstance(self._data, str):
-            return []
-        return self._data.get("select", [])
+    def select(self, direction: str) -> List[str]:
+        return self._get_value("select", direction) or []
 
-    @property
-    def exclude(self) -> List[str]:
-        if isinstance(self._data, str):
-            return []
-        return self._data.get("exclude", [])
+    def exclude(self, direction: str) -> List[str]:
+        return self._get_value("exclude", direction) or []
 
-    def matches(self, spec: "spack.spec.Spec") -> bool:
+    def matches(self, spec: "spack.spec.Spec", direction: str) -> bool:
         """Check if a spec passes this mirror's select/exclude filters."""
-        return _spec_matches_filters(spec, self.select, self.exclude)
+        return _spec_matches_filters(spec, self.select(direction), self.exclude(direction))
 
     @property
     def fetch_url(self) -> str:

--- a/lib/spack/spack/mirrors/mirror.py
+++ b/lib/spack/spack/mirrors/mirror.py
@@ -263,9 +263,11 @@ class Mirror:
             "access_token_variable",
             "profile",
             "endpoint_url",
+            "select",
+            "exclude",
         ]
         if top_level:
-            keys += ["binary", "source", "signed", "autopush", "select", "exclude"]
+            keys += ["binary", "source", "signed", "autopush"]
         changed = False
         for key in keys:
             if key in new_data and current_data.get(key) != new_data[key]:

--- a/lib/spack/spack/mirrors/mirror.py
+++ b/lib/spack/spack/mirrors/mirror.py
@@ -36,14 +36,14 @@ supported_url_schemes = ("file", "http", "https", "sftp", "ftp", "s3", "gs", "oc
 SUPPORTED_LAYOUT_VERSIONS = (3, 2)
 
 
-def _spec_matches_filters(spec: "spack.spec.Spec", select: List[str], exclude: List[str]) -> bool:
-    """Check if a spec matches select/exclude filters.
+def _spec_matches_filters(spec: "spack.spec.Spec", include: List[str], exclude: List[str]) -> bool:
+    """Check if a spec matches include/exclude filters.
 
     A spec is included when:
-    - select is empty, or spec matches at least one select pattern
+    - include is empty, or spec matches at least one include pattern
     - spec does not match any exclude pattern
     """
-    if select and not any(spec.satisfies(s) for s in select):
+    if include and not any(spec.satisfies(s) for s in include):
         return False
 
     if exclude and any(spec.satisfies(e) for e in exclude):
@@ -155,15 +155,17 @@ class Mirror:
             return False
         return self._data.get("autopush", False)
 
-    def select(self, direction: str) -> List[str]:
-        return self._get_value("select", direction) or []
+    def include_binary(self, direction: str) -> List[str]:
+        return self._get_value("include_binary", direction) or []
 
-    def exclude(self, direction: str) -> List[str]:
-        return self._get_value("exclude", direction) or []
+    def exclude_binary(self, direction: str) -> List[str]:
+        return self._get_value("exclude_binary", direction) or []
 
-    def matches(self, spec: "spack.spec.Spec", direction: str) -> bool:
-        """Check if a spec passes this mirror's select/exclude filters."""
-        return _spec_matches_filters(spec, self.select(direction), self.exclude(direction))
+    def matches_binary(self, spec: "spack.spec.Spec", direction: str) -> bool:
+        """Check if a spec passes this mirror's include/exclude buildcache filters."""
+        return _spec_matches_filters(
+            spec, self.include_binary(direction), self.exclude_binary(direction)
+        )
 
     @property
     def fetch_url(self) -> str:

--- a/lib/spack/spack/mirrors/mirror.py
+++ b/lib/spack/spack/mirrors/mirror.py
@@ -21,6 +21,24 @@ supported_url_schemes = ("file", "http", "https", "sftp", "ftp", "s3", "gs", "oc
 SUPPORTED_LAYOUT_VERSIONS = (3, 2)
 
 
+def spec_matches_filters(
+    spec: "spack.spec.Spec", select: List[str], exclude: List[str]
+) -> bool:
+    """Check if a spec matches select/exclude filters.
+
+    A spec is included when:
+    - select is empty, or spec matches at least one select pattern
+    - spec does not match any exclude pattern
+    """
+    if select and not any(spec.satisfies(s) for s in select):
+        return False
+
+    if exclude and any(spec.satisfies(e) for e in exclude):
+        return False
+
+    return True
+
+
 def _url_or_path_to_url(url_or_path: str) -> str:
     """For simplicity we allow mirror URLs in config files to be local, relative paths.
     This helper function takes care of distinguishing between URLs and paths, and
@@ -125,6 +143,22 @@ class Mirror:
         return self._data.get("autopush", False)
 
     @property
+    def select(self) -> List[str]:
+        if isinstance(self._data, str):
+            return []
+        return self._data.get("select", [])
+
+    @property
+    def exclude(self) -> List[str]:
+        if isinstance(self._data, str):
+            return []
+        return self._data.get("exclude", [])
+
+    def matches(self, spec: "spack.spec.Spec") -> bool:
+        """Check if a spec passes this mirror's select/exclude filters."""
+        return spec_matches_filters(spec, self.select, self.exclude)
+
+    @property
     def fetch_url(self) -> str:
         """Get the valid, canonicalized fetch URL"""
         return self.get_url("fetch")
@@ -224,7 +258,7 @@ class Mirror:
             "endpoint_url",
         ]
         if top_level:
-            keys += ["binary", "source", "signed", "autopush"]
+            keys += ["binary", "source", "signed", "autopush", "select", "exclude"]
         changed = False
         for key in keys:
             if key in new_data and current_data.get(key) != new_data[key]:

--- a/lib/spack/spack/mirrors/mirror.py
+++ b/lib/spack/spack/mirrors/mirror.py
@@ -4,7 +4,19 @@
 import operator
 import os
 import urllib.parse
-from typing import IO, Any, Dict, Iterator, List, Mapping, Optional, Tuple, Union, overload
+from typing import (
+    IO,
+    TYPE_CHECKING,
+    Any,
+    Dict,
+    Iterator,
+    List,
+    Mapping,
+    Optional,
+    Tuple,
+    Union,
+    overload,
+)
 
 import spack.config
 import spack.llnl.util.tty as tty
@@ -14,6 +26,9 @@ import spack.util.url as url_util
 from spack.error import MirrorError
 from spack.oci.image import is_oci_url
 
+if TYPE_CHECKING:
+    import spack.spec
+
 #: What schemes do we support
 supported_url_schemes = ("file", "http", "https", "sftp", "ftp", "s3", "gs", "oci", "oci+http")
 
@@ -21,7 +36,7 @@ supported_url_schemes = ("file", "http", "https", "sftp", "ftp", "s3", "gs", "oc
 SUPPORTED_LAYOUT_VERSIONS = (3, 2)
 
 
-def spec_matches_filters(spec: "spack.spec.Spec", select: List[str], exclude: List[str]) -> bool:
+def _spec_matches_filters(spec: "spack.spec.Spec", select: List[str], exclude: List[str]) -> bool:
     """Check if a spec matches select/exclude filters.
 
     A spec is included when:
@@ -154,7 +169,7 @@ class Mirror:
 
     def matches(self, spec: "spack.spec.Spec") -> bool:
         """Check if a spec passes this mirror's select/exclude filters."""
-        return spec_matches_filters(spec, self.select, self.exclude)
+        return _spec_matches_filters(spec, self.select, self.exclude)
 
     @property
     def fetch_url(self) -> str:

--- a/lib/spack/spack/mirrors/mirror.py
+++ b/lib/spack/spack/mirrors/mirror.py
@@ -21,9 +21,7 @@ supported_url_schemes = ("file", "http", "https", "sftp", "ftp", "s3", "gs", "oc
 SUPPORTED_LAYOUT_VERSIONS = (3, 2)
 
 
-def spec_matches_filters(
-    spec: "spack.spec.Spec", select: List[str], exclude: List[str]
-) -> bool:
+def spec_matches_filters(spec: "spack.spec.Spec", select: List[str], exclude: List[str]) -> bool:
     """Check if a spec matches select/exclude filters.
 
     A spec is included when:

--- a/lib/spack/spack/new_installer.py
+++ b/lib/spack/spack/new_installer.py
@@ -305,7 +305,7 @@ def install_from_buildcache(
 ) -> bool:
     # Skip if no configured mirror accepts this spec (select/exclude filters)
     if not any(
-        m.matches(spec) for m in spack.mirrors.mirror.MirrorCollection(binary=True).values()
+        m.matches(spec, direction="fetch") for m in spack.mirrors.mirror.MirrorCollection(binary=True).values()
     ):
         return False
 

--- a/lib/spack/spack/new_installer.py
+++ b/lib/spack/spack/new_installer.py
@@ -305,8 +305,7 @@ def install_from_buildcache(
 ) -> bool:
     # Skip if no configured mirror accepts this spec (select/exclude filters)
     if not any(
-        m.matches(spec)
-        for m in spack.mirrors.mirror.MirrorCollection(binary=True).values()
+        m.matches(spec) for m in spack.mirrors.mirror.MirrorCollection(binary=True).values()
     ):
         return False
 

--- a/lib/spack/spack/new_installer.py
+++ b/lib/spack/spack/new_installer.py
@@ -303,6 +303,13 @@ def install_from_buildcache(
     unsigned: Optional[bool],
     state_stream: io.TextIOWrapper,
 ) -> bool:
+    # Skip if no configured mirror accepts this spec (select/exclude filters)
+    if not any(
+        m.matches(spec)
+        for m in spack.mirrors.mirror.MirrorCollection(binary=True).values()
+    ):
+        return False
+
     send_state("fetching from build cache", state_stream)
     try:
         tarball_stage = spack.binary_distribution.download_tarball(

--- a/lib/spack/spack/new_installer.py
+++ b/lib/spack/spack/new_installer.py
@@ -305,7 +305,7 @@ def install_from_buildcache(
 ) -> bool:
     # Skip if no configured mirror accepts this spec (select/exclude filters)
     if not any(
-        m.matches(spec, direction="fetch")
+        m.matches_binary(spec, direction="fetch")
         for m in spack.mirrors.mirror.MirrorCollection(binary=True).values()
     ):
         return False

--- a/lib/spack/spack/new_installer.py
+++ b/lib/spack/spack/new_installer.py
@@ -305,7 +305,8 @@ def install_from_buildcache(
 ) -> bool:
     # Skip if no configured mirror accepts this spec (select/exclude filters)
     if not any(
-        m.matches(spec, direction="fetch") for m in spack.mirrors.mirror.MirrorCollection(binary=True).values()
+        m.matches(spec, direction="fetch")
+        for m in spack.mirrors.mirror.MirrorCollection(binary=True).values()
     ):
         return False
 

--- a/lib/spack/spack/schema/mirrors.py
+++ b/lib/spack/spack/schema/mirrors.py
@@ -113,6 +113,19 @@ mirror_entry = {
             "description": "Automatically push packages to this build cache immediately after "
             "they are installed locally",
         },
+        "select": {
+            "type": "array",
+            "items": {"type": "string"},
+            "description": "List of spec patterns to include for this build cache. "
+            "If specified, only specs matching at least one pattern will be "
+            "pushed or pulled (default: all specs).",
+        },
+        "exclude": {
+            "type": "array",
+            "items": {"type": "string"},
+            "description": "List of spec patterns to exclude from this build cache "
+            "(default: exclude nothing).",
+        },
         **connection,
     },
 }

--- a/lib/spack/spack/schema/mirrors.py
+++ b/lib/spack/spack/schema/mirrors.py
@@ -10,8 +10,8 @@
 
 from typing import Any, Dict
 
-#: Common properties for connection specification
-connection = {
+#: Properties that can be set at mirror-level and overridden for fetch/push directions
+overridable_per_direction = {
     "url": {
         "type": "string",
         "description": "URL pointing to the mirror directory, can be local filesystem "
@@ -54,6 +54,19 @@ connection = {
         "description": "Environment variable containing an access token for OCI registry "
         "authentication",
     },
+    "select": {
+        "type": "array",
+        "items": {"type": "string"},
+        "description": "List of spec patterns to include for this build cache. "
+        "If specified, only specs matching at least one pattern will be "
+        "pushed or pulled (default: all specs).",
+    },
+    "exclude": {
+        "type": "array",
+        "items": {"type": "string"},
+        "description": "List of spec patterns to exclude from this build cache "
+        "(default: exclude nothing).",
+    },
 }
 
 
@@ -71,7 +84,7 @@ fetch_and_push = {
             "description": "Detailed connection configuration with authentication and custom "
             "settings",
             "additionalProperties": False,
-            "properties": {**connection},
+            "properties": {**overridable_per_direction},
         },
     ],
 }
@@ -113,20 +126,7 @@ mirror_entry = {
             "description": "Automatically push packages to this build cache immediately after "
             "they are installed locally",
         },
-        "select": {
-            "type": "array",
-            "items": {"type": "string"},
-            "description": "List of spec patterns to include for this build cache. "
-            "If specified, only specs matching at least one pattern will be "
-            "pushed or pulled (default: all specs).",
-        },
-        "exclude": {
-            "type": "array",
-            "items": {"type": "string"},
-            "description": "List of spec patterns to exclude from this build cache "
-            "(default: exclude nothing).",
-        },
-        **connection,
+        **overridable_per_direction,
     },
 }
 

--- a/lib/spack/spack/schema/mirrors.py
+++ b/lib/spack/spack/schema/mirrors.py
@@ -54,14 +54,14 @@ overridable_per_direction = {
         "description": "Environment variable containing an access token for OCI registry "
         "authentication",
     },
-    "select": {
+    "include_binary": {
         "type": "array",
         "items": {"type": "string"},
         "description": "List of spec patterns to include for this build cache. "
         "If specified, only specs matching at least one pattern will be "
         "pushed or pulled (default: all specs).",
     },
-    "exclude": {
+    "exclude_binary": {
         "type": "array",
         "items": {"type": "string"},
         "description": "List of spec patterns to exclude from this build cache "

--- a/lib/spack/spack/test/cmd/buildcache.py
+++ b/lib/spack/spack/test/cmd/buildcache.py
@@ -493,9 +493,7 @@ def test_filter_specs_for_push_with_exclude(mock_packages, mutable_config):
         spack.concretize.concretize_one("brillig"),
         spack.concretize.concretize_one("canfail"),
     ]
-    mirror = spack.mirrors.mirror.Mirror(
-        {"url": "https://example.com", "exclude": ["brillig"]}
-    )
+    mirror = spack.mirrors.mirror.Mirror({"url": "https://example.com", "exclude": ["brillig"]})
     filtered = spack.cmd.buildcache._filter_specs_for_push(specs, mirror)
     assert not any(s.name == "brillig" for s in filtered)
     assert any(s.name == "canfail" for s in filtered)
@@ -507,9 +505,7 @@ def test_filter_specs_for_push_with_select(mock_packages, mutable_config):
         spack.concretize.concretize_one("brillig"),
         spack.concretize.concretize_one("canfail"),
     ]
-    mirror = spack.mirrors.mirror.Mirror(
-        {"url": "https://example.com", "select": ["canfail"]}
-    )
+    mirror = spack.mirrors.mirror.Mirror({"url": "https://example.com", "select": ["canfail"]})
     filtered = spack.cmd.buildcache._filter_specs_for_push(specs, mirror)
     assert not any(s.name == "brillig" for s in filtered)
     assert any(s.name == "canfail" for s in filtered)

--- a/lib/spack/spack/test/cmd/buildcache.py
+++ b/lib/spack/spack/test/cmd/buildcache.py
@@ -487,32 +487,32 @@ def test_skip_no_redistribute(mock_packages, config):
     assert any(s.name == "no-redistribute-dependent" for s in filtered)
 
 
-def test_filter_specs_for_push_with_exclude(mock_packages, config):
+def test_filter_specs_for_push_with_exclude(mock_packages, mutable_config):
     """Test that _filter_specs_for_push excludes specs matching the mirror's exclude patterns."""
     specs = [
-        spack.concretize.concretize_one("mpich"),
-        spack.concretize.concretize_one("zmpi"),
+        spack.concretize.concretize_one("brillig"),
+        spack.concretize.concretize_one("canfail"),
     ]
     mirror = spack.mirrors.mirror.Mirror(
-        {"url": "https://example.com", "exclude": ["mpich"]}
+        {"url": "https://example.com", "exclude": ["brillig"]}
     )
     filtered = spack.cmd.buildcache._filter_specs_for_push(specs, mirror)
-    assert not any(s.name == "mpich" for s in filtered)
-    assert any(s.name == "zmpi" for s in filtered)
+    assert not any(s.name == "brillig" for s in filtered)
+    assert any(s.name == "canfail" for s in filtered)
 
 
-def test_filter_specs_for_push_with_select(mock_packages, config):
+def test_filter_specs_for_push_with_select(mock_packages, mutable_config):
     """Test that _filter_specs_for_push only includes specs matching the mirror's select patterns."""
     specs = [
-        spack.concretize.concretize_one("mpich"),
-        spack.concretize.concretize_one("zmpi"),
+        spack.concretize.concretize_one("brillig"),
+        spack.concretize.concretize_one("canfail"),
     ]
     mirror = spack.mirrors.mirror.Mirror(
-        {"url": "https://example.com", "select": ["zmpi"]}
+        {"url": "https://example.com", "select": ["canfail"]}
     )
     filtered = spack.cmd.buildcache._filter_specs_for_push(specs, mirror)
-    assert not any(s.name == "mpich" for s in filtered)
-    assert any(s.name == "zmpi" for s in filtered)
+    assert not any(s.name == "brillig" for s in filtered)
+    assert any(s.name == "canfail" for s in filtered)
 
 
 def test_best_effort_vs_fail_fast_when_dep_not_installed(tmp_path: pathlib.Path, mutable_database):

--- a/lib/spack/spack/test/cmd/buildcache.py
+++ b/lib/spack/spack/test/cmd/buildcache.py
@@ -500,7 +500,8 @@ def test_filter_specs_for_push_with_exclude(mock_packages, mutable_config):
 
 
 def test_filter_specs_for_push_with_select(mock_packages, mutable_config):
-    """Test that _filter_specs_for_push only includes specs matching the mirror's select patterns."""
+    """Test that _filter_specs_for_push only includes specs matching the mirror's select
+    patterns."""
     specs = [
         spack.concretize.concretize_one("brillig"),
         spack.concretize.concretize_one("canfail"),

--- a/lib/spack/spack/test/cmd/buildcache.py
+++ b/lib/spack/spack/test/cmd/buildcache.py
@@ -487,6 +487,34 @@ def test_skip_no_redistribute(mock_packages, config):
     assert any(s.name == "no-redistribute-dependent" for s in filtered)
 
 
+def test_filter_specs_for_push_with_exclude(mock_packages, config):
+    """Test that _filter_specs_for_push excludes specs matching the mirror's exclude patterns."""
+    specs = [
+        spack.concretize.concretize_one("mpich"),
+        spack.concretize.concretize_one("zmpi"),
+    ]
+    mirror = spack.mirrors.mirror.Mirror(
+        {"url": "https://example.com", "exclude": ["mpich"]}
+    )
+    filtered = spack.cmd.buildcache._filter_specs_for_push(specs, mirror)
+    assert not any(s.name == "mpich" for s in filtered)
+    assert any(s.name == "zmpi" for s in filtered)
+
+
+def test_filter_specs_for_push_with_select(mock_packages, config):
+    """Test that _filter_specs_for_push only includes specs matching the mirror's select patterns."""
+    specs = [
+        spack.concretize.concretize_one("mpich"),
+        spack.concretize.concretize_one("zmpi"),
+    ]
+    mirror = spack.mirrors.mirror.Mirror(
+        {"url": "https://example.com", "select": ["zmpi"]}
+    )
+    filtered = spack.cmd.buildcache._filter_specs_for_push(specs, mirror)
+    assert not any(s.name == "mpich" for s in filtered)
+    assert any(s.name == "zmpi" for s in filtered)
+
+
 def test_best_effort_vs_fail_fast_when_dep_not_installed(tmp_path: pathlib.Path, mutable_database):
     """When --fail-fast is passed, the push command should fail if it immediately finds an
     uninstalled dependency. Otherwise, failure to push one dependency shouldn't prevent the

--- a/lib/spack/spack/test/cmd/buildcache.py
+++ b/lib/spack/spack/test/cmd/buildcache.py
@@ -493,20 +493,24 @@ def test_filter_specs_for_push_with_exclude(mock_packages, mutable_config):
         spack.concretize.concretize_one("brillig"),
         spack.concretize.concretize_one("canfail"),
     ]
-    mirror = spack.mirrors.mirror.Mirror({"url": "https://example.com", "exclude": ["brillig"]})
+    mirror = spack.mirrors.mirror.Mirror(
+        {"url": "https://example.com", "exclude_binary": ["brillig"]}
+    )
     filtered = spack.cmd.buildcache._filter_specs_for_push(specs, mirror)
     assert not any(s.name == "brillig" for s in filtered)
     assert any(s.name == "canfail" for s in filtered)
 
 
-def test_filter_specs_for_push_with_select(mock_packages, mutable_config):
-    """Test that _filter_specs_for_push only includes specs matching the mirror's select
+def test_filter_specs_for_push_with_include(mock_packages, mutable_config):
+    """Test that _filter_specs_for_push only includes specs matching the mirror's include
     patterns."""
     specs = [
         spack.concretize.concretize_one("brillig"),
         spack.concretize.concretize_one("canfail"),
     ]
-    mirror = spack.mirrors.mirror.Mirror({"url": "https://example.com", "select": ["canfail"]})
+    mirror = spack.mirrors.mirror.Mirror(
+        {"url": "https://example.com", "include_binary": ["canfail"]}
+    )
     filtered = spack.cmd.buildcache._filter_specs_for_push(specs, mirror)
     assert not any(s.name == "brillig" for s in filtered)
     assert any(s.name == "canfail" for s in filtered)

--- a/lib/spack/spack/test/mirror.py
+++ b/lib/spack/spack/test/mirror.py
@@ -399,3 +399,42 @@ def test_mirror_name_or_url_dir_parsing(tmp_path: pathlib.Path):
     with working_dir(curdir):
         assert mirror_name_or_url(".").fetch_url == curdir.as_uri()
         assert mirror_name_or_url("..").fetch_url == tmp_path.as_uri()
+
+
+@pytest.mark.parametrize(
+    "select,exclude,spec_str,expected",
+    [
+        # No filters: everything matches
+        ([], [], "mpich", True),
+        # Select only: matches if spec satisfies a select pattern
+        (["mpich"], [], "mpich", True),
+        (["mpich"], [], "zlib", False),
+        # Exclude only: matches unless spec satisfies an exclude pattern
+        ([], ["mpich"], "mpich", False),
+        ([], ["mpich"], "zlib", True),
+        # Both select and exclude
+        (["mpich", "zlib"], ["zlib"], "mpich", True),
+        (["mpich", "zlib"], ["zlib"], "zlib", False),
+        # Select with version constraint
+        (["mpich@3:"], [], "mpich@3.0", True),
+        (["mpich@3:"], [], "mpich@1.0", False),
+    ],
+)
+def test_spec_matches_filters(select, exclude, spec_str, expected):
+    """Test the spec_matches_filters standalone function."""
+    spec = spack.concretize.concretize_one(spec_str)
+    assert spack.mirrors.mirror.spec_matches_filters(spec, select, exclude) is expected
+
+
+def test_mirror_matches(mock_packages, config):
+    """Test that Mirror.matches() delegates to spec_matches_filters."""
+    spec = spack.concretize.concretize_one("mpich")
+
+    m = spack.mirrors.mirror.Mirror({"url": "https://example.com"})
+    assert m.matches(spec) is True
+
+    m = spack.mirrors.mirror.Mirror({"url": "https://example.com", "exclude": ["mpich"]})
+    assert m.matches(spec) is False
+
+    m = spack.mirrors.mirror.Mirror({"url": "https://example.com", "select": ["zlib"]})
+    assert m.matches(spec) is False

--- a/lib/spack/spack/test/mirror.py
+++ b/lib/spack/spack/test/mirror.py
@@ -424,45 +424,57 @@ def test_spec_matches_filters(mock_packages, mutable_config, select, exclude, sp
 
 
 def test_mirror_matches(mock_packages, mutable_config):
-    """Test that Mirror.matches() correctly applies select/exclude filters."""
+    """Test that Mirror.matches_binary() correctly applies select/exclude filters."""
     spec = spack.concretize.concretize_one("brillig")
 
     # No filters: everything matches
     m = spack.mirrors.mirror.Mirror({"url": "https://example.com"})
-    assert m.matches(spec, direction="fetch") is True
+    assert m.matches_binary(spec, direction="fetch") is True
 
     # Exclude matches the spec
-    m = spack.mirrors.mirror.Mirror({"url": "https://example.com", "exclude": ["brillig"]})
-    assert m.matches(spec, direction="fetch") is False
+    m = spack.mirrors.mirror.Mirror({"url": "https://example.com", "exclude_binary": ["brillig"]})
+    assert m.matches_binary(spec, direction="fetch") is False
 
     # Select does not include the spec
-    m = spack.mirrors.mirror.Mirror({"url": "https://example.com", "select": ["canfail"]})
-    assert m.matches(spec, direction="fetch") is False
+    m = spack.mirrors.mirror.Mirror({"url": "https://example.com", "include_binary": ["canfail"]})
+    assert m.matches_binary(spec, direction="fetch") is False
 
     # Select includes the spec
-    m = spack.mirrors.mirror.Mirror({"url": "https://example.com", "select": ["brillig"]})
-    assert m.matches(spec, direction="fetch") is True
+    m = spack.mirrors.mirror.Mirror({"url": "https://example.com", "include_binary": ["brillig"]})
+    assert m.matches_binary(spec, direction="fetch") is True
 
     # Exclude does not match the spec
-    m = spack.mirrors.mirror.Mirror({"url": "https://example.com", "exclude": ["canfail"]})
-    assert m.matches(spec, direction="fetch") is True
+    m = spack.mirrors.mirror.Mirror({"url": "https://example.com", "exclude_binary": ["canfail"]})
+    assert m.matches_binary(spec, direction="fetch") is True
 
     # Select includes but exclude also matches: exclude wins
     m = spack.mirrors.mirror.Mirror(
-        {"url": "https://example.com", "select": ["brillig"], "exclude": ["brillig"]}
+        {
+            "url": "https://example.com",
+            "include_binary": ["brillig"],
+            "exclude_binary": ["brillig"],
+        }
     )
-    assert m.matches(spec, direction="fetch") is False
+    assert m.matches_binary(spec, direction="fetch") is False
 
     # Direction-specific filter overrides global filters
     m = spack.mirrors.mirror.Mirror(
-        {"url": "https://example.com", "select": ["canfail"], "fetch": {"select": ["brillig"]}}
+        {
+            "url": "https://example.com",
+            "include_binary": ["canfail"],
+            "fetch": {"include_binary": ["brillig"]},
+        }
     )
-    assert m.matches(spec, direction="fetch") is True
-    assert m.matches(spec, direction="push") is False
+    assert m.matches_binary(spec, direction="fetch") is True
+    assert m.matches_binary(spec, direction="push") is False
 
     # Direction-specific and mirror-level config compose
     m = spack.mirrors.mirror.Mirror(
-        {"url": "https://example.com", "select": ["brillig"], "fetch": {"exclude": ["brillig"]}}
+        {
+            "url": "https://example.com",
+            "include_binary": ["brillig"],
+            "fetch": {"exclude_binary": ["brillig"]},
+        }
     )
-    assert m.matches(spec, direction="fetch") is False
-    assert m.matches(spec, direction="push") is True
+    assert m.matches_binary(spec, direction="fetch") is False
+    assert m.matches_binary(spec, direction="push") is True

--- a/lib/spack/spack/test/mirror.py
+++ b/lib/spack/spack/test/mirror.py
@@ -452,3 +452,17 @@ def test_mirror_matches(mock_packages, mutable_config):
         {"url": "https://example.com", "select": ["brillig"], "exclude": ["brillig"]}
     )
     assert m.matches(spec, direction="fetch") is False
+
+    # Direction-specific filter overrides global filters
+    m = spack.mirrors.mirror.Mirror(
+        {"url": "https://example.com", "select": ["canfail"], "fetch": {"select": ["brillig"]}}
+    )
+    assert m.matches(spec, direction="fetch") is True
+    assert m.matches(spec, direction="push") is False
+
+    # Direction-specific and mirror-level config compose
+    m = spack.mirrors.mirror.Mirror(
+        {"url": "https://example.com", "select": ["brillig"], "fetch": {"exclude": ["brillig"]}}
+    )
+    assert m.matches(spec, direction="fetch") is False
+    assert m.matches(spec, direction="push") is True

--- a/lib/spack/spack/test/mirror.py
+++ b/lib/spack/spack/test/mirror.py
@@ -420,7 +420,7 @@ def test_mirror_name_or_url_dir_parsing(tmp_path: pathlib.Path):
 def test_spec_matches_filters(mock_packages, mutable_config, select, exclude, spec_str, expected):
     """Test the spec_matches_filters standalone function."""
     spec = spack.concretize.concretize_one(spec_str)
-    assert spack.mirrors.mirror.spec_matches_filters(spec, select, exclude) is expected
+    assert spack.mirrors.mirror._spec_matches_filters(spec, select, exclude) is expected
 
 
 def test_mirror_matches(mock_packages, mutable_config):

--- a/lib/spack/spack/test/mirror.py
+++ b/lib/spack/spack/test/mirror.py
@@ -405,36 +405,50 @@ def test_mirror_name_or_url_dir_parsing(tmp_path: pathlib.Path):
     "select,exclude,spec_str,expected",
     [
         # No filters: everything matches
-        ([], [], "mpich", True),
+        ([], [], "brillig", True),
         # Select only: matches if spec satisfies a select pattern
-        (["mpich"], [], "mpich", True),
-        (["mpich"], [], "zlib", False),
+        (["brillig"], [], "brillig", True),
+        (["brillig"], [], "canfail", False),
         # Exclude only: matches unless spec satisfies an exclude pattern
-        ([], ["mpich"], "mpich", False),
-        ([], ["mpich"], "zlib", True),
+        ([], ["brillig"], "brillig", False),
+        ([], ["brillig"], "canfail", True),
         # Both select and exclude
-        (["mpich", "zlib"], ["zlib"], "mpich", True),
-        (["mpich", "zlib"], ["zlib"], "zlib", False),
-        # Select with version constraint
-        (["mpich@3:"], [], "mpich@3.0", True),
-        (["mpich@3:"], [], "mpich@1.0", False),
+        (["brillig", "canfail"], ["canfail"], "brillig", True),
+        (["brillig", "canfail"], ["canfail"], "canfail", False),
     ],
 )
-def test_spec_matches_filters(select, exclude, spec_str, expected):
+def test_spec_matches_filters(mock_packages, mutable_config, select, exclude, spec_str, expected):
     """Test the spec_matches_filters standalone function."""
     spec = spack.concretize.concretize_one(spec_str)
     assert spack.mirrors.mirror.spec_matches_filters(spec, select, exclude) is expected
 
 
-def test_mirror_matches(mock_packages, config):
-    """Test that Mirror.matches() delegates to spec_matches_filters."""
-    spec = spack.concretize.concretize_one("mpich")
+def test_mirror_matches(mock_packages, mutable_config):
+    """Test that Mirror.matches() correctly applies select/exclude filters."""
+    spec = spack.concretize.concretize_one("brillig")
 
+    # No filters: everything matches
     m = spack.mirrors.mirror.Mirror({"url": "https://example.com"})
     assert m.matches(spec) is True
 
-    m = spack.mirrors.mirror.Mirror({"url": "https://example.com", "exclude": ["mpich"]})
+    # Exclude matches the spec
+    m = spack.mirrors.mirror.Mirror({"url": "https://example.com", "exclude": ["brillig"]})
     assert m.matches(spec) is False
 
-    m = spack.mirrors.mirror.Mirror({"url": "https://example.com", "select": ["zlib"]})
+    # Select does not include the spec
+    m = spack.mirrors.mirror.Mirror({"url": "https://example.com", "select": ["canfail"]})
+    assert m.matches(spec) is False
+
+    # Select includes the spec
+    m = spack.mirrors.mirror.Mirror({"url": "https://example.com", "select": ["brillig"]})
+    assert m.matches(spec) is True
+
+    # Exclude does not match the spec
+    m = spack.mirrors.mirror.Mirror({"url": "https://example.com", "exclude": ["canfail"]})
+    assert m.matches(spec) is True
+
+    # Select includes but exclude also matches: exclude wins
+    m = spack.mirrors.mirror.Mirror(
+        {"url": "https://example.com", "select": ["brillig"], "exclude": ["brillig"]}
+    )
     assert m.matches(spec) is False

--- a/lib/spack/spack/test/mirror.py
+++ b/lib/spack/spack/test/mirror.py
@@ -429,26 +429,26 @@ def test_mirror_matches(mock_packages, mutable_config):
 
     # No filters: everything matches
     m = spack.mirrors.mirror.Mirror({"url": "https://example.com"})
-    assert m.matches(spec) is True
+    assert m.matches(spec, direction="fetch") is True
 
     # Exclude matches the spec
     m = spack.mirrors.mirror.Mirror({"url": "https://example.com", "exclude": ["brillig"]})
-    assert m.matches(spec) is False
+    assert m.matches(spec, direction="fetch") is False
 
     # Select does not include the spec
     m = spack.mirrors.mirror.Mirror({"url": "https://example.com", "select": ["canfail"]})
-    assert m.matches(spec) is False
+    assert m.matches(spec, direction="fetch") is False
 
     # Select includes the spec
     m = spack.mirrors.mirror.Mirror({"url": "https://example.com", "select": ["brillig"]})
-    assert m.matches(spec) is True
+    assert m.matches(spec, direction="fetch") is True
 
     # Exclude does not match the spec
     m = spack.mirrors.mirror.Mirror({"url": "https://example.com", "exclude": ["canfail"]})
-    assert m.matches(spec) is True
+    assert m.matches(spec, direction="fetch") is True
 
     # Select includes but exclude also matches: exclude wins
     m = spack.mirrors.mirror.Mirror(
         {"url": "https://example.com", "select": ["brillig"], "exclude": ["brillig"]}
     )
-    assert m.matches(spec) is False
+    assert m.matches(spec, direction="fetch") is False


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->

Following https://github.com/spack/spack/pull/52289, @haampie suggested that a generally useful implementation to filtering binary caches would be config with select/exclude like in views https://spack.readthedocs.io/en/latest/environments.html#advanced-view-configuration. This is an attempt at such an implementation.

The idea is to be able to attach `select`/`exclude` attributes to a given mirror. The following would exclude all specs marked as 'develop' from being pushed/pulled from the mirror, and remaining specs would be filtered to select only those compiled with gcc:

```yaml
# Mirrors: select/exclude are properties of a named mirror entry
mirrors:
  my-mirror:
    url: oci://ghcr.io/example/mirror
    select: ["%gcc"]
    exclude: ["dev_path=*"]
```

These attributes `select`/`exclude` have an effect on both push and pull behaviors.

Similar PRs:

- https://github.com/spack/spack/pull/52289
- https://github.com/spack/spack/pull/50099