### PR TITLE
fix zsh color wrapping

### DIFF
--- a/lib/spack/spack/llnl/util/tty/color.py
+++ b/lib/spack/spack/llnl/util/tty/color.py
@@ -223,7 +223,7 @@ def _escape(s: _ConvertibleToStr, color: bool, enclose: bool, zsh: bool) -> str:
     if not color:
         return ""
     elif zsh:
-        return f"\033[0;{s}m"
+        return f"%{{\033[0;{s}m%}}"
 
     result = f"\033[{s}m"
 


### PR DESCRIPTION
For correct color functionality in zsh (especially when using spack env activate with the -p option), ANSI color codes must be enclosed in %{ %} to be marked as zero width