### PR TITLE
docs: improve page rank of handwritten pages

### DIFF
--- a/lib/spack/docs/conf.py
+++ b/lib/spack/docs/conf.py
@@ -108,6 +108,18 @@ sphinx_apidoc(
     ]
 )
 
+# Ensure that the page rank of the handwritten pages is higher than those of
+# generated ones, by marking the auto-generated hub pages as orphans so their
+# toctrees. This avoid that they show up in the side bar on every page.
+# Users still reach these pages via the package_api page and via :mod:
+# cross-references.
+for _orphan in ("spack.rst", "spack_repo.rst", "spack_repo.builtin.rst"):
+    with open(_orphan, "r", encoding="utf-8") as _f:
+        _content = _f.read()
+    if not _content.lstrip().startswith(":orphan:"):
+        with open(_orphan, "w", encoding="utf-8") as _f:
+            _f.write(":orphan:\n\n" + _content)
+
 
 class NoWhitespaceHtmlFormatter(HtmlFormatter):
     """HTML formatter that suppresses redundant span elements for Text.Whitespace tokens."""

--- a/lib/spack/docs/index.rst
+++ b/lib/spack/docs/index.rst
@@ -123,8 +123,6 @@ If you're new to Spack and want to start using it, see :doc:`getting_started`, o
    :caption: API Docs
 
    Spack Package API <package_api>
-   Spack Builtin Repo <spack_repo>
-   Spack API Docs <spack>
 
 Indices and tables
 ------------------

--- a/lib/spack/docs/package_api.rst
+++ b/lib/spack/docs/package_api.rst
@@ -16,6 +16,8 @@ It is assumed you have already read the :doc:`Spack Packaging Guide <packaging_g
 The Spack Package API is the *only* module in the Spack codebase considered public API.
 It re-exports essential functions and classes from various Spack modules, allowing package authors to import them directly from :mod:`spack.package` without needing to know Spack's internal structure.
 
+See also the :doc:`Spack builtin repo reference <spack_repo>` and the private :doc:`Spack internal API reference <spack>`.
+
 Spack Package API Versioning
 ----------------------------
 


### PR DESCRIPTION
by dropping `spack` and `spack_repo` API docs from the table of
contents. Before, every page referred to every `spack` module page.
After, every `spack` module page refers to every manually written page,
but not the other way around.

We still maintain specific `:mod:` links, there is the module index page
referred to from the landing page, and the Package API links to it as a
"see also".
