### PR TITLE
Use temporary_store to prevent permission errors with xdist parallel

### DIFF
--- a/lib/spack/spack/test/builder.py
+++ b/lib/spack/spack/test/builder.py
@@ -76,7 +76,9 @@ def builder_test_repository(config):
 )
 @pytest.mark.usefixtures("builder_test_repository", "config")
 @pytest.mark.disable_clean_stage_check
-def test_callbacks_and_installation_procedure(spec_str, expected_values, working_env):
+def test_callbacks_and_installation_procedure(
+    spec_str, expected_values, working_env, temporary_store
+):
     """Test the correct execution of callbacks and installation procedures for packages."""
     s = spack.concretize.concretize_one(spec_str)
     builder = spack.builder.create(s.package)
@@ -111,7 +113,7 @@ def test_old_style_compatibility_with_super(spec_str, method_name, expected):
 @pytest.mark.regression("33928")
 @pytest.mark.usefixtures("builder_test_repository", "config", "working_env")
 @pytest.mark.disable_clean_stage_check
-def test_build_time_tests_are_executed_from_default_builder():
+def test_build_time_tests_are_executed_from_default_builder(temporary_store):
     s = spack.concretize.concretize_one("old-style-autotools")
     builder = spack.builder.create(s.package)
     builder.pkg.run_tests = True
@@ -152,7 +154,9 @@ def test_monkey_patching_test_log_file():
 # Windows context manager's __exit__ fails with ValueError ("I/O operation
 # on closed file").
 @pytest.mark.not_on_windows("Does not run on windows")
-def test_install_time_test_callback(tmp_path: pathlib.Path, config, mock_packages, mock_stage):
+def test_install_time_test_callback(
+    tmp_path: pathlib.Path, config, mock_packages, mock_stage, temporary_store
+):
     """Confirm able to run stand-alone test as a post-install callback."""
     s = spack.concretize.concretize_one("py-test-callback")
     builder = spack.builder.create(s.package)


### PR DESCRIPTION
This PR attempts to fix an intermittent failure in CI recently observed in #51760. (Believed to be present in develop.)

The builder tests execute install phases without explicitly activating a writable test store. Thus via pkg.prefix they resolve to the process-global `spack.store.STORE` and under GitHub Actions with xdist, a worker could reach these tests after another test activated a session-scoped read-only `mock_store` which then could cause mkdir to fail with a PermissionError. 

I believe explicitly requesting the temporary_store fixture in the builder tests gives each a fresh writable store which matches what we do for other install tests via `install_mockery`.

https://github.com/spack/spack/actions/runs/26127986129/job/76862235282?pr=51760
