### PR TITLE
Refactor the GPG module to better support signing/verification workflows

### DIFF
--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -648,7 +648,7 @@ def select_signing_key() -> str:
             "Use spack gpg init and spack gpg create"
             " to create a default key."
         )
-    return keys[0]
+    return str(keys[0])
 
 
 def _push_index(db: BuildCacheDatabase, temp_dir: str, cache_prefix: str, name: str = ""):
@@ -2325,7 +2325,7 @@ def _get_keys(
         tty.debug("Found key {0}".format(fingerprint))
         if install:
             if trust:
-                spack.util.gpg.trust(key_blob_path)
+                spack.util.gpg.trust(key_blob_path, True)
                 tty.debug(f"Added {fingerprint} to trusted keys.")
                 saved_fingerprints.append(fingerprint)
             else:
@@ -2375,7 +2375,7 @@ def _get_keys_v2(mirror_url, install=False, trust=False, force=False) -> Optiona
         tty.debug("Found key {0}".format(fingerprint))
         if install:
             if trust:
-                spack.util.gpg.trust(stage.save_filename)
+                spack.util.gpg.trust(stage.save_filename, True)
                 tty.debug("Added this key to trusted keys.")
                 saved_fingerprints.append(fingerprint)
             else:

--- a/lib/spack/spack/ci/__init__.py
+++ b/lib/spack/spack/ci/__init__.py
@@ -581,7 +581,7 @@ def import_signing_key(base64_signing_key: str) -> None:
         with open(sign_key_path, "w", encoding="utf-8") as fd:
             fd.write(decoded_key)
 
-        key_import_output = spack_gpg("trust", sign_key_path)
+        key_import_output = spack_gpg("trust", "-y", sign_key_path)
         tty.debug(f"spack gpg trust {sign_key_path}")
         tty.debug(key_import_output)
 
@@ -1053,7 +1053,11 @@ def reproduce_ci_job(url, work_dir, autostart, gpg_url, runtime, use_local_head)
                 f"share/spack/setup-env.{platform_script_ext}",
             ),
         ],
-        ["spack", "gpg", "trust", mounted_gpg_path if job_image else gpg_path] if gpg_path else [],
+        (
+            ["spack", "gpg", "trust", "-y", mounted_gpg_path if job_image else gpg_path]
+            if gpg_path
+            else []
+        ),
         ["spack", "env", "activate", mounted_env_dir if job_image else repro_dir],
         [
             (

--- a/lib/spack/spack/cmd/ci.py
+++ b/lib/spack/spack/cmd/ci.py
@@ -318,7 +318,7 @@ def ci_rebuild(args):
     # Fail early if signing is required but we don't have a signing key
     sign_binaries = require_signing is not None and require_signing.lower() == "true"
     if sign_binaries and not spack_ci.can_sign_binaries():
-        gpg_util.list(False, True)
+        gpg_util.glist(False, True)
         tty.die("SPACK_REQUIRE_SIGNING=True => spack must have exactly one signing key")
 
     # Construct absolute paths relative to current $CI_PROJECT_DIR

--- a/lib/spack/spack/cmd/gpg.py
+++ b/lib/spack/spack/cmd/gpg.py
@@ -24,7 +24,8 @@ def setup_parser(subparser: argparse.ArgumentParser) -> None:
     subparsers = subparser.add_subparsers(help="GPG sub-commands")
 
     trust = subparsers.add_parser("trust", help=gpg_trust.__doc__)
-    trust.add_argument("keyfile", type=str, help="add a key to the trust store")
+    trust.add_argument("keyfile", type=str, help="add a keyfile to the trust store")
+    arguments.add_common_arguments(trust, ["yes_to_all"])
     trust.set_defaults(func=gpg_trust, subparser=trust)
 
     untrust = subparsers.add_parser("untrust", help=gpg_untrust.__doc__)
@@ -57,15 +58,22 @@ def setup_parser(subparser: argparse.ArgumentParser) -> None:
     )
     create.set_defaults(func=gpg_create, subparser=create)
 
-    list = subparsers.add_parser("list", help=gpg_list.__doc__)
-    list.add_argument("--trusted", action="store_true", default=True, help="list trusted keys")
-    list.add_argument(
+    glist = subparsers.add_parser("list", help=gpg_list.__doc__)
+    glist.add_argument(
+        "--fmt",
+        "-f",
+        action="store",
+        help="Format to list keys with (default (gpg), colons, keys, <key format string>)",
+    )
+    glist.add_argument("--trusted", action="store_true", default=True, help="list trusted keys")
+    glist.add_argument(
         "--signing", action="store_true", help="list keys which may be used for signing"
     )
-    list.set_defaults(func=gpg_list, subparser=list)
+    glist.set_defaults(func=gpg_list, subparser=glist)
 
     init = subparsers.add_parser("init", help=gpg_init.__doc__)
     init.add_argument("--from", metavar="DIR", type=str, dest="import_dir", help=argparse.SUPPRESS)
+    arguments.add_common_arguments(init, ["yes_to_all"])
     init.set_defaults(func=gpg_init, subparser=init)
 
     export = subparsers.add_parser("export", help=gpg_export.__doc__)
@@ -141,6 +149,7 @@ def gpg_create(args):
     if args.export or args.secret:
         new_sec_keys = set(spack.util.gpg.signing_keys())
         new_keys = new_sec_keys.difference(old_sec_keys)
+        new_keys = [str(k) for k in new_keys]
 
     if args.export:
         spack.util.gpg.export_keys(args.export, new_keys)
@@ -152,18 +161,18 @@ def gpg_export(args):
     """export a gpg key, optionally including secret key"""
     keys = args.keys
     if not keys:
-        keys = spack.util.gpg.signing_keys()
+        keys = [str(k) for k in spack.util.gpg.signing_keys()]
     spack.util.gpg.export_keys(args.location, keys, args.secret)
 
 
 def gpg_list(args):
     """list keys available in the keyring"""
-    spack.util.gpg.list(args.trusted, args.signing)
+    spack.util.gpg.list(args.trusted, args.signing, args.fmt)
 
 
 def gpg_trust(args):
     """add a key to the keyring"""
-    spack.util.gpg.trust(args.keyfile)
+    spack.util.gpg.trust(args.keyfile, args.yes_to_all)
 
 
 def gpg_init(args):
@@ -176,7 +185,7 @@ def gpg_init(args):
         for filename in filenames:
             if not filename.endswith(".key"):
                 continue
-            spack.util.gpg.trust(os.path.join(root, filename))
+            spack.util.gpg.trust(os.path.join(root, filename), args.yes_to_all)
 
 
 def gpg_untrust(args):

--- a/lib/spack/spack/cmd/gpg.py
+++ b/lib/spack/spack/cmd/gpg.py
@@ -167,7 +167,7 @@ def gpg_export(args):
 
 def gpg_list(args):
     """list keys available in the keyring"""
-    spack.util.gpg.list(args.trusted, args.signing, args.fmt)
+    spack.util.gpg.glist(args.trusted, args.signing, args.fmt)
 
 
 def gpg_trust(args):

--- a/lib/spack/spack/test/binary_distribution.py
+++ b/lib/spack/spack/test/binary_distribution.py
@@ -151,7 +151,7 @@ def test_push_and_fetch_keys(mock_gnupghome, tmp_path: pathlib.Path):
 
         keys = spack.util.gpg.public_keys()
         assert len(keys) == 1
-        fpr = keys[0]
+        fpr = str(keys[0])
 
         spack.binary_distribution._url_push_keys(
             mirror, keys=[fpr], tmpdir=str(tmp_path), update_index=True
@@ -166,7 +166,7 @@ def test_push_and_fetch_keys(mock_gnupghome, tmp_path: pathlib.Path):
 
         new_keys = spack.util.gpg.public_keys()
         assert len(new_keys) == 1
-        assert new_keys[0] == fpr
+        assert str(new_keys[0]) == fpr
 
 
 @pytest.mark.maybeslow

--- a/lib/spack/spack/test/cmd/gpg.py
+++ b/lib/spack/spack/test/cmd/gpg.py
@@ -48,7 +48,6 @@ def test_find_gpg(cmd_name, version, tmp_path: pathlib.Path, mock_gnupghome, mon
     else:
         spack.util.gpg.init(force=True)
         assert spack.util.gpg.GPG is not None
-        assert spack.util.gpg.GPGCONF is not None
 
 
 def test_no_gpg_in_path(tmp_path: pathlib.Path, mock_gnupghome, monkeypatch, mutable_config):
@@ -63,7 +62,7 @@ def test_gpg(tmp_path: pathlib.Path, mutable_config, mock_gnupghome):
     MOCK_KEY = "B27095DEEF1787C3C8C85917DCA0241840A5DAE2"
 
     # Import the default key.
-    gpg("init", "--from", mock_gpg_keys_path)
+    gpg("init", "-y", "--from", mock_gpg_keys_path)
 
     # List the keys.
     # TODO: Test the output here.
@@ -90,7 +89,7 @@ def test_gpg(tmp_path: pathlib.Path, mutable_config, mock_gnupghome):
         "Spack testing 1",
         "spack@googlegroups.com",
     )
-    keyfp = spack.util.gpg.signing_keys()[0]
+    keyfp = spack.util.gpg.signing_keys()[0].fpr
 
     # List the keys.
     # TODO: Test the output here.
@@ -147,7 +146,8 @@ def test_gpg(tmp_path: pathlib.Path, mutable_config, mock_gnupghome):
     assert out.count(keyfp) == 0
 
     # Trust the exported public key (keyfpr)
-    gpg("trust", str(export_path))
+    # Trust the exported key.
+    gpg("trust", "-y", str(export_path))
     out = gpg("list", "--signing")
     assert out.count("sec ") == 1
     assert out.count("pub ") == 2

--- a/lib/spack/spack/test/util/util_gpg.py
+++ b/lib/spack/spack/test/util/util_gpg.py
@@ -90,4 +90,4 @@ def test_really_long_gnupghome_dir(tmp_path: pathlib.Path, has_socket_dir):
         spack.util.gpg.create(
             name="Spack testing 1", email="test@spack.io", comment="Spack testing key", expires="0"
         )
-        spack.util.gpg.list(True, True)
+        spack.util.gpg.glist(True, True)

--- a/lib/spack/spack/test/util/util_gpg.py
+++ b/lib/spack/spack/test/util/util_gpg.py
@@ -20,7 +20,7 @@ def has_socket_dir():
 def test_parse_gpg_output_case_one():
     now = int(time.time())
     # Two keys, fingerprint for primary keys, but not subkeys
-    output = f"""sec:-:2048:1:AAAAAAAAAAAAAAAA:{now}:{now}::-:::CESces::::::23::0:
+    output = f"""sec:-:2048:1:AAAAAAAAAAAAAAAA:{now}:{now}::-:::CESces::::::23:{now}:0:
 fpr:::::::::XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX:
 uid:-::::{now}::AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA::Joe (Test) <j.s@s.com>::::::::::0:
 ssb:-:2048:1:AAAAAAAAAAAAAAAA:{now}:::-:::ces::::::23:
@@ -133,6 +133,18 @@ def test_gpg_trust_ownertrust():
     assert 8 == spack.util.gpg.GpgKeyTrust.KNOWN.ownertrust
     assert 8 == spack.util.gpg.GpgKeyTrust.SPECIAL.ownertrust
 
+    assert spack.util.gpg.GpgKeyTrust(0) == spack.util.gpg.GpgKeyTrust.UNKNOWN
+    assert spack.util.gpg.GpgKeyTrust(1) == spack.util.gpg.GpgKeyTrust.EXPIRED
+    assert spack.util.gpg.GpgKeyTrust(2) == spack.util.gpg.GpgKeyTrust.UNDEFINED
+    assert spack.util.gpg.GpgKeyTrust(3) == spack.util.gpg.GpgKeyTrust.NEVER
+    assert spack.util.gpg.GpgKeyTrust(4) == spack.util.gpg.GpgKeyTrust.MARGINAL
+    assert spack.util.gpg.GpgKeyTrust(5) == spack.util.gpg.GpgKeyTrust.FULL
+    assert spack.util.gpg.GpgKeyTrust(6) == spack.util.gpg.GpgKeyTrust.ULTIMATE
+    assert spack.util.gpg.GpgKeyTrust(7) == spack.util.gpg.GpgKeyTrust.REVOKED
+    assert spack.util.gpg.GpgKeyTrust(8) == spack.util.gpg.GpgKeyTrust.ERROR
+
+    assert spack.util.gpg.GpgKeyTrust(9) == spack.util.gpg.GpgKeyTrust.ERROR
+
 
 def test_gpg_key_algorithm():
     with pytest.raises(
@@ -149,9 +161,15 @@ def test_gpg_key_algorithm():
 
 
 def test_gpg_key_type():
-    assert spack.util.gpg.GpgKeyType("pub") == spack.util.gpg.GpgKeyType.PUBLIC
-    assert spack.util.gpg.GpgKeyType("sub") == spack.util.gpg.GpgKeyType.PUBLIC_SUBKEY
-    assert spack.util.gpg.GpgKeyType("sec") == spack.util.gpg.GpgKeyType.SECRET
-    assert spack.util.gpg.GpgKeyType("ssb") == spack.util.gpg.GpgKeyType.SECRET_SUBKEY
-    assert spack.util.gpg.GpgKeyType("sec#") == spack.util.gpg.GpgKeyType.SECRET_SUBKEY_ONLY
-    assert spack.util.gpg.GpgKeyType("rvk") == spack.util.gpg.GpgKeyType.REVOCATION
+    str_to_type = [
+        ("pub", spack.util.gpg.GpgKeyType.PUBLIC),
+        ("sub", spack.util.gpg.GpgKeyType.PUBLIC_SUBKEY),
+        ("sec", spack.util.gpg.GpgKeyType.SECRET),
+        ("ssb", spack.util.gpg.GpgKeyType.SECRET_SUBKEY),
+        ("sec#", spack.util.gpg.GpgKeyType.SECRET_SUBKEY_ONLY),
+        ("rvk", spack.util.gpg.GpgKeyType.REVOCATION),
+    ]
+
+    for s, t in str_to_type:
+        assert s == str(t)
+        assert spack.util.gpg.GpgKeyType(s) == t

--- a/lib/spack/spack/test/util/util_gpg.py
+++ b/lib/spack/spack/test/util/util_gpg.py
@@ -4,6 +4,7 @@
 
 import os
 import pathlib
+import time
 
 import pytest
 
@@ -17,60 +18,62 @@ def has_socket_dir():
 
 
 def test_parse_gpg_output_case_one():
+    now = int(time.time())
     # Two keys, fingerprint for primary keys, but not subkeys
-    output = """sec::2048:1:AAAAAAAAAAAAAAAA:AAAAAAAAAA:AAAAAAAAAA:::::::::
+    output = f"""sec::2048:1:AAAAAAAAAAAAAAAA:{now}:{now}:::::::::
 fpr:::::::::XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX:
-uid:::::::AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA::Joe (Test) <j.s@s.com>:
-ssb::2048:1:AAAAAAAAAAAAAAAA:AAAAAAAAAA::::::::::
-sec::2048:1:AAAAAAAAAAAAAAAA:AAAAAAAAAA:AAAAAAAAAA:::::::::
+uid:::::{now}::AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA::Joe (Test) <j.s@s.com>:
+ssb::2048:1:AAAAAAAAAAAAAAAA:{now}::::::::::
+sec::2048:1:AAAAAAAAAAAAAAAA:{now}:{now}:::::::::
 fpr:::::::::YYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYY:
-uid:::::::AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA::Joe (Test) <j.s@s.com>:
-ssb::2048:1:AAAAAAAAAAAAAAAA:AAAAAAAAAA::::::::::
+uid:::::{now}::AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA::Joe (Test) <j.s@s.com>:
+ssb::2048:1:AAAAAAAAAAAAAAAA:{now}::::::::::
 """
-    keys = spack.util.gpg._parse_secret_keys_output(output)
+    keys = spack.util.gpg._parse_gpg_output(output)
 
     assert len(keys) == 2
-    assert keys[0] == "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
-    assert keys[1] == "YYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYY"
+    assert keys[0].fpr == "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
+    assert keys[1].fpr == "YYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYY"
 
 
 def test_parse_gpg_output_case_two():
+    now = int(time.time())
     # One key, fingerprint for primary key as well as subkey
-    output = """sec:-:2048:1:AAAAAAAAAA:AAAAAAAA:::-:::escaESCA:::+:::23::0:
+    output = f"""sec:-:2048:1:AAAAAAAAAA:{now}:::-:::escaESCA:::+:::23::0:
 fpr:::::::::XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX:
 grp:::::::::AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA:
-uid:-::::AAAAAAAAA::AAAAAAAAA::Joe (Test) <j.s@s.com>::::::::::0:
-ssb:-:2048:1:AAAAAAAAA::::::esa:::+:::23:
+uid:-::::{now}::AAAAAAAAA::Joe (Test) <j.s@s.com>::::::::::0:
+ssb:-:2048:1:AAAAAAAAA:{now}:::::esa:::+:::23:
 fpr:::::::::YYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYY:
 grp:::::::::AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA:
 """
-    keys = spack.util.gpg._parse_secret_keys_output(output)
+    keys = spack.util.gpg._parse_gpg_output(output)
 
     assert len(keys) == 1
-    assert keys[0] == "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
+    assert keys[0].fpr == "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
 
 
 def test_parse_gpg_output_case_three():
+    now = int(time.time())
     # Two keys, fingerprint for primary keys as well as subkeys
-    output = """sec::2048:1:AAAAAAAAAAAAAAAA:AAAAAAAAAA:AAAAAAAAAA:::::::::
+    output = f"""sec::2048:1:AAAAAAAAAAAAAAAA:{now}:{now}:::::::::
 fpr:::::::::WWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWW:
-uid:::::::AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA::Joe (Test) <j.s@s.com>:
-ssb::2048:1:AAAAAAAAAAAAAAAA:AAAAAAAAAA::::::::::
+uid:::::{now}::AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA::Joe (Test) <j.s@s.com>:
+ssb::2048:1:AAAAAAAAAAAAAAAA:{now}::::::::::
 fpr:::::::::XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX:
-sec::2048:1:AAAAAAAAAAAAAAAA:AAAAAAAAAA:AAAAAAAAAA:::::::::
+sec::2048:1:AAAAAAAAAAAAAAAA:{now}:{now}:::::::::
 fpr:::::::::YYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYY:
-uid:::::::AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA::Joe (Test) <j.s@s.com>:
-ssb::2048:1:AAAAAAAAAAAAAAAA:AAAAAAAAAA::::::::::
+uid:::::{now}::AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA::Joe (Test) <j.s@s.com>:
+ssb::2048:1:AAAAAAAAAAAAAAAA:{now}::::::::::
 fpr:::::::::ZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ:"""
 
-    keys = spack.util.gpg._parse_secret_keys_output(output)
+    keys = spack.util.gpg._parse_gpg_output(output)
 
     assert len(keys) == 2
-    assert keys[0] == "WWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWW"
-    assert keys[1] == "YYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYY"
+    assert keys[0].fpr == "WWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWW"
+    assert keys[1].fpr == "YYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYY"
 
 
-@pytest.mark.requires_executables("gpg2")
 def test_really_long_gnupghome_dir(tmp_path: pathlib.Path, has_socket_dir):
     if not has_socket_dir:
         pytest.skip("This test requires /var/run/user/$(id -u)")

--- a/lib/spack/spack/test/util/util_gpg.py
+++ b/lib/spack/spack/test/util/util_gpg.py
@@ -20,20 +20,23 @@ def has_socket_dir():
 def test_parse_gpg_output_case_one():
     now = int(time.time())
     # Two keys, fingerprint for primary keys, but not subkeys
-    output = f"""sec::2048:1:AAAAAAAAAAAAAAAA:{now}:{now}:::::::::
+    output = f"""sec:-:2048:1:AAAAAAAAAAAAAAAA:{now}:{now}::-:::CESces::::::23::0:
 fpr:::::::::XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX:
-uid:::::{now}::AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA::Joe (Test) <j.s@s.com>:
-ssb::2048:1:AAAAAAAAAAAAAAAA:{now}::::::::::
-sec::2048:1:AAAAAAAAAAAAAAAA:{now}:{now}:::::::::
+uid:-::::{now}::AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA::Joe (Test) <j.s@s.com>::::::::::0:
+ssb:-:2048:1:AAAAAAAAAAAAAAAA:{now}:::-:::ces::::::23:
+sec:-:2048:1:AAAAAAAAAAAAAAAA:{now}:{now}::-:::CESces::::::23::0:
 fpr:::::::::YYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYY:
-uid:::::{now}::AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA::Joe (Test) <j.s@s.com>:
-ssb::2048:1:AAAAAAAAAAAAAAAA:{now}::::::::::
+uid:-::::{now}::AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA::Joe (Test) <j.s@s.com>::::::::::0:
+ssb:-:2048:1:AAAAAAAAAAAAAAAA:{now}:::-:::ces::::::23:
 """
     keys = spack.util.gpg._parse_gpg_output(output)
 
     assert len(keys) == 2
     assert keys[0].fpr == "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
     assert keys[1].fpr == "YYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYY"
+
+    assert f"{keys[0]:colons}" in output
+    assert f"{keys[1]:colons}" in output
 
 
 def test_parse_gpg_output_case_two():
@@ -91,3 +94,64 @@ def test_really_long_gnupghome_dir(tmp_path: pathlib.Path, has_socket_dir):
             name="Spack testing 1", email="test@spack.io", comment="Spack testing key", expires="0"
         )
         spack.util.gpg.glist(True, True)
+
+
+def test_gpg_capabilities_case_insensitvie():
+    for e in spack.util.gpg.GpgKeyCapability:
+        assert e == spack.util.gpg.GpgKeyCapability(e.value.lower())
+        assert e == spack.util.gpg.GpgKeyCapability(e.value.upper())
+
+    assert spack.util.gpg.GpgKeyCapability("q") == spack.util.gpg.GpgKeyCapability.UNKNOWN
+
+
+def test_gpg_trust_case_insensitive():
+    for e in spack.util.gpg.GpgKeyTrust:
+        assert e == spack.util.gpg.GpgKeyTrust(e.value.lower())
+        assert e == spack.util.gpg.GpgKeyTrust(e.value.upper())
+
+    for alt_unknown in ("i", "o"):
+        assert (
+            spack.util.gpg.GpgKeyTrust(alt_unknown.lower()) == spack.util.gpg.GpgKeyTrust.UNKNOWN
+        )
+        assert (
+            spack.util.gpg.GpgKeyTrust(alt_unknown.upper()) == spack.util.gpg.GpgKeyTrust.UNKNOWN
+        )
+
+    assert spack.util.gpg.GpgKeyTrust("v") == spack.util.gpg.GpgKeyTrust.ERROR
+
+
+def test_gpg_trust_ownertrust():
+    assert 0 == spack.util.gpg.GpgKeyTrust.UNKNOWN.ownertrust
+    assert 1 == spack.util.gpg.GpgKeyTrust.EXPIRED.ownertrust
+    assert 2 == spack.util.gpg.GpgKeyTrust.UNDEFINED.ownertrust
+    assert 3 == spack.util.gpg.GpgKeyTrust.NEVER.ownertrust
+    assert 4 == spack.util.gpg.GpgKeyTrust.MARGINAL.ownertrust
+    assert 5 == spack.util.gpg.GpgKeyTrust.FULL.ownertrust
+    assert 6 == spack.util.gpg.GpgKeyTrust.ULTIMATE.ownertrust
+    assert 7 == spack.util.gpg.GpgKeyTrust.REVOKED.ownertrust
+    assert 8 == spack.util.gpg.GpgKeyTrust.ERROR.ownertrust
+    assert 8 == spack.util.gpg.GpgKeyTrust.KNOWN.ownertrust
+    assert 8 == spack.util.gpg.GpgKeyTrust.SPECIAL.ownertrust
+
+
+def test_gpg_key_algorithm():
+    with pytest.raises(
+        ValueError, match="GpgKeyAlgorithm can only be constructed from another Enum or an `int`"
+    ):
+        spack.util.gpg.GpgKeyAlgorithm("need a number")
+
+    assert spack.util.gpg.GpgKeyAlgorithm(40) == spack.util.gpg.GpgKeyAlgorithm.UNKNOWN
+    assert spack.util.gpg.GpgKeyAlgorithm(300) == spack.util.gpg.GpgKeyAlgorithm.LIBGCRYPT
+
+    for e in spack.util.gpg.GpgKeyAlgorithm:
+        assert str(e) == f"{e}"
+        assert "2048" in f"{e:2048}"
+
+
+def test_gpg_key_type():
+    assert spack.util.gpg.GpgKeyType("pub") == spack.util.gpg.GpgKeyType.PUBLIC
+    assert spack.util.gpg.GpgKeyType("sub") == spack.util.gpg.GpgKeyType.PUBLIC_SUBKEY
+    assert spack.util.gpg.GpgKeyType("sec") == spack.util.gpg.GpgKeyType.SECRET
+    assert spack.util.gpg.GpgKeyType("ssb") == spack.util.gpg.GpgKeyType.SECRET_SUBKEY
+    assert spack.util.gpg.GpgKeyType("sec#") == spack.util.gpg.GpgKeyType.SECRET_SUBKEY_ONLY
+    assert spack.util.gpg.GpgKeyType("rvk") == spack.util.gpg.GpgKeyType.REVOCATION

--- a/lib/spack/spack/util/gpg.py
+++ b/lib/spack/spack/util/gpg.py
@@ -999,7 +999,7 @@ def verify(signature: str, file: Optional[str] = None, suppress_warnings: bool =
 
 
 @_autoinit
-def list(trusted: bool, signing: bool, fmt: str = "default"):
+def glist(trusted: bool, signing: bool, fmt: str = "default"):
     """List known keys.
 
     Args:

--- a/lib/spack/spack/util/gpg.py
+++ b/lib/spack/spack/util/gpg.py
@@ -542,7 +542,7 @@ class Gpg:
             gpg_args.append("--with-colons")
 
         # Get list of keys from keyring
-        return self.gpg(*gpg_args, "--fingerprint", *fprs, output=str)
+        return self.gpg(*gpg_args, *fprs, output=str)
 
     def keys(self, *fprs, ktype: GpgKeyType = GpgKeyType.PUBLIC):
         return _parse_gpg_output(self._list_keys(*fprs, colons=True, ktype=ktype))

--- a/lib/spack/spack/util/gpg.py
+++ b/lib/spack/spack/util/gpg.py
@@ -622,7 +622,12 @@ class Gpg:
         else:
             return out
 
-    def trust(self, keyfile: str, ultimate: bool = True, yes_to_all: bool = False):
+    def trust(
+        self,
+        keyfile: str,
+        ownertrust: GpgKeyTrust = GpgKeyTrust.ULTIMATE,
+        yes_to_all: bool = False,
+    ):
         """Import a public key from a file and trust it.
 
         Args:
@@ -650,15 +655,11 @@ class Gpg:
                 tty.info(f"Spack will not trust key {key}")
                 self.untrust([key])
 
-            ownertrust = GpgKeyTrust.FULL.ownertrust
-            if ultimate:
-                ownertrust = GpgKeyTrust.ULTIMATE.ownertrust
-
             # Update the owner trust to ultimate
             r, w = os.pipe()
             with contextlib.closing(os.fdopen(r, "r")) as rc:
                 with contextlib.closing(os.fdopen(w, "w")) as wc:
-                    wc.write(f"{key.fpr}:{ownertrust}:\n")
+                    wc.write(f"{key.fpr}:{ownertrust.ownertrust}:\n")
                 self.gpg("--import-ownertrust", input=rc)
 
     def untrust(self, keys: List[GpgKey]):
@@ -951,7 +952,7 @@ def trust(keyfile: str, yes_to_all: bool = False):
         keyfile: file with the public key
     """
     assert GPG
-    GPG.trust(keyfile, ultimate=True, yes_to_all=yes_to_all)
+    GPG.trust(keyfile, ownertrust=GpgKeyTrust.ULTIMATE, yes_to_all=yes_to_all)
 
 
 @_autoinit
@@ -1010,15 +1011,7 @@ def glist(trusted: bool, signing: bool, fmt: str = "default"):
     Args:
         trusted: if True list public keys
         signing: if True list private keys
-        fmt: Key formatting string
-            Values:
-                default: print output from gpg
-
-                GpgKey formatting string
-                    c[olons] - Output everything using a gpg style colon format ie.
-                    s[hort] - Shortened output ie. <fingerprint> (<uid>)
-                    f[pr] - Fingerprint only output ie. <fingerprint>
-
+        fmt: Key formatting string (default, colons, short, fpr)
     """
     assert GPG
 

--- a/lib/spack/spack/util/gpg.py
+++ b/lib/spack/spack/util/gpg.py
@@ -2,23 +2,31 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 import contextlib
+import datetime
+import enum
 import errno
 import functools
 import os
+import pathlib
 import re
-from typing import Any, Dict, List
+from typing import Any, Callable, Dict, List, Optional, Union
 
 import spack.error
 import spack.llnl.util.filesystem
+import spack.llnl.util.tty as tty
 import spack.paths
 import spack.util.executable
 import spack.util.spack_json as sjson
 import spack.version
+from spack.util.executable import Executable
+
+GPG_NAMES = ("gpg", "gpg2")
+GPGCONF_NAMES = ("gpgconf", "gpg2conf", "gpgconf2")
 
 #: Executable instance for "gpg", initialized lazily
-GPG = None
+GPG: Optional["Gpg"] = None
 #: Executable instance for "gpgconf", initialized lazily
-GPGCONF = None
+GPGCONF: Optional[Executable] = None
 #: Socket directory required if a non default home directory is used
 SOCKET_DIR = None
 #: GNUPGHOME environment variable in the context of this Python module
@@ -56,71 +64,650 @@ def extract_json_from_clearsig(data) -> Dict[Any, Any]:
     return sjson.load(extract_data_from_clearsig(data))
 
 
+#:
+_GPG_FIELD_MAP = [
+    "type",
+    "trust",
+    "len",
+    "key_algo",
+    "key_id",
+    "created_at",
+    "expire_at",
+    "misc",
+    "owner_trust",
+    "uid",
+    "sig_class",
+    "capabilities",
+    "issuer_cert",
+    "flag",
+    "token",
+    "hash_algo",
+    "curve_name",
+    "compliance",
+    "updated_at",
+    "origin",
+    "comment",
+]
+
+
+class GpgKeyCapability(enum.Enum):
+    """Gpg Capabilities"""
+
+    ENCRYPT = "e"
+    SIGN = "s"
+    CERTIFY = "c"
+    AUTHENTICATE = "a"
+    DISABLED = "D"
+    UNKNOWN = "?"
+
+    @classmethod
+    def _missing_(cls, value):
+        for cap in cls:
+            if value.lower() == cap.value:
+                return cap
+        return GpgKeyCapability.UNKNOWN
+
+
+class GpgKeyTrust(enum.Enum):
+    """Gpg Trust normalized for Field 1 and Field 9"""
+
+    INVALID = "i"
+    REVOKED = "r"
+    EXPIRED = "e"
+    UNKNOWN = "-"  # - o
+    NEVER = "n"
+    MARGINAL = "m"
+    FULL = "f"
+    ULTIMATE = "u"
+    KNOWN = "w"
+    SPECIAL = "s"
+
+    @classmethod
+    def _missing_(cls, value):
+        # If it is not found, then it is unknown
+        return GpgKeyTrust.UNKNOWN
+
+
+class GpgKeyAlgorithm(enum.Enum):
+    """Gpg Algormithms"""
+
+    RSA = 1
+    RSA_SO = 2
+    RSA_EO = 3
+    ELGAMAL_EO = 16
+    DSA = 17
+    EC = 18
+    ECDSA = 19
+    ELGAMAL = 20
+    DH = 21
+    LIBGCRYPT = 256
+
+    @classmethod
+    def _missing_(cls, value):
+        if value > 255:
+            return GpgKeyAlgorithm.LIBGCRYPT
+        return None
+
+    def __str__(cls):
+        name = cls.name.lower()
+        name = name.replace("_so", " (Signing only)")
+        name = name.replace("_eo", " (Encryption only)")
+        return name
+
+    def __format__(cls, fspec):
+        """Format type with length
+        ex. f"{gpg_algo:{gpg_len}}"
+        """
+        int(fspec)
+        name = cls.name.lower()
+        name = name.replace("_so", f"{fspec} (Signing only)")
+        name = name.replace("_eo", f"{fspec} (Encryption only)")
+        return name
+
+
+class GpgKeyCompliance(enum.Enum):
+    """Gpg compliance codes"""
+
+    RFC4880BIS = 8
+    DE_VS = 23
+    DE_VS_EXP = 2023
+    VULN = 6001
+    UNKNOWN = 0
+
+
+class GpgKeyType(enum.Flag):
+    """Gpg Key types"""
+
+    PUBLIC = enum.auto()
+    SUBKEY = enum.auto()
+    SECRET = enum.auto()
+    REVOCATION = enum.auto()
+
+    SECRET_SUBKEY_ONLY = enum.auto()
+
+    PUBLIC_SUBKEY = PUBLIC | SUBKEY
+    SECRET_SUBKEY = SECRET | SUBKEY
+
+    @classmethod
+    def _missing_(cls, value):
+        if not isinstance(value, str):
+            for mem in cls:
+                if mem.value == value:
+                    return mem
+
+        kname = value.strip().lower()
+        if kname == "pub":
+            return GpgKeyType.PUBLIC
+        if kname == "sub":
+            return GpgKeyType.PUBLIC_SUBKEY
+        if kname == "sec":
+            return GpgKeyType.SECRET
+        if kname == "sec#":
+            return GpgKeyType.SECRET_SUBKEY_ONLY
+        if kname == "ssb":
+            return GpgKeyType.SECRET_SUBKEY
+        if kname == "rvk":
+            return GpgKeyType.REVOCATION
+        return None
+
+    def __str__(self):
+        if self == GpgKeyType.PUBLIC:
+            return "pub"
+        if self == GpgKeyType.PUBLIC_SUBKEY:
+            return "sub"
+        if self == GpgKeyType.SECRET:
+            return "sec"
+        if self == GpgKeyType.SECRET_SUBKEY_ONLY:
+            return "sec#"
+        if self == GpgKeyType.SECRET_SUBKEY:
+            return "ssb"
+        if self == GpgKeyType.REVOCATION:
+            return "rvk"
+
+        return self.name
+
+
+class GpgSigType(enum.Enum):
+    """Gpg Key signature types"""
+
+    SIGNATURE = "sig"
+    REVOCATION = "rev"
+    REVOCATION_SO = "rvs"
+
+
+class GpgUserId:
+    def __init__(self, data: Dict[str, str]):
+        assert data["type"] in ("uid", "uat")
+
+        self.type = data["type"]
+        self.trust = GpgKeyTrust(data["trust"])
+        if not data["created_at"]:
+            tty.warn("GPG Key User ID has no creation date")
+            self.created_at = None
+        else:
+            self.created_at = datetime.datetime.fromtimestamp(int(data["created_at"]))
+        self.hash = data["misc"]
+        self.uid = data["uid"]
+        self.origin = data.get("origin")
+
+    def _format_colons(self) -> str:
+        data: Dict[str, Any] = {}
+        data["type"] = self.type
+        data["trust"] = self.trust.value
+        if self.created_at:
+            data["created_at"] = int(self.created_at.timestamp())
+        data["misc"] = self.hash
+        data["uid"] = self.uid
+        data["origin"] = self.origin or ""
+
+        return ":".join([str(data.get(f, "")) for f in _GPG_FIELD_MAP])
+
+
+class GpgSignature:
+    def __init__(self, data: Dict[str, str]):
+        self.type = GpgSigType(data["type"])
+        self.algo = GpgKeyAlgorithm(int(data["key_algo"]))
+        self.id = data["key_id"]
+        self.created_at = datetime.datetime.fromtimestamp(int(data["created_at"]))
+        self.uid = data["uid"]
+        self.sig_class = data["sig_class"]
+
+    def _format_colons(self) -> str:
+        data: Dict[str, Any] = {}
+        data["type"] = self.type.value
+        data["key_algo"] = self.algo.value
+        data["key_id"] = self.id
+        data["created_at"] = int(self.created_at.timestamp())
+        data["uid"] = self.uid
+        data["sig_class"] = self.sig_class
+        return ":".join([str(data.get(f, "")) for f in _GPG_FIELD_MAP])
+
+
+class GpgKey:
+    def __init__(self, data: Dict[str, str]):
+        assert data["type"] in ("pub", "sec", "sec#", "sub", "ssb")
+
+        self.type = GpgKeyType(data["type"])
+
+        self.trust = GpgKeyTrust(data["trust"])
+        self.key_len = data["len"]
+        self.key_algorithm = GpgKeyAlgorithm(int(data["key_algo"]))
+        self.key_id = data["key_id"]
+        self.created_at = datetime.datetime.fromtimestamp(int(data["created_at"]))
+        self.expires_at: Optional[datetime.datetime] = None
+        if data.get("expired_at"):
+            self.expires_at = datetime.datetime.fromtimestamp(int(data["expired_at"]))
+
+        self.owner_trust = GpgKeyTrust(data["owner_trust"])
+
+        self.capabilities = set()
+        for cap in data.get("capabilities", []):
+            self.capabilities.add(GpgKeyCapability(cap))
+
+        self.compliance = GpgKeyCompliance(int(data.get("compliance") or 0))
+
+        self.updated_at: Optional[datetime.datetime] = None
+        if data.get("updated_at"):
+            self.updated_at = datetime.datetime.fromtimestamp(int(data["updated_at"]))
+        self.origin = data.get("origin")
+        self.comment = data.get("comment", "")
+
+        self.fpr: str = ""
+        self.rev: List[GpgSignature] = []
+        self.sig: List[GpgSignature] = []
+        self.uid: List[GpgUserId] = []
+        self.subkey: List[GpgKey] = []
+
+    def add(self, data: Dict[str, str]):
+        """Add metadata to a key"""
+
+        if data["type"] in ("fpr", "fp2"):
+            self.fpr = data["uid"]
+
+        elif data["type"] in ("uid", "uat"):
+            self.uid.append(GpgUserId(data))
+
+        elif data["type"] == "sig":
+            self.sig.append(GpgSignature(data))
+
+        elif data["type"] == "rev":
+            assert self.trust == GpgKeyTrust.REVOKED
+            self.rev.append(GpgSignature(data))
+
+    def __eq__(self, otherkey):
+        def _subkey_fpr_list(key):
+            # return an ordered list of key fingerprints for comparison
+            return set([k.fpr for k in key.subkey])
+
+        if isinstance(otherkey, str):
+            return self.fpr == otherkey
+        elif isinstance(otherkey, GpgKey):
+            # return f"{self:c}" == f"{otherkey:c}"
+            return self.fpr == otherkey.fpr
+        else:
+            return NotImplemented
+
+    def __hash__(self):
+        return hash(self.fpr)
+
+    def __str__(self):
+        return self.fpr
+
+    def _format_colons(self) -> List[str]:
+        data: Dict[str, Any] = {}
+        data["type"] = self.type
+        data["trust"] = self.trust.value
+
+        data["len"] = self.key_len
+        data["key_algo"] = self.key_algorithm.value
+        data["key_id"] = self.key_id
+        data["created_at"] = int(self.created_at.timestamp())
+        if self.expires_at:
+            data["expired_at"] = int(self.expires_at.timestamp())
+        if self.updated_at:
+            data["updated_at"] = int(self.updated_at.timestamp())
+
+        data["owner_trust"] = self.owner_trust.value
+        cap_list = set()
+        if self.subkey:
+            cap_list.update([c.value.upper() for c in self.capabilities])
+            for k in self.subkey:
+                cap_list.update([c.value.lower() for c in k.capabilities])
+        else:
+            cap_list.update([c.value.lower() for c in self.capabilities])
+        data["capabilities"] = "".join(sorted(cap_list))
+
+        data["compliance"] = self.compliance.value
+
+        data["origin"] = self.origin or ""
+        data["comment"] = self.comment
+
+        colons = []
+        nkey_fields = len(_GPG_FIELD_MAP)
+        if self.type.value & GpgKeyType.SUBKEY.value:
+            nkey_fields -= 3
+        colons.append(":".join([str(data.get(f, "")) for f in _GPG_FIELD_MAP[: nkey_fields + 1]]))
+
+        if self.fpr:
+            fpr_data = {}
+            fpr_data["type"] = "fpr"
+            fpr_data["uid"] = self.fpr
+            colons.append(":".join([str(fpr_data.get(f, "")) for f in _GPG_FIELD_MAP[:11]]))
+
+        for u in self.uid:
+            colons.append(u._format_colons())
+
+        for s in self.sig:
+            colons.append(s._format_colons())
+
+        for r in self.rev:
+            colons.append(r._format_colons())
+
+        for k in self.subkey:
+            colons.extend(k._format_colons())
+
+        return colons
+
+    def __format__(self, fspec):
+        """Formatted output for GPG key
+
+        Default:
+            <fingerprint>
+
+        c[olons] - Output everything using a gpg style colon format ie.
+        s[hort] - Shortened output ie. <fingerprint> (<uid>)
+        f[pr] - Fingerprint only output ie. <fingerprint>
+        """
+
+        if fspec.startswith("s"):
+            return f"{self.fpr} ({self.uid[0].uid})"
+        elif fspec.startswith("f"):
+            return self.fpr
+        elif fspec.startswith("c"):
+            return "\n".join(self._format_colons())
+        else:
+            return str(self)
+
+
+class Gpg:
+    """Wrapper for GPG"""
+
+    def __init__(self, gnupghome: Optional[str] = None):
+        self.home = Gpg._init_gnupghome(gnupghome)
+        self._gpg: Optional[Executable] = None
+        self._gpgconf: Optional[Executable] = None
+        self._socket_dir: Optional[pathlib.Path] = None
+
+    @staticmethod
+    def _init_gnupghome(gnupghome: Optional[str] = None) -> pathlib.Path:
+        # Make sure that the gnupghome exists
+        gnupghome = gnupghome or os.getenv("SPACK_GNUPGHOME") or spack.paths.gpg_path
+        if not os.path.exists(gnupghome):
+            os.makedirs(gnupghome)
+            os.chmod(gnupghome, 0o700)
+
+        if not os.path.isdir(gnupghome):
+            msg = 'gnupghome "{0}" exists and is not a directory'.format(gnupghome)
+            raise SpackGPGError(msg)
+
+        return pathlib.Path(gnupghome)
+
+    def _create_gpgfn(
+        self, *find_gpgfn: Callable[..., Optional[Executable]]
+    ) -> List[Optional[Executable]]:
+        """Create a GPG function wrapper"""
+        import spack.bootstrap
+
+        fnwrappers = []
+        with spack.bootstrap.ensure_bootstrap_configuration():
+            spack.bootstrap.ensure_gpg_in_path_or_raise()
+            for finder in find_gpgfn:
+                gpgfn = finder()
+                fnwrappers.append(gpgfn)
+
+        for gpgfn in fnwrappers:
+            if gpgfn:
+                gpgfn.add_default_env("GNUPGHOME", str(self.home))
+
+        return fnwrappers
+
+    @property
+    def gpg(self):
+        if not self._gpg:
+            self._gpg = self._create_gpgfn(_gpg)[0]
+            # Ensure the GPG Socket exists
+            _ = self.socket_dir
+
+        return self._gpg
+
+    def __call__(self, *args, **kwargs):
+        return self.gpg(*args, **kwargs)
+
+    @property
+    def conf(self) -> Optional[Executable]:
+        if not self._gpgconf:
+            self._gpgconf = self._create_gpgfn(_gpgconf)[0]
+
+        return self._gpgconf
+
+    @property
+    def socket_dir(self) -> Optional[pathlib.Path]:
+        if self._socket_dir:
+            return self._socket_dir
+
+        if self.conf:
+            # Set the socket dir if not using GnuPG defaults
+            self._socket_dir = _socket_dir(self.conf)
+
+            if self._socket_dir is not None:
+                self.conf("--create-socketdir")
+
+        return self._socket_dir
+
+    def _list_keys(self, *fprs, colons: bool = True, ktype: GpgKeyType = GpgKeyType.PUBLIC) -> str:
+        gpg_args = []
+
+        # Determine the list option
+        if GpgKeyType.PUBLIC in ktype:
+            gpg_args.append("--list-public-keys")
+        elif GpgKeyType.SECRET in ktype:
+            gpg_args.append("--list-secret-keys")
+        else:
+            gpg_args.append("--list-keys")
+
+        # Determine output format
+        # colons or a spack abbreviated format
+        if colons:
+            gpg_args.append("--with-colons")
+
+        # Get list of keys from keyring
+        return self.gpg(*gpg_args, "--fingerprint", *fprs, output=str)
+
+    def keys(self, *fprs, ktype: GpgKeyType = GpgKeyType.PUBLIC):
+        return _parse_gpg_output(self._list_keys(*fprs, colons=True, ktype=ktype))
+
+    def list_keys(
+        self, *fprs, ktype: GpgKeyType = GpgKeyType.PUBLIC, fmt: str = ""
+    ) -> Union[str, List[GpgKey]]:
+        """List known keys.
+
+        Args:
+            fprs: list of key fingerprints
+            ktype: Type of dey to list (default: PUBLIC)
+            fmt: format to print/return keys (default: None)
+                default (aka "") -> return default output from gpg
+                GpgKey format string->  See GpgKey __format__
+        """
+
+        # Get list of keys from keyring
+        out = self._list_keys(*fprs, colons=bool(fmt), ktype=ktype)
+        if fmt:
+            buffer = ""
+            keys = _parse_gpg_output(out)
+            for key in keys:
+                buffer += f"{{key:{fmt}}}".format(key=key)
+            return buffer
+        else:
+            return out
+
+    def trust(self, keyfile: str, ultimate: bool = True, yes_to_all: bool = False):
+        """Import a public key from a file and trust it.
+
+        Args:
+            keyfile: file with the public key
+        """
+        # This global method is safe to use to list keys in a file
+        keys = extract_public_keys(keyfile)
+        if not keys:
+            tty.info(f"No keys to trust in {keyfile}")
+            return
+
+        # Import the keys from they keyfile and verify trust for all new keys after.
+        # This avoids TOCTOU errors where the keyfile may change between extracting
+        # the expected keys and trusting the keys.
+        known_keys = self.keys()
+        self.gpg("--batch", "--import", keyfile)
+
+        # Iterate all of the keys in the keychain and confirm trust
+        for key in self.keys():
+            # Skip keys we had before trusting the keys in the file
+            if known_keys and key in known_keys:
+                continue
+
+            # Check if this key is expected, untrust anything that was not expected
+            unexpected_key = key not in keys
+            if unexpected_key:
+                tty.info(f"Untrusting unexpected key {key}")
+                self.untrust(key)
+
+            # Confirm with the user that the key should be trusted
+            if not yes_to_all and not tty.get_yes_or_no(f"Trust key: {key}", default=False):
+                tty.info(f"Untrusting key {key}")
+                self.untrust(key)
+
+            # If promoting trust level to ultimate, continue
+            if not ultimate:
+                continue
+
+            # Update the owner trust to ultimate
+            r, w = os.pipe()
+            with contextlib.closing(os.fdopen(r, "r")) as rc:
+                with contextlib.closing(os.fdopen(w, "w")) as wc:
+                    wc.write("{0}:6:\n".format(str(key)))
+                self.gpg("--import-ownertrust", input=rc)
+
+    def untrust(self, keys: List[GpgKey]):
+        """Delete known keys.
+
+        Args:
+            keys: keys to be deleted
+        """
+        skeys = [str(k) for k in keys if GpgKeyType.SECRET in k.type]
+        if skeys:
+            self.gpg("--batch", "--yes", "--delete-secret-keys", *skeys)
+
+        pkeys = [str(k) for k in keys if GpgKeyType.PUBLIC in k.type]
+        if pkeys:
+            self.gpg("--batch", "--yes", "--delete-keys", *pkeys)
+
+    def verify(
+        self,
+        signature: Union[str, pathlib.Path],
+        blob: Union[str, pathlib.Path],
+        suppress_warnings: bool = False,
+    ):
+        """Verify the signature on a blob.
+
+        Args:
+            signature: signature file (or clearsigned file)
+            blob: blob to be verified.  If None, then signature is
+                assumed to be a clearsigned file.
+            suppress_warnings: whether or not to suppress warnings
+                from GnuPG
+        """
+        args = [str(signature)]
+        if blob and str(blob) != str(signature):
+            args.append(str(blob))
+        kwargs = {"error": str} if suppress_warnings else {}
+        print('args: {" ".join(args)}')
+        self.gpg("--verify", *args, **kwargs)
+
+    def sign(
+        self,
+        blob: Union[str, pathlib.Path],
+        output: Union[str, pathlib.Path] = "",
+        key: Optional[Union[str, GpgKey]] = None,
+        armor: bool = True,
+        clearsign: bool = False,
+    ):
+        """Sign a file with a key.
+
+        Args:
+            blob: file to be signed
+            output: output file (default: f"{blob}.sig")
+            key: key to be used to sign (default: first secret key in keyring)
+            armor: ascii armored output
+            clearsign: if True wraps the document in an ASCII-armored
+                signature, if False creates a detached signature
+        """
+        args = []
+        if armor:
+            args.append("--armor")
+
+        if key:
+            args.extend(["--local-user", str(key)])
+
+        if output:
+            args.extend(["--output", str(output)])
+
+        args.append("--clearsign" if clearsign else "--detach-sign")
+        self.gpg(*args, blob)
+
+    def export_keys(self, keyfile: str, keys: List[GpgKey], ktype: GpgKeyType = GpgKeyType.PUBLIC):
+        """Export public keys to a location passed as argument.
+
+        Args:
+            keyfile: where to export the keys
+            keys: keys to be exported
+            secret: whether to export secret keys or not
+        """
+        args = ["--armor", "--output", keyfile]
+
+        if GpgKeyType.SECRET in ktype:
+            args.append("--export-secret-keys")
+        else:
+            args.extend(["--yes", "--batch", "--export"])
+
+        fprs = [str(k) for k in keys]
+        self.gpg(*args, *fprs)
+
+
 def clear():
     """Reset the global state to uninitialized."""
     global GPG, GPGCONF, SOCKET_DIR, GNUPGHOME
     GPG, GPGCONF, SOCKET_DIR, GNUPGHOME = None, None, None, None
 
 
-def init(gnupghome=None, force=False):
-    """Initialize the global objects in the module, if not set.
-
-    When calling any gpg executable, the GNUPGHOME environment
-    variable is set to:
-
-    1. The value of the ``gnupghome`` argument, if not None
-    2. The value of the "SPACK_GNUPGHOME" environment variable, if set
-    3. The default gpg path for Spack otherwise
-
-    Args:
-        gnupghome (str): value to be used for GNUPGHOME when calling
-            GnuPG executables
-        force (bool): if True forces the re-initialization even if the
-            global objects are set already
-    """
+def init(gnupghome: Optional[str] = None, force: bool = False):
+    """Initialize the global state for Gpg."""
     global GPG, GPGCONF, SOCKET_DIR, GNUPGHOME
-    import spack.bootstrap
 
     if force:
         clear()
 
-    # If the executables are already set, there's nothing to do
     if GPG and GNUPGHOME:
         return
 
-    # Set the value of GNUPGHOME to be used in this module
-    GNUPGHOME = gnupghome or os.getenv("SPACK_GNUPGHOME") or spack.paths.gpg_path
-
-    # Set the executable objects for "gpg" and "gpgconf"
-    with spack.bootstrap.ensure_bootstrap_configuration():
-        spack.bootstrap.ensure_gpg_in_path_or_raise()
-        GPG, GPGCONF = _gpg(), _gpgconf()
-
-    GPG.add_default_env("GNUPGHOME", GNUPGHOME)
-    if GPGCONF:
-        GPGCONF.add_default_env("GNUPGHOME", GNUPGHOME)
-        # Set the socket dir if not using GnuPG defaults
-        SOCKET_DIR = _socket_dir(GPGCONF)
-
-    # Make sure that the GNUPGHOME exists
-    if not os.path.exists(GNUPGHOME):
-        os.makedirs(GNUPGHOME)
-        os.chmod(GNUPGHOME, 0o700)
-
-    if not os.path.isdir(GNUPGHOME):
-        msg = 'GNUPGHOME "{0}" exists and is not a directory'.format(GNUPGHOME)
-        raise SpackGPGError(msg)
-
-    if SOCKET_DIR is not None:
-        GPGCONF("--create-socketdir")
+    GPG = Gpg(gnupghome)
+    GNUPGHOME, GPGCONF, SOCKET_DIR = GPG.home, GPG.conf, GPG.socket_dir
 
 
-def _autoinit(func):
+def _autoinit(func: Callable[..., Any]):
     """Decorator to ensure that global variables have been initialized before
     running the decorated function.
 
     Args:
-        func (callable): decorated function
+        func: decorated function
     """
 
     @functools.wraps(func)
@@ -132,69 +719,93 @@ def _autoinit(func):
 
 
 @contextlib.contextmanager
-def gnupghome_override(dir):
+def gnupghome_override(dir: str):
     """Set the GNUPGHOME to a new location for this context.
 
     Args:
-        dir (str): new value for GNUPGHOME
+        dir: new value for GNUPGHOME
     """
     global GPG, GPGCONF, SOCKET_DIR, GNUPGHOME
 
     # Store backup values
-    _GPG, _GPGCONF = GPG, GPGCONF
-    _SOCKET_DIR, _GNUPGHOME = SOCKET_DIR, GNUPGHOME
-    clear()
+    _GPG = GPG
 
-    # Clear global state
-    init(gnupghome=dir, force=True)
+    # Reset global state
+    clear()
+    GPG = Gpg(gnupghome=dir)
+    GNUPGHOME, GPGCONF, SOCKET_DIR = GPG.home, GPG.conf, GPG.socket_dir
 
     yield
 
+    # Restore previous state
     clear()
-    GPG, GPGCONF = _GPG, _GPGCONF
-    SOCKET_DIR, GNUPGHOME = _SOCKET_DIR, _GNUPGHOME
+    GPG = _GPG
+    if GPG:
+        GNUPGHOME, GPGCONF, SOCKET_DIR = GPG.home, GPG.conf, GPG.socket_dir
 
 
-def _parse_secret_keys_output(output: str) -> List[str]:
-    keys: List[str] = []
-    found_sec = False
-    for line in output.split("\n"):
-        if found_sec:
-            if line.startswith("fpr"):
-                keys.append(line.split(":")[9])
-                found_sec = False
-            elif line.startswith("ssb"):
-                found_sec = False
-        elif line.startswith("sec"):
-            found_sec = True
-    return keys
+def _parse_gpg_fields(karray: List[str]):
+    """Parse gpg line into a dict"""
+    data = {}
+    for key, value in zip(_GPG_FIELD_MAP, karray):
+        data[key] = value
+
+    return data
 
 
-def _parse_public_keys_output(output):
-    """
-    Returns a list of public keys with their fingerprints
-    """
-    keys = []
-    found_pub = False
-    current_pub_key = ""
-    for line in output.split("\n"):
-        if found_pub:
-            if line.startswith("fpr"):
-                keys.append((current_pub_key, line.split(":")[9]))
-                found_pub = False
-            elif line.startswith("ssb"):
-                found_pub = False
-        elif line.startswith("pub"):
-            current_pub_key = line.split(":")[4]
-            found_pub = True
-    return keys
-
-
-def _get_unimported_public_keys(output):
+def _parse_gpg_output(output: str) -> List[GpgKey]:
+    current_key: Optional[GpgKey] = None
+    current_subkey: Optional[GpgKey] = None
     keys = []
     for line in output.split("\n"):
-        if line.startswith("pub"):
-            keys.append(line.split(":")[4])
+        # Only parse lines with colons
+        if ":" not in line:
+            continue
+
+        data = _parse_gpg_fields(line.split(":"))
+        # Skip special fields, Spack doesn't use them
+        if data["type"] in ("cfg", "pfc", "pkd", "tfs", "tru", "spk"):
+            continue
+
+        # Start of a new key
+        if data["type"] in ("pub", "sec", "sec#"):
+            if current_subkey:
+                assert current_key
+                current_key.subkey.append(current_subkey)
+                current_subkey = None
+            if current_key:
+                keys.append(current_key)
+            current_key = GpgKey(data)
+
+        # This should never happen, but in case it does continue
+        # as spack doesn't care about lines before the first key
+        # is found.
+        if not current_key:
+            continue
+
+        # Start of a new subkey
+        if data["type"] in ("sub", "ssb"):
+            if current_subkey:
+                current_key.subkey.append(current_subkey)
+            current_subkey = GpgKey(data)
+
+        # For the fields that can be in both key and subkey
+        if data["type"] in ("sig", "fpr", "fp2"):
+            if current_subkey:
+                current_subkey.add(data)
+            else:
+                current_key.add(data)
+        else:
+            current_key.add(data)
+
+    # Append the last keys
+    if current_key:
+        if current_subkey:
+            current_key.subkey.append(current_subkey)
+            # Sort subkeys by creation time, then by capability
+            current_key.subkey.sort(key=lambda k: k.created_at)
+        keys.append(current_key)
+
     return keys
 
 
@@ -226,137 +837,127 @@ Expire-Date: %(expires)s
 
 
 @_autoinit
-def signing_keys(*args) -> List[str]:
+def signing_keys(*args) -> List[GpgKey]:
     """Return the keys that can be used to sign binaries."""
     assert GPG
-    output: str = GPG("--list-secret-keys", "--with-colons", "--fingerprint", *args, output=str)
-    return _parse_secret_keys_output(output)
+    return GPG.keys(*args, ktype=GpgKeyType.SECRET)
 
 
 @_autoinit
-def public_keys_to_fingerprint(*args):
-    """Return the keys that can be used to verify binaries."""
-    output = GPG("--list-public-keys", "--with-colons", "--fingerprint", *args, output=str)
-    return _parse_public_keys_output(output)
-
-
-@_autoinit
-def public_keys(*args):
+def public_keys(*args) -> List[GpgKey]:
     """Return a list of fingerprints"""
-    keys_and_fpr = public_keys_to_fingerprint(*args)
-    return [key_and_fpr[1] for key_and_fpr in keys_and_fpr]
+    assert GPG
+    return GPG.keys(*args, ktype=GpgKeyType.PUBLIC)
 
 
 @_autoinit
-def export_keys(location, keys, secret=False):
+def export_keys(location: str, keys: List[GpgKey], secret: bool = False):
     """Export public keys to a location passed as argument.
 
     Args:
-        location (str): where to export the keys
-        keys (list): keys to be exported
-        secret (bool): whether to export secret keys or not
+        location: where to export the keys
+        keys: keys to be exported
+        secret: whether to export secret keys or not
     """
-    if secret:
-        GPG("--export-secret-keys", "--armor", "--output", location, *keys)
-    else:
-        GPG("--batch", "--yes", "--armor", "--export", "--output", location, *keys)
+    assert GPG
+    ktype = GpgKeyType.SECRET if secret else GpgKeyType.PUBLIC
+    GPG.export_keys(location, keys, ktype=ktype)
 
 
 @_autoinit
-def trust(keyfile):
+def extract_public_keys(keyfile: str):
+    """Extract the public key ids from a file
+
+    Args:
+        keyfile: file with the public key
+    """
+    assert GPG
+    # Get the public keys we are about to import
+    output = GPG("--with-colons", "--with-fingerprint", keyfile, output=str, error=str)
+    return [k for k in _parse_gpg_output(output) if k.type == GpgKeyType.PUBLIC]
+
+
+@_autoinit
+def trust(keyfile: str, yes_to_all: bool = False):
     """Import a public key from a file and trust it.
 
     Args:
-        keyfile (str): file with the public key
+        keyfile: file with the public key
     """
-    # Get the public keys we are about to import
-    output = GPG("--with-colons", keyfile, output=str, error=str)
-    keys = _get_unimported_public_keys(output)
-
-    # Import them
-    GPG("--batch", "--import", keyfile)
-
-    # Set trust to ultimate
-    key_to_fpr = dict(public_keys_to_fingerprint())
-    for key in keys:
-        # Skip over keys we cannot find a fingerprint for.
-        if key not in key_to_fpr:
-            continue
-
-        fpr = key_to_fpr[key]
-        r, w = os.pipe()
-        with contextlib.closing(os.fdopen(r, "r")) as r:
-            with contextlib.closing(os.fdopen(w, "w")) as w:
-                w.write("{0}:6:\n".format(fpr))
-            GPG("--import-ownertrust", input=r)
+    assert GPG
+    GPG.trust(keyfile, ultimate=True, yes_to_all=yes_to_all)
 
 
 @_autoinit
-def untrust(signing, *keys):
+def untrust(signing: bool, *keys):
     """Delete known keys.
 
     Args:
-        signing (bool): if True deletes the secret keys
+        signing: if True deletes the secret keys
         *keys: keys to be deleted
     """
+    assert GPG
     if signing:
-        skeys = signing_keys(*keys)
-        GPG("--batch", "--yes", "--delete-secret-keys", *skeys)
+        GPG.untrust(GPG.keys(*keys, ktype=GpgKeyType.SECRET))
 
-    pkeys = public_keys(*keys)
-    GPG("--batch", "--yes", "--delete-keys", *pkeys)
+    untrust_keys = GPG.keys(*keys, ktype=GpgKeyType.PUBLIC)
+    GPG.untrust(untrust_keys)
 
 
 @_autoinit
-def sign(key, file, output, clearsign=False):
+def sign(key: str, file: str, output: str, clearsign: bool = False):
     """Sign a file with a key.
 
     Args:
         key: key to be used to sign
-        file (str): file to be signed
-        output (str): output file (either the clearsigned file or
+        file: file to be signed
+        output: output file (either the clearsigned file or
             the detached signature)
-        clearsign (bool): if True wraps the document in an ASCII-armored
+        clearsign: if True wraps the document in an ASCII-armored
             signature, if False creates a detached signature
     """
-    signopt = "--clearsign" if clearsign else "--detach-sign"
-    GPG(signopt, "--armor", "--local-user", key, "--output", output, file)
+    assert GPG
+    GPG.sign(file, output, key, clearsign=clearsign)
 
 
 @_autoinit
-def verify(signature, file=None, suppress_warnings=False):
+def verify(signature: str, file: Optional[str] = None, suppress_warnings: bool = False):
     """Verify the signature on a file.
 
     Args:
-        signature (str): signature of the file (or clearsigned file)
-        file (str): file to be verified.  If None, then signature is
+        signature: signature of the file (or clearsigned file)
+        file: file to be verified.  If None, then signature is
             assumed to be a clearsigned file.
-        suppress_warnings (bool): whether or not to suppress warnings
+        suppress_warnings: whether or not to suppress warnings
             from GnuPG
     """
-    args = [signature]
-    if file:
-        args.append(file)
-    kwargs = {"error": str} if suppress_warnings else {}
-    GPG("--verify", *args, **kwargs)
+    assert GPG
+    if not file:
+        file = signature
+    GPG.verify(signature, file, suppress_warnings=suppress_warnings)
 
 
 @_autoinit
-def list(trusted, signing):
+def list(trusted: bool, signing: bool, fmt: str = "default"):
     """List known keys.
 
     Args:
-        trusted (bool): if True list public keys
-        signing (bool): if True list private keys
+        trusted: if True list public keys
+        signing: if True list private keys
     """
+    assert GPG
+
     if trusted:
-        GPG("--list-public-keys")
+        tty.msg("Trusted keys")
+        print(GPG.list_keys(ktype=GpgKeyType.PUBLIC, fmt=fmt))
 
     if signing:
-        GPG("--list-secret-keys")
+        tty.msg("Signing keys")
+        print(GPG.list_keys(ktype=GpgKeyType.SECRET, fmt=fmt))
 
 
 def _verify_exe_or_raise(exe):
+    """"""
     msg = (
         "Spack requires gpgconf version >= 2\n"
         "  To install a suitable version using Spack, run\n"
@@ -376,12 +977,12 @@ def _verify_exe_or_raise(exe):
         raise SpackGPGError(msg)
 
 
-def _gpgconf():
-    exe = spack.util.executable.which("gpgconf", "gpg2conf", "gpgconf2")
-    _verify_exe_or_raise(exe)
-
+def _gpgconf() -> Optional[Executable]:
+    """Get executable for gpgconf if it exists"""
     # ensure that the gpgconf we found can run "gpgconf --create-socketdir"
     try:
+        exe = spack.util.executable.which(*GPGCONF_NAMES, required=True)
+        _verify_exe_or_raise(exe)
         exe("--dry-run", "--create-socketdir", output=os.devnull, error=os.devnull)
     except spack.util.executable.ProcessError:
         # no dice
@@ -390,21 +991,29 @@ def _gpgconf():
     return exe
 
 
-def _gpg():
-    exe = spack.util.executable.which("gpg2", "gpg")
+def _gpg() -> Executable:
+    """Get executable for gpg"""
+    exe = spack.util.executable.which(*GPG_NAMES, required=True)
     _verify_exe_or_raise(exe)
     return exe
 
 
-def _socket_dir(gpgconf):
-    # Try to ensure that (/var)/run/user/$(id -u) exists so that
-    # `gpgconf --create-socketdir` can be run later.
-    #
-    # NOTE(opadron): This action helps prevent a large class of
-    #                "file-name-too-long" errors in gpg.
+def _socket_dir(gpgconf) -> Optional[pathlib.Path]:
+    """Try to ensure that (/var)/run/user/$(id -u) exists so that
+       `gpgconf --create-socketdir` can be run later.
 
-    # If there is no suitable gpgconf, don't even bother trying to
-    # pre-create a user run dir.
+    NOTE(opadron): This action helps prevent a large class of
+                   "file-name-too-long" errors in gpg.
+
+    If there is no suitable gpgconf, don't even bother trying to
+    pre-create a user run dir.
+
+    Args:
+            gpgconf: spack.util.executable.Excutable for gpgconf
+
+    Returns:
+        path to gpg socket directory
+    """
     if not gpgconf:
         return None
 
@@ -442,6 +1051,6 @@ def _socket_dir(gpgconf):
 
         # return the last iteration that provides a usable user run dir
         if user_dir is not None:
-            result = user_dir
+            result = pathlib.Path(user_dir)
 
     return result

--- a/lib/spack/spack/util/gpg.py
+++ b/lib/spack/spack/util/gpg.py
@@ -129,7 +129,10 @@ class GpgKeyTrust(enum.Enum):
 
 
 class GpgKeyAlgorithm(enum.Enum):
-    """Gpg Algormithms"""
+    """Gpg Algormithms
+
+    ref. https://www.iana.org/assignments/openpgp/openpgp.xhtml#openpgp-public-key-algorithms
+    """
 
     RSA = 1
     RSA_SO = 2
@@ -140,12 +143,30 @@ class GpgKeyAlgorithm(enum.Enum):
     ECDSA = 19
     ELGAMAL = 20
     DH = 21
+    EDDSA = 22
+    X25519 = 25
+    X448 = 26
+    ED25519 = 27
+    ED448 = 28
+    ML_DSA_65 = 30
+    ML_DSA_87 = 31
+    SLH_DSA_SHAKE_128S = 32
+    SLH_DSA_SHAKE_128F = 33
+    SLH_DSA_SHAKE_256S = 34
+    ML_KEM_786 = 35
+    ML_KEM_1024 = 36
+    UNKNOWN = 255
     LIBGCRYPT = 256
 
     @classmethod
     def _missing_(cls, value):
         if value > 255:
             return GpgKeyAlgorithm.LIBGCRYPT
+
+        # Note: 255 is currently unassigned
+        # use it as a catch all for anything not listed
+        if value == 255:
+            return GpgKeyAlgorithm.UNKNOWN
         return None
 
     def __str__(cls):

--- a/lib/spack/spack/util/gpg.py
+++ b/lib/spack/spack/util/gpg.py
@@ -139,7 +139,7 @@ class GpgKeyTrust(enum.Enum):
 
         if isinstance(value, int):
             try:
-                return list(GpgKeyTrust)[value]
+                return list(GpgKeyTrust)[:8][value]
             except IndexError:
                 return GpgKeyTrust.ERROR
 
@@ -247,11 +247,6 @@ class GpgKeyType(enum.Flag):
 
     @classmethod
     def _missing_(cls, value):
-        if not isinstance(value, str):
-            for mem in cls:
-                if mem.value == value:
-                    return mem
-
         kname = value.strip().lower()
         if kname == "pub":
             return GpgKeyType.PUBLIC

--- a/lib/spack/spack/util/gpg.py
+++ b/lib/spack/spack/util/gpg.py
@@ -299,13 +299,13 @@ class GpgUserId:
         assert data["type"] in ("uid", "uat")
 
         self.type = data["type"]
-        self.trust = GpgKeyTrust(data["trust"])
-        if not data["created_at"]:
+        self.trust = GpgKeyTrust(data.get("trust", ""))
+        if "created_at" not in data:
             tty.warn("GPG Key User ID has no creation date")
             self.created_at = None
         else:
             self.created_at = datetime.datetime.fromtimestamp(int(data["created_at"]))
-        self.hash = data["misc"]
+        self.hash = data.get("misc", "")
         self.uid = data["uid"]
         self.origin = data.get("origin")
 
@@ -348,7 +348,7 @@ class GpgKey:
 
         self.type = GpgKeyType(data["type"])
 
-        self.trust = GpgKeyTrust(data["trust"])
+        self.trust = GpgKeyTrust(data.get("trust", ""))
         self.key_len = data["len"]
         self.key_algorithm = GpgKeyAlgorithm(int(data["key_algo"]))
         self.key_id = data["key_id"]
@@ -357,7 +357,7 @@ class GpgKey:
         if data.get("expired_at"):
             self.expires_at = datetime.datetime.fromtimestamp(int(data["expired_at"]))
 
-        self.owner_trust = GpgKeyTrust(data["owner_trust"])
+        self.owner_trust = GpgKeyTrust(data.get("owner_trust", ""))
 
         self.capabilities = set()
         for cap in data.get("capabilities", []):
@@ -808,7 +808,8 @@ def _parse_gpg_fields(karray: List[str]):
     """Parse gpg line into a dict"""
     data = {}
     for key, value in zip(_GPG_FIELD_MAP, karray):
-        data[key] = value
+        if value:
+            data[key] = value
 
     return data
 

--- a/lib/spack/spack/util/gpg.py
+++ b/lib/spack/spack/util/gpg.py
@@ -9,6 +9,7 @@ import functools
 import os
 import pathlib
 import re
+import sys
 from typing import Any, Callable, Dict, List, Optional, Union
 
 import spack.error
@@ -489,13 +490,18 @@ class Gpg:
     """Wrapper for GPG"""
 
     def __init__(self, gnupghome: Optional[str] = None):
-        self.home = Gpg._init_gnupghome(gnupghome)
+        if sys.platform == "win32":
+            self.home = Gpg._init_gnupghome_dir(gnupghome)
+        else:
+            self.home = Gpg._init_gnupghome_posix(gnupghome)
+
         self._gpg: Optional[Executable] = None
         self._gpgconf: Optional[Executable] = None
         self._socket_dir: Optional[pathlib.Path] = None
 
     @staticmethod
-    def _init_gnupghome(gnupghome: Optional[str] = None) -> pathlib.Path:
+    def _init_gnupghome_dir(gnupghome: Optional[str] = None) -> pathlib.Path:
+        """Init gnupg home but don't check permissions"""
         # Make sure that the gnupghome exists
         gnupghome = gnupghome or os.getenv("SPACK_GNUPGHOME") or spack.paths.gpg_path
         if not os.path.exists(gnupghome):
@@ -506,12 +512,23 @@ class Gpg:
             msg = 'gnupghome "{0}" exists and is not a directory'.format(gnupghome)
             raise SpackGPGError(msg)
 
-        st = os.stat(gnupghome)
-        if st.st_mode != (st.st_mode & 0o040700):
-            msg = 'gnupghome "{0}" has unsafe permissions for a GPG directory'.format(gnupghome)
+        if not os.access(gnupghome, os.R_OK | os.W_OK | os.X_OK):
+            msg = 'gnupghome "{0}" exists but is not accessible'.format(gnupghome)
             raise SpackGPGError(msg)
 
         return pathlib.Path(gnupghome)
+
+    @staticmethod
+    def _init_gnupghome_posix(gnupghome: Optional[str] = None) -> pathlib.Path:
+        """Init gnupg home and check permissions."""
+        gnupghome = Gpg._init_gnupghome_dir(gnupghome)
+
+        # Ensure safe permissions on posix systems
+        st = gnupghome.stat()
+        if st.st_mode != (st.st_mode & 0o040700):
+            os.chmod(gnupghome, 0o700)
+
+        return gnupghome
 
     def _create_gpgfn(self, finder: Callable[..., Optional[Executable]]) -> Optional[Executable]:
         """Create a GPG function wrapper"""

--- a/lib/spack/spack/util/gpg.py
+++ b/lib/spack/spack/util/gpg.py
@@ -731,7 +731,7 @@ class Gpg:
             keys: keys to be exported
             secret: whether to export secret keys or not
         """
-        args = ["--armor", "--output", keyfile]
+        args = ["--yes", "--batch", "--armor", "--output", keyfile]
 
         if GpgKeyType.SECRET in ktype:
             args.append("--export-secret-keys")

--- a/lib/spack/spack/util/gpg.py
+++ b/lib/spack/spack/util/gpg.py
@@ -192,8 +192,6 @@ class GpgKeyAlgorithm(enum.Enum):
 
         if value > 255:
             return GpgKeyAlgorithm.LIBGCRYPT
-        elif value == 255:
-            raise ValueError("Algorithm id 255 is assumed to be unassigned")
         else:  # value < 255
             return GpgKeyAlgorithm.UNKNOWN
 

--- a/lib/spack/spack/util/gpg.py
+++ b/lib/spack/spack/util/gpg.py
@@ -9,6 +9,7 @@ import functools
 import os
 import pathlib
 import re
+import warnings
 from typing import Any, Callable, Dict, List, Optional, Union
 
 import spack.error
@@ -155,19 +156,24 @@ class GpgKeyAlgorithm(enum.Enum):
     SLH_DSA_SHAKE_256S = 34
     ML_KEM_786 = 35
     ML_KEM_1024 = 36
+    # Note: 255 is currently unassigned
+    # use it as a catch all for anything not listed
     UNKNOWN = 255
     LIBGCRYPT = 256
 
     @classmethod
     def _missing_(cls, value):
+        if not isinstance(value, int):
+            raise ValueError(
+                "GpgKeyAlgorithm can only be constructed from another Enum or an `int`"
+            )
+
         if value > 255:
             return GpgKeyAlgorithm.LIBGCRYPT
-
-        # Note: 255 is currently unassigned
-        # use it as a catch all for anything not listed
-        if value == 255:
+        elif value == 255:
+            raise ValueError("Algorithm id 255 is assumed to be unassigned")
+        else: # value < 255
             return GpgKeyAlgorithm.UNKNOWN
-        return None
 
     def __str__(cls):
         name = cls.name.lower()
@@ -177,12 +183,21 @@ class GpgKeyAlgorithm(enum.Enum):
 
     def __format__(cls, fspec):
         """Format type with length
-        ex. f"{gpg_algo:{gpg_len}}"
+        ex.
+            gpg_algo = GpgKeyAlgorithm.RSA
+            gpg_len = 2046
+            f"{gpg_algo:{gpg_len}}" -> "rsa 2046"
+
+            f"{gpg_algo}" -> "rsa"
         """
-        int(fspec)
+        # Only allow integer sizes
         name = cls.name.lower()
-        name = name.replace("_so", f"{fspec} (Signing only)")
-        name = name.replace("_eo", f"{fspec} (Encryption only)")
+        if fspec:
+            fspec = int(fspec)
+            name += f" {fspec}"
+
+        name = name.replace("_so", " (Signing only)")
+        name = name.replace("_eo", " (Encryption only)")
         return name
 
 
@@ -471,31 +486,32 @@ class Gpg:
             msg = 'gnupghome "{0}" exists and is not a directory'.format(gnupghome)
             raise SpackGPGError(msg)
 
+        st = os.stat(gnupghome)
+        if st.st_mode != (st.st_mode & 0o040700):
+            msg = 'gnupghome "{0}" has unsafe permissions for a GPG directory'.format(gnupghome)
+            raise SpackGPGError(msg)
+
         return pathlib.Path(gnupghome)
 
     def _create_gpgfn(
-        self, *find_gpgfn: Callable[..., Optional[Executable]]
-    ) -> List[Optional[Executable]]:
+        self, finder: Callable[..., Optional[Executable]]
+    ) -> Optional[Executable]:
         """Create a GPG function wrapper"""
         import spack.bootstrap
 
-        fnwrappers = []
         with spack.bootstrap.ensure_bootstrap_configuration():
             spack.bootstrap.ensure_gpg_in_path_or_raise()
-            for finder in find_gpgfn:
-                gpgfn = finder()
-                fnwrappers.append(gpgfn)
+            gpgfn = finder()
 
-        for gpgfn in fnwrappers:
-            if gpgfn:
-                gpgfn.add_default_env("GNUPGHOME", str(self.home))
+        if gpgfn:
+            gpgfn.add_default_env("GNUPGHOME", str(self.home))
 
-        return fnwrappers
+        return gpgfn
 
     @property
     def gpg(self):
         if not self._gpg:
-            self._gpg = self._create_gpgfn(_gpg)[0]
+            self._gpg = self._create_gpgfn(_gpg)
             # Ensure the GPG Socket exists
             _ = self.socket_dir
 
@@ -507,7 +523,7 @@ class Gpg:
     @property
     def conf(self) -> Optional[Executable]:
         if not self._gpgconf:
-            self._gpgconf = self._create_gpgfn(_gpgconf)[0]
+            self._gpgconf = self._create_gpgfn(_gpgconf)
 
         return self._gpgconf
 
@@ -544,7 +560,7 @@ class Gpg:
         # Get list of keys from keyring
         return self.gpg(*gpg_args, *fprs, output=str)
 
-    def keys(self, *fprs, ktype: GpgKeyType = GpgKeyType.PUBLIC):
+    def keys(self, *fprs, ktype: GpgKeyType = GpgKeyType.PUBLIC) -> List[GpgKey]:
         return _parse_gpg_output(self._list_keys(*fprs, colons=True, ktype=ktype))
 
     def list_keys(
@@ -592,13 +608,15 @@ class Gpg:
         # Iterate all of the keys in the keychain and confirm trust
         for key in self.keys():
             # Skip keys we had before trusting the keys in the file
-            if known_keys and key in known_keys:
+            if key in known_keys:
                 continue
 
             # Check if this key is expected, untrust anything that was not expected
             unexpected_key = key not in keys
             if unexpected_key:
-                tty.info(f"Untrusting unexpected key {key}")
+                warnings.warn(
+                    f"Untrusting unexpected new key {key} discovered in keyring but not in {keyfile}. "
+                )
                 self.untrust(key)
 
             # Confirm with the user that the key should be trusted
@@ -649,14 +667,13 @@ class Gpg:
         args = [str(signature)]
         if blob and str(blob) != str(signature):
             args.append(str(blob))
-        kwargs = {"error": str} if suppress_warnings else {}
-        print('args: {" ".join(args)}')
+        kwargs = {"error": os.devnull} if suppress_warnings else {}
         self.gpg("--verify", *args, **kwargs)
 
     def sign(
         self,
         blob: Union[str, pathlib.Path],
-        output: Union[str, pathlib.Path] = "",
+        output: Optional[Union[str, pathlib.Path]] = None,
         key: Optional[Union[str, GpgKey]] = None,
         armor: bool = True,
         clearsign: bool = False,
@@ -697,7 +714,7 @@ class Gpg:
         if GpgKeyType.SECRET in ktype:
             args.append("--export-secret-keys")
         else:
-            args.extend(["--yes", "--batch", "--export"])
+            args.extend(["--export"])
 
         fprs = [str(k) for k in keys]
         self.gpg(*args, *fprs)
@@ -793,6 +810,7 @@ def _parse_gpg_output(output: str) -> List[GpgKey]:
             if current_subkey:
                 assert current_key
                 current_key.subkey.append(current_subkey)
+                current_key.subkey.sort(key=lambda k: k.created_at)
                 current_subkey = None
             if current_key:
                 keys.append(current_key)
@@ -978,7 +996,8 @@ def list(trusted: bool, signing: bool, fmt: str = "default"):
 
 
 def _verify_exe_or_raise(exe):
-    """"""
+    """Verify that the gpg executable is a new enough version."""
+
     msg = (
         "Spack requires gpgconf version >= 2\n"
         "  To install a suitable version using Spack, run\n"
@@ -1001,15 +1020,17 @@ def _verify_exe_or_raise(exe):
 def _gpgconf() -> Optional[Executable]:
     """Get executable for gpgconf if it exists"""
     # ensure that the gpgconf we found can run "gpgconf --create-socketdir"
+    exe = spack.util.executable.which(*GPGCONF_NAMES)
+    if not exe:
+        return None
+
     try:
-        exe = spack.util.executable.which(*GPGCONF_NAMES, required=True)
         _verify_exe_or_raise(exe)
         exe("--dry-run", "--create-socketdir", output=os.devnull, error=os.devnull)
+        return exe
     except spack.util.executable.ProcessError:
         # no dice
-        exe = None
-
-    return exe
+        return None
 
 
 def _gpg() -> Executable:
@@ -1019,7 +1040,7 @@ def _gpg() -> Executable:
     return exe
 
 
-def _socket_dir(gpgconf) -> Optional[pathlib.Path]:
+def _socket_dir(gpgconf: Optional[Executable]) -> Optional[pathlib.Path]:
     """Try to ensure that (/var)/run/user/$(id -u) exists so that
        `gpgconf --create-socketdir` can be run later.
 
@@ -1028,9 +1049,6 @@ def _socket_dir(gpgconf) -> Optional[pathlib.Path]:
 
     If there is no suitable gpgconf, don't even bother trying to
     pre-create a user run dir.
-
-    Args:
-            gpgconf: spack.util.executable.Excutable for gpgconf
 
     Returns:
         path to gpg socket directory

--- a/lib/spack/spack/util/gpg.py
+++ b/lib/spack/spack/util/gpg.py
@@ -612,8 +612,7 @@ class Gpg:
                 continue
 
             # Check if this key is expected, untrust anything that was not expected
-            unexpected_key = key not in keys
-            if unexpected_key:
+            if key not in keys:
                 warnings.warn(
                     f"Untrusting unexpected new key {key} discovered in keyring but not in {keyfile}. "
                 )
@@ -983,6 +982,15 @@ def list(trusted: bool, signing: bool, fmt: str = "default"):
     Args:
         trusted: if True list public keys
         signing: if True list private keys
+        fmt: Key formatting string
+            Values:
+                default: print output from gpg
+
+                GpgKey formatting string
+                    c[olons] - Output everything using a gpg style colon format ie.
+                    s[hort] - Shortened output ie. <fingerprint> (<uid>)
+                    f[pr] - Fingerprint only output ie. <fingerprint>
+
     """
     assert GPG
 
@@ -1044,7 +1052,7 @@ def _socket_dir(gpgconf: Optional[Executable]) -> Optional[pathlib.Path]:
     """Try to ensure that (/var)/run/user/$(id -u) exists so that
        `gpgconf --create-socketdir` can be run later.
 
-    NOTE(opadron): This action helps prevent a large class of
+    NOTE: This action helps prevent a large class of
                    "file-name-too-long" errors in gpg.
 
     If there is no suitable gpgconf, don't even bother trying to
@@ -1076,13 +1084,12 @@ def _socket_dir(gpgconf: Optional[Executable]) -> Optional[pathlib.Path]:
         # If the above operation fails due to lack of permissions, then
         # just carry on without running gpgconf and hope for the best.
         #
-        # NOTE(opadron): Without a dir in which to create a socket for IPC,
+        # NOTE: Without a dir in which to create a socket for IPC,
         #                gnupg may fail if GNUPGHOME is set to a path that
         #                is too long, where "too long" in this context is
         #                actually quite short; somewhere in the
         #                neighborhood of more than 100 characters.
         #
-        # TODO(opadron): Maybe a warning should be printed in this case?
         except OSError as exc:
             if exc.errno not in (errno.EPERM, errno.EACCES):
                 raise

--- a/lib/spack/spack/util/gpg.py
+++ b/lib/spack/spack/util/gpg.py
@@ -72,7 +72,7 @@ _GPG_FIELD_MAP = [
     "key_algo",
     "key_id",
     "created_at",
-    "expire_at",
+    "expires_at",
     "misc",
     "owner_trust",
     "uid",
@@ -103,7 +103,7 @@ class GpgKeyCapability(enum.Enum):
     @classmethod
     def _missing_(cls, value):
         for cap in cls:
-            if value.lower() == cap.value:
+            if value.lower() == cap.value.lower():
                 return cap
         return GpgKeyCapability.UNKNOWN
 
@@ -146,7 +146,7 @@ class GpgKeyTrust(enum.Enum):
     def ownertrust(self) -> int:
         """Return the ownertrust file integer corresponding to the GpgKeyTrust"""
         try:
-            return list(GpgKeyTrust).index(self)
+            return list(GpgKeyTrust)[:8].index(self)
         except ValueError:
             return 8  # GpgKeyTrust.ERROR
 
@@ -351,8 +351,8 @@ class GpgKey:
         self.key_id = data["key_id"]
         self.created_at = datetime.datetime.fromtimestamp(int(data["created_at"]))
         self.expires_at: Optional[datetime.datetime] = None
-        if data.get("expired_at"):
-            self.expires_at = datetime.datetime.fromtimestamp(int(data["expired_at"]))
+        if data.get("expires_at"):
+            self.expires_at = datetime.datetime.fromtimestamp(int(data["expires_at"]))
 
         self.owner_trust = GpgKeyTrust(data.get("owner_trust", ""))
 
@@ -419,7 +419,7 @@ class GpgKey:
         data["key_id"] = self.key_id
         data["created_at"] = int(self.created_at.timestamp())
         if self.expires_at:
-            data["expired_at"] = int(self.expires_at.timestamp())
+            data["expires_at"] = int(self.expires_at.timestamp())
         if self.updated_at:
             data["updated_at"] = int(self.updated_at.timestamp())
 
@@ -631,7 +631,7 @@ class Gpg:
             # Confirm with the user that the key should be trusted
             if not yes_to_all and not tty.get_yes_or_no(f"Trust key: {key}", default=False):
                 tty.info(f"Spack will not trust key {key}")
-                self.untrust(key)
+                self.untrust([key])
 
             ownertrust = GpgKeyTrust.FULL.ownertrust
             if ultimate:

--- a/lib/spack/spack/util/gpg.py
+++ b/lib/spack/spack/util/gpg.py
@@ -112,21 +112,44 @@ class GpgKeyCapability(enum.Enum):
 class GpgKeyTrust(enum.Enum):
     """Gpg Trust normalized for Field 1 and Field 9"""
 
-    INVALID = "i"
-    REVOKED = "r"
+    UNKNOWN = "-"  # also o or i
     EXPIRED = "e"
-    UNKNOWN = "-"  # - o
+    UNDEFINED = "q"
     NEVER = "n"
     MARGINAL = "m"
     FULL = "f"
     ULTIMATE = "u"
+    REVOKED = "r"
+    ERROR = "?"
     KNOWN = "w"
     SPECIAL = "s"
 
     @classmethod
     def _missing_(cls, value):
-        # If it is not found, then it is unknown
-        return GpgKeyTrust.UNKNOWN
+
+        if isinstance(value, str):
+            value = value.lower()
+
+            # If it is not found, then it is unknown
+            if value in ("o", "i"):
+                return GpgKeyTrust.UNKNOWN
+
+            value_to_trust = dict([(t.value, t) for t in GpgKeyTrust])
+            return value_to_trust.get(value, GpgKeyTrust.ERROR)
+
+        if isinstance(value, int):
+            try:
+                return list(GpgKeyTrust)[value]
+            except IndexError:
+                return GpgKeyTrust.ERROR
+
+    @property
+    def ownertrust(self) -> int:
+        """Return the ownertrust file integer corresponding to the GpgKeyTrust"""
+        try:
+            return list(GpgKeyTrust).index(self)
+        except ValueError:
+            return 8  # GpgKeyTrust.ERROR
 
 
 class GpgKeyAlgorithm(enum.Enum):
@@ -172,7 +195,7 @@ class GpgKeyAlgorithm(enum.Enum):
             return GpgKeyAlgorithm.LIBGCRYPT
         elif value == 255:
             raise ValueError("Algorithm id 255 is assumed to be unassigned")
-        else: # value < 255
+        else:  # value < 255
             return GpgKeyAlgorithm.UNKNOWN
 
     def __str__(cls):
@@ -493,9 +516,7 @@ class Gpg:
 
         return pathlib.Path(gnupghome)
 
-    def _create_gpgfn(
-        self, finder: Callable[..., Optional[Executable]]
-    ) -> Optional[Executable]:
+    def _create_gpgfn(self, finder: Callable[..., Optional[Executable]]) -> Optional[Executable]:
         """Create a GPG function wrapper"""
         import spack.bootstrap
 
@@ -614,7 +635,8 @@ class Gpg:
             # Check if this key is expected, untrust anything that was not expected
             if key not in keys:
                 warnings.warn(
-                    f"Untrusting unexpected new key {key} discovered in keyring but not in {keyfile}. "
+                    f"Untrusting unexpected new key {key} discovered in keyring but not "
+                    f"in {keyfile}."
                 )
                 self.untrust(key)
 
@@ -624,14 +646,15 @@ class Gpg:
                 self.untrust(key)
 
             # If promoting trust level to ultimate, continue
-            if not ultimate:
-                continue
+            ownertrust = GpgKeyTrust.FULL.ownertrust
+            if ultimate:
+                ownertrust = GpgKeyTrust.ULTIMATE.ownertrust
 
             # Update the owner trust to ultimate
             r, w = os.pipe()
             with contextlib.closing(os.fdopen(r, "r")) as rc:
                 with contextlib.closing(os.fdopen(w, "w")) as wc:
-                    wc.write("{0}:6:\n".format(str(key)))
+                    wc.write(f"{key.fpr}:{ownertrust}:\n")
                 self.gpg("--import-ownertrust", input=rc)
 
     def untrust(self, keys: List[GpgKey]):

--- a/lib/spack/spack/util/gpg.py
+++ b/lib/spack/spack/util/gpg.py
@@ -9,7 +9,6 @@ import functools
 import os
 import pathlib
 import re
-import warnings
 from typing import Any, Callable, Dict, List, Optional, Union
 
 import spack.error
@@ -615,37 +614,27 @@ class Gpg:
             keyfile: file with the public key
         """
         # This global method is safe to use to list keys in a file
-        keys = extract_public_keys(keyfile)
-        if not keys:
+        imported_keys = extract_public_keys(keyfile)
+        if not imported_keys:
             tty.info(f"No keys to trust in {keyfile}")
             return
 
         # Import the keys from they keyfile and verify trust for all new keys after.
         # This avoids TOCTOU errors where the keyfile may change between extracting
         # the expected keys and trusting the keys.
-        known_keys = self.keys()
-        self.gpg("--batch", "--import", keyfile)
+        self.gpg("--yes", "--batch", "--import", keyfile)
 
         # Iterate all of the keys in the keychain and confirm trust
         for key in self.keys():
             # Skip keys we had before trusting the keys in the file
-            if key in known_keys:
+            if key not in imported_keys:
                 continue
-
-            # Check if this key is expected, untrust anything that was not expected
-            if key not in keys:
-                warnings.warn(
-                    f"Untrusting unexpected new key {key} discovered in keyring but not "
-                    f"in {keyfile}."
-                )
-                self.untrust(key)
 
             # Confirm with the user that the key should be trusted
             if not yes_to_all and not tty.get_yes_or_no(f"Trust key: {key}", default=False):
-                tty.info(f"Untrusting key {key}")
+                tty.info(f"Spack will not trust key {key}")
                 self.untrust(key)
 
-            # If promoting trust level to ultimate, continue
             ownertrust = GpgKeyTrust.FULL.ownertrust
             if ultimate:
                 ownertrust = GpgKeyTrust.ULTIMATE.ownertrust

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -1264,7 +1264,7 @@ _spack_gpg() {
 _spack_gpg_trust() {
     if $list_options
     then
-        SPACK_COMPREPLY="-h --help"
+        SPACK_COMPREPLY="-h --help -y --yes-to-all"
     else
         SPACK_COMPREPLY=""
     fi
@@ -1289,11 +1289,11 @@ _spack_gpg_create() {
 }
 
 _spack_gpg_list() {
-    SPACK_COMPREPLY="-h --help --trusted --signing"
+    SPACK_COMPREPLY="-h --help --fmt -f --trusted --signing"
 }
 
 _spack_gpg_init() {
-    SPACK_COMPREPLY="-h --help --from"
+    SPACK_COMPREPLY="-h --help --from -y --yes-to-all"
 }
 
 _spack_gpg_export() {

--- a/share/spack/spack-completion.fish
+++ b/share/spack/spack-completion.fish
@@ -1978,10 +1978,12 @@ complete -c spack -n '__fish_spack_using_command gpg' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command gpg' -s h -l help -d 'show this help message and exit'
 
 # spack gpg trust
-set -g __fish_spack_optspecs_spack_gpg_trust h/help
+set -g __fish_spack_optspecs_spack_gpg_trust h/help y/yes-to-all
 
 complete -c spack -n '__fish_spack_using_command gpg trust' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command gpg trust' -s h -l help -d 'show this help message and exit'
+complete -c spack -n '__fish_spack_using_command gpg trust' -s y -l yes-to-all -f -a yes_to_all
+complete -c spack -n '__fish_spack_using_command gpg trust' -s y -l yes-to-all -d 'assume "yes" is the answer to every confirmation request'
 
 # spack gpg untrust
 set -g __fish_spack_optspecs_spack_gpg_untrust h/help signing
@@ -2006,19 +2008,23 @@ complete -c spack -n '__fish_spack_using_command gpg create' -l export-secret -r
 complete -c spack -n '__fish_spack_using_command gpg create' -l export-secret -r -d 'export the private key to a file'
 
 # spack gpg list
-set -g __fish_spack_optspecs_spack_gpg_list h/help trusted signing
+set -g __fish_spack_optspecs_spack_gpg_list h/help f/fmt= trusted signing
 complete -c spack -n '__fish_spack_using_command gpg list' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command gpg list' -s h -l help -d 'show this help message and exit'
+complete -c spack -n '__fish_spack_using_command gpg list' -l fmt -s f -r -f -a fmt
+complete -c spack -n '__fish_spack_using_command gpg list' -l fmt -s f -r -d 'Format to list keys with (default (gpg), colons, keys, <key format string>)'
 complete -c spack -n '__fish_spack_using_command gpg list' -l trusted -f -a trusted
 complete -c spack -n '__fish_spack_using_command gpg list' -l trusted -d 'list trusted keys'
 complete -c spack -n '__fish_spack_using_command gpg list' -l signing -f -a signing
 complete -c spack -n '__fish_spack_using_command gpg list' -l signing -d 'list keys which may be used for signing'
 
 # spack gpg init
-set -g __fish_spack_optspecs_spack_gpg_init h/help from=
+set -g __fish_spack_optspecs_spack_gpg_init h/help from= y/yes-to-all
 complete -c spack -n '__fish_spack_using_command gpg init' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command gpg init' -s h -l help -d 'show this help message and exit'
 complete -c spack -n '__fish_spack_using_command gpg init' -l from -r -f -a import_dir
+complete -c spack -n '__fish_spack_using_command gpg init' -s y -l yes-to-all -f -a yes_to_all
+complete -c spack -n '__fish_spack_using_command gpg init' -s y -l yes-to-all -d 'assume "yes" is the answer to every confirmation request'
 
 # spack gpg export
 set -g __fish_spack_optspecs_spack_gpg_export h/help secret


### PR DESCRIPTION
The GPG module is central to the verification pipeline used for
build cache binaries. This is important for both bootstrapping and for
install. However, the current architecture for GPG utilizes a shared
global state for all signing and verification which can lead to
incorrect contexts being used.

In order to improve Spack's ability to control the context of GPG, the
GPG util has been refactored to wrap all of the components required to
configuring GPG into a single class `Gpg`. This class owns its own gpg
home, socket, gpgconf, and gpg command wrapper. This model enables
bootstrap and install to create their own configurable instances of gpg
without needing to update global state.

In addition to cleaning up global state, this refactored also
implements a more complete parsing of GPG keys and signature information
allowing for more detailed interactions with GPG keys beyond just
fingerprint in Spack without having to re-consult Gpg to extract
additional information.

This refactor also improves the workflow around trusting keys. The
previous workflow had a TOCTOU where the keys were listed and then
trusted from the keyfile. The list was verified before promoting keys to
ultimate, but could leave unexpected keys in the keyring if the file
changed. The new version automatically untrusts keys
that are new but not found in the initial listing. It also prompts the user to
verify that each new key should be trusted before finalizing the
ultimate trust step.