### PR TITLE
Add a better message to developers when clingo is absent

### DIFF
--- a/lib/spack/spack/bootstrap/core.py
+++ b/lib/spack/spack/bootstrap/core.py
@@ -337,6 +337,18 @@ def source_is_enabled(conf: ConfigDictionary) -> bool:
     return spack.config.get("bootstrap:trusted").get(conf["name"], False)
 
 
+def _module_import_failure_hint(module: str) -> str:
+    """Return additional guidance for known bootstrap module failures."""
+    if module != "clingo":
+        return ""
+
+    return (
+        "\n\nSpack could not import or bootstrap the clingo Python module. "
+        "Run `spack bootstrap now` before running tests directly with "
+        "pytest, so Spack can install its required bootstrap dependencies."
+    )
+
+
 def ensure_module_importable_or_raise(module: str, abstract_spec: Optional[str] = None):
     """Make the requested module available for import, or raise.
 
@@ -381,6 +393,8 @@ def ensure_module_importable_or_raise(module: str, abstract_spec: Optional[str] 
         msg += exception_handler.grouped_message(with_tracebacks=True)
     else:
         msg += exception_handler.grouped_message(with_tracebacks=False)
+    msg += _module_import_failure_hint(module)
+    if exception_handler and not (spack.error.debug or spack.error.SHOW_BACKTRACE):
         msg += "\nRun `spack --backtrace ...` for more detailed errors"
     raise ImportError(msg)
 

--- a/lib/spack/spack/test/bootstrap.py
+++ b/lib/spack/spack/test/bootstrap.py
@@ -106,6 +106,16 @@ def test_raising_exception_module_importable(config, monkeypatch):
         spack.bootstrap.core.ensure_module_importable_or_raise("asdf")
 
 
+def test_raising_exception_clingo_mentions_bootstrap_now(config, monkeypatch):
+    monkeypatch.setattr(spack.bootstrap.core, "_python_import", lambda module: False)
+    monkeypatch.setattr(spack.bootstrap.core, "bootstrapping_sources", lambda: [])
+
+    with pytest.raises(ImportError) as exc_info:
+        spack.bootstrap.core.ensure_module_importable_or_raise("clingo")
+
+    assert "spack bootstrap now" in str(exc_info.value)
+
+
 def test_raising_exception_executables_in_path(config, monkeypatch):
     monkeypatch.setattr(spack.bootstrap.core, "source_is_enabled", _true)
     with pytest.raises(RuntimeError, match="cannot bootstrap any of the asdf, fdsa executables"):


### PR DESCRIPTION
If a user runs our unit-tests directly with pytest instead of `spack unit-tests` clingo is not guarenteed to be bootstrapped and thus many tests can fail. I noticed this was [happening in our own CI](https://github.com/spack/spack/actions/runs/26893103506/job/79324698163) after we removed the concretizer matrix and was causing failures.

This PR adds some better error messages to let users know they need to bootstrap clingo first.