### PR TITLE
Warn about missing index only during concretization

### DIFF
--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -164,6 +164,7 @@ class _MirrorIndexResult(NamedTuple):
     regenerate: bool
     had_cache_entry: bool
     error: Optional[Exception]
+    no_index: bool = False
 
 
 class _LastFetch(NamedTuple):
@@ -217,6 +218,8 @@ class BinaryIndexCache:
         self._known_specs: Dict[str, spack.spec.Spec] = {}
         #: Dictionary mapping DAG hashes of specs to a list of mirrors where they can be found
         self._mirrors_for_spec: Dict[str, Set[MirrorMetadata]] = defaultdict(set)
+        #: URLs of binary mirrors that had no buildcache index during the last update()
+        self.mirrors_without_index: Set[str] = set()
 
     def _init_local_index_cache(self):
         if not self._index_file_cache_initialized:
@@ -335,6 +338,7 @@ class BinaryIndexCache:
         from each configured mirror and stored locally (both in memory and
         on disk under ``_index_cache_root``)."""
         self._init_local_index_cache()
+        self.mirrors_without_index = set()
 
         supported_mirror_versions = {
             (m.fetch_url, m.fetch_view): m.supported_layout_versions
@@ -353,6 +357,9 @@ class BinaryIndexCache:
 
             if result.succeeded:
                 all_failed = False
+
+            if result.no_index:
+                self.mirrors_without_index.add(url)
 
             regenerate_cache |= result.regenerate
             clear_cache |= result.regenerate and result.had_cache_entry
@@ -419,10 +426,9 @@ class BinaryIndexCache:
                 self._last_fetch_times[meta] = _LastFetch(time=now, succeeded=False)
                 continue
 
-        # All versions reported no index found. This is not a failure
-        warnings.warn(f"the mirror at {url} cannot be used in concretization (no index found)")
+        # All versions reported no index found. Record it for concretization callers to warn.
         return _MirrorIndexResult(
-            succeeded=True, regenerate=False, had_cache_entry=False, error=None
+            succeeded=True, regenerate=False, had_cache_entry=False, error=None, no_index=True
         )
 
     def _remove_stale_cache_entries(

--- a/lib/spack/spack/solver/reuse.py
+++ b/lib/spack/spack/solver/reuse.py
@@ -4,6 +4,7 @@
 import enum
 import functools
 import typing
+import warnings
 from typing import Any, Callable, List, Mapping, Optional
 
 import spack.binary_distribution
@@ -129,12 +130,15 @@ def _specs_from_store(configuration):
 
 def _specs_from_mirror():
     try:
-        return spack.binary_distribution.update_cache_and_get_specs()
+        specs = spack.binary_distribution.update_cache_and_get_specs()
     except (spack.binary_distribution.FetchCacheError, IndexError):
         # this is raised when no mirrors had indices.
         # TODO: update mirror configuration so it can indicate that the
         # TODO: source cache (or any mirror really) doesn't have binaries.
         return []
+    for url in sorted(spack.binary_distribution.BINARY_INDEX.mirrors_without_index):
+        warnings.warn(f"the mirror at {url} cannot be used in concretization (no index found)")
+    return specs
 
 
 def _specs_from_environment(env):

--- a/lib/spack/spack/test/binary_distribution.py
+++ b/lib/spack/spack/test/binary_distribution.py
@@ -13,6 +13,7 @@ import tarfile
 import urllib.error
 import urllib.request
 import urllib.response
+import warnings
 from pathlib import Path, PurePath
 from typing import Any, Callable, Dict, NamedTuple, Optional
 
@@ -1500,12 +1501,13 @@ def test_mirror_metadata_with_view():
         spack.binary_distribution.MirrorMetadata.from_string("https://dummy.io/__v3%asdf__@aview")
 
 
-def test_update_warns_on_mirror_with_no_index(monkeypatch, tmp_path: pathlib.Path, mutable_config):
-    """Tests that BinaryCacheIndex.update() warns when a mirror has no index for any supported
-    layout version.
+def test_update_does_not_warn_on_mirror_with_no_index(monkeypatch, tmp_path, mutable_config):
+    """Tests that BinaryIndexCache.update() does NOT warn when a mirror has no index but records
+    that information for later use.
     """
     mirror_url = url_util.path_to_file_url(str(tmp_path / "mirror_dir"))
-    spack.config.set("mirrors", {"test": mirror_url})
+    mirror_url2 = url_util.path_to_file_url(str(tmp_path / "mirror_dir2"))
+    mutable_config.set("mirrors", {"test1": mirror_url, "test2": mirror_url2})
 
     def no_index(*args, **kwargs):
         raise spack.binary_distribution.BuildcacheIndexNotExists("no index")
@@ -1513,5 +1515,12 @@ def test_update_warns_on_mirror_with_no_index(monkeypatch, tmp_path: pathlib.Pat
     binary_index = spack.binary_distribution.BinaryIndexCache(str(tmp_path / "index_cache"))
     monkeypatch.setattr(binary_index, "_fetch_and_cache_index", no_index)
 
-    with pytest.warns(UserWarning, match="cannot be used in concretization"):
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
         binary_index.update()
+
+    concretization_warnings = [
+        w for w in caught if "cannot be used in concretization" in str(w.message)
+    ]
+    assert not concretization_warnings, "update() must not warn about concretization"
+    assert binary_index.mirrors_without_index == {mirror_url, mirror_url2}

--- a/lib/spack/spack/test/concretization/core.py
+++ b/lib/spack/spack/test/concretization/core.py
@@ -5077,3 +5077,16 @@ packages:
     assert mpileaks.satisfies("%c,cxx=llvm %fortran=gcc"), mpileaks.tree()
     assert mpileaks.satisfies("%mpi=mpich")
     assert mpileaks["mpich"].satisfies("%c,cxx=llvm %fortran=gcc")
+
+
+def test_specs_from_mirror_warns_when_index_missing(monkeypatch):
+    """Tests that we get a warning when a binary mirror has no index."""
+
+    def fake_update_cache():
+        spack.binary_distribution.BINARY_INDEX.mirrors_without_index = {"file:///fake-mirror"}
+        return []
+
+    monkeypatch.setattr(spack.binary_distribution, "update_cache_and_get_specs", fake_update_cache)
+
+    with pytest.warns(UserWarning, match="cannot be used in concretization"):
+        spack.solver.reuse._specs_from_mirror()


### PR DESCRIPTION
The warning for missing index was unconditionally emitted for every update, which is noisy. Since the warning is only helpful during concretization, restrict it to just that code path

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
