### PR TITLE
parallel.py: enable under forkserver/spawn

### DIFF
--- a/lib/spack/spack/concretize.py
+++ b/lib/spack/spack/concretize.py
@@ -191,7 +191,12 @@ def concretize_separately(
 
     for j, (i, concrete, duration) in enumerate(
         spack.util.parallel.imap_unordered(
-            _concretize_task, args, processes=num_procs, debug=tty.is_debug(), maxtaskperchild=1
+            _concretize_task,
+            args,
+            processes=num_procs,
+            debug=tty.is_debug(),
+            maxtaskperchild=1,
+            serialize_env=True,
         )
     ):
         ret.append((i, concrete))

--- a/lib/spack/spack/detection/path.py
+++ b/lib/spack/spack/detection/path.py
@@ -441,7 +441,7 @@ def by_path(
     if max_workers == 1:
         executor = spack.util.parallel.SequentialExecutor()
     else:
-        executor = spack.util.parallel.make_concurrent_executor(max_workers, require_fork=False)
+        executor = spack.util.parallel.make_concurrent_executor(max_workers)
     with executor:
         for pkg in packages_to_search:
             executable_future = executor.submit(

--- a/lib/spack/spack/stage.py
+++ b/lib/spack/spack/stage.py
@@ -1299,7 +1299,7 @@ def get_checksums_for_versions(
         else:
             version_hashes[version] = result
 
-    with spack.util.parallel.make_concurrent_executor(concurrency, require_fork=False) as executor:
+    with spack.util.parallel.make_concurrent_executor(concurrency) as executor:
         results = [
             (version, executor.submit(_fetch_and_checksum, url, fetch_options, keep_stage))
             for url, version in search_arguments

--- a/lib/spack/spack/subprocess_context.py
+++ b/lib/spack/spack/subprocess_context.py
@@ -72,7 +72,7 @@ class PackageInstallContext:
         ctx: Optional[multiprocessing.context.BaseContext] = None,
     ):
         ctx = ctx or multiprocessing.get_context()
-        self.global_state = GlobalStateMarshaler(ctx=ctx)
+        self.global_state = GlobalStateMarshaler(ctx=ctx, serialize_env=True)
         self.pkg = pkg if ctx.get_start_method() == "fork" else serialize(pkg)
         self.spack_working_dir = spack.paths.spack_working_dir
 
@@ -90,23 +90,38 @@ class GlobalStateMarshaler:
     """
 
     def __init__(
-        self, *, ctx: Optional[Optional[multiprocessing.context.BaseContext]] = None
+        self,
+        *,
+        ctx: Optional[Optional[multiprocessing.context.BaseContext]] = None,
+        serialize_env: bool = False,
     ) -> None:
         ctx = ctx or multiprocessing.get_context()
         self.is_forked = ctx.get_start_method() == "fork"
         if self.is_forked:
             return
 
-        from spack.environment import active_environment
-
         self.config = spack.config.CONFIG.ensure_unwrapped()
         self.platform = spack.platforms.host
         self.store = spack.store.STORE
         self.test_patches = TestPatches.create()
-        self.env = active_environment()
+        if serialize_env:
+            from spack.environment import active_environment
+
+            self.env = active_environment()
+        else:
+            self.env = None
 
     def restore(self):
         if self.is_forked:
+            # Erase singletons that hold open SSL contexts / boto3 clients, since OpenSSL
+            # and botocore connection pools are not fork-safe.
+            from spack.oci import opener
+            from spack.util import web
+            from spack.util.s3 import s3_client_cache
+
+            web.urlopen._instance = None
+            opener.urlopen._instance = None
+            s3_client_cache.clear()
             return
         spack.config.CONFIG = self.config
         spack.repo.enable_repo(spack.repo.RepoPath.from_config(self.config))

--- a/lib/spack/spack/util/parallel.py
+++ b/lib/spack/spack/util/parallel.py
@@ -60,7 +60,13 @@ class Task:
 
 
 def imap_unordered(
-    f, list_of_args, *, processes: int, maxtaskperchild: Optional[int] = None, debug=False
+    f,
+    list_of_args,
+    *,
+    processes: int,
+    maxtaskperchild: Optional[int] = None,
+    debug=False,
+    serialize_env: bool = False,
 ):
     """Wrapper around multiprocessing.Pool.imap_unordered.
 
@@ -83,7 +89,7 @@ def imap_unordered(
 
     from spack.subprocess_context import GlobalStateMarshaler
 
-    marshaler = GlobalStateMarshaler()
+    marshaler = GlobalStateMarshaler(serialize_env=serialize_env)
     with multiprocessing.Pool(
         processes, initializer=marshaler.restore, maxtasksperchild=maxtaskperchild
     ) as p:
@@ -107,22 +113,18 @@ class SequentialExecutor(concurrent.futures.Executor):
 
 
 def make_concurrent_executor(
-    jobs: Optional[int] = None, *, require_fork: bool = True
+    jobs: Optional[int] = None, *, serialize_env: bool = False
 ) -> concurrent.futures.Executor:
-    """Create a concurrent executor. If require_fork is True, then the executor is sequential
-    if the platform does not enable forking as the default start method. Effectively
-    require_fork=True makes the executor sequential in the current process on Windows, macOS, and
-    Linux from Python 3.14+ (which changes defaults)"""
+    """Create a concurrent executor.
 
-    if (
-        not ENABLE_PARALLELISM
-        or (require_fork and multiprocessing.get_start_method() != "fork")
-        or sys.version_info[:2] == (3, 6)
-    ):
+    If serialize_env is False (default), the active Spack environment is not transmitted to the
+    worker processes, which avoids the cost of pickling potentially large environment state."""
+
+    if not ENABLE_PARALLELISM or sys.version_info[:2] == (3, 6):
         return SequentialExecutor()
 
     from spack.subprocess_context import GlobalStateMarshaler
 
     jobs = jobs or spack.config.determine_number_of_jobs(parallel=True)
-    marshaler = GlobalStateMarshaler()
+    marshaler = GlobalStateMarshaler(serialize_env=serialize_env)
     return concurrent.futures.ProcessPoolExecutor(jobs, initializer=marshaler.restore)  # novermin

--- a/lib/spack/spack/util/web.py
+++ b/lib/spack/spack/util/web.py
@@ -786,7 +786,7 @@ def spider(
         root = urllib.parse.urlparse(root_str)
         spider_args.append((root, go_deeper, _visited))
 
-    with spack.util.parallel.make_concurrent_executor(concurrency, require_fork=False) as tp:
+    with spack.util.parallel.make_concurrent_executor(concurrency) as tp:
         while current_depth <= depth:
             tty.debug(
                 f"SPIDER: [depth={current_depth}, max_depth={depth}, urls={len(spider_args)}]"


### PR DESCRIPTION
With Python 3.14 using forkserver, and macOS using spawn, spack
buildcache push is sequential. This PR makes it parallel.

That's beneficial if we can avoid expensive pickling of environments, so
make that opt-in. The concretizer does need the env, otherwise I don't
think anything parallel needs it.

Further, improve fork-safety by clearing urlopen related state, similar
to what the new installer does.

