### PR TITLE
solver: support clingo v6

### DIFF
--- a/.github/workflows/unit_tests.yaml
+++ b/.github/workflows/unit_tests.yaml
@@ -188,7 +188,7 @@ jobs:
         spack bootstrap disable github-actions-v2
         spack bootstrap status
         spack solve zlib
-        pytest --verbose --cov --cov-config=pyproject.toml --cov-report=xml:coverage.xml -x -n3 lib/spack/spack/test/concretization/core.py
+        pytest --verbose --cov --cov-config=pyproject.toml --cov-report=xml:coverage.xml -x -n3 lib/spack/spack/test/concretization/
     - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
       with:
         name: coverage-clingo-cffi
@@ -226,7 +226,7 @@ jobs:
         spack bootstrap disable github-actions-v2
         spack bootstrap status
         spack solve zlib
-        pytest --verbose --cov --cov-config=pyproject.toml --cov-report=xml:coverage.xml -x -n3 lib/spack/spack/test/concretization/core.py
+        pytest --verbose --cov --cov-config=pyproject.toml --cov-report=xml:coverage.xml -x -n3 lib/spack/spack/test/concretization/
     - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
       with:
         name: coverage-clingo-v6

--- a/.github/workflows/unit_tests.yaml
+++ b/.github/workflows/unit_tests.yaml
@@ -194,6 +194,44 @@ jobs:
         name: coverage-clingo-cffi
         path: coverage
         include-hidden-files: true
+  # Test for the clingo based solver (using the development clingo v6 from Test PyPI).
+  # clingo v6 is still pre-release; allow this job to fail without blocking the workflow.
+  clingo-v6:
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+      with:
+        fetch-depth: 0
+    - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
+      with:
+        python-version: '3.13'
+    - name: Install System packages
+      run: |
+          sudo apt-get -y update
+          sudo apt-get -y install coreutils gfortran graphviz gnupg2
+    - name: Install Python packages
+      run: |
+          pip install --upgrade pip -r .github/workflows/requirements/unit_tests/requirements.txt
+          pip install --upgrade -r .github/workflows/requirements/style/requirements.txt
+          pip install --upgrade --pre --extra-index-url https://test.pypi.org/simple clingo
+    - name: Run unit tests (full suite with coverage)
+      env:
+          COVERAGE: true
+          COVERAGE_FILE: coverage/.coverage-clingo-v6
+      run: |
+        . share/spack/setup-env.sh
+        spack bootstrap disable spack-install
+        spack bootstrap disable github-actions-v0.6
+        spack bootstrap disable github-actions-v2
+        spack bootstrap status
+        spack solve zlib
+        pytest --verbose --cov --cov-config=pyproject.toml --cov-report=xml:coverage.xml -x -n3 lib/spack/spack/test/concretization/core.py
+    - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+      with:
+        name: coverage-clingo-v6
+        path: coverage
+        include-hidden-files: true
   # Run unit tests on MacOS
   macos:
     runs-on: ${{ matrix.os }}

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -73,9 +73,10 @@ from .core import (
     AspVar,
     NodeId,
     SourceContext,
-    clingo,
+    default_clingo_control,
     extract_args,
     fn,
+    make_error_control,
     using_libc_compatibility,
 )
 from .input_analysis import create_counter, create_graph_analyzer
@@ -106,15 +107,6 @@ class OutputConfiguration(NamedTuple):
 DEFAULT_OUTPUT_CONFIGURATION = OutputConfiguration(
     timers=False, stats=False, out=None, setup_only=False
 )
-
-
-def default_clingo_control():
-    """Return a control object with the default settings used in Spack"""
-    control = clingo().Control()
-    control.configuration.configuration = "tweety"
-    control.configuration.solver.heuristic = "Domain"
-    control.configuration.solver.opt_strategy = "usc"
-    return control
 
 
 # Below numbers are used to map names of criteria to the order
@@ -872,7 +864,7 @@ class ErrorHandler:
         if not initial_error_args:
             return
 
-        error_causation = clingo().Control()
+        error_causation = make_error_control()
 
         parent_dir = pathlib.Path(__file__).parent
         errors_lp = parent_dir / "error_messages.lp"

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -68,15 +68,14 @@ from spack.llnl.util.lang import elide_list
 from spack.spec import EMPTY_SPEC
 from spack.util.compression import GZipFileType
 
+from .compat import default_clingo_control, make_error_control
 from .core import (
     AspFunction,
     AspVar,
     NodeId,
     SourceContext,
-    default_clingo_control,
     extract_args,
     fn,
-    make_error_control,
     using_libc_compatibility,
 )
 from .input_analysis import create_counter, create_graph_analyzer

--- a/lib/spack/spack/solver/compat.py
+++ b/lib/spack/spack/solver/compat.py
@@ -1,0 +1,257 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+"""Loads clingo and abstracts over the differences between its Python API variants.
+
+Spack supports three clingo Python APIs: the pre-CFFI API, the CFFI-based API, and the clingo 6
+rewrite, which moved everything into ``clingo.*`` submodules, replaced the top-level ``Control``
+constructor with one that takes a shared ``Library`` plus CLI options, renamed backend methods
+(``add_atom``/``add_rule`` to ``atom``/``rule``), and made statistics a lazy view that must be
+``nestify()``-ed.
+
+This module bootstraps/imports the right clingo and exposes a single uniform interface (a
+legacy-shaped ``Control`` plus ``symbol_name`` / ``symbol_string`` helpers) so the rest of Spack
+does not have to branch on the flavor in use.
+"""
+
+import enum
+import functools
+import importlib
+import pathlib
+from types import ModuleType
+from typing import Any, Optional, Tuple
+
+#: Process-global cache of the lazily-imported clingo module.
+_CLINGO_MODULE: Optional[ModuleType] = None
+
+
+def clingo() -> ModuleType:
+    """Lazy imports the Python module for clingo, and returns it."""
+    if _CLINGO_MODULE is not None:
+        return _CLINGO_MODULE
+
+    try:
+        clingo_mod = importlib.import_module("clingo")
+        # Make sure we didn't import an empty module
+        _ensure_clingo_or_raise(clingo_mod)
+    except ImportError:
+        clingo_mod = None
+
+    if clingo_mod is not None:
+        return _set_clingo_module_cache(clingo_mod)
+
+    clingo_mod = _bootstrap_clingo()
+    return _set_clingo_module_cache(clingo_mod)
+
+
+def _set_clingo_module_cache(clingo_mod: ModuleType) -> ModuleType:
+    """Cache the lazily-imported clingo module."""
+    global _CLINGO_MODULE
+    importlib.import_module("clingo.ast")
+    _CLINGO_MODULE = clingo_mod
+    return clingo_mod
+
+
+def _ensure_clingo_or_raise(clingo_mod: ModuleType) -> None:
+    """Ensures the clingo module can access expected attributes, otherwise raises an error."""
+    # These are imports that may be problematic at top level (circular imports). They are used
+    # only to provide exhaustive details when erroring due to a broken clingo module.
+    import spack.config
+    import spack.paths as sp
+    import spack.util.path as sup
+
+    try:
+        clingo_mod.Symbol
+    except AttributeError:
+        # clingo 6 moved Symbol into the clingo.symbol submodule
+        try:
+            if importlib.import_module("clingo.symbol").Symbol is not None:
+                return
+        except (ImportError, AttributeError):
+            pass
+        assert clingo_mod.__file__ is not None, "clingo installation is incomplete or invalid"
+        # Reaching this point indicates a broken clingo installation
+        # If Spack derived clingo, suggest user re-run bootstrap
+        # if non-spack, suggest user investigate installation
+        # assume Spack is not responsible for broken clingo
+        msg = (
+            f"Clingo installation at {clingo_mod.__file__} is incomplete or invalid."
+            "Please repair installation or re-install. "
+            "Alternatively, consider installing clingo via Spack."
+        )
+        # check whether Spack is responsible
+        if (
+            pathlib.Path(
+                sup.canonicalize_path(
+                    spack.config.CONFIG.get("bootstrap:root", sp.default_user_bootstrap_path)
+                )
+            )
+            in pathlib.Path(clingo_mod.__file__).parents
+        ):
+            # Spack is responsible for the broken clingo
+            msg = (
+                "Spack bootstrapped copy of Clingo is broken, "
+                "please re-run the bootstrapping process via command `spack bootstrap now`."
+                " If this issue persists, please file a bug at: github.com/spack/spack"
+            )
+        raise RuntimeError(
+            "Clingo installation may be broken or incomplete, "
+            "please verify clingo has been installed correctly"
+            "\n\nClingo does not provide symbol clingo.Symbol"
+            f"{msg}"
+        )
+
+
+def _bootstrap_clingo() -> ModuleType:
+    """Bootstraps the clingo module and returns it"""
+    import spack.bootstrap
+
+    with spack.bootstrap.ensure_bootstrap_configuration():
+        spack.bootstrap.ensure_clingo_importable_or_raise()
+        clingo_mod = importlib.import_module("clingo")
+
+    return clingo_mod
+
+
+class ClingoFlavor(enum.Enum):
+    """The clingo Python API variant in use.
+
+    Spack supports three: the legacy pre-CFFI API, the CFFI-based API (clingo ``@5.5:5``), and the
+    clingo 6 rewrite, which restructured everything into submodules ``clingo.*``."""
+
+    LEGACY = enum.auto()
+    CFFI = enum.auto()
+    V6 = enum.auto()
+
+
+def _detect_clingo_flavor(clingo_mod: ModuleType) -> ClingoFlavor:
+    """Determine which of the three supported clingo Python APIs is in use."""
+    if not hasattr(clingo_mod, "Control"):
+        # clingo 6 dropped the top-level Control/Symbol.
+        return ClingoFlavor.V6
+    if hasattr(getattr(clingo_mod, "Symbol", None), "_rep"):
+        return ClingoFlavor.CFFI
+    return ClingoFlavor.LEGACY
+
+
+@functools.lru_cache(maxsize=None)
+def clingo_flavor() -> ClingoFlavor:
+    """Return the :class:`ClingoFlavor` of the loaded clingo module (detected once)."""
+    return _detect_clingo_flavor(clingo())
+
+
+@functools.lru_cache(maxsize=None)
+def clingo_library() -> Any:
+    """Return a process-global ``clingo.core.Library`` (clingo 6 only).
+
+    A single shared library lets symbols produced by one control object be reused by another
+    (e.g. when ``raise_if_errors`` feeds a model from the main solve into a second control).
+    """
+    clingo()  # ensure the clingo module is importable / bootstrapped
+    return importlib.import_module("clingo.core").Library()
+
+
+def symbol_name(sym: Any) -> Optional[str]:
+    """Return ``sym.name`` if ``sym`` is a function symbol, otherwise ``None``.
+
+    Non-function symbols raise ``RuntimeError`` on clingo+CFFI and ``ValueError`` on clingo 6;
+    legacy clingo returns an empty string.
+    """
+    try:
+        return sym.name or None
+    except (RuntimeError, ValueError):
+        return None
+
+
+def symbol_string(sym: Any) -> str:
+    """Return ``sym.string`` for a string symbol, otherwise ``str(sym)``."""
+    if clingo_flavor() is ClingoFlavor.CFFI:
+        # CFFI throws RuntimeError on ".string" for non-string symbols.
+        try:
+            return sym.string
+        except RuntimeError:
+            return str(sym)
+    # Legacy returns "" for non-string symbols; clingo 6 raises ValueError.
+    try:
+        return sym.string or str(sym)
+    except (RuntimeError, ValueError):
+        return str(sym)
+
+
+class _ClingoBackend:
+    """Context manager adapting the clingo 6 backend to the legacy interface."""
+
+    __slots__ = ("_manager", "_backend")
+
+    def __init__(self, manager: Any) -> None:
+        self._manager = manager
+        self._backend: Any = None
+
+    def __enter__(self) -> "_ClingoBackend":
+        self._backend = self._manager.__enter__()
+        return self
+
+    def __exit__(self, *exc_info) -> Any:
+        return self._manager.__exit__(*exc_info)
+
+    def add_atom(self, symbol: Any = None) -> int:
+        return self._backend.atom(symbol)
+
+    def add_rule(self, head: Any, body: Any = (), choice: bool = False) -> None:
+        self._backend.rule(head, body, choice)
+
+
+class _ClingoV6Control:
+    """Adapter exposing the legacy clingo ``Control`` interface on top of the restructured clingo
+    6 Python API. Only the subset of the API used by Spack's solver is implemented; instantiate
+    via :func:`default_clingo_control` / :func:`make_error_control`."""
+
+    __slots__ = ("_control",)
+
+    def __init__(self, options: Tuple[str, ...] = ()) -> None:
+        control_mod = importlib.import_module("clingo.control")
+        self._control = control_mod.Control(clingo_library(), list(options))
+
+    def add(self, name: str, parameters: Tuple[str, ...], program: str) -> None:
+        # Spack only ever adds the implicit "base" part without parameters.
+        self._control.parse_string(program)
+
+    def load(self, path: str) -> None:
+        self._control.parse_files([path])
+
+    def ground(self, parts: Any) -> None:
+        self._control.ground([(name, list(args)) for name, args in parts])
+
+    def solve(self, on_model: Any = None, async_: bool = False) -> Any:
+        if async_:
+            return self._control.start_solve(on_model=on_model, async_=True)
+        return self._control.solve(on_model=on_model)
+
+    def backend(self) -> _ClingoBackend:
+        return _ClingoBackend(self._control.backend)
+
+    @property
+    def statistics(self) -> Any:
+        # clingo 6 returns a lazy StatsView; nestify() yields the plain dict older versions did.
+        return self._control.stats.nestify()
+
+
+def default_clingo_control() -> Any:
+    """Return a control object configured with Spack's default solver settings."""
+    if clingo_flavor() is ClingoFlavor.V6:
+        # clingo 6 has no `.configuration` API; pass equivalents as CLI options.
+        return _ClingoV6Control(
+            ("--configuration=tweety", "--heuristic=Domain", "--opt-strategy=usc")
+        )
+    control = clingo().Control()
+    control.configuration.configuration = "tweety"
+    control.configuration.solver.heuristic = "Domain"
+    control.configuration.solver.opt_strategy = "usc"
+    return control
+
+
+def make_error_control() -> Any:
+    """Return a plain control object, used to derive error causation on unsat."""
+    if clingo_flavor() is ClingoFlavor.V6:
+        return _ClingoV6Control()
+    return clingo().Control()

--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -33,8 +33,12 @@ duplicate_penalty(node(ID1, Package), 1, "version")
    ID2 = ID1 + 1, Weight2 < Weight1,
    max_dupes(Virtual, X), X > 1, ID2 < X.
 
-% Auxiliary predicates: each projects away one or more arguments of an
-% existing predicate so it can be used in a negative body literal.
+% Anonymous variables that appear only in negative body literals like `not
+% foo(..., _, ...)` are projected implicitly by clingo v5, but not in clingo
+% v6. Each predicate below is the explicit projection of an existing predicate
+% that replaces such a body literal elsewhere in the program, letting the same
+% encoding work on all supported clingo versions with no per-version flags.
+
 has_provider(VirtualNode) :- provider(_, VirtualNode).
 is_provider_of_virtual(ProviderNode, Virtual) :- provider(ProviderNode, node(_, Virtual)).
 any_provider_for(Provider, Virtual) :- provider(node(_, Provider), node(_, Virtual)).

--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -33,6 +33,46 @@ duplicate_penalty(node(ID1, Package), 1, "version")
    ID2 = ID1 + 1, Weight2 < Weight1,
    max_dupes(Virtual, X), X > 1, ID2 < X.
 
+% Auxiliary predicates: each projects away one or more arguments of an
+% existing predicate so it can be used in a negative body literal.
+has_provider(VirtualNode) :- provider(_, VirtualNode).
+is_provider_of_virtual(ProviderNode, Virtual) :- provider(ProviderNode, node(_, Virtual)).
+any_provider_for(Provider, Virtual) :- provider(node(_, Provider), node(_, Virtual)).
+any_reused_provider_for(Provider, Virtual) :- reused_provider(node(_, Provider), node(_, Virtual)).
+provides_language(ProviderNode, Language) :- provider(ProviderNode, node(_, Language)).
+has_provider_weight_config(Virtual, Provider) :- provider_weight_from_config(Virtual, Provider, _).
+virtual_has_incoming_edges(Virtual) :- attr("virtual_on_incoming_edges", _, Virtual).
+virtual_is_a_root(Virtual) :- attr("virtual_root", node(_, Virtual)).
+has_virtual_on_edge_to(ParentNode, ChildPkg, Virtual) :- attr("virtual_on_edge", ParentNode, node(_, ChildPkg), Virtual).
+pkg_has_virtual_on_any_edge(PackageNode, Virtual) :- attr("virtual_on_edge", PackageNode, _, Virtual).
+
+node_has_namespace(PackageNode) :- attr("namespace", PackageNode, _).
+node_has_namespace_set(PackageNode) :- attr("namespace_set", PackageNode, _).
+in_unification_set(PackageNode) :- unification_set(_, PackageNode).
+has_condition_set_node(PackageNode, A1) :- condition_set(PackageNode, node(_, A1)).
+has_imposed_node(PackageNode, A1) :- imposed_nodes(PackageNode, node(_, A1)).
+is_a_subcondition(ConditionID) :- subcondition(ConditionID, _).
+has_a_subcondition(ConditionID) :- subcondition(_, ConditionID).
+has_requirement_conditional(Package, X) :- requirement_conditional(Package, X, _).
+has_requirement_message(Package, X) :- requirement_message(Package, X, _).
+
+node_has_any_compiler(PackageNode) :- node_compiler(_, PackageNode).
+pkg_has_any_compiler(PkgName) :- node_compiler(_, node(_, PkgName)).
+compiler_used_as_lib(PkgName, Hash) :- compiler_used_as_a_library(node(_, PkgName), Hash).
+
+has_concrete_build_dep(ParentNode, BuildDep) :- attr("concrete_build_dependency", ParentNode, BuildDep, _).
+is_self_build_req(PackageNode) :- self_build_requirement(_, PackageNode).
+hash_is_assigned(Hash) :- attr("hash", _, Hash).
+hash_imposes_node_flag(Hash, Pkg, FlagType, Flag) :- imposed_constraint(Hash, "node_flag", Pkg, node_flag(FlagType, Flag, _, _)).
+
+pkg_has_variant(PackageNode, Variant) :- node_has_variant(PackageNode, Variant, _).
+node_has_variant_value(PackageNode, Variant) :- attr("variant_value", PackageNode, Variant, _).
+has_pkg_yaml_variant_default(Package, VName) :- variant_default_value_from_packages_yaml(Package, VName, _).
+has_cli_variant_default(Package, VName) :- attr("variant_default_value_from_cli", node(min_dupe_id, Package), VName, _).
+has_variant_penalty_fact(Pkg, VID, Val) :- pkg_fact(Pkg, variant_penalty(VID, Val, _)).
+pkg_has_literal_flag_set(PackageNode, FlagType) :- attr("node_flag_set", PackageNode, node_flag(FlagType, _, _, "literal")).
+has_target_weight(PackageNode) :- node_target_weight(PackageNode, _).
+
 % Integrity constraints on DAG nodes
 :- attr("root", PackageNode), not attr("node", PackageNode).
 :- attr("version", PackageNode, _), not attr("node", PackageNode), not attr("virtual_node", PackageNode).
@@ -45,7 +85,7 @@ duplicate_penalty(node(ID1, Package), 1, "version")
 :- attr("node_flag", PackageNode, _), not attr("node", PackageNode).
 :- attr("depends_on", ParentNode, _, _), not attr("node", ParentNode).
 :- attr("depends_on", _, ChildNode, _), not attr("node", ChildNode).
-:- attr("virtual_node", VirtualNode), not provider(_, VirtualNode).
+:- attr("virtual_node", VirtualNode), not has_provider(VirtualNode).
 :- provider(_, VirtualNode), not attr("virtual_node", VirtualNode).
 :- provider(PackageNode, _), not attr("node", PackageNode).
 :- node_has_variant(PackageNode, _, _), not attr("node", PackageNode).
@@ -60,7 +100,7 @@ duplicate_penalty(node(ID1, Package), 1, "version")
 
 % Namespaces are statically assigned by a package fact if not otherwise set
 error(100, "{0} does not have a namespace", Package) :- attr("node", node(ID, Package)),
-   not attr("namespace", node(ID, Package), _).
+   not node_has_namespace(node(ID, Package)).
 
 error(100, "{0} cannot come from both {1} and {2} namespaces", Package, NS1, NS2) :- attr("node", node(ID, Package)),
    attr("namespace", node(ID, Package), NS1),
@@ -70,7 +110,7 @@ error(100, "{0} cannot come from both {1} and {2} namespaces", Package, NS1, NS2
 attr("namespace", node(ID, Package), Namespace) :- attr("namespace_set", node(ID, Package), Namespace).
 attr("namespace", node(ID, Package), Namespace)
   :- attr("node", node(ID, Package)),
-     not attr("namespace_set", node(ID, Package), _),
+     not node_has_namespace_set(node(ID, Package)),
      pkg_fact(Package, namespace(Namespace)).
 
 % Rules on "unification sets", i.e. on sets of nodes allowing a single configuration of any given package
@@ -128,23 +168,23 @@ compute_closure(node(ID, Package), "linkrun")  :-
 
 attr("closure", PackageNode, DependencyNode, "linkrun") :-
   attr("depends_on", PackageNode, DependencyNode, "link"),
-  not provider(DependencyNode, node(_, Language)) : language(Language);
+  not provides_language(DependencyNode, Language) : language(Language);
   compute_closure(PackageNode, "linkrun").
 
 attr("closure", PackageNode, DependencyNode, "linkrun") :-
   attr("depends_on", PackageNode, DependencyNode, "run"),
-  not provider(DependencyNode, node(_, Language)) : language(Language);
+  not provides_language(DependencyNode, Language) : language(Language);
   compute_closure(PackageNode, "linkrun").
 
 attr("closure", PackageNode, DependencyNode, "linkrun") :-
   attr("depends_on", ParentNode, DependencyNode, "link"),
-  not provider(DependencyNode, node(_, Language)) : language(Language);
+  not provides_language(DependencyNode, Language) : language(Language);
   attr("closure", PackageNode, ParentNode, "linkrun"),
   compute_closure(PackageNode, "linkrun").
 
 attr("closure", PackageNode, DependencyNode, "linkrun") :-
   attr("depends_on", ParentNode, DependencyNode, "run"),
-  not provider(DependencyNode, node(_, Language)) : language(Language);
+  not provides_language(DependencyNode, Language) : language(Language);
   attr("closure", PackageNode, ParentNode, "linkrun"),
   compute_closure(PackageNode, "linkrun").
 
@@ -171,7 +211,7 @@ related(NodeA, NodeB) :- attr("closure", NodeA, NodeB, "linkrun").
 :- unification_set("root", node(_, Package)), not possible_in_link_run(Package), not virtual(Package).
 
 % Each node must belong to at least one unification set
-:- attr("node", PackageNode), not unification_set(_, PackageNode).
+:- attr("node", PackageNode), not in_unification_set(PackageNode).
 
 % Cannot have a node with an ID, if lower ID of the same package are not used
 :- attr("node", node(ID1, Package)),
@@ -269,11 +309,14 @@ attr_single_value("node_platform").
 attr_single_value("node_os").
 attr_single_value("node_target").
 
+node_has_single_value_attr(node(ID, Package), Attribute) :-
+  attr(Attribute, node(ID, Package), _).
+
 % Error when no attribute is selected
 error(10000, no_value_error, Attribute, Package)
   :- attr("node", node(ID, Package)),
      attr_single_value(Attribute),
-     not attr(Attribute, node(ID, Package), _).
+     not node_has_single_value_attr(node(ID, Package), Attribute).
 
 % Error when multiple attr need to be selected
 error(100, multiple_values_error, Attribute, Package)
@@ -427,7 +470,7 @@ condition_nodes(PackageNode, node(X, A1))
 
 cannot_hold(TriggerID, PackageNode)
   :- condition_packages(TriggerID, A1),
-     not condition_set(PackageNode, node(_, A1)),
+     not has_condition_set_node(PackageNode, A1),
      trigger_real_node(TriggerID, PackageNode),
      attr("node", PackageNode).
 
@@ -565,7 +608,7 @@ trigger_and_effect(Package, TriggerID, EffectID) :- trigger_and_effect(Package, 
 
 % Effects of direct conditions hold if the trigger holds
 impose(EffectID, node(X, Package))
-  :- not subcondition(ConditionID, _),
+  :- not is_a_subcondition(ConditionID),
      trigger_and_effect(Package, ConditionID, TriggerID, EffectID),
      trigger_requestor_node(TriggerID, node(X, Package)),
      trigger_condition_holds(TriggerID, node(X, Package)),
@@ -601,8 +644,8 @@ imposed_nodes(PackageNode, node(X, A1))
      condition_set(PackageNode, node(X, A1)),
      attr("hash", PackageNode, ConditionID).
 
-:- imposed_packages(ID, A1), impose(ID, PackageNode), not condition_set(PackageNode, node(_, A1)).
-:- imposed_packages(ID, A1), impose(ID, PackageNode), not imposed_nodes(PackageNode, node(_, A1)).
+:- imposed_packages(ID, A1), impose(ID, PackageNode), not has_condition_set_node(PackageNode, A1).
+:- imposed_packages(ID, A1), impose(ID, PackageNode), not has_imposed_node(PackageNode, A1).
 
 % Conditions that hold impose may impose constraints on other specs
 attr(Name, node(X, A1))             :- impose(ID, PackageNode), imposed_constraint(ID, Name, A1),             imposed_nodes(PackageNode, node(X, A1)).
@@ -652,7 +695,7 @@ attr("concrete_variant_set", node(X, A1), Variant, Value, ID)
      imposed_constraint(ID, "depends_on", A1, A2, A3).
 
 :- attr("direct_dependency", ParentNode, node_requirement("virtual_on_incoming_edges", ChildPkg, Virtual)),
-   not attr("virtual_on_edge", ParentNode, node(_, ChildPkg), Virtual).
+   not has_virtual_on_edge_to(ParentNode, ChildPkg, Virtual).
 
 % If the parent is built, then we have a build_requirement on another node. For concrete nodes,
 % we don't since we are trimming their build dependencies.
@@ -661,7 +704,7 @@ attr("concrete_variant_set", node(X, A1), Variant, Value, ID)
 :- attr("direct_dependency", ParentNode, node_requirement("node", BuildDependency)),
    concrete_build_requirement(ParentNode, BuildDependency),
    concrete(ParentNode),
-   not attr("concrete_build_dependency", ParentNode, BuildDependency, _).
+   not has_concrete_build_dep(ParentNode, BuildDependency).
 
 :- attr("direct_dependency", ParentNode, node_requirement("node_version_satisfies", BuildDependency, Constraint)),
    concrete_build_requirement(ParentNode, BuildDependency),
@@ -678,12 +721,12 @@ attr("concrete_variant_set", node(X, A1), Variant, Value, ID)
 compiler_from_reuse(Hash, DependencyPackage) :-
   attr("concrete_build_dependency", ParentNode, DependencyPackage, Hash),
   attr("virtual_on_build_edge", ParentNode, DependencyPackage, Virtual),
-  not node_compiler(_, ParentNode),
+  not node_has_any_compiler(ParentNode),
   language(Virtual).
 
 compiler_penalty_from_reuse(Hash) :-
   compiler_from_reuse(Hash, DependencyPackage),
-  not node_compiler(_, node(_, DependencyPackage)),
+  not pkg_has_any_compiler(DependencyPackage),
   % We don't want to give penalties if we're just installing binaries
   will_build_packages().
 
@@ -806,7 +849,7 @@ error(10, "{0} cannot have a dependency on {1}", Package, Virtual)
 % For a spec like `hdf5 %cxx` we need to ensure that the virtual is needed on a direct edge
 error(10, "{0} cannot have a dependency on {1}", Package, Virtual)
   :- attr("direct_dependency", node(ID, Package), node_requirement("virtual_node", Virtual)),
-     not attr("virtual_on_edge", node(ID, Package), _, Virtual).
+     not pkg_has_virtual_on_any_edge(node(ID, Package), Virtual).
 
 % Reconstruct virtual dependencies for reused specs
 attr("virtual_on_edge", node(X, A1), node(Y, A2), Virtual)
@@ -840,7 +883,7 @@ attr("uses_virtual", PackageNode, Virtual) :-
 :- attr("node", node(ID, Package)),
    attr("hash", node(ID, Package), Hash),
    attr("node_flag", node(ID, Package), node_flag(FlagType, Flag, _, _)),
-   not imposed_constraint(Hash, "node_flag", Package, node_flag(FlagType, Flag, _, _)).
+   not hash_imposes_node_flag(Hash, Package, FlagType, Flag).
 
 % we cannot have two nodes with the same hash
 :- attr("hash", PackageNode1, Hash), attr("hash", PackageNode2, Hash), PackageNode1 < PackageNode2.
@@ -866,7 +909,7 @@ concrete(PackageNode) :- attr("hash", PackageNode, _), attr("node", PackageNode)
 :- concrete(PackageNode),
    depends_on(PackageNode, DependencyNode),
    not concrete(DependencyNode),
-   not abi_splice_conditions_hold(_, DependencyNode, _, _).
+   not any_splice_holds_for(DependencyNode).
 
 %-----------------------------------------------------------------------------
 % Dependency semantics
@@ -1017,8 +1060,8 @@ attr("depends_on", PackageNode, ProviderNode, Type) :- virtual_on_edge(PackageNo
 % If a virtual node is in the answer set, it must be either a virtual root,
 % or used somewhere
 :- attr("virtual_node", node(_, Virtual)),
-   not attr("virtual_on_incoming_edges", _, Virtual),
-   not attr("virtual_root", node(_, Virtual)).
+   not virtual_has_incoming_edges(Virtual),
+   not virtual_is_a_root(Virtual).
 
 attr("virtual_on_incoming_edges", ProviderNode, Virtual)
   :- attr("virtual_on_edge", _, ProviderNode, Virtual).
@@ -1042,7 +1085,7 @@ error(100, "'{0}' cannot be a provider for the '{1}' virtual", Package, Virtual)
 
 error(100, "Cannot find valid provider for virtual {0}", Virtual)
   :- attr("virtual_node", node(X, Virtual)),
-     not provider(_, node(X, Virtual)).
+     not has_provider(node(X, Virtual)).
 
 error(100, "Cannot select a single provider for virtual '{0}'", Virtual)
   :- attr("virtual_node", node(X, Virtual)),
@@ -1071,7 +1114,7 @@ virtual_condition_holds(ID, node(ProviderID, Provider), Virtual) :-
 do_not_impose(EffectID, node(X, Package))
   :- virtual_condition_holds(ID, node(X, Package), Virtual),
      pkg_fact(Package, condition_effect(ID, EffectID)),
-     not provider(node(X, Package), node(_, Virtual)).
+     not is_provider_of_virtual(node(X, Package), Virtual).
 
 % Choose the provider among root specs, if possible
 :- provider(ProviderNode, node(min_dupe_id, Virtual)),
@@ -1101,7 +1144,7 @@ provider_weight(node(ProviderID, Provider), node(VirtualID, Virtual), Weight)
 % Any non-configured provider has a default weight of 100
 provider_weight(node(ProviderID, Provider), node(VirtualID, Virtual), 100)
   :- provider(node(ProviderID, Provider), node(VirtualID, Virtual)),
-     not provider_weight_from_config(Virtual, Provider, _).
+     not has_provider_weight_config(Virtual, Provider).
 
 % do not warn if generated program contains none of these.
 #defined virtual/1.
@@ -1123,7 +1166,7 @@ error(1000, "Cannot build {0}, since it is configured `buildable:false` and no e
 % Account for compiler annotation on externals
 :- not attr("root", ExternalNode),
    attr("external_build_requirement", ExternalNode, node_requirement("node", Compiler)),
-   not node_compiler(_, node(_, Compiler)).
+   not pkg_has_any_compiler(Compiler).
 
 1 { attr("node_version_satisfies", node(X, Compiler), Constraint) : node_compiler(_, node(X, Compiler)) }
   :- not attr("root", ExternalNode),
@@ -1152,7 +1195,7 @@ trigger_node(ID, node(PackageID, Package), node(VirtualID, Virtual)) :- pkg_fact
 activate_requirement(node(ID, Package), X) :-
   package_in_dag(node(ID, Package)),
   requirement_group(Package, X),
-  not requirement_conditional(Package, X, _).
+  not has_requirement_conditional(Package, X).
 
 activate_requirement(node(ID, Package), X) :-
   package_in_dag(node(ID, Package)),
@@ -1199,7 +1242,7 @@ requirement_group_satisfied(node(ID, Package), GroupID) :-
 requirement_is_met(GroupID, ConditionID, node(X, Package)) :-
   requirement_group_member(ConditionID, Package, GroupID),
   condition_holds(ConditionID, node(X, Package)),
-  not subcondition(_, ConditionID).
+  not has_a_subcondition(ConditionID).
 
 requirement_is_met(GroupID, ConditionID, node(X, Package)) :-
   requirement_group_member(ConditionID, Package, GroupID),
@@ -1250,8 +1293,8 @@ required_provider(Provider, Virtual)
 
 error(1, "Cannot use {1} for the {0} virtual, but that is required", Virtual, Provider) :-
    required_provider(Provider, Virtual),
-   not reused_provider(node(_, Provider), node(_, Virtual)),
-   not provider(node(_, Provider), node(_, Virtual)).
+   not any_reused_provider_for(Provider, Virtual),
+   not any_provider_for(Provider, Virtual).
 
 % TODO: the following choice rule allows the solver to add compiler
 % flags if their only source is from a requirement. This is overly-specific
@@ -1304,7 +1347,7 @@ requirement_penalty(PackageNode, Language, Group, W) :-
 error(60000, "cannot satisfy a requirement for package '{0}'.", Package) :-
   activate_requirement(node(ID, Package), X),
   requirement_group(Package, X),
-  not requirement_message(Package, X, _),
+  not has_requirement_message(Package, X),
   not requirement_group_satisfied(node(ID, Package), X).
 
 
@@ -1369,13 +1412,13 @@ node_has_variant(PackageNode, Name, SelectedVariantID) :-
 variant_default_value(node(ID, Package), VariantName, Value) :-
   node_has_variant(node(ID, Package), VariantName, VariantID),
   pkg_fact(Package, variant_default_value_from_package_py(VariantID, Value)),
-  not variant_default_value_from_packages_yaml(Package, VariantName, _),
-  not attr("variant_default_value_from_cli", node(min_dupe_id, Package), VariantName, _).
+  not has_pkg_yaml_variant_default(Package, VariantName),
+  not has_cli_variant_default(Package, VariantName).
 
 variant_default_value(node(ID, Package), VariantName, Value) :-
   node_has_variant(node(ID, Package), VariantName, _),
   variant_default_value_from_packages_yaml(Package, VariantName, Value),
-  not attr("variant_default_value_from_cli", node(min_dupe_id, Package), VariantName, _).
+  not has_cli_variant_default(Package, VariantName).
 
 variant_default_value(node(ID, Package), VariantName, Value) :-
     node_has_variant(node(ID, Package), VariantName, _),
@@ -1388,7 +1431,7 @@ possible_variant_penalty(VariantID, Value, Penalty) :- pkg_fact(Package, variant
 % for instance those defined implicitly by a validator.
 possible_variant_penalty(VariantID, Value, 100) :-
     pkg_fact(Package, variant_possible_value(VariantID, Value)),
-    not pkg_fact(Package, variant_penalty(VariantID, Value, _)).
+    not has_variant_penalty_fact(Package, VariantID, Value).
 
 variant_penalty(node(NodeID, Package), Variant, Value, Penalty) :-
     node_has_variant(node(NodeID, Package), Variant, VariantID),
@@ -1398,7 +1441,7 @@ variant_penalty(node(NodeID, Package), Variant, Value, Penalty) :-
     % variants set explicitly from a directive don't count as non-default
     not attr("variant_set", node(NodeID, Package), Variant, Value),
     % variant values forced by propagation don't count as non-default
-    not propagate(node(NodeID, Package), variant_value(Variant, Value, _)).
+    not propagated_variant_value(node(NodeID, Package), Variant, Value).
 
 % -- Associate the definition's possible values with the node
 variant_possible_value(node(ID, Package), VariantName, Value) :-
@@ -1445,13 +1488,13 @@ attr("variant_selected", PackageNode, Variant, Value, VariantType, VariantID) :-
 % a variant cannot be set if it is not a variant on the package
 error(100, "Cannot set variant '{0}' for package '{1}' because the variant condition cannot be satisfied for the given spec", Variant, Package)
   :- attr("variant_set", node(ID, Package), Variant),
-     not node_has_variant(node(ID, Package), Variant, _),
+     not pkg_has_variant(node(ID, Package), Variant),
      build(node(ID, Package)).
 
 % a variant cannot take on a value if it is not a variant of the package
 error(100, "Cannot set variant '{0}' for package '{1}' because the variant condition cannot be satisfied for the given spec", Variant, Package)
   :- attr("variant_value", node(ID, Package), Variant, _),
-     not node_has_variant(node(ID, Package), Variant, _),
+     not pkg_has_variant(node(ID, Package), Variant),
      build(node(ID, Package)).
 
 % at most one variant value for single-valued variants.
@@ -1468,7 +1511,7 @@ error(100, "No valid value for variant '{1}' of package '{0}'", Package, Variant
   :- attr("node", node(ID, Package)),
      node_has_variant(node(ID, Package), Variant, _),
      build(node(ID, Package)),
-     not attr("variant_value", node(ID, Package), Variant, _).
+     not node_has_variant_value(node(ID, Package), Variant).
 
 % if a variant is set to anything, it is considered 'set'.
 attr("variant_set", PackageNode, Variant) :- attr("variant_set", PackageNode, Variant, _).
@@ -1527,7 +1570,7 @@ variant_default_not_used(node(ID, Package), Variant, Value)
      node_has_variant(node(ID, Package), Variant, VariantID),
      variant_type(VariantID, VariantType), VariantType == "multi",
      not attr("variant_value", node(ID, Package), Variant, Value),
-     not propagate(node(ID, Package), variant_value(Variant, Value, _)),
+     not propagated_variant_value(node(ID, Package), Variant, Value),
      % variant set explicitly don't count for this metric
      not attr("variant_set", node(ID, Package), Variant, Value),
      attr("node", node(ID, Package)).
@@ -1587,6 +1630,17 @@ propagate(ChildNode, PropagatedAttribute) :-
   propagate(ParentNode, PropagatedAttribute),
   depends_on(ParentNode, ChildNode).
 
+% Project the source-tag (and value, respectively) out of propagate/2 explicitly.
+% clingo v5 grounded `propagate(N, variant_value(V, Val, _))` via an internal
+% #p_propagate projection auxiliary; clingo v6's --project-anonymous does the
+% syntactic `_` -> `*` rewrite but skips the auxiliary, leaving `*` as a literal
+% constant that never matches concrete sources derived through recursion.
+propagated_variant_value(PackageNode, Variant, Value) :-
+  propagate(PackageNode, variant_value(Variant, Value, Source)).
+
+self_propagated_variant(PackageNode, Variant) :-
+  propagate(PackageNode, variant_value(Variant, AnyValue, PackageNode)).
+
 propagate(ChildNode, PropagatedAttribute, edge_types(DepType1, DepType2)) :-
   propagate(ParentNode, PropagatedAttribute, edge_types(DepType1, DepType2)),
   depends_on(ParentNode, ChildNode),
@@ -1602,19 +1656,19 @@ propagate(ChildNode, PropagatedAttribute, edge_types(DepType1, DepType2)) :-
 
 % If a variant is propagated, and can be accepted, set its value
 attr("variant_value", PackageNode, Variant, Value) :-
-  propagate(PackageNode, variant_value(Variant, Value, _)),
+  propagated_variant_value(PackageNode, Variant, Value),
   node_has_variant(PackageNode, Variant, _),
   variant_possible_value(PackageNode, Variant, Value).
 
 % If a variant is propagated, we cannot have extraneous values
 variant_is_propagated(PackageNode, Variant) :-
   attr("variant_value", PackageNode, Variant, Value),
-  propagate(PackageNode, variant_value(Variant, Value, _)),
+  propagated_variant_value(PackageNode, Variant, Value),
   not attr("variant_set", PackageNode, Variant).
 
 :- variant_is_propagated(PackageNode, Variant),
    attr("variant_value", PackageNode, Variant, Value),
-   not propagate(PackageNode, variant_value(Variant, Value, _)).
+   not propagated_variant_value(PackageNode, Variant, Value).
 
 error(100, "{0} and {1} cannot both propagate variant '{2}' to the shared dependency: {3}",
   Package1, Package2, Variant, Dependency) :-
@@ -1625,7 +1679,7 @@ error(100, "{0} and {1} cannot both propagate variant '{2}' to the shared depend
   propagate(node(Z, Dependency), variant_value(Variant, Value2, node(Y, Package2))),
   % Package1 and Package2 and their values are different
   Package1 > Package2,  Value1 != Value2,
-  not propagate(node(Z, Dependency), variant_value(Variant, _, node(Z, Dependency))).
+  not self_propagated_variant(node(Z, Dependency), Variant).
 
 % Cannot propagate the same variant from two different packages if one is a dependency of the other
 error(100, "{0} and {1} cannot both propagate variant '{2}'", Package1, Package2, Variant) :-
@@ -1665,7 +1719,7 @@ node_compiler(node(X, Package), node(Y, Compiler), Language) :-
 
 propagated_flag(node(PackageID, Package), node_flag(FlagType, Flag, FlagGroup, Source), SourceNode) :-
   propagate(node(PackageID, Package), node_flag(FlagType, Flag, FlagGroup, Source), _),
-  not attr("node_flag_set", node(PackageID, Package), node_flag(FlagType, _, _, "literal")),
+  not pkg_has_literal_flag_set(node(PackageID, Package), FlagType),
   % Same compilers as propagation source
   node_compiler(node(PackageID, Package), CompilerNode, Language) : node_compiler(SourceNode, CompilerNode, Language);
   attr("propagate", SourceNode, node_flag(FlagType, Flag, FlagGroup, Source), _),
@@ -1749,7 +1803,7 @@ unification_set_compiler("root", CompilerNode, Language) :-
 % root unification set are reused.
 unification_set_compiler("root", node(CompilerHash, Compiler), Language) :-
     reused_node_compiler(node(ID, Package), node(CompilerHash, Compiler), Language),
-    not attr("hash", _, CompilerHash),
+    not hash_is_assigned(CompilerHash),
     no_compiler_mixing(Language),
     not allow_mixing(Package),
     unification_set("root", node(ID, Package)).
@@ -1896,7 +1950,7 @@ node_target_weight(PackageNode, MinWeight)
     target(Target),
     MinWeight = #min { Weight : target_weight(Target, Weight) }.
 
-:- attr("node_target", PackageNode, Target), not node_target_weight(PackageNode, _).
+:- attr("node_target", PackageNode, Target), not has_target_weight(PackageNode).
 
 % compatibility rules for targets among nodes
 node_target_match(ParentNode, DependencyNode)
@@ -1979,7 +2033,7 @@ avoid_link_dependency(Hash, DepName) :-
   not hash_attr(Hash, "depends_on", PackageName, DepName, "run"),
   hash_attr(Hash, "hash", DepName, DepHash),
   compiler_package(PackageName),
-  not compiler_used_as_a_library(node(_, PackageName), Hash).
+  not compiler_used_as_lib(PackageName, Hash).
 
 % When a compiler is not used as a library, its transitive run-type dependencies are unified in the
 % build environment (they appear in PATH etc.), but their pure link-type dependencies are NOT. This
@@ -1990,7 +2044,7 @@ avoid_link_dependency(Hash, DepName) :-
 % Base case: direct run dep of a non-library compiler
 compiler_non_lib_run_dep(DepHash, DepName) :-
   compiler_package(CompilerName),
-  not compiler_used_as_a_library(node(_, CompilerName), CompilerHash),
+  not compiler_used_as_lib(CompilerName, CompilerHash),
   hash_attr(CompilerHash, "depends_on", CompilerName, DepName, "run"),
   hash_attr(CompilerHash, "hash", DepName, DepHash).
 
@@ -2006,29 +2060,35 @@ avoid_link_dependency(DepHash, LinkDepName) :-
   hash_attr(DepHash, "depends_on", DepName, LinkDepName, "link"),
   not hash_attr(DepHash, "depends_on", DepName, LinkDepName, "run").
 
+% Auxiliary splice predicates (project away unused arguments).
+any_splice_holds_for(DepNode) :- abi_splice_conditions_hold(_, DepNode, _, _).
+any_splice_holds_for_hash(ChildName, ChildHash) :- abi_splice_conditions_hold(_, _, ChildName, ChildHash).
+splice_at_hash_exists(DepName, DepHash) :- attr("splice_at_hash", _, _, DepName, DepHash).
+any_splice_at_hash_for_dep(DepName) :- attr("splice_at_hash", _, _, DepName, _).
+
 % Without splicing, we simply recover the exact semantics
 imposed_constraint(ParentHash, "hash", ChildName, ChildHash) :-
   hash_attr(ParentHash, "hash", ChildName, ChildHash),
   ChildHash != ParentHash,
   not avoid_link_dependency(ParentHash, ChildName),
-  not abi_splice_conditions_hold(_, _, ChildName, ChildHash).
+  not any_splice_holds_for_hash(ChildName, ChildHash).
 
 imposed_constraint(Hash, "depends_on", PackageName, DepName, Type) :-
   hash_attr(Hash, "depends_on", PackageName, DepName, Type),
   hash_attr(Hash, "hash", DepName, DepHash),
   not avoid_link_dependency(Hash, DepName),
-  not attr("splice_at_hash", _, _, DepName, DepHash).
+  not splice_at_hash_exists(DepName, DepHash).
 
 imposed_constraint(Hash, "virtual_on_edge", PackageName, DepName, VirtName) :-
   hash_attr(Hash, "virtual_on_edge", PackageName, DepName, VirtName),
   not avoid_link_dependency(Hash, DepName),
-  not attr("splice_at_hash", _, _, DepName,_).
+  not any_splice_at_hash_for_dep(DepName).
 
 imposed_constraint(Hash, "virtual_node", VirtName) :-
   hash_attr(Hash, "virtual_on_edge", PackageName, DepName, VirtName),
   hash_attr(Hash, "virtual_node", VirtName),
   not avoid_link_dependency(Hash, DepName),
-  not attr("splice_at_hash", _, _, DepName,_).
+  not any_splice_at_hash_for_dep(DepName).
 
 
 % Rules pertaining to attr("splice_at_hash") and abi_splice_conditions_hold will
@@ -2109,7 +2169,7 @@ opt_criterion(120, "number of packages to build (vs. reuse)").
 
 opt_criterion(110, "number of nodes from the same package").
 #minimize { 0@110: #true }.
-#minimize { ID@110,Package : attr("node", node(ID, Package)), not self_build_requirement(_, node(ID, Package)) }.
+#minimize { ID@110,Package : attr("node", node(ID, Package)), not is_self_build_req(node(ID, Package)) }.
 #minimize { ID@110,Package : attr("virtual_node", node(ID, Package)) }.
 #defined optimize_for_reuse/0.
 

--- a/lib/spack/spack/solver/core.py
+++ b/lib/spack/spack/solver/core.py
@@ -3,30 +3,14 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 """Low-level wrappers around clingo API and other basic functionality related to ASP"""
 
+import enum
 import importlib
 import pathlib
 from types import ModuleType
-from typing import Any, Callable, NamedTuple, Optional, Tuple
+from typing import Any, NamedTuple, Optional, Tuple
 
 import spack.platforms
 from spack.llnl.util import lang
-
-
-def _ast_getter(*names: str) -> Callable[[Any], Any]:
-    """Helper to retrieve AST attributes from different versions of the clingo API"""
-
-    def getter(node):
-        for name in names:
-            result = getattr(node, name, None)
-            if result:
-                return result
-        raise KeyError(f"node has no such keys: {names}")
-
-    return getter
-
-
-ast_type = _ast_getter("ast_type", "type")
-ast_sym = _ast_getter("symbol", "term")
 
 
 class AspVar:
@@ -102,7 +86,21 @@ class _AspFunctionBuilder:
 #: Global AspFunction builder
 fn = _AspFunctionBuilder()
 
+
+class ClingoFlavor(enum.Enum):
+    """The clingo Python API variant in use.
+
+    Spack supports three: the legacy pre-CFFI API, the CFFI-based API (clingo ``@5.5:5``), and the
+    clingo 6 rewrite, which restructured everything into submodules ``clingo.*``."""
+
+    LEGACY = enum.auto()
+    CFFI = enum.auto()
+    V6 = enum.auto()
+
+
+#: Process-global clingo module and its API flavor, both set once on first import.
 _CLINGO_MODULE: Optional[ModuleType] = None
+_CLINGO_FLAVOR: Optional[ClingoFlavor] = None
 
 
 def clingo() -> ModuleType:
@@ -125,11 +123,22 @@ def clingo() -> ModuleType:
 
 
 def _set_clingo_module_cache(clingo_mod: ModuleType) -> ModuleType:
-    """Sets the global cache to the lazy imported clingo module"""
-    global _CLINGO_MODULE
+    """Caches the lazily-imported clingo module and detects its API flavor once."""
+    global _CLINGO_MODULE, _CLINGO_FLAVOR
     importlib.import_module("clingo.ast")
+    _CLINGO_FLAVOR = _detect_clingo_flavor(clingo_mod)
     _CLINGO_MODULE = clingo_mod
     return clingo_mod
+
+
+def _detect_clingo_flavor(clingo_mod: ModuleType) -> ClingoFlavor:
+    """Determine which of the three supported clingo Python APIs is in use."""
+    if not hasattr(clingo_mod, "Control"):
+        # clingo 6 dropped the top-level Control/Symbol.
+        return ClingoFlavor.V6
+    if hasattr(getattr(clingo_mod, "Symbol", None), "_rep"):
+        return ClingoFlavor.CFFI
+    return ClingoFlavor.LEGACY
 
 
 def _ensure_clingo_or_raise(clingo_mod: ModuleType) -> None:
@@ -143,6 +152,12 @@ def _ensure_clingo_or_raise(clingo_mod: ModuleType) -> None:
     try:
         clingo_mod.Symbol
     except AttributeError:
+        # clingo 6 moved Symbol into the clingo.symbol submodule
+        try:
+            if importlib.import_module("clingo.symbol").Symbol is not None:
+                return
+        except (ImportError, AttributeError):
+            pass
         assert clingo_mod.__file__ is not None, "clingo installation is incomplete or invalid"
         # Reaching this point indicates a broken clingo installation
         # If Spack derived clingo, suggest user re-run bootstrap
@@ -176,9 +191,16 @@ def _ensure_clingo_or_raise(clingo_mod: ModuleType) -> None:
         )
 
 
-def clingo_cffi() -> bool:
-    """Returns True if clingo uses the CFFI interface"""
-    return hasattr(clingo().Symbol, "_rep")
+def clingo_flavor() -> ClingoFlavor:
+    """Return the cached :class:`ClingoFlavor` of the loaded clingo module.
+
+    The flavor is detected exactly once, when clingo is first imported; callers
+    dispatch off the cached value rather than re-probing the module.
+    """
+    if _CLINGO_FLAVOR is None:
+        clingo()  # forces the import and the one-time flavor detection
+    assert _CLINGO_FLAVOR is not None, "clingo flavor was not detected"
+    return _CLINGO_FLAVOR
 
 
 def _bootstrap_clingo() -> ModuleType:
@@ -192,26 +214,122 @@ def _bootstrap_clingo() -> ModuleType:
     return clingo_mod
 
 
-def parse_files(*args, **kwargs):
-    """Wrapper around clingo parse_files, that dispatches the function according
-    to clingo API version.
-    """
-    clingo()
-    try:
-        return importlib.import_module("clingo.ast").parse_files(*args, **kwargs)
-    except (ImportError, AttributeError):
-        return clingo().parse_files(*args, **kwargs)
+#: Process-global clingo 6 library object (lazily created)
+_CLINGO_LIBRARY: Optional[Any] = None
 
 
-def parse_term(*args, **kwargs):
-    """Wrapper around clingo parse_term, that dispatches the function according
-    to clingo API version.
+def clingo_library() -> Any:
+    """Return a process-global ``clingo.core.Library`` (clingo 6 only).
+
+    A single shared library lets symbols produced by one control object be
+    reused by another (e.g. when ``raise_if_errors`` feeds a model from the
+    main solve into a second control object).
     """
-    clingo()
-    try:
-        return importlib.import_module("clingo.symbol").parse_term(*args, **kwargs)
-    except (ImportError, AttributeError):
-        return clingo().parse_term(*args, **kwargs)
+    global _CLINGO_LIBRARY
+    if _CLINGO_LIBRARY is None:
+        clingo()  # ensure the clingo module is importable
+        _CLINGO_LIBRARY = importlib.import_module("clingo.core").Library()
+    return _CLINGO_LIBRARY
+
+
+class _ClingoBackend:
+    """Context manager adapting the clingo 6 backend to the legacy interface."""
+
+    def __init__(self, manager: Any) -> None:
+        self._manager = manager
+        self._backend: Any = None
+
+    def __enter__(self) -> "_ClingoBackend":
+        self._backend = self._manager.__enter__()
+        return self
+
+    def __exit__(self, *exc_info) -> Any:
+        return self._manager.__exit__(*exc_info)
+
+    def add_atom(self, symbol: Any = None) -> int:
+        return self._backend.atom(symbol)
+
+    def add_rule(self, head: Any, body: Any = (), choice: bool = False) -> None:
+        self._backend.rule(head, body, choice)
+
+
+class _ClingoV6Control:
+    """Adapter exposing the legacy clingo ``Control`` interface on top of the restructured clingo 6
+    Python API.
+
+    Only the subset of the API used by Spack's solver is implemented. This keeps ``asp.py``
+    agnostic to which clingo version is in use; it is created through
+    :func:`default_clingo_control` / :func:`make_error_control` rather than directly."""
+
+    def __init__(self, options: Optional[Tuple[str, ...]] = None) -> None:
+        control_mod = importlib.import_module("clingo.control")
+        # clingo 6's grounder no longer implicitly projects anonymous variables
+        # that occur only in negative body literals (older gringo did). Spack's
+        # logic program relies on that behavior, so request it explicitly.
+        control_options = ["--project-anonymous", *(options or ())]
+        self._control = control_mod.Control(clingo_library(), control_options)
+
+    def add(self, name: str, parameters: Tuple[str, ...], program: str) -> None:
+        # Spack only ever adds the implicit "base" part without parameters.
+        self._control.parse_string(program)
+
+    def load(self, path: str) -> None:
+        self._control.parse_files([path])
+
+    def ground(self, parts: Any) -> None:
+        # ``parts`` looks like ``[("base", [])]``; clingo 6 expects a sequence
+        # of ``(name, [symbols])`` tuples.
+        self._control.ground([(name, list(args)) for name, args in parts])
+
+    def solve(self, on_model: Any = None, async_: bool = False) -> Any:
+        # The returned async handle supports timed ``wait()`` / ``get()`` /
+        # ``cancel()``, matching what ``_run_clingo`` expects.
+        if async_:
+            return self._control.start_solve(on_model=on_model, async_=True)
+        return self._control.solve(on_model=on_model)
+
+    def backend(self) -> _ClingoBackend:
+        return _ClingoBackend(self._control.backend)
+
+    @property
+    def statistics(self) -> Any:
+        # clingo 6 exposes a lazy StatsView; nestify() turns it into a plain
+        # nested dict, matching what older clingo versions returned.
+        return self._control.stats.nestify()
+
+
+def _make_control(options: Tuple[str, ...] = ()) -> Any:
+    """Create a clingo control object for the loaded clingo flavor.
+
+    For clingo 6 the result is a :class:`_ClingoV6Control` adapter; for the
+    legacy/CFFI APIs it is a raw ``clingo.Control``. Both expose the subset of
+    the control interface Spack's solver relies on. ``options`` (command-line
+    options) only apply to clingo 6 -- legacy/CFFI configure the solver through
+    the ``.configuration`` attribute instead.
+    """
+    if clingo_flavor() is ClingoFlavor.V6:
+        return _ClingoV6Control(options)
+    return clingo().Control()
+
+
+def default_clingo_control() -> Any:
+    """Return a control object configured with Spack's default solver settings."""
+    if clingo_flavor() is ClingoFlavor.V6:
+        # clingo 6 has no `configuration` API; the equivalent settings are
+        # passed as command line options instead.
+        return _make_control(
+            ("--configuration=tweety", "--heuristic=Domain", "--opt-strategy=usc")
+        )
+    control = _make_control()
+    control.configuration.configuration = "tweety"
+    control.configuration.solver.heuristic = "Domain"
+    control.configuration.solver.opt_strategy = "usc"
+    return control
+
+
+def make_error_control() -> Any:
+    """Return a plain control object, used to derive error causation on unsat."""
+    return _make_control()
 
 
 class NodeId(NamedTuple):
@@ -253,19 +371,22 @@ def intermediate_repr(sym):
                 flag_group=intermediate_repr(sym.arguments[2]),
                 source=intermediate_repr(sym.arguments[3]),
             )
-    except RuntimeError:
-        # This happens when using clingo w/ CFFI and trying to access ".name" for symbols
-        # that are not functions
+    except (RuntimeError, ValueError):
+        # Accessing ".name" on a non-function symbol raises: RuntimeError with
+        # clingo+CFFI, ValueError with clingo 6.
         pass
 
-    if clingo_cffi():
-        # Clingo w/ CFFI will throw an exception on failure
+    if clingo_flavor() is ClingoFlavor.CFFI:
+        # Clingo w/ CFFI throws RuntimeError on ".string" for a non-string symbol.
         try:
             return sym.string
         except RuntimeError:
             return str(sym)
-    else:
+    # Legacy clingo returns "" for non-string symbols; clingo 6 raises ValueError.
+    try:
         return sym.string or str(sym)
+    except (RuntimeError, ValueError):
+        return str(sym)
 
 
 def extract_args(model, predicate_name):
@@ -274,7 +395,15 @@ def extract_args(model, predicate_name):
     Pull out all the predicates with name ``predicate_name`` from the model, and
     return their intermediate representation.
     """
-    return [intermediate_repr(sym.arguments) for sym in model if sym.name == predicate_name]
+
+    def _matches(sym):
+        try:
+            return sym.name == predicate_name
+        except (RuntimeError, ValueError):
+            # ".name" raises for non-function symbols (CFFI / clingo 6)
+            return False
+
+    return [intermediate_repr(sym.arguments) for sym in model if _matches(sym)]
 
 
 class SourceContext:

--- a/lib/spack/spack/solver/core.py
+++ b/lib/spack/spack/solver/core.py
@@ -3,14 +3,12 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 """Low-level wrappers around clingo API and other basic functionality related to ASP"""
 
-import enum
-import importlib
-import pathlib
-from types import ModuleType
 from typing import Any, NamedTuple, Optional, Tuple
 
 import spack.platforms
 from spack.llnl.util import lang
+
+from .compat import symbol_name, symbol_string
 
 
 class AspVar:
@@ -87,248 +85,6 @@ class _AspFunctionBuilder:
 fn = _AspFunctionBuilder()
 
 
-class ClingoFlavor(enum.Enum):
-    """The clingo Python API variant in use.
-
-    Spack supports three: the legacy pre-CFFI API, the CFFI-based API (clingo ``@5.5:5``), and the
-    clingo 6 rewrite, which restructured everything into submodules ``clingo.*``."""
-
-    LEGACY = enum.auto()
-    CFFI = enum.auto()
-    V6 = enum.auto()
-
-
-#: Process-global clingo module and its API flavor, both set once on first import.
-_CLINGO_MODULE: Optional[ModuleType] = None
-_CLINGO_FLAVOR: Optional[ClingoFlavor] = None
-
-
-def clingo() -> ModuleType:
-    """Lazy imports the Python module for clingo, and returns it."""
-    if _CLINGO_MODULE is not None:
-        return _CLINGO_MODULE
-
-    try:
-        clingo_mod = importlib.import_module("clingo")
-        # Make sure we didn't import an empty module
-        _ensure_clingo_or_raise(clingo_mod)
-    except ImportError:
-        clingo_mod = None
-
-    if clingo_mod is not None:
-        return _set_clingo_module_cache(clingo_mod)
-
-    clingo_mod = _bootstrap_clingo()
-    return _set_clingo_module_cache(clingo_mod)
-
-
-def _set_clingo_module_cache(clingo_mod: ModuleType) -> ModuleType:
-    """Caches the lazily-imported clingo module and detects its API flavor once."""
-    global _CLINGO_MODULE, _CLINGO_FLAVOR
-    importlib.import_module("clingo.ast")
-    _CLINGO_FLAVOR = _detect_clingo_flavor(clingo_mod)
-    _CLINGO_MODULE = clingo_mod
-    return clingo_mod
-
-
-def _detect_clingo_flavor(clingo_mod: ModuleType) -> ClingoFlavor:
-    """Determine which of the three supported clingo Python APIs is in use."""
-    if not hasattr(clingo_mod, "Control"):
-        # clingo 6 dropped the top-level Control/Symbol.
-        return ClingoFlavor.V6
-    if hasattr(getattr(clingo_mod, "Symbol", None), "_rep"):
-        return ClingoFlavor.CFFI
-    return ClingoFlavor.LEGACY
-
-
-def _ensure_clingo_or_raise(clingo_mod: ModuleType) -> None:
-    """Ensures the clingo module can access expected attributes, otherwise raises an error."""
-    # These are imports that may be problematic at top level (circular imports). They are used
-    # only to provide exhaustive details when erroring due to a broken clingo module.
-    import spack.config
-    import spack.paths as sp
-    import spack.util.path as sup
-
-    try:
-        clingo_mod.Symbol
-    except AttributeError:
-        # clingo 6 moved Symbol into the clingo.symbol submodule
-        try:
-            if importlib.import_module("clingo.symbol").Symbol is not None:
-                return
-        except (ImportError, AttributeError):
-            pass
-        assert clingo_mod.__file__ is not None, "clingo installation is incomplete or invalid"
-        # Reaching this point indicates a broken clingo installation
-        # If Spack derived clingo, suggest user re-run bootstrap
-        # if non-spack, suggest user investigate installation
-        # assume Spack is not responsible for broken clingo
-        msg = (
-            f"Clingo installation at {clingo_mod.__file__} is incomplete or invalid."
-            "Please repair installation or re-install. "
-            "Alternatively, consider installing clingo via Spack."
-        )
-        # check whether Spack is responsible
-        if (
-            pathlib.Path(
-                sup.canonicalize_path(
-                    spack.config.CONFIG.get("bootstrap:root", sp.default_user_bootstrap_path)
-                )
-            )
-            in pathlib.Path(clingo_mod.__file__).parents
-        ):
-            # Spack is responsible for the broken clingo
-            msg = (
-                "Spack bootstrapped copy of Clingo is broken, "
-                "please re-run the bootstrapping process via command `spack bootstrap now`."
-                " If this issue persists, please file a bug at: github.com/spack/spack"
-            )
-        raise RuntimeError(
-            "Clingo installation may be broken or incomplete, "
-            "please verify clingo has been installed correctly"
-            "\n\nClingo does not provide symbol clingo.Symbol"
-            f"{msg}"
-        )
-
-
-def clingo_flavor() -> ClingoFlavor:
-    """Return the cached :class:`ClingoFlavor` of the loaded clingo module.
-
-    The flavor is detected exactly once, when clingo is first imported; callers
-    dispatch off the cached value rather than re-probing the module.
-    """
-    if _CLINGO_FLAVOR is None:
-        clingo()  # forces the import and the one-time flavor detection
-    assert _CLINGO_FLAVOR is not None, "clingo flavor was not detected"
-    return _CLINGO_FLAVOR
-
-
-def _bootstrap_clingo() -> ModuleType:
-    """Bootstraps the clingo module and returns it"""
-    import spack.bootstrap
-
-    with spack.bootstrap.ensure_bootstrap_configuration():
-        spack.bootstrap.ensure_clingo_importable_or_raise()
-        clingo_mod = importlib.import_module("clingo")
-
-    return clingo_mod
-
-
-#: Process-global clingo 6 library object (lazily created)
-_CLINGO_LIBRARY: Optional[Any] = None
-
-
-def clingo_library() -> Any:
-    """Return a process-global ``clingo.core.Library`` (clingo 6 only).
-
-    A single shared library lets symbols produced by one control object be
-    reused by another (e.g. when ``raise_if_errors`` feeds a model from the
-    main solve into a second control object).
-    """
-    global _CLINGO_LIBRARY
-    if _CLINGO_LIBRARY is None:
-        clingo()  # ensure the clingo module is importable
-        _CLINGO_LIBRARY = importlib.import_module("clingo.core").Library()
-    return _CLINGO_LIBRARY
-
-
-class _ClingoBackend:
-    """Context manager adapting the clingo 6 backend to the legacy interface."""
-
-    def __init__(self, manager: Any) -> None:
-        self._manager = manager
-        self._backend: Any = None
-
-    def __enter__(self) -> "_ClingoBackend":
-        self._backend = self._manager.__enter__()
-        return self
-
-    def __exit__(self, *exc_info) -> Any:
-        return self._manager.__exit__(*exc_info)
-
-    def add_atom(self, symbol: Any = None) -> int:
-        return self._backend.atom(symbol)
-
-    def add_rule(self, head: Any, body: Any = (), choice: bool = False) -> None:
-        self._backend.rule(head, body, choice)
-
-
-class _ClingoV6Control:
-    """Adapter exposing the legacy clingo ``Control`` interface on top of the restructured clingo 6
-    Python API.
-
-    Only the subset of the API used by Spack's solver is implemented. This keeps ``asp.py``
-    agnostic to which clingo version is in use; it is created through
-    :func:`default_clingo_control` / :func:`make_error_control` rather than directly."""
-
-    def __init__(self, options: Optional[Tuple[str, ...]] = None) -> None:
-        control_mod = importlib.import_module("clingo.control")
-        control_options = [*(options or ())]
-        self._control = control_mod.Control(clingo_library(), control_options)
-
-    def add(self, name: str, parameters: Tuple[str, ...], program: str) -> None:
-        # Spack only ever adds the implicit "base" part without parameters.
-        self._control.parse_string(program)
-
-    def load(self, path: str) -> None:
-        self._control.parse_files([path])
-
-    def ground(self, parts: Any) -> None:
-        # ``parts`` looks like ``[("base", [])]``; clingo 6 expects a sequence
-        # of ``(name, [symbols])`` tuples.
-        self._control.ground([(name, list(args)) for name, args in parts])
-
-    def solve(self, on_model: Any = None, async_: bool = False) -> Any:
-        # The returned async handle supports timed ``wait()`` / ``get()`` /
-        # ``cancel()``, matching what ``_run_clingo`` expects.
-        if async_:
-            return self._control.start_solve(on_model=on_model, async_=True)
-        return self._control.solve(on_model=on_model)
-
-    def backend(self) -> _ClingoBackend:
-        return _ClingoBackend(self._control.backend)
-
-    @property
-    def statistics(self) -> Any:
-        # clingo 6 exposes a lazy StatsView; nestify() turns it into a plain
-        # nested dict, matching what older clingo versions returned.
-        return self._control.stats.nestify()
-
-
-def _make_control(options: Tuple[str, ...] = ()) -> Any:
-    """Create a clingo control object for the loaded clingo flavor.
-
-    For clingo 6 the result is a :class:`_ClingoV6Control` adapter; for the
-    legacy/CFFI APIs it is a raw ``clingo.Control``. Both expose the subset of
-    the control interface Spack's solver relies on. ``options`` (command-line
-    options) only apply to clingo 6 -- legacy/CFFI configure the solver through
-    the ``.configuration`` attribute instead.
-    """
-    if clingo_flavor() is ClingoFlavor.V6:
-        return _ClingoV6Control(options)
-    return clingo().Control()
-
-
-def default_clingo_control() -> Any:
-    """Return a control object configured with Spack's default solver settings."""
-    if clingo_flavor() is ClingoFlavor.V6:
-        # clingo 6 has no `configuration` API; the equivalent settings are
-        # passed as command line options instead.
-        return _make_control(
-            ("--configuration=tweety", "--heuristic=Domain", "--opt-strategy=usc")
-        )
-    control = _make_control()
-    control.configuration.configuration = "tweety"
-    control.configuration.solver.heuristic = "Domain"
-    control.configuration.solver.opt_strategy = "usc"
-    return control
-
-
-def make_error_control() -> Any:
-    """Return a plain control object, used to derive error causation on unsat."""
-    return _make_control()
-
-
 class NodeId(NamedTuple):
     """Represents a node in the DAG"""
 
@@ -352,38 +108,22 @@ def intermediate_repr(sym):
         This will turn a ``clingo.Symbol`` into a string or NodeId, or a sequence of
         ``clingo.Symbol`` objects into a tuple of those objects.
     """
-    # TODO: simplify this when we no longer have to support older clingo versions.
     if isinstance(sym, (list, tuple)):
         return tuple(intermediate_repr(a) for a in sym)
 
-    try:
-        if sym.name == "node":
-            return NodeId(
-                id=intermediate_repr(sym.arguments[0]), pkg=intermediate_repr(sym.arguments[1])
-            )
-        elif sym.name == "node_flag":
-            return NodeFlag(
-                flag_type=intermediate_repr(sym.arguments[0]),
-                flag=intermediate_repr(sym.arguments[1]),
-                flag_group=intermediate_repr(sym.arguments[2]),
-                source=intermediate_repr(sym.arguments[3]),
-            )
-    except (RuntimeError, ValueError):
-        # Accessing ".name" on a non-function symbol raises: RuntimeError with
-        # clingo+CFFI, ValueError with clingo 6.
-        pass
-
-    if clingo_flavor() is ClingoFlavor.CFFI:
-        # Clingo w/ CFFI throws RuntimeError on ".string" for a non-string symbol.
-        try:
-            return sym.string
-        except RuntimeError:
-            return str(sym)
-    # Legacy clingo returns "" for non-string symbols; clingo 6 raises ValueError.
-    try:
-        return sym.string or str(sym)
-    except (RuntimeError, ValueError):
-        return str(sym)
+    name = symbol_name(sym)
+    if name == "node":
+        return NodeId(
+            id=intermediate_repr(sym.arguments[0]), pkg=intermediate_repr(sym.arguments[1])
+        )
+    if name == "node_flag":
+        return NodeFlag(
+            flag_type=intermediate_repr(sym.arguments[0]),
+            flag=intermediate_repr(sym.arguments[1]),
+            flag_group=intermediate_repr(sym.arguments[2]),
+            source=intermediate_repr(sym.arguments[3]),
+        )
+    return symbol_string(sym)
 
 
 def extract_args(model, predicate_name):
@@ -392,15 +132,9 @@ def extract_args(model, predicate_name):
     Pull out all the predicates with name ``predicate_name`` from the model, and
     return their intermediate representation.
     """
-
-    def _matches(sym):
-        try:
-            return sym.name == predicate_name
-        except (RuntimeError, ValueError):
-            # ".name" raises for non-function symbols (CFFI / clingo 6)
-            return False
-
-    return [intermediate_repr(sym.arguments) for sym in model if _matches(sym)]
+    return [
+        intermediate_repr(sym.arguments) for sym in model if symbol_name(sym) == predicate_name
+    ]
 
 
 class SourceContext:

--- a/lib/spack/spack/solver/core.py
+++ b/lib/spack/spack/solver/core.py
@@ -263,10 +263,7 @@ class _ClingoV6Control:
 
     def __init__(self, options: Optional[Tuple[str, ...]] = None) -> None:
         control_mod = importlib.import_module("clingo.control")
-        # clingo 6's grounder no longer implicitly projects anonymous variables
-        # that occur only in negative body literals (older gringo did). Spack's
-        # logic program relies on that behavior, so request it explicitly.
-        control_options = ["--project-anonymous", *(options or ())]
+        control_options = [*(options or ())]
         self._control = control_mod.Control(clingo_library(), control_options)
 
     def add(self, name: str, parameters: Tuple[str, ...], program: str) -> None:

--- a/lib/spack/spack/solver/error_messages.lp
+++ b/lib/spack/spack/solver/error_messages.lp
@@ -126,7 +126,7 @@ error(0, "Cannot satisfy '{0}@{1}' and '{0}@{2}'", Package, Constraint1, Constra
 % causation tracking error for no or multiple virtual providers
 error(0, "Cannot find a valid provider for virtual {0}", Virtual, startcauses, Cause, CID)
   :- attr("virtual_node", node(X, Virtual)),
-     not provider(_, node(X, Virtual)),
+     not has_provider(node(X, Virtual)),
      imposed_constraint(EID, "dependency_holds", Parent, Virtual, Type),
      pkg_fact(TriggerPkg, condition_effect(Cause, EID)),
      condition_holds(Cause, node(CID, TriggerPkg)).

--- a/lib/spack/spack/solver/libc_compatibility.lp
+++ b/lib/spack/spack/solver/libc_compatibility.lp
@@ -22,11 +22,12 @@ error(100, "Cannot reuse {0} since we cannot determine libc compatibility", Reus
      not attr("compatible_libc", node(R, ReusedPackage), LibcPackage, LibcVersion).
 
 % In case we don't need a provider for libc, ensure there's at least one compatible libc on the host
+has_compatible_libc(PackageNode) :- attr("compatible_libc", PackageNode, _, _).
 error(100, "Cannot reuse {0} since we cannot determine libc compatibility", ReusedPackage)
-  :- not provider(_, node(0, "libc")),
+  :- not has_provider(node(0, "libc")),
      concrete(node(R, ReusedPackage)),
      attr("needs_libc", node(R, ReusedPackage)),
-     not attr("compatible_libc", node(R, ReusedPackage), _, _).
+     not has_compatible_libc(node(R, ReusedPackage)).
 
 % The libc provider must be one that a compiler can target
 :- will_build_packages(),

--- a/lib/spack/spack/solver/splices.lp
+++ b/lib/spack/spack/solver/splices.lp
@@ -53,12 +53,3 @@ imposed_constraint(Hash, "virtual_on_edge", ParentName, SpliceName, VirtName) :-
   hash_attr(Hash, "virtual_on_edge", ParentName, DepName, VirtName),
   attr("splice_at_hash", node(ID, ParentName), node(SID, SpliceName), DepName, DepHash).
 
-% When a splice is taken, the parent depends on the splice node directly.
-attr("depends_on", ParentNode, node(SID, SpliceName), Type) :-
-  attr("hash", ParentNode, ParentHash),
-  hash_attr(ParentHash, "depends_on", ParentName, DepName, Type),
-  hash_attr(ParentHash, "hash", DepName, DepHash),
-  abi_splice_conditions_hold(_, node(SID, SpliceName), DepName, DepHash),
-  ParentHash != DepHash,
-  not imposed_constraint(ParentHash, "hash", DepName, DepHash).
-

--- a/lib/spack/spack/solver/splices.lp
+++ b/lib/spack/spack/solver/splices.lp
@@ -53,3 +53,12 @@ imposed_constraint(Hash, "virtual_on_edge", ParentName, SpliceName, VirtName) :-
   hash_attr(Hash, "virtual_on_edge", ParentName, DepName, VirtName),
   attr("splice_at_hash", node(ID, ParentName), node(SID, SpliceName), DepName, DepHash).
 
+% When a splice is taken, the parent depends on the splice node directly.
+attr("depends_on", ParentNode, node(SID, SpliceName), Type) :-
+  attr("hash", ParentNode, ParentHash),
+  hash_attr(ParentHash, "depends_on", ParentName, DepName, Type),
+  hash_attr(ParentHash, "hash", DepName, DepHash),
+  abi_splice_conditions_hold(_, node(SID, SpliceName), DepName, DepHash),
+  ParentHash != DepHash,
+  not imposed_constraint(ParentHash, "hash", DepName, DepHash).
+


### PR DESCRIPTION
Clingo v6 is a full rewrite with two changes that affect us:

* New Python API
* Deprecation of anonymous variables inside negative literals (like `not p(X, _)`)

With https://github.com/potassco/clingo/commit/a2b3e450d23d565d2e0e38f1f9d22d813b4f6059 now upstream the tests are passing; at the start of this PR splicing and propagation tests were failing.
