### PR TITLE
doc style: use ruff for consistent formatting 

### DIFF
--- a/.github/workflows/bin/format-rst.py
+++ b/.github/workflows/bin/format-rst.py
@@ -16,7 +16,6 @@ import subprocess
 import sys
 from typing import List
 
-import black
 from docutils import nodes
 from docutils.core import publish_doctree
 from docutils.parsers.rst import Directive, directives
@@ -135,15 +134,10 @@ def _ruff_format(code: str) -> str:
     ruff has no python interface so we use subprocess
     and feed the code through stdin and read from stdout
     """
-    cmd = ["ruff", "format", "--line-length", "99", "-", ]
+    cmd = ["ruff", "format", "--line-length", "99", "-"]
     try:
         result = subprocess.run(
-            cmd,
-            input=code,
-            capture_output=True,
-            text=True,
-            encoding="utf-8",
-            check=True
+            cmd, input=code, capture_output=True, text=True, encoding="utf-8", check=True
         )
     except FileNotFoundError:
         raise RuntimeError("Ruff formatting failed: The 'ruff' executable was not found.")

--- a/.github/workflows/bin/format-rst.py
+++ b/.github/workflows/bin/format-rst.py
@@ -135,7 +135,7 @@ def _ruff_format(code: str) -> str:
     ruff has no python interface so we use subprocess
     and feed the code through stdin and read from stdout
     """
-    cmd = ["ruff", "format", "--line-lenght", "99", "-", ]
+    cmd = ["ruff", "format", "--line-length", "99", "-", ]
     try:
         result = subprocess.run(
             cmd,

--- a/.github/workflows/bin/format-rst.py
+++ b/.github/workflows/bin/format-rst.py
@@ -129,6 +129,29 @@ class ParagraphInfo:
         self.end_lineno = line + len(self.lines) - 1
 
 
+def _ruff_format(code: str) -> str:
+    """Formats code block using ruff
+
+    ruff has no python interface so we use subprocess
+    and feed the code through stdin and read from stdout
+    """
+    cmd = ["ruff", "format", "--line-lenght", "99", "-", ]
+    try:
+        result = subprocess.run(
+            cmd,
+            input=code,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            check=True
+        )
+    except FileNotFoundError:
+        raise RuntimeError("Ruff formatting failed: The 'ruff' executable was not found.")
+    except subprocess.CalledProcessError as e:
+        raise RuntimeError(f"ruff formatting failed: {e}") from e
+    return result.stdout
+
+
 def _is_node_in_table(node: nodes.Node) -> bool:
     """Check if a node is inside a table by walking up the parent chain."""
     while node.parent:
@@ -160,7 +183,7 @@ def _format_code_blocks(document: nodes.document, path: str) -> List[Warning]:
 
         try:
             if language == "python":
-                formatted = black.format_str(original, mode=black.FileMode(line_length=99))
+                formatted = _ruff_format(original)
             elif language == "yaml":
                 yaml = YAML(pure=True)
                 yaml.width = 10000  # do not wrap lines

--- a/.github/workflows/requirements/style/requirements.txt
+++ b/.github/workflows/requirements/style/requirements.txt
@@ -1,4 +1,3 @@
-black==25.12.0
 clingo==5.8.0
 flake8==7.3.0
 isort==7.0.0


### PR DESCRIPTION
We use ruff for spack style, use it for codeblock in the docs as well.

ruff has no python api, instead this PR calls it via subprocess and pipes the code to stdin
No post processing is necessary as ruff echos back the properly formatted code to std with no additional output. This differs from file mode behavior.

Remove last black reference. 