### PR TITLE
Narrow type variable used by `package_base` as annotation for dictionary key to be hashable as well

### DIFF
--- a/lib/spack/spack/package_base.py
+++ b/lib/spack/spack/package_base.py
@@ -62,7 +62,7 @@ from spack.llnl.util.filesystem import (
 from spack.llnl.util.lang import ClassProperty, classproperty, dedupe, memoized
 from spack.resource import Resource
 from spack.util.package_hash import package_hash
-from spack.util.typing import SupportsRichComparison
+from spack.util.typing import SupportsRichComparisonAndHash
 from spack.version import GitVersion, StandardVersion, VersionError, is_git_version
 
 FLAG_HANDLER_RETURN_TYPE = Tuple[
@@ -400,7 +400,7 @@ Pb = TypeVar("Pb", bound="PackageBase")
 #
 # K might be a variant name, a version, etc. V is a definition of some Spack object.
 # The methods below transform these types of dictionaries.
-K = TypeVar("K", bound=SupportsRichComparison)
+K = TypeVar("K", bound=SupportsRichComparisonAndHash)
 V = TypeVar("V")
 
 

--- a/lib/spack/spack/util/typing.py
+++ b/lib/spack/spack/util/typing.py
@@ -18,7 +18,7 @@ from spack.vendor.typing_extensions import Protocol
 if TYPE_CHECKING:
 
     class SupportsRichComparison(Protocol):
-        """Objects that support =, !=, <, <=, >, and >=."""
+        """Objects that support ==, !=, <, <=, >, and >=."""
 
         def __eq__(self, other: Any) -> bool:
             raise NotImplementedError
@@ -38,5 +38,11 @@ if TYPE_CHECKING:
         def __ge__(self, other: Any) -> bool:
             raise NotImplementedError
 
+    class SupportsRichComparisonAndHash(Protocol):
+        """The above, but also implementing or inheriting `__hash__`."""
+
+        def __hash__(self) -> int:
+            raise NotImplementedError
+
 else:
-    SupportsRichComparison = object
+    SupportsRichComparison = SupportsRichComparisonAndHash = object

--- a/lib/spack/spack/util/typing.py
+++ b/lib/spack/spack/util/typing.py
@@ -38,7 +38,7 @@ if TYPE_CHECKING:
         def __ge__(self, other: Any) -> bool:
             raise NotImplementedError
 
-    class SupportsRichComparisonAndHash(Protocol):
+    class SupportsRichComparisonAndHash(SupportsRichComparison, Protocol):
         """The above, but also implementing or inheriting `__hash__`."""
 
         def __hash__(self) -> int:


### PR DESCRIPTION
Closes #52405.