### PR TITLE
Error on toolchain references in externals

### DIFF
--- a/lib/spack/docs/toolchains_yaml.rst
+++ b/lib/spack/docs/toolchains_yaml.rst
@@ -168,7 +168,45 @@ Without toolchains, it would be difficult to enforce compilers directly, because
 * ``hdf5~cxx+fortran`` depends on C and Fortran, but not C++
 * ``py-scipy`` depends on C, C++, and Fortran
 
-.. note::
+Limitations
+-----------
 
-   Toolchains are currently limited to using only direct dependencies (``%``) in their definition.
-   Transitive dependencies are not allowed.
+Toolchain definitions may only use direct dependencies (``%``).
+Transitive dependencies (``^``) are not allowed.
+
+Toolchains cannot be used in external spec definitions in :ref:`packages.yaml <packages-yaml-externals>`.
+Consider a ``gcc-15`` toolchain defined as:
+
+.. code-block:: yaml
+   :caption: ``~/.spack/toolchains.yaml``
+
+   toolchains:
+     gcc-15:
+     - spec: "%c=gcc@15"
+       when: "%c"
+     - spec: "%cxx=gcc@15"
+       when: "%cxx"
+     - spec: "%fortran=gcc@15"
+       when: "%fortran"
+
+An entry like:
+
+.. code-block:: yaml
+
+   packages:
+     zlib-ng:
+       externals:
+       - spec: zlib-ng@3.3.3 %gcc-15
+         prefix: /usr
+
+will raise an error.
+External specs describe pre-built software, so the conditional nature of toolchains does not apply: there is no build step during which to evaluate ``when:`` conditions.
+Use the explicit compiler form instead:
+
+.. code-block:: yaml
+
+   packages:
+     zlib-ng:
+       externals:
+       - spec: zlib-ng@3.3.3 %c=gcc@15
+         prefix: /usr

--- a/lib/spack/docs/toolchains_yaml.rst
+++ b/lib/spack/docs/toolchains_yaml.rst
@@ -174,7 +174,7 @@ Limitations
 Toolchain definitions may only use direct dependencies (``%``).
 Transitive dependencies (``^``) are not allowed.
 
-Toolchains cannot be used in external spec definitions in :ref:`packages.yaml <packages-yaml-externals>`.
+Toolchains cannot be used in external spec definitions in :ref:`packages.yaml <sec-external-packages>`.
 Consider a ``gcc-15`` toolchain defined as:
 
 .. code-block:: yaml

--- a/lib/spack/spack/externals.py
+++ b/lib/spack/spack/externals.py
@@ -18,7 +18,7 @@ into the intermediate representation.
 import re
 import uuid
 import warnings
-from typing import Any, Callable, Dict, List, NamedTuple, Tuple, Union
+from typing import Any, Callable, Dict, List, NamedTuple, Optional, Tuple, Union
 
 from spack.vendor.typing_extensions import TypedDict
 
@@ -197,6 +197,7 @@ class ExternalSpecsParser:
         *,
         complete_node: Callable[[spack.spec.Spec], None] = complete_variants_and_architecture,
         allow_nonexisting: bool = True,
+        toolchains: Optional[Dict] = None,
     ):
         """Initializes a class to manage and process external specifications in ``packages.yaml``.
 
@@ -205,6 +206,7 @@ class ExternalSpecsParser:
             complete_node: a callable that completes a node with missing variants, targets, etc.
                 Defaults to `complete_architecture`.
             allow_nonexisting: whether to allow non-existing packages. Defaults to True.
+            toolchains: optional toolchain definitions to expand in external specs.
 
         Raises:
             spack.repo.UnknownPackageError: if a package does not exist,
@@ -215,6 +217,7 @@ class ExternalSpecsParser:
         self.specs_by_name: Dict[str, List[ExternalSpecAndConfig]] = {}
         self.nodes: List[spack.spec.Spec] = []
         self.allow_nonexisting = allow_nonexisting
+        self.toolchains = toolchains
         # Fill the data structures above (can be done lazily)
         self.complete_node = complete_node
         self._parse()
@@ -346,6 +349,7 @@ class ExternalSpecsParser:
 
     def _parse_all_nodes(self) -> None:
         """Parses all the nodes from the external dicts but doesn't add any edge."""
+        toolchain_errors: List[str] = []
         for external_dict in self.external_dicts:
             line_info = _line_info(external_dict)
             try:
@@ -359,6 +363,17 @@ class ExternalSpecsParser:
                 continue
             except ExternalSpecError as e:
                 warnings.warn(f"{e}{line_info}")
+                continue
+
+            has_toolchain_error = False
+            if self.toolchains:
+                for edge in node.edges_to_dependencies():
+                    if edge.spec.name in self.toolchains:
+                        msg = f"  {node.cformat()} uses toolchain {edge.spec.cformat()}{line_info}"
+                        toolchain_errors.append(msg)
+                        has_toolchain_error = True
+
+            if has_toolchain_error:
                 continue
 
             package_exists = spack.repo.PATH.exists(node.name)
@@ -400,6 +415,12 @@ class ExternalSpecsParser:
             self.specs_by_external_id[eid] = spec_and_config
             self.specs_by_name.setdefault(node.name, []).append(spec_and_config)
             self.nodes.append(node)
+
+        if toolchain_errors:
+            raise ExternalSpecError(
+                "toolchains are not supported in external spec definitions:\n"
+                + "\n".join(toolchain_errors)
+            )
 
     def get_specs_for_package(self, package_name: str) -> List[spack.spec.Spec]:
         """Returns the external specs for a given package name."""

--- a/lib/spack/spack/solver/reuse.py
+++ b/lib/spack/spack/solver/reuse.py
@@ -168,7 +168,8 @@ def create_external_parser(
         raise ValueError(
             f"Unknown value for concretizer:externals:completion: {completion_mode!r}"
         )
-    return ExternalSpecsParser(external_dicts, complete_node=complete_fn)
+    toolchains = spack.config.CONFIG.get_config("toolchains")
+    return ExternalSpecsParser(external_dicts, complete_node=complete_fn, toolchains=toolchains)
 
 
 SpecFiltersFactory = Callable[

--- a/lib/spack/spack/test/externals.py
+++ b/lib/spack/spack/test/externals.py
@@ -372,3 +372,21 @@ def test_external_spec_multi_valued_variant_is_not_changed():
     specs = parser.all_specs()
     assert len(specs) == 1
     assert specs[0].variants["v"].value == ("bar", "foo")
+
+
+def test_toolchain_in_external_spec_raises_error():
+    """Toolchain references in external specs are not supported; all offending entries reported."""
+    externals_dict = [
+        {"spec": "gmake@1.0 %my_toolchain", "prefix": "/usr/gmake"},
+        {"spec": "gcc@12.0", "prefix": "/usr/gcc"},
+        {"spec": "cmake@3.0 %my_toolchain", "prefix": "/usr/cmake"},
+    ]
+    toolchains = {"my_toolchain": "%c=gcc"}
+
+    with pytest.raises(ExternalSpecError) as exc_info:
+        ExternalSpecsParser(externals_dict, toolchains=toolchains)
+    error_message = str(exc_info.value)
+
+    assert "gmake" in error_message
+    assert "cmake" in error_message
+    assert "my_toolchain" in error_message


### PR DESCRIPTION
Conditional specs don't make sense in external spec definitions. External specs are already installed and concrete: there is nothing conditional to evaluate.

Since toolchains are composed of conditional specs in most cases, here we disallow using toolchains in external definitions and raise a clear error when that is done.
