### PR TITLE
move .spack-db to unpadded root

### DIFF
--- a/lib/spack/spack/cmd/reindex.py
+++ b/lib/spack/spack/cmd/reindex.py
@@ -14,7 +14,8 @@ level = "long"
 
 
 def reindex(parser, args):
-    current_index = spack.store.STORE.db._index_path
+    store = spack.store.STORE
+    current_index = store.db._index_path
     needs_backup = os.path.isfile(current_index)
 
     if needs_backup:
@@ -22,9 +23,43 @@ def reindex(parser, args):
         shutil.copy(current_index, backup)
         tty.msg("Created a backup copy of the DB at", backup)
 
-    spack.store.STORE.reindex()
-
-    extra = ["If you need to restore, replace it with the backup."] if needs_backup else []
-    tty.msg(
-        f"The DB at {current_index} has been reindexed to v{spack.database._DB_VERSION}", *extra
+    old_db_path = os.path.join(store.root, spack.database._DB_DIRNAME)
+    new_db_path = os.path.join(store.unpadded_root, spack.database._DB_DIRNAME)
+    migrating = (
+        store.root != store.unpadded_root
+        and os.path.exists(old_db_path)
+        and not os.path.exists(new_db_path)
     )
+
+    if migrating:
+        old_db_temp = old_db_path + ".old"
+        tty.msg(f"Migrating database from {old_db_path} to {new_db_path}")
+        shutil.move(old_db_path, old_db_temp)
+
+        try:
+            from spack.store import Store
+
+            store = Store(
+                store.root,
+                unpadded_root=store.unpadded_root,
+                projections=store.projections,
+                hash_length=store.hash_length,
+                upstreams=store.upstreams,
+                lock_cfg=store.lock_cfg,
+            )
+            spack.store.STORE = store
+
+            store.reindex()
+
+            shutil.rmtree(old_db_temp)
+            tty.msg(f"Removed old database at {old_db_path}")
+        except Exception:
+            if os.path.exists(old_db_temp):
+                shutil.move(old_db_temp, old_db_path)
+            raise
+    else:
+        store.reindex()
+
+    final_index = store.db._index_path
+    extra = ["If you need to restore, replace it with the backup."] if needs_backup else []
+    tty.msg(f"The DB at {final_index} has been reindexed to v{spack.database._DB_VERSION}", *extra)

--- a/lib/spack/spack/store.py
+++ b/lib/spack/spack/store.py
@@ -190,10 +190,16 @@ class Store:
         self.upstreams = upstreams
         self.lock_cfg = lock_cfg
         self.layout = spack.directory_layout.DirectoryLayout(
-            root, projections=projections, hash_length=hash_length
+            self.root, projections=projections, hash_length=hash_length
         )
+        # For backwards compatibility: if the database exists in the old location (root),
+        # use it; otherwise, use the new location (unpadded_root)
+        if os.path.exists(os.path.join(self.root, spack.database._DB_DIRNAME)):
+            self.metadata_root = self.root
+        else:
+            self.metadata_root = self.unpadded_root
         self.db = spack.database.Database(
-            root, upstream_dbs=upstreams, lock_cfg=lock_cfg, layout=self.layout
+            self.metadata_root, upstream_dbs=upstreams, lock_cfg=lock_cfg, layout=self.layout
         )
 
         timeout_format_str = (
@@ -202,9 +208,9 @@ class Store:
         tty.debug("PACKAGE LOCK TIMEOUT: {0}".format(str(timeout_format_str)))
 
         self.prefix_locker = spack.database.SpecLocker(
-            spack.database.prefix_lock_path(root), lock_cfg=lock_cfg
+            spack.database.prefix_lock_path(self.metadata_root), lock_cfg=lock_cfg
         )
-        self.failure_tracker = spack.database.FailureTracker(self.root, lock_cfg=lock_cfg)
+        self.failure_tracker = spack.database.FailureTracker(self.metadata_root, lock_cfg=lock_cfg)
 
     def has_padding(self) -> bool:
         """Returns True if the store layout includes path padding."""

--- a/lib/spack/spack/test/cmd/reindex.py
+++ b/lib/spack/spack/test/cmd/reindex.py
@@ -4,6 +4,9 @@
 import pathlib
 import shutil
 
+import spack.database
+import spack.store
+import spack.util.path
 from spack.database import Database
 from spack.enums import InstallRecordStatus
 from spack.main import SpackCommand
@@ -85,3 +88,64 @@ def test_reindex_with_deprecated_packages(
     assert old_libelf.deprecated_for == new_libelf.spec.dag_hash()
     assert new_libelf.deprecated_for is None
     assert new_libelf.ref_count == 1
+
+
+def test_reindex_migrates_db_from_padded_to_unpadded_root(
+    mock_packages, mock_archive, mock_fetch, install_mockery, tmp_path: pathlib.Path, monkeypatch
+):
+    """Test that reindex migrates database from padded root to unpadded root."""
+    unpadded = str(tmp_path / "opt" / "spack")
+    padded = spack.util.path.add_padding(unpadded, 128)
+
+    store = Store(root=padded, unpadded_root=unpadded, projections={"all": "{name}/{version}"})
+
+    old_db_path = pathlib.Path(store.root) / spack.database._DB_DIRNAME
+    old_db_path.mkdir(parents=True, exist_ok=True)
+    store.metadata_root = store.root
+    store.db = spack.database.Database(store.root, layout=store.layout)
+
+    monkeypatch.setattr(spack.store, "STORE", store)
+
+    install("--fake", "libelf@0.8.13")
+    install("--fake", "libelf@0.8.12")
+    all_installed = store.db.query()
+
+    new_db_path = pathlib.Path(store.unpadded_root) / spack.database._DB_DIRNAME
+    assert old_db_path.exists()
+    assert not new_db_path.exists()
+
+    reindex()
+
+    assert not old_db_path.exists()
+    assert new_db_path.exists()
+    assert spack.store.STORE.db.query() == all_installed
+    assert spack.store.STORE.metadata_root == spack.store.STORE.unpadded_root
+
+
+def test_reindex_no_migration_when_already_migrated(
+    mock_packages, mock_archive, mock_fetch, install_mockery, tmp_path: pathlib.Path, monkeypatch
+):
+    """Test that reindex doesn't migrate when DB already in new location."""
+    unpadded = str(tmp_path / "opt" / "spack")
+    padded = spack.util.path.add_padding(unpadded, 128)
+
+    store = Store(root=padded, unpadded_root=unpadded, projections={"all": "{name}/{version}"})
+
+    monkeypatch.setattr(spack.store, "STORE", store)
+
+    install("--fake", "libelf@0.8.13")
+    install("--fake", "libelf@0.8.12")
+    all_installed = store.db.query()
+
+    new_db_path = pathlib.Path(store.unpadded_root) / spack.database._DB_DIRNAME
+    old_db_path = pathlib.Path(store.root) / spack.database._DB_DIRNAME
+    assert new_db_path.exists()
+    assert not old_db_path.exists()
+    assert store.metadata_root == store.unpadded_root
+
+    reindex()
+
+    assert new_db_path.exists()
+    assert not old_db_path.exists()
+    assert store.db.query() == all_installed
+    assert store.metadata_root == store.unpadded_root


### PR DESCRIPTION
When building with padding (e.g. for build caches), the .spack-db ends up in a deep directory structure. Using the same Spack instances as upstream becomes cumbersome because you need to somehow get that long padded install tree location. This moves the `.spack-db` folder to the unpadded root.

For backwards compatibility this will keep using the existing DB if it already exists.