### PR TITLE
Remove template with HTML comment

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,6 +1,0 @@
-<!--  
-Remember that `spackbot` can help with your PR in multiple ways:
-- `@spackbot help` shows all the commands that are currently available
-- `@spackbot fix style` tries to push a commit to fix style issues in this PR
-- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
--->


### PR DESCRIPTION
We recently updated the default merge option to squash the commits and use the PR description as the initial message.

Here we are removing the PR template which just contains an HTML comment with info for the PR submitter, to avoid that the comment slips in by chance in the commit message of merged PRs
