### PR TITLE
new_installer: add Windows TUI (WindowsTerminalState)

### DIFF
--- a/.github/workflows/prechecks.yml
+++ b/.github/workflows/prechecks.yml
@@ -40,7 +40,7 @@ jobs:
     # Check that __slots__ are used properly
     - name: slotscheck
       run: |
-        ./bin/spack python -m slotscheck --exclude-modules="spack.test|spack.vendor" lib/spack/spack/
+        ./bin/spack python -m slotscheck --exclude-modules="spack.test|spack.vendor|spack.new_installer_windows" lib/spack/spack/
 
   # Run style checks on the files that have been changed
   style:

--- a/lib/spack/docs/conf.py
+++ b/lib/spack/docs/conf.py
@@ -96,6 +96,7 @@ sphinx_apidoc(
         "_spack_root/lib/spack/spack/vendor",
         "_spack_root/lib/spack/spack/test",
         "_spack_root/lib/spack/spack/package.py",
+        "_spack_root/lib/spack/spack/new_installer_windows.py",
     ]
 )
 sphinx_apidoc(
@@ -357,6 +358,7 @@ nitpick_ignore = [
     ("py:class", "spack_repo.builtin.build_systems._checks.BuilderWithDefaults"),
     ("py:class", "spack.repo._PrependFileLoader"),
     # Spack classes that intersphinx is unable to resolve
+    ("py:class", "BuildStatus"),
     ("py:class", "GitOrStandardVersion"),
     ("py:class", "spack.bootstrap._common.QueryInfo"),
     ("py:class", "spack.filesystem_view.SimpleFilesystemView"),

--- a/lib/spack/spack/new_installer.py
+++ b/lib/spack/spack/new_installer.py
@@ -2324,7 +2324,7 @@ class PackageInstaller:
             len(self.build_graph.nodes),
             verbose=verbose,
             filter_padding=spack.store.STORE.has_padding(),
-            is_tty=TerminalState.stdout_is_interactive()
+            is_tty=TerminalState.stdout_is_interactive(),
         )
         self.jobs = spack.config.determine_number_of_jobs(parallel=True)
         self.build_status.actual_jobs = self.jobs

--- a/lib/spack/spack/new_installer.py
+++ b/lib/spack/spack/new_installer.py
@@ -20,8 +20,6 @@ output to both a log file and the UI process (if the UI process has requested it
 runs an event loop to listen for control messages from the UI process (to enable/disable echoing
 of logs), and for output from the build process."""
 
-import abc
-import codecs
 import glob
 import io
 import json
@@ -31,7 +29,6 @@ import selectors
 import shlex
 import shutil
 import signal
-import socket
 import sys
 import tempfile
 import threading
@@ -82,27 +79,17 @@ from spack.installer import _do_fake_install, dump_packages
 from spack.llnl.util.lang import pretty_duration
 from spack.llnl.util.tty.log import _is_background_tty, ignore_signal
 from spack.subprocess_context import GlobalStateMarshaler
+from spack.new_installer_terminal import BaseTerminalState, StdinReaderBase
 from spack.util.executable import ProcessError
 from spack.util.log_parse import make_log_context, parse_log_events
 from spack.util.path import padding_filter, padding_filter_bytes
 
-IS_WINDOWS = sys.platform == "win32"
-
-if IS_WINDOWS:
-    import ctypes
-    import msvcrt
-    from ctypes import wintypes
-
-    # Windows console mode flags used by WindowsTerminalState
-    ENABLE_LINE_INPUT = 0x0002
-    ENABLE_ECHO_INPUT = 0x0004
-    ENABLE_QUICK_EDIT_MODE = 0x0040
-    ENABLE_EXTENDED_FLAGS = 0x0080
-    ENABLE_VIRTUAL_TERMINAL_PROCESSING = 0x0004  # for stdout handle
+if sys.platform == "win32":
+    from spack.new_installer_windows import WindowsTerminalState as TerminalState
 else:
     import fcntl
-    import termios
-    import tty
+
+    from spack.new_installer_posix import PosixTerminalState as TerminalState
 
 if TYPE_CHECKING:
     import spack.package_base
@@ -2216,349 +2203,6 @@ class NullReportData(ReportData):
         pass
 
 
-class BaseTerminalState(abc.ABC):
-    """Abstract base for platform-specific terminal state management."""
-
-    def __init__(
-        self,
-        selector: selectors.BaseSelector,
-        build_status: "BuildStatus",
-        on_suspend: Optional[Callable[[], None]] = None,
-        on_resume: Optional[Callable[[], None]] = None,
-    ) -> None:
-        self.selector = selector
-        self.build_status = build_status
-        self.on_suspend = on_suspend
-        self.on_resume = on_resume
-
-    @classmethod
-    def stdout_is_interactive(cls) -> bool:
-        return sys.stdout.isatty()
-
-    @classmethod
-    def stdin_is_interactive(cls) -> bool:
-        return sys.stdin.isatty()
-
-    def create_stdin_reader(self) -> "StdinReader":
-        return StdinReader(sys.stdin.fileno())
-
-    @abc.abstractmethod
-    def setup(self) -> None:
-        pass
-
-    @abc.abstractmethod
-    def teardown_input(self) -> None:
-        """Restore input settings and signal handlers. Called before the final UI render."""
-        pass
-
-    @abc.abstractmethod
-    def teardown_output(self) -> None:
-        """Restore output settings. Called after the final UI render."""
-        pass
-
-    def teardown(self) -> None:
-        self.teardown_input()
-        self.teardown_output()
-
-    @abc.abstractmethod
-    def enter_foreground(self) -> None:
-        pass
-
-    @abc.abstractmethod
-    def enter_background(self) -> None:
-        pass
-
-    @abc.abstractmethod
-    def handle_continue(self) -> None:
-        pass
-
-    @abc.abstractmethod
-    def drain_sigwinch(self) -> None:
-        """Drain the platform-specific sigwinch notification channel."""
-        pass
-
-    @abc.abstractmethod
-    def should_enter_foreground(self) -> bool:
-        """Return True if the process should switch from headless to foreground mode."""
-        pass
-
-
-class TerminalState(BaseTerminalState):
-    """Manages terminal settings, stdin selector registration, and suspend/resume signals.
-
-    Installs a SIGTSTP handler that restores the terminal before suspending and re-applies it
-    on resume. After waking up it checks whether the process is in the foreground or background
-    and enables or suppresses interactive output accordingly.
-
-    Optional ``on_suspend`` / ``on_resume`` hooks are called just before the process suspends
-    and just after it wakes, allowing callers to pause and resume child processes."""
-
-    def __init__(
-        self,
-        selector: selectors.BaseSelector,
-        build_status: BuildStatus,
-        on_suspend: Optional[Callable[[], None]] = None,
-        on_resume: Optional[Callable[[], None]] = None,
-    ) -> None:
-        super().__init__(selector, build_status, on_suspend, on_resume)
-        self.old_stdin_settings = termios.tcgetattr(sys.stdin)  # type: ignore[name-defined]
-        self.sigwinch_r = -1
-        self.sigwinch_w = -1
-
-    def setup(self) -> None:
-        """Set cbreak mode, register stdin and signal pipes in the selector."""
-
-        # SIGWINCH self-pipe (stdout must be a tty too)
-        if sys.stdout.isatty():
-            self.sigwinch_r, self.sigwinch_w = os.pipe()
-            os.set_blocking(self.sigwinch_r, False)
-            os.set_blocking(self.sigwinch_w, False)
-            self.selector.register(self.sigwinch_r, selectors.EVENT_READ, "sigwinch")
-            self.old_sigwinch = signal.signal(signal.SIGWINCH, self._handle_sigwinch)
-        else:
-            self.old_sigwinch = None
-
-        self.old_sigtstp = signal.signal(signal.SIGTSTP, self._handle_sigtstp)
-
-        # Start correctly depending on whether we're foregrounded or backgrounded
-        self.build_status.headless = True
-        if not _is_background_tty(sys.stdin):
-            self.enter_foreground()
-
-    def teardown_input(self) -> None:
-        """Restore terminal settings and signal handlers, close pipes."""
-        with ignore_signal(signal.SIGTTOU):
-            termios.tcsetattr(sys.stdin, termios.TCSADRAIN, self.old_stdin_settings)
-
-        for sig, old in ((signal.SIGTSTP, self.old_sigtstp), (signal.SIGWINCH, self.old_sigwinch)):
-            if old is not None:
-                try:
-                    signal.signal(sig, old)
-                except Exception as e:
-                    spack.llnl.util.tty.debug(f"Failed to restore signal handler for {sig}: {e}")
-
-        if sys.stdin.fileno() in self.selector.get_map():
-            self.selector.unregister(sys.stdin.fileno())
-
-        for fd in (self.sigwinch_r, self.sigwinch_w):
-            if fd < 0:
-                continue
-            if fd in self.selector.get_map():
-                self.selector.unregister(fd)
-            try:
-                os.close(fd)
-            except Exception as e:
-                spack.llnl.util.tty.debug(f"Failed to close sigwinch pipe {fd}: {e}")
-
-    def teardown_output(self) -> None:
-        pass
-
-    def _handle_sigtstp(self, signum: int, frame: object) -> None:
-        """Restore terminal before suspending, then re-install handler after resume."""
-
-        # Reset so the first redraw after resume doesn't overwrite the shell's
-        # prompt / "$ fg" line.
-        self.build_status.active_area_rows = 0
-
-        # Restore terminal so the user's shell works normally while we're stopped.
-        with ignore_signal(signal.SIGTTOU):
-            termios.tcsetattr(sys.stdin, termios.TCSANOW, self.old_stdin_settings)
-
-        # Force headless mode before suspending so that enter_foreground() doesn't
-        # exit early when we resume, ensuring terminal settings are re-applied.
-        self.build_status.headless = True
-
-        # Actually suspend: reset to default handler then re-send SIGTSTP.
-        if self.on_suspend is not None:
-            self.on_suspend()
-        signal.signal(signal.SIGTSTP, signal.SIG_DFL)
-        os.kill(os.getpid(), signal.SIGTSTP)
-
-        # Execution resumes here after SIGCONT. Re-install our handler.
-        signal.signal(signal.SIGTSTP, self._handle_sigtstp)
-
-        if self.on_resume is not None:
-            self.on_resume()
-        self.handle_continue()
-
-    def _handle_sigwinch(self, signum: int, frame: object) -> None:
-        try:
-            os.write(self.sigwinch_w, b"\x00")
-        except OSError:
-            pass
-
-    def enter_foreground(self) -> None:
-        """Restore interactive terminal mode."""
-        if not self.build_status.headless:
-            return
-
-        # We save old settings right before applying cbreak.
-        # If we started in the background, bash may have had the terminal in its own
-        # readline (raw) mode when __init__ ran. Waiting until we are foregrounded
-        # ensures we capture the shell's exported 'sane' configuration for this job.
-        self.old_stdin_settings = termios.tcgetattr(sys.stdin)
-
-        with ignore_signal(signal.SIGTTOU):
-            tty.setcbreak(sys.stdin.fileno())
-
-        if sys.stdin.fileno() not in self.selector.get_map():
-            self.selector.register(sys.stdin.fileno(), selectors.EVENT_READ, "stdin")
-        self.build_status.headless = False
-        self.build_status.dirty = True
-
-    def enter_background(self) -> None:
-        """Suppress output and stop reading stdin to avoid SIGTTIN/SIGTTOU."""
-        if sys.stdin.fileno() in self.selector.get_map():
-            self.selector.unregister(sys.stdin.fileno())
-        self.build_status.headless = True
-
-    def handle_continue(self) -> None:
-        """Detect whether the process is in the foreground or background and adjust accordingly."""
-        if _is_background_tty(sys.stdin):
-            self.enter_background()
-        else:
-            self.enter_foreground()
-
-    def drain_sigwinch(self) -> None:
-        os.read(self.sigwinch_r, 64)  # type: ignore[arg-type]
-
-    def should_enter_foreground(self) -> bool:
-        return not _is_background_tty(sys.stdin)
-
-
-class WindowsTerminalState(BaseTerminalState):
-    """Terminal State management class for Windows"""
-
-    @classmethod
-    def stdout_is_interactive(cls) -> bool:
-        """Use GetConsoleMode so this works correctly through Windows Terminal's ConPTY."""
-        mode = wintypes.DWORD()  # type: ignore[name-defined]
-        kernel32 = ctypes.windll.kernel32  # type: ignore[attr-defined]
-        handle = kernel32.GetStdHandle(-11)
-        return bool(kernel32.GetConsoleMode(handle, ctypes.byref(mode)))  # type: ignore[attr-defined]
-
-    @classmethod
-    def stdin_is_interactive(cls) -> bool:
-        mode = wintypes.DWORD()  # type: ignore[name-defined]
-        kernel32 = ctypes.windll.kernel32  # type: ignore[attr-defined]
-        handle = kernel32.GetStdHandle(-10)
-        return bool(kernel32.GetConsoleMode(handle, ctypes.byref(mode)))  # type: ignore[attr-defined]
-
-    def __init__(self, selector, build_status, on_suspend=None, on_resume=None):
-        super().__init__(selector, build_status, on_suspend, on_resume)
-        self.kernel32 = ctypes.windll.kernel32  # type: ignore[attr-defined]
-        self.hStdin = self.kernel32.GetStdHandle(-10)
-        self.hStdout = self.kernel32.GetStdHandle(-11)
-        self.old_stdin_settings = wintypes.DWORD()  # type: ignore[name-defined]
-        self.old_stdout_settings = wintypes.DWORD()  # type: ignore[name-defined]
-        self.kernel32.GetConsoleMode(self.hStdin, ctypes.byref(self.old_stdin_settings))
-        self.kernel32.GetConsoleMode(self.hStdout, ctypes.byref(self.old_stdout_settings))
-
-        self.stdin_r, self.stdin_w = socket.socketpair()
-        self.stdin_r.setblocking(False)
-        self.sigwinch_r, self.sigwinch_w = socket.socketpair()
-        self.sigwinch_r.setblocking(False)
-
-    def create_stdin_reader(self) -> "StdinReader":
-        return StdinReader(self.stdin_r.fileno(), sock=self.stdin_r)
-
-    def setup(self) -> None:
-        # Enable VT100 ANSI escapes on stdout
-        new_out_mode = self.old_stdout_settings.value | ENABLE_VIRTUAL_TERMINAL_PROCESSING  # type: ignore[name-defined]
-        self.kernel32.SetConsoleMode(self.hStdout, new_out_mode)
-
-        self.selector.register(self.sigwinch_r, selectors.EVENT_READ, "sigwinch")
-        self.build_status.headless = True
-
-        self._running = True
-        threading.Thread(target=self._input_thread, daemon=True).start()
-        threading.Thread(target=self._resize_thread, daemon=True).start()
-
-        self.enter_foreground()
-
-    def teardown_input(self) -> None:
-        self._running = False
-        self.kernel32.SetConsoleMode(self.hStdin, self.old_stdin_settings.value)
-
-        for sock in (self.stdin_r, self.sigwinch_r, self.stdin_w, self.sigwinch_w):
-            try:
-                self.selector.unregister(sock)
-            except KeyError:
-                pass
-            sock.close()
-
-    def teardown_output(self) -> None:
-        self.kernel32.SetConsoleMode(self.hStdout, self.old_stdout_settings.value)
-
-    def enter_foreground(self) -> None:
-        if not self.build_status.headless:
-            return
-
-        self.kernel32.GetConsoleMode(self.hStdin, ctypes.byref(self.old_stdin_settings))  # type: ignore[attr-defined]
-
-        disable = ENABLE_LINE_INPUT | ENABLE_ECHO_INPUT | ENABLE_QUICK_EDIT_MODE  # type: ignore[name-defined]
-        new_in_mode = (self.old_stdin_settings.value & ~disable) | ENABLE_EXTENDED_FLAGS  # type: ignore[name-defined]
-        self.kernel32.SetConsoleMode(self.hStdin, new_in_mode)
-
-        if self.stdin_is_interactive() and self.stdin_r.fileno() not in self.selector.get_map():
-            self.selector.register(self.stdin_r, selectors.EVENT_READ, "stdin")
-
-        self.build_status.headless = False
-        self.build_status.dirty = True
-
-    def enter_background(self) -> None:
-        if self.stdin_r.fileno() in self.selector.get_map():
-            self.selector.unregister(self.stdin_r)
-        self.build_status.headless = True
-
-    def handle_continue(self) -> None:
-        self.enter_foreground()
-
-    def drain_sigwinch(self) -> None:
-        self.sigwinch_r.recv(64)
-
-    def should_enter_foreground(self) -> bool:
-        return True
-
-    def _input_thread(self):
-        while self._running:
-            if self.build_status.headless:
-                time.sleep(0.1)
-                continue
-            if msvcrt.kbhit():  # type: ignore[name-defined]
-                char = msvcrt.getwch()  # type: ignore[name-defined]
-                if char in ("\x00", "\xe0"):
-                    msvcrt.getwch()  # type: ignore[name-defined]
-                    continue
-                try:
-                    self.stdin_w.sendall(char.encode("utf-8"))
-                except OSError:
-                    pass
-            else:
-                time.sleep(0.05)
-
-    def _resize_thread(self) -> None:
-        last_size = shutil.get_terminal_size()
-        while self._running:
-            time.sleep(0.1)
-            curr = shutil.get_terminal_size()
-            if curr != last_size:
-                last_size = curr
-                try:
-                    self.sigwinch_w.sendall(b"\x00")
-                except OSError:
-                    pass
-
-
-def _establish_terminal_state(*args, **kwargs) -> Optional[BaseTerminalState]:
-    """Create and return the appropriate terminal state for the current platform, or None if
-    stdin is not interactive."""
-    cls = WindowsTerminalState if IS_WINDOWS else TerminalState
-    if not cls.stdin_is_interactive():
-        return None
-    return cls(*args, **kwargs)
-
-
 def _signal_children(running_builds: Dict[int, ChildInfo], sig: signal.Signals) -> None:
     """Send a signal to the process group of each running build."""
     for child in running_builds.values():
@@ -2568,36 +2212,6 @@ def _signal_children(running_builds: Dict[int, ChildInfo], sig: signal.Signals) 
                 os.killpg(pid, sig)
         except OSError:
             pass
-
-
-class StdinReader:
-    """Helper class to do non-blocking, incremental decoding of stdin, stripping ANSI escape
-    sequences. The input is the backing file descriptor for stdin (instead of the TextIOWrapper) to
-    avoid double buffering issues: the event loop triggers when the fd is ready to read, and if we
-    do a partial read from the TextIOWrapper, it will likely drain the fd and buffer the remainder
-    internally, which the event loop is not aware of, and user input doesn't come through."""
-
-    def __init__(self, fd: int, sock: Optional[socket.socket] = None) -> None:
-        self.fd = fd
-        #: On Windows, stdin is piped through a socket pair; use recv() not os.read()
-        self.sock = sock
-        #: Handle multi-byte UTF-8 characters
-        self.decoder = codecs.getincrementaldecoder("utf-8")(errors="replace")
-        #: For stripping out arrow and navigation keys
-        self.ansi_escape_re = re.compile(r"\x1b\[[0-9;]*[A-Za-z~]")
-
-    def _decode(self, raw: bytes) -> str:
-        return self.ansi_escape_re.sub("", self.decoder.decode(raw))
-
-    def read(self) -> str:
-        try:
-            if self.sock is not None:
-                raw = self.sock.recv(1024)
-            else:
-                raw = os.read(self.fd, 1024)
-            return self._decode(raw)
-        except OSError:
-            return ""
 
 
 class PackageInstaller:
@@ -2745,14 +2359,14 @@ class PackageInstaller:
 
         # Set up terminal handling (cbreak, signals, stdin registration)
         terminal: Optional[BaseTerminalState] = None
-        stdin_reader: Optional[StdinReader] = None
-        terminal = _establish_terminal_state(
-            selector,
-            self.build_status,
-            on_suspend=lambda: _signal_children(self.running_builds, signal.SIGSTOP),
-            on_resume=lambda: _signal_children(self.running_builds, signal.SIGCONT),
-        )
-        if terminal is not None:
+        stdin_reader: Optional[StdinReaderBase] = None
+        if TerminalState.stdin_is_interactive():
+            terminal = TerminalState(
+                selector,
+                self.build_status,
+                on_suspend=lambda: _signal_children(self.running_builds, signal.SIGSTOP),
+                on_resume=lambda: _signal_children(self.running_builds, signal.SIGCONT),
+            )
             terminal.setup()
             self.build_status.is_tty = True
             stdin_reader = terminal.create_stdin_reader()
@@ -2898,12 +2512,9 @@ class PackageInstaller:
                 # Finally update the UI
                 self.build_status.update()
         finally:
-            # Restore input settings and signal handlers. On Linux this runs TCSADRAIN,
+            # Restore input settings and signal handlers. On POSIX this runs TCSADRAIN,
             # ensuring buffered cursor-movement codes from the event loop are transmitted
-            # before the final render. On Windows this stops input threads and restores
-            # hStdin, but leaves VT100 output processing active for the final render.
-            # VT100 processing is required to prevent leaking raw control characters
-            # to output streams.
+            # before the final render.
             if terminal is not None:
                 terminal.teardown_input()
 
@@ -2986,11 +2597,6 @@ class PackageInstaller:
             for s in failures:
                 dag_hash = s.dag_hash()
                 build_info = self.build_status.builds.get(dag_hash)
-                if build_info is None and IS_WINDOWS:
-                    # On Windows, headless mode can prevent the final update(finalize=True) from
-                    # flushing finished_builds, so a build's info may linger there instead.
-                    finished = self.build_status.finished_builds
-                    build_info = next((b for b in finished if dag_hash.startswith(b.hash)), None)
                 if build_info and build_info.log_summary:
                     sys.stderr.write(build_info.log_summary)
             lines = [f"{s}: {self.log_paths[s.dag_hash()]}" for s in failures]

--- a/lib/spack/spack/new_installer.py
+++ b/lib/spack/spack/new_installer.py
@@ -2324,6 +2324,7 @@ class PackageInstaller:
             len(self.build_graph.nodes),
             verbose=verbose,
             filter_padding=spack.store.STORE.has_padding(),
+            is_tty=TerminalState.stdout_is_interactive()
         )
         self.jobs = spack.config.determine_number_of_jobs(parallel=True)
         self.build_status.actual_jobs = self.jobs
@@ -2367,7 +2368,6 @@ class PackageInstaller:
                 on_resume=lambda: _signal_children(self.running_builds, signal.SIGCONT),
             )
             terminal.setup()
-            self.build_status.is_tty = True
             stdin_reader = terminal.create_stdin_reader()
 
         # Finished builds that have not yet been written to the database.

--- a/lib/spack/spack/new_installer.py
+++ b/lib/spack/spack/new_installer.py
@@ -20,8 +20,8 @@ output to both a log file and the UI process (if the UI process has requested it
 runs an event loop to listen for control messages from the UI process (to enable/disable echoing
 of logs), and for output from the build process."""
 
+import abc
 import codecs
-import fcntl
 import glob
 import io
 import json
@@ -31,13 +31,12 @@ import selectors
 import shlex
 import shutil
 import signal
+import socket
 import sys
 import tempfile
-import termios
 import threading
 import time
 import traceback
-import tty
 import warnings
 from gzip import GzipFile
 from multiprocessing import Pipe, Process
@@ -86,6 +85,24 @@ from spack.subprocess_context import GlobalStateMarshaler
 from spack.util.executable import ProcessError
 from spack.util.log_parse import make_log_context, parse_log_events
 from spack.util.path import padding_filter, padding_filter_bytes
+
+IS_WINDOWS = sys.platform == "win32"
+
+if IS_WINDOWS:
+    import ctypes
+    import msvcrt
+    from ctypes import wintypes
+
+    # Windows console mode flags used by WindowsTerminalState
+    ENABLE_LINE_INPUT = 0x0002
+    ENABLE_ECHO_INPUT = 0x0004
+    ENABLE_QUICK_EDIT_MODE = 0x0040
+    ENABLE_EXTENDED_FLAGS = 0x0080
+    ENABLE_VIRTUAL_TERMINAL_PROCESSING = 0x0004  # for stdout handle
+else:
+    import fcntl
+    import termios
+    import tty
 
 if TYPE_CHECKING:
     import spack.package_base
@@ -2199,7 +2216,74 @@ class NullReportData(ReportData):
         pass
 
 
-class TerminalState:
+class BaseTerminalState(abc.ABC):
+    """Abstract base for platform-specific terminal state management."""
+
+    def __init__(
+        self,
+        selector: selectors.BaseSelector,
+        build_status: "BuildStatus",
+        on_suspend: Optional[Callable[[], None]] = None,
+        on_resume: Optional[Callable[[], None]] = None,
+    ) -> None:
+        self.selector = selector
+        self.build_status = build_status
+        self.on_suspend = on_suspend
+        self.on_resume = on_resume
+
+    @classmethod
+    def stdout_is_interactive(cls) -> bool:
+        return sys.stdout.isatty()
+
+    @classmethod
+    def stdin_is_interactive(cls) -> bool:
+        return sys.stdin.isatty()
+
+    def create_stdin_reader(self) -> "StdinReader":
+        return StdinReader(sys.stdin.fileno())
+
+    @abc.abstractmethod
+    def setup(self) -> None:
+        pass
+
+    @abc.abstractmethod
+    def teardown_input(self) -> None:
+        """Restore input settings and signal handlers. Called before the final UI render."""
+        pass
+
+    @abc.abstractmethod
+    def teardown_output(self) -> None:
+        """Restore output settings. Called after the final UI render."""
+        pass
+
+    def teardown(self) -> None:
+        self.teardown_input()
+        self.teardown_output()
+
+    @abc.abstractmethod
+    def enter_foreground(self) -> None:
+        pass
+
+    @abc.abstractmethod
+    def enter_background(self) -> None:
+        pass
+
+    @abc.abstractmethod
+    def handle_continue(self) -> None:
+        pass
+
+    @abc.abstractmethod
+    def drain_sigwinch(self) -> None:
+        """Drain the platform-specific sigwinch notification channel."""
+        pass
+
+    @abc.abstractmethod
+    def should_enter_foreground(self) -> bool:
+        """Return True if the process should switch from headless to foreground mode."""
+        pass
+
+
+class TerminalState(BaseTerminalState):
     """Manages terminal settings, stdin selector registration, and suspend/resume signals.
 
     Installs a SIGTSTP handler that restores the terminal before suspending and re-applies it
@@ -2216,11 +2300,8 @@ class TerminalState:
         on_suspend: Optional[Callable[[], None]] = None,
         on_resume: Optional[Callable[[], None]] = None,
     ) -> None:
-        self.selector = selector
-        self.build_status = build_status
-        self.on_suspend = on_suspend
-        self.on_resume = on_resume
-        self.old_stdin_settings = termios.tcgetattr(sys.stdin)
+        super().__init__(selector, build_status, on_suspend, on_resume)
+        self.old_stdin_settings = termios.tcgetattr(sys.stdin)  # type: ignore[name-defined]
         self.sigwinch_r = -1
         self.sigwinch_w = -1
 
@@ -2244,7 +2325,7 @@ class TerminalState:
         if not _is_background_tty(sys.stdin):
             self.enter_foreground()
 
-    def teardown(self) -> None:
+    def teardown_input(self) -> None:
         """Restore terminal settings and signal handlers, close pipes."""
         with ignore_signal(signal.SIGTTOU):
             termios.tcsetattr(sys.stdin, termios.TCSADRAIN, self.old_stdin_settings)
@@ -2268,6 +2349,9 @@ class TerminalState:
                 os.close(fd)
             except Exception as e:
                 spack.llnl.util.tty.debug(f"Failed to close sigwinch pipe {fd}: {e}")
+
+    def teardown_output(self) -> None:
+        pass
 
     def _handle_sigtstp(self, signum: int, frame: object) -> None:
         """Restore terminal before suspending, then re-install handler after resume."""
@@ -2335,6 +2419,145 @@ class TerminalState:
         else:
             self.enter_foreground()
 
+    def drain_sigwinch(self) -> None:
+        os.read(self.sigwinch_r, 64)  # type: ignore[arg-type]
+
+    def should_enter_foreground(self) -> bool:
+        return not _is_background_tty(sys.stdin)
+
+
+class WindowsTerminalState(BaseTerminalState):
+    """Terminal State management class for Windows"""
+
+    @classmethod
+    def stdout_is_interactive(cls) -> bool:
+        """Use GetConsoleMode so this works correctly through Windows Terminal's ConPTY."""
+        mode = wintypes.DWORD()  # type: ignore[name-defined]
+        kernel32 = ctypes.windll.kernel32  # type: ignore[attr-defined]
+        handle = kernel32.GetStdHandle(-11)
+        return bool(kernel32.GetConsoleMode(handle, ctypes.byref(mode)))  # type: ignore[attr-defined]
+
+    @classmethod
+    def stdin_is_interactive(cls) -> bool:
+        mode = wintypes.DWORD()  # type: ignore[name-defined]
+        kernel32 = ctypes.windll.kernel32  # type: ignore[attr-defined]
+        handle = kernel32.GetStdHandle(-10)
+        return bool(kernel32.GetConsoleMode(handle, ctypes.byref(mode)))  # type: ignore[attr-defined]
+
+    def __init__(self, selector, build_status, on_suspend=None, on_resume=None):
+        super().__init__(selector, build_status, on_suspend, on_resume)
+        self.kernel32 = ctypes.windll.kernel32  # type: ignore[attr-defined]
+        self.hStdin = self.kernel32.GetStdHandle(-10)
+        self.hStdout = self.kernel32.GetStdHandle(-11)
+        self.old_stdin_settings = wintypes.DWORD()  # type: ignore[name-defined]
+        self.old_stdout_settings = wintypes.DWORD()  # type: ignore[name-defined]
+        self.kernel32.GetConsoleMode(self.hStdin, ctypes.byref(self.old_stdin_settings))
+        self.kernel32.GetConsoleMode(self.hStdout, ctypes.byref(self.old_stdout_settings))
+
+        self.stdin_r, self.stdin_w = socket.socketpair()
+        self.stdin_r.setblocking(False)
+        self.sigwinch_r, self.sigwinch_w = socket.socketpair()
+        self.sigwinch_r.setblocking(False)
+
+    def create_stdin_reader(self) -> "StdinReader":
+        return StdinReader(self.stdin_r.fileno(), sock=self.stdin_r)
+
+    def setup(self) -> None:
+        # Enable VT100 ANSI escapes on stdout
+        new_out_mode = self.old_stdout_settings.value | ENABLE_VIRTUAL_TERMINAL_PROCESSING  # type: ignore[name-defined]
+        self.kernel32.SetConsoleMode(self.hStdout, new_out_mode)
+
+        self.selector.register(self.sigwinch_r, selectors.EVENT_READ, "sigwinch")
+        self.build_status.headless = True
+
+        self._running = True
+        threading.Thread(target=self._input_thread, daemon=True).start()
+        threading.Thread(target=self._resize_thread, daemon=True).start()
+
+        self.enter_foreground()
+
+    def teardown_input(self) -> None:
+        self._running = False
+        self.kernel32.SetConsoleMode(self.hStdin, self.old_stdin_settings.value)
+
+        for sock in (self.stdin_r, self.sigwinch_r, self.stdin_w, self.sigwinch_w):
+            try:
+                self.selector.unregister(sock)
+            except KeyError:
+                pass
+            sock.close()
+
+    def teardown_output(self) -> None:
+        self.kernel32.SetConsoleMode(self.hStdout, self.old_stdout_settings.value)
+
+    def enter_foreground(self) -> None:
+        if not self.build_status.headless:
+            return
+
+        self.kernel32.GetConsoleMode(self.hStdin, ctypes.byref(self.old_stdin_settings))  # type: ignore[attr-defined]
+
+        disable = ENABLE_LINE_INPUT | ENABLE_ECHO_INPUT | ENABLE_QUICK_EDIT_MODE  # type: ignore[name-defined]
+        new_in_mode = (self.old_stdin_settings.value & ~disable) | ENABLE_EXTENDED_FLAGS  # type: ignore[name-defined]
+        self.kernel32.SetConsoleMode(self.hStdin, new_in_mode)
+
+        if self.stdin_is_interactive() and self.stdin_r.fileno() not in self.selector.get_map():
+            self.selector.register(self.stdin_r, selectors.EVENT_READ, "stdin")
+
+        self.build_status.headless = False
+        self.build_status.dirty = True
+
+    def enter_background(self) -> None:
+        if self.stdin_r.fileno() in self.selector.get_map():
+            self.selector.unregister(self.stdin_r)
+        self.build_status.headless = True
+
+    def handle_continue(self) -> None:
+        self.enter_foreground()
+
+    def drain_sigwinch(self) -> None:
+        self.sigwinch_r.recv(64)
+
+    def should_enter_foreground(self) -> bool:
+        return True
+
+    def _input_thread(self):
+        while self._running:
+            if self.build_status.headless:
+                time.sleep(0.1)
+                continue
+            if msvcrt.kbhit():  # type: ignore[name-defined]
+                char = msvcrt.getwch()  # type: ignore[name-defined]
+                if char in ("\x00", "\xe0"):
+                    msvcrt.getwch()  # type: ignore[name-defined]
+                    continue
+                try:
+                    self.stdin_w.sendall(char.encode("utf-8"))
+                except OSError:
+                    pass
+            else:
+                time.sleep(0.05)
+
+    def _resize_thread(self) -> None:
+        last_size = shutil.get_terminal_size()
+        while self._running:
+            time.sleep(0.1)
+            curr = shutil.get_terminal_size()
+            if curr != last_size:
+                last_size = curr
+                try:
+                    self.sigwinch_w.sendall(b"\x00")
+                except OSError:
+                    pass
+
+
+def _establish_terminal_state(*args, **kwargs) -> Optional[BaseTerminalState]:
+    """Create and return the appropriate terminal state for the current platform, or None if
+    stdin is not interactive."""
+    cls = WindowsTerminalState if IS_WINDOWS else TerminalState
+    if not cls.stdin_is_interactive():
+        return None
+    return cls(*args, **kwargs)
+
 
 def _signal_children(running_builds: Dict[int, ChildInfo], sig: signal.Signals) -> None:
     """Send a signal to the process group of each running build."""
@@ -2354,17 +2577,25 @@ class StdinReader:
     do a partial read from the TextIOWrapper, it will likely drain the fd and buffer the remainder
     internally, which the event loop is not aware of, and user input doesn't come through."""
 
-    def __init__(self, fd: int) -> None:
+    def __init__(self, fd: int, sock: Optional[socket.socket] = None) -> None:
         self.fd = fd
+        #: On Windows, stdin is piped through a socket pair; use recv() not os.read()
+        self.sock = sock
         #: Handle multi-byte UTF-8 characters
         self.decoder = codecs.getincrementaldecoder("utf-8")(errors="replace")
         #: For stripping out arrow and navigation keys
         self.ansi_escape_re = re.compile(r"\x1b\[[0-9;]*[A-Za-z~]")
 
+    def _decode(self, raw: bytes) -> str:
+        return self.ansi_escape_re.sub("", self.decoder.decode(raw))
+
     def read(self) -> str:
         try:
-            chars = self.decoder.decode(os.read(self.fd, 1024))
-            return self.ansi_escape_re.sub("", chars)
+            if self.sock is not None:
+                raw = self.sock.recv(1024)
+            else:
+                raw = os.read(self.fd, 1024)
+            return self._decode(raw)
         except OSError:
             return ""
 
@@ -2513,17 +2744,18 @@ class PackageInstaller:
         selector = selectors.DefaultSelector()
 
         # Set up terminal handling (cbreak, signals, stdin registration)
-        terminal: Optional[TerminalState] = None
+        terminal: Optional[BaseTerminalState] = None
         stdin_reader: Optional[StdinReader] = None
-        if sys.stdin.isatty():
-            stdin_reader = StdinReader(sys.stdin.fileno())
-            terminal = TerminalState(
-                selector,
-                self.build_status,
-                on_suspend=lambda: _signal_children(self.running_builds, signal.SIGSTOP),
-                on_resume=lambda: _signal_children(self.running_builds, signal.SIGCONT),
-            )
+        terminal = _establish_terminal_state(
+            selector,
+            self.build_status,
+            on_suspend=lambda: _signal_children(self.running_builds, signal.SIGSTOP),
+            on_resume=lambda: _signal_children(self.running_builds, signal.SIGCONT),
+        )
+        if terminal is not None:
             terminal.setup()
+            self.build_status.is_tty = True
+            stdin_reader = terminal.create_stdin_reader()
 
         # Finished builds that have not yet been written to the database.
         database_actions: List[DatabaseAction] = []
@@ -2579,7 +2811,7 @@ class PackageInstaller:
                 # handler, but there's no SIGCONT event in the transition of background to
                 # foreground, so we conditionally poll for that here (headless case). In the
                 # headless case the event loop only fires once per second, so this is cheap enough.
-                if terminal and self.build_status.headless and not _is_background_tty(sys.stdin):
+                if terminal and self.build_status.headless and terminal.should_enter_foreground():
                     terminal.enter_foreground()
 
                 for key, _ in events:
@@ -2597,7 +2829,7 @@ class PackageInstaller:
                         stdin_ready = True
                     elif data == "sigwinch":
                         assert terminal is not None
-                        os.read(terminal.sigwinch_r, 64)  # drain the pipe
+                        terminal.drain_sigwinch()
                         self.build_status.on_resize()
                     elif data == "jobserver" and not jobserver.has_target_parallelism():
                         jobserver.maybe_discard_tokens()
@@ -2666,9 +2898,14 @@ class PackageInstaller:
                 # Finally update the UI
                 self.build_status.update()
         finally:
-            # First ensure that the user's terminal state is restored.
+            # Restore input settings and signal handlers. On Linux this runs TCSADRAIN,
+            # ensuring buffered cursor-movement codes from the event loop are transmitted
+            # before the final render. On Windows this stops input threads and restores
+            # hStdin, but leaves VT100 output processing active for the final render.
+            # VT100 processing is required to prevent leaking raw control characters
+            # to output streams.
             if terminal is not None:
-                terminal.teardown()
+                terminal.teardown_input()
 
             # Flush any not-yet-written successful builds to the DB; save the exception on error
             # to be re-raised after best-effort cleanup.
@@ -2720,6 +2957,11 @@ class PackageInstaller:
             except Exception:
                 pass
 
+            # Restore output settings. On Linux this is a no-op. On Windows this disables
+            # VT100 processing and must happen after the final render.
+            if terminal is not None:
+                terminal.teardown_output()
+
             # Re-raise the DB exception if any.
             if db_exc is not None:
                 raise db_exc
@@ -2742,7 +2984,13 @@ class PackageInstaller:
 
         if failures:
             for s in failures:
-                build_info = self.build_status.builds[s.dag_hash()]
+                dag_hash = s.dag_hash()
+                build_info = self.build_status.builds.get(dag_hash)
+                if build_info is None and IS_WINDOWS:
+                    # On Windows, headless mode can prevent the final update(finalize=True) from
+                    # flushing finished_builds, so a build's info may linger there instead.
+                    finished = self.build_status.finished_builds
+                    build_info = next((b for b in finished if dag_hash.startswith(b.hash)), None)
                 if build_info and build_info.log_summary:
                     sys.stderr.write(build_info.log_summary)
             lines = [f"{s}: {self.log_paths[s.dag_hash()]}" for s in failures]

--- a/lib/spack/spack/new_installer.py
+++ b/lib/spack/spack/new_installer.py
@@ -2594,8 +2594,7 @@ class PackageInstaller:
 
         if failures:
             for s in failures:
-                dag_hash = s.dag_hash()
-                build_info = self.build_status.builds.get(dag_hash)
+                build_info = self.build_status.builds[s.dag_hash()]
                 if build_info and build_info.log_summary:
                     sys.stderr.write(build_info.log_summary)
             lines = [f"{s}: {self.log_paths[s.dag_hash()]}" for s in failures]

--- a/lib/spack/spack/new_installer.py
+++ b/lib/spack/spack/new_installer.py
@@ -77,9 +77,8 @@ import spack.util.environment
 import spack.util.lock
 from spack.installer import _do_fake_install, dump_packages
 from spack.llnl.util.lang import pretty_duration
-from spack.llnl.util.tty.log import _is_background_tty, ignore_signal
-from spack.subprocess_context import GlobalStateMarshaler
 from spack.new_installer_terminal import BaseTerminalState, StdinReaderBase
+from spack.subprocess_context import GlobalStateMarshaler
 from spack.util.executable import ProcessError
 from spack.util.log_parse import make_log_context, parse_log_events
 from spack.util.path import padding_filter, padding_filter_bytes

--- a/lib/spack/spack/new_installer_posix.py
+++ b/lib/spack/spack/new_installer_posix.py
@@ -47,7 +47,7 @@ class PosixTerminalState(BaseTerminalState):
     def __init__(
         self,
         selector: selectors.BaseSelector,
-        build_status: BuildStatus,
+        build_status: "BuildStatus",
         on_suspend: Optional[Callable[[], None]] = None,
         on_resume: Optional[Callable[[], None]] = None,
     ) -> None:

--- a/lib/spack/spack/new_installer_posix.py
+++ b/lib/spack/spack/new_installer_posix.py
@@ -1,0 +1,180 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+"""POSIX-specific terminal state and stdin reader for the new_installer TUI."""
+
+import os
+import selectors
+import signal
+import sys
+import termios
+import tty
+from typing import TYPE_CHECKING, Callable, Optional
+
+import spack.llnl.util.tty
+from spack.llnl.util.tty.log import _is_background_tty, ignore_signal
+from spack.new_installer_terminal import BaseTerminalState, StdinReaderBase
+
+if TYPE_CHECKING:
+    from spack.new_installer import BuildStatus
+
+
+class PosixStdinReader(StdinReaderBase):
+    """Non-blocking stdin reader for POSIX"""
+
+    def __init__(self, fd: int) -> None:
+        super().__init__()
+        self.fd = fd
+
+    def read(self) -> str:
+        try:
+            return self._decode(os.read(self.fd, 1024))
+        except OSError:
+            return ""
+
+
+class PosixTerminalState(BaseTerminalState):
+    """Manages terminal settings, stdin selector registration, and suspend/resume signals.
+
+    Installs a SIGTSTP handler that restores the terminal before suspending and re-applies it
+    on resume. After waking up it checks whether the process is in the foreground or background
+    and enables or suppresses interactive output accordingly.
+
+    Optional ``on_suspend`` / ``on_resume`` hooks are called just before the process suspends
+    and just after it wakes, allowing callers to pause and resume child processes."""
+
+    def __init__(
+        self,
+        selector: selectors.BaseSelector,
+        build_status: BuildStatus,
+        on_suspend: Optional[Callable[[], None]] = None,
+        on_resume: Optional[Callable[[], None]] = None,
+    ) -> None:
+        super().__init__(selector, build_status, on_suspend, on_resume)
+        self.old_stdin_settings = termios.tcgetattr(sys.stdin)
+        self.sigwinch_r = -1
+        self.sigwinch_w = -1
+
+    def create_stdin_reader(self) -> PosixStdinReader:
+        return PosixStdinReader(sys.stdin.fileno())
+
+    def setup(self) -> None:
+        """Set cbreak mode, register stdin and signal pipes in the selector."""
+
+        # SIGWINCH self-pipe (stdout must be a tty too)
+        if sys.stdout.isatty():
+            self.sigwinch_r, self.sigwinch_w = os.pipe()
+            os.set_blocking(self.sigwinch_r, False)
+            os.set_blocking(self.sigwinch_w, False)
+            self.selector.register(self.sigwinch_r, selectors.EVENT_READ, "sigwinch")
+            self.old_sigwinch = signal.signal(signal.SIGWINCH, self._handle_sigwinch)
+        else:
+            self.old_sigwinch = None
+
+        self.old_sigtstp = signal.signal(signal.SIGTSTP, self._handle_sigtstp)
+
+        # Start correctly depending on whether we're foregrounded or backgrounded
+        self.build_status.headless = True
+        if not _is_background_tty(sys.stdin):
+            self.enter_foreground()
+
+    def teardown_input(self) -> None:
+        """Restore terminal settings and signal handlers, close pipes."""
+        with ignore_signal(signal.SIGTTOU):
+            termios.tcsetattr(sys.stdin, termios.TCSADRAIN, self.old_stdin_settings)
+
+        for sig, old in ((signal.SIGTSTP, self.old_sigtstp), (signal.SIGWINCH, self.old_sigwinch)):
+            if old is not None:
+                try:
+                    signal.signal(sig, old)
+                except Exception as e:
+                    spack.llnl.util.tty.debug(f"Failed to restore signal handler for {sig}: {e}")
+
+        if sys.stdin.fileno() in self.selector.get_map():
+            self.selector.unregister(sys.stdin.fileno())
+
+        for fd in (self.sigwinch_r, self.sigwinch_w):
+            if fd < 0:
+                continue
+            if fd in self.selector.get_map():
+                self.selector.unregister(fd)
+            try:
+                os.close(fd)
+            except Exception as e:
+                spack.llnl.util.tty.debug(f"Failed to close sigwinch pipe {fd}: {e}")
+
+    def teardown_output(self) -> None:
+        pass
+
+    def _handle_sigtstp(self, signum: int, frame: object) -> None:
+        """Restore terminal before suspending, then re-install handler after resume."""
+
+        # Reset so the first redraw after resume doesn't overwrite the shell's
+        # prompt / "$ fg" line.
+        self.build_status.active_area_rows = 0
+
+        # Restore terminal so the user's shell works normally while we're stopped.
+        with ignore_signal(signal.SIGTTOU):
+            termios.tcsetattr(sys.stdin, termios.TCSANOW, self.old_stdin_settings)
+
+        # Force headless mode before suspending so that enter_foreground() doesn't
+        # exit early when we resume, ensuring terminal settings are re-applied.
+        self.build_status.headless = True
+
+        # Actually suspend: reset to default handler then re-send SIGTSTP.
+        if self.on_suspend is not None:
+            self.on_suspend()
+        signal.signal(signal.SIGTSTP, signal.SIG_DFL)
+        os.kill(os.getpid(), signal.SIGTSTP)
+
+        # Execution resumes here after SIGCONT. Re-install our handler.
+        signal.signal(signal.SIGTSTP, self._handle_sigtstp)
+
+        if self.on_resume is not None:
+            self.on_resume()
+        self.handle_continue()
+
+    def _handle_sigwinch(self, signum: int, frame: object) -> None:
+        try:
+            os.write(self.sigwinch_w, b"\x00")
+        except OSError:
+            pass
+
+    def enter_foreground(self) -> None:
+        """Restore interactive terminal mode."""
+        if not self.build_status.headless:
+            return
+
+        # We save old settings right before applying cbreak.
+        # If we started in the background, bash may have had the terminal in its own
+        # readline (raw) mode when __init__ ran. Waiting until we are foregrounded
+        # ensures we capture the shell's exported 'sane' configuration for this job.
+        self.old_stdin_settings = termios.tcgetattr(sys.stdin)
+
+        with ignore_signal(signal.SIGTTOU):
+            tty.setcbreak(sys.stdin.fileno())
+
+        if sys.stdin.fileno() not in self.selector.get_map():
+            self.selector.register(sys.stdin.fileno(), selectors.EVENT_READ, "stdin")
+        self.build_status.headless = False
+        self.build_status.dirty = True
+
+    def enter_background(self) -> None:
+        """Suppress output and stop reading stdin to avoid SIGTTIN/SIGTTOU."""
+        if sys.stdin.fileno() in self.selector.get_map():
+            self.selector.unregister(sys.stdin.fileno())
+        self.build_status.headless = True
+
+    def handle_continue(self) -> None:
+        """Detect whether the process is in the foreground or background and adjust accordingly."""
+        if _is_background_tty(sys.stdin):
+            self.enter_background()
+        else:
+            self.enter_foreground()
+
+    def drain_sigwinch(self) -> None:
+        os.read(self.sigwinch_r, 64)
+
+    def should_enter_foreground(self) -> bool:
+        return not _is_background_tty(sys.stdin)

--- a/lib/spack/spack/new_installer_terminal.py
+++ b/lib/spack/spack/new_installer_terminal.py
@@ -36,7 +36,8 @@ class StdinReaderBase:
     def _decode(self, raw: bytes) -> str:
         return self.ansi_escape_re.sub("", self.decoder.decode(raw))
 
-    def read(self) -> str: ...
+    def read(self) -> str:
+        raise NotImplementedError
 
 
 class BaseTerminalState(abc.ABC):

--- a/lib/spack/spack/new_installer_terminal.py
+++ b/lib/spack/spack/new_installer_terminal.py
@@ -1,0 +1,107 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+"""Abstract base classes for the new_installer TUI terminal state and stdin reading.
+
+Kept in a leaf module (no imports from new_installer.py or the platform modules) so that
+new_installer_posix and new_installer_windows can import from here without introducing a
+circular dependency."""
+
+import abc
+import codecs
+import re
+import selectors
+import sys
+from typing import TYPE_CHECKING, Callable, Optional
+
+if TYPE_CHECKING:
+    from spack.new_installer import BuildStatus
+
+
+class StdinReaderBase:
+    """Base class for platform-specific non-blocking stdin reading with UTF-8 decoding.
+
+    The input is the backing file descriptor for stdin (instead of the TextIOWrapper) to
+    avoid double buffering issues: the event loop triggers when the fd is ready to read, and if we
+    do a partial read from the TextIOWrapper, it will likely drain the fd and buffer the remainder
+    internally, which the event loop is not aware of, and user input doesn't come through."""
+
+    def __init__(self) -> None:
+        #: Handle multi-byte UTF-8 characters
+        self.decoder = codecs.getincrementaldecoder("utf-8")(errors="replace")
+        #: For stripping out arrow and navigation keys
+        self.ansi_escape_re = re.compile(r"\x1b\[[0-9;]*[A-Za-z~]")
+
+    def _decode(self, raw: bytes) -> str:
+        return self.ansi_escape_re.sub("", self.decoder.decode(raw))
+
+    def read(self) -> str: ...
+
+
+class BaseTerminalState(abc.ABC):
+    """Abstract base for platform-specific terminal state management."""
+
+    def __init__(
+        self,
+        selector: selectors.BaseSelector,
+        build_status: "BuildStatus",
+        on_suspend: Optional[Callable[[], None]] = None,
+        on_resume: Optional[Callable[[], None]] = None,
+    ) -> None:
+        self.selector = selector
+        self.build_status = build_status
+        self.on_suspend = on_suspend
+        self.on_resume = on_resume
+
+    @classmethod
+    def stdout_is_interactive(cls) -> bool:
+        return sys.stdout.isatty()
+
+    @classmethod
+    def stdin_is_interactive(cls) -> bool:
+        return sys.stdin.isatty()
+
+    @abc.abstractmethod
+    def create_stdin_reader(self) -> StdinReaderBase:
+        pass
+
+    @abc.abstractmethod
+    def setup(self) -> None:
+        pass
+
+    @abc.abstractmethod
+    def teardown_input(self) -> None:
+        """Restore input settings and signal handlers. Called before the final UI render."""
+        pass
+
+    @abc.abstractmethod
+    def teardown_output(self) -> None:
+        """Restore output settings. Called after the final UI render."""
+        pass
+
+    def teardown(self) -> None:
+        self.teardown_input()
+        self.teardown_output()
+
+    @abc.abstractmethod
+    def enter_foreground(self) -> None:
+        pass
+
+    @abc.abstractmethod
+    def enter_background(self) -> None:
+        pass
+
+    @abc.abstractmethod
+    def handle_continue(self) -> None:
+        pass
+
+    @abc.abstractmethod
+    def drain_sigwinch(self) -> None:
+        """Drain the platform-specific sigwinch notification channel."""
+        pass
+
+    @abc.abstractmethod
+    def should_enter_foreground(self) -> bool:
+        """Return True if the process should switch from headless to foreground mode."""
+        pass

--- a/lib/spack/spack/new_installer_windows.py
+++ b/lib/spack/spack/new_installer_windows.py
@@ -71,7 +71,7 @@ class WindowsTerminalState(BaseTerminalState):
     def __init__(
         self,
         selector: selectors.BaseSelector,
-        build_status: BuildStatus,
+        build_status: "BuildStatus",
         on_suspend: Optional[Callable[[], None]] = None,
         on_resume: Optional[Callable[[], None]] = None,
     ) -> None:
@@ -155,10 +155,10 @@ class WindowsTerminalState(BaseTerminalState):
             if self.build_status.headless:
                 time.sleep(0.1)
                 continue
-            if msvcrt.kbhit():
-                char = msvcrt.getwch()
+            if msvcrt.kbhit():  # type: ignore[attr-defined]
+                char = msvcrt.getwch()  # type: ignore[attr-defined]
                 if char in ("\x00", "\xe0"):
-                    msvcrt.getwch()
+                    msvcrt.getwch()  # type: ignore[attr-defined]
                     continue
                 try:
                     self.stdin_w.sendall(char.encode("utf-8"))

--- a/lib/spack/spack/new_installer_windows.py
+++ b/lib/spack/spack/new_installer_windows.py
@@ -1,0 +1,180 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+"""Windows-specific terminal state and stdin reader for the new_installer TUI."""
+
+import ctypes
+import msvcrt
+import selectors
+import shutil
+import socket
+import threading
+import time
+from ctypes import wintypes
+from typing import TYPE_CHECKING, Callable, Optional
+
+from spack.new_installer_terminal import BaseTerminalState, StdinReaderBase
+
+if TYPE_CHECKING:
+    from spack.new_installer import BuildStatus
+
+# Windows console mode flags
+ENABLE_LINE_INPUT = 0x0002
+ENABLE_ECHO_INPUT = 0x0004
+ENABLE_QUICK_EDIT_MODE = 0x0040
+ENABLE_EXTENDED_FLAGS = 0x0080
+ENABLE_VIRTUAL_TERMINAL_PROCESSING = 0x0004  # for stdout handle
+
+
+class WindowsStdinReader(StdinReaderBase):
+    """Non-blocking stdin reader for Windows using socket.recv() on the stdin socketpair."""
+
+    def __init__(self, fd: int, sock: socket.socket) -> None:
+        super().__init__()
+        self.fd = fd
+        self.sock = sock
+
+    def read(self) -> str:
+        try:
+            return self._decode(self.sock.recv(1024))
+        except OSError:
+            return ""
+
+
+class WindowsTerminalState(BaseTerminalState):
+    """Terminal State management class for Windows.
+
+    Enables VT100/ANSI processing on stdout via SetConsoleMode and bridges keyboard input
+    (_input_thread / msvcrt.kbhit) and terminal-resize events (_resize_thread /
+    shutil.get_terminal_size) to socketpairs that the selector-based event loop can watch.
+
+    teardown_input() stops the input threads and restores hStdin, but intentionally leaves
+    VT100 output processing active so that the final UI render can use ANSI escape sequences
+    without leaking raw control characters to the output stream."""
+
+    @classmethod
+    def stdout_is_interactive(cls) -> bool:
+        """Use GetConsoleMode so this works correctly through Windows Terminal's ConPTY."""
+        mode = wintypes.DWORD()
+        kernel32 = ctypes.windll.kernel32  # type: ignore[attr-defined]
+        handle = kernel32.GetStdHandle(-11)
+        return bool(kernel32.GetConsoleMode(handle, ctypes.byref(mode)))
+
+    @classmethod
+    def stdin_is_interactive(cls) -> bool:
+        mode = wintypes.DWORD()
+        kernel32 = ctypes.windll.kernel32  # type: ignore[attr-defined]
+        handle = kernel32.GetStdHandle(-10)
+        return bool(kernel32.GetConsoleMode(handle, ctypes.byref(mode)))
+
+    def __init__(
+        self,
+        selector: selectors.BaseSelector,
+        build_status: BuildStatus,
+        on_suspend: Optional[Callable[[], None]] = None,
+        on_resume: Optional[Callable[[], None]] = None,
+    ) -> None:
+        super().__init__(selector, build_status, on_suspend, on_resume)
+        self.kernel32 = ctypes.windll.kernel32  # type: ignore[attr-defined]
+        self.hStdin = self.kernel32.GetStdHandle(-10)
+        self.hStdout = self.kernel32.GetStdHandle(-11)
+        self.old_stdin_settings = wintypes.DWORD()
+        self.old_stdout_settings = wintypes.DWORD()
+        self.kernel32.GetConsoleMode(self.hStdin, ctypes.byref(self.old_stdin_settings))
+        self.kernel32.GetConsoleMode(self.hStdout, ctypes.byref(self.old_stdout_settings))
+
+        self.stdin_r, self.stdin_w = socket.socketpair()
+        self.stdin_r.setblocking(False)
+        self.sigwinch_r, self.sigwinch_w = socket.socketpair()
+        self.sigwinch_r.setblocking(False)
+
+    def create_stdin_reader(self) -> WindowsStdinReader:
+        return WindowsStdinReader(self.stdin_r.fileno(), sock=self.stdin_r)
+
+    def setup(self) -> None:
+        # Enable VT100 ANSI escapes on stdout
+        new_out_mode = self.old_stdout_settings.value | ENABLE_VIRTUAL_TERMINAL_PROCESSING
+        self.kernel32.SetConsoleMode(self.hStdout, new_out_mode)
+
+        self.selector.register(self.sigwinch_r, selectors.EVENT_READ, "sigwinch")
+        self.build_status.headless = True
+
+        self._running = True
+        threading.Thread(target=self._input_thread, daemon=True).start()
+        threading.Thread(target=self._resize_thread, daemon=True).start()
+
+        self.enter_foreground()
+
+    def teardown_input(self) -> None:
+        self._running = False
+        self.kernel32.SetConsoleMode(self.hStdin, self.old_stdin_settings.value)
+
+        for sock in (self.stdin_r, self.sigwinch_r, self.stdin_w, self.sigwinch_w):
+            try:
+                self.selector.unregister(sock)
+            except KeyError:
+                pass
+            sock.close()
+
+    def teardown_output(self) -> None:
+        self.kernel32.SetConsoleMode(self.hStdout, self.old_stdout_settings.value)
+
+    def enter_foreground(self) -> None:
+        if not self.build_status.headless:
+            return
+
+        self.kernel32.GetConsoleMode(self.hStdin, ctypes.byref(self.old_stdin_settings))
+
+        disable = ENABLE_LINE_INPUT | ENABLE_ECHO_INPUT | ENABLE_QUICK_EDIT_MODE
+        new_in_mode = (self.old_stdin_settings.value & ~disable) | ENABLE_EXTENDED_FLAGS
+        self.kernel32.SetConsoleMode(self.hStdin, new_in_mode)
+
+        if self.stdin_is_interactive() and self.stdin_r.fileno() not in self.selector.get_map():
+            self.selector.register(self.stdin_r, selectors.EVENT_READ, "stdin")
+
+        self.build_status.headless = False
+        self.build_status.dirty = True
+
+    def enter_background(self) -> None:
+        if self.stdin_r.fileno() in self.selector.get_map():
+            self.selector.unregister(self.stdin_r)
+        self.build_status.headless = True
+
+    def handle_continue(self) -> None:
+        self.enter_foreground()
+
+    def drain_sigwinch(self) -> None:
+        self.sigwinch_r.recv(64)
+
+    def should_enter_foreground(self) -> bool:
+        return True
+
+    def _input_thread(self) -> None:
+        while self._running:
+            if self.build_status.headless:
+                time.sleep(0.1)
+                continue
+            if msvcrt.kbhit():
+                char = msvcrt.getwch()
+                if char in ("\x00", "\xe0"):
+                    msvcrt.getwch()
+                    continue
+                try:
+                    self.stdin_w.sendall(char.encode("utf-8"))
+                except OSError:
+                    pass
+            else:
+                time.sleep(0.05)
+
+    def _resize_thread(self) -> None:
+        last_size = shutil.get_terminal_size()
+        while self._running:
+            time.sleep(0.1)
+            curr = shutil.get_terminal_size()
+            if curr != last_size:
+                last_size = curr
+                try:
+                    self.sigwinch_w.sendall(b"\x00")
+                except OSError:
+                    pass

--- a/lib/spack/spack/test/installer_tui.py
+++ b/lib/spack/spack/test/installer_tui.py
@@ -17,7 +17,8 @@ from multiprocessing import Pipe
 from typing import List, Optional, Tuple
 
 import spack.new_installer as inst
-from spack.new_installer import BuildStatus, StdinReader
+from spack.new_installer import BuildStatus
+from spack.new_installer_posix import PosixStdinReader as StdinReader
 
 
 class MockConnection:

--- a/lib/spack/spack/test/windows_tui.py
+++ b/lib/spack/spack/test/windows_tui.py
@@ -14,8 +14,6 @@ import selectors
 import shutil
 import socket
 import sys
-import threading
-import time
 import types
 
 import pytest
@@ -100,27 +98,62 @@ class _NoopThread:
         pass
 
 
-def _drain(sock, timeout=0.5):
-    """Read all available bytes from a socket within *timeout* seconds."""
+class _FakePipe:
+    """In-process unidirectional byte pipe.
+
+    sendall() on one end places bytes directly into the peer's buffer; recv() on the
+    other end returns them immediately or raises BlockingIOError if the buffer is empty.
+    """
+
+    def __init__(self, fd: int) -> None:
+        self._fd = fd
+        self._buf = bytearray()
+        self._peer: "_FakePipe"
+
+    def fileno(self) -> int:
+        return self._fd
+
+    def sendall(self, data: bytes) -> None:
+        self._peer._buf.extend(data)
+
+    def recv(self, n: int) -> bytes:
+        if not self._buf:
+            raise BlockingIOError
+        chunk, self._buf = bytes(self._buf[:n]), self._buf[n:]
+        return chunk
+
+    def setblocking(self, flag: bool) -> None:
+        pass
+
+    def settimeout(self, timeout: object) -> None:
+        pass
+
+    def close(self) -> None:
+        pass
+
+
+def _fakepair(fd1: int, fd2: int) -> tuple:
+    """Return a connected (_FakePipe, _FakePipe) pair (analogous to socket.socketpair)."""
+    a, b = _FakePipe(fd1), _FakePipe(fd2)
+    a._peer = b
+    b._peer = a
+    return a, b
+
+
+def _recv(sock) -> bytes:
+    """Read all available bytes from a socket without blocking."""
     sock.setblocking(False)
-    data = b""
-    deadline = time.monotonic() + timeout
-    while time.monotonic() < deadline:
-        try:
-            chunk = sock.recv(4096)
-            if not chunk:
-                break
-            data += chunk
-        except BlockingIOError:
-            time.sleep(0.01)
-    return data
+    try:
+        return sock.recv(4096)
+    except BlockingIOError:
+        return b""
 
 
 def _make_state(headless=True):
     """Create a WindowsTerminalState bypassing __init__ to avoid real Win32 calls.
 
-    All kernel32 calls go through _FakeKernel32; real socket pairs are created so
-    that thread tests can send/receive actual bytes.
+    All kernel32 calls go through _FakeKernel32; _FakePipe pairs replace real OS
+    sockets.
     """
     sel = _FakeSelector()
     bs = types.SimpleNamespace(headless=headless, dirty=False)
@@ -137,10 +170,8 @@ def _make_state(headless=True):
     # ENABLE_PROCESSED_INPUT | ENABLE_LINE_INPUT | ENABLE_ECHO_INPUT
     state.old_stdin_settings = wintypes.DWORD(0x0007)
     state.old_stdout_settings = wintypes.DWORD(0x0003)
-    state.stdin_r, state.stdin_w = socket.socketpair()
-    state.stdin_r.setblocking(False)
-    state.sigwinch_r, state.sigwinch_w = socket.socketpair()
-    state.sigwinch_r.setblocking(False)
+    state.stdin_r, state.stdin_w = _fakepair(10, 11)
+    state.sigwinch_r, state.sigwinch_w = _fakepair(12, 13)
     state._running = False
     return state, sel, bs, k32
 
@@ -286,15 +317,14 @@ class TestForegroundBackground:
 class TestInputThread:
     """Tests for WindowsTerminalState._input_thread."""
 
-    def _run_thread(self, state, fake_msvcrt, monkeypatch, *, timeout=0.5):
-        """Run _input_thread in a daemon thread and return bytes received on stdin_r."""
+    def _run_thread(self, state, fake_msvcrt, monkeypatch):
+        """Call _input_thread directly and return bytes received on stdin_r."""
         state._running = True
         state.build_status.headless = False
         monkeypatch.setattr(_niw, "msvcrt", fake_msvcrt)
-        t = threading.Thread(target=state._input_thread, daemon=True)
-        t.start()
-        t.join(timeout=timeout)
-        return _drain(state.stdin_r)
+        monkeypatch.setattr(_niw.time, "sleep", lambda _: None)
+        state._input_thread()
+        return _recv(state.stdin_r)
 
     def test_keystroke_forwarded_to_stdin_r(self, monkeypatch):
         """A normal keypress is sent to stdin_r."""
@@ -369,20 +399,16 @@ class TestInputThread:
         state.build_status.headless = True
         kbhit_calls = []
 
-        def kbhit():
-            kbhit_calls.append(None)
-            return False
+        def fake_sleep(_):
+            state._running = False  # stop the loop on first sleep in the headless branch
 
-        fake_msvcrt = types.SimpleNamespace(kbhit=kbhit, getwch=lambda: "")
+        fake_msvcrt = types.SimpleNamespace(
+            kbhit=lambda: kbhit_calls.append(None) or False, getwch=lambda: ""
+        )
 
         state._running = True
-
-        def stop():
-            time.sleep(0.15)
-            state._running = False
-
-        threading.Thread(target=stop, daemon=True).start()
         monkeypatch.setattr(_niw, "msvcrt", fake_msvcrt)
+        monkeypatch.setattr(_niw.time, "sleep", fake_sleep)
         state._input_thread()
 
         assert not kbhit_calls
@@ -411,10 +437,10 @@ class TestResizeThread:
             return sizes[idx]
 
         monkeypatch.setattr(shutil, "get_terminal_size", get_size)
+        monkeypatch.setattr(_niw.time, "sleep", lambda _: None)
         state._resize_thread()
 
-        data = _drain(state.sigwinch_r)
-        assert b"\x00" in data
+        assert b"\x00" in _recv(state.sigwinch_r)
 
     def test_no_resize_event_on_same_size(self, monkeypatch):
         """_resize_thread does not send if dimensions are unchanged."""
@@ -429,10 +455,10 @@ class TestResizeThread:
             return os.terminal_size((80, 24))
 
         monkeypatch.setattr(shutil, "get_terminal_size", get_size)
+        monkeypatch.setattr(_niw.time, "sleep", lambda _: None)
         state._resize_thread()
 
-        data = _drain(state.sigwinch_r)
-        assert data == b""
+        assert _recv(state.sigwinch_r) == b""
 
 
 class TestStdinReaderSocketPath:

--- a/lib/spack/spack/test/windows_tui.py
+++ b/lib/spack/spack/test/windows_tui.py
@@ -25,16 +25,16 @@ if sys.platform != "win32":
 
 from ctypes import wintypes
 
-import spack.new_installer as _ni
-from spack.new_installer import (
+import spack.new_installer_windows as _niw
+from spack.new_installer_windows import (
     ENABLE_ECHO_INPUT,
     ENABLE_EXTENDED_FLAGS,
     ENABLE_LINE_INPUT,
     ENABLE_QUICK_EDIT_MODE,
     ENABLE_VIRTUAL_TERMINAL_PROCESSING,
-    StdinReader,
     WindowsTerminalState,
 )
+from spack.new_installer_windows import WindowsStdinReader as StdinReader
 
 
 class _FakeSelector:
@@ -149,7 +149,7 @@ class TestSetupTeardown:
     def test_setup_enables_vt100_on_stdout(self, monkeypatch):
         """setup() ORs ENABLE_VIRTUAL_TERMINAL_PROCESSING into the stdout console mode."""
         state, sel, bs, k32 = _make_state()
-        monkeypatch.setattr(_ni.threading, "Thread", _NoopThread)
+        monkeypatch.setattr(_niw.threading, "Thread", _NoopThread)
         monkeypatch.setattr(state, "enter_foreground", lambda: None)
 
         state.setup()
@@ -161,7 +161,7 @@ class TestSetupTeardown:
     def test_setup_registers_sigwinch_socket(self, monkeypatch):
         """setup() registers sigwinch_r in the selector with tag 'sigwinch'."""
         state, sel, bs, k32 = _make_state()
-        monkeypatch.setattr(_ni.threading, "Thread", _NoopThread)
+        monkeypatch.setattr(_niw.threading, "Thread", _NoopThread)
         monkeypatch.setattr(state, "enter_foreground", lambda: None)
 
         state.setup()
@@ -182,7 +182,7 @@ class TestSetupTeardown:
             def start(self):
                 pass
 
-        monkeypatch.setattr(_ni.threading, "Thread", _FakeThread)
+        monkeypatch.setattr(_niw.threading, "Thread", _FakeThread)
         monkeypatch.setattr(state, "enter_foreground", lambda: None)
 
         state.setup()
@@ -290,7 +290,7 @@ class TestInputThread:
         """Run _input_thread in a daemon thread and return bytes received on stdin_r."""
         state._running = True
         state.build_status.headless = False
-        monkeypatch.setattr(_ni, "msvcrt", fake_msvcrt)
+        monkeypatch.setattr(_niw, "msvcrt", fake_msvcrt)
         t = threading.Thread(target=state._input_thread, daemon=True)
         t.start()
         t.join(timeout=timeout)
@@ -382,7 +382,7 @@ class TestInputThread:
             state._running = False
 
         threading.Thread(target=stop, daemon=True).start()
-        monkeypatch.setattr(_ni, "msvcrt", fake_msvcrt)
+        monkeypatch.setattr(_niw, "msvcrt", fake_msvcrt)
         state._input_thread()
 
         assert not kbhit_calls

--- a/lib/spack/spack/test/windows_tui.py
+++ b/lib/spack/spack/test/windows_tui.py
@@ -1,0 +1,487 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+"""Tests for Windows-specific TUI components in new_installer.py.
+
+WindowsTerminalState uses two daemon threads (_input_thread, _resize_thread) and
+a pair of socketpairs (stdin_r/w, sigwinch_r/w) to bridge Win32 console events
+into the selector-based event loop.  All tests here use pytest's monkeypatch and
+plain fake objects so that no real Win32 API calls are required.
+"""
+
+import os
+import selectors
+import shutil
+import socket
+import sys
+import threading
+import time
+import types
+
+import pytest
+
+if sys.platform != "win32":
+    pytest.skip("Windows-only tests", allow_module_level=True)
+
+from ctypes import wintypes
+
+import spack.new_installer as _ni
+from spack.new_installer import (
+    ENABLE_ECHO_INPUT,
+    ENABLE_EXTENDED_FLAGS,
+    ENABLE_LINE_INPUT,
+    ENABLE_QUICK_EDIT_MODE,
+    ENABLE_VIRTUAL_TERMINAL_PROCESSING,
+    StdinReader,
+    WindowsTerminalState,
+)
+
+
+class _FakeSelector:
+    """Selector that records register/unregister calls without OS involvement."""
+
+    def __init__(self):
+        self._reg = {}
+        self.register_calls = []  # [(fileobj, events, data), ...]
+        self.unregister_calls = []  # [fileobj, ...]
+
+    def register(self, fileobj, events, data=None):
+        key = fileobj.fileno() if hasattr(fileobj, "fileno") else fileobj
+        self._reg[key] = (fileobj, events, data)
+        self.register_calls.append((fileobj, events, data))
+
+    def unregister(self, fileobj):
+        key = fileobj.fileno() if hasattr(fileobj, "fileno") else fileobj
+        self._reg.pop(key, None)
+        self.unregister_calls.append(fileobj)
+
+    def get_map(self):
+        return self._reg
+
+
+class _FakeKernel32:
+    """Minimal kernel32 stand-in that records SetConsoleMode calls."""
+
+    def __init__(self):
+        self.set_console_mode_calls = []  # [(handle, value), ...]
+
+    def GetStdHandle(self, handle_id):
+        return object()
+
+    def GetConsoleMode(self, handle, byref_mode):
+        return True
+
+    def SetConsoleMode(self, handle, mode):
+        self.set_console_mode_calls.append((handle, mode))
+        return True
+
+
+class _FakeSocket:
+    """Socket stand-in that counts close() calls."""
+
+    def __init__(self, fd):
+        self._fd = fd
+        self.close_count = 0
+
+    def fileno(self):
+        return self._fd
+
+    def close(self):
+        self.close_count += 1
+
+
+class _NoopThread:
+    """Thread replacement that records daemon flag but never starts a real thread."""
+
+    def __init__(self, target=None, daemon=None):
+        self.daemon = daemon
+
+    def start(self):
+        pass
+
+
+def _drain(sock, timeout=0.5):
+    """Read all available bytes from a socket within *timeout* seconds."""
+    sock.setblocking(False)
+    data = b""
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        try:
+            chunk = sock.recv(4096)
+            if not chunk:
+                break
+            data += chunk
+        except BlockingIOError:
+            time.sleep(0.01)
+    return data
+
+
+def _make_state(headless=True):
+    """Create a WindowsTerminalState bypassing __init__ to avoid real Win32 calls.
+
+    All kernel32 calls go through _FakeKernel32; real socket pairs are created so
+    that thread tests can send/receive actual bytes.
+    """
+    sel = _FakeSelector()
+    bs = types.SimpleNamespace(headless=headless, dirty=False)
+    k32 = _FakeKernel32()
+
+    state = object.__new__(WindowsTerminalState)
+    state.selector = sel
+    state.build_status = bs
+    state.on_suspend = None
+    state.on_resume = None
+    state.kernel32 = k32
+    state.hStdin = object()
+    state.hStdout = object()
+    # ENABLE_PROCESSED_INPUT | ENABLE_LINE_INPUT | ENABLE_ECHO_INPUT
+    state.old_stdin_settings = wintypes.DWORD(0x0007)
+    state.old_stdout_settings = wintypes.DWORD(0x0003)
+    state.stdin_r, state.stdin_w = socket.socketpair()
+    state.stdin_r.setblocking(False)
+    state.sigwinch_r, state.sigwinch_w = socket.socketpair()
+    state.sigwinch_r.setblocking(False)
+    state._running = False
+    return state, sel, bs, k32
+
+
+class TestSetupTeardown:
+    def test_setup_enables_vt100_on_stdout(self, monkeypatch):
+        """setup() ORs ENABLE_VIRTUAL_TERMINAL_PROCESSING into the stdout console mode."""
+        state, sel, bs, k32 = _make_state()
+        monkeypatch.setattr(_ni.threading, "Thread", _NoopThread)
+        monkeypatch.setattr(state, "enter_foreground", lambda: None)
+
+        state.setup()
+
+        vt_flag = ENABLE_VIRTUAL_TERMINAL_PROCESSING
+        vt_calls = [v for _, v in k32.set_console_mode_calls if v & vt_flag]
+        assert vt_calls, "VT100 flag not set in any SetConsoleMode call during setup()"
+
+    def test_setup_registers_sigwinch_socket(self, monkeypatch):
+        """setup() registers sigwinch_r in the selector with tag 'sigwinch'."""
+        state, sel, bs, k32 = _make_state()
+        monkeypatch.setattr(_ni.threading, "Thread", _NoopThread)
+        monkeypatch.setattr(state, "enter_foreground", lambda: None)
+
+        state.setup()
+
+        tags = [data for _, _, data in sel.register_calls]
+        assert "sigwinch" in tags
+
+    def test_setup_starts_two_daemon_threads(self, monkeypatch):
+        """setup() starts exactly two daemon threads."""
+        state, sel, bs, k32 = _make_state()
+        threads = []
+
+        class _FakeThread:
+            def __init__(self, target, daemon):
+                threads.append(self)
+                self.daemon = daemon
+
+            def start(self):
+                pass
+
+        monkeypatch.setattr(_ni.threading, "Thread", _FakeThread)
+        monkeypatch.setattr(state, "enter_foreground", lambda: None)
+
+        state.setup()
+
+        assert len(threads) == 2
+        assert all(t.daemon for t in threads)
+
+    def test_teardown_restores_console_mode_with_int_values(self):
+        """teardown() passes plain ints (not DWORD structs) to SetConsoleMode."""
+        state, sel, bs, k32 = _make_state()
+
+        state.teardown()
+
+        assert k32.set_console_mode_calls, "SetConsoleMode not called during teardown()"
+        for _, v in k32.set_console_mode_calls:
+            assert isinstance(v, int), f"Expected int, got {type(v)}: {v!r}"
+
+    def test_teardown_closes_stdin_and_sigwinch_sockets(self):
+        """teardown() closes stdin_r and sigwinch_r."""
+        state, sel, bs, k32 = _make_state()
+        stdin_fake = _FakeSocket(99)
+        sigwinch_fake = _FakeSocket(100)
+        state.stdin_r = stdin_fake
+        state.sigwinch_r = sigwinch_fake
+
+        state.teardown()
+
+        assert stdin_fake.close_count == 1
+        assert sigwinch_fake.close_count == 1
+
+    def test_teardown_sets_running_false(self):
+        """teardown() sets _running=False to stop background threads."""
+        state, sel, bs, k32 = _make_state()
+        state._running = True
+
+        state.teardown()
+
+        assert not state._running
+
+
+class TestForegroundBackground:
+    def test_enter_foreground_noop_when_already_foreground(self):
+        """enter_foreground() is a no-op when headless is already False."""
+        state, sel, bs, k32 = _make_state(headless=False)
+
+        state.enter_foreground()
+
+        assert not k32.set_console_mode_calls
+
+    def test_enter_foreground_disables_line_echo_quickedit(self, monkeypatch):
+        """enter_foreground() clears LINE_INPUT, ECHO_INPUT, QUICK_EDIT_MODE."""
+        state, sel, bs, k32 = _make_state(headless=True)
+        monkeypatch.setattr(
+            WindowsTerminalState, "stdin_is_interactive", staticmethod(lambda: True)
+        )
+
+        state.enter_foreground()
+
+        assert k32.set_console_mode_calls, "SetConsoleMode not called"
+        new_mode = k32.set_console_mode_calls[0][1]
+        disable = ENABLE_LINE_INPUT | ENABLE_ECHO_INPUT | ENABLE_QUICK_EDIT_MODE
+        assert (new_mode & disable) == 0, f"Disabled flags still set: {new_mode:#010x}"
+        assert new_mode & ENABLE_EXTENDED_FLAGS, "ENABLE_EXTENDED_FLAGS not set"
+
+    def test_enter_foreground_registers_stdin_when_interactive(self, monkeypatch):
+        """enter_foreground() registers stdin_r with tag 'stdin' when interactive."""
+        state, sel, bs, k32 = _make_state(headless=True)
+        monkeypatch.setattr(
+            WindowsTerminalState, "stdin_is_interactive", staticmethod(lambda: True)
+        )
+
+        state.enter_foreground()
+
+        tags = [data for _, _, data in sel.register_calls]
+        assert "stdin" in tags
+        assert bs.headless is False
+
+    def test_enter_foreground_skips_stdin_when_not_interactive(self, monkeypatch):
+        """enter_foreground() does not register stdin_r when not interactive."""
+        state, sel, bs, k32 = _make_state(headless=True)
+        monkeypatch.setattr(
+            WindowsTerminalState, "stdin_is_interactive", staticmethod(lambda: False)
+        )
+
+        state.enter_foreground()
+
+        tags = [data for _, _, data in sel.register_calls]
+        assert "stdin" not in tags
+
+    def test_enter_background_unregisters_stdin_and_sets_headless(self):
+        """enter_background() unregisters stdin_r and sets headless=True."""
+        state, sel, bs, k32 = _make_state(headless=False)
+        sel._reg[state.stdin_r.fileno()] = (state.stdin_r, selectors.EVENT_READ, "stdin")
+
+        state.enter_background()
+
+        assert sel.unregister_calls
+        assert bs.headless is True
+
+
+class TestInputThread:
+    """Tests for WindowsTerminalState._input_thread."""
+
+    def _run_thread(self, state, fake_msvcrt, monkeypatch, *, timeout=0.5):
+        """Run _input_thread in a daemon thread and return bytes received on stdin_r."""
+        state._running = True
+        state.build_status.headless = False
+        monkeypatch.setattr(_ni, "msvcrt", fake_msvcrt)
+        t = threading.Thread(target=state._input_thread, daemon=True)
+        t.start()
+        t.join(timeout=timeout)
+        return _drain(state.stdin_r)
+
+    def test_keystroke_forwarded_to_stdin_r(self, monkeypatch):
+        """A normal keypress is sent to stdin_r."""
+        state, sel, bs, k32 = _make_state()
+        call_count = [0]
+
+        def kbhit():
+            call_count[0] += 1
+            if call_count[0] == 1:
+                return True
+            state._running = False
+            return False
+
+        fake_msvcrt = types.SimpleNamespace(kbhit=kbhit, getwch=lambda: "v")
+
+        data = self._run_thread(state, fake_msvcrt, monkeypatch)
+        assert b"v" in data
+
+    def test_extended_key_e0_reads_two_bytes_and_discards(self, monkeypatch):
+        """The 0xe0 prefix (arrow/nav keys) reads a second byte but discards both."""
+        state, sel, bs, k32 = _make_state()
+        call_count = [0]
+        getwch_results = ["\xe0", "H"]
+        getwch_calls = [0]
+
+        def kbhit():
+            call_count[0] += 1
+            if call_count[0] == 1:
+                return True
+            state._running = False
+            return False
+
+        def getwch():
+            v = getwch_results[getwch_calls[0]]
+            getwch_calls[0] += 1
+            return v
+
+        fake_msvcrt = types.SimpleNamespace(kbhit=kbhit, getwch=getwch)
+
+        data = self._run_thread(state, fake_msvcrt, monkeypatch)
+        assert getwch_calls[0] == 2
+        assert data == b""
+
+    def test_extended_key_null_reads_two_bytes_and_discards(self, monkeypatch):
+        """The 0x00 prefix (F-keys) reads a second byte but discards both."""
+        state, sel, bs, k32 = _make_state()
+        call_count = [0]
+        getwch_results = ["\x00", "K"]
+        getwch_calls = [0]
+
+        def kbhit():
+            call_count[0] += 1
+            if call_count[0] == 1:
+                return True
+            state._running = False
+            return False
+
+        def getwch():
+            v = getwch_results[getwch_calls[0]]
+            getwch_calls[0] += 1
+            return v
+
+        fake_msvcrt = types.SimpleNamespace(kbhit=kbhit, getwch=getwch)
+
+        data = self._run_thread(state, fake_msvcrt, monkeypatch)
+        assert getwch_calls[0] == 2
+        assert data == b""
+
+    def test_no_keypress_when_headless(self, monkeypatch):
+        """_input_thread does not call kbhit when headless=True."""
+        state, sel, bs, k32 = _make_state()
+        state.build_status.headless = True
+        kbhit_calls = []
+
+        def kbhit():
+            kbhit_calls.append(None)
+            return False
+
+        fake_msvcrt = types.SimpleNamespace(kbhit=kbhit, getwch=lambda: "")
+
+        state._running = True
+
+        def stop():
+            time.sleep(0.15)
+            state._running = False
+
+        threading.Thread(target=stop, daemon=True).start()
+        monkeypatch.setattr(_ni, "msvcrt", fake_msvcrt)
+        state._input_thread()
+
+        assert not kbhit_calls
+
+
+class TestResizeThread:
+    """Tests for WindowsTerminalState._resize_thread."""
+
+    def test_resize_event_sent_on_size_change(self, monkeypatch):
+        """_resize_thread sends b'\\x00' to sigwinch_w when terminal dimensions change."""
+        state, sel, bs, k32 = _make_state()
+        state._running = True
+        call_count = [0]
+        sizes = [
+            os.terminal_size((80, 24)),
+            os.terminal_size((80, 24)),
+            os.terminal_size((100, 30)),
+        ]
+
+        def get_size(**_kwargs):
+            idx = call_count[0]
+            call_count[0] += 1
+            if idx >= len(sizes):
+                state._running = False
+                return sizes[-1]
+            return sizes[idx]
+
+        monkeypatch.setattr(shutil, "get_terminal_size", get_size)
+        state._resize_thread()
+
+        data = _drain(state.sigwinch_r)
+        assert b"\x00" in data
+
+    def test_no_resize_event_on_same_size(self, monkeypatch):
+        """_resize_thread does not send if dimensions are unchanged."""
+        state, sel, bs, k32 = _make_state()
+        state._running = True
+        call_count = [0]
+
+        def get_size(**_kwargs):
+            call_count[0] += 1
+            if call_count[0] > 4:
+                state._running = False
+            return os.terminal_size((80, 24))
+
+        monkeypatch.setattr(shutil, "get_terminal_size", get_size)
+        state._resize_thread()
+
+        data = _drain(state.sigwinch_r)
+        assert data == b""
+
+
+class TestStdinReaderSocketPath:
+    """Tests for StdinReader when constructed with a socket (Windows path)."""
+
+    def _make_reader(self):
+        r, w = socket.socketpair()
+        # Keep blocking so recv() returns data immediately, mirroring production behaviour
+        # where read() is only called after the selector has already signalled data ready.
+        reader = StdinReader(r.fileno(), sock=r)
+        return reader, r, w
+
+    def test_basic_ascii_via_socket(self):
+        """Bytes sent through the socket are decoded and returned."""
+        reader, r, w = self._make_reader()
+        try:
+            w.sendall(b"hello")
+            assert reader.read() == "hello"
+        finally:
+            r.close()
+            w.close()
+
+    def test_ansi_stripping_via_socket(self):
+        """ANSI escape sequences are stripped when reading from the socket."""
+        reader, r, w = self._make_reader()
+        try:
+            w.sendall(b"go\x1b[Aup\x1b[B!")
+            assert reader.read() == "goup!"
+        finally:
+            r.close()
+            w.close()
+
+    def test_multibyte_utf8_via_socket(self):
+        """Multi-byte UTF-8 characters split across two recvs are reassembled correctly."""
+        reader, r, w = self._make_reader()
+        try:
+            encoded = "é".encode("utf-8")  # 0xc3 0xa9
+            w.sendall(encoded[:1])
+            result1 = reader.read()
+            w.sendall(encoded[1:])
+            result2 = reader.read()
+            assert result1 + result2 == "é"
+        finally:
+            r.close()
+            w.close()
+
+    def test_oserror_returns_empty_via_socket(self):
+        """A closed socket raises OSError on recv(); read() returns '' rather than propagating."""
+        reader, r, w = self._make_reader()
+        r.close()
+        w.close()
+        assert reader.read() == ""


### PR DESCRIPTION
Introduces BaseTerminalState as an abstract base class so that WindowsTerminalState and the existing TerminalState (POSIX) share a common interface without scattering IS_WINDOWS guards through the event loop.

Two new abstract methods:
    - drain_sigwinch(): TerminalState uses os.read(); WindowsTerminalState uses socket.recv() on its internal socketpair
    - should_enter_foreground(): TerminalState queries _is_background_tty(); WindowsTerminalState always returns True (Windows has no bg-TTY concept)

WindowsTerminalState manages the Win32 console for TUI mode:
    - enables VT100/ANSI processing on stdout via SetConsoleMode
    - bridges keyboard input (_input_thread / msvcrt.kbhit) and terminal-resize events (_resize_thread / shutil.get_terminal_size) to socketpairs that the selector-based event loop can watch like any other fd

Other changes:
    - _establish_terminal_state() factory selects the right class at runtime
    - StdinReader gains an optional sock= parameter for Windows socket input

Tests: lib/spack/spack/test/windows_tui.py
