### PR TITLE
repo cmd: add --no-deprecated flag to show-version-updates

### DIFF
--- a/lib/spack/spack/cmd/repo.py
+++ b/lib/spack/spack/cmd/repo.py
@@ -209,6 +209,9 @@ def setup_parser(subparser: argparse.ArgumentParser):
         "--only-redistributable", action="store_true", help="exclude non-redistributable packages"
     )
     show_version_updates_parser.add_argument(
+        "--no-deprecated", action="store_true", help="exclude deprecated versions"
+    )
+    show_version_updates_parser.add_argument(
         "repository", help="name or path of the repository to analyze"
     )
     show_version_updates_parser.add_argument(
@@ -668,11 +671,7 @@ def repo_show_version_updates(args):
 
     # Filter out manual packages if requested
     if args.no_manual_packages:
-        pkgs = {
-            pkg_name
-            for pkg_name in pkgs
-            if not spack.repo.PATH.get_pkg_class(pkg_name).manual_download
-        }
+        pkgs = {pkg_name for pkg_name in pkgs if not repo.get_pkg_class(pkg_name).manual_download}
 
     if not pkgs:
         tty.info("No packages were added or changed between the specified refs", stream=sys.stderr)
@@ -682,8 +681,8 @@ def repo_show_version_updates(args):
     specs_to_output = []
 
     for pkg_name in pkgs:
-        pkg_cls = spack.repo.PATH.get_pkg_class(pkg_name)
-        path = spack.repo.PATH.package_path(pkg_name)
+        pkg_cls = repo.get_pkg_class(pkg_name)
+        path = repo.filename_for_package_name(pkg_name)
 
         # Get all versions with checksums or commits
         version_to_checksum: Dict[StandardVersion, str] = {}
@@ -712,7 +711,7 @@ def repo_show_version_updates(args):
         specs_to_output = [
             spec
             for spec in specs_to_output
-            if "commit" not in spack.repo.PATH.get_pkg_class(spec.name).versions[spec.version]
+            if "commit" not in repo.get_pkg_class(spec.name).versions[spec.version]
         ]
 
     # Filter out non-redistributable packages if requested
@@ -720,7 +719,15 @@ def repo_show_version_updates(args):
         specs_to_output = [
             spec
             for spec in specs_to_output
-            if spack.repo.PATH.get_pkg_class(spec.name).redistribute_source(spec)
+            if repo.get_pkg_class(spec.name).redistribute_source(spec)
+        ]
+
+    # Filter out deprecated versions if requested
+    if args.no_deprecated:
+        specs_to_output = [
+            spec
+            for spec in specs_to_output
+            if not repo.get_pkg_class(spec.name).versions[spec.version].get("deprecated", False)
         ]
 
     if not specs_to_output:

--- a/lib/spack/spack/test/cmd/repo.py
+++ b/lib/spack/spack/test/cmd/repo.py
@@ -1049,3 +1049,33 @@ def test_repo_show_version_updates_excludes_git_versions(mock_git_package_change
         assert "diff-test@" in output
         assert "2.1.7" in output
         assert "2.1.8" in output
+
+
+def test_repo_show_version_updates_excludes_deprecated(monkeypatch, mock_git_package_changes):
+    """Test --no-deprecated flag excludes versions marked with deprecated=True"""
+    test_repo, _, commits = mock_git_package_changes
+
+    with spack.repo.use_repositories(test_repo):
+        # Mark version 2.1.7 as deprecated
+        pkg_class = spack.repo.PATH.get_pkg_class("diff-test")
+        for v in pkg_class.versions:
+            if str(v) == "2.1.7":
+                pkg_class.versions[v]["deprecated"] = True
+                break
+
+        # Run show-version-updates with --no-deprecated flag
+        output = repo(
+            "show-version-updates",
+            "--no-deprecated",
+            test_repo.root,
+            commits[-2],
+            commits[-4],
+        )
+
+        # v2.1.7 (deprecated) should be excluded
+        assert "2.1.7" not in output
+
+        # v2.1.6 and v2.1.8 (not deprecated) should be included
+        assert "diff-test@" in output
+        assert "2.1.6" in output
+        assert "2.1.8" in output

--- a/lib/spack/spack/test/cmd/repo.py
+++ b/lib/spack/spack/test/cmd/repo.py
@@ -1065,11 +1065,7 @@ def test_repo_show_version_updates_excludes_deprecated(monkeypatch, mock_git_pac
 
         # Run show-version-updates with --no-deprecated flag
         output = repo(
-            "show-version-updates",
-            "--no-deprecated",
-            test_repo.root,
-            commits[-2],
-            commits[-4],
+            "show-version-updates", "--no-deprecated", test_repo.root, commits[-2], commits[-4]
         )
 
         # v2.1.7 (deprecated) should be excluded

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -1880,7 +1880,7 @@ _spack_repo_update() {
 _spack_repo_show_version_updates() {
     if $list_options
     then
-        SPACK_COMPREPLY="-h --help --no-manual-packages --no-git-versions --only-redistributable"
+        SPACK_COMPREPLY="-h --help --no-manual-packages --no-git-versions --only-redistributable --no-deprecated"
     else
         SPACK_COMPREPLY=""
     fi

--- a/share/spack/spack-completion.fish
+++ b/share/spack/spack-completion.fish
@@ -2958,7 +2958,7 @@ complete -c spack -n '__fish_spack_using_command repo update' -l commit -s c -r 
 complete -c spack -n '__fish_spack_using_command repo update' -l commit -s c -r -d 'name of a commit to change to'
 
 # spack repo show-version-updates
-set -g __fish_spack_optspecs_spack_repo_show_version_updates h/help no-manual-packages no-git-versions only-redistributable
+set -g __fish_spack_optspecs_spack_repo_show_version_updates h/help no-manual-packages no-git-versions only-redistributable no-deprecated
 
 complete -c spack -n '__fish_spack_using_command repo show-version-updates' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command repo show-version-updates' -s h -l help -d 'show this help message and exit'
@@ -2968,6 +2968,8 @@ complete -c spack -n '__fish_spack_using_command repo show-version-updates' -l n
 complete -c spack -n '__fish_spack_using_command repo show-version-updates' -l no-git-versions -d 'exclude versions from git'
 complete -c spack -n '__fish_spack_using_command repo show-version-updates' -l only-redistributable -f -a only_redistributable
 complete -c spack -n '__fish_spack_using_command repo show-version-updates' -l only-redistributable -d 'exclude non-redistributable packages'
+complete -c spack -n '__fish_spack_using_command repo show-version-updates' -l no-deprecated -f -a no_deprecated
+complete -c spack -n '__fish_spack_using_command repo show-version-updates' -l no-deprecated -d 'exclude deprecated versions'
 
 # spack resource
 set -g __fish_spack_optspecs_spack_resource h/help


### PR DESCRIPTION
Add a `--no-deprecated` flag to limit outputting deprecated specs in `spack repo show-version-updates`.

If you're creating a mirror with the output of `spack repo show-version-updates` you likely do not want to mirror new deprecated versions into your source mirror. (And if you do you'll need to specifically allow deprecated specs in your concretization during mirror creation.)

Also swapped from `spack.repo.PATH.get_pkg_class()` to `repo.get_pkg_class()` since we are specifically looking at one repository at a time during this command.