### PR TITLE
Add `--refresh-buildcaches` to sync buildcaches when using `-I`

### DIFF
--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -2251,6 +2251,15 @@ def update_cache_and_get_specs():
     return BINARY_INDEX.get_all_built_specs()
 
 
+def specs_in_buildcaches(specs: Iterable["spack.spec.Spec"]) -> Set[str]:
+    """Returns the dag hashes of *specs* that are available in any configured buildcache."""
+    try:
+        BINARY_INDEX.update(with_cooldown=True)
+    except Exception:
+        return set()
+    return {s.dag_hash() for s in specs if BINARY_INDEX.find_by_hash(s.dag_hash())}
+
+
 def get_keys(
     yes_to_all: bool = False,
     install: bool = False,

--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -2255,13 +2255,20 @@ def update_cache_and_get_specs():
     return BINARY_INDEX.get_all_built_specs()
 
 
-def load_buildcache_index() -> None:
+def load_buildcache_index(refresh: bool = False) -> None:
     """Populates BINARY_INDEX from the local on-disk index cache.
 
     Failures are swallowed, so the status display never breaks a command.
+
+    Args:
+        refresh: run a full network update when True. Reload only from the locally cached
+            index files when False.
     """
     try:
-        BINARY_INDEX.regenerate_spec_cache()
+        if refresh:
+            BINARY_INDEX.update(with_cooldown=True)
+        else:
+            BINARY_INDEX.regenerate_spec_cache()
     except Exception:
         pass
 

--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -316,6 +316,10 @@ class BinaryIndexCache:
         """
         return list(self._mirrors_for_spec.get(dag_hash, []))
 
+    def __contains__(self, dag_hash: str) -> bool:
+        """Returns True if *dag_hash* is known to be available in at least one buildcache."""
+        return dag_hash in self._mirrors_for_spec
+
     def update_spec(self, spec: spack.spec.Spec, found_list: List[MirrorMetadata]) -> None:
         """Update the cache with a new list of mirrors for a given spec."""
         spec_dag_hash = spec.dag_hash()
@@ -2251,13 +2255,15 @@ def update_cache_and_get_specs():
     return BINARY_INDEX.get_all_built_specs()
 
 
-def specs_in_buildcaches(specs: Iterable["spack.spec.Spec"]) -> Set[str]:
-    """Returns the dag hashes of *specs* that are available in any configured buildcache."""
+def load_buildcache_index() -> None:
+    """Populates BINARY_INDEX from the local on-disk index cache.
+
+    Failures are swallowed, so the status display never breaks a command.
+    """
     try:
-        BINARY_INDEX.update(with_cooldown=True)
+        BINARY_INDEX.regenerate_spec_cache()
     except Exception:
-        return set()
-    return {s.dag_hash() for s in specs if BINARY_INDEX.find_by_hash(s.dag_hash())}
+        pass
 
 
 def get_keys(

--- a/lib/spack/spack/cmd/__init__.py
+++ b/lib/spack/spack/cmd/__init__.py
@@ -11,7 +11,7 @@ import subprocess
 import sys
 import textwrap
 from collections import Counter
-from typing import Generator, List, Optional, Sequence, Union
+from typing import Callable, Generator, List, Optional, Sequence, Set, Union
 
 import spack.concretize
 import spack.config
@@ -351,6 +351,27 @@ def gray_hash(spec, length):
         length = 32
     h = spec.dag_hash(length) if spec.concrete else "-" * length
     return colorize("@K{%s}" % h)
+
+
+def buildcache_status_fn(
+    available_hashes: Set[str],
+) -> Callable[["spack.spec.Spec"], "spack.spec.InstallStatus"]:
+    """Return a status_fn that marks not-installed specs present in a buildcache as [B].
+
+    Args:
+        available_hashes: set of dag hashes known to be available in at least one buildcache.
+    """
+
+    def _status_fn(spec: "spack.spec.Spec") -> "spack.spec.InstallStatus":
+        status = spec.install_status()
+        if (
+            status in (spack.spec.InstallStatus.absent, spack.spec.InstallStatus.missing)
+            and spec.dag_hash() in available_hashes
+        ):
+            return spack.spec.InstallStatus.buildcache
+        return status
+
+    return _status_fn
 
 
 def display_specs_as_json(specs, deps=False):

--- a/lib/spack/spack/cmd/__init__.py
+++ b/lib/spack/spack/cmd/__init__.py
@@ -11,7 +11,7 @@ import subprocess
 import sys
 import textwrap
 from collections import Counter
-from typing import Callable, Generator, List, Optional, Sequence, Set, Union
+from typing import Callable, Container, Generator, List, Optional, Sequence, Union
 
 import spack.concretize
 import spack.config
@@ -354,12 +354,13 @@ def gray_hash(spec, length):
 
 
 def buildcache_status_fn(
-    available_hashes: Set[str],
+    available_hashes: Container[str],
 ) -> Callable[["spack.spec.Spec"], "spack.spec.InstallStatus"]:
-    """Return a status_fn that marks not-installed specs present in a buildcache as [B].
+    """Return a status_fn that marks not-installed specs present in a buildcache as [b].
 
     Args:
-        available_hashes: set of dag hashes known to be available in at least one buildcache.
+        available_hashes: any container supporting ``in`` lookups whose elements are dag hashes
+            known to be available in at least one buildcache.
     """
 
     def _status_fn(spec: "spack.spec.Spec") -> "spack.spec.InstallStatus":

--- a/lib/spack/spack/cmd/common/arguments.py
+++ b/lib/spack/spack/cmd/common/arguments.py
@@ -458,6 +458,7 @@ def install_status():
             "show install status of packages\n"
             "[+] installed       [^] installed in an upstream\n"
             " -  not installed   [-] missing dep of installed package\n"
+            "[B] in a buildcache (requires -B / --buildcache-status)\n"
         ),
     )
 
@@ -470,6 +471,20 @@ def no_install_status():
         action="store_false",
         default=True,
         help="do not show install status annotations",
+    )
+
+
+@arg
+def buildcache_status():
+    return Args(
+        "-B",
+        "--buildcache-status",
+        action="store_true",
+        default=False,
+        help=(
+            "show buildcache availability alongside install status\n"
+            "(refreshes the mirror index, which may incur network I/O)\n"
+        ),
     )
 
 

--- a/lib/spack/spack/cmd/common/arguments.py
+++ b/lib/spack/spack/cmd/common/arguments.py
@@ -458,7 +458,7 @@ def install_status():
             "show install status of packages\n"
             "[+] installed       [^] installed in an upstream\n"
             " -  not installed   [-] missing dep of installed package\n"
-            "[B] in a buildcache (requires -B / --buildcache-status)\n"
+            "[b] available in a buildcache\n"
         ),
     )
 
@@ -471,20 +471,6 @@ def no_install_status():
         action="store_false",
         default=True,
         help="do not show install status annotations",
-    )
-
-
-@arg
-def buildcache_status():
-    return Args(
-        "-B",
-        "--buildcache-status",
-        action="store_true",
-        default=False,
-        help=(
-            "show buildcache availability alongside install status\n"
-            "(refreshes the mirror index, which may incur network I/O)\n"
-        ),
     )
 
 

--- a/lib/spack/spack/cmd/common/arguments.py
+++ b/lib/spack/spack/cmd/common/arguments.py
@@ -475,6 +475,18 @@ def no_install_status():
 
 
 @arg
+def refresh_buildcaches():
+    return Args(
+        "--refresh-buildcaches",
+        action="store_true",
+        default=False,
+        help=(
+            "refresh the buildcache mirror index over the network before showing install status\n"
+        ),
+    )
+
+
+@arg
 def show_non_defaults():
     return Args(
         "--non-defaults",

--- a/lib/spack/spack/cmd/find.py
+++ b/lib/spack/spack/cmd/find.py
@@ -5,7 +5,9 @@
 import argparse
 import copy
 import sys
+from typing import List, Optional, Tuple
 
+import spack.binary_distribution
 import spack.cmd as cmd
 import spack.config
 import spack.environment as ev
@@ -16,6 +18,7 @@ import spack.repo
 import spack.solver.reuse
 import spack.spec
 import spack.store
+import spack.traverse
 from spack.cmd.common import arguments
 from spack.externals_config import create_external_parser, external_config_with_implicit_externals
 from spack.llnl.util.tty.color import colorize
@@ -53,6 +56,8 @@ def setup_parser(subparser: argparse.ArgumentParser) -> None:
     subparser.add_argument(
         "-I", "--install-status", action="store_true", help="show install status of packages"
     )
+
+    arguments.add_common_arguments(subparser, ["buildcache_status"])
 
     subparser.add_argument(
         "--specfile-format",
@@ -335,7 +340,9 @@ def display_env(env, args, decorator, results):
         print()
 
 
-def _find_query(args, env):
+def _find_query(
+    args: argparse.Namespace, env: Optional[ev.Environment]
+) -> Tuple[List[spack.spec.Spec], List[spack.spec.Spec]]:
     q_args = query_arguments(args)
     concretized_but_not_installed = []
     if args.show_configured_externals:
@@ -355,8 +362,8 @@ def _find_query(args, env):
         else:
             env_specs = all_env_specs
 
-        spec_hashes = set(x.dag_hash() for x in env_specs)
-        specs_meeting_q_args = set(spack.store.STORE.db.query(hashes=spec_hashes, **q_args))
+        spec_hashes = {x.dag_hash() for x in env_specs}
+        specs_meeting_q_args = set(spack.store.STORE.db.query(hashes=list(spec_hashes), **q_args))
 
         results = list()
         with spack.store.STORE.db.read_transaction():
@@ -412,7 +419,14 @@ def find(parser, args):
         # the latter only exists if you call args.specs()
         tty.die(f"No package matches the query: {' '.join(args.constraint)}")
 
-    if args.install_status or args.show_concretized:
+    if args.buildcache_status:
+        available_hashes = spack.binary_distribution.specs_in_buildcaches(
+            spack.traverse.traverse_nodes(
+                results + concretized_but_not_installed, key=spack.traverse.by_dag_hash
+            )
+        )
+        status_fn = cmd.buildcache_status_fn(available_hashes)
+    elif args.install_status or args.show_concretized:
         status_fn = spack.spec.Spec.install_status
     else:
         status_fn = None

--- a/lib/spack/spack/cmd/find.py
+++ b/lib/spack/spack/cmd/find.py
@@ -18,7 +18,6 @@ import spack.repo
 import spack.solver.reuse
 import spack.spec
 import spack.store
-import spack.traverse
 from spack.cmd.common import arguments
 from spack.externals_config import create_external_parser, external_config_with_implicit_externals
 from spack.llnl.util.tty.color import colorize
@@ -56,8 +55,6 @@ def setup_parser(subparser: argparse.ArgumentParser) -> None:
     subparser.add_argument(
         "-I", "--install-status", action="store_true", help="show install status of packages"
     )
-
-    arguments.add_common_arguments(subparser, ["buildcache_status"])
 
     subparser.add_argument(
         "--specfile-format",
@@ -419,15 +416,9 @@ def find(parser, args):
         # the latter only exists if you call args.specs()
         tty.die(f"No package matches the query: {' '.join(args.constraint)}")
 
-    if args.buildcache_status:
-        available_hashes = spack.binary_distribution.specs_in_buildcaches(
-            spack.traverse.traverse_nodes(
-                results + concretized_but_not_installed, key=spack.traverse.by_dag_hash
-            )
-        )
-        status_fn = cmd.buildcache_status_fn(available_hashes)
-    elif args.install_status or args.show_concretized:
-        status_fn = spack.spec.Spec.install_status
+    if args.install_status or args.show_concretized:
+        spack.binary_distribution.load_buildcache_index()
+        status_fn = cmd.buildcache_status_fn(spack.binary_distribution.BINARY_INDEX)
     else:
         status_fn = None
 

--- a/lib/spack/spack/cmd/find.py
+++ b/lib/spack/spack/cmd/find.py
@@ -56,6 +56,8 @@ def setup_parser(subparser: argparse.ArgumentParser) -> None:
         "-I", "--install-status", action="store_true", help="show install status of packages"
     )
 
+    arguments.add_common_arguments(subparser, ["refresh_buildcaches"])
+
     subparser.add_argument(
         "--specfile-format",
         action="store_true",
@@ -416,8 +418,8 @@ def find(parser, args):
         # the latter only exists if you call args.specs()
         tty.die(f"No package matches the query: {' '.join(args.constraint)}")
 
-    if args.install_status or args.show_concretized:
-        spack.binary_distribution.load_buildcache_index()
+    if args.install_status or args.refresh_buildcaches or args.show_concretized:
+        spack.binary_distribution.load_buildcache_index(refresh=args.refresh_buildcaches)
         status_fn = cmd.buildcache_status_fn(spack.binary_distribution.BINARY_INDEX)
     else:
         status_fn = None

--- a/lib/spack/spack/cmd/solve.py
+++ b/lib/spack/spack/cmd/solve.py
@@ -3,7 +3,6 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 import argparse
-import enum
 import re
 import sys
 
@@ -19,17 +18,10 @@ import spack.llnl.util.tty.color as color
 import spack.package_base
 import spack.solver.asp as asp
 import spack.spec
-import spack.traverse
 
 description = "concretize a specs using an ASP solver"
 section = "developer"
 level = "long"
-
-
-class StatusMode(enum.Enum):
-    NONE = "none"
-    INSTALL = "install"
-    BUILDCACHE = "buildcache"
 
 
 #: output options
@@ -62,7 +54,7 @@ def setup_parser(subparser: argparse.ArgumentParser) -> None:
     spack.cmd.spec.setup_parser(subparser)
 
 
-def _process_result(result, show, required_format, kwargs, *, status_mode=StatusMode.NONE):
+def _process_result(result, show, required_format, kwargs):
     opt, _, _ = min(result.answers)
     if ("opt" in show) and (not required_format):
         tty.msg("Best of %d considered solutions." % result.nmodels)
@@ -107,18 +99,7 @@ def _process_result(result, show, required_format, kwargs, *, status_mode=Status
                 elif required_format == "json":
                     sys.stdout.write(spec.to_json(hash=ht.dag_hash))
         else:
-            if status_mode == StatusMode.BUILDCACHE:
-                available_hashes = spack.binary_distribution.specs_in_buildcaches(
-                    spack.traverse.traverse_nodes(result.specs, key=spack.traverse.by_dag_hash)
-                )
-                status_fn = spack.cmd.buildcache_status_fn(available_hashes)
-            elif status_mode == StatusMode.INSTALL:
-                status_fn = spack.spec.Spec.install_status
-            else:
-                status_fn = None
-            tree_str = spack.spec.tree(
-                result.specs, color=sys.stdout.isatty(), status_fn=status_fn, **kwargs
-            )
+            tree_str = spack.spec.tree(result.specs, color=sys.stdout.isatty(), **kwargs)
             sys.stdout.write(tree_str)
         print()
 
@@ -132,18 +113,19 @@ def solve(parser, args):
     if args.namespaces:
         fmt = "{namespace}." + fmt
 
-    if args.buildcache_status:
-        status_mode = StatusMode.BUILDCACHE
-    elif args.install_status:
-        status_mode = StatusMode.INSTALL
+    show_status = args.install_status
+    if show_status:
+        spack.binary_distribution.load_buildcache_index()
+        status_fn = spack.cmd.buildcache_status_fn(spack.binary_distribution.BINARY_INDEX)
     else:
-        status_mode = StatusMode.NONE
+        status_fn = None
 
     kwargs = {
         "cover": args.cover,
         "format": fmt,
         "hashlen": None if args.very_long else 7,
         "show_types": args.types,
+        "status_fn": status_fn,
         "hashes": args.long or args.very_long,
         "highlight_version_fn": (
             spack.package_base.non_preferred_version if args.non_defaults else None
@@ -197,7 +179,7 @@ def solve(parser, args):
             else:
                 print("% END ROUND {0}\n".format(idx))
             if not setup_only:
-                _process_result(result, show, required_format, kwargs, status_mode=status_mode)
+                _process_result(result, show, required_format, kwargs)
     elif unify:
         # set up solver parameters
         # Note: reuse and other concretizer prefs are passed as configuration
@@ -210,7 +192,7 @@ def solve(parser, args):
             allow_deprecated=allow_deprecated,
         )
         if not setup_only:
-            _process_result(result, show, required_format, kwargs, status_mode=status_mode)
+            _process_result(result, show, required_format, kwargs)
     else:
         for spec in specs:
             tty.msg("SOLVING SPEC:", spec)
@@ -223,4 +205,4 @@ def solve(parser, args):
                 allow_deprecated=allow_deprecated,
             )
             if not setup_only:
-                _process_result(result, show, required_format, kwargs, status_mode=status_mode)
+                _process_result(result, show, required_format, kwargs)

--- a/lib/spack/spack/cmd/solve.py
+++ b/lib/spack/spack/cmd/solve.py
@@ -113,9 +113,9 @@ def solve(parser, args):
     if args.namespaces:
         fmt = "{namespace}." + fmt
 
-    show_status = args.install_status
+    show_status = args.install_status or args.refresh_buildcaches
     if show_status:
-        spack.binary_distribution.load_buildcache_index()
+        spack.binary_distribution.load_buildcache_index(refresh=args.refresh_buildcaches)
         status_fn = spack.cmd.buildcache_status_fn(spack.binary_distribution.BINARY_INDEX)
     else:
         status_fn = None

--- a/lib/spack/spack/cmd/solve.py
+++ b/lib/spack/spack/cmd/solve.py
@@ -3,10 +3,12 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 import argparse
+import enum
 import re
 import sys
 
 import spack
+import spack.binary_distribution
 import spack.cmd
 import spack.cmd.spec
 import spack.config
@@ -17,10 +19,18 @@ import spack.llnl.util.tty.color as color
 import spack.package_base
 import spack.solver.asp as asp
 import spack.spec
+import spack.traverse
 
 description = "concretize a specs using an ASP solver"
 section = "developer"
 level = "long"
+
+
+class StatusMode(enum.Enum):
+    NONE = "none"
+    INSTALL = "install"
+    BUILDCACHE = "buildcache"
+
 
 #: output options
 show_options = ("asp", "opt", "output", "solutions")
@@ -52,7 +62,7 @@ def setup_parser(subparser: argparse.ArgumentParser) -> None:
     spack.cmd.spec.setup_parser(subparser)
 
 
-def _process_result(result, show, required_format, kwargs):
+def _process_result(result, show, required_format, kwargs, *, status_mode=StatusMode.NONE):
     opt, _, _ = min(result.answers)
     if ("opt" in show) and (not required_format):
         tty.msg("Best of %d considered solutions." % result.nmodels)
@@ -97,7 +107,19 @@ def _process_result(result, show, required_format, kwargs):
                 elif required_format == "json":
                     sys.stdout.write(spec.to_json(hash=ht.dag_hash))
         else:
-            sys.stdout.write(spack.spec.tree(result.specs, color=sys.stdout.isatty(), **kwargs))
+            if status_mode == StatusMode.BUILDCACHE:
+                available_hashes = spack.binary_distribution.specs_in_buildcaches(
+                    spack.traverse.traverse_nodes(result.specs, key=spack.traverse.by_dag_hash)
+                )
+                status_fn = spack.cmd.buildcache_status_fn(available_hashes)
+            elif status_mode == StatusMode.INSTALL:
+                status_fn = spack.spec.Spec.install_status
+            else:
+                status_fn = None
+            tree_str = spack.spec.tree(
+                result.specs, color=sys.stdout.isatty(), status_fn=status_fn, **kwargs
+            )
+            sys.stdout.write(tree_str)
         print()
 
     if result.unsolved_specs and "solutions" in show:
@@ -106,18 +128,22 @@ def _process_result(result, show, required_format, kwargs):
 
 def solve(parser, args):
     # these are the same options as `spack spec`
-    install_status_fn = spack.spec.Spec.install_status
-
     fmt = spack.spec.DISPLAY_FORMAT
     if args.namespaces:
         fmt = "{namespace}." + fmt
+
+    if args.buildcache_status:
+        status_mode = StatusMode.BUILDCACHE
+    elif args.install_status:
+        status_mode = StatusMode.INSTALL
+    else:
+        status_mode = StatusMode.NONE
 
     kwargs = {
         "cover": args.cover,
         "format": fmt,
         "hashlen": None if args.very_long else 7,
         "show_types": args.types,
-        "status_fn": install_status_fn if args.install_status else None,
         "hashes": args.long or args.very_long,
         "highlight_version_fn": (
             spack.package_base.non_preferred_version if args.non_defaults else None
@@ -171,7 +197,7 @@ def solve(parser, args):
             else:
                 print("% END ROUND {0}\n".format(idx))
             if not setup_only:
-                _process_result(result, show, required_format, kwargs)
+                _process_result(result, show, required_format, kwargs, status_mode=status_mode)
     elif unify:
         # set up solver parameters
         # Note: reuse and other concretizer prefs are passed as configuration
@@ -184,7 +210,7 @@ def solve(parser, args):
             allow_deprecated=allow_deprecated,
         )
         if not setup_only:
-            _process_result(result, show, required_format, kwargs)
+            _process_result(result, show, required_format, kwargs, status_mode=status_mode)
     else:
         for spec in specs:
             tty.msg("SOLVING SPEC:", spec)
@@ -197,4 +223,4 @@ def solve(parser, args):
                 allow_deprecated=allow_deprecated,
             )
             if not setup_only:
-                _process_result(result, show, required_format, kwargs)
+                _process_result(result, show, required_format, kwargs, status_mode=status_mode)

--- a/lib/spack/spack/cmd/spec.py
+++ b/lib/spack/spack/cmd/spec.py
@@ -34,8 +34,6 @@ for further documentation regarding the spec syntax, see:
 
     install_status_group = subparser.add_mutually_exclusive_group()
     arguments.add_common_arguments(install_status_group, ["install_status", "no_install_status"])
-    arguments.add_common_arguments(subparser, ["buildcache_status"])
-
     format_group = subparser.add_mutually_exclusive_group()
     format_group.add_argument(
         "-y",
@@ -93,14 +91,10 @@ def spec(parser, args):
     else:
         args.subparser.error("requires at least one spec or an active environment")
 
-    show_status = args.install_status or args.buildcache_status
-    if args.buildcache_status:
-        available_hashes = spack.binary_distribution.specs_in_buildcaches(
-            spack.traverse.traverse_nodes(concrete_specs, key=spack.traverse.by_dag_hash)
-        )
-        status_fn = spack.cmd.buildcache_status_fn(available_hashes)
-    elif show_status:
-        status_fn = spack.spec.Spec.install_status
+    show_status = args.install_status
+    if show_status:
+        spack.binary_distribution.load_buildcache_index()
+        status_fn = spack.cmd.buildcache_status_fn(spack.binary_distribution.BINARY_INDEX)
     else:
         status_fn = None
 

--- a/lib/spack/spack/cmd/spec.py
+++ b/lib/spack/spack/cmd/spec.py
@@ -6,6 +6,7 @@ import argparse
 import sys
 
 import spack
+import spack.binary_distribution
 import spack.cmd
 import spack.environment as ev
 import spack.hash_types as ht
@@ -33,6 +34,7 @@ for further documentation regarding the spec syntax, see:
 
     install_status_group = subparser.add_mutually_exclusive_group()
     arguments.add_common_arguments(install_status_group, ["install_status", "no_install_status"])
+    arguments.add_common_arguments(subparser, ["buildcache_status"])
 
     format_group = subparser.add_mutually_exclusive_group()
     format_group.add_argument(
@@ -77,17 +79,9 @@ for further documentation regarding the spec syntax, see:
 
 
 def spec(parser, args):
-    install_status_fn = spack.spec.Spec.install_status
-
     fmt = spack.spec.DISPLAY_FORMAT
     if args.namespaces:
         fmt = "{namespace}." + fmt
-
-    # use a read transaction if we are getting install status for every
-    # spec in the DAG.  This avoids repeatedly querying the DB.
-    tree_context = lang.nullcontext
-    if args.install_status:
-        tree_context = spack.store.STORE.db.read_transaction
 
     env = ev.active_environment()
 
@@ -98,6 +92,21 @@ def spec(parser, args):
         concrete_specs = env.concrete_roots()
     else:
         args.subparser.error("requires at least one spec or an active environment")
+
+    show_status = args.install_status or args.buildcache_status
+    if args.buildcache_status:
+        available_hashes = spack.binary_distribution.specs_in_buildcaches(
+            spack.traverse.traverse_nodes(concrete_specs, key=spack.traverse.by_dag_hash)
+        )
+        status_fn = spack.cmd.buildcache_status_fn(available_hashes)
+    elif show_status:
+        status_fn = spack.spec.Spec.install_status
+    else:
+        status_fn = None
+
+    # use a read transaction if we are getting install status for every
+    # spec in the DAG.  This avoids repeatedly querying the DB.
+    tree_context = spack.store.STORE.db.read_transaction if show_status else lang.nullcontext
 
     # With --yaml, --json, or --format, just print the raw specs to output
     if args.format:
@@ -119,7 +128,7 @@ def spec(parser, args):
                 format=fmt,
                 hashlen=None if args.very_long else 7,
                 show_types=args.types,
-                status_fn=install_status_fn if args.install_status else None,
+                status_fn=status_fn,
                 hashes=args.long or args.very_long,
                 key=spack.traverse.by_dag_hash,
                 highlight_version_fn=(

--- a/lib/spack/spack/cmd/spec.py
+++ b/lib/spack/spack/cmd/spec.py
@@ -34,6 +34,8 @@ for further documentation regarding the spec syntax, see:
 
     install_status_group = subparser.add_mutually_exclusive_group()
     arguments.add_common_arguments(install_status_group, ["install_status", "no_install_status"])
+    arguments.add_common_arguments(subparser, ["refresh_buildcaches"])
+
     format_group = subparser.add_mutually_exclusive_group()
     format_group.add_argument(
         "-y",
@@ -91,9 +93,9 @@ def spec(parser, args):
     else:
         args.subparser.error("requires at least one spec or an active environment")
 
-    show_status = args.install_status
+    show_status = args.install_status or args.refresh_buildcaches
     if show_status:
-        spack.binary_distribution.load_buildcache_index()
+        spack.binary_distribution.load_buildcache_index(refresh=args.refresh_buildcaches)
         status_fn = spack.cmd.buildcache_status_fn(spack.binary_distribution.BINARY_INDEX)
     else:
         status_fn = None

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -199,6 +199,7 @@ class InstallStatus(enum.Enum):
     external = "@M{[e]}  "
     absent = "@K{ - }  "
     missing = "@r{[-]}  "
+    buildcache = "@c{[B]}  "
 
 
 # regexes used in spec formatting

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -199,7 +199,7 @@ class InstallStatus(enum.Enum):
     external = "@M{[e]}  "
     absent = "@K{ - }  "
     missing = "@r{[-]}  "
-    buildcache = "@c{[B]}  "
+    buildcache = "@g{[b]}  "
 
 
 # regexes used in spec formatting

--- a/lib/spack/spack/test/binary_distribution.py
+++ b/lib/spack/spack/test/binary_distribution.py
@@ -1576,3 +1576,52 @@ def test_update_does_not_warn_on_mirror_with_no_index(monkeypatch, tmp_path, mut
     ]
     assert not concretization_warnings, "update() must not warn about concretization"
     assert binary_index.mirrors_without_index == {mirror_url, mirror_url2}
+
+
+def test_specs_in_buildcaches_returns_hash_of_available_spec(monkeypatch, tmp_path):
+    """Tests that specs_in_buildcaches returns the dag hash of a spec whose hash is in the
+    binary index.
+    """
+    # Concretize before patching so the solver's own index calls are unaffected.
+    available = spack.concretize.concretize_one("mpich")
+    not_available = spack.concretize.concretize_one("libelf")
+
+    # Use a fresh, isolated index cache so we do not touch any real mirror.
+    mock_index = spack.binary_distribution.BinaryIndexCache(str(tmp_path / "idx"))
+
+    # update() must be called with cooldown so it doesn't hit the network.
+    update_calls = []
+
+    def fake_update(with_cooldown=False):
+        update_calls.append(with_cooldown)
+
+    monkeypatch.setattr(mock_index, "update", fake_update)
+    monkeypatch.setattr(spack.binary_distribution, "BINARY_INDEX", mock_index)
+
+    # Simulate the index knowing about `available` but not `not_available`.
+    mock_index._mirrors_for_spec[available.dag_hash()] = {"some-mirror"}
+
+    result = spack.binary_distribution.specs_in_buildcaches([available, not_available])
+
+    assert available.dag_hash() in result
+    assert not_available.dag_hash() not in result
+    # update() must have been called with cooldown=True exactly once.
+    assert update_calls == [True]
+
+
+def test_specs_in_buildcaches_degrades_gracefully_on_update_error(monkeypatch, tmp_path):
+    """Tests that we return an empty set when the index update raises."""
+    # Concretize before patching so the solver's own index calls are unaffected.
+    s = spack.concretize.concretize_one("mpich")
+
+    mock_index = spack.binary_distribution.BinaryIndexCache(str(tmp_path / "idx"))
+
+    def exploding_update(with_cooldown=False):
+        raise OSError("network unreachable")
+
+    monkeypatch.setattr(mock_index, "update", exploding_update)
+    monkeypatch.setattr(spack.binary_distribution, "BINARY_INDEX", mock_index)
+
+    result = spack.binary_distribution.specs_in_buildcaches([s])
+
+    assert result == set()

--- a/lib/spack/spack/test/binary_distribution.py
+++ b/lib/spack/spack/test/binary_distribution.py
@@ -1578,8 +1578,13 @@ def test_update_does_not_warn_on_mirror_with_no_index(monkeypatch, tmp_path, mut
     assert binary_index.mirrors_without_index == {mirror_url, mirror_url2}
 
 
-def test_load_buildcache_index(monkeypatch, tmp_path):
-    """Tests that load_buildcache_index uses the local cache (no network call)."""
+@pytest.mark.parametrize(
+    "refresh_value,expected_regenerate,expected_update", [(False, [False], []), (True, [], [True])]
+)
+def test_load_buildcache_index(
+    refresh_value, expected_regenerate, expected_update, monkeypatch, tmp_path
+):
+    """Tests that we don't call update without ``refresh=True``"""
     mock_index = spack.binary_distribution.BinaryIndexCache(str(tmp_path / "idx"))
     regenerate_calls = []
     update_calls = []
@@ -1594,20 +1599,26 @@ def test_load_buildcache_index(monkeypatch, tmp_path):
     monkeypatch.setattr(mock_index, "update", fake_update)
     monkeypatch.setattr(spack.binary_distribution, "BINARY_INDEX", mock_index)
 
-    spack.binary_distribution.load_buildcache_index()
+    spack.binary_distribution.load_buildcache_index(refresh=refresh_value)
 
-    assert regenerate_calls == [False] and update_calls == []
+    assert regenerate_calls == expected_regenerate and update_calls == expected_update
 
 
 def test_load_buildcache_index_degrades_gracefully(monkeypatch, tmp_path):
     """Tests that load_buildcache_index swallows errors; status display never breaks a command."""
+    # Concretize before patching so the solver's own index calls are unaffected.
     mock_index = spack.binary_distribution.BinaryIndexCache(str(tmp_path / "idx"))
+
+    def exploding_update(with_cooldown=False):
+        raise OSError("network unreachable")
 
     def exploding_regenerate(clear_existing=False):
         raise OSError("disk error")
 
+    monkeypatch.setattr(mock_index, "update", exploding_update)
     monkeypatch.setattr(mock_index, "regenerate_spec_cache", exploding_regenerate)
     monkeypatch.setattr(spack.binary_distribution, "BINARY_INDEX", mock_index)
 
-    # Should not raise.
-    spack.binary_distribution.load_buildcache_index()
+    # Neither call should raise.
+    spack.binary_distribution.load_buildcache_index(refresh=True)
+    spack.binary_distribution.load_buildcache_index(refresh=False)

--- a/lib/spack/spack/test/binary_distribution.py
+++ b/lib/spack/spack/test/binary_distribution.py
@@ -1578,50 +1578,36 @@ def test_update_does_not_warn_on_mirror_with_no_index(monkeypatch, tmp_path, mut
     assert binary_index.mirrors_without_index == {mirror_url, mirror_url2}
 
 
-def test_specs_in_buildcaches_returns_hash_of_available_spec(monkeypatch, tmp_path):
-    """Tests that specs_in_buildcaches returns the dag hash of a spec whose hash is in the
-    binary index.
-    """
-    # Concretize before patching so the solver's own index calls are unaffected.
-    available = spack.concretize.concretize_one("mpich")
-    not_available = spack.concretize.concretize_one("libelf")
-
-    # Use a fresh, isolated index cache so we do not touch any real mirror.
+def test_load_buildcache_index(monkeypatch, tmp_path):
+    """Tests that load_buildcache_index uses the local cache (no network call)."""
     mock_index = spack.binary_distribution.BinaryIndexCache(str(tmp_path / "idx"))
-
-    # update() must be called with cooldown so it doesn't hit the network.
+    regenerate_calls = []
     update_calls = []
+
+    def fake_regenerate(clear_existing=False):
+        regenerate_calls.append(clear_existing)
 
     def fake_update(with_cooldown=False):
         update_calls.append(with_cooldown)
 
+    monkeypatch.setattr(mock_index, "regenerate_spec_cache", fake_regenerate)
     monkeypatch.setattr(mock_index, "update", fake_update)
     monkeypatch.setattr(spack.binary_distribution, "BINARY_INDEX", mock_index)
 
-    # Simulate the index knowing about `available` but not `not_available`.
-    mock_index._mirrors_for_spec[available.dag_hash()] = {"some-mirror"}
+    spack.binary_distribution.load_buildcache_index()
 
-    result = spack.binary_distribution.specs_in_buildcaches([available, not_available])
-
-    assert available.dag_hash() in result
-    assert not_available.dag_hash() not in result
-    # update() must have been called with cooldown=True exactly once.
-    assert update_calls == [True]
+    assert regenerate_calls == [False] and update_calls == []
 
 
-def test_specs_in_buildcaches_degrades_gracefully_on_update_error(monkeypatch, tmp_path):
-    """Tests that we return an empty set when the index update raises."""
-    # Concretize before patching so the solver's own index calls are unaffected.
-    s = spack.concretize.concretize_one("mpich")
-
+def test_load_buildcache_index_degrades_gracefully(monkeypatch, tmp_path):
+    """Tests that load_buildcache_index swallows errors; status display never breaks a command."""
     mock_index = spack.binary_distribution.BinaryIndexCache(str(tmp_path / "idx"))
 
-    def exploding_update(with_cooldown=False):
-        raise OSError("network unreachable")
+    def exploding_regenerate(clear_existing=False):
+        raise OSError("disk error")
 
-    monkeypatch.setattr(mock_index, "update", exploding_update)
+    monkeypatch.setattr(mock_index, "regenerate_spec_cache", exploding_regenerate)
     monkeypatch.setattr(spack.binary_distribution, "BINARY_INDEX", mock_index)
 
-    result = spack.binary_distribution.specs_in_buildcaches([s])
-
-    assert result == set()
+    # Should not raise.
+    spack.binary_distribution.load_buildcache_index()

--- a/lib/spack/spack/test/cmd/spec.py
+++ b/lib/spack/spack/test/cmd/spec.py
@@ -6,12 +6,19 @@ import re
 
 import pytest
 
+import spack.cmd
+import spack.concretize
 import spack.config
 import spack.environment as ev
 import spack.error
 import spack.spec
 import spack.store
 from spack.main import SpackCommand, SpackCommandError
+
+buildcache = SpackCommand("buildcache")
+install = SpackCommand("install")
+mirror = SpackCommand("mirror")
+uninstall = SpackCommand("uninstall")
 
 # Unit tests should not be affected by the user's managed environments
 pytestmark = pytest.mark.usefixtures(
@@ -223,3 +230,45 @@ def test_spec_unification_from_cli(
     else:
         output = spec(*hashes)
         assert match in output
+
+
+def test_buildcache_status_fn_marks_absent_spec(install_mockery, mock_packages):
+    """Tests the basic semantics of build_cache_status_fn."""
+    s = spack.concretize.concretize_one("mpileaks")
+    assert s.install_status() == spack.spec.InstallStatus.absent
+
+    status_fn = spack.cmd.buildcache_status_fn({s.dag_hash()})
+    assert status_fn(s) == spack.spec.InstallStatus.buildcache
+
+    status_fn = spack.cmd.buildcache_status_fn(set())
+    assert status_fn(s) == spack.spec.InstallStatus.absent
+
+
+def test_buildcache_status_fn_installed_not_overridden(mutable_database):
+    """Tests that an installed spec stays installed even if its hash is in the cache."""
+    s = spack.store.STORE.db.query_one("mpileaks^mpich")
+    assert s.install_status() == spack.spec.InstallStatus.installed
+
+    status_fn = spack.cmd.buildcache_status_fn({s.dag_hash()})
+    assert status_fn(s) == spack.spec.InstallStatus.installed
+
+
+def test_spec_buildcache_status_flag(install_mockery, mock_fetch, tmp_path):
+    """Tests that -B shows [B] for a not-installed spec whose hash is in a buildcache."""
+    pkg = "trivial-install-test-package"
+
+    # Install, push to buildcache with a fully updated index, then uninstall.
+    install(pkg)
+    buildcache("push", "--unsigned", "--update-index", str(tmp_path), pkg)
+    uninstall("-y", pkg)
+
+    # Register the mirror so BINARY_INDEX can fetch its index.
+    mirror("add", "--unsigned", "test-buildcache", tmp_path.as_uri())
+
+    # With -B: the top-level spec is absent but available in the buildcache -> [B]
+    output_with_b = spec("-B", pkg)
+    assert "[B]" in output_with_b
+
+    # Without -B: plain invocation must not show [B] (no buildcache query).
+    output_without_b = spec(pkg)
+    assert "[B]" not in output_without_b

--- a/lib/spack/spack/test/cmd/spec.py
+++ b/lib/spack/spack/test/cmd/spec.py
@@ -251,24 +251,3 @@ def test_buildcache_status_fn_installed_not_overridden(mutable_database):
 
     status_fn = spack.cmd.buildcache_status_fn({s.dag_hash()})
     assert status_fn(s) == spack.spec.InstallStatus.installed
-
-
-def test_spec_buildcache_status_flag(install_mockery, mock_fetch, tmp_path):
-    """Tests that -B shows [B] for a not-installed spec whose hash is in a buildcache."""
-    pkg = "trivial-install-test-package"
-
-    # Install, push to buildcache with a fully updated index, then uninstall.
-    install(pkg)
-    buildcache("push", "--unsigned", "--update-index", str(tmp_path), pkg)
-    uninstall("-y", pkg)
-
-    # Register the mirror so BINARY_INDEX can fetch its index.
-    mirror("add", "--unsigned", "test-buildcache", tmp_path.as_uri())
-
-    # With -B: the top-level spec is absent but available in the buildcache -> [B]
-    output_with_b = spec("-B", pkg)
-    assert "[B]" in output_with_b
-
-    # Without -B: plain invocation must not show [B] (no buildcache query).
-    output_without_b = spec(pkg)
-    assert "[B]" not in output_without_b

--- a/lib/spack/spack/test/cmd/spec.py
+++ b/lib/spack/spack/test/cmd/spec.py
@@ -251,3 +251,26 @@ def test_buildcache_status_fn_installed_not_overridden(mutable_database):
 
     status_fn = spack.cmd.buildcache_status_fn({s.dag_hash()})
     assert status_fn(s) == spack.spec.InstallStatus.installed
+
+
+def test_spec_buildcache_status_flag(install_mockery, mock_fetch, tmp_path):
+    """Tests that --refresh-buildcaches shows [b] for a non-installed spec in a buildcache,
+    and that a subsequent plain -I also shows [b] using the already-populated index.
+    """
+    pkg = "trivial-install-test-package"
+
+    # Install, push to buildcache with a fully updated index, then uninstall.
+    install(pkg)
+    buildcache("push", "--unsigned", "--update-index", str(tmp_path), pkg)
+    uninstall("-y", pkg)
+
+    # Register the mirror so BINARY_INDEX can fetch its index.
+    mirror("add", "--unsigned", "test-buildcache", tmp_path.as_uri())
+
+    # With --refresh-buildcaches: fetches remote index -> [b] for the absent spec.
+    output_with_refresh = spec("--refresh-buildcaches", pkg)
+    assert "[b]" in output_with_refresh
+
+    # Plain -I: with the index already in memory, [b] shows without a fresh network fetch.
+    output_no_refresh = spec("-I", pkg)
+    assert "[b]" in output_no_refresh

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -1242,7 +1242,7 @@ _spack_fetch() {
 _spack_find() {
     if $list_options
     then
-        SPACK_COMPREPLY="-h --help --format -H --hashes --json -I --install-status --specfile-format -d --deps -p --paths --groups --no-groups -l --long -L --very-long -t --tag -N --namespaces -r --only-roots -c --show-concretized --show-configured-externals -f --show-flags --show-full-compiler -x --explicit -X --implicit -e --external -u --unknown -m --missing -v --variants --loaded -M --only-missing --only-deprecated --deprecated --install-tree --start-date --end-date"
+        SPACK_COMPREPLY="-h --help --format -H --hashes --json -I --install-status --refresh-buildcaches --specfile-format -d --deps -p --paths --groups --no-groups -l --long -L --very-long -t --tag -N --namespaces -r --only-roots -c --show-concretized --show-configured-externals -f --show-flags --show-full-compiler -x --explicit -X --implicit -e --external -u --unknown -m --missing -v --variants --loaded -M --only-missing --only-deprecated --deprecated --install-tree --start-date --end-date"
     else
         _installed_packages
     fi
@@ -1925,7 +1925,7 @@ _spack_restage() {
 _spack_solve() {
     if $list_options
     then
-        SPACK_COMPREPLY="-h --help --show --timers --stats -l --long -L --very-long -N --namespaces -I --install-status --no-install-status -y --yaml -j --json --format --non-defaults -c --cover -t --types -f --force -U --fresh --reuse --fresh-roots --reuse-deps --deprecated"
+        SPACK_COMPREPLY="-h --help --show --timers --stats -l --long -L --very-long -N --namespaces -I --install-status --no-install-status --refresh-buildcaches -y --yaml -j --json --format --non-defaults -c --cover -t --types -f --force -U --fresh --reuse --fresh-roots --reuse-deps --deprecated"
     else
         _all_packages
     fi
@@ -1934,7 +1934,7 @@ _spack_solve() {
 _spack_spec() {
     if $list_options
     then
-        SPACK_COMPREPLY="-h --help -l --long -L --very-long -N --namespaces -I --install-status --no-install-status -y --yaml -j --json --format --non-defaults -c --cover -t --types -f --force -U --fresh --reuse --fresh-roots --reuse-deps --deprecated"
+        SPACK_COMPREPLY="-h --help -l --long -L --very-long -N --namespaces -I --install-status --no-install-status --refresh-buildcaches -y --yaml -j --json --format --non-defaults -c --cover -t --types -f --force -U --fresh --reuse --fresh-roots --reuse-deps --deprecated"
     else
         _all_packages
     fi

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -1242,7 +1242,7 @@ _spack_fetch() {
 _spack_find() {
     if $list_options
     then
-        SPACK_COMPREPLY="-h --help --format -H --hashes --json -I --install-status --specfile-format -d --deps -p --paths --groups --no-groups -l --long -L --very-long -t --tag -N --namespaces -r --only-roots -c --show-concretized --show-configured-externals -f --show-flags --show-full-compiler -x --explicit -X --implicit -e --external -u --unknown -m --missing -v --variants --loaded -M --only-missing --only-deprecated --deprecated --install-tree --start-date --end-date"
+        SPACK_COMPREPLY="-h --help --format -H --hashes --json -I --install-status -B --buildcache-status --specfile-format -d --deps -p --paths --groups --no-groups -l --long -L --very-long -t --tag -N --namespaces -r --only-roots -c --show-concretized --show-configured-externals -f --show-flags --show-full-compiler -x --explicit -X --implicit -e --external -u --unknown -m --missing -v --variants --loaded -M --only-missing --only-deprecated --deprecated --install-tree --start-date --end-date"
     else
         _installed_packages
     fi
@@ -1925,7 +1925,7 @@ _spack_restage() {
 _spack_solve() {
     if $list_options
     then
-        SPACK_COMPREPLY="-h --help --show --timers --stats -l --long -L --very-long -N --namespaces -I --install-status --no-install-status -y --yaml -j --json --format --non-defaults -c --cover -t --types -f --force -U --fresh --reuse --fresh-roots --reuse-deps --deprecated"
+        SPACK_COMPREPLY="-h --help --show --timers --stats -l --long -L --very-long -N --namespaces -I --install-status --no-install-status -B --buildcache-status -y --yaml -j --json --format --non-defaults -c --cover -t --types -f --force -U --fresh --reuse --fresh-roots --reuse-deps --deprecated"
     else
         _all_packages
     fi
@@ -1934,7 +1934,7 @@ _spack_solve() {
 _spack_spec() {
     if $list_options
     then
-        SPACK_COMPREPLY="-h --help -l --long -L --very-long -N --namespaces -I --install-status --no-install-status -y --yaml -j --json --format --non-defaults -c --cover -t --types -f --force -U --fresh --reuse --fresh-roots --reuse-deps --deprecated"
+        SPACK_COMPREPLY="-h --help -l --long -L --very-long -N --namespaces -I --install-status --no-install-status -B --buildcache-status -y --yaml -j --json --format --non-defaults -c --cover -t --types -f --force -U --fresh --reuse --fresh-roots --reuse-deps --deprecated"
     else
         _all_packages
     fi

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -1242,7 +1242,7 @@ _spack_fetch() {
 _spack_find() {
     if $list_options
     then
-        SPACK_COMPREPLY="-h --help --format -H --hashes --json -I --install-status -B --buildcache-status --specfile-format -d --deps -p --paths --groups --no-groups -l --long -L --very-long -t --tag -N --namespaces -r --only-roots -c --show-concretized --show-configured-externals -f --show-flags --show-full-compiler -x --explicit -X --implicit -e --external -u --unknown -m --missing -v --variants --loaded -M --only-missing --only-deprecated --deprecated --install-tree --start-date --end-date"
+        SPACK_COMPREPLY="-h --help --format -H --hashes --json -I --install-status --specfile-format -d --deps -p --paths --groups --no-groups -l --long -L --very-long -t --tag -N --namespaces -r --only-roots -c --show-concretized --show-configured-externals -f --show-flags --show-full-compiler -x --explicit -X --implicit -e --external -u --unknown -m --missing -v --variants --loaded -M --only-missing --only-deprecated --deprecated --install-tree --start-date --end-date"
     else
         _installed_packages
     fi
@@ -1925,7 +1925,7 @@ _spack_restage() {
 _spack_solve() {
     if $list_options
     then
-        SPACK_COMPREPLY="-h --help --show --timers --stats -l --long -L --very-long -N --namespaces -I --install-status --no-install-status -B --buildcache-status -y --yaml -j --json --format --non-defaults -c --cover -t --types -f --force -U --fresh --reuse --fresh-roots --reuse-deps --deprecated"
+        SPACK_COMPREPLY="-h --help --show --timers --stats -l --long -L --very-long -N --namespaces -I --install-status --no-install-status -y --yaml -j --json --format --non-defaults -c --cover -t --types -f --force -U --fresh --reuse --fresh-roots --reuse-deps --deprecated"
     else
         _all_packages
     fi
@@ -1934,7 +1934,7 @@ _spack_solve() {
 _spack_spec() {
     if $list_options
     then
-        SPACK_COMPREPLY="-h --help -l --long -L --very-long -N --namespaces -I --install-status --no-install-status -B --buildcache-status -y --yaml -j --json --format --non-defaults -c --cover -t --types -f --force -U --fresh --reuse --fresh-roots --reuse-deps --deprecated"
+        SPACK_COMPREPLY="-h --help -l --long -L --very-long -N --namespaces -I --install-status --no-install-status -y --yaml -j --json --format --non-defaults -c --cover -t --types -f --force -U --fresh --reuse --fresh-roots --reuse-deps --deprecated"
     else
         _all_packages
     fi

--- a/share/spack/spack-completion.fish
+++ b/share/spack/spack-completion.fish
@@ -1885,7 +1885,7 @@ complete -c spack -n '__fish_spack_using_command fetch' -l deprecated -f -a conf
 complete -c spack -n '__fish_spack_using_command fetch' -l deprecated -d 'allow concretizer to select deprecated versions'
 
 # spack find
-set -g __fish_spack_optspecs_spack_find h/help format= H/hashes json I/install-status specfile-format d/deps p/paths groups no-groups l/long L/very-long t/tag= N/namespaces r/only-roots c/show-concretized show-configured-externals f/show-flags show-full-compiler x/explicit X/implicit e/external u/unknown m/missing v/variants loaded M/only-missing only-deprecated deprecated install-tree= start-date= end-date=
+set -g __fish_spack_optspecs_spack_find h/help format= H/hashes json I/install-status refresh-buildcaches specfile-format d/deps p/paths groups no-groups l/long L/very-long t/tag= N/namespaces r/only-roots c/show-concretized show-configured-externals f/show-flags show-full-compiler x/explicit X/implicit e/external u/unknown m/missing v/variants loaded M/only-missing only-deprecated deprecated install-tree= start-date= end-date=
 complete -c spack -n '__fish_spack_using_command_pos_remainder 0 find' -f -a '(__fish_spack_installed_specs)'
 complete -c spack -n '__fish_spack_using_command find' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command find' -s h -l help -d 'show this help message and exit'
@@ -1897,6 +1897,8 @@ complete -c spack -n '__fish_spack_using_command find' -l json -f -a json
 complete -c spack -n '__fish_spack_using_command find' -l json -d 'output specs as machine-readable json records'
 complete -c spack -n '__fish_spack_using_command find' -s I -l install-status -f -a install_status
 complete -c spack -n '__fish_spack_using_command find' -s I -l install-status -d 'show install status of packages'
+complete -c spack -n '__fish_spack_using_command find' -l refresh-buildcaches -f -a refresh_buildcaches
+complete -c spack -n '__fish_spack_using_command find' -l refresh-buildcaches -d 'refresh the buildcache mirror index over the network before showing install status'
 complete -c spack -n '__fish_spack_using_command find' -l specfile-format -f -a specfile_format
 complete -c spack -n '__fish_spack_using_command find' -l specfile-format -d 'show the specfile format for installed deps '
 complete -c spack -n '__fish_spack_using_command find' -s d -l deps -f -a deps
@@ -3005,7 +3007,7 @@ complete -c spack -n '__fish_spack_using_command restage' -s h -l help -f -a hel
 complete -c spack -n '__fish_spack_using_command restage' -s h -l help -d 'show this help message and exit'
 
 # spack solve
-set -g __fish_spack_optspecs_spack_solve h/help show= timers stats l/long L/very-long N/namespaces I/install-status no-install-status y/yaml j/json format= non-defaults c/cover= t/types f/force U/fresh reuse fresh-roots deprecated
+set -g __fish_spack_optspecs_spack_solve h/help show= timers stats l/long L/very-long N/namespaces I/install-status no-install-status refresh-buildcaches y/yaml j/json format= non-defaults c/cover= t/types f/force U/fresh reuse fresh-roots deprecated
 complete -c spack -n '__fish_spack_using_command_pos_remainder 0 solve' -f -k -a '(__fish_spack_specs_or_id)'
 complete -c spack -n '__fish_spack_using_command solve' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command solve' -s h -l help -d 'show this help message and exit'
@@ -3025,6 +3027,8 @@ complete -c spack -n '__fish_spack_using_command solve' -s I -l install-status -
 complete -c spack -n '__fish_spack_using_command solve' -s I -l install-status -d 'show install status of packages'
 complete -c spack -n '__fish_spack_using_command solve' -l no-install-status -f -a install_status
 complete -c spack -n '__fish_spack_using_command solve' -l no-install-status -d 'do not show install status annotations'
+complete -c spack -n '__fish_spack_using_command solve' -l refresh-buildcaches -f -a refresh_buildcaches
+complete -c spack -n '__fish_spack_using_command solve' -l refresh-buildcaches -d 'refresh the buildcache mirror index over the network before showing install status'
 complete -c spack -n '__fish_spack_using_command solve' -s y -l yaml -f -a format
 complete -c spack -n '__fish_spack_using_command solve' -s y -l yaml -d 'print concrete spec as YAML'
 complete -c spack -n '__fish_spack_using_command solve' -s j -l json -f -a format
@@ -3049,7 +3053,7 @@ complete -c spack -n '__fish_spack_using_command solve' -l deprecated -f -a conf
 complete -c spack -n '__fish_spack_using_command solve' -l deprecated -d 'allow concretizer to select deprecated versions'
 
 # spack spec
-set -g __fish_spack_optspecs_spack_spec h/help l/long L/very-long N/namespaces I/install-status no-install-status y/yaml j/json format= non-defaults c/cover= t/types f/force U/fresh reuse fresh-roots deprecated
+set -g __fish_spack_optspecs_spack_spec h/help l/long L/very-long N/namespaces I/install-status no-install-status refresh-buildcaches y/yaml j/json format= non-defaults c/cover= t/types f/force U/fresh reuse fresh-roots deprecated
 complete -c spack -n '__fish_spack_using_command_pos_remainder 0 spec' -f -k -a '(__fish_spack_specs_or_id)'
 complete -c spack -n '__fish_spack_using_command spec' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command spec' -s h -l help -d 'show this help message and exit'
@@ -3063,6 +3067,8 @@ complete -c spack -n '__fish_spack_using_command spec' -s I -l install-status -f
 complete -c spack -n '__fish_spack_using_command spec' -s I -l install-status -d 'show install status of packages'
 complete -c spack -n '__fish_spack_using_command spec' -l no-install-status -f -a install_status
 complete -c spack -n '__fish_spack_using_command spec' -l no-install-status -d 'do not show install status annotations'
+complete -c spack -n '__fish_spack_using_command spec' -l refresh-buildcaches -f -a refresh_buildcaches
+complete -c spack -n '__fish_spack_using_command spec' -l refresh-buildcaches -d 'refresh the buildcache mirror index over the network before showing install status'
 complete -c spack -n '__fish_spack_using_command spec' -s y -l yaml -f -a format
 complete -c spack -n '__fish_spack_using_command spec' -s y -l yaml -d 'print concrete spec as YAML'
 complete -c spack -n '__fish_spack_using_command spec' -s j -l json -f -a format

--- a/share/spack/spack-completion.fish
+++ b/share/spack/spack-completion.fish
@@ -1885,7 +1885,7 @@ complete -c spack -n '__fish_spack_using_command fetch' -l deprecated -f -a conf
 complete -c spack -n '__fish_spack_using_command fetch' -l deprecated -d 'allow concretizer to select deprecated versions'
 
 # spack find
-set -g __fish_spack_optspecs_spack_find h/help format= H/hashes json I/install-status specfile-format d/deps p/paths groups no-groups l/long L/very-long t/tag= N/namespaces r/only-roots c/show-concretized show-configured-externals f/show-flags show-full-compiler x/explicit X/implicit e/external u/unknown m/missing v/variants loaded M/only-missing only-deprecated deprecated install-tree= start-date= end-date=
+set -g __fish_spack_optspecs_spack_find h/help format= H/hashes json I/install-status B/buildcache-status specfile-format d/deps p/paths groups no-groups l/long L/very-long t/tag= N/namespaces r/only-roots c/show-concretized show-configured-externals f/show-flags show-full-compiler x/explicit X/implicit e/external u/unknown m/missing v/variants loaded M/only-missing only-deprecated deprecated install-tree= start-date= end-date=
 complete -c spack -n '__fish_spack_using_command_pos_remainder 0 find' -f -a '(__fish_spack_installed_specs)'
 complete -c spack -n '__fish_spack_using_command find' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command find' -s h -l help -d 'show this help message and exit'
@@ -1897,6 +1897,8 @@ complete -c spack -n '__fish_spack_using_command find' -l json -f -a json
 complete -c spack -n '__fish_spack_using_command find' -l json -d 'output specs as machine-readable json records'
 complete -c spack -n '__fish_spack_using_command find' -s I -l install-status -f -a install_status
 complete -c spack -n '__fish_spack_using_command find' -s I -l install-status -d 'show install status of packages'
+complete -c spack -n '__fish_spack_using_command find' -s B -l buildcache-status -f -a buildcache_status
+complete -c spack -n '__fish_spack_using_command find' -s B -l buildcache-status -d 'show buildcache availability alongside install status'
 complete -c spack -n '__fish_spack_using_command find' -l specfile-format -f -a specfile_format
 complete -c spack -n '__fish_spack_using_command find' -l specfile-format -d 'show the specfile format for installed deps '
 complete -c spack -n '__fish_spack_using_command find' -s d -l deps -f -a deps
@@ -3005,7 +3007,7 @@ complete -c spack -n '__fish_spack_using_command restage' -s h -l help -f -a hel
 complete -c spack -n '__fish_spack_using_command restage' -s h -l help -d 'show this help message and exit'
 
 # spack solve
-set -g __fish_spack_optspecs_spack_solve h/help show= timers stats l/long L/very-long N/namespaces I/install-status no-install-status y/yaml j/json format= non-defaults c/cover= t/types f/force U/fresh reuse fresh-roots deprecated
+set -g __fish_spack_optspecs_spack_solve h/help show= timers stats l/long L/very-long N/namespaces I/install-status no-install-status B/buildcache-status y/yaml j/json format= non-defaults c/cover= t/types f/force U/fresh reuse fresh-roots deprecated
 complete -c spack -n '__fish_spack_using_command_pos_remainder 0 solve' -f -k -a '(__fish_spack_specs_or_id)'
 complete -c spack -n '__fish_spack_using_command solve' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command solve' -s h -l help -d 'show this help message and exit'
@@ -3025,6 +3027,8 @@ complete -c spack -n '__fish_spack_using_command solve' -s I -l install-status -
 complete -c spack -n '__fish_spack_using_command solve' -s I -l install-status -d 'show install status of packages'
 complete -c spack -n '__fish_spack_using_command solve' -l no-install-status -f -a install_status
 complete -c spack -n '__fish_spack_using_command solve' -l no-install-status -d 'do not show install status annotations'
+complete -c spack -n '__fish_spack_using_command solve' -s B -l buildcache-status -f -a buildcache_status
+complete -c spack -n '__fish_spack_using_command solve' -s B -l buildcache-status -d 'show buildcache availability alongside install status'
 complete -c spack -n '__fish_spack_using_command solve' -s y -l yaml -f -a format
 complete -c spack -n '__fish_spack_using_command solve' -s y -l yaml -d 'print concrete spec as YAML'
 complete -c spack -n '__fish_spack_using_command solve' -s j -l json -f -a format
@@ -3049,7 +3053,7 @@ complete -c spack -n '__fish_spack_using_command solve' -l deprecated -f -a conf
 complete -c spack -n '__fish_spack_using_command solve' -l deprecated -d 'allow concretizer to select deprecated versions'
 
 # spack spec
-set -g __fish_spack_optspecs_spack_spec h/help l/long L/very-long N/namespaces I/install-status no-install-status y/yaml j/json format= non-defaults c/cover= t/types f/force U/fresh reuse fresh-roots deprecated
+set -g __fish_spack_optspecs_spack_spec h/help l/long L/very-long N/namespaces I/install-status no-install-status B/buildcache-status y/yaml j/json format= non-defaults c/cover= t/types f/force U/fresh reuse fresh-roots deprecated
 complete -c spack -n '__fish_spack_using_command_pos_remainder 0 spec' -f -k -a '(__fish_spack_specs_or_id)'
 complete -c spack -n '__fish_spack_using_command spec' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command spec' -s h -l help -d 'show this help message and exit'
@@ -3063,6 +3067,8 @@ complete -c spack -n '__fish_spack_using_command spec' -s I -l install-status -f
 complete -c spack -n '__fish_spack_using_command spec' -s I -l install-status -d 'show install status of packages'
 complete -c spack -n '__fish_spack_using_command spec' -l no-install-status -f -a install_status
 complete -c spack -n '__fish_spack_using_command spec' -l no-install-status -d 'do not show install status annotations'
+complete -c spack -n '__fish_spack_using_command spec' -s B -l buildcache-status -f -a buildcache_status
+complete -c spack -n '__fish_spack_using_command spec' -s B -l buildcache-status -d 'show buildcache availability alongside install status'
 complete -c spack -n '__fish_spack_using_command spec' -s y -l yaml -f -a format
 complete -c spack -n '__fish_spack_using_command spec' -s y -l yaml -d 'print concrete spec as YAML'
 complete -c spack -n '__fish_spack_using_command spec' -s j -l json -f -a format

--- a/share/spack/spack-completion.fish
+++ b/share/spack/spack-completion.fish
@@ -1885,7 +1885,7 @@ complete -c spack -n '__fish_spack_using_command fetch' -l deprecated -f -a conf
 complete -c spack -n '__fish_spack_using_command fetch' -l deprecated -d 'allow concretizer to select deprecated versions'
 
 # spack find
-set -g __fish_spack_optspecs_spack_find h/help format= H/hashes json I/install-status B/buildcache-status specfile-format d/deps p/paths groups no-groups l/long L/very-long t/tag= N/namespaces r/only-roots c/show-concretized show-configured-externals f/show-flags show-full-compiler x/explicit X/implicit e/external u/unknown m/missing v/variants loaded M/only-missing only-deprecated deprecated install-tree= start-date= end-date=
+set -g __fish_spack_optspecs_spack_find h/help format= H/hashes json I/install-status specfile-format d/deps p/paths groups no-groups l/long L/very-long t/tag= N/namespaces r/only-roots c/show-concretized show-configured-externals f/show-flags show-full-compiler x/explicit X/implicit e/external u/unknown m/missing v/variants loaded M/only-missing only-deprecated deprecated install-tree= start-date= end-date=
 complete -c spack -n '__fish_spack_using_command_pos_remainder 0 find' -f -a '(__fish_spack_installed_specs)'
 complete -c spack -n '__fish_spack_using_command find' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command find' -s h -l help -d 'show this help message and exit'
@@ -1897,8 +1897,6 @@ complete -c spack -n '__fish_spack_using_command find' -l json -f -a json
 complete -c spack -n '__fish_spack_using_command find' -l json -d 'output specs as machine-readable json records'
 complete -c spack -n '__fish_spack_using_command find' -s I -l install-status -f -a install_status
 complete -c spack -n '__fish_spack_using_command find' -s I -l install-status -d 'show install status of packages'
-complete -c spack -n '__fish_spack_using_command find' -s B -l buildcache-status -f -a buildcache_status
-complete -c spack -n '__fish_spack_using_command find' -s B -l buildcache-status -d 'show buildcache availability alongside install status'
 complete -c spack -n '__fish_spack_using_command find' -l specfile-format -f -a specfile_format
 complete -c spack -n '__fish_spack_using_command find' -l specfile-format -d 'show the specfile format for installed deps '
 complete -c spack -n '__fish_spack_using_command find' -s d -l deps -f -a deps
@@ -3007,7 +3005,7 @@ complete -c spack -n '__fish_spack_using_command restage' -s h -l help -f -a hel
 complete -c spack -n '__fish_spack_using_command restage' -s h -l help -d 'show this help message and exit'
 
 # spack solve
-set -g __fish_spack_optspecs_spack_solve h/help show= timers stats l/long L/very-long N/namespaces I/install-status no-install-status B/buildcache-status y/yaml j/json format= non-defaults c/cover= t/types f/force U/fresh reuse fresh-roots deprecated
+set -g __fish_spack_optspecs_spack_solve h/help show= timers stats l/long L/very-long N/namespaces I/install-status no-install-status y/yaml j/json format= non-defaults c/cover= t/types f/force U/fresh reuse fresh-roots deprecated
 complete -c spack -n '__fish_spack_using_command_pos_remainder 0 solve' -f -k -a '(__fish_spack_specs_or_id)'
 complete -c spack -n '__fish_spack_using_command solve' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command solve' -s h -l help -d 'show this help message and exit'
@@ -3027,8 +3025,6 @@ complete -c spack -n '__fish_spack_using_command solve' -s I -l install-status -
 complete -c spack -n '__fish_spack_using_command solve' -s I -l install-status -d 'show install status of packages'
 complete -c spack -n '__fish_spack_using_command solve' -l no-install-status -f -a install_status
 complete -c spack -n '__fish_spack_using_command solve' -l no-install-status -d 'do not show install status annotations'
-complete -c spack -n '__fish_spack_using_command solve' -s B -l buildcache-status -f -a buildcache_status
-complete -c spack -n '__fish_spack_using_command solve' -s B -l buildcache-status -d 'show buildcache availability alongside install status'
 complete -c spack -n '__fish_spack_using_command solve' -s y -l yaml -f -a format
 complete -c spack -n '__fish_spack_using_command solve' -s y -l yaml -d 'print concrete spec as YAML'
 complete -c spack -n '__fish_spack_using_command solve' -s j -l json -f -a format
@@ -3053,7 +3049,7 @@ complete -c spack -n '__fish_spack_using_command solve' -l deprecated -f -a conf
 complete -c spack -n '__fish_spack_using_command solve' -l deprecated -d 'allow concretizer to select deprecated versions'
 
 # spack spec
-set -g __fish_spack_optspecs_spack_spec h/help l/long L/very-long N/namespaces I/install-status no-install-status B/buildcache-status y/yaml j/json format= non-defaults c/cover= t/types f/force U/fresh reuse fresh-roots deprecated
+set -g __fish_spack_optspecs_spack_spec h/help l/long L/very-long N/namespaces I/install-status no-install-status y/yaml j/json format= non-defaults c/cover= t/types f/force U/fresh reuse fresh-roots deprecated
 complete -c spack -n '__fish_spack_using_command_pos_remainder 0 spec' -f -k -a '(__fish_spack_specs_or_id)'
 complete -c spack -n '__fish_spack_using_command spec' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command spec' -s h -l help -d 'show this help message and exit'
@@ -3067,8 +3063,6 @@ complete -c spack -n '__fish_spack_using_command spec' -s I -l install-status -f
 complete -c spack -n '__fish_spack_using_command spec' -s I -l install-status -d 'show install status of packages'
 complete -c spack -n '__fish_spack_using_command spec' -l no-install-status -f -a install_status
 complete -c spack -n '__fish_spack_using_command spec' -l no-install-status -d 'do not show install status annotations'
-complete -c spack -n '__fish_spack_using_command spec' -s B -l buildcache-status -f -a buildcache_status
-complete -c spack -n '__fish_spack_using_command spec' -s B -l buildcache-status -d 'show buildcache availability alongside install status'
 complete -c spack -n '__fish_spack_using_command spec' -s y -l yaml -f -a format
 complete -c spack -n '__fish_spack_using_command spec' -s y -l yaml -d 'print concrete spec as YAML'
 complete -c spack -n '__fish_spack_using_command spec' -s j -l json -f -a format


### PR DESCRIPTION
depends on #52471

In some cases, e.g. when looking at specs that were not concretized immediately before the command using `-I`, it could happen that the buildcache information is outdated.

This PR adds the `--refresh-buildcaches` flag to ensure buildcaches are up-to-date (at the cost of some network I/O).