### PR TITLE
Extract external config helpers into `spack.externals_config`

### DIFF
--- a/lib/spack/spack/cmd/find.py
+++ b/lib/spack/spack/cmd/find.py
@@ -17,9 +17,8 @@ import spack.solver.reuse
 import spack.spec
 import spack.store
 from spack.cmd.common import arguments
+from spack.externals_config import create_external_parser, external_config_with_implicit_externals
 from spack.llnl.util.tty.color import colorize
-from spack.solver.reuse import create_external_parser
-from spack.solver.runtimes import external_config_with_implicit_externals
 
 from ..enums import InstallRecordStatus
 

--- a/lib/spack/spack/externals_config.py
+++ b/lib/spack/spack/externals_config.py
@@ -1,0 +1,86 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+"""Helpers to build an ExternalSpecsParser from Spack configuration."""
+
+import itertools
+from typing import Any, Dict
+
+import spack.compilers.config
+import spack.compilers.libraries
+import spack.config
+import spack.platforms
+import spack.repo
+import spack.spec
+from spack.externals import (
+    ExternalSpecsParser,
+    complete_architecture,
+    complete_variants_and_architecture,
+    extract_dicts_from_configuration,
+)
+
+
+def _normalize_packages_yaml(packages_yaml: Dict[str, Any]) -> None:
+    for pkg_name in list(packages_yaml.keys()):
+        is_virtual = spack.repo.PATH.is_virtual(pkg_name)
+        if pkg_name == "all" or not is_virtual:
+            continue
+
+        # Remove the virtual entry from the normalized configuration
+        data = packages_yaml.pop(pkg_name)
+        is_buildable = data.get("buildable", True)
+        if not is_buildable:
+            for provider in spack.repo.PATH.providers_for(pkg_name):
+                entry = packages_yaml.setdefault(provider.name, {})
+                entry["buildable"] = False
+
+        externals = data.get("externals", [])
+
+        def keyfn(x):
+            return spack.spec.Spec(x["spec"]).name
+
+        for provider, specs in itertools.groupby(externals, key=keyfn):
+            entry = packages_yaml.setdefault(provider, {})
+            entry.setdefault("externals", []).extend(specs)
+
+
+def external_config_with_implicit_externals(
+    configuration: spack.config.Configuration,
+) -> Dict[str, Any]:
+    """Return packages.yaml augmented with implicit libc externals on Linux.
+
+    Normalizes the configuration so that virtual-package keys are replaced by
+    their concrete providers, then adds any libc specs detected from configured
+    compilers when running on a libc-compatibility platform.
+    """
+    packages_yaml = configuration.deepcopy_as_builtin("packages", line_info=True)
+    _normalize_packages_yaml(packages_yaml)
+
+    # Add externals for libc from compilers on Linux
+    if not spack.platforms.using_libc_compatibility():
+        return packages_yaml
+
+    seen = set()
+    for compiler in spack.compilers.config.all_compilers_from(configuration):
+        libc = spack.compilers.libraries.CompilerPropertyDetector(compiler).default_libc()
+        if libc and libc not in seen:
+            seen.add(libc)
+            entry = {"spec": f"{libc}", "prefix": libc.external_path}
+            packages_yaml.setdefault(libc.name, {}).setdefault("externals", []).append(entry)
+    return packages_yaml
+
+
+def create_external_parser(
+    packages_with_externals: Any, completion_mode: str
+) -> ExternalSpecsParser:
+    """Get externals from a pre-processed packages.yaml (with implicit externals)."""
+    external_dicts = extract_dicts_from_configuration(packages_with_externals)
+    if completion_mode == "default_variants":
+        complete_fn = complete_variants_and_architecture
+    elif completion_mode == "architecture_only":
+        complete_fn = complete_architecture
+    else:
+        raise ValueError(
+            f"Unknown value for concretizer:externals:completion: {completion_mode!r}"
+        )
+    return ExternalSpecsParser(external_dicts, complete_node=complete_fn)

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -44,6 +44,7 @@ import spack.concretize
 import spack.config
 import spack.deptypes as dt
 import spack.error
+import spack.externals_config
 import spack.llnl.util.lang
 import spack.llnl.util.tty as tty
 import spack.package_base
@@ -73,8 +74,8 @@ from .compat import default_clingo_control, make_error_control
 from .core import AspFunction, AspVar, NodeId, SourceContext, extract_args, fn
 from .input_analysis import create_counter, create_graph_analyzer
 from .requirements import RequirementKind, RequirementOrigin, RequirementParser, RequirementRule
-from .reuse import ReusableSpecsSelector, SpecFiltersFactory, create_external_parser
-from .runtimes import RuntimePropertyRecorder, all_libcs, external_config_with_implicit_externals
+from .reuse import ReusableSpecsSelector, SpecFiltersFactory
+from .runtimes import RuntimePropertyRecorder, all_libcs
 from .versions import Provenance
 
 GitOrStandardVersion = Union[vn.GitVersion, vn.StandardVersion]
@@ -2921,7 +2922,9 @@ class SpackSolverSetup:
 
         reuse = reuse or []
         if packages_with_externals is None:
-            packages_with_externals = external_config_with_implicit_externals(spack.config.CONFIG)
+            packages_with_externals = (
+                spack.externals_config.external_config_with_implicit_externals(spack.config.CONFIG)
+            )
         self._validate_input_specs(specs)
         self.gen = ProblemInstanceBuilder()
 
@@ -3914,11 +3917,15 @@ class Solver:
         self.driver = PyclingoDriver(conc_cache=self._conc_cache)
 
         # Compute packages configuration with implicit externals once and reuse it
-        self.packages_with_externals = external_config_with_implicit_externals(spack.config.CONFIG)
+        self.packages_with_externals = (
+            spack.externals_config.external_config_with_implicit_externals(spack.config.CONFIG)
+        )
         completion_mode = spack.config.CONFIG.get("concretizer:externals:completion")
         self.selector = ReusableSpecsSelector(
             configuration=spack.config.CONFIG,
-            external_parser=create_external_parser(self.packages_with_externals, completion_mode),
+            external_parser=spack.externals_config.create_external_parser(
+                self.packages_with_externals, completion_mode
+            ),
             factory=specs_factory,
             packages_with_externals=self.packages_with_externals,
         )

--- a/lib/spack/spack/solver/reuse.py
+++ b/lib/spack/spack/solver/reuse.py
@@ -14,12 +14,7 @@ import spack.repo
 import spack.spec
 import spack.store
 import spack.traverse
-from spack.externals import (
-    ExternalSpecsParser,
-    complete_architecture,
-    complete_variants_and_architecture,
-    extract_dicts_from_configuration,
-)
+from spack.externals import ExternalSpecsParser
 from spack.spec_filter import SpecFilter
 
 from .runtimes import all_libcs
@@ -153,22 +148,6 @@ class ReuseStrategy(enum.Enum):
     ROOTS = enum.auto()
     DEPENDENCIES = enum.auto()
     NONE = enum.auto()
-
-
-def create_external_parser(
-    packages_with_externals: Any, completion_mode: str
-) -> ExternalSpecsParser:
-    """Get externals from a pre-processed packages.yaml (with implicit externals)."""
-    external_dicts = extract_dicts_from_configuration(packages_with_externals)
-    if completion_mode == "default_variants":
-        complete_fn = complete_variants_and_architecture
-    elif completion_mode == "architecture_only":
-        complete_fn = complete_architecture
-    else:
-        raise ValueError(
-            f"Unknown value for concretizer:externals:completion: {completion_mode!r}"
-        )
-    return ExternalSpecsParser(external_dicts, complete_node=complete_fn)
 
 
 SpecFiltersFactory = Callable[

--- a/lib/spack/spack/solver/runtimes.py
+++ b/lib/spack/spack/solver/runtimes.py
@@ -1,13 +1,11 @@
 # Copyright Spack Project Developers. See COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
-import itertools
-from typing import Any, Dict, Set, Tuple
+from typing import Set, Tuple
 
 import spack.compilers.config
 import spack.compilers.libraries
 import spack.config
-import spack.platforms
 import spack.repo
 import spack.spec
 import spack.util.libc
@@ -256,52 +254,6 @@ class RuntimePropertyRecorder:
 
         self._setup.trigger_rules()
         self._setup.effect_rules()
-
-
-def _normalize_packages_yaml(packages_yaml: Dict[str, Any]) -> None:
-    for pkg_name in list(packages_yaml.keys()):
-        is_virtual = spack.repo.PATH.is_virtual(pkg_name)
-        if pkg_name == "all" or not is_virtual:
-            continue
-
-        # Remove the virtual entry from the normalized configuration
-        data = packages_yaml.pop(pkg_name)
-        is_buildable = data.get("buildable", True)
-        if not is_buildable:
-            for provider in spack.repo.PATH.providers_for(pkg_name):
-                entry = packages_yaml.setdefault(provider.name, {})
-                entry["buildable"] = False
-
-        externals = data.get("externals", [])
-
-        def keyfn(x):
-            return spack.spec.Spec(x["spec"]).name
-
-        for provider, specs in itertools.groupby(externals, key=keyfn):
-            entry = packages_yaml.setdefault(provider, {})
-            entry.setdefault("externals", []).extend(specs)
-
-
-def external_config_with_implicit_externals(
-    configuration: spack.config.Configuration,
-) -> Dict[str, Any]:
-    # Read packages.yaml and normalize it so that it will not contain entries referring to
-    # virtual packages.
-    packages_yaml = configuration.deepcopy_as_builtin("packages", line_info=True)
-    _normalize_packages_yaml(packages_yaml)
-
-    # Add externals for libc from compilers on Linux
-    if not spack.platforms.using_libc_compatibility():
-        return packages_yaml
-
-    seen = set()
-    for compiler in spack.compilers.config.all_compilers_from(configuration):
-        libc = spack.compilers.libraries.CompilerPropertyDetector(compiler).default_libc()
-        if libc and libc not in seen:
-            seen.add(libc)
-            entry = {"spec": f"{libc}", "prefix": libc.external_path}
-            packages_yaml.setdefault(libc.name, {}).setdefault("externals", []).append(entry)
-    return packages_yaml
 
 
 def all_libcs() -> Set[spack.spec.Spec]:

--- a/lib/spack/spack/test/concretization/compiler_runtimes.py
+++ b/lib/spack/spack/test/concretization/compiler_runtimes.py
@@ -16,8 +16,8 @@ import spack.repo
 import spack.solver.asp
 import spack.spec
 from spack.environment.environment import ViewDescriptor
-from spack.solver.reuse import create_external_parser, spec_filter_from_packages_yaml
-from spack.solver.runtimes import external_config_with_implicit_externals
+from spack.externals_config import create_external_parser, external_config_with_implicit_externals
+from spack.solver.reuse import spec_filter_from_packages_yaml
 from spack.version import Version
 
 

--- a/lib/spack/spack/test/concretization/core.py
+++ b/lib/spack/spack/test/concretization/core.py
@@ -25,6 +25,7 @@ import spack.config
 import spack.deptypes as dt
 import spack.environment as ev
 import spack.error
+import spack.externals_config
 import spack.hash_types as ht
 import spack.llnl.util.lang
 import spack.package_base
@@ -36,7 +37,6 @@ import spack.solver.asp
 import spack.solver.core
 import spack.solver.input_analysis
 import spack.solver.reuse
-import spack.solver.runtimes
 import spack.spec
 import spack.spec_filter
 import spack.util.file_cache
@@ -44,10 +44,10 @@ import spack.util.hash
 import spack.util.spack_yaml as syaml
 import spack.variant as vt
 from spack.externals import ExternalDependencyError
+from spack.externals_config import create_external_parser, external_config_with_implicit_externals
 from spack.installer import PackageInstaller
 from spack.solver.asp import Result
-from spack.solver.reuse import create_external_parser, spec_filter_from_packages_yaml
-from spack.solver.runtimes import external_config_with_implicit_externals
+from spack.solver.reuse import spec_filter_from_packages_yaml
 from spack.spec import Spec
 from spack.test.conftest import RepoBuilder
 from spack.version import Version, VersionList, ver
@@ -3299,7 +3299,7 @@ def test_filtering_reused_specs(
     """Tests that we can select which specs are to be reused, using constraints as filters"""
     # Assume all specs have a runtime dependency
     mutable_config.set("concretizer:reuse", reuse_yaml)
-    packages_with_externals = spack.solver.runtimes.external_config_with_implicit_externals(
+    packages_with_externals = spack.externals_config.external_config_with_implicit_externals(
         mutable_config
     )
     completion_mode = mutable_config.get("concretizer:externals:completion")
@@ -3340,7 +3340,7 @@ def test_selecting_reused_sources(reuse_yaml, expected_length, mutable_config):
     """Tests that we can turn on/off sources of reusable specs"""
     # Assume all specs have a runtime dependency
     mutable_config.set("concretizer:reuse", reuse_yaml)
-    packages_with_externals = spack.solver.runtimes.external_config_with_implicit_externals(
+    packages_with_externals = spack.externals_config.external_config_with_implicit_externals(
         mutable_config
     )
     completion_mode = mutable_config.get("concretizer:externals:completion")

--- a/lib/spack/spack/test/concretization/requirements.py
+++ b/lib/spack/spack/test/concretization/requirements.py
@@ -18,10 +18,10 @@ import spack.spec
 import spack.store
 import spack.util.spack_yaml as syaml
 import spack.version
+from spack.externals_config import create_external_parser, external_config_with_implicit_externals
 from spack.installer import PackageInstaller
 from spack.solver.asp import InternalConcretizerError, UnsatisfiableSpecError
-from spack.solver.reuse import create_external_parser, spec_filter_from_packages_yaml
-from spack.solver.runtimes import external_config_with_implicit_externals
+from spack.solver.reuse import spec_filter_from_packages_yaml
 from spack.spec import Spec
 from spack.util.url import path_to_file_url
 


### PR DESCRIPTION
Extracted from #52441

Move create_external_parser() from spack.solver.reuse and external_config_with_implicit_externals() from spack.solver.runtimes into a new spack.externals_config module.

The new module is intentionally free of `spack.solver imports`, which allows it to be used by both the solver and other utilities without creating circular import cycles.