### PR TITLE
Allow env variables in package_attributes

### DIFF
--- a/lib/spack/docs/packages_yaml.rst
+++ b/lib/spack/docs/packages_yaml.rst
@@ -769,7 +769,7 @@ For example, you can reference local source archives or build artifacts:
 All the variables documented in :ref:`config-file-variables` are supported, including:
 
 * ``$spack``: path to the Spack installation
-* ``$env``: name of the currently active environment
+* ``$env``: path to the currently active environment
 * ``$user``: current user name
 * ``${VARNAME}``: environment variables
 * ``~`` or ``~user``: user home directory expansion

--- a/lib/spack/docs/packages_yaml.rst
+++ b/lib/spack/docs/packages_yaml.rst
@@ -760,7 +760,7 @@ For example, you can reference local source archives or build artifacts:
          # Use Spack installation directory
          url: file://$spack/local-sources/mypackage-1.0.tar.gz
          # Use environment name
-         git: /projects/$env/mypackage.git
+         git: $env/mypackage.git
          # Use environment variables
          custom_path: ${HOME}/build/artifacts
          # Use user expansion

--- a/lib/spack/docs/packages_yaml.rst
+++ b/lib/spack/docs/packages_yaml.rst
@@ -744,4 +744,39 @@ You can assign class-level attributes in the configuration:
 Attributes set this way will be accessible to any method executed in the package.py file (e.g. the ``install()`` method).
 Values for these attributes may be any value parseable by yaml.
 
-These can only be applied to specific packages, not "all" or virtual packages.
+Variable substitution in package attributes
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Package attribute values support variable substitution, allowing you to use Spack-specific variables, environment variables, and user path expansion in your configuration.
+This is particularly useful for specifying paths relative to your Spack installation, environment, or home directory.
+
+For example, you can reference local source archives or build artifacts:
+
+.. code-block:: yaml
+
+   packages:
+     mypackage:
+       package_attributes:
+         # Use Spack installation directory
+         url: file://$spack/local-sources/mypackage-1.0.tar.gz
+         # Use environment name
+         git: /projects/$env/mypackage.git
+         # Use environment variables
+         custom_path: ${HOME}/build/artifacts
+         # Use user expansion
+         license_file: ~/licenses/mypackage.lic
+
+All the variables documented in :ref:`config-file-variables` are supported, including:
+
+* ``$spack``: path to the Spack installation
+* ``$env``: name of the currently active environment
+* ``$user``: current user name
+* ``${VARNAME}``: environment variables
+* ``~`` or ``~user``: user home directory expansion
+
+Variable substitution is applied to string values in ``package_attributes``.
+This allows you to create portable configurations that adapt to different environments and user contexts.
+
+.. note::
+
+   These can only be applied to specific packages, not "all" or virtual packages.

--- a/lib/spack/spack/repo.py
+++ b/lib/spack/spack/repo.py
@@ -733,7 +733,7 @@ class RepoPath:
         """Create a RepoPath from a configuration object."""
         overrides = {
             pkg_name: {
-                k: spack.util.path.substitute_path_variables(v)
+                k: spack.util.path.substitute_path_variables(v) if isinstance(v, str) else v
                 for k, v in data["package_attributes"].items()
             }
             for pkg_name, data in config.get_config("packages").items()

--- a/lib/spack/spack/repo.py
+++ b/lib/spack/spack/repo.py
@@ -731,15 +731,11 @@ class RepoPath:
     @staticmethod
     def from_config(config: spack.config.Configuration) -> "RepoPath":
         """Create a RepoPath from a configuration object."""
-
-        def replace_vars_in_package_attrs(attrs):
-            for a in ("git", "url"):
-                if a in attrs:
-                    attrs[a] = spack.util.path.substitute_path_variables(attrs[a])
-            return attrs
-
         overrides = {
-            pkg_name: replace_vars_in_package_attrs(data["package_attributes"])
+            pkg_name: {
+                k: spack.util.path.substitute_path_variables(v)
+                for k, v in data["package_attributes"].items()
+            }
             for pkg_name, data in config.get_config("packages").items()
             if pkg_name != "all" and "package_attributes" in data
         }

--- a/lib/spack/spack/repo.py
+++ b/lib/spack/spack/repo.py
@@ -731,8 +731,15 @@ class RepoPath:
     @staticmethod
     def from_config(config: spack.config.Configuration) -> "RepoPath":
         """Create a RepoPath from a configuration object."""
+
+        def replace_vars_in_package_attrs(attrs):
+            for a in ("git", "url"):
+                if a in attrs:
+                    attrs[a] = spack.util.path.substitute_path_variables(attrs[a])
+            return attrs
+
         overrides = {
-            pkg_name: data["package_attributes"]
+            pkg_name: replace_vars_in_package_attrs(data["package_attributes"])
             for pkg_name, data in config.get_config("packages").items()
             if pkg_name != "all" and "package_attributes" in data
         }

--- a/lib/spack/spack/test/concretization/preferences.py
+++ b/lib/spack/spack/test/concretization/preferences.py
@@ -167,11 +167,16 @@ class TestConcretizePreferences:
                 {"url": "http://www.somewhereelse.com/mpileaks-1.0.tar.gz"},
                 "http://www.somewhereelse.com/mpileaks-2.3.tar.gz",
             ),
+            (
+                {"url": "$SOMEPATH/mpileaks-1.0.tar.gz"},
+                "file:///some/where/else/mpileaks-2.3.tar.gz",
+            ),
             ({}, "http://www.spack.llnl.gov/mpileaks-2.3.tar.gz"),
         ],
     )
-    def test_config_set_pkg_property_url(self, update, expected, mock_packages_repo):
+    def test_config_set_pkg_property_url(self, update, expected, mock_packages_repo, monkeypatch):
         """Test setting an existing attribute in the package class"""
+        monkeypatch.setenv("SOMEPATH", "file:///some/where/else")
         update_packages("mpileaks", "package_attributes", update)
         with spack.repo.use_repositories(mock_packages_repo):
             spec = concretize("mpileaks")


### PR DESCRIPTION
Simplified version of #51098, only for package_attributes.