### PR TITLE
add audit check for placeholders in package licenses

### DIFF
--- a/lib/spack/spack/audit.py
+++ b/lib/spack/spack/audit.py
@@ -1204,6 +1204,34 @@ def _ensure_maintainers_are_not_placeholders(pkgs, error_cls):
     return errors
 
 
+@package_directives
+def _ensure_license_is_not_placeholder(pkgs, error_cls):
+    """Ensure a license placeholder is not defined in the package."""
+    errors = []
+    invalid_license = "UNKNOWN"
+    invalid_checked_by = "github_user1"
+
+    for pkg_name in pkgs:
+        pkg_cls = spack.repo.PATH.get_pkg_class(pkg_name)
+
+        licenses, checked_bys = set(), set()
+        for license in pkg_cls.licenses.values():
+            licenses.add(license["id"])
+            checked_bys.add(license["checked_by"])
+
+        if invalid_license in licenses:
+            summary = f"Package '{pkg_name}' has placeholder licenses(s)"
+            details = [f"Remove placeholder license(s): {invalid_license}"]
+            errors.append(error_cls(summary, details))
+
+        if invalid_checked_by in checked_bys:
+            summary = f"Package '{pkg_name}' has placeholder license checker(s)"
+            details = [f"Remove placeholder checker(s): {invalid_checked_by}"]
+            errors.append(error_cls(summary, details))
+
+    return errors
+
+
 def _issues_in_directive_constraint(pkg, constraint, *, directive, error_cls, filename, requestor):
     errors = []
     errors.extend(

--- a/lib/spack/spack/cmd/info.py
+++ b/lib/spack/spack/cmd/info.py
@@ -490,8 +490,11 @@ def print_by_name(
         spec = getattr(definition, "spec", None)
         if spec:
             return (spec != spack.spec.Spec(spec.name), spec)
-        else:
-            return getattr(definition, "name", None)  # type: ignore[return-value]
+        # Handle dictionary definitions (e.g., licenses with 'id' field)
+        if isinstance(definition, dict):
+            return (True, definition.get("id", ""))  # type: ignore[return-value]
+        name = getattr(definition, "name", None)
+        return (True, name or "")  # type: ignore[return-value]
 
     for subkey in spack.package_base._subkeys(when_indexed_dictionary):
         for when, definition in sorted(
@@ -564,7 +567,11 @@ def print_variants(pkg: PackageBase, args: Namespace) -> None:
 
 def print_licenses(pkg: PackageBase, args: Namespace) -> None:
     """Output the licenses of the project."""
-    print_definitions(pkg, "Licenses", pkg.licenses, Formatter(), args.by_name)
+    license_ids = {
+        when: data.get("id") if isinstance(data, dict) else data
+        for when, data in pkg.licenses.items()
+    }
+    print_definitions(pkg, "Licenses", license_ids, Formatter(), args.by_name)
 
 
 def print_versions(pkg: PackageBase, args: Namespace) -> None:

--- a/lib/spack/spack/directives.py
+++ b/lib/spack/spack/directives.py
@@ -923,10 +923,17 @@ def license(
         when: A spec specifying when the license applies.
     """
 
-    return partial(_execute_license, license_identifier=license_identifier, when=when)
+    return partial(
+        _execute_license, license_identifier=license_identifier, checked_by=checked_by, when=when
+    )
 
 
-def _execute_license(pkg: PackageType, license_identifier: str, when: Optional[Union[str, bool]]):
+def _execute_license(
+    pkg: PackageType,
+    license_identifier: str,
+    checked_by: Optional[Union[str, List[str]]],
+    when: Optional[Union[str, bool]],
+):
     # If when is not specified the license always holds
     when_spec = _make_when_spec(when)
     if not when_spec:
@@ -943,11 +950,11 @@ def _execute_license(pkg: PackageType, license_identifier: str, when: Optional[U
             err_msg = (
                 f"{pkg.name} is specified as being licensed as {license_identifier} "
                 f"{when_message}, but it is also specified as being licensed under "
-                f"{pkg.licenses[other_when_spec]} {other_when_message}, which conflict."
+                f"{pkg.licenses[other_when_spec]['id']} {other_when_message}, which conflict."
             )
             raise OverlappingLicenseError(err_msg)
 
-    pkg.licenses[when_spec] = license_identifier
+    pkg.licenses[when_spec] = {"id": license_identifier, "checked_by": checked_by}
 
 
 @directive("requirements")

--- a/lib/spack/spack/package_base.py
+++ b/lib/spack/spack/package_base.py
@@ -570,7 +570,7 @@ class PackageBase(WindowsRPath, PackageViewMixin, metaclass=PackageMeta):
     #: Class level dictionary populated by :func:`~spack.directives.variant` directives
     variants: Dict[spack.spec.Spec, Dict[str, spack.variant.Variant]]
     #: Class level dictionary populated by :func:`~spack.directives.license` directives
-    licenses: Dict[spack.spec.Spec, str]
+    licenses: Dict[spack.spec.Spec, Dict[str, Union[str, List[str], None]]]
     #: Class level dictionary populated by :func:`~spack.directives.can_splice` directives
     splice_specs: Dict[spack.spec.Spec, Tuple[spack.spec.Spec, Union[None, str, List[str]]]]
     #: Class level dictionary populated by :func:`~spack.directives.redistribute` directives

--- a/lib/spack/spack/test/audit.py
+++ b/lib/spack/spack/test/audit.py
@@ -34,6 +34,8 @@ import spack.config
         (["fail-test-audit-impl"], ["PKG-PROPERTIES"]),
         # This package has maintainers with placeholders
         (["invalid-maintainer"], ["PKG-DIRECTIVES"]),
+        # This package has a placeholder license
+        (["invalid-license"], ["PKG-DIRECTIVES"]),
         # This package has no issues
         (["mpileaks"], None),
         # This package has a conflict with a trigger which cannot constrain the constraint

--- a/lib/spack/spack/test/directives.py
+++ b/lib/spack/spack/test/directives.py
@@ -113,12 +113,12 @@ def test_license_directive(config, mock_packages, package_name, expected_license
     pkg_cls = spack.repo.PATH.get_pkg_class(package_name)
     for license in expected_licenses:
         assert spack.spec.Spec(license[1]) in pkg_cls.licenses
-        assert license[0] == pkg_cls.licenses[spack.spec.Spec(license[1])]
+        assert license[0] == pkg_cls.licenses[spack.spec.Spec(license[1])]["id"]
 
 
 def test_duplicate_exact_range_license():
     package = namedtuple("package", ["licenses", "name"])
-    package.licenses = {spack.spec.Spec("+foo"): "Apache-2.0"}
+    package.licenses = {spack.spec.Spec("+foo"): {"id": "Apache-2.0", "checked_by": None}}
     package.name = "test_package"
 
     msg = (
@@ -127,12 +127,12 @@ def test_duplicate_exact_range_license():
     )
 
     with pytest.raises(spack.directives.OverlappingLicenseError, match=msg):
-        spack.directives._execute_license(package, "MIT", "+foo")
+        spack.directives._execute_license(package, "MIT", None, "+foo")
 
 
 def test_overlapping_duplicate_licenses():
     package = namedtuple("package", ["licenses", "name"])
-    package.licenses = {spack.spec.Spec("+foo"): "Apache-2.0"}
+    package.licenses = {spack.spec.Spec("+foo"): {"id": "Apache-2.0", "checked_by": None}}
     package.name = "test_package"
 
     msg = (
@@ -141,7 +141,7 @@ def test_overlapping_duplicate_licenses():
     )
 
     with pytest.raises(spack.directives.OverlappingLicenseError, match=msg):
-        spack.directives._execute_license(package, "MIT", "+bar")
+        spack.directives._execute_license(package, "MIT", None, "+bar")
 
 
 def test_version_type_validation():

--- a/var/spack/test_repos/spack_repo/builtin_mock/packages/invalid_license/package.py
+++ b/var/spack/test_repos/spack_repo/builtin_mock/packages/invalid_license/package.py
@@ -1,0 +1,14 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+from spack.package import *
+
+
+class InvalidLicense(Package):
+    """Package invalid license (placeholders)."""
+
+    url = "https://www.invalid-license.org/archive/v1.0.tar.gz"
+
+    license("UNKNOWN", checked_by="github_user1")
+
+    version("1.0", sha256="0f22de2391d80d8b393c4f9d11488600126c60ae36ceef780c6a4b3d9dab2e96")


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
Follow up to https://github.com/spack/spack/pull/52399. To validate the checked_by attribute, I needed to make a change to the structure of the license directive to be a dict with both the license id and checked_by. Open to suggestions about alternatives!