### PR TITLE
solver: fix a bug with toolchain expansion in `prefer` rules

### DIFF
--- a/lib/spack/spack/solver/requirements.py
+++ b/lib/spack/spack/solver/requirements.py
@@ -117,7 +117,7 @@ class RequirementRule(NamedTuple):
 def preference(
     pkg_name: str,
     constraint: spack.spec.Spec,
-    condition: spack.spec.Spec = spack.spec.Spec(),
+    condition: spack.spec.Spec = spack.spec.EMPTY_SPEC,
     origin: RequirementOrigin = RequirementOrigin.PREFER_YAML,
     kind: RequirementKind = RequirementKind.PACKAGE,
     message: Optional[str] = None,
@@ -141,7 +141,7 @@ def preference(
 def conflict(
     pkg_name: str,
     constraint: spack.spec.Spec,
-    condition: spack.spec.Spec = spack.spec.Spec(),
+    condition: spack.spec.Spec = spack.spec.EMPTY_SPEC,
     origin: RequirementOrigin = RequirementOrigin.CONFLICT_YAML,
     kind: RequirementKind = RequirementKind.PACKAGE,
     message: Optional[str] = None,
@@ -277,12 +277,12 @@ class RequirementParser:
         # The item is either a string or an object with at least a "spec" attribute
         if isinstance(item, str):
             spec = self._parse_and_expand(item)
-            condition = spack.spec.Spec()
+            condition = spack.spec.EMPTY_SPEC
             message = None
         else:
             spec = self._parse_and_expand(item["spec"])
             when_str = item.get("when")
-            condition = self._parse_and_expand(when_str) if when_str else spack.spec.Spec()
+            condition = self._parse_and_expand(when_str) if when_str else spack.spec.EMPTY_SPEC
             message = item.get("message")
         raw_key = item if isinstance(item, str) else item.get("spec", item)
         _check_unknown_targets([raw_key], [spec], always_warn=True)
@@ -339,7 +339,7 @@ class RequirementParser:
                 _check_unknown_targets(raw_strs, constraints)
                 _check_unknown_virtuals_on_edges(raw_strs, constraints)
                 when_str = requirement.get("when")
-                when = self._parse_and_expand(when_str) if when_str else spack.spec.Spec()
+                when = self._parse_and_expand(when_str) if when_str else spack.spec.EMPTY_SPEC
 
                 constraints = [
                     x

--- a/lib/spack/spack/solver/requirements.py
+++ b/lib/spack/spack/solver/requirements.py
@@ -281,7 +281,8 @@ class RequirementParser:
             message = None
         else:
             spec = self._parse_and_expand(item["spec"])
-            condition = spack.spec.Spec(item.get("when"))
+            when_str = item.get("when")
+            condition = self._parse_and_expand(when_str) if when_str else spack.spec.Spec()
             message = item.get("message")
         raw_key = item if isinstance(item, str) else item.get("spec", item)
         _check_unknown_targets([raw_key], [spec], always_warn=True)

--- a/lib/spack/spack/test/concretization/requirements.py
+++ b/lib/spack/spack/test/concretization/requirements.py
@@ -1643,3 +1643,23 @@ def test_penalties_for_language_preferences(concretize_scope, mock_packages):
     assert s.satisfies("%c=gcc@10")
     assert all(s[name].satisfies("%c=clang") for name in dependency_names)
     assert s["mpi"].satisfies("%c,cxx=clang %fortran=gcc@10")
+
+
+def test_prefer_when_condition_expands_toolchain(concretize_scope, mutable_config, mock_packages):
+    """Tests that toolchains in the 'when' condition of a 'prefer' rule must are expanded."""
+    # If the expansion to %gcc doesn't happen, the preference for @2.1 is silently ignored
+    mutable_config.set("toolchains", {"gcc_toolchain": "%c=gcc"}, scope="concretize")
+    update_packages_config("""
+packages:
+  multivalue-variant:
+    prefer:
+    - spec: "@2.1"
+      when: "%gcc_toolchain"
+""")
+
+    s_gcc = spack.concretize.concretize_one("multivalue-variant %c=gcc")
+    assert s_gcc.satisfies("@2.1 %c=gcc"), f"expected @2.1 with gcc, got {s_gcc.version}"
+
+    # With clang as compiler, condition does not fire -> default highest version @2.3
+    s_clang = spack.concretize.concretize_one("multivalue-variant %clang")
+    assert s_clang.satisfies("@2.3 %c=clang"), f"expected @2.3 with clang, got {s_clang.version}"


### PR DESCRIPTION
Toolchains are currently not expanded in the condition of a conditional preference. Here we fix the issue and add a regression test.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
