### PR TITLE
Windows: Safer stage cleanup

### DIFF
--- a/lib/spack/spack/stage.py
+++ b/lib/spack/spack/stage.py
@@ -7,6 +7,7 @@ import glob
 import hashlib
 import io
 import os
+import pathlib
 import shutil
 import stat
 import sys
@@ -736,6 +737,16 @@ class Stage(AbstractStage):
 
     def destroy(self):
         """Removes this stage directory."""
+        # On Windows a directory that is the CWD of any process cannot be deleted (WinError 32).
+        # Proactively chdir to the parent before removal so the worker's CWD doesn't block rmtree.
+        if sys.platform == "win32":
+            try:
+                cwd = pathlib.Path(os.getcwd()).resolve()
+                stage = pathlib.Path(self.path).resolve()
+                if cwd == stage or stage in cwd.parents:
+                    os.chdir(stage.parent)
+            except OSError:
+                pass
         remove_linked_tree(self.path)
 
         # Make sure we don't end up in a removed directory


### PR DESCRIPTION
If the CWD of the process is still in the stage while we try to destroy it, the process will crash with winerror 32, which indicates the file is being used by another process, which is a bit obtuse if you don't know what to look for.

Instead just chdir to the stage's parent dir.

Windows only change.