### PR TITLE
Require verification for mirror keys and allow specifying mirrors to trust from

### DIFF
--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -2252,6 +2252,7 @@ def update_cache_and_get_specs():
 
 
 def get_keys(
+    yes_to_all: bool = False,
     install: bool = False,
     trust: bool = False,
     force: bool = False,
@@ -2271,10 +2272,10 @@ def get_keys(
         for layout_version in mirror.supported_layout_versions:
             fetch_url = mirror.fetch_url
             if layout_version == 2:
-                mirror_layout_fingerprints = _get_keys_v2(fetch_url, install, trust, force)
+                mirror_layout_fingerprints = _get_keys_v2(fetch_url, yes_to_all, install, trust, force)
             else:
                 mirror_layout_fingerprints = _get_keys(
-                    fetch_url, layout_version, install, trust, force
+                    fetch_url, layout_version, yes_to_all, install, trust, force
                 )
             if mirror_layout_fingerprints:
                 fingerprints.extend(mirror_layout_fingerprints)
@@ -2284,6 +2285,7 @@ def get_keys(
 def _get_keys(
     mirror_url: str,
     layout_version: int = CURRENT_BUILD_CACHE_LAYOUT_VERSION,
+    yes_to_all: bool = False,
     install: bool = False,
     trust: bool = False,
     force: bool = False,
@@ -2325,7 +2327,7 @@ def _get_keys(
         tty.debug("Found key {0}".format(fingerprint))
         if install:
             if trust:
-                spack.util.gpg.trust(key_blob_path, yes_to_all=True)
+                spack.util.gpg.trust(key_blob_path, yes_to_all=yes_to_all)
                 tty.debug(f"Added {fingerprint} to trusted keys.")
                 saved_fingerprints.append(fingerprint)
             else:
@@ -2337,7 +2339,7 @@ def _get_keys(
     return saved_fingerprints
 
 
-def _get_keys_v2(mirror_url, install=False, trust=False, force=False) -> Optional[List[str]]:
+def _get_keys_v2(mirror_url, yes_to_all=False, install=False, trust=False, force=False) -> Optional[List[str]]:
     cache_class = get_url_buildcache_class(layout_version=2)
 
     keys_url = url_util.join(
@@ -2375,7 +2377,7 @@ def _get_keys_v2(mirror_url, install=False, trust=False, force=False) -> Optiona
         tty.debug("Found key {0}".format(fingerprint))
         if install:
             if trust:
-                spack.util.gpg.trust(stage.save_filename, yes_to_all=True)
+                spack.util.gpg.trust(stage.save_filename, yes_to_all=yes_to_all)
                 tty.debug("Added this key to trusted keys.")
                 saved_fingerprints.append(fingerprint)
             else:

--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -2272,7 +2272,9 @@ def get_keys(
         for layout_version in mirror.supported_layout_versions:
             fetch_url = mirror.fetch_url
             if layout_version == 2:
-                mirror_layout_fingerprints = _get_keys_v2(fetch_url, yes_to_all, install, trust, force)
+                mirror_layout_fingerprints = _get_keys_v2(
+                    fetch_url, yes_to_all, install, trust, force
+                )
             else:
                 mirror_layout_fingerprints = _get_keys(
                     fetch_url, layout_version, yes_to_all, install, trust, force
@@ -2339,7 +2341,9 @@ def _get_keys(
     return saved_fingerprints
 
 
-def _get_keys_v2(mirror_url, yes_to_all=False, install=False, trust=False, force=False) -> Optional[List[str]]:
+def _get_keys_v2(
+    mirror_url, yes_to_all=False, install=False, trust=False, force=False
+) -> Optional[List[str]]:
     cache_class = get_url_buildcache_class(layout_version=2)
 
     keys_url = url_util.join(

--- a/lib/spack/spack/cmd/buildcache.py
+++ b/lib/spack/spack/cmd/buildcache.py
@@ -637,7 +637,9 @@ def keys_fn(args):
     if args.mirrors:
         mirror_map = dict([(m.name, m) for m in args.mirrors])
 
-    spack.binary_distribution.get_keys(args.yes_to_all, args.install, args.trust, args.force, mirrors=mirror_map)
+    spack.binary_distribution.get_keys(
+        args.yes_to_all, args.install, args.trust, args.force, mirrors=mirror_map
+    )
 
 
 def check_fn(args: argparse.Namespace):

--- a/lib/spack/spack/cmd/buildcache.py
+++ b/lib/spack/spack/cmd/buildcache.py
@@ -8,7 +8,7 @@ import json
 import os
 import sys
 import tempfile
-from typing import List, Optional, Tuple
+from typing import List, Mapping, Optional, Tuple
 
 import spack.binary_distribution
 import spack.cmd
@@ -199,6 +199,13 @@ def setup_parser(subparser: argparse.ArgumentParser):
     )
     keys.add_argument("-t", "--trust", action="store_true", help="trust all downloaded keys")
     keys.add_argument("-f", "--force", action="store_true", help="force new download of keys")
+    arguments.add_common_arguments(keys, ["yes_to_all"])
+    keys.add_argument(
+        "mirrors",
+        nargs=argparse.REMAINDER,
+        type=arguments.mirror_name_or_url,
+        help="mirror name, path, or URL",
+    )
     keys.set_defaults(func=keys_fn, subparser=keys)
 
     # Check if binaries need to be rebuilt on remote mirror
@@ -626,7 +633,11 @@ def list_fn(args):
 
 def keys_fn(args):
     """get public keys available on mirrors"""
-    spack.binary_distribution.get_keys(args.install, args.trust, args.force)
+    mirror_map: Optional[Mapping[str, spack.mirrors.mirror.Mirror]] = None
+    if args.mirrors:
+        mirror_map = dict([(m.name, m) for m in args.mirrors])
+
+    spack.binary_distribution.get_keys(args.yes_to_all, args.install, args.trust, args.force, mirrors=mirror_map)
 
 
 def check_fn(args: argparse.Namespace):

--- a/lib/spack/spack/test/binary_distribution.py
+++ b/lib/spack/spack/test/binary_distribution.py
@@ -162,7 +162,7 @@ def test_push_and_fetch_keys(mock_gnupghome, tmp_path: pathlib.Path):
     with spack.util.gpg.gnupghome_override(gpg_dir2):
         assert len(spack.util.gpg.public_keys()) == 0
 
-        spack.binary_distribution.get_keys(mirrors=mirrors, install=True, trust=True, force=True)
+        spack.binary_distribution.get_keys(mirrors=mirrors, yes_to_all=True, install=True, trust=True, force=True)
 
         new_keys = spack.util.gpg.public_keys()
         assert len(new_keys) == 1

--- a/lib/spack/spack/test/binary_distribution.py
+++ b/lib/spack/spack/test/binary_distribution.py
@@ -162,7 +162,9 @@ def test_push_and_fetch_keys(mock_gnupghome, tmp_path: pathlib.Path):
     with spack.util.gpg.gnupghome_override(gpg_dir2):
         assert len(spack.util.gpg.public_keys()) == 0
 
-        spack.binary_distribution.get_keys(mirrors=mirrors, yes_to_all=True, install=True, trust=True, force=True)
+        spack.binary_distribution.get_keys(
+            mirrors=mirrors, yes_to_all=True, install=True, trust=True, force=True
+        )
 
         new_keys = spack.util.gpg.public_keys()
         assert len(new_keys) == 1

--- a/lib/spack/spack/test/cmd/buildcache.py
+++ b/lib/spack/spack/test/cmd/buildcache.py
@@ -636,7 +636,7 @@ def test_install_v2_layout(
     mirror("add", "my-mirror", str(test_mirror_path))
 
     # Trust original signing key (no-op if this is the unsigned pass)
-    buildcache("keys", "--install", "--trust")
+    buildcache("keys", "-y", "--install", "--trust")
 
     output = install("--fake", "--no-check-signature", "libdwarf")
 
@@ -711,7 +711,7 @@ def test_basic_migrate_signed(v2_buildcache_layout, mock_gnupghome, mutable_conf
 
     # Trust original signing key (since it's in the original layout location,
     # this is where the monkeypatched attribute is used)
-    output = buildcache("keys", "--install", "--trust")
+    output = buildcache("keys", "-y", "--install", "--trust")
 
     output = buildcache("migrate", "my-mirror")
 

--- a/lib/spack/spack/test/packaging.py
+++ b/lib/spack/spack/test/packaging.py
@@ -118,7 +118,7 @@ def test_buildcache(mock_archive, tmp_path: pathlib.Path, monkeypatch, mutable_c
         args = parser.parse_args(["keys", "-f"])
         buildcache.buildcache(parser, args)
 
-        args = parser.parse_args(["keys", "-i", "-t"])
+        args = parser.parse_args(["keys", "-y", "-i", "-t"])
         buildcache.buildcache(parser, args)
 
 

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -600,7 +600,12 @@ _spack_buildcache_list() {
 }
 
 _spack_buildcache_keys() {
-    SPACK_COMPREPLY="-h --help -i --install -t --trust -f --force"
+    if $list_options
+    then
+        SPACK_COMPREPLY="-h --help -i --install -t --trust -f --force -y --yes-to-all"
+    else
+        _mirrors
+    fi
 }
 
 _spack_buildcache_check() {

--- a/share/spack/spack-completion.fish
+++ b/share/spack/spack-completion.fish
@@ -804,7 +804,8 @@ complete -c spack -n '__fish_spack_using_command buildcache list' -s a -l allarc
 complete -c spack -n '__fish_spack_using_command buildcache list' -s a -l allarch -d 'list specs for all available architectures instead of default platform and OS'
 
 # spack buildcache keys
-set -g __fish_spack_optspecs_spack_buildcache_keys h/help i/install t/trust f/force
+set -g __fish_spack_optspecs_spack_buildcache_keys h/help i/install t/trust f/force y/yes-to-all
+
 complete -c spack -n '__fish_spack_using_command buildcache keys' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command buildcache keys' -s h -l help -d 'show this help message and exit'
 complete -c spack -n '__fish_spack_using_command buildcache keys' -s i -l install -f -a install
@@ -813,6 +814,8 @@ complete -c spack -n '__fish_spack_using_command buildcache keys' -s t -l trust 
 complete -c spack -n '__fish_spack_using_command buildcache keys' -s t -l trust -d 'trust all downloaded keys'
 complete -c spack -n '__fish_spack_using_command buildcache keys' -s f -l force -f -a force
 complete -c spack -n '__fish_spack_using_command buildcache keys' -s f -l force -d 'force new download of keys'
+complete -c spack -n '__fish_spack_using_command buildcache keys' -s y -l yes-to-all -f -a yes_to_all
+complete -c spack -n '__fish_spack_using_command buildcache keys' -s y -l yes-to-all -d 'assume "yes" is the answer to every confirmation request'
 
 # spack buildcache check
 set -g __fish_spack_optspecs_spack_buildcache_check h/help m/mirror-url= o/output-file= scope=


### PR DESCRIPTION
Only allowing batch trust was a bug that has gone unnoticed.
Added verification of keys on trust by default.