### PR TITLE
pyproject: configure ruff check to implicitly fix

### DIFF
--- a/lib/spack/spack/cmd/style.py
+++ b/lib/spack/spack/cmd/style.py
@@ -246,7 +246,7 @@ def ruff_check(file_list, args):
     """Run the ruff-check command. Handles config and non generic ruff argument logic"""
     cmd_args = ["--config", os.path.join(spack.paths.prefix, "pyproject.toml"), "--quiet"]
     if args.fix:
-        cmd_args += ["--fix", "--no-unsafe-fixes"]
+        cmd_args += ["--no-unsafe-fixes"]
     else:
         cmd_args += ["--no-fix"]
     return run_ruff(

--- a/lib/spack/spack/cmd/style.py
+++ b/lib/spack/spack/cmd/style.py
@@ -246,7 +246,7 @@ def ruff_check(file_list, args):
     """Run the ruff-check command. Handles config and non generic ruff argument logic"""
     cmd_args = ["--config", os.path.join(spack.paths.prefix, "pyproject.toml"), "--quiet"]
     if args.fix:
-        cmd_args += ["--no-unsafe-fixes"]
+        cmd_args += ["--fix", "--no-unsafe-fixes"]
     else:
         cmd_args += ["--no-fix"]
     return run_ruff(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,6 +55,7 @@ test = "./bin/spack unit-test"
 features = ["dev", "ci"]
 
 [tool.ruff]
+fix = true
 target-version = "py37"
 line-length = 99
 extend-include = ["bin/spack"]


### PR DESCRIPTION
Configure ruff via pyproject.toml settings to implicitly fix errors uncaught by ruff format.

Sibling to https://github.com/spack/spack-packages/pull/4751

