### PR TITLE
solver: moved `using_libc_compatibility` to `spack.platforms`

### DIFF
--- a/lib/spack/spack/platforms/__init__.py
+++ b/lib/spack/spack/platforms/__init__.py
@@ -23,6 +23,7 @@ __all__ = [
     "host",
     "by_name",
     "reset",
+    "using_libc_compatibility",
 ]
 
 #: The "real" platform of the host running Spack. This should not be changed
@@ -45,6 +46,11 @@ class _PickleableCallable:
 
     def __call__(self):
         return self.return_value
+
+
+def using_libc_compatibility() -> bool:
+    """Returns True if we are using libc compatibility on this platform."""
+    return host().name == "linux"
 
 
 @contextlib.contextmanager

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -70,15 +70,7 @@ from spack.spec import EMPTY_SPEC
 from spack.util.compression import GZipFileType
 
 from .compat import default_clingo_control, make_error_control
-from .core import (
-    AspFunction,
-    AspVar,
-    NodeId,
-    SourceContext,
-    extract_args,
-    fn,
-    using_libc_compatibility,
-)
+from .core import AspFunction, AspVar, NodeId, SourceContext, extract_args, fn
 from .input_analysis import create_counter, create_graph_analyzer
 from .requirements import RequirementKind, RequirementOrigin, RequirementParser, RequirementRule
 from .reuse import ReusableSpecsSelector, SpecFiltersFactory, create_external_parser
@@ -1065,7 +1057,7 @@ class PyclingoDriver:
         control_files = ["concretize.lp", "heuristic.lp", "display.lp", "direct_dependency.lp"]
         if not setup.concretize_everything:
             control_files.append("when_possible.lp")
-        if using_libc_compatibility():
+        if spack.platforms.using_libc_compatibility():
             control_files.append("libc_compatibility.lp")
         else:
             control_files.append("os_compatibility.lp")
@@ -2306,7 +2298,7 @@ class SpackSolverSetup:
                 clauses.append(fn.attr("virtual_on_incoming_edges", name, virtual))
 
         # If the spec is external and concrete, we allow all the libcs on the system
-        if spec.external and spec.concrete and using_libc_compatibility():
+        if spec.external and spec.concrete and spack.platforms.using_libc_compatibility():
             clauses.append(fn.attr("needs_libc", name))
             for libc in self.libcs:
                 clauses.append(fn.attr("compatible_libc", name, libc.name, libc.version))
@@ -2973,7 +2965,7 @@ class SpackSolverSetup:
 
         self.requirement_parser.parse_rules_from_input_specs(specs)
         self.gen.h1("Generic information")
-        if using_libc_compatibility():
+        if spack.platforms.using_libc_compatibility():
             for libc in self.libcs:
                 self.gen.fact(fn.host_libc(libc.name, libc.version))
 
@@ -3131,7 +3123,7 @@ class SpackSolverSetup:
                     description=f"Add compiler wrapper when using {compiler.name} for {language}",
                 )
 
-            if not using_libc_compatibility():
+            if not spack.platforms.using_libc_compatibility():
                 continue
 
             current_libc = None
@@ -3420,7 +3412,7 @@ def possible_compilers(*, configuration) -> Tuple[Set["spack.spec.Spec"], Set["s
 
     # Compilers defined in configuration
     for c in spack.compilers.config.all_compilers_from(configuration):
-        if using_libc_compatibility() and not c_compiler_runs(c):
+        if spack.platforms.using_libc_compatibility() and not c_compiler_runs(c):
             rejected.add(c)
             try:
                 compiler = c.extra_attributes["compilers"]["c"]
@@ -3433,7 +3425,10 @@ def possible_compilers(*, configuration) -> Tuple[Set["spack.spec.Spec"], Set["s
 
             continue
 
-        if using_libc_compatibility() and not CompilerPropertyDetector(c).default_libc():
+        if (
+            spack.platforms.using_libc_compatibility()
+            and not CompilerPropertyDetector(c).default_libc()
+        ):
             rejected.add(c)
             warnings.warn(
                 f"cannot detect libc from {c}. The compiler will not be used "

--- a/lib/spack/spack/solver/core.py
+++ b/lib/spack/spack/solver/core.py
@@ -5,7 +5,6 @@
 
 from typing import Any, NamedTuple, Optional, Tuple
 
-import spack.platforms
 from spack.llnl.util import lang
 
 from .compat import symbol_name, symbol_string
@@ -152,8 +151,3 @@ class SourceContext:
         # in that case).
         self.source = "none" if source is None else source
         self.wrap_node_requirement: Optional[bool] = None
-
-
-def using_libc_compatibility() -> bool:
-    """Returns True if we are currently using libc compatibility"""
-    return spack.platforms.host().name == "linux"

--- a/lib/spack/spack/solver/runtimes.py
+++ b/lib/spack/spack/solver/runtimes.py
@@ -7,12 +7,13 @@ from typing import Any, Dict, Set, Tuple
 import spack.compilers.config
 import spack.compilers.libraries
 import spack.config
+import spack.platforms
 import spack.repo
 import spack.spec
 import spack.util.libc
 import spack.version
 
-from .core import SourceContext, fn, using_libc_compatibility
+from .core import SourceContext, fn
 from .versions import Provenance
 
 
@@ -290,7 +291,7 @@ def external_config_with_implicit_externals(
     _normalize_packages_yaml(packages_yaml)
 
     # Add externals for libc from compilers on Linux
-    if not using_libc_compatibility():
+    if not spack.platforms.using_libc_compatibility():
         return packages_yaml
 
     seen = set()

--- a/lib/spack/spack/test/concretization/core.py
+++ b/lib/spack/spack/test/concretization/core.py
@@ -106,9 +106,7 @@ def binary_compatibility(monkeypatch, request):
         # Databases have been created without glibc support
         return
 
-    monkeypatch.setattr(spack.solver.core, "using_libc_compatibility", _true)
-    monkeypatch.setattr(spack.solver.runtimes, "using_libc_compatibility", _true)
-    monkeypatch.setattr(spack.solver.asp, "using_libc_compatibility", _true)
+    monkeypatch.setattr(spack.platforms, "using_libc_compatibility", _true)
 
 
 @pytest.fixture(
@@ -2784,7 +2782,7 @@ packages:
     def test_cannot_reuse_host_incompatible_libc(self):
         """Test whether reuse concretization correctly fails to reuse a spec with a host
         incompatible libc."""
-        if not spack.solver.core.using_libc_compatibility():
+        if not spack.platforms.using_libc_compatibility():
             pytest.skip("This test requires libc nodes")
 
         # We install b@1 ^glibc@2.30, and b@0 ^glibc@2.28. The former is not host compatible, the


### PR DESCRIPTION
Extracted from #52441 

The function `using_libc_compatibility` only needs platform information, and is thus better suited for the `spack.platforms` module.