### PR TITLE
winlog: use os.pipe

### DIFF
--- a/lib/spack/spack/llnl/util/tty/log.py
+++ b/lib/spack/spack/llnl/util/tty/log.py
@@ -733,7 +733,10 @@ class winlog:
 
         try:
             with open(logfile, mode=write_mode, encoding="utf-8") as log_writer:
-                for line in read_file:
+                while True:
+                    line = read_file.readline(4096)
+                    if not line:
+                        break
                     process_message(line)
 
         except Exception as e:

--- a/lib/spack/spack/llnl/util/tty/log.py
+++ b/lib/spack/spack/llnl/util/tty/log.py
@@ -704,7 +704,7 @@ class winlog:
 
     @staticmethod
     def _background_reader(
-        read: int,
+        read_fd: int,
         logfile: str,
         stdout: io.TextIOWrapper,
         append: bool,
@@ -712,16 +712,13 @@ class winlog:
         filter_fn: Optional[Callable],
     ):
         force_echo = False
-        write_mode = "ab" if append else "wb"
-        log_writer = open(logfile, mode=write_mode)
-
-        buffer = ""
-        decoder = codecs.getincrementaldecoder("utf-8")(errors="replace")
+        write_mode = "a" if append else "w"
+        read_file = os.fdopen(read_fd, "r", encoding="utf-8", errors="replace", buffering=1)
 
         def process_message(message):
             nonlocal force_echo
             clean_line, num_controls = control.subn("", message)
-            log_writer.write(_strip(clean_line).encode(encoding="utf-8"))
+            log_writer.write(_strip(clean_line))
             log_writer.flush()
             if echo or force_echo:
                 output = clean_line
@@ -737,28 +734,15 @@ class winlog:
                 force_echo = force_echo_on(force_echo, controls)
 
         try:
-            while True:
-                data = os.read(read, 4096)
-                if not data:
-                    buffer += decoder.decode(b"", final=True)
-                    # the pipe is closed or otherwise inaccesible
-                    break
-                buffer += decoder.decode(data)
-                while True:
-                    idx = buffer.find("\n")
-                    if idx == -1:
-                        break
-                    message = buffer[: idx + 1]
-                    buffer = buffer[idx + 1 :]
-                    process_message(message)
-            if buffer:
-                process_message(buffer)
+            with open(logfile, mode=write_mode, encoding="utf-8") as log_writer:
+                for line in read_file:
+                    process_message(line)
+            
         except Exception as e:
             tty.error(f"Exception in log writer thread! {e}", stream=stdout)
             traceback.print_exc(file=stdout)
         finally:
-            os.close(read)
-            log_writer.close()
+            read_file.close()
             stdout.close()
 
 

--- a/lib/spack/spack/llnl/util/tty/log.py
+++ b/lib/spack/spack/llnl/util/tty/log.py
@@ -5,7 +5,6 @@
 """Utility classes for logging the output of blocks of code."""
 
 import atexit
-import codecs
 import ctypes
 import errno
 import io
@@ -737,7 +736,7 @@ class winlog:
             with open(logfile, mode=write_mode, encoding="utf-8") as log_writer:
                 for line in read_file:
                     process_message(line)
-            
+
         except Exception as e:
             tty.error(f"Exception in log writer thread! {e}", stream=stdout)
             traceback.print_exc(file=stdout)

--- a/lib/spack/spack/llnl/util/tty/log.py
+++ b/lib/spack/spack/llnl/util/tty/log.py
@@ -745,11 +745,11 @@ class winlog:
                     break
                 buffer += decoder.decode(data)
                 while True:
-                    idx = buffer.find('\n')
+                    idx = buffer.find("\n")
                     if idx == -1:
                         break
-                    message = buffer[:idx + 1]
-                    buffer = buffer[idx + 1:]
+                    message = buffer[: idx + 1]
+                    buffer = buffer[idx + 1 :]
                     process_message(message)
             if buffer:
                 process_message(buffer)

--- a/lib/spack/spack/llnl/util/tty/log.py
+++ b/lib/spack/spack/llnl/util/tty/log.py
@@ -585,7 +585,6 @@ class StreamWrapper:
         redirect_h = msvcrt.get_osfhandle(redirect_fd)
         # duplicate handle for local copy we own
         dup_redirect_h = dup_fh(redirect_h)
-        os.set_handle_inheritable(redirect_h, True)
         self.redirect_fd = msvcrt.open_osfhandle(dup_redirect_h, os.O_WRONLY)
         kernel32.SetStdHandle(self.STD_HANDLE, wintypes.HANDLE(dup_redirect_h))
         os.dup2(self.redirect_fd, self.std_fd)

--- a/lib/spack/spack/llnl/util/tty/log.py
+++ b/lib/spack/spack/llnl/util/tty/log.py
@@ -5,6 +5,7 @@
 """Utility classes for logging the output of blocks of code."""
 
 import atexit
+import codecs
 import ctypes
 import errno
 import io
@@ -662,7 +663,7 @@ class winlog:
             raise RuntimeError("Can't re-enter the same log_output!")
 
         read_fd, write_fd = os.pipe()
-        self.read_p = os.fdopen(read_fd, "rb", buffering=0)
+        self.read_p = read_fd
         self.write_p = os.fdopen(write_fd, "wb", buffering=0)
 
         # Dup stdout so we can still write to it after redirection
@@ -703,7 +704,7 @@ class winlog:
 
     @staticmethod
     def _background_reader(
-        read: io.FileIO,
+        read: int,
         logfile: str,
         stdout: io.TextIOWrapper,
         append: bool,
@@ -711,45 +712,52 @@ class winlog:
         filter_fn: Optional[Callable],
     ):
         force_echo = False
-
         write_mode = "ab" if append else "wb"
         log_writer = open(logfile, mode=write_mode)
+
+        buffer = ""
+        decoder = codecs.getincrementaldecoder("utf-8")(errors="replace")
+
+        def process_message(message):
+            nonlocal force_echo
+            clean_line, num_controls = control.subn("", message)
+            log_writer.write(_strip(clean_line).encode(encoding="utf-8"))
+            log_writer.flush()
+            if echo or force_echo:
+                output = clean_line
+                if filter_fn:
+                    output = filter_fn(output)
+                enc = stdout.encoding
+                if enc != "utf-8":
+                    output = output.encode(enc, "replace").decode(enc)
+                stdout.write(output)
+                stdout.flush()
+            if num_controls > 0:
+                controls = control.findall(message)
+                force_echo = force_echo_on(force_echo, controls)
+
         try:
             while True:
-                data = read.read(4096)
+                data = os.read(read, 4096)
                 if not data:
+                    buffer += decoder.decode(b"", final=True)
                     # the pipe is closed or otherwise inaccesible
-                    return
-                norm_data = data.decode(encoding="utf-8", errors="replace")
-                clean_line, num_controls = control.subn("", norm_data)
-
-                log_writer.write(_strip(clean_line).encode(encoding="utf-8"))
-                log_writer.flush()
-                if echo or force_echo:
-                    output = clean_line
-                    if filter_fn:
-                        output = filter_fn(output)
-                    enc = stdout.encoding
-                    if enc != "utf-8":
-                        output = output.encode(enc, "replace").decode(enc)
-                    stdout.write(output)
-                    stdout.flush()
-                if num_controls > 0:
-                    controls = control.findall(norm_data)
-                    force_echo = force_echo_on(force_echo, controls)
-                if read.closed:
                     break
-
-        # swallow valid errors
-        except EOFError:
-            pass
-        except OSError:
-            pass
-        except BaseException as e:
+                buffer += decoder.decode(data)
+                while True:
+                    idx = buffer.find('\n')
+                    if idx == -1:
+                        break
+                    message = buffer[:idx + 1]
+                    buffer = buffer[idx + 1:]
+                    process_message(message)
+            if buffer:
+                process_message(buffer)
+        except Exception as e:
             tty.error(f"Exception in log writer thread! {e}", stream=stdout)
             traceback.print_exc(file=stdout)
         finally:
-            read.close()
+            os.close(read)
             log_writer.close()
             stdout.close()
 

--- a/lib/spack/spack/llnl/util/tty/log.py
+++ b/lib/spack/spack/llnl/util/tty/log.py
@@ -575,15 +575,19 @@ class StreamWrapper:
         self.saved_stream_fd = os.dup(self.std_fd)
         self.redirect_fd = None
 
-    def redirect_stream(self, write_conn):
+    def redirect_stream(self, writer):
         """Redirect stdout to the given file descriptor."""
         self.flush()
         # Get fd for new stream
-        redirect_h = write_conn.fileno()
+        # new stream is file object
+        redirect_fd = writer.fileno()
+        # get windows file handle
+        redirect_h = msvcrt.get_osfhandle(redirect_fd)
+        # duplicate handle for local copy we own
         dup_redirect_h = dup_fh(redirect_h)
         os.set_handle_inheritable(redirect_h, True)
         self.redirect_fd = msvcrt.open_osfhandle(dup_redirect_h, os.O_WRONLY)
-        kernel32.SetStdHandle(self.STD_HANDLE, wintypes.HANDLE(redirect_h))
+        kernel32.SetStdHandle(self.STD_HANDLE, wintypes.HANDLE(dup_redirect_h))
         os.dup2(self.redirect_fd, self.std_fd)
         setattr(
             sys,
@@ -657,7 +661,9 @@ class winlog:
         if self._active:
             raise RuntimeError("Can't re-enter the same log_output!")
 
-        self.read_p, self.write_p = multiprocessing.Pipe(duplex=False)
+        read_fd, write_fd = os.pipe()
+        self.read_p = os.fdopen(read_fd, "rb", buffering=0)
+        self.write_p = os.fdopen(write_fd, "wb", buffering=0)
 
         # Dup stdout so we can still write to it after redirection
         original_stdout_fd = sys.stdout.fileno()
@@ -697,7 +703,7 @@ class winlog:
 
     @staticmethod
     def _background_reader(
-        read,
+        read: io.FileIO,
         logfile: str,
         stdout: io.TextIOWrapper,
         append: bool,
@@ -710,7 +716,7 @@ class winlog:
         log_writer = open(logfile, mode=write_mode)
         try:
             while True:
-                data = read.recv_bytes(maxlength=4096)
+                data = read.read(4096)
                 if not data:
                     # the pipe is closed or otherwise inaccesible
                     return

--- a/lib/spack/spack/test/llnl/util/tty/log.py
+++ b/lib/spack/spack/test/llnl/util/tty/log.py
@@ -168,7 +168,7 @@ def test_log_subproc_and_echo_output(capfd, tmp_path: pathlib.Path):
         # subject to change with future versions of pytest.
         # if this test suddenly starts failing, verifying the line
         # endings from capfd is a good starting place.
-        assert capfd.readouterr()[0] == f"echo\n"
+        assert capfd.readouterr()[0] == "echo\n"
 
 
 def test_nested_logging_contexts(capfd, tmp_path):

--- a/lib/spack/spack/test/llnl/util/tty/log.py
+++ b/lib/spack/spack/test/llnl/util/tty/log.py
@@ -190,15 +190,35 @@ def test_nested_logging_contexts(capfd, tmp_path):
 
 
 def test_logging_multibyte(capfd, tmp_path):
-    # one byte char (normal characters)
-    # two byte char (©)
-    # three byte char (€)
-    # four byte char (🐸)
-    test_string = "Build complete: 100% 🐸! €©"
+    # 🐸 is 4 bytes long.
+    # We want to force reads to slice it
+    
+    # Slice after 1 byte. 
+    pad_1 = "A" * 4095
+    str_1 = f"{pad_1}🐸!\n"
+
+    # Slice after 2 bytes.
+    pad_2 = "B" * 4094
+    str_2 = f"{pad_2}🐸!\n"
+
+    # Case 3: Slice after 3 bytes.
+    pad_3 = "C" * 4093
+    str_3 = f"{pad_3}🐸!\n"
+    
     with working_dir(str(tmp_path)):
         with log.log_output("foo.txt") as logger:
             with logger.force_echo():
-                print(test_string)
+                sys.stdout.write(str_1)
+                sys.stdout.flush()
+                
+                sys.stdout.write(str_2)
+                sys.stdout.flush()
+                
+                sys.stdout.write(str_3)
+                sys.stdout.flush()
+
         with open("foo.txt", "r", encoding="utf-8") as f:
-            assert f.read() == test_string + "\n"
-        assert capfd.readouterr()[0] == test_string + "\n"
+            file_content = f.read()
+            assert file_content == str_1 + str_2 + str_3
+            
+        assert capfd.readouterr()[0] == str_1 + str_2 + str_3

--- a/lib/spack/spack/test/llnl/util/tty/log.py
+++ b/lib/spack/spack/test/llnl/util/tty/log.py
@@ -168,8 +168,7 @@ def test_log_subproc_and_echo_output(capfd, tmp_path: pathlib.Path):
         # subject to change with future versions of pytest.
         # if this test suddenly starts failing, verifying the line
         # endings from capfd is a good starting place.
-        newline = "\r\n" if sys.platform == "win32" else "\n"
-        assert capfd.readouterr()[0] == f"echo{newline}"
+        assert capfd.readouterr()[0] == f"echo\n"
 
 
 def test_nested_logging_contexts(capfd, tmp_path):
@@ -187,38 +186,3 @@ def test_nested_logging_contexts(capfd, tmp_path):
             log_captured_out = f.read()
             assert "inner\n" in log_captured_out
             assert "outer\n" not in log_captured_out
-
-
-def test_logging_multibyte(capfd, tmp_path):
-    # 🐸 is 4 bytes long.
-    # We want to force reads to slice it
-
-    # Slice after 1 byte.
-    pad_1 = "A" * 4095
-    str_1 = f"{pad_1}🐸!\n"
-
-    # Slice after 2 bytes.
-    pad_2 = "B" * 4094
-    str_2 = f"{pad_2}🐸!\n"
-
-    # Case 3: Slice after 3 bytes.
-    pad_3 = "C" * 4093
-    str_3 = f"{pad_3}🐸!\n"
-
-    with working_dir(str(tmp_path)):
-        with log.log_output("foo.txt") as logger:
-            with logger.force_echo():
-                sys.stdout.write(str_1)
-                sys.stdout.flush()
-
-                sys.stdout.write(str_2)
-                sys.stdout.flush()
-
-                sys.stdout.write(str_3)
-                sys.stdout.flush()
-
-        with open("foo.txt", "r", encoding="utf-8") as f:
-            file_content = f.read()
-            assert file_content == str_1 + str_2 + str_3
-
-        assert capfd.readouterr()[0] == str_1 + str_2 + str_3

--- a/lib/spack/spack/test/llnl/util/tty/log.py
+++ b/lib/spack/spack/test/llnl/util/tty/log.py
@@ -192,8 +192,8 @@ def test_nested_logging_contexts(capfd, tmp_path):
 def test_logging_multibyte(capfd, tmp_path):
     # 🐸 is 4 bytes long.
     # We want to force reads to slice it
-    
-    # Slice after 1 byte. 
+
+    # Slice after 1 byte.
     pad_1 = "A" * 4095
     str_1 = f"{pad_1}🐸!\n"
 
@@ -204,21 +204,21 @@ def test_logging_multibyte(capfd, tmp_path):
     # Case 3: Slice after 3 bytes.
     pad_3 = "C" * 4093
     str_3 = f"{pad_3}🐸!\n"
-    
+
     with working_dir(str(tmp_path)):
         with log.log_output("foo.txt") as logger:
             with logger.force_echo():
                 sys.stdout.write(str_1)
                 sys.stdout.flush()
-                
+
                 sys.stdout.write(str_2)
                 sys.stdout.flush()
-                
+
                 sys.stdout.write(str_3)
                 sys.stdout.flush()
 
         with open("foo.txt", "r", encoding="utf-8") as f:
             file_content = f.read()
             assert file_content == str_1 + str_2 + str_3
-            
+
         assert capfd.readouterr()[0] == str_1 + str_2 + str_3

--- a/lib/spack/spack/test/llnl/util/tty/log.py
+++ b/lib/spack/spack/test/llnl/util/tty/log.py
@@ -192,7 +192,7 @@ def test_nested_logging_contexts(capfd, tmp_path):
 def test_logging_multibyte(capfd, tmp_path):
     # one byte char (normal characters)
     # two byte char (©)
-    # three byte char (€) 
+    # three byte char (€)
     # four byte char (🐸)
     test_string = "Build complete: 100% 🐸! €©"
     with working_dir(str(tmp_path)):
@@ -200,5 +200,5 @@ def test_logging_multibyte(capfd, tmp_path):
             with logger.force_echo():
                 print(test_string)
         with open("foo.txt", "r", encoding="utf-8") as f:
-            assert f.read() == test_string +"\n"
+            assert f.read() == test_string + "\n"
         assert capfd.readouterr()[0] == test_string + "\n"

--- a/lib/spack/spack/test/llnl/util/tty/log.py
+++ b/lib/spack/spack/test/llnl/util/tty/log.py
@@ -187,3 +187,18 @@ def test_nested_logging_contexts(capfd, tmp_path):
             log_captured_out = f.read()
             assert "inner\n" in log_captured_out
             assert "outer\n" not in log_captured_out
+
+
+def test_logging_multibyte(capfd, tmp_path):
+    # one byte char (normal characters)
+    # two byte char (©)
+    # three byte char (€) 
+    # four byte char (🐸)
+    test_string = "Build complete: 100% 🐸! €©"
+    with working_dir(str(tmp_path)):
+        with log.log_output("foo.txt") as logger:
+            with logger.force_echo():
+                print(test_string)
+        with open("foo.txt", "r", encoding="utf-8") as f:
+            assert f.read() == test_string +"\n"
+        assert capfd.readouterr()[0] == test_string + "\n"


### PR DESCRIPTION
The new installer already does this "correctly" for windows, so this is a quick stopgap until we drop support for the old installer/logger

Previously we used multiprocessing.pipe, which creates connection objects, which are named pipes. When we recv bytes > 4096 in our tee thread, we hit an error, and end our reading, resulting in a full buffer on the writer (build) side, deadlock, and crash. To maintain robust io streaming we now use os.pipe wrapper in a textiowrapper. This allows us the same easy reads as before, but without the internal connection buffers introducing deadlocking behavior. 

The change from connection objects (which have windows file handles but no fds) to using fds, is the fds both have fds and file handles associated with them. This slightly changes our redirect streams flow, as we no longer need to create the fd associated with the handle, we can just fetch the handle for duplication. 
I was also previously pointlessly setting a handle to be inheritable that was already inheritable, remove the pointless op. 

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
