### PR TITLE
Bootstrap Environment: ensure paths are posix

### DIFF
--- a/lib/spack/spack/bootstrap/environment.py
+++ b/lib/spack/spack/bootstrap/environment.py
@@ -122,11 +122,11 @@ class BootstrapEnvironment(spack.environment.Environment):
         template = env.get_template("bootstrap/spack.yaml")
         context = {
             "python_spec": f"{spec_for_current_python()}+ctypes",
-            "python_prefix": sys.exec_prefix,
+            "python_prefix": pathlib.Path(sys.exec_prefix).as_posix(),
             "architecture": spack.vendor.archspec.cpu.host().family,
-            "environment_path": self.environment_root(),
+            "environment_path": self.environment_root().as_posix(),
             "environment_specs": self.spack_dev_requirements(),
-            "store_path": store_path(),
+            "store_path": pathlib.Path(store_path()).as_posix(),
             "bootstrap_mirrors": dev_bootstrap_mirror_names(),
         }
         self.environment_root().mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
Write env config paths as posix as they'll be read by spack first and thus can remain posix and do not need to be Windows style.

Fixes https://github.com/spack/spack/issues/52358