### PR TITLE
Remove GPG commands that no longer apply 

### DIFF
--- a/lib/spack/spack/cmd/gpg.py
+++ b/lib/spack/spack/cmd/gpg.py
@@ -23,11 +23,6 @@ def setup_parser(subparser: argparse.ArgumentParser) -> None:
     setattr(setup_parser, "parser", subparser)
     subparsers = subparser.add_subparsers(help="GPG sub-commands")
 
-    verify = subparsers.add_parser("verify", help=gpg_verify.__doc__)
-    arguments.add_common_arguments(verify, ["installed_spec"])
-    verify.add_argument("signature", type=str, nargs="?", help="the signature file")
-    verify.set_defaults(func=gpg_verify, subparser=verify)
-
     trust = subparsers.add_parser("trust", help=gpg_trust.__doc__)
     trust.add_argument("keyfile", type=str, help="add a key to the trust store")
     trust.set_defaults(func=gpg_trust, subparser=trust)
@@ -36,17 +31,6 @@ def setup_parser(subparser: argparse.ArgumentParser) -> None:
     untrust.add_argument("--signing", action="store_true", help="allow untrusting signing keys")
     untrust.add_argument("keys", nargs="+", type=str, help="remove keys from the trust store")
     untrust.set_defaults(func=gpg_untrust, subparser=untrust)
-
-    sign = subparsers.add_parser("sign", help=gpg_sign.__doc__)
-    sign.add_argument(
-        "--output", metavar="DEST", type=str, help="the directory to place signatures"
-    )
-    sign.add_argument("--key", metavar="KEY", type=str, help="the key to use for signing")
-    sign.add_argument(
-        "--clearsign", action="store_true", help="if specified, create a clearsign signature"
-    )
-    arguments.add_common_arguments(sign, ["installed_spec"])
-    sign.set_defaults(func=gpg_sign, subparser=sign)
 
     create = subparsers.add_parser("create", help=gpg_create.__doc__)
     create.add_argument("name", type=str, help="the name to use for the new key")
@@ -127,6 +111,23 @@ def setup_parser(subparser: argparse.ArgumentParser) -> None:
     )
     publish.set_defaults(func=gpg_publish, subparser=publish)
 
+    # Deprecated
+    verify = subparsers.add_parser("verify", help=gpg_verify.__doc__, deprecated=True)
+    arguments.add_common_arguments(verify, ["installed_spec"])
+    verify.add_argument("signature", type=str, nargs="?", help="the signature file")
+    verify.set_defaults(func=gpg_verify, subparser=verify)
+
+    sign = subparsers.add_parser("sign", help=gpg_sign.__doc__, deprecated=True)
+    sign.add_argument(
+        "--output", metavar="DEST", type=str, help="the directory to place signatures"
+    )
+    sign.add_argument("--key", metavar="KEY", type=str, help="the key to use for signing")
+    sign.add_argument(
+        "--clearsign", action="store_true", help="if specified, create a clearsign signature"
+    )
+    arguments.add_common_arguments(sign, ["installed_spec"])
+    sign.set_defaults(func=gpg_sign, subparser=sign)
+
 
 def gpg_create(args):
     """create a new key"""
@@ -160,24 +161,6 @@ def gpg_list(args):
     spack.util.gpg.list(args.trusted, args.signing)
 
 
-def gpg_sign(args):
-    """sign a package"""
-    key = args.key
-    if key is None:
-        keys = spack.util.gpg.signing_keys()
-        if len(keys) == 1:
-            key = keys[0]
-        elif not keys:
-            raise RuntimeError("no signing keys are available")
-        else:
-            raise RuntimeError("multiple signing keys are available; please choose one")
-    output = args.output
-    if not output:
-        output = args.spec[0] + ".asc"
-    # TODO: Support the package format Spack creates.
-    spack.util.gpg.sign(key, " ".join(args.spec), output, args.clearsign)
-
-
 def gpg_trust(args):
     """add a key to the keyring"""
     spack.util.gpg.trust(args.keyfile)
@@ -201,15 +184,6 @@ def gpg_untrust(args):
     spack.util.gpg.untrust(args.signing, *args.keys)
 
 
-def gpg_verify(args):
-    """verify a signed package"""
-    # TODO: Support the package format Spack creates.
-    signature = args.signature
-    if signature is None:
-        signature = args.spec[0] + ".asc"
-    spack.util.gpg.verify(signature, " ".join(args.spec))
-
-
 def gpg_publish(args):
     """publish public keys to a build cache"""
 
@@ -226,6 +200,22 @@ def gpg_publish(args):
         spack.binary_distribution._url_push_keys(
             mirror, keys=args.keys, tmpdir=tmpdir, update_index=args.update_index
         )
+
+
+def gpg_sign(args):
+    """sign a package"""
+    raise NotImplementedError(
+        "This command has been deprecated as it no longer applies to any supported build cache. "
+        "Use `gpg --detach-sign` instead"
+    )
+
+
+def gpg_verify(args):
+    """verify a signed package"""
+    raise NotImplementedError(
+        "This command has been deprecated as it no longer applies to any supported build cache. "
+        "Use `gpg --verify` instead"
+    )
 
 
 def gpg(parser, args):

--- a/lib/spack/spack/cmd/gpg.py
+++ b/lib/spack/spack/cmd/gpg.py
@@ -204,7 +204,7 @@ def gpg_publish(args):
 
 def gpg_sign(args):
     """sign a package"""
-    raise NotImplementedError(
+    args.subparser.error(
         "This command has been deprecated as it no longer applies to any supported build cache. "
         "Use `gpg --detach-sign` instead"
     )
@@ -212,7 +212,7 @@ def gpg_sign(args):
 
 def gpg_verify(args):
     """verify a signed package"""
-    raise NotImplementedError(
+    args.subparser.error(
         "This command has been deprecated as it no longer applies to any supported build cache. "
         "Use `gpg --verify` instead"
     )

--- a/lib/spack/spack/cmd/gpg.py
+++ b/lib/spack/spack/cmd/gpg.py
@@ -112,12 +112,12 @@ def setup_parser(subparser: argparse.ArgumentParser) -> None:
     publish.set_defaults(func=gpg_publish, subparser=publish)
 
     # Deprecated
-    verify = subparsers.add_parser("verify", help=gpg_verify.__doc__, deprecated=True)
+    verify = subparsers.add_parser("verify", help=gpg_verify.__doc__)
     arguments.add_common_arguments(verify, ["installed_spec"])
     verify.add_argument("signature", type=str, nargs="?", help="the signature file")
     verify.set_defaults(func=gpg_verify, subparser=verify)
 
-    sign = subparsers.add_parser("sign", help=gpg_sign.__doc__, deprecated=True)
+    sign = subparsers.add_parser("sign", help=gpg_sign.__doc__)
     sign.add_argument(
         "--output", metavar="DEST", type=str, help="the directory to place signatures"
     )

--- a/lib/spack/spack/test/cmd/gpg.py
+++ b/lib/spack/spack/test/cmd/gpg.py
@@ -11,7 +11,7 @@ import spack.binary_distribution
 import spack.llnl.util.filesystem as fs
 import spack.util.gpg
 from spack.main import SpackCommand
-from spack.paths import mock_gpg_data_path, mock_gpg_keys_path
+from spack.paths import mock_gpg_keys_path
 from spack.util.executable import ProcessError
 
 #: spack command used by tests below
@@ -60,37 +60,24 @@ def test_no_gpg_in_path(tmp_path: pathlib.Path, mock_gnupghome, monkeypatch, mut
 
 @pytest.mark.maybeslow
 def test_gpg(tmp_path: pathlib.Path, mutable_config, mock_gnupghome):
-    # Verify a file with an empty keyring.
-    with pytest.raises(ProcessError):
-        gpg("verify", os.path.join(mock_gpg_data_path, "content.txt"))
+    MOCK_KEY = "B27095DEEF1787C3C8C85917DCA0241840A5DAE2"
 
     # Import the default key.
     gpg("init", "--from", mock_gpg_keys_path)
 
     # List the keys.
     # TODO: Test the output here.
-    gpg("list", "--trusted")
-    gpg("list", "--signing")
+    out = gpg("list", "--trusted")
+    assert out.count(MOCK_KEY) == 1
 
-    # Verify the file now that the key has been trusted.
-    gpg("verify", os.path.join(mock_gpg_data_path, "content.txt"))
+    out = gpg("list", "--signing")
+    assert out.count(MOCK_KEY) == 1
 
     # Untrust the default key.
     gpg("untrust", "Spack testing")
 
-    # Now that the key is untrusted, verification should fail.
-    with pytest.raises(ProcessError):
-        gpg("verify", os.path.join(mock_gpg_data_path, "content.txt"))
-
-    # Create a file to test signing.
-    test_path = tmp_path / "to-sign.txt"
-    with open(str(test_path), "w+", encoding="utf-8") as fout:
-        fout.write("Test content for signing.\n")
-
-    # Signing without a private key should fail.
-    with pytest.raises(RuntimeError) as exc_info:
-        gpg("sign", str(test_path))
-    assert exc_info.value.args[0] == "no signing keys are available"
+    out = gpg("list", "--trusted")
+    assert out.count(MOCK_KEY) == 0
 
     # Create a key for use in the tests.
     keypath = tmp_path / "testing-1.key"
@@ -107,21 +94,29 @@ def test_gpg(tmp_path: pathlib.Path, mutable_config, mock_gnupghome):
 
     # List the keys.
     # TODO: Test the output here.
-    gpg("list")
-    gpg("list", "--trusted")
-    gpg("list", "--signing")
+    out = gpg("list")
+    assert out.count(MOCK_KEY) == 0
+    assert out.count(keyfp) == 1
 
-    # Signing with the default (only) key.
-    gpg("sign", str(test_path))
+    out = gpg("list", "--trusted")
+    assert out.count(MOCK_KEY) == 0
+    assert out.count(keyfp) == 1
 
-    # Verify the file we just verified.
-    gpg("verify", str(test_path))
+    out = gpg("list", "--signing")
+    assert out.count(MOCK_KEY) == 0
+    # Once for trusted, once for signing
+    assert out.count(keyfp) == 2
 
-    # Export the key for future use.
+    # Export the public key for future use (keyfp).
     export_path = tmp_path / "export.testing.key"
     gpg("export", str(export_path))
 
-    # Test exporting the private key
+    # Ensure we exported the right content!
+    with open(str(export_path), "r", encoding="utf-8") as fd:
+        content = fd.read()
+    assert "BEGIN PGP PUBLIC KEY BLOCK" in content
+
+    # Export the private key
     private_export_path = tmp_path / "export-secret.testing.key"
     gpg("export", "--secret", str(private_export_path))
 
@@ -130,30 +125,15 @@ def test_gpg(tmp_path: pathlib.Path, mutable_config, mock_gnupghome):
         content = fd.read()
     assert "BEGIN PGP PRIVATE KEY BLOCK" in content
 
-    # and for the public key
-    with open(str(export_path), "r", encoding="utf-8") as fd:
-        content = fd.read()
-    assert "BEGIN PGP PUBLIC KEY BLOCK" in content
-
     # Create a second key for use in the tests.
     gpg("create", "--comment", "Spack testing key", "Spack testing 2", "spack@googlegroups.com")
 
     # List the keys.
-    # TODO: Test the output here.
-    gpg("list", "--trusted")
-    gpg("list", "--signing")
-
-    test_path = tmp_path / "to-sign-2.txt"
-    with open(str(test_path), "w+", encoding="utf-8") as fout:
-        fout.write("Test content for signing.\n")
-
-    # Signing with multiple signing keys is ambiguous.
-    with pytest.raises(RuntimeError) as exc_info:
-        gpg("sign", str(test_path))
-    assert exc_info.value.args[0] == "multiple signing keys are available; please choose one"
-
-    # Signing with a specified key.
-    gpg("sign", "--key", keyfp, str(test_path))
+    out = gpg("list", "--trusted")
+    # Spack testing 1 and Spack testing 2
+    assert out.count("pub ") == 2
+    out = gpg("list", "--signing")
+    assert out.count("sec ") == 2
 
     # Untrusting signing keys needs a flag.
     with pytest.raises(ProcessError):
@@ -162,15 +142,16 @@ def test_gpg(tmp_path: pathlib.Path, mutable_config, mock_gnupghome):
     # Untrust the key we created.
     gpg("untrust", "--signing", keyfp)
 
-    # Verification should now fail.
-    with pytest.raises(ProcessError):
-        gpg("verify", str(test_path))
+    out = gpg("list", "--signing")
+    assert out.count("sec ") == 1
+    assert out.count(keyfp) == 0
 
-    # Trust the exported key.
+    # Trust the exported public key (keyfpr)
     gpg("trust", str(export_path))
-
-    # Verification should now succeed again.
-    gpg("verify", str(test_path))
+    out = gpg("list", "--signing")
+    assert out.count("sec ") == 1
+    assert out.count("pub ") == 2
+    assert out.count(keyfp) == 1
 
     relative_keys_path = spack.binary_distribution.buildcache_relative_keys_path()
 

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -1257,16 +1257,7 @@ _spack_gpg() {
     then
         SPACK_COMPREPLY="-h --help"
     else
-        SPACK_COMPREPLY="verify trust untrust sign create list init export publish"
-    fi
-}
-
-_spack_gpg_verify() {
-    if $list_options
-    then
-        SPACK_COMPREPLY="-h --help"
-    else
-        _installed_packages
+        SPACK_COMPREPLY="trust untrust create list init export publish verify sign"
     fi
 }
 
@@ -1285,15 +1276,6 @@ _spack_gpg_untrust() {
         SPACK_COMPREPLY="-h --help --signing"
     else
         _keys
-    fi
-}
-
-_spack_gpg_sign() {
-    if $list_options
-    then
-        SPACK_COMPREPLY="-h --help --output --key --clearsign"
-    else
-        _installed_packages
     fi
 }
 
@@ -1329,6 +1311,24 @@ _spack_gpg_publish() {
         SPACK_COMPREPLY="-h --help -d --directory -m --mirror-name --mirror-url --update-index --rebuild-index"
     else
         _keys
+    fi
+}
+
+_spack_gpg_verify() {
+    if $list_options
+    then
+        SPACK_COMPREPLY="-h --help"
+    else
+        _installed_packages
+    fi
+}
+
+_spack_gpg_sign() {
+    if $list_options
+    then
+        SPACK_COMPREPLY="-h --help --output --key --clearsign"
+    else
+        _installed_packages
     fi
 }
 

--- a/share/spack/spack-completion.fish
+++ b/share/spack/spack-completion.fish
@@ -1965,23 +1965,17 @@ complete -c spack -n '__fish_spack_using_command gc' -s y -l yes-to-all -d 'assu
 
 # spack gpg
 set -g __fish_spack_optspecs_spack_gpg h/help
-complete -c spack -n '__fish_spack_using_command_pos 0 gpg' -f -a verify -d 'verify a signed package'
 complete -c spack -n '__fish_spack_using_command_pos 0 gpg' -f -a trust -d 'add a key to the keyring'
 complete -c spack -n '__fish_spack_using_command_pos 0 gpg' -f -a untrust -d 'remove a key from the keyring'
-complete -c spack -n '__fish_spack_using_command_pos 0 gpg' -f -a sign -d 'sign a package'
 complete -c spack -n '__fish_spack_using_command_pos 0 gpg' -f -a create -d 'create a new key'
 complete -c spack -n '__fish_spack_using_command_pos 0 gpg' -f -a list -d 'list keys available in the keyring'
 complete -c spack -n '__fish_spack_using_command_pos 0 gpg' -f -a init -d 'add the default keys to the keyring'
 complete -c spack -n '__fish_spack_using_command_pos 0 gpg' -f -a export -d 'export a gpg key, optionally including secret key'
 complete -c spack -n '__fish_spack_using_command_pos 0 gpg' -f -a publish -d 'publish public keys to a build cache'
+complete -c spack -n '__fish_spack_using_command_pos 0 gpg' -f -a verify -d 'verify a signed package'
+complete -c spack -n '__fish_spack_using_command_pos 0 gpg' -f -a sign -d 'sign a package'
 complete -c spack -n '__fish_spack_using_command gpg' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command gpg' -s h -l help -d 'show this help message and exit'
-
-# spack gpg verify
-set -g __fish_spack_optspecs_spack_gpg_verify h/help
-complete -c spack -n '__fish_spack_using_command_pos_remainder 0 gpg verify' -f -a '(__fish_spack_installed_specs)'
-complete -c spack -n '__fish_spack_using_command gpg verify' -s h -l help -f -a help
-complete -c spack -n '__fish_spack_using_command gpg verify' -s h -l help -d 'show this help message and exit'
 
 # spack gpg trust
 set -g __fish_spack_optspecs_spack_gpg_trust h/help
@@ -1996,18 +1990,6 @@ complete -c spack -n '__fish_spack_using_command gpg untrust' -s h -l help -f -a
 complete -c spack -n '__fish_spack_using_command gpg untrust' -s h -l help -d 'show this help message and exit'
 complete -c spack -n '__fish_spack_using_command gpg untrust' -l signing -f -a signing
 complete -c spack -n '__fish_spack_using_command gpg untrust' -l signing -d 'allow untrusting signing keys'
-
-# spack gpg sign
-set -g __fish_spack_optspecs_spack_gpg_sign h/help output= key= clearsign
-complete -c spack -n '__fish_spack_using_command_pos_remainder 0 gpg sign' -f -a '(__fish_spack_installed_specs)'
-complete -c spack -n '__fish_spack_using_command gpg sign' -s h -l help -f -a help
-complete -c spack -n '__fish_spack_using_command gpg sign' -s h -l help -d 'show this help message and exit'
-complete -c spack -n '__fish_spack_using_command gpg sign' -l output -r -f -a output
-complete -c spack -n '__fish_spack_using_command gpg sign' -l output -r -d 'the directory to place signatures'
-complete -c spack -n '__fish_spack_using_command gpg sign' -l key -r -f -a key
-complete -c spack -n '__fish_spack_using_command gpg sign' -l key -r -d 'the key to use for signing'
-complete -c spack -n '__fish_spack_using_command gpg sign' -l clearsign -f -a clearsign
-complete -c spack -n '__fish_spack_using_command gpg sign' -l clearsign -d 'if specified, create a clearsign signature'
 
 # spack gpg create
 set -g __fish_spack_optspecs_spack_gpg_create h/help comment= expires= export= export-secret=
@@ -2059,6 +2041,24 @@ complete -c spack -n '__fish_spack_using_command gpg publish' -l mirror-url -r -
 complete -c spack -n '__fish_spack_using_command gpg publish' -l mirror-url -r -d 'URL of the mirror where keys will be published'
 complete -c spack -n '__fish_spack_using_command gpg publish' -l update-index -l rebuild-index -f -a update_index
 complete -c spack -n '__fish_spack_using_command gpg publish' -l update-index -l rebuild-index -d 'regenerate buildcache key index after publishing key(s)'
+
+# spack gpg verify
+set -g __fish_spack_optspecs_spack_gpg_verify h/help
+complete -c spack -n '__fish_spack_using_command_pos_remainder 0 gpg verify' -f -a '(__fish_spack_installed_specs)'
+complete -c spack -n '__fish_spack_using_command gpg verify' -s h -l help -f -a help
+complete -c spack -n '__fish_spack_using_command gpg verify' -s h -l help -d 'show this help message and exit'
+
+# spack gpg sign
+set -g __fish_spack_optspecs_spack_gpg_sign h/help output= key= clearsign
+complete -c spack -n '__fish_spack_using_command_pos_remainder 0 gpg sign' -f -a '(__fish_spack_installed_specs)'
+complete -c spack -n '__fish_spack_using_command gpg sign' -s h -l help -f -a help
+complete -c spack -n '__fish_spack_using_command gpg sign' -s h -l help -d 'show this help message and exit'
+complete -c spack -n '__fish_spack_using_command gpg sign' -l output -r -f -a output
+complete -c spack -n '__fish_spack_using_command gpg sign' -l output -r -d 'the directory to place signatures'
+complete -c spack -n '__fish_spack_using_command gpg sign' -l key -r -f -a key
+complete -c spack -n '__fish_spack_using_command gpg sign' -l key -r -d 'the key to use for signing'
+complete -c spack -n '__fish_spack_using_command gpg sign' -l clearsign -f -a clearsign
+complete -c spack -n '__fish_spack_using_command gpg sign' -l clearsign -d 'if specified, create a clearsign signature'
 
 # spack graph
 set -g __fish_spack_optspecs_spack_graph h/help a/ascii d/dot s/static c/color i/installed deptype=


### PR DESCRIPTION
The existing gpg commands sign and verify were tailored for the v1 build
cache layout. The assumptions they make are no longer relevant for Spack
and should not be generally used. Spack handles signing and verification
as part of the install/publish steps and it should not be encouraged for
users to manually sign or verify arbitrary blobs using Spack.