### PR TITLE
Iterator class for retry with backoff and jitter

### DIFF
--- a/lib/spack/spack/test/conftest.py
+++ b/lib/spack/spack/test/conftest.py
@@ -19,6 +19,7 @@ import stat
 import sys
 import tempfile
 import textwrap
+import time
 import xml.etree.ElementTree
 from pathlib import Path
 from typing import Callable, List, Optional, Tuple, Union
@@ -2614,3 +2615,22 @@ class FsTree:
                     p.write_bytes(content.content)
                 elif isinstance(content.content, str):
                     p.write_text(content.content, encoding="utf-8")
+
+
+@pytest.fixture(scope="function")
+def mock_sleep(monkeypatch):
+
+    class CallCounter:
+        def __init__(self):
+            self.times = []
+
+        def __call__(self, time):
+            self.times.append(time)
+
+        @property
+        def count(self):
+            return len(self.times)
+
+    _sleep = CallCounter()
+    monkeypatch.setattr(time, "sleep", _sleep)
+    yield _sleep

--- a/lib/spack/spack/test/conftest.py
+++ b/lib/spack/spack/test/conftest.py
@@ -19,7 +19,6 @@ import stat
 import sys
 import tempfile
 import textwrap
-import time
 import xml.etree.ElementTree
 from pathlib import Path
 from typing import Callable, List, Optional, Tuple, Union
@@ -2624,13 +2623,13 @@ def mock_sleep(monkeypatch):
         def __init__(self):
             self.times = []
 
-        def __call__(self, time):
-            self.times.append(time)
+        def __call__(self, duration):
+            self.times.append(duration)
 
         @property
         def count(self):
             return len(self.times)
 
     _sleep = CallCounter()
-    monkeypatch.setattr(time, "sleep", _sleep)
+    monkeypatch.setattr(spack.util.web.Retry, "sleep", lambda self: _sleep(self.backoff()))
     yield _sleep

--- a/lib/spack/spack/test/oci/urlopen.py
+++ b/lib/spack/spack/test/oci/urlopen.py
@@ -743,14 +743,11 @@ class BrokenServer(DummyServer):
         ("https://example.com/not-found/", 3, True, 1),
     ],
 )
-def test_retry(url, max_retries, expect_failure, expect_requests):
+def test_retry(url, max_retries, expect_failure, expect_requests, mock_sleep):
     server = BrokenServer("example.com")
     urlopen = create_opener(server).open
-    sleep_time = []
-    dont_sleep = lambda t: sleep_time.append(t)  # keep track of sleep times
-
     try:
-        response = default_retry(urlopen, retries=max_retries, sleep=dont_sleep)(url)
+        response = default_retry(urlopen, spack.util.web.Retry(total=max_retries))(url)
     except urllib.error.HTTPError as e:
         if not expect_failure:
             assert False, f"Unexpected HTTPError: {e}"
@@ -760,7 +757,7 @@ def test_retry(url, max_retries, expect_failure, expect_requests):
         assert response.status == 200
 
     assert len(server.requests) == expect_requests
-    assert sleep_time == [2**i for i in range(expect_requests - 1)]
+    assert mock_sleep.times == [2**i for i in range(expect_requests - 1)]
 
 
 def test_list_tags():

--- a/lib/spack/spack/test/oci/urlopen.py
+++ b/lib/spack/spack/test/oci/urlopen.py
@@ -15,6 +15,7 @@ from urllib.request import Request
 import pytest
 
 import spack.mirrors.mirror
+import spack.util.web
 from spack.oci.image import Digest, ImageReference, default_config, default_manifest
 from spack.oci.oci import (
     copy_missing_layers,

--- a/lib/spack/spack/test/util/util_web.py
+++ b/lib/spack/spack/test/util/util_web.py
@@ -3,7 +3,3 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 """Test Spack's Web utility functions."""
-
-from spack.util.web import Retry
-
-import pytest

--- a/lib/spack/spack/test/util/util_web.py
+++ b/lib/spack/spack/test/util/util_web.py
@@ -1,5 +1,0 @@
-# Copyright Spack Project Developers. See COPYRIGHT file for details.
-#
-# SPDX-License-Identifier: (Apache-2.0 OR MIT)
-
-"""Test Spack's Web utility functions."""

--- a/lib/spack/spack/test/util/util_web.py
+++ b/lib/spack/spack/test/util/util_web.py
@@ -1,0 +1,9 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+"""Test Spack's Web utility functions."""
+
+from spack.util.web import Retry
+
+import pytest

--- a/lib/spack/spack/test/web.py
+++ b/lib/spack/spack/test/web.py
@@ -524,9 +524,6 @@ def test_retry(monkeypatch, mock_sleep):
     assert retry.count == 5
     assert mock_sleep.count == 4
 
-    retry.reset()
-    assert retry.count == 0
-
     # Exit early on last attempt
     count = 0
     for _ in retry:
@@ -541,8 +538,6 @@ def test_retry(monkeypatch, mock_sleep):
     assert retry.count == 4
     assert mock_sleep.count == 8
 
-    retry.reset()
-
     count = 0
     # Exit early on first attempt
     for _ in retry:
@@ -553,8 +548,6 @@ def test_retry(monkeypatch, mock_sleep):
     assert count == 1
     assert retry.count == 0
     assert mock_sleep.count == 8
-
-    retry.reset()
 
     count = 0
     # Exit early on second attempt

--- a/lib/spack/spack/test/web.py
+++ b/lib/spack/spack/test/web.py
@@ -7,7 +7,6 @@ import os
 import pathlib
 import pickle
 import ssl
-import time
 import urllib.request
 from typing import Dict
 
@@ -39,25 +38,6 @@ page_4 = _create_url("4.html")
 
 root_with_fragment = _create_url("index_with_fragment.html")
 root_with_javascript = _create_url("index_with_javascript.html")
-
-
-@pytest.fixture(scope="function")
-def mock_sleep(monkeypatch):
-
-    class CallCounter:
-        def __init__(self):
-            self.times = []
-
-        def __call__(self, time):
-            self.times.append(time)
-
-        @property
-        def count(self):
-            return len(self.times)
-
-    _sleep = CallCounter()
-    monkeypatch.setattr(time, "sleep", _sleep)
-    yield _sleep
 
 
 @pytest.mark.parametrize(
@@ -495,7 +475,9 @@ def test_retry_on_transient_error(error_code, num_errors, max_retries, expect_fa
             )
         return "ok"
 
-    retrying = spack.util.web.retry_on_transient_error(flaky_func, retries=max_retries)
+    retrying = spack.util.web.retry_on_transient_error(
+        flaky_func, spack.util.web.Retry(total=max_retries)
+    )
 
     if expect_failure:
         with pytest.raises(urllib.error.HTTPError):
@@ -520,7 +502,7 @@ def test_retry_on_transient_error_non_oserror(mock_sleep):
             raise ResponseStreamingError("IncompleteRead")
         return "ok"
 
-    retrying = spack.util.web.retry_on_transient_error(flaky_func, retries=5)
+    retrying = spack.util.web.retry_on_transient_error(flaky_func)
 
     assert retrying() == "ok"
     assert call_count == 3

--- a/lib/spack/spack/test/web.py
+++ b/lib/spack/spack/test/web.py
@@ -511,7 +511,7 @@ def test_retry_on_transient_error_non_oserror(mock_sleep):
 
 def test_retry(monkeypatch, mock_sleep):
 
-    retry = spack.util.web.Retry(total=5, backoff_factor=1.0e-4, backoff_jitter=1.0e-9, backoff_max=1)
+    retry = spack.util.web.Retry(total=5, backoff_factor=1.0, backoff_jitter=1.0, backoff_max=1)
 
     # No early exit
     count = 0
@@ -521,7 +521,7 @@ def test_retry(monkeypatch, mock_sleep):
 
     assert count == 5
     assert retry.count == 5
-    assert mock_sleep.count  == 4
+    assert mock_sleep.count == 4
 
     retry.reset()
     assert retry.count == 0
@@ -538,7 +538,7 @@ def test_retry(monkeypatch, mock_sleep):
 
     assert count == 5
     assert retry.count == 4
-    assert mock_sleep.count  == 8
+    assert mock_sleep.count == 8
 
     retry.reset()
 

--- a/lib/spack/spack/test/web.py
+++ b/lib/spack/spack/test/web.py
@@ -7,6 +7,7 @@ import os
 import pathlib
 import pickle
 import ssl
+import urllib.error
 import urllib.request
 from typing import Dict
 
@@ -565,3 +566,23 @@ def test_retry(monkeypatch, mock_sleep):
     assert count == 2
     assert retry.count == 1
     assert mock_sleep.count == 9
+
+
+def test_retry_on_transient_error_reuse(mock_sleep):
+    """A shared Retry instance must be reset on each wrapper invocation."""
+    call_count = 0
+
+    def flaky_func():
+        nonlocal call_count
+        call_count += 1
+        if call_count % 2 != 0:
+            raise urllib.error.HTTPError(
+                url="https://example.com", code=503, msg="err", hdrs={}, fp=None
+            )
+        return "ok"
+
+    retry = spack.util.web.Retry(total=2)
+    retrying = spack.util.web.retry_on_transient_error(flaky_func, retry)
+
+    assert retrying() == "ok"
+    assert retrying() == "ok"

--- a/lib/spack/spack/test/web.py
+++ b/lib/spack/spack/test/web.py
@@ -7,6 +7,7 @@ import os
 import pathlib
 import pickle
 import ssl
+import time
 import urllib.request
 from typing import Dict
 
@@ -38,6 +39,25 @@ page_4 = _create_url("4.html")
 
 root_with_fragment = _create_url("index_with_fragment.html")
 root_with_javascript = _create_url("index_with_javascript.html")
+
+
+@pytest.fixture(scope="function")
+def mock_sleep(monkeypatch):
+
+    class CallCounter:
+        def __init__(self):
+            self.times = []
+
+        def __call__(self, time):
+            self.times.append(time)
+
+        @property
+        def count(self):
+            return len(self.times)
+
+    _sleep = CallCounter()
+    monkeypatch.setattr(time, "sleep", _sleep)
+    yield _sleep
 
 
 @pytest.mark.parametrize(
@@ -461,11 +481,10 @@ def test_ssl_curl_cert_file(
         (404, 1, 5, True),  # not transient, never retried
     ],
 )
-def test_retry_on_transient_error(error_code, num_errors, max_retries, expect_failure):
+def test_retry_on_transient_error(error_code, num_errors, max_retries, expect_failure, mock_sleep):
     import urllib.error
 
     call_count = 0
-    sleep_times = []
 
     def flaky_func():
         nonlocal call_count
@@ -476,26 +495,23 @@ def test_retry_on_transient_error(error_code, num_errors, max_retries, expect_fa
             )
         return "ok"
 
-    retrying = spack.util.web.retry_on_transient_error(
-        flaky_func, retries=max_retries, sleep=sleep_times.append
-    )
+    retrying = spack.util.web.retry_on_transient_error(flaky_func, retries=max_retries)
 
     if expect_failure:
         with pytest.raises(urllib.error.HTTPError):
             retrying()
     else:
         assert retrying() == "ok"
-        assert sleep_times == [2**i for i in range(num_errors)]
+        assert mock_sleep.times == [2**i for i in range(num_errors)]
 
 
-def test_retry_on_transient_error_non_oserror():
+def test_retry_on_transient_error_non_oserror(mock_sleep):
     """Non-OSError exceptions with transient names (e.g. botocore) should be retried."""
 
     class ResponseStreamingError(Exception):
         pass
 
     call_count = 0
-    sleep_times = []
 
     def flaky_func():
         nonlocal call_count
@@ -504,10 +520,66 @@ def test_retry_on_transient_error_non_oserror():
             raise ResponseStreamingError("IncompleteRead")
         return "ok"
 
-    retrying = spack.util.web.retry_on_transient_error(
-        flaky_func, retries=5, sleep=sleep_times.append
-    )
+    retrying = spack.util.web.retry_on_transient_error(flaky_func, retries=5)
 
     assert retrying() == "ok"
     assert call_count == 3
-    assert sleep_times == [1, 2]
+    assert mock_sleep.times == [1, 2]
+
+
+def test_retry(monkeypatch, mock_sleep):
+
+    retry = spack.util.web.Retry(total=5, backoff_factor=1.0e-4, backoff_jitter=1.0e-9, backoff_max=1)
+
+    # No early exit
+    count = 0
+    for _ in retry:
+        assert retry.count == count
+        count += 1
+
+    assert count == 5
+    assert retry.count == 5
+    assert mock_sleep.count  == 4
+
+    retry.reset()
+    assert retry.count == 0
+
+    # Exit early on last attempt
+    count = 0
+    for _ in retry:
+        assert retry.count == count
+        count += 1
+
+        # Skip the last increment step
+        if retry.is_last_attempt():
+            break
+
+    assert count == 5
+    assert retry.count == 4
+    assert mock_sleep.count  == 8
+
+    retry.reset()
+
+    count = 0
+    # Exit early on first attempt
+    for _ in retry:
+        count += 1
+        # Never increment retry, skips sleep
+        break
+
+    assert count == 1
+    assert retry.count == 0
+    assert mock_sleep.count == 8
+
+    retry.reset()
+
+    count = 0
+    # Exit early on second attempt
+    for _ in retry:
+        count += 1
+        if count == 2:
+            break
+
+    assert count == 2
+    assert retry.count == 1
+    assert mock_sleep.count == 9

--- a/lib/spack/spack/util/web.py
+++ b/lib/spack/spack/util/web.py
@@ -72,10 +72,6 @@ class Retry:
         """Return if this the retry counter is exhausted"""
         return self.count >= self.total
 
-    def reset(self):
-        """Reset the retry counter"""
-        self.count = 0
-
     def backoff(self) -> float:
         """Return the backoff duration in seconds for the current attempt"""
         value: float = self.backoff_factor * (2 ** (self.count - 1))
@@ -89,6 +85,7 @@ class Retry:
 
     def __iter__(self):
         """Convenient iterator function that handles doing backoff automatically"""
+        self.count = 0
         while True:
             yield self.count
             self.count += 1
@@ -130,7 +127,6 @@ def retry_on_transient_error(
     @functools.wraps(f)
     def wrapper(*args: _P.args, **kwargs: _P.kwargs) -> _R:
         _retry = retry or Retry()
-        _retry.reset()
         for _ in _retry:
             try:
                 return f(*args, **kwargs)

--- a/lib/spack/spack/util/web.py
+++ b/lib/spack/spack/util/web.py
@@ -59,6 +59,9 @@ class Retry:
         self.backoff_jitter = backoff_jitter
         self.backoff_max = backoff_max
 
+        assert self.backoff_max > 0, "Maximum backoff must be a positive value"
+        assert self.total >= 0, "Retry total cannot be negative"
+
     def is_last_attempt(self):
         """Return if this the retry counter is on last attempt"""
         return self.count == self.total - 1
@@ -122,6 +125,7 @@ def retry_on_transient_error(
     f: Callable[_P, _R], retry: Optional[Retry] = None
 ) -> Callable[_P, _R]:
     """Retry a function on transient HTTP/network errors with exponential backoff."""
+
     @functools.wraps(f)
     def wrapper(*args: _P.args, **kwargs: _P.kwargs) -> _R:
         _retry = retry or Retry()

--- a/lib/spack/spack/util/web.py
+++ b/lib/spack/spack/util/web.py
@@ -8,6 +8,7 @@ import functools
 import io
 import json
 import os
+import random
 import re
 import shutil
 import socket
@@ -40,6 +41,56 @@ from spack.llnl.util.filesystem import mkdirp, rename, working_dir
 from .executable import CommandNotFoundError, Executable
 from .gcs import GCSBlob, GCSBucket, GCSHandler
 from .s3 import UrllibS3Handler, get_s3_session
+
+
+class Retry:
+    """Wrapper class around retry logic"""
+
+    def __init__(
+        self,
+        total: int = 5,
+        backoff_factor: float = 0.1,
+        backoff_jitter: float = 0.0,
+        backoff_max: float = 120.0,
+    ):
+        self.total = total
+        self.count = 0
+        self.backoff_factor = backoff_factor
+        self.backoff_jitter = backoff_jitter
+        self.backoff_max = backoff_max
+
+    def is_last_attempt(self):
+        """Return if this the retry counter is on last attempt"""
+        return self.count == self.total - 1
+
+    def is_exhausted(self):
+        """Return if this the retry counter is exhausted"""
+        return self.count >= self.total
+
+    def reset(self):
+        """Reset the retry counter"""
+        self.count = 0
+
+    def _increment(self):
+        """Increment the attempt counter"""
+        self.count += 1
+
+    def _sleep(self):
+        """Sleep for the current attempts backoff waiting period"""
+        backoff: float = self.backoff_factor * (2**self.count)
+        if self.backoff_jitter != 0.0:
+            backoff += random.random() * self.backoff_jitter
+        backoff = float(max(0, min(self.backoff_max, backoff)))
+        time.sleep(backoff)
+
+    def __iter__(self):
+        """Convenient iterator function that handles doing backoff automatically"""
+        while True:
+            yield self.count
+            self._increment()
+            if self.is_exhausted():
+                break
+            self._sleep()
 
 
 def is_transient_error(e: Exception) -> bool:

--- a/lib/spack/spack/util/web.py
+++ b/lib/spack/spack/util/web.py
@@ -49,7 +49,7 @@ class Retry:
     def __init__(
         self,
         total: int = 5,
-        backoff_factor: float = 0.1,
+        backoff_factor: float = 0.5,
         backoff_jitter: float = 0.0,
         backoff_max: float = 120.0,
     ):
@@ -119,19 +119,17 @@ _R = TypeVar("_R")
 
 
 def retry_on_transient_error(
-    f: Callable[_P, _R], retries: int = 5, sleep: Optional[Callable[[float], None]] = None
+    f: Callable[_P, _R], retry: Optional[Retry] = None
 ) -> Callable[_P, _R]:
     """Retry a function on transient HTTP/network errors with exponential backoff."""
-    sleep = sleep or time.sleep
-
     @functools.wraps(f)
     def wrapper(*args: _P.args, **kwargs: _P.kwargs) -> _R:
-        for i in range(retries):
+        _retry = retry or Retry()
+        for _ in _retry:
             try:
                 return f(*args, **kwargs)
             except Exception as e:
-                if i + 1 != retries and is_transient_error(e):
-                    sleep(2**i)  # type: ignore[misc]  # mypy still thinks it's possibly None.
+                if not _retry.is_last_attempt() and is_transient_error(e):
                     continue
                 raise
         raise AssertionError("unreachable")

--- a/lib/spack/spack/util/web.py
+++ b/lib/spack/spack/util/web.py
@@ -49,7 +49,7 @@ class Retry:
     def __init__(
         self,
         total: int = 5,
-        backoff_factor: float = 0.5,
+        backoff_factor: float = 1.0,
         backoff_jitter: float = 0.0,
         backoff_max: float = 120.0,
     ):
@@ -59,12 +59,14 @@ class Retry:
         self.backoff_jitter = backoff_jitter
         self.backoff_max = backoff_max
 
-        assert self.backoff_max > 0, "Maximum backoff must be a positive value"
-        assert self.total >= 0, "Retry total cannot be negative"
+        if self.backoff_max <= 0:
+            raise ValueError("Maximum backoff must be a positive value")
+        if self.total < 1:
+            raise ValueError("Retry total must be at least 1")
 
     def is_last_attempt(self):
         """Return if this the retry counter is on last attempt"""
-        return self.count == self.total - 1
+        return self.count >= self.total - 1
 
     def is_exhausted(self):
         """Return if this the retry counter is exhausted"""
@@ -78,13 +80,16 @@ class Retry:
         """Increment the attempt counter"""
         self.count += 1
 
-    def _sleep(self):
-        """Sleep for the current attempts backoff waiting period"""
-        backoff: float = self.backoff_factor * (2**self.count)
+    def backoff(self) -> float:
+        """Return the backoff duration in seconds for the current attempt"""
+        value: float = self.backoff_factor * (2 ** (self.count - 1))
         if self.backoff_jitter != 0.0:
-            backoff += random.random() * self.backoff_jitter
-        backoff = float(max(0, min(self.backoff_max, backoff)))
-        time.sleep(backoff)
+            value += random.random() * self.backoff_jitter
+        return float(max(0, min(self.backoff_max, value)))
+
+    def sleep(self) -> None:
+        """Sleep for the backoff duration of the current attempt"""
+        time.sleep(self.backoff())
 
     def __iter__(self):
         """Convenient iterator function that handles doing backoff automatically"""
@@ -93,7 +98,7 @@ class Retry:
             self._increment()
             if self.is_exhausted():
                 break
-            self._sleep()
+            self.sleep()
 
 
 def is_transient_error(e: Exception) -> bool:
@@ -129,6 +134,7 @@ def retry_on_transient_error(
     @functools.wraps(f)
     def wrapper(*args: _P.args, **kwargs: _P.kwargs) -> _R:
         _retry = retry or Retry()
+        _retry.reset()
         for _ in _retry:
             try:
                 return f(*args, **kwargs)

--- a/lib/spack/spack/util/web.py
+++ b/lib/spack/spack/util/web.py
@@ -76,10 +76,6 @@ class Retry:
         """Reset the retry counter"""
         self.count = 0
 
-    def _increment(self):
-        """Increment the attempt counter"""
-        self.count += 1
-
     def backoff(self) -> float:
         """Return the backoff duration in seconds for the current attempt"""
         value: float = self.backoff_factor * (2 ** (self.count - 1))
@@ -95,7 +91,7 @@ class Retry:
         """Convenient iterator function that handles doing backoff automatically"""
         while True:
             yield self.count
-            self._increment()
+            self.count += 1
             if self.is_exhausted():
                 break
             self.sleep()


### PR DESCRIPTION
Add iterator class to facilitate implementing retries with exponential backoff (and jitter).

The formula implemented for exponential backoff, where $t_{retry}$ is the retry count

$$
T_{backoff} = MAX(0, MIN(F * 2^ t_{retry} + J, M_t))
$$

The jitter is computed as

$$
J = J_{factor} * U(0,1)
$$

The `Retry` class provides a simple interface for configuring retries.

| Options              | Description  |
| --------------------- | ---------------- |
| `total`                 | Total number of allowed retries |
| `backoff_factor` |  Scaling factor applied to base backoff ($F$) |
| `backoff_jitter`   | Scaling factor used for the jitter ($J_{factor}$) |
| `backoff_max`   | Maximum backoff in seconds ($M_t$) |