### PR TITLE
new_installer.py: do not add token if decrease is pending

### DIFF
--- a/lib/spack/spack/new_installer.py
+++ b/lib/spack/spack/new_installer.py
@@ -850,8 +850,11 @@ class JobServer:
         """Add one token to the jobserver to increase parallelism; this should always work."""
         if not self.created:
             return
-        os.write(self.w, b"+")
         self.target_jobs += 1
+        # If a decrease was pending, don't add a token.
+        if self.target_jobs <= self.num_jobs:
+            return
+        os.write(self.w, b"+")
         self.num_jobs += 1
 
     def decrease_parallelism(self) -> None:

--- a/lib/spack/spack/test/jobserver.py
+++ b/lib/spack/spack/test/jobserver.py
@@ -366,7 +366,8 @@ class TestJobServer:
             js.close()
 
     def test_decrease_parallelism_no_token_available(self):
-        """When all tokens are held, decrease_parallelism defers the discard."""
+        """When all tokens are held, decrease_parallelism defers the discard.
+        A subsequent increase cancels the pending decrease instead of adding a token."""
         js = JobServer(3)
         try:
             # Drain the pipe so no tokens are available for immediate discard.
@@ -375,6 +376,10 @@ class TestJobServer:
             js.decrease_parallelism()
             # target_jobs decremented but num_jobs unchanged (no token to discard yet).
             assert js.target_jobs == original_num - 1
+            assert js.num_jobs == original_num
+            # increase should cancel the pending decrease, not write a new token.
+            js.increase_parallelism()
+            assert js.target_jobs == original_num
             assert js.num_jobs == original_num
         finally:
             js.close()


### PR DESCRIPTION
If you do `-` to decrease parallelism, and the decrease is pending because no
job token is returned, then `+` should only update the target value, without
adding a new token the jobserver.

