### PR TITLE
Fix format error for specs with no compilers showing as nonenone

### DIFF
--- a/lib/spack/spack/cmd/__init__.py
+++ b/lib/spack/spack/cmd/__init__.py
@@ -335,7 +335,7 @@ def ensure_single_spec_or_die(spec, matching_specs):
     format_string = (
         "{name}{@version}"
         "{ platform=architecture.platform}{ os=architecture.os}{ target=architecture.target}"
-        "{ %compiler.name}{@compiler.version}"
+        "{compilers}"
     )
     args = ["%s matches multiple packages." % spec, "Matching packages:"]
     args += [

--- a/lib/spack/spack/cmd/__init__.py
+++ b/lib/spack/spack/cmd/__init__.py
@@ -335,7 +335,7 @@ def ensure_single_spec_or_die(spec, matching_specs):
     format_string = (
         "{name}{@version}"
         "{ platform=architecture.platform}{ os=architecture.os}{ target=architecture.target}"
-        "{%compiler.name}{@compiler.version}"
+        "{ %compiler.name}{@compiler.version}"
     )
     args = ["%s matches multiple packages." % spec, "Matching packages:"]
     args += [

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -4298,7 +4298,7 @@ class Spec:
                         current = getattr(current, part)
                     except AttributeError:
                         if part == "compiler":
-                            return ""
+                            return "none"
                         elif part == "specfile_version":
                             return f"v{current.original_spec_format()}"
 

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -4298,7 +4298,7 @@ class Spec:
                         current = getattr(current, part)
                     except AttributeError:
                         if part == "compiler":
-                            return "none"
+                            return ""
                         elif part == "specfile_version":
                             return f"v{current.original_spec_format()}"
 


### PR DESCRIPTION
I noticed the following weird formatting when attempting to load a spec with no compiler. Switching to `{compilers}` instead to follow how we format specs elsewhere.

### Before
```                                                                                                                                                                              
$ spack load pass
==> Error: pass matches multiple packages.
  Matching packages:
    w5y4g34 pass@1.7.4 platform=darwin os=tahoe target=m4nonenone
    phqshrc pass@1.7.4 platform=darwin os=tahoe target=m4nonenone
```

```
$ spack load aspell
==> Error: aspell matches multiple packages.
  Matching packages:
    vkwpbdn aspell@0.60.8.2 platform=darwin os=tahoe target=m4%apple-clang@17.0.0
    x2u7qj6 aspell@0.60.8.2 platform=darwin os=tahoe target=m4%apple-clang@17.0.0
```

### After
```
$ spack load pass
==> Error: pass matches multiple packages.
  Matching packages:
    w5y4g34 pass@1.7.4 platform=darwin os=tahoe target=m4
    phqshrc pass@1.7.4 platform=darwin os=tahoe target=m4
```

```
$ spack load aspell
==> Error: aspell matches multiple packages.
  Matching packages:
    vkwpbdn aspell@0.60.8.2 platform=darwin os=tahoe target=m4 %c=apple-clang@17.0.0
    x2u7qj6 aspell@0.60.8.2 platform=darwin os=tahoe target=m4 %c=apple-clang@17.0.0
```