### PR TITLE
new_installer.py: bold, not bold white

### DIFF
--- a/lib/spack/spack/new_installer.py
+++ b/lib/spack/spack/new_installer.py
@@ -1587,10 +1587,10 @@ class BuildStatus:
             yield "\033[0m"  # reset
         yield " "
 
-        # Package name in bold white if explicit, default otherwise
+        # Package name in bold if explicit, default otherwise
         if build_info.explicit:
             if self.color:
-                yield "\033[1;37m"  # bold white
+                yield "\033[1m"
             yield build_info.name
             if self.color:
                 yield "\033[0m"  # reset


### PR DESCRIPTION
Mark Krentel reported that bold white does not render legible in his terminal.
It's better to use just bold (which happens to render red by default on macOS,
but is configurable).

