### PR TITLE
[WIP] Allow setting an entire config section 

### DIFF
--- a/lib/spack/spack/config.py
+++ b/lib/spack/spack/config.py
@@ -918,6 +918,11 @@ class Configuration:
         parts = process_config_path(path)
         section = parts.pop(0)
 
+        # Handle setting an entire section's value (e.g., "upstreams:{}" or "upstreams::{}").
+        if len(parts) == 0:
+            self.update_config(section, value, scope=scope)
+            return
+
         section_data = self.get_config(section, scope=scope)
 
         data = section_data

--- a/lib/spack/spack/test/config.py
+++ b/lib/spack/spack/test/config.py
@@ -2173,3 +2173,22 @@ def test_config_add_override_whole_section_existing(mock_low_high_config, write_
     (section_key,) = data.keys()
     assert section_key.override
     assert not data["upstreams"]
+
+
+def test_config_set_override_whole_section_existing(mock_low_high_config, write_config_file):
+    """Check if whole-section `spack config add` can convert
+    non-override to override (similar to previous test, except the
+    high config starts with an empty upstreams section that does not
+    use double-colon)"""
+    upstream_data_low = {
+        "upstreams": {"spack-instance-1": {"install_tree": "/path/to/upstream/install"}}
+    }
+    write_config_file("upstreams", upstream_data_low, "low")
+
+    upstream_data_high = {"upstreams": {}}
+    write_config_file("upstreams", upstream_data_high, "high")
+
+    spack.config.add("upstreams::{}", scope="high")
+
+    result = spack.config.get("upstreams")
+    assert result == {}

--- a/lib/spack/spack/test/config.py
+++ b/lib/spack/spack/test/config.py
@@ -2132,3 +2132,44 @@ def test_config_invalid_scope(mock_low_high_config):
     err = "Must be one of \\['low', 'high'\\]"  # noqa: W605
     with pytest.raises(ValueError, match=err):
         spack.config.CONFIG.get_config_filename("noscope", "nosection")
+
+
+def test_config_add_set_whole_section_empty(mock_low_high_config):
+    """Test adding an override to set an entire config section."""
+    spack.config.add("upstreams::{}", scope="low")
+
+    result = spack.config.get("upstreams", scope="low")
+    assert result == {}
+
+    # Verify it's written with override syntax in the file
+    config_file = spack.config.CONFIG.get_config_filename("low", "upstreams")
+    with open(config_file) as f:
+        data = syaml.load_config(f)
+    (section_key,) = data.keys()
+    assert section_key.override
+    assert not data["upstreams"]
+
+
+def test_config_add_override_whole_section_existing(mock_low_high_config, write_config_file):
+    """Test using override to replace pre-existing config section."""
+    upstream_data = {
+        "upstreams": {"spack-instance-1": {"install_tree": "/path/to/upstream/install"}}
+    }
+    write_config_file("upstreams", upstream_data, "low")
+
+    result = spack.config.get("upstreams", scope="low")
+    assert "spack-instance-1" in result
+
+    # Add an override in the high scope to disable upstreams
+    spack.config.add("upstreams::{}", scope="high")
+
+    # Verify the override took effect (high scope wins)
+    result = spack.config.get("upstreams")
+    assert result == {}
+
+    config_file = spack.config.CONFIG.get_config_filename("high", "upstreams")
+    with open(config_file) as f:
+        data = syaml.load_config(f)
+    (section_key,) = data.keys()
+    assert section_key.override
+    assert not data["upstreams"]

--- a/lib/spack/spack/test/config.py
+++ b/lib/spack/spack/test/config.py
@@ -2143,7 +2143,7 @@ def test_config_add_set_whole_section_empty(mock_low_high_config):
 
     # Verify it's written with override syntax in the file
     config_file = spack.config.CONFIG.get_config_filename("low", "upstreams")
-    with open(config_file) as f:
+    with open(config_file, encoding="utf-8") as f:
         data = syaml.load_config(f)
     (section_key,) = data.keys()
     assert section_key.override
@@ -2168,7 +2168,7 @@ def test_config_add_override_whole_section_existing(mock_low_high_config, write_
     assert result == {}
 
     config_file = spack.config.CONFIG.get_config_filename("high", "upstreams")
-    with open(config_file) as f:
+    with open(config_file, encoding="utf-8") as f:
         data = syaml.load_config(f)
     (section_key,) = data.keys()
     assert section_key.override


### PR DESCRIPTION
This generally is only useful if you are overriding an entire config section with an empty config (because parsing of yaml dicts in path has issues)

Example usage:

`spack config add "upstreams::{}"`

(e.g. you could do this when an env is active to make the environment ignore upstreams in lower layers)