### PR TITLE
feat: `spack ci verify-patches` akin to `verify-versions`

### DIFF
--- a/lib/spack/spack/cmd/ci.py
+++ b/lib/spack/spack/cmd/ci.py
@@ -864,7 +864,6 @@ def _collect_url_patches(pkg_cls) -> List[spack.patch.UrlPatch]:
     return patches
 
 
-
 def validate_patch_urls(pkg_name: str, patches: List[spack.patch.UrlPatch]) -> bool:
     valid = True
     seen: Set[Tuple[str, str, Optional[str]]] = set()
@@ -897,9 +896,8 @@ def validate_patch_urls(pkg_name: str, patches: List[spack.patch.UrlPatch]) -> b
 def ci_verify_patches(args):
     """\
     validate patch checksums between git refs
-    This command takes from_ref and to_ref arguments and checks any newly added patch
-    checksums in changed package files for valid sha256 format, then downloads the
-    corresponding URL patches and validates their checksums.
+    This command takes from_ref and to_ref arguments and downloads any newly added
+    URL patches in changed package files and validates their checksums.
     """
     # Get a list of all packages that have been changed or added
     # between from_ref and to_ref

--- a/lib/spack/spack/cmd/ci.py
+++ b/lib/spack/spack/cmd/ci.py
@@ -837,7 +837,7 @@ def _collect_url_patch_checksums(
 ) -> List[str]:
     checksums = set()
 
-    for patch in (url_patches if url_patches is not None else _collect_url_patches(pkg_cls)):
+    for patch in url_patches if url_patches is not None else _collect_url_patches(pkg_cls):
         checksums.add(patch.sha256)
         if patch.archive_sha256:
             checksums.add(patch.archive_sha256)

--- a/lib/spack/spack/cmd/ci.py
+++ b/lib/spack/spack/cmd/ci.py
@@ -8,7 +8,7 @@ import os
 import re
 import shutil
 import sys
-from typing import Dict, List
+from typing import Dict, List, Set, Tuple
 from urllib.parse import urlparse, urlunparse
 
 import spack.binary_distribution
@@ -837,13 +837,22 @@ def validate_git_versions(
 def _collect_url_patch_checksums(pkg_cls) -> List[str]:
     checksums = set()
 
+    for patch in _collect_url_patches(pkg_cls):
+        checksums.add(patch.sha256)
+        if patch.archive_sha256:
+            checksums.add(patch.archive_sha256)
+
+    return list(checksums)
+
+
+def _collect_url_patches(pkg_cls) -> List[spack.patch.UrlPatch]:
+    patches: List[spack.patch.UrlPatch] = []
+
     for patch_list in pkg_cls.patches.values():
         for patch in patch_list:
             if not isinstance(patch, spack.patch.UrlPatch):
                 continue
-            checksums.add(patch.sha256)
-            if patch.archive_sha256:
-                checksums.add(patch.archive_sha256)
+            patches.append(patch)
 
     for deps_by_name in pkg_cls.dependencies.values():
         for dependency in deps_by_name.values():
@@ -851,11 +860,9 @@ def _collect_url_patch_checksums(pkg_cls) -> List[str]:
                 for patch in patch_list:
                     if not isinstance(patch, spack.patch.UrlPatch):
                         continue
-                    checksums.add(patch.sha256)
-                    if patch.archive_sha256:
-                        checksums.add(patch.archive_sha256)
+                    patches.append(patch)
 
-    return list(checksums)
+    return patches
 
 
 def validate_patch_checksums(pkg_name: str, checksums: List[str]) -> bool:
@@ -875,11 +882,41 @@ def validate_patch_checksums(pkg_name: str, checksums: List[str]) -> bool:
     return valid
 
 
+def validate_patch_urls(pkg_name: str, patches: List[spack.patch.UrlPatch]) -> bool:
+    valid = True
+    seen: Set[Tuple[str, str, str]] = set()
+
+    for patch in patches:
+        key = (patch.url, patch.sha256, patch.archive_sha256 or "")
+        if key in seen:
+            continue
+        seen.add(key)
+
+        try:
+            with spack.stage.Stage(patch.fetcher()) as stage:
+                stage.fetch()
+                stage.check()
+                stage.expand_archive()
+        except spack.error.SpackError as e:
+            tty.error(
+                f"Failed to verify patch URL and checksum in {pkg_name}\n"
+                f"    [URL] {patch.url}\n"
+                f"    [Error] {e}"
+            )
+            valid = False
+            continue
+
+        tty.info(f"Validated patch URL and checksum in {pkg_name} --> {patch.url}")
+
+    return valid
+
+
 def ci_verify_patches(args):
     """\
     validate patch checksums between git refs
     This command takes from_ref and to_ref arguments and checks any newly added patch
-    checksums in changed package files for valid sha256 format.
+    checksums in changed package files for valid sha256 format, then downloads the
+    corresponding URL patches and validates their checksums.
     """
     # Get a list of all packages that have been changed or added
     # between from_ref and to_ref
@@ -902,6 +939,8 @@ def ci_verify_patches(args):
         if not patch_checksums:
             continue
 
+        url_patches = _collect_url_patches(pkg_cls)
+
         with fs.working_dir(os.path.dirname(path)):
             added_patch_checksums = spack_ci.filter_added_checksums(
                 patch_checksums, path, from_ref=args.from_ref, to_ref=args.to_ref
@@ -909,6 +948,19 @@ def ci_verify_patches(args):
 
         if added_patch_checksums:
             success = success and validate_patch_checksums(pkg_name, added_patch_checksums)
+
+            valid_added_patch_checksums = {
+                checksum for checksum in added_patch_checksums if SHA256_REGEX.fullmatch(checksum)
+            }
+            patches_to_verify = [
+                patch
+                for patch in url_patches
+                if patch.sha256 in valid_added_patch_checksums
+                or patch.archive_sha256 in valid_added_patch_checksums
+            ]
+
+            if patches_to_verify:
+                success = success and validate_patch_urls(pkg_name, patches_to_verify)
 
     if not success:
         sys.exit(1)

--- a/lib/spack/spack/cmd/ci.py
+++ b/lib/spack/spack/cmd/ci.py
@@ -8,7 +8,7 @@ import os
 import re
 import shutil
 import sys
-from typing import Dict, List, Set, Tuple
+from typing import Dict, List, Optional, Set, Tuple
 from urllib.parse import urlparse, urlunparse
 
 import spack.binary_distribution
@@ -834,15 +834,17 @@ def validate_git_versions(
     return valid_commit
 
 
-def _collect_url_patch_checksums(pkg_cls) -> List[str]:
+def _collect_url_patch_checksums(
+    pkg_cls, url_patches: Optional[List[spack.patch.UrlPatch]] = None
+) -> List[str]:
     checksums = set()
 
-    for patch in _collect_url_patches(pkg_cls):
+    for patch in (url_patches if url_patches is not None else _collect_url_patches(pkg_cls)):
         checksums.add(patch.sha256)
         if patch.archive_sha256:
             checksums.add(patch.archive_sha256)
 
-    return list(checksums)
+    return sorted(checksums)
 
 
 def _collect_url_patches(pkg_cls) -> List[spack.patch.UrlPatch]:
@@ -884,10 +886,10 @@ def validate_patch_checksums(pkg_name: str, checksums: List[str]) -> bool:
 
 def validate_patch_urls(pkg_name: str, patches: List[spack.patch.UrlPatch]) -> bool:
     valid = True
-    seen: Set[Tuple[str, str, str]] = set()
+    seen: Set[Tuple[str, str, Optional[str]]] = set()
 
     for patch in patches:
-        key = (patch.url, patch.sha256, patch.archive_sha256 or "")
+        key = (patch.url, patch.sha256, patch.archive_sha256)
         if key in seen:
             continue
         seen.add(key)
@@ -935,11 +937,11 @@ def ci_verify_patches(args):
             tty.warn(f"Skipping manual download package: {pkg_name}")
             continue
 
-        patch_checksums = _collect_url_patch_checksums(pkg_cls)
-        if not patch_checksums:
+        url_patches = _collect_url_patches(pkg_cls)
+        if not url_patches:
             continue
 
-        url_patches = _collect_url_patches(pkg_cls)
+        patch_checksums = _collect_url_patch_checksums(pkg_cls, url_patches=url_patches)
 
         with fs.working_dir(os.path.dirname(path)):
             added_patch_checksums = spack_ci.filter_added_checksums(

--- a/lib/spack/spack/cmd/ci.py
+++ b/lib/spack/spack/cmd/ci.py
@@ -46,6 +46,7 @@ level = "long"
 SPACK_COMMAND = "spack"
 INSTALL_FAIL_CODE = 1
 FAILED_CREATE_BUILDCACHE_CODE = 100
+SHA256_REGEX = re.compile(r"^[A-Fa-f0-9]{64}$")
 
 
 def deindent(desc):
@@ -844,9 +845,6 @@ def _collect_url_patch_checksums(pkg_cls) -> List[str]:
             if patch.archive_sha256:
                 checksums.add(patch.archive_sha256)
 
-    if not pkg_cls._patches_dependencies:
-        return list(checksums)
-
     for deps_by_name in pkg_cls.dependencies.values():
         for dependency in deps_by_name.values():
             for patch_list in dependency.patches.values():
@@ -863,7 +861,7 @@ def _collect_url_patch_checksums(pkg_cls) -> List[str]:
 def validate_patch_checksums(pkg_name: str, checksums: List[str]) -> bool:
     valid = True
     for checksum in checksums:
-        if not re.fullmatch(r"[A-Fa-f0-9]{64}", checksum):
+        if not SHA256_REGEX.fullmatch(checksum):
             tty.error(
                 f"Invalid patch checksum found in {pkg_name}\n"
                 f"    {checksum}\n"
@@ -910,7 +908,7 @@ def ci_verify_patches(args):
             )
 
         if added_patch_checksums:
-            success &= validate_patch_checksums(pkg_name, added_patch_checksums)
+            success = success and validate_patch_checksums(pkg_name, added_patch_checksums)
 
     if not success:
         sys.exit(1)

--- a/lib/spack/spack/cmd/ci.py
+++ b/lib/spack/spack/cmd/ci.py
@@ -5,6 +5,7 @@
 import argparse
 import json
 import os
+import re
 import shutil
 import sys
 from typing import Dict, List
@@ -24,6 +25,7 @@ import spack.llnl.util.filesystem as fs
 import spack.llnl.util.tty.color as clr
 import spack.mirrors.mirror
 import spack.package_base
+import spack.patch
 import spack.repo
 import spack.spec
 import spack.stage
@@ -242,6 +244,15 @@ def setup_parser(subparser: argparse.ArgumentParser) -> None:
     verify_versions.add_argument("from_ref", help="git ref from which start looking at changes")
     verify_versions.add_argument("to_ref", help="git ref to end looking at changes")
     verify_versions.set_defaults(func=ci_verify_versions, subparser=verify_versions)
+
+    verify_patches = subparsers.add_parser(
+        "verify-patches",
+        description=doc_dedented(ci_verify_patches),
+        help=doc_first_line(ci_verify_patches),
+    )
+    verify_patches.add_argument("from_ref", help="git ref from which start looking at changes")
+    verify_patches.add_argument("to_ref", help="git ref to end looking at changes")
+    verify_patches.set_defaults(func=ci_verify_patches, subparser=verify_patches)
 
 
 def ci_generate(args):
@@ -820,6 +831,89 @@ def validate_git_versions(
             tty.info(f"Validated {pkg.name}@{version} --> {known_commit}")
 
     return valid_commit
+
+
+def _collect_url_patch_checksums(pkg_cls) -> List[str]:
+    checksums = set()
+
+    for patch_list in pkg_cls.patches.values():
+        for patch in patch_list:
+            if not isinstance(patch, spack.patch.UrlPatch):
+                continue
+            checksums.add(patch.sha256)
+            if patch.archive_sha256:
+                checksums.add(patch.archive_sha256)
+
+    if not pkg_cls._patches_dependencies:
+        return list(checksums)
+
+    for deps_by_name in pkg_cls.dependencies.values():
+        for dependency in deps_by_name.values():
+            for patch_list in dependency.patches.values():
+                for patch in patch_list:
+                    if not isinstance(patch, spack.patch.UrlPatch):
+                        continue
+                    checksums.add(patch.sha256)
+                    if patch.archive_sha256:
+                        checksums.add(patch.archive_sha256)
+
+    return list(checksums)
+
+
+def validate_patch_checksums(pkg_name: str, checksums: List[str]) -> bool:
+    valid = True
+    for checksum in checksums:
+        if not re.fullmatch(r"[A-Fa-f0-9]{64}", checksum):
+            tty.error(
+                f"Invalid patch checksum found in {pkg_name}\n"
+                f"    {checksum}\n"
+                "    Patch checksums must be 64 hexadecimal characters"
+            )
+            valid = False
+            continue
+
+        tty.info(f"Validated patch checksum in {pkg_name} --> {checksum}")
+
+    return valid
+
+
+def ci_verify_patches(args):
+    """\
+    validate patch checksums between git refs
+    This command takes from_ref and to_ref arguments and checks any newly added patch
+    checksums in changed package files for valid sha256 format.
+    """
+    # Get a list of all packages that have been changed or added
+    # between from_ref and to_ref
+    pkgs = spack.repo.get_all_package_diffs(
+        "AC", spack.repo.builtin_repo(), args.from_ref, args.to_ref
+    )
+
+    success = True
+    for pkg_name in pkgs:
+        spec = spack.spec.Spec(pkg_name)
+        pkg = spack.repo.PATH.get_pkg_class(spec.name)(spec)
+        pkg_cls = type(pkg)
+        path = spack.repo.PATH.package_path(pkg_name)
+
+        if pkg.manual_download:
+            tty.warn(f"Skipping manual download package: {pkg_name}")
+            continue
+
+        patch_checksums = _collect_url_patch_checksums(pkg_cls)
+        if not patch_checksums:
+            continue
+
+        with fs.working_dir(os.path.dirname(path)):
+            added_patch_checksums = spack_ci.filter_added_checksums(
+                patch_checksums, path, from_ref=args.from_ref, to_ref=args.to_ref
+            )
+
+        if added_patch_checksums:
+            success &= validate_patch_checksums(pkg_name, added_patch_checksums)
+
+    if not success:
+        sys.exit(1)
 
 
 def ci_verify_versions(args):

--- a/lib/spack/spack/cmd/ci.py
+++ b/lib/spack/spack/cmd/ci.py
@@ -46,6 +46,7 @@ SPACK_COMMAND = "spack"
 INSTALL_FAIL_CODE = 1
 FAILED_CREATE_BUILDCACHE_CODE = 100
 
+
 def deindent(desc):
     return desc.replace("    ", "")
 

--- a/lib/spack/spack/cmd/ci.py
+++ b/lib/spack/spack/cmd/ci.py
@@ -5,7 +5,6 @@
 import argparse
 import json
 import os
-import re
 import shutil
 import sys
 from typing import Dict, List, Optional, Set, Tuple
@@ -46,8 +45,6 @@ level = "long"
 SPACK_COMMAND = "spack"
 INSTALL_FAIL_CODE = 1
 FAILED_CREATE_BUILDCACHE_CODE = 100
-SHA256_REGEX = re.compile(r"^[A-Fa-f0-9]{64}$")
-
 
 def deindent(desc):
     return desc.replace("    ", "")
@@ -867,22 +864,6 @@ def _collect_url_patches(pkg_cls) -> List[spack.patch.UrlPatch]:
     return patches
 
 
-def validate_patch_checksums(pkg_name: str, checksums: List[str]) -> bool:
-    valid = True
-    for checksum in checksums:
-        if not SHA256_REGEX.fullmatch(checksum):
-            tty.error(
-                f"Invalid patch checksum found in {pkg_name}\n"
-                f"    {checksum}\n"
-                "    Patch checksums must be 64 hexadecimal characters"
-            )
-            valid = False
-            continue
-
-        tty.info(f"Validated patch checksum in {pkg_name} --> {checksum}")
-
-    return valid
-
 
 def validate_patch_urls(pkg_name: str, patches: List[spack.patch.UrlPatch]) -> bool:
     valid = True
@@ -949,16 +930,12 @@ def ci_verify_patches(args):
             )
 
         if added_patch_checksums:
-            success = success and validate_patch_checksums(pkg_name, added_patch_checksums)
-
-            valid_added_patch_checksums = {
-                checksum for checksum in added_patch_checksums if SHA256_REGEX.fullmatch(checksum)
-            }
+            added_patch_checksums_set = set(added_patch_checksums)
             patches_to_verify = [
                 patch
                 for patch in url_patches
-                if patch.sha256 in valid_added_patch_checksums
-                or patch.archive_sha256 in valid_added_patch_checksums
+                if patch.sha256 in added_patch_checksums_set
+                or patch.archive_sha256 in added_patch_checksums_set
             ]
 
             if patches_to_verify:

--- a/lib/spack/spack/test/cmd/ci.py
+++ b/lib/spack/spack/test/cmd/ci.py
@@ -2231,13 +2231,15 @@ def test_ci_verify_patches_valid(monkeypatch, mock_packages, mock_git_package_ch
         monkeypatch.setattr(
             spack.cmd.ci,
             "_collect_url_patch_checksums",
-            lambda pkg_cls: [
+            lambda pkg_cls, **kwargs: [
                 "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
             ],
         )
         monkeypatch.setattr(spack.cmd.ci, "_collect_url_patches", lambda pkg_cls: [Patch()])
         monkeypatch.setattr(
-            ci, "filter_added_checksums", lambda checksums, path, **kwargs: checksums
+            ci,
+            "filter_added_checksums",
+            lambda checksums, path, **kwargs: checksums,
         )
         monkeypatch.setattr(spack.cmd.ci, "validate_patch_urls", lambda pkg_name, patches: True)
 
@@ -2254,10 +2256,14 @@ def test_ci_verify_patches_invalid(monkeypatch, mock_packages, mock_git_package_
     repo, _, commits = mock_git_package_changes
     with spack.repo.use_repositories(repo):
         monkeypatch.setattr(spack.repo, "builtin_repo", lambda: repo)
-        monkeypatch.setattr(spack.cmd.ci, "_collect_url_patch_checksums", lambda pkg_cls: ["abc"])
+        monkeypatch.setattr(
+            spack.cmd.ci, "_collect_url_patch_checksums", lambda pkg_cls, **kwargs: ["abc"]
+        )
         monkeypatch.setattr(spack.cmd.ci, "_collect_url_patches", lambda pkg_cls: [Patch()])
         monkeypatch.setattr(
-            ci, "filter_added_checksums", lambda checksums, path, **kwargs: checksums
+            ci,
+            "filter_added_checksums",
+            lambda checksums, path, **kwargs: checksums,
         )
         monkeypatch.setattr(spack.cmd.ci, "validate_patch_urls", lambda pkg_name, patches: True)
 
@@ -2280,7 +2286,7 @@ def test_ci_verify_patches_validates_patch_urls(
         monkeypatch.setattr(
             spack.cmd.ci,
             "_collect_url_patch_checksums",
-            lambda pkg_cls: [
+            lambda pkg_cls, **kwargs: [
                 "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
             ],
         )
@@ -2299,7 +2305,11 @@ def test_ci_verify_patches_validates_patch_urls(
             ],
         )
         monkeypatch.setattr(
-            ci, "filter_added_checksums", lambda checksums, path, **kwargs: checksums
+            ci,
+            "filter_added_checksums",
+            lambda checksums, path, **kwargs: [
+                "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890"
+            ],
         )
 
         captured = {}

--- a/lib/spack/spack/test/cmd/ci.py
+++ b/lib/spack/spack/test/cmd/ci.py
@@ -2188,6 +2188,65 @@ def verify_git_versions_invalid(monkeypatch):
     monkeypatch.setattr(spack.cmd.ci, "validate_git_versions", validate_git_versions)
 
 
+def test_ci_validate_patch_checksums_valid(capfd):
+    checksum = "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890"
+    assert spack.cmd.ci.validate_patch_checksums("diff-test", [checksum])
+
+    out, err = capfd.readouterr()
+    assert "Validated patch checksum in diff-test" in out
+
+
+def test_ci_validate_patch_checksums_invalid(capfd):
+    checksum = "abcdef1234567890abcdef1234567890"
+    assert spack.cmd.ci.validate_patch_checksums("diff-test", [checksum]) is False
+
+    out, err = capfd.readouterr()
+    assert "Invalid patch checksum found in diff-test" in err
+
+
+def test_ci_collect_url_patch_checksums_includes_dependency_patches(mock_packages):
+    pkg_cls = spack.repo.PATH.get_pkg_class("patch-several-dependencies")
+    checksums = set(spack.cmd.ci._collect_url_patch_checksums(pkg_cls))
+
+    assert (
+        "abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234" in checksums
+    )
+    assert (
+        "1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd" in checksums
+    )
+    assert (
+        "abcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcd" in checksums
+    )
+
+
+def test_ci_verify_patches_valid(monkeypatch, mock_packages, mock_git_package_changes):
+    repo, _, commits = mock_git_package_changes
+    with spack.repo.use_repositories(repo):
+        monkeypatch.setattr(spack.repo, "builtin_repo", lambda: repo)
+        monkeypatch.setattr(
+            spack.cmd.ci,
+            "_collect_url_patch_checksums",
+            lambda pkg_cls: [
+                "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
+            ],
+        )
+        monkeypatch.setattr(ci, "filter_added_checksums", lambda checksums, path, **kwargs: checksums)
+
+        out = ci_cmd("verify-patches", commits[-1], commits[-3])
+        assert "Validated patch checksum in diff-test" in out
+
+
+def test_ci_verify_patches_invalid(monkeypatch, mock_packages, mock_git_package_changes):
+    repo, _, commits = mock_git_package_changes
+    with spack.repo.use_repositories(repo):
+        monkeypatch.setattr(spack.repo, "builtin_repo", lambda: repo)
+        monkeypatch.setattr(spack.cmd.ci, "_collect_url_patch_checksums", lambda pkg_cls: ["abc"])
+        monkeypatch.setattr(ci, "filter_added_checksums", lambda checksums, path, **kwargs: checksums)
+
+        out = ci_cmd("verify-patches", commits[-1], commits[-3], fail_on_error=False)
+        assert "Invalid patch checksum found in diff-test" in out
+
+
 def test_ci_verify_versions_valid(
     monkeypatch,
     mock_packages,

--- a/lib/spack/spack/test/cmd/ci.py
+++ b/lib/spack/spack/test/cmd/ci.py
@@ -2265,7 +2265,9 @@ def test_ci_verify_patches_invalid(monkeypatch, mock_packages, mock_git_package_
         assert "Invalid patch checksum found in diff-test" in out
 
 
-def test_ci_verify_patches_validates_patch_urls(monkeypatch, mock_packages, mock_git_package_changes):
+def test_ci_verify_patches_validates_patch_urls(
+    monkeypatch, mock_packages, mock_git_package_changes
+):
     class Patch:
         def __init__(self, url, sha256, archive_sha256=None):
             self.url = url

--- a/lib/spack/spack/test/cmd/ci.py
+++ b/lib/spack/spack/test/cmd/ci.py
@@ -2187,23 +2187,6 @@ def verify_git_versions_invalid(monkeypatch):
 
     monkeypatch.setattr(spack.cmd.ci, "validate_git_versions", validate_git_versions)
 
-
-def test_ci_validate_patch_checksums_valid(capfd):
-    checksum = "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890"
-    assert spack.cmd.ci.validate_patch_checksums("diff-test", [checksum])
-
-    out, err = capfd.readouterr()
-    assert "Validated patch checksum in diff-test" in out
-
-
-def test_ci_validate_patch_checksums_invalid(capfd):
-    checksum = "abcdef1234567890abcdef1234567890"
-    assert spack.cmd.ci.validate_patch_checksums("diff-test", [checksum]) is False
-
-    out, err = capfd.readouterr()
-    assert "Invalid patch checksum found in diff-test" in err
-
-
 def test_ci_collect_url_patch_checksums_includes_dependency_patches(mock_packages):
     pkg_cls = spack.repo.PATH.get_pkg_class("patch-several-dependencies")
     checksums = set(spack.cmd.ci._collect_url_patch_checksums(pkg_cls))
@@ -2243,32 +2226,7 @@ def test_ci_verify_patches_valid(monkeypatch, mock_packages, mock_git_package_ch
         )
         monkeypatch.setattr(spack.cmd.ci, "validate_patch_urls", lambda pkg_name, patches: True)
 
-        out = ci_cmd("verify-patches", commits[-1], commits[-3])
-        assert "Validated patch checksum in diff-test" in out
-
-
-def test_ci_verify_patches_invalid(monkeypatch, mock_packages, mock_git_package_changes):
-    class Patch:
-        url = "https://example.com/patch"
-        sha256 = "abc"
-        archive_sha256 = None
-
-    repo, _, commits = mock_git_package_changes
-    with spack.repo.use_repositories(repo):
-        monkeypatch.setattr(spack.repo, "builtin_repo", lambda: repo)
-        monkeypatch.setattr(
-            spack.cmd.ci, "_collect_url_patch_checksums", lambda pkg_cls, **kwargs: ["abc"]
-        )
-        monkeypatch.setattr(spack.cmd.ci, "_collect_url_patches", lambda pkg_cls: [Patch()])
-        monkeypatch.setattr(
-            ci,
-            "filter_added_checksums",
-            lambda checksums, path, **kwargs: checksums,
-        )
-        monkeypatch.setattr(spack.cmd.ci, "validate_patch_urls", lambda pkg_name, patches: True)
-
-        out = ci_cmd("verify-patches", commits[-1], commits[-3], fail_on_error=False)
-        assert "Invalid patch checksum found in diff-test" in out
+        ci_cmd("verify-patches", commits[-1], commits[-3])
 
 
 def test_ci_verify_patches_validates_patch_urls(

--- a/lib/spack/spack/test/cmd/ci.py
+++ b/lib/spack/spack/test/cmd/ci.py
@@ -2192,15 +2192,9 @@ def test_ci_collect_url_patch_checksums_includes_dependency_patches(mock_package
     pkg_cls = spack.repo.PATH.get_pkg_class("patch-several-dependencies")
     checksums = set(spack.cmd.ci._collect_url_patch_checksums(pkg_cls))
 
-    assert (
-        "abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234" in checksums
-    )
-    assert (
-        "1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd" in checksums
-    )
-    assert (
-        "abcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcd" in checksums
-    )
+    assert "abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234" in checksums
+    assert "1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd" in checksums
+    assert "abcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcd" in checksums
 
 
 def test_ci_verify_patches_valid(monkeypatch, mock_packages, mock_git_package_changes):
@@ -2216,14 +2210,12 @@ def test_ci_verify_patches_valid(monkeypatch, mock_packages, mock_git_package_ch
             spack.cmd.ci,
             "_collect_url_patch_checksums",
             lambda pkg_cls, **kwargs: [
-                "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
+                "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890"
             ],
         )
         monkeypatch.setattr(spack.cmd.ci, "_collect_url_patches", lambda pkg_cls: [Patch()])
         monkeypatch.setattr(
-            ci,
-            "filter_added_checksums",
-            lambda checksums, path, **kwargs: checksums,
+            ci, "filter_added_checksums", lambda checksums, path, **kwargs: checksums
         )
         monkeypatch.setattr(spack.cmd.ci, "validate_patch_urls", lambda pkg_name, patches: True)
 
@@ -2246,7 +2238,7 @@ def test_ci_verify_patches_validates_patch_urls(
             spack.cmd.ci,
             "_collect_url_patch_checksums",
             lambda pkg_cls, **kwargs: [
-                "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
+                "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890"
             ],
         )
         monkeypatch.setattr(

--- a/lib/spack/spack/test/cmd/ci.py
+++ b/lib/spack/spack/test/cmd/ci.py
@@ -2220,6 +2220,58 @@ def test_ci_collect_url_patch_checksums_includes_dependency_patches(mock_package
 
 
 def test_ci_verify_patches_valid(monkeypatch, mock_packages, mock_git_package_changes):
+    class Patch:
+        url = "https://example.com/patch"
+        sha256 = "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890"
+        archive_sha256 = None
+
+    repo, _, commits = mock_git_package_changes
+    with spack.repo.use_repositories(repo):
+        monkeypatch.setattr(spack.repo, "builtin_repo", lambda: repo)
+        monkeypatch.setattr(
+            spack.cmd.ci,
+            "_collect_url_patch_checksums",
+            lambda pkg_cls: [
+                "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
+            ],
+        )
+        monkeypatch.setattr(spack.cmd.ci, "_collect_url_patches", lambda pkg_cls: [Patch()])
+        monkeypatch.setattr(
+            ci, "filter_added_checksums", lambda checksums, path, **kwargs: checksums
+        )
+        monkeypatch.setattr(spack.cmd.ci, "validate_patch_urls", lambda pkg_name, patches: True)
+
+        out = ci_cmd("verify-patches", commits[-1], commits[-3])
+        assert "Validated patch checksum in diff-test" in out
+
+
+def test_ci_verify_patches_invalid(monkeypatch, mock_packages, mock_git_package_changes):
+    class Patch:
+        url = "https://example.com/patch"
+        sha256 = "abc"
+        archive_sha256 = None
+
+    repo, _, commits = mock_git_package_changes
+    with spack.repo.use_repositories(repo):
+        monkeypatch.setattr(spack.repo, "builtin_repo", lambda: repo)
+        monkeypatch.setattr(spack.cmd.ci, "_collect_url_patch_checksums", lambda pkg_cls: ["abc"])
+        monkeypatch.setattr(spack.cmd.ci, "_collect_url_patches", lambda pkg_cls: [Patch()])
+        monkeypatch.setattr(
+            ci, "filter_added_checksums", lambda checksums, path, **kwargs: checksums
+        )
+        monkeypatch.setattr(spack.cmd.ci, "validate_patch_urls", lambda pkg_name, patches: True)
+
+        out = ci_cmd("verify-patches", commits[-1], commits[-3], fail_on_error=False)
+        assert "Invalid patch checksum found in diff-test" in out
+
+
+def test_ci_verify_patches_validates_patch_urls(monkeypatch, mock_packages, mock_git_package_changes):
+    class Patch:
+        def __init__(self, url, sha256, archive_sha256=None):
+            self.url = url
+            self.sha256 = sha256
+            self.archive_sha256 = archive_sha256
+
     repo, _, commits = mock_git_package_changes
     with spack.repo.use_repositories(repo):
         monkeypatch.setattr(spack.repo, "builtin_repo", lambda: repo)
@@ -2231,24 +2283,36 @@ def test_ci_verify_patches_valid(monkeypatch, mock_packages, mock_git_package_ch
             ],
         )
         monkeypatch.setattr(
-            ci, "filter_added_checksums", lambda checksums, path, **kwargs: checksums
+            spack.cmd.ci,
+            "_collect_url_patches",
+            lambda pkg_cls: [
+                Patch(
+                    "https://example.com/a.patch",
+                    "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
+                ),
+                Patch(
+                    "https://example.com/b.patch",
+                    "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+                ),
+            ],
         )
-
-        out = ci_cmd("verify-patches", commits[-1], commits[-3])
-        assert "Validated patch checksum in diff-test" in out
-
-
-def test_ci_verify_patches_invalid(monkeypatch, mock_packages, mock_git_package_changes):
-    repo, _, commits = mock_git_package_changes
-    with spack.repo.use_repositories(repo):
-        monkeypatch.setattr(spack.repo, "builtin_repo", lambda: repo)
-        monkeypatch.setattr(spack.cmd.ci, "_collect_url_patch_checksums", lambda pkg_cls: ["abc"])
         monkeypatch.setattr(
             ci, "filter_added_checksums", lambda checksums, path, **kwargs: checksums
         )
 
-        out = ci_cmd("verify-patches", commits[-1], commits[-3], fail_on_error=False)
-        assert "Invalid patch checksum found in diff-test" in out
+        captured = {}
+
+        def _validate_patch_urls(pkg_name, patches):
+            captured["pkg_name"] = pkg_name
+            captured["urls"] = [patch.url for patch in patches]
+            return True
+
+        monkeypatch.setattr(spack.cmd.ci, "validate_patch_urls", _validate_patch_urls)
+
+        ci_cmd("verify-patches", commits[-1], commits[-3])
+
+        assert captured["pkg_name"] == "diff-test"
+        assert captured["urls"] == ["https://example.com/a.patch"]
 
 
 def test_ci_verify_versions_valid(

--- a/lib/spack/spack/test/cmd/ci.py
+++ b/lib/spack/spack/test/cmd/ci.py
@@ -2187,6 +2187,7 @@ def verify_git_versions_invalid(monkeypatch):
 
     monkeypatch.setattr(spack.cmd.ci, "validate_git_versions", validate_git_versions)
 
+
 def test_ci_collect_url_patch_checksums_includes_dependency_patches(mock_packages):
     pkg_cls = spack.repo.PATH.get_pkg_class("patch-several-dependencies")
     checksums = set(spack.cmd.ci._collect_url_patch_checksums(pkg_cls))

--- a/lib/spack/spack/test/cmd/ci.py
+++ b/lib/spack/spack/test/cmd/ci.py
@@ -2230,7 +2230,9 @@ def test_ci_verify_patches_valid(monkeypatch, mock_packages, mock_git_package_ch
                 "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
             ],
         )
-        monkeypatch.setattr(ci, "filter_added_checksums", lambda checksums, path, **kwargs: checksums)
+        monkeypatch.setattr(
+            ci, "filter_added_checksums", lambda checksums, path, **kwargs: checksums
+        )
 
         out = ci_cmd("verify-patches", commits[-1], commits[-3])
         assert "Validated patch checksum in diff-test" in out
@@ -2241,7 +2243,9 @@ def test_ci_verify_patches_invalid(monkeypatch, mock_packages, mock_git_package_
     with spack.repo.use_repositories(repo):
         monkeypatch.setattr(spack.repo, "builtin_repo", lambda: repo)
         monkeypatch.setattr(spack.cmd.ci, "_collect_url_patch_checksums", lambda pkg_cls: ["abc"])
-        monkeypatch.setattr(ci, "filter_added_checksums", lambda checksums, path, **kwargs: checksums)
+        monkeypatch.setattr(
+            ci, "filter_added_checksums", lambda checksums, path, **kwargs: checksums
+        )
 
         out = ci_cmd("verify-patches", commits[-1], commits[-3], fail_on_error=False)
         assert "Invalid patch checksum found in diff-test" in out

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -706,7 +706,7 @@ _spack_ci() {
     then
         SPACK_COMPREPLY="-h --help"
     else
-        SPACK_COMPREPLY="generate rebuild-index rebuild reproduce-build verify-versions"
+        SPACK_COMPREPLY="generate rebuild-index rebuild reproduce-build verify-patches verify-versions"
     fi
 }
 

--- a/share/spack/spack-completion.fish
+++ b/share/spack/spack-completion.fish
@@ -993,6 +993,7 @@ complete -c spack -n '__fish_spack_using_command_pos 0 ci' -f -a generate -d 'ge
 complete -c spack -n '__fish_spack_using_command_pos 0 ci' -f -a rebuild-index -d 'rebuild the buildcache index for the remote mirror'
 complete -c spack -n '__fish_spack_using_command_pos 0 ci' -f -a rebuild -d 'rebuild a spec if it is not on the remote mirror'
 complete -c spack -n '__fish_spack_using_command_pos 0 ci' -f -a reproduce-build -d 'generate instructions for reproducing the spec rebuild job'
+complete -c spack -n '__fish_spack_using_command_pos 0 ci' -f -a verify-patches -d 'validate patches checksum between git refs'
 complete -c spack -n '__fish_spack_using_command_pos 0 ci' -f -a verify-versions -d 'validate version checksum & commits between git refs'
 complete -c spack -n '__fish_spack_using_command ci' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command ci' -s h -l help -d 'show this help message and exit'
@@ -1071,6 +1072,12 @@ complete -c spack -n '__fish_spack_using_command ci reproduce-build' -l gpg-file
 complete -c spack -n '__fish_spack_using_command ci reproduce-build' -l gpg-file -r -d 'Path to public GPG key for validating binary cache installs'
 complete -c spack -n '__fish_spack_using_command ci reproduce-build' -l gpg-url -r -f -a gpg_url
 complete -c spack -n '__fish_spack_using_command ci reproduce-build' -l gpg-url -r -d 'URL to public GPG key for validating binary cache installs'
+
+# spack ci verify-patches
+set -g __fish_spack_optspecs_spack_ci_verify_patches h/help 
+
+complete -c spack -n '__fish_spack_using_command ci verify-patches' -s h -l help -f -a help
+complete -c spack -n '__fish_spack_using_command ci verify-patches' -s h -l help -d 'show this help message and exit'
 
 # spack ci verify-versions
 set -g __fish_spack_optspecs_spack_ci_verify_versions h/help


### PR DESCRIPTION
This adds a new subcommand `spack ci verify-patches` to be used in spack-packages CI to check the checksums of url-defined patches. Checks both direct patches and dependency patches. Very similar to what `verify-versions` already does.

AI-assisted, but verified.

Note to self, add to bash completion.