### PR TITLE
Fix multi-process race condition failure with gpg tests

### DIFF
--- a/lib/spack/spack/test/conftest.py
+++ b/lib/spack/spack/test/conftest.py
@@ -1412,13 +1412,16 @@ def mock_gnupghome(monkeypatch):
     # have to make our own tmp_path with a shorter name than pytest's.
     # This comes up because tmp paths on macOS are already long-ish, and
     # pytest makes them longer.
+    short_name_tmpdir = tempfile.mkdtemp()
     try:
-        spack.util.gpg.init()
+        # We must manually set gnupghome here, else tests run in parallel
+        # will all fall back to the system default location and cause
+        # failures when multiple try to init the same location concurrently
+        spack.util.gpg.init(gnupghome=short_name_tmpdir)
     except spack.util.gpg.SpackGPGError:
         if not spack.util.gpg.GPG:
             pytest.skip("This test requires gpg")
 
-    short_name_tmpdir = tempfile.mkdtemp()
     with spack.util.gpg.gnupghome_override(short_name_tmpdir):
         yield short_name_tmpdir
 


### PR DESCRIPTION
First observed in https://github.com/spack/spack/actions/runs/26192820980/job/77065430888.

It's possible for multiple tests to initialize the mock gnupg at the same time, in that process we use `gpg.init()` as a test to see if the system has a gnupg installation, however when run in parallel multiple threads attempt to initialize the system default gnupghome location and fail. 

This PR moves the temporary directory creation earlier in the function and uses it as we would for the tests, for the installation checking logic so that the gnupghome directories are always separate amongst each worker.