### PR TITLE
Dev bootstrap: add dev bootstrap source default && documentation

### DIFF
--- a/etc/spack/defaults/bootstrap.yaml
+++ b/etc/spack/defaults/bootstrap.yaml
@@ -21,3 +21,5 @@ bootstrap:
     github-actions-v2: true
     github-actions-v0.6: true
     spack-install: true
+  dev:
+    enable_source: false

--- a/lib/spack/docs/developer_guide.rst
+++ b/lib/spack/docs/developer_guide.rst
@@ -542,8 +542,7 @@ This process can be driven manually with:
     $ spack bootstrap now --dev
    
 By default, Spack's "development" bootstrap dependencies are set to install from the cache only.
-If for whatever reason you wish to allows for the options to build these dependencies from source,
-you can configure Spack to do so:
+If for whatever reason you wish to allows for the options to build these dependencies from source, you can configure Spack to do so:
 
 .. code-block::console 
 
@@ -551,8 +550,7 @@ you can configure Spack to do so:
 
 .. note:: 
     Spack defaults to bootstrapping development dependencies from binary due to the space and time required to build rust.
-    If you enable from source development dependency bootstrapping, be sure your home drive has sufficient storage and be aware the bootstrap
-    may take some time to complete.
+    If you enable from source development dependency bootstrapping, be sure your home drive has sufficient storage and be aware the bootstrap may take some time to complete.
 
 ``spack unit-test``
 ^^^^^^^^^^^^^^^^^^^

--- a/lib/spack/docs/developer_guide.rst
+++ b/lib/spack/docs/developer_guide.rst
@@ -519,14 +519,14 @@ Developer commands
 ``spack style``
 ^^^^^^^^^^^^^^^
 
-``spack style`` exists to help the developer check imports and style with mypy, Flake8, isort, and (soon) Black.
+``spack style`` exists to help the developer check imports and style with mypy and ruff (check and format).
 To run all style checks, simply do:
 
 .. code-block:: console
 
     $ spack style
 
-To run automatic fixes for isort, you can do:
+To run automatic fixes for ruff format and check, you can do:
 
 .. code-block:: console
 
@@ -534,6 +534,25 @@ To run automatic fixes for isort, you can do:
 
 You do not need any of these Python packages installed on your system for the checks to work!
 Spack will bootstrap install them from packages for your use.
+
+This process can be driven manually with:
+
+.. code-block:: console
+
+    $ spack bootstrap now --dev
+   
+By default, Spack's "development" bootstrap dependencies are set to install from the cache only.
+If for whatever reason you wish to allows for the options to build these dependencies from source,
+you can configure Spack to do so:
+
+.. code-block::console 
+
+    $ spack config add bootstrap:dev:enable_source:true
+
+.. note:: 
+    Spack defaults to bootstrapping development dependencies from binary due to the space and time required to build rust.
+    If you enable from source development dependency bootstrapping, be sure your home drive has sufficient storage and be aware the bootstrap
+    may take some time to complete.
 
 ``spack unit-test``
 ^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
Add default false option for `bootstrap:dev:enable_source` and document existence and behavior of said config setting in developer docs in the context of spack style. 