### PR TITLE
Bootstrap: new keytrust approach

### DIFF
--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -2325,7 +2325,7 @@ def _get_keys(
         tty.debug("Found key {0}".format(fingerprint))
         if install:
             if trust:
-                spack.util.gpg.trust(key_blob_path, True)
+                spack.util.gpg.trust(key_blob_path, yes_to_all=True)
                 tty.debug(f"Added {fingerprint} to trusted keys.")
                 saved_fingerprints.append(fingerprint)
             else:
@@ -2375,7 +2375,7 @@ def _get_keys_v2(mirror_url, install=False, trust=False, force=False) -> Optiona
         tty.debug("Found key {0}".format(fingerprint))
         if install:
             if trust:
-                spack.util.gpg.trust(stage.save_filename, True)
+                spack.util.gpg.trust(stage.save_filename, yes_to_all=True)
                 tty.debug("Added this key to trusted keys.")
                 saved_fingerprints.append(fingerprint)
             else:

--- a/lib/spack/spack/bootstrap/environment.py
+++ b/lib/spack/spack/bootstrap/environment.py
@@ -58,7 +58,7 @@ class BootstrapEnvironment(spack.environment.Environment):
                 os.path.join(bootstrap_root_path, "environments", environment_dir)
             )
         )
-    
+
     @classmethod
     def bootstrap_gpg_home(cls) -> pathlib.Path:
         """Location of the GPG home directory used for bootstrapping"""
@@ -105,7 +105,9 @@ class BootstrapEnvironment(spack.environment.Environment):
                     )
                     try:
                         self.install_all(
-                            fail_fast=True, root_policy=fetch_policy, dependencies_policy=fetch_policy
+                            fail_fast=True,
+                            root_policy=fetch_policy,
+                            dependencies_policy=fetch_policy,
                         )
                     except BaseException:
                         # catch any exception as we always want to clean up

--- a/lib/spack/spack/bootstrap/environment.py
+++ b/lib/spack/spack/bootstrap/environment.py
@@ -180,7 +180,7 @@ def download_and_trust_key():
             stage.fetch()
         except spack.error.FetchError as e:
             raise RuntimeError("Cannot fetch Spack Public key for binary cache validation") from e
-        spack.util.gpg.validate_fingerprint_and_trust(fingerprint, stage.save_filename)
+        spack.util.gpg.trust(stage.save_filename, fprs=[fingerprint])
 
 
 def ensure_environment_dependencies() -> None:

--- a/lib/spack/spack/bootstrap/environment.py
+++ b/lib/spack/spack/bootstrap/environment.py
@@ -62,7 +62,7 @@ class BootstrapEnvironment(spack.environment.Environment):
     @classmethod
     def bootstrap_gpg_home(cls) -> pathlib.Path:
         """Location of the GPG home directory used for bootstrapping"""
-        return cls.environment_root().joinpath(".bootstrap_gpg_home")
+        return pathlib.Path(root_path()).joinpath(".bootstrap_gpg_home")
 
     @classmethod
     def view_root(cls) -> pathlib.Path:

--- a/lib/spack/spack/bootstrap/environment.py
+++ b/lib/spack/spack/bootstrap/environment.py
@@ -180,7 +180,7 @@ def download_and_trust_key():
             stage.fetch()
         except spack.error.FetchError as e:
             raise RuntimeError("Cannot fetch Spack Public key for binary cache validation") from e
-        spack.util.gpg.validate_fingerprint(fingerprint, stage.save_filename)
+        spack.util.gpg.validate_fingerprint_and_trust(fingerprint, stage.save_filename)
 
 
 def ensure_environment_dependencies() -> None:

--- a/lib/spack/spack/bootstrap/environment.py
+++ b/lib/spack/spack/bootstrap/environment.py
@@ -58,6 +58,11 @@ class BootstrapEnvironment(spack.environment.Environment):
                 os.path.join(bootstrap_root_path, "environments", environment_dir)
             )
         )
+    
+    @classmethod
+    def bootstrap_gpg_home(cls) -> pathlib.Path:
+        """Location of the GPG home directory used for bootstrapping"""
+        return cls.environment_root().joinpath(".bootstrap_gpg_home")
 
     @classmethod
     def view_root(cls) -> pathlib.Path:
@@ -91,21 +96,22 @@ class BootstrapEnvironment(spack.environment.Environment):
             tty.msg(f"[BOOTSTRAPPING] Installing dependencies ({', '.join(colorized_specs)})")
             self.write(regenerate=False)
             with tty.SuppressOutput(msg_enabled=log_enabled, warn_enabled=log_enabled):
-                download_and_trust_key()
-                fetch_policy = (
-                    "cache_only"
-                    if not spack.config.get("bootstrap:dev:enable_source", False)
-                    else "auto"
-                )
-                try:
-                    self.install_all(
-                        fail_fast=True, root_policy=fetch_policy, dependencies_policy=fetch_policy
+                with spack.util.gpg.gnupghome_override(str(self.bootstrap_gpg_home())):
+                    download_and_trust_key()
+                    fetch_policy = (
+                        "cache_only"
+                        if not spack.config.get("bootstrap:dev:enable_source", False)
+                        else "auto"
                     )
-                except BaseException:
-                    # catch any exception as we always want to clean up
-                    shutil.rmtree(self.environment_root())
-                    raise
-                self.write(regenerate=True)
+                    try:
+                        self.install_all(
+                            fail_fast=True, root_policy=fetch_policy, dependencies_policy=fetch_policy
+                        )
+                    except BaseException:
+                        # catch any exception as we always want to clean up
+                        shutil.rmtree(self.environment_root())
+                        raise
+                    self.write(regenerate=True)
 
     def load(self) -> None:
         """Update PATH and sys.path."""

--- a/lib/spack/spack/bootstrap/environment.py
+++ b/lib/spack/spack/bootstrap/environment.py
@@ -3,7 +3,6 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 """Bootstrap non-core Spack dependencies from an environment."""
 
-import contextlib
 import hashlib
 import os
 import pathlib
@@ -13,10 +12,12 @@ from typing import Iterable, List
 
 import spack.vendor.archspec.cpu
 
-import spack.binary_distribution
 import spack.config
 import spack.environment
+import spack.error
+import spack.paths
 import spack.spec
+import spack.stage
 import spack.tengine
 import spack.util.gpg
 import spack.util.path
@@ -77,12 +78,6 @@ class BootstrapEnvironment(spack.environment.Environment):
         """Environment spack.yaml file"""
         return cls.environment_root().joinpath("spack.yaml")
 
-    @contextlib.contextmanager
-    def trust_bootstrap_mirror_keys(self):
-        with spack.util.gpg.gnupghome_override(os.path.join(root_path(), ".bootstrap-gpg")):
-            spack.binary_distribution.get_keys(install=True, trust=True)
-            yield
-
     def update_installations(self) -> None:
         """Update the installations of this environment."""
         log_enabled = tty.is_debug() or tty.is_verbose()
@@ -96,23 +91,23 @@ class BootstrapEnvironment(spack.environment.Environment):
             tty.msg(f"[BOOTSTRAPPING] Installing dependencies ({', '.join(colorized_specs)})")
             self.write(regenerate=False)
             with tty.SuppressOutput(msg_enabled=log_enabled, warn_enabled=log_enabled):
-                with self.trust_bootstrap_mirror_keys():
-                    fetch_policy = (
-                        "cache_only"
-                        if not spack.config.get("bootstrap:dev:enable_source", False)
-                        else "auto"
+                download_and_trust_key()
+                fetch_policy = (
+                    "cache_only"
+                    if not spack.config.get("bootstrap:dev:enable_source", False)
+                    else "auto"
+                )
+                try:
+                    self.install_all(
+                        fail_fast=True,
+                        root_policy=fetch_policy,
+                        dependencies_policy=fetch_policy,
                     )
-                    try:
-                        self.install_all(
-                            fail_fast=True,
-                            root_policy=fetch_policy,
-                            dependencies_policy=fetch_policy,
-                        )
-                    except BaseException:
-                        # catch any exception as we always want to clean up
-                        shutil.rmtree(self.environment_root())
-                        raise
-                    self.write(regenerate=True)
+                except BaseException:
+                    # catch any exception as we always want to clean up
+                    shutil.rmtree(self.environment_root())
+                    raise
+                self.write(regenerate=True)
 
     def load(self) -> None:
         """Update PATH and sys.path."""
@@ -164,6 +159,19 @@ def dev_bootstrap_mirror_names() -> List[str]:
         "developer-tools-x86_64_v3-linux-gnu",
         "developer-tools-aarch64-linux-gnu",
     ]
+
+
+def download_and_trust_key():
+    """Fetches and verifies the validity of Spack's public key"""
+    fingerprint_file = pathlib.Path(spack.paths.share_path) / "bootstrap" / "fingerprints" / "public.txt"
+    with open(fingerprint_file, "r", encoding="utf-8") as f:
+        fingerprint, key_endpoint = f.readline().split(":")
+    with spack.stage.Stage(key_endpoint) as stage:
+        try:
+            stage.fetch()
+        except spack.error.FetchError as e:
+            raise RuntimeError("Cannot fetch Spack Public key for binary cache validation") from e
+        spack.util.gpg.validate_fingerprint(fingerprint, stage.save_filename)
 
 
 def ensure_environment_dependencies() -> None:

--- a/lib/spack/spack/bootstrap/environment.py
+++ b/lib/spack/spack/bootstrap/environment.py
@@ -99,9 +99,7 @@ class BootstrapEnvironment(spack.environment.Environment):
                 )
                 try:
                     self.install_all(
-                        fail_fast=True,
-                        root_policy=fetch_policy,
-                        dependencies_policy=fetch_policy,
+                        fail_fast=True, root_policy=fetch_policy, dependencies_policy=fetch_policy
                     )
                 except BaseException:
                     # catch any exception as we always want to clean up
@@ -163,9 +161,12 @@ def dev_bootstrap_mirror_names() -> List[str]:
 
 def download_and_trust_key():
     """Fetches and verifies the validity of Spack's public key"""
-    fingerprint_file = pathlib.Path(spack.paths.share_path) / "bootstrap" / "fingerprints" / "public.txt"
+    fingerprint_file = (
+        pathlib.Path(spack.paths.share_path) / "bootstrap" / "fingerprints" / "public.txt"
+    )
     with open(fingerprint_file, "r", encoding="utf-8") as f:
-        fingerprint, key_endpoint = f.readline().split(":")
+        fingerprint, key_endpoint = f.readline().strip("\n").split(";")
+    fingerprint = fingerprint.strip().upper()
     with spack.stage.Stage(key_endpoint) as stage:
         try:
             stage.fetch()

--- a/lib/spack/spack/cmd/gpg.py
+++ b/lib/spack/spack/cmd/gpg.py
@@ -172,7 +172,7 @@ def gpg_list(args):
 
 def gpg_trust(args):
     """add a key to the keyring"""
-    spack.util.gpg.trust(args.keyfile, args.yes_to_all)
+    spack.util.gpg.trust(args.keyfile, yes_to_all=args.yes_to_all)
 
 
 def gpg_init(args):
@@ -185,7 +185,7 @@ def gpg_init(args):
         for filename in filenames:
             if not filename.endswith(".key"):
                 continue
-            spack.util.gpg.trust(os.path.join(root, filename), args.yes_to_all)
+            spack.util.gpg.trust(os.path.join(root, filename), yes_to_all=args.yes_to_all)
 
 
 def gpg_untrust(args):

--- a/lib/spack/spack/new_installer.py
+++ b/lib/spack/spack/new_installer.py
@@ -346,18 +346,31 @@ class GlobalState:
     but excludes the Spack environment, which is slow to serialize and should not be needed
     during the build."""
 
-    __slots__ = ("store", "config", "monkey_patches", "spack_working_dir", "repo_cache", "gpg")
+    __slots__ = (
+        "store",
+        "config",
+        "monkey_patches",
+        "spack_working_dir",
+        "repo_cache",
+        "gnupg_home",
+    )
 
     def __init__(self):
+        import spack.util.gpg
+
+        self.gnupg_home = str(spack.util.gpg.GNUPGHOME)
         if multiprocessing.get_start_method() == "fork":
             return
         self.config = spack.config.CONFIG.ensure_unwrapped()
         self.store = spack.store.STORE
         self.monkey_patches = spack.subprocess_context.TestPatches.create()
         self.spack_working_dir = spack.paths.spack_working_dir
-        self.gpg = spack.util.gpg.GPG
 
     def restore(self):
+        import spack.util.gpg
+
+        if self.gnupg_home:
+            spack.util.gpg.init(gnupghome=self.gnupg_home, force=True)
         if multiprocessing.get_start_method() == "fork":
             # In the forking case we must erase SSL contexts.
             from spack.oci import opener

--- a/lib/spack/spack/new_installer.py
+++ b/lib/spack/spack/new_installer.py
@@ -356,19 +356,15 @@ class GlobalState:
     )
 
     def __init__(self):
-        import spack.util.gpg
-
         if multiprocessing.get_start_method() == "fork":
             return
         self.config = spack.config.CONFIG.ensure_unwrapped()
         self.store = spack.store.STORE
         self.monkey_patches = spack.subprocess_context.TestPatches.create()
         self.spack_working_dir = spack.paths.spack_working_dir
-        self.gnupg_home = str(spack.util.gpg.GNUPGHOME)
+        self.gnupg_home = str(spack.util.gpg.GNUPGHOME) if spack.util.gpg.GNUPGHOME else None
 
     def restore(self):
-        import spack.util.gpg
-
         if multiprocessing.get_start_method() == "fork":
             # In the forking case we must erase SSL contexts.
             from spack.oci import opener
@@ -380,7 +376,8 @@ class GlobalState:
             s3_client_cache.clear()
             return
         if self.gnupg_home:
-            spack.util.gpg.init(gnupghome=self.gnupg_home, force=True)
+            spack.util.gpg.GPG = spack.util.gpg.Gpg(self.gnupg_home)
+            spack.util.gpg.GNUPGHOME = spack.util.gpg.GPG.home
         spack.store.STORE = self.store
         spack.config.CONFIG = self.config
         self.monkey_patches.restore()

--- a/lib/spack/spack/new_installer.py
+++ b/lib/spack/spack/new_installer.py
@@ -81,6 +81,7 @@ import spack.subprocess_context
 import spack.traverse
 import spack.url_buildcache
 import spack.util.environment
+import spack.util.gpg
 import spack.util.lock
 from spack.installer import _do_fake_install, dump_packages
 from spack.llnl.util.lang import pretty_duration
@@ -345,7 +346,7 @@ class GlobalState:
     but excludes the Spack environment, which is slow to serialize and should not be needed
     during the build."""
 
-    __slots__ = ("store", "config", "monkey_patches", "spack_working_dir", "repo_cache")
+    __slots__ = ("store", "config", "monkey_patches", "spack_working_dir", "repo_cache", "gpg")
 
     def __init__(self):
         if multiprocessing.get_start_method() == "fork":
@@ -354,6 +355,7 @@ class GlobalState:
         self.store = spack.store.STORE
         self.monkey_patches = spack.subprocess_context.TestPatches.create()
         self.spack_working_dir = spack.paths.spack_working_dir
+        self.gpg = spack.util.gpg.GPG
 
     def restore(self):
         if multiprocessing.get_start_method() == "fork":
@@ -370,6 +372,7 @@ class GlobalState:
         spack.config.CONFIG = self.config
         self.monkey_patches.restore()
         spack.paths.spack_working_dir = self.spack_working_dir
+        spack.util.gpg.GPG = self.gpg
 
 
 class PrefixPivoter:

--- a/lib/spack/spack/new_installer.py
+++ b/lib/spack/spack/new_installer.py
@@ -358,19 +358,17 @@ class GlobalState:
     def __init__(self):
         import spack.util.gpg
 
-        self.gnupg_home = str(spack.util.gpg.GNUPGHOME)
         if multiprocessing.get_start_method() == "fork":
             return
         self.config = spack.config.CONFIG.ensure_unwrapped()
         self.store = spack.store.STORE
         self.monkey_patches = spack.subprocess_context.TestPatches.create()
         self.spack_working_dir = spack.paths.spack_working_dir
+        self.gnupg_home = str(spack.util.gpg.GNUPGHOME)
 
     def restore(self):
         import spack.util.gpg
 
-        if self.gnupg_home:
-            spack.util.gpg.init(gnupghome=self.gnupg_home, force=True)
         if multiprocessing.get_start_method() == "fork":
             # In the forking case we must erase SSL contexts.
             from spack.oci import opener
@@ -381,11 +379,12 @@ class GlobalState:
             opener.urlopen._instance = None
             s3_client_cache.clear()
             return
+        if self.gnupg_home:
+            spack.util.gpg.init(gnupghome=self.gnupg_home, force=True)
         spack.store.STORE = self.store
         spack.config.CONFIG = self.config
         self.monkey_patches.restore()
         spack.paths.spack_working_dir = self.spack_working_dir
-        spack.util.gpg.GPG = self.gpg
 
 
 class PrefixPivoter:

--- a/lib/spack/spack/subprocess_context.py
+++ b/lib/spack/spack/subprocess_context.py
@@ -25,6 +25,7 @@ import spack.paths
 import spack.platforms
 import spack.repo
 import spack.store
+import spack.util.gpg
 
 if TYPE_CHECKING:
     import spack.package_base
@@ -104,6 +105,7 @@ class GlobalStateMarshaler:
         self.platform = spack.platforms.host
         self.store = spack.store.STORE
         self.test_patches = TestPatches.create()
+        self.gpg = spack.util.gpg.GPG
         if serialize_env:
             from spack.environment import active_environment
 
@@ -127,6 +129,7 @@ class GlobalStateMarshaler:
         spack.repo.enable_repo(spack.repo.RepoPath.from_config(self.config))
         spack.platforms.host = self.platform
         spack.store.STORE = self.store
+        spack.util.gpg.GPG = self.gpg
         self.test_patches.restore()
         if self.env:
             from spack.environment import activate

--- a/lib/spack/spack/subprocess_context.py
+++ b/lib/spack/spack/subprocess_context.py
@@ -105,7 +105,7 @@ class GlobalStateMarshaler:
         self.platform = spack.platforms.host
         self.store = spack.store.STORE
         self.test_patches = TestPatches.create()
-        self.gnupg_home = str(spack.util.gpg.GNUPGHOME)
+        self.gnupg_home = str(spack.util.gpg.GNUPGHOME) if spack.util.gpg.GNUPGHOME else None
         if serialize_env:
             from spack.environment import active_environment
 
@@ -129,8 +129,9 @@ class GlobalStateMarshaler:
         spack.repo.enable_repo(spack.repo.RepoPath.from_config(self.config))
         spack.platforms.host = self.platform
         spack.store.STORE = self.store
-        spack.util.gpg.GPG = spack.util.gpg.Gpg(self.gnupg_home)
-        spack.util.gpg.GNUPGHOME = spack.util.gpg.GPG.home
+        if self.gnupg_home:
+            spack.util.gpg.GPG = spack.util.gpg.Gpg(self.gnupg_home)
+            spack.util.gpg.GNUPGHOME = spack.util.gpg.GPG.home
         self.test_patches.restore()
         if self.env:
             from spack.environment import activate

--- a/lib/spack/spack/subprocess_context.py
+++ b/lib/spack/spack/subprocess_context.py
@@ -105,7 +105,7 @@ class GlobalStateMarshaler:
         self.platform = spack.platforms.host
         self.store = spack.store.STORE
         self.test_patches = TestPatches.create()
-        self.gpg = spack.util.gpg.GPG
+        self.gnupg_home = str(spack.util.gpg.GNUPGHOME)
         if serialize_env:
             from spack.environment import active_environment
 
@@ -129,7 +129,8 @@ class GlobalStateMarshaler:
         spack.repo.enable_repo(spack.repo.RepoPath.from_config(self.config))
         spack.platforms.host = self.platform
         spack.store.STORE = self.store
-        spack.util.gpg.GPG = self.gpg
+        spack.util.gpg.GPG = spack.util.gpg.Gpg(self.gnupg_home)
+        spack.util.gpg.GNUPGHOME = spack.util.gpg.GPG.home
         self.test_patches.restore()
         if self.env:
             from spack.environment import activate

--- a/lib/spack/spack/util/gpg.py
+++ b/lib/spack/spack/util/gpg.py
@@ -906,25 +906,6 @@ def signing_keys(*args) -> List[GpgKey]:
 
 
 @_autoinit
-def public_keys_to_fingerprint(*args):
-    """Return the keys that can be used to verify binaries."""
-    output = GPG("--list-public-keys", "--with-colons", "--fingerprint", *args, output=str)
-    return _parse_public_keys_output(output)
-
-
-@_autoinit
-def fingerprint_from_key(keyfile):
-    output = GPG("--show-keys", "--with-fingerprint", keyfile, output=str)
-    fingerprint_pattern = re.compile(r"^[A-Fa-f0-9]{40}$")
-    for line in output.splitlines():
-        # re.sub with '\s+' strips spaces, tabs, and non-breaking spaces (\xa0)
-        cleaned_line = re.sub(r"\s+", "", line)
-        if fingerprint_pattern.match(cleaned_line):
-            return cleaned_line.upper()
-    return None
-
-
-@_autoinit
 def public_keys(*args) -> List[GpgKey]:
     """Return a list of fingerprints"""
     assert GPG
@@ -1021,20 +1002,23 @@ def verify(signature: str, file: Optional[str] = None, suppress_warnings: bool =
 @_autoinit
 def validate_fingerprint(fingerprint: str, keyfile: str):
     """Verify a given key's fingerprint matches the provided fingerprint
+    and if it does, trust the key.
 
     Args:
         fingerpint: fingerprint used to verify the public key
         keyfile: filepath to public key that needs fingerprint confirmation
     """
-    key_fpr = fingerprint_from_key(keyfile)
+    key = extract_public_keys(keyfile)
+    if not key:
+        raise SpackGPGError(f"No public keys found in file: {keyfile}")
+    key_fpr = key[0].fpr
     if not key_fpr:
         raise SpackGPGError(f"Could not extract fingerprint from public key: {keyfile}")
-    key_fpr = key_fpr.strip().upper()
     if key_fpr != fingerprint:
         raise SpackGPGError(
             f"Trusted fingerprint does not match fingerprint from public key: {keyfile}"
         )
-    trust(keyfile)
+    trust(keyfile, yes_to_all=True)
 
 
 @_autoinit

--- a/lib/spack/spack/util/gpg.py
+++ b/lib/spack/spack/util/gpg.py
@@ -650,11 +650,12 @@ class Gpg:
             # Skip keys we had before trusting the keys in the file
             if key not in imported_keys:
                 continue
-
+            # if fprs is provided, then only trust keys in the file with matching fingerprints
+            # yes_to_all is ignored in this case
             if fprs:
                 trusted = key.fpr in fprs
             else:
-                trusted = yes_to_all or tty.get_yes_or_no(f"Trust key: {key}", default=False)
+                trusted = yes_to_all or bool(tty.get_yes_or_no(f"Trust key: {key}", default=False))
 
             if not trusted:
                 tty.info(f"Spack will not trust key {key}")

--- a/lib/spack/spack/util/gpg.py
+++ b/lib/spack/spack/util/gpg.py
@@ -626,10 +626,12 @@ class Gpg:
         yes_to_all: bool = False,
     ):
         """Import a public key from a file and trust it.
-
+        
         Args:
             keyfile: file with the public key
-            keys: list of keys to trust
+            fprs: list of fingerprints to trust, if provided, then yes_to_all is ignored
+            ownertrust: level of trust to assign to the key(s)
+            yes_to_all: trust all keys in the file if True, otherwise ask for each key
         """
 
         # This global method is safe to use to list keys in a file
@@ -649,12 +651,12 @@ class Gpg:
             if key not in imported_keys:
                 continue
 
-            if fprs and key.fpr in fprs:
-                pass
-            # Confirm with the user that the key should be trusted
-            if (fprs and key.fpr not in fprs) or (
-                not yes_to_all and not tty.get_yes_or_no(f"Trust key: {key}", default=False)
-            ):
+            if fprs:
+                trusted = key.fpr in fprs
+            else:
+                trusted = yes_to_all or tty.get_yes_or_no(f"Trust key: {key}", default=False)
+
+            if not trusted:
                 tty.info(f"Spack will not trust key {key}")
                 self.untrust([key])
                 continue

--- a/lib/spack/spack/util/gpg.py
+++ b/lib/spack/spack/util/gpg.py
@@ -906,6 +906,25 @@ def signing_keys(*args) -> List[GpgKey]:
 
 
 @_autoinit
+def public_keys_to_fingerprint(*args):
+    """Return the keys that can be used to verify binaries."""
+    output = GPG("--list-public-keys", "--with-colons", "--fingerprint", *args, output=str)
+    return _parse_public_keys_output(output)
+
+
+@_autoinit
+def fingerprint_from_key(keyfile):
+    output = GPG("--show-keys", "--with-fingerprint", keyfile, output=str)
+    fingerprint_pattern = re.compile(r"^[A-Fa-f0-9]{40}$")
+    for line in output.splitlines():
+        # re.sub with '\s+' strips spaces, tabs, and non-breaking spaces (\xa0)
+        cleaned_line = re.sub(r"\s+", "", line)
+        if fingerprint_pattern.match(cleaned_line):
+            return cleaned_line.upper()
+    return None
+
+
+@_autoinit
 def public_keys(*args) -> List[GpgKey]:
     """Return a list of fingerprints"""
     assert GPG
@@ -1002,16 +1021,19 @@ def verify(signature: str, file: Optional[str] = None, suppress_warnings: bool =
 @_autoinit
 def validate_fingerprint(fingerprint: str, keyfile: str):
     """Verify a given key's fingerprint matches the provided fingerprint
-    
+
     Args:
         fingerpint: fingerprint used to verify the public key
         keyfile: filepath to public key that needs fingerprint confirmation
     """
-    key_fpr = public_keys_to_fingerprint(keyfile)
-    # just one key, so we know it's the first index
-    fpr = key_fpr[0][1]
-    if fpr != fingerprint:
-        raise SpackGPGError(f"Trusted fingerprint does not match fingerprint from public key: {keyfile}")
+    key_fpr = fingerprint_from_key(keyfile)
+    if not key_fpr:
+        raise SpackGPGError(f"Could not extract fingerprint from public key: {keyfile}")
+    key_fpr = key_fpr.strip().upper()
+    if key_fpr != fingerprint:
+        raise SpackGPGError(
+            f"Trusted fingerprint does not match fingerprint from public key: {keyfile}"
+        )
     trust(keyfile)
 
 

--- a/lib/spack/spack/util/gpg.py
+++ b/lib/spack/spack/util/gpg.py
@@ -957,6 +957,8 @@ def trust(keyfile: str, *, fprs: Optional[List[str]] = None, yes_to_all: bool = 
     Args:
         keyfile: file with the public key
         fprs: fingerprints of keys to trust.
+        yes_to_all: trust all keys in the file if True, otherwise ask for each key.
+                    Ignored if fprs is provided.
     """
     assert GPG
     GPG.trust(keyfile, fprs=fprs, ownertrust=GpgKeyTrust.ULTIMATE, yes_to_all=yes_to_all)

--- a/lib/spack/spack/util/gpg.py
+++ b/lib/spack/spack/util/gpg.py
@@ -949,7 +949,7 @@ def extract_public_keys(keyfile: str):
 
 
 @_autoinit
-def trust(keyfile: str, *, yes_to_all: bool = False, fprs: Optional[List[str]] = None):
+def trust(keyfile: str, *, fprs: Optional[List[str]] = None, yes_to_all: bool = False):
     """Import a public key from a file and trust it.
 
     Args:

--- a/lib/spack/spack/util/gpg.py
+++ b/lib/spack/spack/util/gpg.py
@@ -648,7 +648,7 @@ class Gpg:
             # Skip keys we had before trusting the keys in the file
             if key not in imported_keys:
                 continue
-            fingerprint_trust_yes = (fprs and yes_to_all)
+            fingerprint_trust_yes = fprs and yes_to_all
             if fprs and key.fpr in fprs:
                 pass
             # Confirm with the user that the key should be trusted

--- a/lib/spack/spack/util/gpg.py
+++ b/lib/spack/spack/util/gpg.py
@@ -626,7 +626,7 @@ class Gpg:
         yes_to_all: bool = False,
     ):
         """Import a public key from a file and trust it.
-        
+
         Args:
             keyfile: file with the public key
             fprs: list of fingerprints to trust, if provided, then yes_to_all is ignored

--- a/lib/spack/spack/util/gpg.py
+++ b/lib/spack/spack/util/gpg.py
@@ -620,7 +620,7 @@ class Gpg:
     def trust(
         self,
         keyfile: str,
-        keys: List[GpgKey] = [],
+        fprs: List[str] = [],
         ownertrust: GpgKeyTrust = GpgKeyTrust.ULTIMATE,
         yes_to_all: bool = False,
     ):
@@ -647,13 +647,14 @@ class Gpg:
             # Skip keys we had before trusting the keys in the file
             if key not in imported_keys:
                 continue
-            key_specified = key in keys
-            if keys and yes_to_all and not key_specified:
-                raise SpackGPGError("Cannot specify keys to trust when yes_to_all is True")
 
-            auto_trust_key = key_specified or yes_to_all
+            fingerprint_trust_yes = fprs and yes_to_all
+            if key.fpr in fprs:
+                pass
             # Confirm with the user that the key should be trusted
-            if not auto_trust_key and not tty.get_yes_or_no(f"Trust key: {key}", default=False):
+            elif fingerprint_trust_yes or (
+                not yes_to_all and not tty.get_yes_or_no(f"Trust key: {key}", default=False)
+            ):
                 tty.info(f"Spack will not trust key {key}")
                 self.untrust([key])
 
@@ -947,14 +948,15 @@ def extract_public_keys(keyfile: str):
 
 
 @_autoinit
-def trust(keyfile: str, keys: Optional[List[GpgKey]] = None, yes_to_all: bool = False):
+def trust(keyfile: str, fprs: List[str] = [], yes_to_all: bool = False):
     """Import a public key from a file and trust it.
 
     Args:
         keyfile: file with the public key
+        fprs: fingerprints of keys to trust.
     """
     assert GPG
-    GPG.trust(keyfile, ownertrust=GpgKeyTrust.ULTIMATE, yes_to_all=yes_to_all)
+    GPG.trust(keyfile, fprs=fprs, ownertrust=GpgKeyTrust.ULTIMATE, yes_to_all=yes_to_all)
 
 
 @_autoinit
@@ -1004,28 +1006,6 @@ def verify(signature: str, file: Optional[str] = None, suppress_warnings: bool =
     if not file:
         file = signature
     GPG.verify(signature, file, suppress_warnings=suppress_warnings)
-
-
-@_autoinit
-def validate_fingerprint_and_trust(fingerprint: str, keyfile: str):
-    """Verify a given key's fingerprint matches the provided fingerprint
-    and if it does, trust the key.
-
-    Args:
-        fingerpint: fingerprint used to verify the public key
-        keyfile: filepath to public key that needs fingerprint confirmation
-    """
-    key = extract_public_keys(keyfile)
-    if not key:
-        raise SpackGPGError(f"No public keys found in file: {keyfile}")
-    key_fpr = key[0].fpr
-    if not key_fpr:
-        raise SpackGPGError(f"Could not extract fingerprint from public key: {keyfile}")
-    if key_fpr != fingerprint:
-        raise SpackGPGError(
-            f"Trusted fingerprint does not match fingerprint from public key: {keyfile}"
-        )
-    trust(keyfile, keys=key)
 
 
 @_autoinit

--- a/lib/spack/spack/util/gpg.py
+++ b/lib/spack/spack/util/gpg.py
@@ -620,6 +620,7 @@ class Gpg:
     def trust(
         self,
         keyfile: str,
+        keys: Optional[List[GpgKey]] = None,
         ownertrust: GpgKeyTrust = GpgKeyTrust.ULTIMATE,
         yes_to_all: bool = False,
     ):
@@ -627,7 +628,12 @@ class Gpg:
 
         Args:
             keyfile: file with the public key
+            keys: list of keys to trust
         """
+
+        if keys and yes_to_all:
+            raise SpackGPGError("Cannot specify keys to trust when yes_to_all is True")
+
         # This global method is safe to use to list keys in a file
         imported_keys = extract_public_keys(keyfile)
         if not imported_keys:
@@ -644,9 +650,9 @@ class Gpg:
             # Skip keys we had before trusting the keys in the file
             if key not in imported_keys:
                 continue
-
+            auto_trust_key = (keys and key in keys) or yes_to_all
             # Confirm with the user that the key should be trusted
-            if not yes_to_all and not tty.get_yes_or_no(f"Trust key: {key}", default=False):
+            if not auto_trust_key and not tty.get_yes_or_no(f"Trust key: {key}", default=False):
                 tty.info(f"Spack will not trust key {key}")
                 self.untrust([key])
 
@@ -940,7 +946,7 @@ def extract_public_keys(keyfile: str):
 
 
 @_autoinit
-def trust(keyfile: str, yes_to_all: bool = False):
+def trust(keyfile: str, keys: Optional[List[GpgKey]] = None, yes_to_all: bool = False):
     """Import a public key from a file and trust it.
 
     Args:
@@ -1018,7 +1024,7 @@ def validate_fingerprint_and_trust(fingerprint: str, keyfile: str):
         raise SpackGPGError(
             f"Trusted fingerprint does not match fingerprint from public key: {keyfile}"
         )
-    trust(keyfile, yes_to_all=True)
+    trust(keyfile, keys=key)
 
 
 @_autoinit

--- a/lib/spack/spack/util/gpg.py
+++ b/lib/spack/spack/util/gpg.py
@@ -621,7 +621,7 @@ class Gpg:
         self,
         keyfile: str,
         *,
-        fprs: List[str] = [],
+        fprs: Optional[List[str]] = None,
         ownertrust: GpgKeyTrust = GpgKeyTrust.ULTIMATE,
         yes_to_all: bool = False,
     ):
@@ -649,7 +649,7 @@ class Gpg:
             if key not in imported_keys:
                 continue
             fingerprint_trust_yes = (fprs and yes_to_all)
-            if key.fpr in fprs:
+            if fprs and key.fpr in fprs:
                 pass
             # Confirm with the user that the key should be trusted
             elif fingerprint_trust_yes or (
@@ -657,6 +657,7 @@ class Gpg:
             ):
                 tty.info(f"Spack will not trust key {key}")
                 self.untrust([key])
+                continue
 
             # Update the owner trust to ultimate
             r, w = os.pipe()
@@ -948,7 +949,7 @@ def extract_public_keys(keyfile: str):
 
 
 @_autoinit
-def trust(keyfile: str, *, yes_to_all: bool = False, fprs: List[str] = []):
+def trust(keyfile: str, *, yes_to_all: bool = False, fprs: Optional[List[str]] = None):
     """Import a public key from a file and trust it.
 
     Args:

--- a/lib/spack/spack/util/gpg.py
+++ b/lib/spack/spack/util/gpg.py
@@ -1000,7 +1000,7 @@ def verify(signature: str, file: Optional[str] = None, suppress_warnings: bool =
 
 
 @_autoinit
-def validate_fingerprint(fingerprint: str, keyfile: str):
+def validate_fingerprint_and_trust(fingerprint: str, keyfile: str):
     """Verify a given key's fingerprint matches the provided fingerprint
     and if it does, trust the key.
 

--- a/lib/spack/spack/util/gpg.py
+++ b/lib/spack/spack/util/gpg.py
@@ -620,6 +620,7 @@ class Gpg:
     def trust(
         self,
         keyfile: str,
+        *,
         fprs: List[str] = [],
         ownertrust: GpgKeyTrust = GpgKeyTrust.ULTIMATE,
         yes_to_all: bool = False,
@@ -647,8 +648,7 @@ class Gpg:
             # Skip keys we had before trusting the keys in the file
             if key not in imported_keys:
                 continue
-
-            fingerprint_trust_yes = fprs and yes_to_all
+            fingerprint_trust_yes = (fprs and yes_to_all)
             if key.fpr in fprs:
                 pass
             # Confirm with the user that the key should be trusted
@@ -948,7 +948,7 @@ def extract_public_keys(keyfile: str):
 
 
 @_autoinit
-def trust(keyfile: str, fprs: List[str] = [], yes_to_all: bool = False):
+def trust(keyfile: str, *, yes_to_all: bool = False, fprs: List[str] = []):
     """Import a public key from a file and trust it.
 
     Args:

--- a/lib/spack/spack/util/gpg.py
+++ b/lib/spack/spack/util/gpg.py
@@ -631,9 +631,6 @@ class Gpg:
             keys: list of keys to trust
         """
 
-        if keys and yes_to_all:
-            raise SpackGPGError("Cannot specify keys to trust when yes_to_all is True")
-
         # This global method is safe to use to list keys in a file
         imported_keys = extract_public_keys(keyfile)
         if not imported_keys:
@@ -650,7 +647,11 @@ class Gpg:
             # Skip keys we had before trusting the keys in the file
             if key not in imported_keys:
                 continue
-            auto_trust_key = key in keys or yes_to_all
+            key_specified = key in keys
+            if keys and yes_to_all and not key_specified:
+                raise SpackGPGError("Cannot specify keys to trust when yes_to_all is True")
+
+            auto_trust_key = key_specified or yes_to_all
             # Confirm with the user that the key should be trusted
             if not auto_trust_key and not tty.get_yes_or_no(f"Trust key: {key}", default=False):
                 tty.info(f"Spack will not trust key {key}")

--- a/lib/spack/spack/util/gpg.py
+++ b/lib/spack/spack/util/gpg.py
@@ -1000,6 +1000,22 @@ def verify(signature: str, file: Optional[str] = None, suppress_warnings: bool =
 
 
 @_autoinit
+def validate_fingerprint(fingerprint: str, keyfile: str):
+    """Verify a given key's fingerprint matches the provided fingerprint
+    
+    Args:
+        fingerpint: fingerprint used to verify the public key
+        keyfile: filepath to public key that needs fingerprint confirmation
+    """
+    key_fpr = public_keys_to_fingerprint(keyfile)
+    # just one key, so we know it's the first index
+    fpr = key_fpr[0][1]
+    if fpr != fingerprint:
+        raise SpackGPGError(f"Trusted fingerprint does not match fingerprint from public key: {keyfile}")
+    trust(keyfile)
+
+
+@_autoinit
 def glist(trusted: bool, signing: bool, fmt: str = "default"):
     """List known keys.
 

--- a/lib/spack/spack/util/gpg.py
+++ b/lib/spack/spack/util/gpg.py
@@ -648,11 +648,11 @@ class Gpg:
             # Skip keys we had before trusting the keys in the file
             if key not in imported_keys:
                 continue
-            fingerprint_trust_yes = fprs and yes_to_all
+
             if fprs and key.fpr in fprs:
                 pass
             # Confirm with the user that the key should be trusted
-            elif fingerprint_trust_yes or (
+            if (fprs and key.fpr not in fprs) or (
                 not yes_to_all and not tty.get_yes_or_no(f"Trust key: {key}", default=False)
             ):
                 tty.info(f"Spack will not trust key {key}")

--- a/lib/spack/spack/util/gpg.py
+++ b/lib/spack/spack/util/gpg.py
@@ -620,7 +620,7 @@ class Gpg:
     def trust(
         self,
         keyfile: str,
-        keys: Optional[List[GpgKey]] = None,
+        keys: List[GpgKey] = [],
         ownertrust: GpgKeyTrust = GpgKeyTrust.ULTIMATE,
         yes_to_all: bool = False,
     ):
@@ -650,7 +650,7 @@ class Gpg:
             # Skip keys we had before trusting the keys in the file
             if key not in imported_keys:
                 continue
-            auto_trust_key = (keys and key in keys) or yes_to_all
+            auto_trust_key = key in keys or yes_to_all
             # Confirm with the user that the key should be trusted
             if not auto_trust_key and not tty.get_yes_or_no(f"Trust key: {key}", default=False):
                 tty.info(f"Spack will not trust key {key}")

--- a/share/spack/bootstrap/fingerprints/public.txt
+++ b/share/spack/bootstrap/fingerprints/public.txt
@@ -1,1 +1,1 @@
-2C8DD3224EF3573A42BD221FA8E0CA3C1C2ADA2F:https://spack.github.io/keys/spack-public-binary-key.pub
+2C8DD3224EF3573A42BD221FA8E0CA3C1C2ADA2F;https://spack.github.io/keys/spack-public-binary-key.pub

--- a/share/spack/bootstrap/fingerprints/public.txt
+++ b/share/spack/bootstrap/fingerprints/public.txt
@@ -1,0 +1,1 @@
+2C8DD3224EF3573A42BD221FA8E0CA3C1C2ADA2F:https://spack.github.io/keys/spack-public-binary-key.pub


### PR DESCRIPTION
Instead of using the bin-dist module `get_keys` we store the fingerprint for the spack public key in `share/spack/bootstrap/fingerprints`, download the public key directly via the url in the fingerprint file, and verify with the fingerprint before trusting. We then use that for bootstrap binary cache signing validation, by redirectiong gpg home to a bootstrap specific location.

gpghome override location is piped to build processes by adding the current gpghome to the global context objects passed to those processes. 

Made the non keyfile arguments to `spack.util.gpg.trust`  keyword only for readability