### PR TITLE
Lock: Skip try_acquire_* on Windows

### DIFF
--- a/lib/spack/spack/util/lock.py
+++ b/lib/spack/spack/util/lock.py
@@ -68,6 +68,18 @@ class Lock(Llnl_lock):
         if self._enable:
             super()._unlock()
 
+    def try_acquire_read(self) -> bool:
+        if not self._enable:
+            self._reads += 1
+            return True
+        return super().try_acquire_read()
+
+    def try_acquire_write(self) -> bool:
+        if not self._enable:
+            self._writes += 1
+            return True
+        return super().try_acquire_write()
+
     def cleanup(self, *args) -> None:
         if self._enable:
             super().cleanup(*args)

--- a/lib/spack/spack/util/lock.py
+++ b/lib/spack/spack/util/lock.py
@@ -69,16 +69,14 @@ class Lock(Llnl_lock):
             super()._unlock()
 
     def try_acquire_read(self) -> bool:
-        if not self._enable:
-            self._reads += 1
-            return True
-        return super().try_acquire_read()
+        if self._enable:
+            return super().try_acquire_read()
+        return True
 
     def try_acquire_write(self) -> bool:
-        if not self._enable:
-            self._writes += 1
-            return True
-        return super().try_acquire_write()
+        if self._enable:
+            return super().try_acquire_write()
+        return True
 
     def cleanup(self, *args) -> None:
         if self._enable:


### PR DESCRIPTION
Add more methods to the `spack.util.lock.Lock` interface to `spack.llnl.util.lock.Lock` to gate the invocation of the llnl util locking class on Windows, where we don't have locking support yet and invoking these methods will crash.