### PR TITLE
doc: add note about DYLD_FALLBACK_LIBRARY_PATH behavior on macOS Big Sur

### DIFF
--- a/lib/spack/docs/module_file_support.rst
+++ b/lib/spack/docs/module_file_support.rst
@@ -511,6 +511,20 @@ On Linux however, the corresponding ``LD_LIBRARY_PATH`` variable is *not* set, b
 
 .. note::
 
+   On macOS Big Sur and later, ``DYLD_FALLBACK_LIBRARY_PATH`` may not be
+   exported correctly by Spack-generated module files due to macOS System
+   Integrity Protection (SIP). SIP strips ``DYLD_*`` environment variables
+   when launching protected processes, which can cause the variable to appear
+   set (via ``echo $DYLD_FALLBACK_LIBRARY_PATH``) but missing from the
+   environment of child processes (via ``env | grep DYLD``).
+   
+   If you experience issues with libraries not being found on macOS Big Sur
+   or later, consider using ``CMAKE_PREFIX_PATH`` or ``PKG_CONFIG_PATH``
+   as alternatives, or consult the `Apple documentation on System Integrity
+   Protection <https://developer.apple.com/documentation/security/disabling_and_enabling_system_integrity_protection>`_.
+
+.. note::
+
    In general, the ``LD_LIBRARY_PATH`` variable is not required when using packages built with Spack, thanks to the use of RPATH.
    Some packages may still need the variable, which is best handled on a per-package basis instead of globally, as explained in :ref:`overide-api-calls-in-package-py`.
 


### PR DESCRIPTION
Fixes #24306

## What this PR does
Adds a warning note in `module_file_support.rst` documenting the known 
behavior of `DYLD_FALLBACK_LIBRARY_PATH` on macOS Big Sur and later, 
where System Integrity Protection (SIP) strips DYLD_* variables from 
child processes.

## Why
Users on macOS Big Sur reported confusing behavior where the variable 
appears set via `echo` but is missing from `env | grep DYLD`. This note 
clarifies the cause and suggests alternative approaches.

## Testing
Documentation-only change, no code modified.