### PR TITLE
solver: fix bugs with multiple intel-oneapi-compilers versions

### DIFF
--- a/lib/spack/spack/cmd/__init__.py
+++ b/lib/spack/spack/cmd/__init__.py
@@ -18,6 +18,7 @@ import spack.config
 import spack.environment as ev
 import spack.error
 import spack.extensions
+import spack.hash_lookup
 import spack.llnl.string
 import spack.llnl.util.tty as tty
 import spack.paths
@@ -213,7 +214,8 @@ def _concretize_spec_pairs(
     ):
         # Get all the concrete specs
         ret = [
-            concrete or (abstract if abstract.concrete else abstract.lookup_hash())
+            concrete
+            or (abstract if abstract.concrete else spack.hash_lookup.lookup_hash(abstract))
             for abstract, concrete in to_concretize
         ]
 

--- a/lib/spack/spack/cmd/diff.py
+++ b/lib/spack/spack/cmd/diff.py
@@ -8,6 +8,7 @@ import sys
 
 import spack.cmd
 import spack.environment as ev
+import spack.hash_lookup
 import spack.llnl.util.tty as tty
 import spack.solver.asp as asp
 import spack.util.spack_json as sjson
@@ -214,7 +215,7 @@ def diff(parser, args):
     specs = []
     for spec in spack.cmd.parse_specs(args.specs):
         # If the spec has a hash, check it before disambiguating
-        spec.replace_hash()
+        spack.hash_lookup.replace_hash(spec)
         if spec.concrete:
             specs.append(spec)
         else:

--- a/lib/spack/spack/concretize.py
+++ b/lib/spack/spack/concretize.py
@@ -12,6 +12,7 @@ import spack.compilers
 import spack.compilers.config
 import spack.config
 import spack.error
+import spack.hash_lookup
 import spack.llnl.util.tty as tty
 import spack.repo
 import spack.util.parallel
@@ -241,7 +242,7 @@ def concretize_one(
 
     if isinstance(spec, str):
         spec = Spec(spec)
-    spec = spec.lookup_hash()
+    spec = spack.hash_lookup.lookup_hash(spec)
 
     if spec.concrete:
         return spec.copy()

--- a/lib/spack/spack/environment/list.py
+++ b/lib/spack/spack/environment/list.py
@@ -113,6 +113,9 @@ class SpecList:
 
 
 def _expand_matrix_constraints(matrix_config):
+    # Avoid circular import
+    import spack.hash_lookup
+
     # recurse so we can handle nested matrices
     expanded_rows = []
     for row in matrix_config["matrix"]:
@@ -154,7 +157,7 @@ def _expand_matrix_constraints(matrix_config):
             pass
 
         # Resolve abstract hashes for exclusion criteria
-        if any(test_spec.lookup_hash().satisfies(x) for x in excludes):
+        if any(spack.hash_lookup.lookup_hash(test_spec).satisfies(x) for x in excludes):
             continue
 
         if sigil:

--- a/lib/spack/spack/hash_lookup.py
+++ b/lib/spack/spack/hash_lookup.py
@@ -1,0 +1,102 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+"""Resolve abstract hash references in Specs to concrete specs.
+
+This module is free of spack.solver imports. It locates matching specs by
+searching the active environment, the installed store, the binary cache, and
+configured externals (via spack.externals_config).
+"""
+
+from typing import List
+
+import spack.binary_distribution
+import spack.config
+import spack.environment
+import spack.error
+import spack.externals_config
+import spack.spec
+import spack.store
+from spack.enums import InstallRecordStatus
+
+
+def _matching_external_specs(spec: "spack.spec.Spec") -> List["spack.spec.Spec"]:
+    """Return configured externals from packages.yaml that match spec by abstract hash."""
+    config = spack.config.CONFIG
+    try:
+        packages_with_externals = spack.externals_config.external_config_with_implicit_externals(
+            config
+        )
+        completion_mode = config.get("concretizer:externals:completion")
+        parser = spack.externals_config.create_external_parser(
+            packages_with_externals, completion_mode
+        )
+    except spack.error.SpackError:
+        return []
+    return parser.query(spec)
+
+
+def _lookup_one(spec: "spack.spec.Spec") -> "spack.spec.Spec":
+    """Return the single concrete spec matching an abstract-hash spec.
+
+    Searches in order: active environment, configured externals, installed store, binary cache.
+    Raises InvalidHashError if nothing matches, AmbiguousHashError if more than one matches.
+    """
+    active_env = spack.environment.active_environment()
+
+    matches = (
+        (active_env.all_matching_specs(spec) if active_env else [])
+        or _matching_external_specs(spec)
+        or spack.store.STORE.db.query(spec, installed=InstallRecordStatus.ANY)
+        or spack.binary_distribution.BinaryCacheQuery(True)(spec)
+    )
+
+    if not matches:
+        raise spack.spec.InvalidHashError(spec, spec.abstract_hash)
+
+    if len(matches) != 1:
+        raise spack.spec.AmbiguousHashError(
+            f"Multiple packages specify hash beginning '{spec.abstract_hash}'.", *matches
+        )
+
+    return matches[0]
+
+
+def lookup_hash(spec: "spack.spec.Spec") -> "spack.spec.Spec":
+    """Return a copy of spec with all abstract-hash nodes replaced by their concrete counterparts.
+
+    Non-destructive: always returns a new Spec object. If spec is already concrete or has no
+    abstract-hash nodes, returns spec unchanged.
+    """
+    if spec.concrete or not any(node.abstract_hash for node in spec.traverse()):
+        return spec
+
+    result = spec.copy(deps=False)
+    if result.abstract_hash:
+        result._dup(_lookup_one(spec))
+        return result
+
+    node_lookup = {
+        id(node): _lookup_one(node) for node in spec.traverse(root=False) if node.abstract_hash
+    }
+
+    for edge in spec.traverse_edges(root=False):
+        key = edge.parent.name
+        current_node = result if key == result.name else result[key]
+        child_node = node_lookup.get(id(edge.spec), edge.spec.copy())
+        current_node._add_dependency(
+            child_node, depflag=edge.depflag, virtuals=edge.virtuals, direct=edge.direct
+        )
+
+    return result
+
+
+def replace_hash(spec: "spack.spec.Spec") -> None:
+    """Populate spec in-place by resolving all abstract-hash nodes.
+
+    Destructive counterpart to lookup_hash. No-op if spec has no abstract-hash nodes.
+    """
+    if not any(node for node in spec.traverse(order="post") if node.abstract_hash):
+        return
+
+    spec._dup(lookup_hash(spec))

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -47,6 +47,7 @@ import spack.config
 import spack.deptypes as dt
 import spack.error
 import spack.externals_config
+import spack.hash_lookup
 import spack.hash_types as ht
 import spack.llnl.util.lang
 import spack.llnl.util.tty as tty
@@ -1996,7 +1997,7 @@ class SpackSolverSetup:
 
             for input_spec in requirement_grp:
                 spec = spack.spec.Spec(input_spec)
-                spec.replace_hash()
+                spack.hash_lookup.replace_hash(spec)
                 if not spec.name:
                     spec.name = pkg_name
                 spec.attach_git_version_lookup()
@@ -3853,7 +3854,7 @@ def execute_explicit_splices(specs: SpecDict) -> SpecDict:
 
                 # The first iteration, we need to replace the abstract hash
                 if not replacement.concrete:
-                    replacement.replace_hash()
+                    spack.hash_lookup.replace_hash(replacement)
                 current_spec = current_spec.splice(replacement, transitive)
         new_key = NodeId(id=key.id, pkg=current_spec.name)
         new_specs[new_key] = current_spec
@@ -3978,7 +3979,7 @@ class Solver:
           setup_only: if True, stop after setup and don't solve (default False).
           allow_deprecated: allow deprecated version in the solve
         """
-        specs = [s.lookup_hash() for s in specs]
+        specs = [spack.hash_lookup.lookup_hash(s) for s in specs]
         reusable_specs = self._extract_concrete_specs(specs)
         reusable_specs.extend(self.selector.reusable_specs(specs))
         setup = SpackSolverSetup(tests=tests)
@@ -4029,7 +4030,7 @@ class Solver:
             tests (bool): add test dependencies to the solve
             allow_deprecated (bool): allow deprecated version in the solve
         """
-        specs = [s.lookup_hash() for s in specs]
+        specs = [spack.hash_lookup.lookup_hash(s) for s in specs]
         reusable_specs = self._extract_concrete_specs(specs)
         reusable_specs.extend(self.selector.reusable_specs(specs))
         setup = SpackSolverSetup(tests=tests)

--- a/lib/spack/spack/solver/runtimes.py
+++ b/lib/spack/spack/solver/runtimes.py
@@ -6,6 +6,7 @@ from typing import Set, Tuple
 import spack.compilers.config
 import spack.compilers.libraries
 import spack.config
+import spack.hash_lookup
 import spack.repo
 import spack.spec
 import spack.util.libc
@@ -165,7 +166,7 @@ class RuntimePropertyRecorder:
 
         imposed_spec = spack.spec.Spec(f"{self.current_package}{impose}")
         when_spec = spack.spec.Spec(f"{self.current_package}{when}")
-        when_spec = when_spec.lookup_hash()
+        when_spec = spack.hash_lookup.lookup_hash(when_spec)
 
         assert imposed_spec.versions.concrete, f"{impose} must have a concrete version"
 

--- a/lib/spack/spack/solver/runtimes.py
+++ b/lib/spack/spack/solver/runtimes.py
@@ -165,6 +165,7 @@ class RuntimePropertyRecorder:
 
         imposed_spec = spack.spec.Spec(f"{self.current_package}{impose}")
         when_spec = spack.spec.Spec(f"{self.current_package}{when}")
+        when_spec = when_spec.lookup_hash()
 
         assert imposed_spec.versions.concrete, f"{impose} must have a concrete version"
 

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -2302,6 +2302,11 @@ class Spec:
         """Given a spec with an abstract hash, return a copy of the spec with all properties and
         dependencies by looking up the hash in the environment, store, or finally, binary caches.
         This is non-destructive."""
+        warnings.warn(
+            "Spec.lookup_hash() is deprecated; use spack.hash_lookup.lookup_hash(spec) instead",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         import spack.hash_lookup
 
         return spack.hash_lookup.lookup_hash(self)
@@ -2310,6 +2315,11 @@ class Spec:
         """Given a spec with an abstract hash, attempt to populate all properties and dependencies
         by looking up the hash in the environment, store, or finally, binary caches.
         This is destructive."""
+        warnings.warn(
+            "Spec.replace_hash() is deprecated; use spack.hash_lookup.replace_hash(spec) instead",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         import spack.hash_lookup
 
         spack.hash_lookup.replace_hash(self)

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -1548,6 +1548,27 @@ def _satisfies_edge(lhs: "DependencySpec", rhs: "DependencySpec", resolve_virtua
     return lhs.spec._provides_virtual(rhs.spec)
 
 
+def _matching_external_specs(spec: "Spec") -> List["Spec"]:
+    """Return configured externals from packages.yaml that match spec by abstract hash.
+
+    Externals are parsed the same way the solver does, so dag hashes line up.
+    """
+    import spack.config
+    from spack.externals_config import (
+        create_external_parser,
+        external_config_with_implicit_externals,
+    )
+
+    config = spack.config.CONFIG
+    try:
+        packages_with_externals = external_config_with_implicit_externals(config)
+        completion_mode = config.get("concretizer:externals:completion")
+        parser = create_external_parser(packages_with_externals, completion_mode)
+    except spack.error.SpackError:
+        return []
+    return parser.query(spec)
+
+
 @lang.lazy_lexicographic_ordering(set_hash=False)
 class Spec:
     compiler = DeprecatedCompilerSpec()
@@ -2300,16 +2321,17 @@ class Spec:
 
     def _lookup_hash(self):
         """Lookup just one spec with an abstract hash, returning a spec from the the environment,
-        store, or finally, binary caches."""
+        store, binary caches, or configured externals."""
         from spack.binary_distribution import BinaryCacheQuery
         from spack.environment import active_environment
         from spack.store import STORE
 
         active_env = active_environment()
 
-        # First env, then store, then binary cache
+        # First env, then store, then binary cache, then configured externals
         matches = (
             (active_env.all_matching_specs(self) if active_env else [])
+            or _matching_external_specs(self)
             or STORE.db.query(self, installed=InstallRecordStatus.ANY)
             or BinaryCacheQuery(True)(self)
         )

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -2298,32 +2298,6 @@ class Spec:
         """Get the first <bits> bits of the DAG hash as an integer type."""
         return spack.util.hash.base32_prefix_bits(self.dag_hash(), bits)
 
-    def lookup_hash(self):
-        """Given a spec with an abstract hash, return a copy of the spec with all properties and
-        dependencies by looking up the hash in the environment, store, or finally, binary caches.
-        This is non-destructive."""
-        warnings.warn(
-            "Spec.lookup_hash() is deprecated; use spack.hash_lookup.lookup_hash(spec) instead",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        import spack.hash_lookup
-
-        return spack.hash_lookup.lookup_hash(self)
-
-    def replace_hash(self):
-        """Given a spec with an abstract hash, attempt to populate all properties and dependencies
-        by looking up the hash in the environment, store, or finally, binary caches.
-        This is destructive."""
-        warnings.warn(
-            "Spec.replace_hash() is deprecated; use spack.hash_lookup.replace_hash(spec) instead",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        import spack.hash_lookup
-
-        spack.hash_lookup.replace_hash(self)
-
     def to_node_dict(self, hash: ht.SpecHashDescriptor = ht.dag_hash) -> Dict[str, Any]:
         """Create a dictionary representing the state of this Spec.
 

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -109,7 +109,7 @@ import spack.version
 import spack.version as vn
 import spack.version.git_ref_lookup
 
-from .enums import InstallRecordStatus, PropagationPolicy
+from .enums import PropagationPolicy
 
 __all__ = [
     "CompilerSpec",
@@ -1548,27 +1548,6 @@ def _satisfies_edge(lhs: "DependencySpec", rhs: "DependencySpec", resolve_virtua
     return lhs.spec._provides_virtual(rhs.spec)
 
 
-def _matching_external_specs(spec: "Spec") -> List["Spec"]:
-    """Return configured externals from packages.yaml that match spec by abstract hash.
-
-    Externals are parsed the same way the solver does, so dag hashes line up.
-    """
-    import spack.config
-    from spack.externals_config import (
-        create_external_parser,
-        external_config_with_implicit_externals,
-    )
-
-    config = spack.config.CONFIG
-    try:
-        packages_with_externals = external_config_with_implicit_externals(config)
-        completion_mode = config.get("concretizer:externals:completion")
-        parser = create_external_parser(packages_with_externals, completion_mode)
-    except spack.error.SpackError:
-        return []
-    return parser.query(spec)
-
-
 @lang.lazy_lexicographic_ordering(set_hash=False)
 class Spec:
     compiler = DeprecatedCompilerSpec()
@@ -2319,73 +2298,21 @@ class Spec:
         """Get the first <bits> bits of the DAG hash as an integer type."""
         return spack.util.hash.base32_prefix_bits(self.dag_hash(), bits)
 
-    def _lookup_hash(self):
-        """Lookup just one spec with an abstract hash, returning a spec from the the environment,
-        store, binary caches, or configured externals."""
-        from spack.binary_distribution import BinaryCacheQuery
-        from spack.environment import active_environment
-        from spack.store import STORE
-
-        active_env = active_environment()
-
-        # First env, then store, then binary cache, then configured externals
-        matches = (
-            (active_env.all_matching_specs(self) if active_env else [])
-            or _matching_external_specs(self)
-            or STORE.db.query(self, installed=InstallRecordStatus.ANY)
-            or BinaryCacheQuery(True)(self)
-        )
-
-        if not matches:
-            raise InvalidHashError(self, self.abstract_hash)
-
-        if len(matches) != 1:
-            raise AmbiguousHashError(
-                f"Multiple packages specify hash beginning '{self.abstract_hash}'.", *matches
-            )
-
-        return matches[0]
-
     def lookup_hash(self):
         """Given a spec with an abstract hash, return a copy of the spec with all properties and
         dependencies by looking up the hash in the environment, store, or finally, binary caches.
         This is non-destructive."""
-        if self.concrete or not any(node.abstract_hash for node in self.traverse()):
-            return self
+        import spack.hash_lookup
 
-        spec = self.copy(deps=False)
-        # root spec is replaced
-        if spec.abstract_hash:
-            spec._dup(self._lookup_hash())
-            return spec
-
-        # Map the dependencies that need to be replaced
-        node_lookup = {
-            id(node): node._lookup_hash()
-            for node in self.traverse(root=False)
-            if node.abstract_hash
-        }
-
-        # Reconstruct dependencies
-        for edge in self.traverse_edges(root=False):
-            key = edge.parent.name
-            current_node = spec if key == spec.name else spec[key]
-            child_node = node_lookup.get(id(edge.spec), edge.spec.copy())
-            current_node._add_dependency(
-                child_node, depflag=edge.depflag, virtuals=edge.virtuals, direct=edge.direct
-            )
-
-        return spec
+        return spack.hash_lookup.lookup_hash(self)
 
     def replace_hash(self):
         """Given a spec with an abstract hash, attempt to populate all properties and dependencies
         by looking up the hash in the environment, store, or finally, binary caches.
         This is destructive."""
+        import spack.hash_lookup
 
-        if not any(node for node in self.traverse(order="post") if node.abstract_hash):
-            return
-
-        self._dup(self.lookup_hash())
+        spack.hash_lookup.replace_hash(self)
 
     def to_node_dict(self, hash: ht.SpecHashDescriptor = ht.dag_hash) -> Dict[str, Any]:
         """Create a dictionary representing the state of this Spec.

--- a/lib/spack/spack/test/concretization/compiler_runtimes.py
+++ b/lib/spack/spack/test/concretization/compiler_runtimes.py
@@ -203,3 +203,40 @@ def test_runtimes_are_not_reused_if_compiler_not_used(runtime_repo, mutable_conf
     assert gcc.satisfies("@9") and not gcc.satisfies("@10")
     # Same gcc used for both languages
     assert root["c"] == root["cxx"]
+
+
+@pytest.mark.regression("52375")
+def test_multiple_intel_oneapi_compilers_versions(mutable_config, runtime_repo):
+    """Tests that multiple installed versions of intel-oneapi-compilers don't interfere with each
+    other during concretization.
+    """
+    # Configure two external versions of intel-oneapi-compilers, each depending on a different gcc.
+    extra_attributes = {"compilers": {"c": "/usr/bin/icx", "cxx": "/usr/bin/icpx"}}
+    mutable_config.set(
+        "packages:intel-oneapi-compilers",
+        {
+            "externals": [
+                {
+                    "spec": "intel-oneapi-compilers@1.0",
+                    "prefix": "/fake/v1",
+                    "extra_attributes": extra_attributes,
+                    "dependencies": [{"spec": "gcc@9.4.0", "deptypes": "build"}],
+                },
+                {
+                    "spec": "intel-oneapi-compilers@2.0",
+                    "prefix": "/fake/v2",
+                    "extra_attributes": extra_attributes,
+                    "dependencies": [{"spec": "gcc@10.2.1", "deptypes": "build"}],
+                },
+            ],
+            "buildable": False,
+        },
+    )
+
+    pkga_v1 = spack.concretize.concretize_one("pkg-a %c,cxx=intel-oneapi-compilers@1.0")
+    assert pkga_v1.satisfies("%intel-oneapi-runtime@1.0"), pkga_v1.tree()
+    assert pkga_v1["intel-oneapi-runtime"].satisfies("%gcc-runtime@9.4.0"), pkga_v1.tree()
+
+    pkga_v2 = spack.concretize.concretize_one("pkg-a %c,cxx=intel-oneapi-compilers@2.0")
+    assert pkga_v2.satisfies("%intel-oneapi-runtime@2.0")
+    assert pkga_v2["intel-oneapi-runtime"].satisfies("%gcc-runtime@10.2.1"), pkga_v2.tree()

--- a/lib/spack/spack/test/spec_syntax.py
+++ b/lib/spack/spack/test/spec_syntax.py
@@ -1369,7 +1369,7 @@ def test_ambiguous_hash(mutable_database):
     # This is a very sketchy as manually setting hashes easily breaks invariants
     x1 = spack.concretize.concretize_one("pkg-a")
     x2 = x1.copy()
-    x1._hash = "xyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy"
+    x1._hash = "xxxyyyyyyyyyyyyyyyyyyyyyyyyyyyyy"
     x2._hash = "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
 
     assert x1 != x2  # doesn't hold when only the dag hash is modified.
@@ -1378,12 +1378,12 @@ def test_ambiguous_hash(mutable_database):
     mutable_database.add(x2)
 
     # ambiguity in first hash character
-    s1 = SpecParser("/x").next_spec()
+    s1 = SpecParser("/xxx").next_spec()
     with pytest.raises(spack.spec.AmbiguousHashError):
         s1.lookup_hash()
 
     # ambiguity in first hash character AND spec name
-    s2 = SpecParser("pkg-a/x").next_spec()
+    s2 = SpecParser("pkg-a/xxx").next_spec()
     with pytest.raises(spack.spec.AmbiguousHashError):
         s2.lookup_hash()
 

--- a/lib/spack/spack/test/spec_syntax.py
+++ b/lib/spack/spack/test/spec_syntax.py
@@ -13,6 +13,7 @@ import spack.binary_distribution
 import spack.cmd
 import spack.concretize
 import spack.error
+import spack.hash_lookup
 import spack.llnl.util.filesystem as fs
 import spack.platforms.test
 import spack.repo
@@ -1278,22 +1279,22 @@ def test_spec_by_hash(database, monkeypatch, config):
 
     hash_str = f"/{mpileaks.dag_hash()}"
     parsed_spec = SpecParser(hash_str).next_spec()
-    parsed_spec.replace_hash()
+    spack.hash_lookup.replace_hash(parsed_spec)
     assert parsed_spec == mpileaks
 
     short_hash_str = f"/{mpileaks.dag_hash()[:5]}"
     parsed_spec = SpecParser(short_hash_str).next_spec()
-    parsed_spec.replace_hash()
+    spack.hash_lookup.replace_hash(parsed_spec)
     assert parsed_spec == mpileaks
 
     name_version_and_hash = f"{mpileaks.name}@{mpileaks.version} /{mpileaks.dag_hash()[:5]}"
     parsed_spec = SpecParser(name_version_and_hash).next_spec()
-    parsed_spec.replace_hash()
+    spack.hash_lookup.replace_hash(parsed_spec)
     assert parsed_spec == mpileaks
 
     b_hash = f"/{b.dag_hash()}"
     parsed_spec = SpecParser(b_hash).next_spec()
-    parsed_spec.replace_hash()
+    spack.hash_lookup.replace_hash(parsed_spec)
     assert parsed_spec == b
 
 
@@ -1307,21 +1308,21 @@ def test_dep_spec_by_hash(database, config):
     assert "zmpi" in mpileaks_zmpi
 
     mpileaks_hash_fake = SpecParser(f"mpileaks ^/{fake.dag_hash()} ^zmpi").next_spec()
-    mpileaks_hash_fake.replace_hash()
+    spack.hash_lookup.replace_hash(mpileaks_hash_fake)
     assert "fake" in mpileaks_hash_fake
     assert mpileaks_hash_fake["fake"] == fake
     assert "zmpi" in mpileaks_hash_fake
     assert mpileaks_hash_fake["zmpi"] == spack.spec.Spec("zmpi")
 
     mpileaks_hash_zmpi = SpecParser(f"mpileaks ^ /{zmpi.dag_hash()}").next_spec()
-    mpileaks_hash_zmpi.replace_hash()
+    spack.hash_lookup.replace_hash(mpileaks_hash_zmpi)
     assert "zmpi" in mpileaks_hash_zmpi
     assert mpileaks_hash_zmpi["zmpi"] == zmpi
 
     mpileaks_hash_fake_and_zmpi = SpecParser(
         f"mpileaks ^/{fake.dag_hash()[:4]} ^ /{zmpi.dag_hash()[:5]}"
     ).next_spec()
-    mpileaks_hash_fake_and_zmpi.replace_hash()
+    spack.hash_lookup.replace_hash(mpileaks_hash_fake_and_zmpi)
     assert "zmpi" in mpileaks_hash_fake_and_zmpi
     assert mpileaks_hash_fake_and_zmpi["zmpi"] == zmpi
 
@@ -1380,12 +1381,12 @@ def test_ambiguous_hash(mutable_database):
     # ambiguity in first hash character
     s1 = SpecParser("/xxx").next_spec()
     with pytest.raises(spack.spec.AmbiguousHashError):
-        s1.lookup_hash()
+        spack.hash_lookup.lookup_hash(s1)
 
     # ambiguity in first hash character AND spec name
     s2 = SpecParser("pkg-a/xxx").next_spec()
     with pytest.raises(spack.spec.AmbiguousHashError):
-        s2.lookup_hash()
+        spack.hash_lookup.lookup_hash(s2)
 
 
 @pytest.mark.db
@@ -1396,22 +1397,23 @@ def test_invalid_hash(database, config):
     # name + incompatible hash
     with pytest.raises(spack.spec.InvalidHashError):
         parsed_spec = SpecParser(f"zmpi /{mpich.dag_hash()}").next_spec()
-        parsed_spec.replace_hash()
+        spack.hash_lookup.replace_hash(parsed_spec)
     with pytest.raises(spack.spec.InvalidHashError):
         parsed_spec = SpecParser(f"mpich /{zmpi.dag_hash()}").next_spec()
-        parsed_spec.replace_hash()
+        spack.hash_lookup.replace_hash(parsed_spec)
 
     # name + dep + incompatible hash
     with pytest.raises(spack.spec.InvalidHashError):
         parsed_spec = SpecParser(f"mpileaks ^zmpi /{mpich.dag_hash()}").next_spec()
-        parsed_spec.replace_hash()
+        spack.hash_lookup.replace_hash(parsed_spec)
 
 
 def test_invalid_hash_dep(database, config):
     mpich = database.query_one("mpich")
     hash = mpich.dag_hash()
     with pytest.raises(spack.spec.InvalidHashError):
-        spack.spec.Spec(f"callpath ^zlib/{hash}").replace_hash()
+        s = spack.spec.Spec(f"callpath ^zlib/{hash}")
+        spack.hash_lookup.replace_hash(s)
 
 
 @pytest.mark.db
@@ -1426,7 +1428,7 @@ def test_nonexistent_hash(database, config):
 
     with pytest.raises(spack.spec.InvalidHashError):
         parsed_spec = SpecParser(f"/{no_such_hash}").next_spec()
-        parsed_spec.replace_hash()
+        spack.hash_lookup.replace_hash(parsed_spec)
 
 
 @pytest.mark.parametrize(
@@ -1457,7 +1459,7 @@ def test_disambiguate_hash_by_spec(spec1, spec2, constraint, mock_packages, monk
     else:
         spec = spack.spec.Spec("/spec" + constraint)
 
-    assert spec.lookup_hash() == spec1_concrete
+    assert spack.hash_lookup.lookup_hash(spec) == spec1_concrete
 
 
 @pytest.mark.parametrize(
@@ -1827,4 +1829,4 @@ def test_external_spec_hash_can_be_looked_up(config, mock_packages):
     parser = ExternalSpecsParser(externals_dict, complete_node=complete_variants_and_architecture)
     abstract_hashes = [f"{x.name}/{x.dag_hash()[:5]}" for x in parser.all_specs()]
 
-    assert all(spack.spec.Spec(x).lookup_hash() for x in abstract_hashes)
+    assert all(spack.hash_lookup.lookup_hash(spack.spec.Spec(x)) for x in abstract_hashes)

--- a/lib/spack/spack/test/spec_syntax.py
+++ b/lib/spack/spack/test/spec_syntax.py
@@ -18,6 +18,11 @@ import spack.platforms.test
 import spack.repo
 import spack.solver.asp
 import spack.spec
+from spack.externals import (
+    ExternalSpecsParser,
+    complete_variants_and_architecture,
+    extract_dicts_from_configuration,
+)
 from spack.spec_parser import (
     UNIX_FILENAME,
     WINDOWS_FILENAME,
@@ -1812,3 +1817,14 @@ def test_parse_multiple_edge_attributes(input_args, expected):
     s, *_ = spack.cmd.parse_specs(input_args)
     for c in expected:
         assert s.satisfies(c)
+
+
+@pytest.mark.regression("52375")
+def test_external_spec_hash_can_be_looked_up(config, mock_packages):
+    """Tests that the hash of an external can be successfully looked up."""
+    packages_yaml = config.deepcopy_as_builtin("packages")
+    externals_dict = extract_dicts_from_configuration(packages_yaml)
+    parser = ExternalSpecsParser(externals_dict, complete_node=complete_variants_and_architecture)
+    abstract_hashes = [f"{x.name}/{x.dag_hash()[:5]}" for x in parser.all_specs()]
+
+    assert all(spack.spec.Spec(x).lookup_hash() for x in abstract_hashes)

--- a/var/spack/test_repos/spack_repo/compiler_runtime_test/packages/intel_oneapi_compilers/package.py
+++ b/var/spack/test_repos/spack_repo/compiler_runtime_test/packages/intel_oneapi_compilers/package.py
@@ -1,0 +1,69 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+import os
+
+from spack_repo.builtin_mock.build_systems.compiler import CompilerPackage
+
+from spack.package import *
+
+
+class IntelOneapiCompilers(CompilerPackage, Package):
+    """Injects a link dependency on the corresponding runtime package."""
+
+    homepage = "http://www.example.com"
+    url = "http://www.example.com/intel-oneapi-compilers-1.0.tar.gz"
+
+    version("2.0", md5="abcdef0123456789abcdef0123456789")
+    version("1.0", md5="0123456789abcdef0123456789abcdef")
+
+    provides("c")
+    provides("cxx")
+
+    compiler_languages = ["c", "cxx"]
+    c_names = ["icx"]
+    cxx_names = ["icpx"]
+    compiler_version_regex = r"([0-9.]+)"
+    compiler_version_argument = "-dumpversion"
+
+    compiler_wrapper_link_paths = {
+        "c": os.path.join("intel-oneapi-compilers", "icx"),
+        "cxx": os.path.join("intel-oneapi-compilers", "icpx"),
+    }
+
+    depends_on("gcc", type="run")
+
+    @classmethod
+    def runtime_constraints(cls, *, spec, pkg):
+        for language in ("c", "cxx", "fortran"):
+            pkg("*").depends_on(
+                f"intel-oneapi-runtime@{spec.version}:",
+                when=f"%[deptypes=build virtuals={language}] {spec.name}@{spec.versions}",
+                type="link",
+                description="Inject intel-oneapi-runtime when oneapi is used as "
+                f"a {language} compiler",
+            )
+
+        # The version of intel-oneapi-runtime is the same as the %oneapi used to "compile" it
+        pkg("intel-oneapi-runtime").requires(
+            f"@{spec.versions}", when=f"%[deptypes=build] {spec.name}@{spec.versions}"
+        )
+
+        # If the compiler depends on gcc@X.Y, the runtime must depend on gcc-runtime@X.Y
+        if spec.satisfies("%gcc"):
+            try:
+                gcc = spec["gcc"]
+                pkg("intel-oneapi-runtime").requires(
+                    f"@{spec.versions} %gcc-runtime@{gcc.version}",
+                    when=f"%[deptypes=build] {spec.name}/{spec.dag_hash()}",
+                )
+            except (RuntimeError, KeyError):
+                # Externals may not have gcc as a dependency, but still satisfy %gcc
+                pass
+
+        # If a node used %intel-oneapi-runtime@X.Y its dependencies must use @:X.Y
+        # (technically @:X is broader than ... <= @=X but this should work in practice)
+        pkg("*").propagate(
+            f"intel-oneapi-compilers@:{spec.version}",
+            when=f"%[deptypes=build] {spec.name}@{spec.versions}",
+        )

--- a/var/spack/test_repos/spack_repo/compiler_runtime_test/packages/intel_oneapi_runtime/package.py
+++ b/var/spack/test_repos/spack_repo/compiler_runtime_test/packages/intel_oneapi_runtime/package.py
@@ -1,0 +1,18 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+from spack.package import *
+
+
+class IntelOneapiRuntime(Package):
+    """Declares a build dependency on the compiler, and a link dependency on gcc-runtime."""
+
+    homepage = "http://www.example.com"
+    has_code = False
+
+    tags = ["runtime"]
+
+    # The runtime has a build dependency on the corresponding compiler
+    depends_on("intel-oneapi-compilers", type="build")
+    # ... and a link dependency on the gcc-runtime corresponding to the gcc used by the compiler
+    depends_on("gcc-runtime", type="link")


### PR DESCRIPTION
fixes #52375
fixes https://github.com/spack/spack-packages/issues/4749 
closes https://github.com/spack/spack-packages/pull/4890

When multiple versions of intel-oneapi-compilers were installed or configured as externals, Spack couldn't concretize using them due to an unresolved abstract hash.

This is fixed here by resolving the abstract hashes before generating requirements for the runtime constraints.

A fix for resolving externals that have not been installed already is added too, in case OneAPI compilers are registered as externals together with their GCC dependencies.