### PR TITLE
Improve config defaults

### DIFF
--- a/lib/spack/spack/cmd/config.py
+++ b/lib/spack/spack/cmd/config.py
@@ -443,7 +443,10 @@ def _can_update_config_file(scope: spack.config.ConfigScope, cfg_file):
 
 def _config_change_requires_scope(path, spec, scope, match_spec=None):
     """Return whether or not anything changed."""
-    require = spack.config.get(path, [], scope=scope)
+    require = spack.config.get(path, scope=scope)
+    if not require:
+        return False
+
     changed = False
 
     def override_cfg_spec(spec_str):

--- a/lib/spack/spack/cmd/config.py
+++ b/lib/spack/spack/cmd/config.py
@@ -443,10 +443,7 @@ def _can_update_config_file(scope: spack.config.ConfigScope, cfg_file):
 
 def _config_change_requires_scope(path, spec, scope, match_spec=None):
     """Return whether or not anything changed."""
-    require = spack.config.get(path, scope=scope)
-    if not require:
-        return False
-
+    require = spack.config.get(path, [], scope=scope)
     changed = False
 
     def override_cfg_spec(spec_str):

--- a/lib/spack/spack/config.py
+++ b/lib/spack/spack/config.py
@@ -760,7 +760,7 @@ class Configuration:
            }
 
         """
-        merged_section, default_type =  self._get_config_memoized(
+        merged_section, default_type = self._get_config_memoized(
             section, scope=scope, _merged_scope=_merged_scope
         )
 
@@ -827,7 +827,7 @@ class Configuration:
     @lang.memoized
     def _get_config_memoized(
         self, section: str, scope: Optional[str], _merged_scope: Optional[str] = None
-    ) -> YamlConfigDict:
+    ) -> Tuple[YamlConfigDict, Any]:
         """Memoized helper for ``get_config()``.
 
         Note that the memoization cache for this function is cleared whenever

--- a/lib/spack/spack/config.py
+++ b/lib/spack/spack/config.py
@@ -867,7 +867,7 @@ class Configuration:
 
         # no config files -- empty config.
         if section not in merged_section:
-            return syaml.syaml_dict()
+            return get_valid_type(section)
 
         # take the top key off before returning.
         ret = merged_section[section]

--- a/lib/spack/spack/config.py
+++ b/lib/spack/spack/config.py
@@ -904,7 +904,7 @@ class Configuration:
         # We use the helper method here to handle defaults
         value, default_type = self._get_config_memoized(section, scope=scope)
 
-        if section not in value and default is default_sigil:
+        if len(parts) == 1 and section not in value and default is default_sigil:
             return default_type
 
         while parts:

--- a/lib/spack/spack/config.py
+++ b/lib/spack/spack/config.py
@@ -882,7 +882,7 @@ class Configuration:
 
         # Return the full dict including the section name so we can gracefuly handle defaults
         # Also return the default type for the section so that calculation is memoized
-        return merged_section, get_valid_type(section)
+        return merged_section, get_default_from_schema(section)
 
     def get(self, path: str, default: Any = default_sigil, scope: Optional[str] = None) -> Any:
         """Get a config section or a single value from one.
@@ -1646,7 +1646,7 @@ def add(fullpath: str, scope: Optional[str] = None) -> None:
             # We've nested further than existing config, so we need the
             # type information for validation to know how to handle bare
             # values appended to lists.
-            existing = get_valid_type(path)
+            existing = get_default_from_schema(path)
 
             # construct value from this point down
             for component in reversed(components[idx + 1 : -1]):
@@ -1868,7 +1868,7 @@ def _mark_internal(data, name):
     return d
 
 
-def get_valid_type(path):
+def get_default_from_schema(path):
     """Returns an instance of a type that will pass validation for path.
 
     The instance is created by calling the constructor with no arguments.

--- a/lib/spack/spack/config.py
+++ b/lib/spack/spack/config.py
@@ -137,6 +137,9 @@ YamlConfigDict = Dict[str, Any]
 #: safeguard for recursive includes -- maximum include depth
 MAX_RECURSIVE_INCLUDES = 100
 
+# placeholder object for unspecified default for get methods
+default_sigil = object()
+
 
 class ConfigScope:
     def __init__(self, name: str, included: bool = False) -> None:
@@ -757,7 +760,19 @@ class Configuration:
            }
 
         """
-        return self._get_config_memoized(section, scope=scope, _merged_scope=_merged_scope)
+        merged_section, default_type =  self._get_config_memoized(
+            section, scope=scope, _merged_scope=_merged_scope
+        )
+
+        # no config files -- empty config.
+        if section not in merged_section:
+            return default_type
+
+        # take the top key off before returning.
+        ret = merged_section[section]
+        if isinstance(ret, dict):
+            ret = syaml.syaml_dict(ret)
+        return ret
 
     def deepcopy_as_builtin(
         self, section: str, scope: Optional[str] = None, *, line_info: bool = False
@@ -811,7 +826,7 @@ class Configuration:
 
     @lang.memoized
     def _get_config_memoized(
-        self, section: str, scope: Optional[str], _merged_scope: Optional[str]
+        self, section: str, scope: Optional[str], _merged_scope: Optional[str] = None
     ) -> YamlConfigDict:
         """Memoized helper for ``get_config()``.
 
@@ -865,17 +880,11 @@ class Configuration:
 
         self.updated_scopes_by_section[section] = updated_scopes
 
-        # no config files -- empty config.
-        if section not in merged_section:
-            return get_valid_type(section)
+        # Return the full dict including the section name so we can gracefuly handle defaults
+        # Also return the default type for the section so that calculation is memoized
+        return merged_section, get_valid_type(section)
 
-        # take the top key off before returning.
-        ret = merged_section[section]
-        if isinstance(ret, dict):
-            ret = syaml.syaml_dict(ret)
-        return ret
-
-    def get(self, path: str, default: Optional[Any] = None, scope: Optional[str] = None) -> Any:
+    def get(self, path: str, default: Any = default_sigil, scope: Optional[str] = None) -> Any:
         """Get a config section or a single value from one.
 
         Accepts a path syntax that allows us to grab nested config map
@@ -890,16 +899,20 @@ class Configuration:
         We use ``:`` as the separator, like YAML objects.
         """
         parts = process_config_path(path)
-        section = parts.pop(0)
+        section = parts[0]
 
-        value = self.get_config(section, scope=scope)
+        # We use the helper method here to handle defaults
+        value, default_type = self._get_config_memoized(section, scope=scope)
+
+        if section not in value and default is default_sigil:
+            return default_type
 
         while parts:
             key = parts.pop(0)
             # cannot use value.get(key, default) in case there is another part
             # and default is not a dict
             if key not in value:
-                return default
+                return default if default is not default_sigil else None
             value = value[key]
 
         return value
@@ -923,6 +936,10 @@ class Configuration:
         data = section_data
         while len(parts) > 1:
             key = parts.pop(0)
+            if key not in data:
+                # Put the key back to process later
+                parts.insert(0, key)
+                break
 
             if spack.schema.override(key):
                 new = type(data[key])()
@@ -936,6 +953,11 @@ class Configuration:
                 # reattach to parent object
                 data[key] = new
             data = new
+
+        # This only happens if the key wasn't present before
+        while len(parts) > 1:
+            leaf = parts.pop()
+            value = {leaf: value}
 
         if spack.schema.override(parts[0]):
             data.pop(parts[0], None)
@@ -1646,7 +1668,7 @@ def add(fullpath: str, scope: Optional[str] = None) -> None:
     CONFIG.set(path, new, scope)
 
 
-def get(path: str, default: Optional[Any] = None, scope: Optional[str] = None) -> Any:
+def get(path: str, default: Any = default_sigil, scope: Optional[str] = None) -> Any:
     """Module-level wrapper for ``Configuration.get()``."""
     return CONFIG.get(path, default, scope)
 
@@ -1710,7 +1732,6 @@ def change_or_add(
     config, then update the highest-priority config scope.
     """
     configs_by_section = matched_config(section_name)
-
     found = False
     for scope, section in configs_by_section:
         found = find_fn(section)
@@ -1881,9 +1902,15 @@ def get_valid_type(path):
         schema_path = jsonschema_error.schema_path
         schema_part = SECTION_SCHEMAS[section]
         for part in list(schema_path)[:-1]:
+            if part not in schema_part:
+                break
             schema_part = schema_part[part]
-        if "default" in schema_part:
-            return schema_part["default"]
+        else:
+            if "default" in schema_part:
+                default = schema_part["default"]
+                if isinstance(default, (dict, list)):
+                    default = default.copy()
+                return default
 
         # If there is no default, infer the type from the validator
         if jsonschema_error.validator == "type":

--- a/lib/spack/spack/config.py
+++ b/lib/spack/spack/config.py
@@ -1876,6 +1876,16 @@ def get_valid_type(path):
         validate(test_data, SECTION_SCHEMAS[section])
     except (ConfigFormatError, AttributeError) as e:
         jsonschema_error = e.validation_error
+
+        # Try to get the type from the default value
+        schema_path = jsonschema_error.schema_path
+        schema_part = SECTION_SCHEMAS[section]
+        for part in list(schema_path)[:-1]:
+            schema_part = schema_part[part]
+        if "default" in schema_part:
+            return schema_part["default"]
+
+        # If there is no default, infer the type from the validator
         if jsonschema_error.validator == "type":
             return types[jsonschema_error.validator_value]()
         elif jsonschema_error.validator in ("anyOf", "oneOf"):

--- a/lib/spack/spack/schema/view.py
+++ b/lib/spack/spack/schema/view.py
@@ -17,6 +17,7 @@ properties: Dict[str, Any] = {
     "view": {
         "description": "Environment filesystem view configuration for creating a directory with "
         "traditional structure where all files of installed packages are linked",
+        "default": True,
         "anyOf": [
             {
                 "type": "boolean",

--- a/lib/spack/spack/test/cmd/config.py
+++ b/lib/spack/spack/test/cmd/config.py
@@ -165,7 +165,7 @@ def test_config_scopes_path(mutable_config):
 
 
 def test_get_config_scope(mock_low_high_config):
-    assert config("get", "compilers").strip() == "compilers: {}"
+    assert config("get", "repos").strip() == "repos: {}"
 
 
 def test_get_config_roundtrip(mutable_config):

--- a/lib/spack/spack/test/config.py
+++ b/lib/spack/spack/test/config.py
@@ -423,6 +423,23 @@ packages_merge_high = {
 }
 
 
+@pytest.mark.regression("52423")
+def test_config_set_beyond_existing(mutable_config):
+    # no raised error is the primary test for this regression
+    # Needs to be for a repo that does not already exist for valid test
+    spack.config.CONFIG.set("repos:nonexistent", "foo")
+    assert spack.config.CONFIG.get("repos:nonexistent") == "foo"
+
+
+@pytest.mark.regression("52423")
+def test_config_section_defaults(mutable_config):
+    view_default = spack.config.CONFIG.get("view")
+    assert view_default == spack.config.get_default_from_schema("view") == True
+
+    view_with_default = spack.config.get("view", default="my default")
+    assert view_with_default == "my default"
+
+
 @pytest.mark.regression("7924")
 def test_merge_with_defaults(mock_low_high_config, write_config_file):
     """This ensures that specified preferences merge with defaults as

--- a/lib/spack/spack/test/config.py
+++ b/lib/spack/spack/test/config.py
@@ -434,7 +434,8 @@ def test_config_set_beyond_existing(mutable_config):
 @pytest.mark.regression("52423")
 def test_config_section_defaults(mutable_config):
     view_default = spack.config.CONFIG.get("view")
-    assert view_default == spack.config.get_default_from_schema("view") == True
+    assert view_default == spack.config.get_default_from_schema("view")
+    assert view_default is True
 
     view_with_default = spack.config.get("view", default="my default")
     assert view_with_default == "my default"


### PR DESCRIPTION
In working on #50207, I discovered a variety of minor nits in how config defaults are handled.

1. `get_valid_type` returns the first valid type from the schema and does not respect the default value
2. `spack.config.get(section_name, default=default)` returns the section config default, not the provided default
3. `spack.config.set("path:that:goes:past:last:existing:key", value)` fails, instead of instantiating the nonexistent keys
4. The `view` section did not define a default value in schema, so it would default to `False`. But the default in the code was `True`, leading to a mismatch between the behavior expectation from schema behavior in the code (once other bugs were fixed).

This PR fixes the listed bugs.