### PR TITLE
Isolate unit tests from user config

### DIFF
--- a/lib/spack/spack/test/concretization/core.py
+++ b/lib/spack/spack/test/concretization/core.py
@@ -4858,7 +4858,7 @@ packages:
     assert mpileaks.satisfies("%c=gcc@12")
 
 
-def test_concrete_specs_skip_prechecks(mock_packages):
+def test_concrete_specs_skip_prechecks(config, mock_packages):
     """Test that concrete specs are not checked for unknown versions and dependencies."""
 
     specs = [spack.spec.Spec("zlib"), spack.spec.Spec("deprecated-versions@=1.1.0")]
@@ -4954,7 +4954,7 @@ def test_penalties_for_variant_defined_by_function(
     assert s.satisfies(expected)
 
 
-def test_default_values_used_if_subset_required_by_dependent(mock_packages):
+def test_default_values_used_if_subset_required_by_dependent(config, mock_packages):
     """If a dependent requires *at least* a subset of default values of a multi-valued variant of
     a dependency, that should not influence concretization; the default values should be used."""
     # multivalue-variant-multi-defaults-dependent requires myvariant=bar without baz.

--- a/lib/spack/spack/test/directives.py
+++ b/lib/spack/spack/test/directives.py
@@ -173,7 +173,7 @@ def test_version_type_validation():
         ("redistribute-y@2.1+bar", False, False),
     ],
 )
-def test_redistribute_directive(mock_packages, spec_str, distribute_src, distribute_bin):
+def test_redistribute_directive(config, mock_packages, spec_str, distribute_src, distribute_bin):
     spec = spack.spec.Spec(spec_str)
     assert spack.repo.PATH.get_pkg_class(spec.fullname).redistribute_source(spec) == distribute_src
     concretized_spec = spack.concretize.concretize_one(spec)

--- a/lib/spack/spack/test/installer.py
+++ b/lib/spack/spack/test/installer.py
@@ -651,9 +651,9 @@ def false(*args, **kwargs):
     return False
 
 
-def test_rewire_task_no_tarball(monkeypatch, mock_packages):
-    spec = spack.concretize.concretize_one("splice-t")
-    dep = spack.concretize.concretize_one("splice-h+foo")
+def test_rewire_task_no_tarball(default_mock_concretization, monkeypatch):
+    spec = default_mock_concretization("splice-t")
+    dep = default_mock_concretization("splice-h+foo")
     out = spec.splice(dep)
 
     rewire_task = inst.RewireTask(out.package, inst.BuildRequest(out.package, {}))

--- a/lib/spack/spack/test/sandbox.py
+++ b/lib/spack/spack/test/sandbox.py
@@ -15,7 +15,6 @@ import pathlib
 import tempfile
 from typing import List, Tuple
 
-import spack.concretize
 import spack.sandbox
 import spack.store
 from spack.new_installer import _enable_sandbox
@@ -137,7 +136,10 @@ class MockSandbox(spack.sandbox.Sandbox):
 
 
 def test_enable_sandbox_paths(
-    default_mock_concretization, monkeypatch, temporary_store: spack.store.Store, tmp_path: pathlib.Path
+    default_mock_concretization,
+    monkeypatch,
+    temporary_store: spack.store.Store,
+    tmp_path: pathlib.Path,
 ):
     """Test that _enable_sandbox in new_installer calls allow_read/allow_write correctly."""
     mock_sandbox = MockSandbox()

--- a/lib/spack/spack/test/sandbox.py
+++ b/lib/spack/spack/test/sandbox.py
@@ -137,13 +137,13 @@ class MockSandbox(spack.sandbox.Sandbox):
 
 
 def test_enable_sandbox_paths(
-    monkeypatch, mock_packages, temporary_store: spack.store.Store, tmp_path: pathlib.Path
+    default_mock_concretization, monkeypatch, temporary_store: spack.store.Store, tmp_path: pathlib.Path
 ):
     """Test that _enable_sandbox in new_installer calls allow_read/allow_write correctly."""
     mock_sandbox = MockSandbox()
     monkeypatch.setattr(spack.sandbox, "get_sandbox", lambda: mock_sandbox)
 
-    spec = spack.concretize.concretize_one("dependent-install")
+    spec = default_mock_concretization("dependent-install")
 
     # Create prefix directories so resolved.exists() passes
     pathlib.Path(spec.prefix).mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
Some unit tests were not isolated from user config. This fixes the issue by using the `config` fixture.