### PR TITLE
add audit check for placeholder maintainers

### DIFF
--- a/lib/spack/spack/audit.py
+++ b/lib/spack/spack/audit.py
@@ -1195,12 +1195,12 @@ def _ensure_maintainers_are_not_placeholders(pkgs, error_cls):
     placeholder_maintainers = ("github_user1", "github_user2")
     for pkg_name in pkgs:
         pkg_cls = spack.repo.PATH.get_pkg_class(pkg_name)
+        found_placeholders = set(pkg_cls.maintainers).intersection(placeholder_maintainers)
 
-        for maintainer in pkg_cls.maintainers:
-            if maintainer in placeholder_maintainers:
-                summary = f"Package '{pkg_name}' has placeholder maintainers"
-                details = [f"Remove placeholder maintainer: {maintainer}"]
-                errors.append(error_cls(summary, details))
+        if found_placeholders:
+            summary = f"Package '{pkg_name}' has placeholder maintainer(s)"
+            details = [f"Remove placeholder maintainer(s): {found_placeholders}"]
+            errors.append(error_cls(summary, details))
     return errors
 
 

--- a/lib/spack/spack/audit.py
+++ b/lib/spack/spack/audit.py
@@ -1188,6 +1188,22 @@ def _version_constraints_are_satisfiable_by_some_version_in_repo(pkgs, error_cls
     return errors
 
 
+@package_directives
+def _ensure_maintainers_are_not_placeholders(pkgs, error_cls):
+    """Ensure placeholder maintainers are not defined in the package."""
+    errors = []
+    placeholder_maintainers = ("github_user1", "github_user2")
+    for pkg_name in pkgs:
+        pkg_cls = spack.repo.PATH.get_pkg_class(pkg_name)
+
+        for maintainer in pkg_cls.maintainers:
+            if maintainer in placeholder_maintainers:
+                summary = f"Package '{pkg_name}' has placeholder maintainers"
+                details = [f"Remove placeholder maintainer: {maintainer}"]
+                errors.append(error_cls(summary, details))
+    return errors
+
+
 def _issues_in_directive_constraint(pkg, constraint, *, directive, error_cls, filename, requestor):
     errors = []
     errors.extend(

--- a/lib/spack/spack/test/audit.py
+++ b/lib/spack/spack/test/audit.py
@@ -32,6 +32,8 @@ import spack.config
         (["fail-test-audit-docstring"], ["PKG-PROPERTIES"]),
         # This package has a stand-alone test method without an implementation
         (["fail-test-audit-impl"], ["PKG-PROPERTIES"]),
+        # This package has maintainers with placeholders
+        (["invalid-maintainer"], ["PKG-DIRECTIVES"]),
         # This package has no issues
         (["mpileaks"], None),
         # This package has a conflict with a trigger which cannot constrain the constraint

--- a/lib/spack/spack/test/cmd/maintainers.py
+++ b/lib/spack/spack/test/cmd/maintainers.py
@@ -15,6 +15,7 @@ maintainers = spack.main.SpackCommand("maintainers")
 
 MAINTAINED_PACKAGES = [
     "gcc-runtime",
+    "invalid-maintainer",
     "maintainers-1",
     "maintainers-2",
     "maintainers-3",
@@ -43,6 +44,9 @@ def test_all():
     assert out == [
         "gcc-runtime:",
         "haampie",
+        "invalid-maintainer:",
+        "github_user1,",
+        "github_user2",
         "maintainers-1:",
         "user1,",
         "user2",
@@ -66,6 +70,10 @@ def test_all():
 def test_all_by_user():
     out = split(maintainers("--all", "--by-user"))
     assert out == [
+        "github_user1:",
+        "invalid-maintainer",
+        "github_user2:",
+        "invalid-maintainer",
         "haampie:",
         "gcc-runtime",
         "user0:",

--- a/var/spack/test_repos/spack_repo/builtin_mock/packages/invalid_maintainer/package.py
+++ b/var/spack/test_repos/spack_repo/builtin_mock/packages/invalid_maintainer/package.py
@@ -1,0 +1,14 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+from spack.package import *
+
+
+class InvalidMaintainer(Package):
+    """Package with invalid maintainers (placeholders)."""
+
+    url = "https://www.example.com/archive/v1.0.tar.gz"
+
+    maintainers("github_user1", "github_user2")
+
+    version("1.0", sha256="abcdefg")

--- a/var/spack/test_repos/spack_repo/builtin_mock/packages/invalid_maintainer/package.py
+++ b/var/spack/test_repos/spack_repo/builtin_mock/packages/invalid_maintainer/package.py
@@ -7,7 +7,7 @@ from spack.package import *
 class InvalidMaintainer(Package):
     """Package with invalid maintainers (placeholders)."""
 
-    url = "https://www.example.com/archive/v1.0.tar.gz"
+    url = "https://www.invalid-maintainer.org/archive/v1.0.tar.gz"
 
     maintainers("github_user1", "github_user2")
 

--- a/var/spack/test_repos/spack_repo/builtin_mock/packages/invalid_maintainer/package.py
+++ b/var/spack/test_repos/spack_repo/builtin_mock/packages/invalid_maintainer/package.py
@@ -11,4 +11,4 @@ class InvalidMaintainer(Package):
 
     maintainers("github_user1", "github_user2")
 
-    version("1.0", sha256="abcdefg")
+    version("1.0", sha256="0f22de2391d80d8b393c4f9d11488600126c60ae36ceef780c6a4b3d9dab2e96")


### PR DESCRIPTION
https://github.com/spack/spack-packages/pull/4821 is the only package that has this issue; this will ensure it can't get past CI.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
