### PR TITLE
new_installer: Windows IPC support

### DIFF
--- a/lib/spack/spack/new_installer.py
+++ b/lib/spack/spack/new_installer.py
@@ -20,6 +20,7 @@ output to both a log file and the UI process (if the UI process has requested it
 runs an event loop to listen for control messages from the UI process (to enable/disable echoing
 of logs), and for output from the build process."""
 
+import codecs
 import glob
 import io
 import json
@@ -119,7 +120,6 @@ CLEANUP_TIMEOUT = 2.0
 
 #: How often to flush completed builds to the database
 DATABASE_WRITE_INTERVAL = 5.0
-
 
 #: Suffix for temporary backup during overwrite install
 OVERWRITE_BACKUP_SUFFIX = ".old"
@@ -269,7 +269,7 @@ class PrefixPivoter:
         return os.path.lexists(path)
 
     def _rename(self, src: str, dst: str) -> None:
-        os.rename(src, dst)
+        fs.rename(src, dst)
 
     def _mkdtemp(self, dir: str, prefix: str, suffix: str) -> str:
         return tempfile.mkdtemp(dir=dir, prefix=prefix, suffix=suffix)
@@ -292,9 +292,9 @@ def worker_function(
     fake: bool,
     install_source: bool,
     run_tests: bool,
-    state: Connection,
-    parent: Connection,
-    echo_control: Connection,
+    state: Union[Connection, socket.socket],
+    parent: Union[Connection, socket.socket],
+    echo_control: Union[Connection, socket.socket],
     jobserver_info: Tuple[Optional[str], Any],
     log_path: str,
     global_state: GlobalStateMarshaler,
@@ -333,12 +333,13 @@ def worker_function(
 
     global_state.restore()
 
-    # Isolate the process group to shield against Ctrl+C and enable safe killpg() cleanup. In
-    # constrast to setsid(), this keeps a neat process group hierarchy for utils like pstree.
-    os.setpgid(0, 0)
+    if sys.platform != "win32":
+        # Isolate the process group to shield against Ctrl+C and enable safe killpg() cleanup. In
+        # constrast to setsid(), this keeps a neat process group hierarchy for utils like pstree.
+        os.setpgid(0, 0)
 
-    # Reset SIGTSTP to default in case the parent had a custom handler.
-    signal.signal(signal.SIGTSTP, signal.SIG_DFL)
+        # Reset SIGTSTP to default in case the parent had a custom handler.
+        signal.signal(signal.SIGTSTP, signal.SIG_DFL)
 
     def handle_sigterm(signum, frame):
         # This SIGTERM handler forwards the signal to child processes (cmake, make, etc). We wait
@@ -347,13 +348,13 @@ def worker_function(
         # get to clean up the prefix without risking that the child process writes to it
         # afterwards.
         signal.signal(signal.SIGTERM, signal.SIG_IGN)
-        os.killpg(0, signal.SIGTERM)
-
-        try:
-            while True:
-                os.waitpid(-1, 0)
-        except ChildProcessError:
-            pass
+        if sys.platform != "win32":
+            os.killpg(0, signal.SIGTERM)
+            try:
+                while True:
+                    os.waitpid(-1, 0)
+            except ChildProcessError:
+                pass
 
         raise KeyboardInterrupt("Installation interrupted")
 
@@ -363,15 +364,10 @@ def worker_function(
     if makeflags is not None:
         os.environ["MAKEFLAGS"] = makeflags
 
-    # Force line buffering for Python's textio wrappers of stdout/stderr. We're not going to print
-    # much ourselves, but what we print should appear before output from `make` and other build
-    # tools.
-    sys.stdout = os.fdopen(
-        sys.stdout.fileno(), "w", buffering=1, encoding=sys.stdout.encoding, closefd=False
-    )
-    sys.stderr = os.fdopen(
-        sys.stderr.fileno(), "w", buffering=1, encoding=sys.stderr.encoding, closefd=False
-    )
+    # Save encodings before the Tee redirects fds 1/2 to the pipe. We need them to create the
+    # line-buffered wrappers after the Tee starts.
+    _stdout_enc = sys.stdout.encoding or "utf-8"
+    _stderr_enc = sys.stderr.encoding or "utf-8"
 
     # Detach stdin from the terminal like `./build < /dev/null`. This would not be necessary if we
     # used os.setsid() instead of os.setpgid(), but that would "break" pstree output.
@@ -384,6 +380,16 @@ def worker_function(
     tee = Tee(echo_control, parent, log_path)
 
     # Use closedfd=false because of the connection objects. Use line buffering.
+    # Replace sys.stdout/stderr AFTER Tee.dup2() so Python creates FileIO (WriteFile) rather
+    # than ConsoleIO (WriteConsoleW). On Windows, if fds 1/2 are still console handles when
+    # os.fdopen() is called, Python picks ConsoleIO; WriteConsoleW on a pipe handle returns
+    # ERROR_INVALID_FUNCTION. Post-dup2 the fds are pipe handles, so FileIO is chosen.
+    sys.stdout = os.fdopen(
+        sys.stdout.fileno(), "w", buffering=1, encoding=_stdout_enc, closefd=False
+    )
+    sys.stderr = os.fdopen(
+        sys.stderr.fileno(), "w", buffering=1, encoding=_stderr_enc, closefd=False
+    )
     state_stream = make_state_stream(state)
     exit_code = ExitCode.SUCCESS
 
@@ -1940,6 +1946,8 @@ class PackageInstaller:
         self.keep_prefix = keep_prefix
         self.fail_fast = fail_fast
 
+        # Per-pid incremental UTF-8 decoders for state pipes
+        self.state_decoders: Dict[int, codecs.IncrementalDecoder] = {}
         # Buffer for incoming, partially received state data from child processes
         self.state_buffers: Dict[int, str] = {}
 
@@ -2493,6 +2501,7 @@ class PackageInstaller:
         pid = child_info.proc.pid
         assert type(pid) is int
         self.running_builds[pid] = child_info
+        self.state_decoders[pid] = codecs.getincrementaldecoder("utf-8")(errors="replace")
         child_info.register_with_selector(selector, pid)
         self.build_status.add_build(
             child_info.spec,
@@ -2543,6 +2552,10 @@ class PackageInstaller:
         """Handle reading state updates from a child process pipe."""
         pid = child_info.proc.pid
         assert pid is not None
+        # state_decoders / state_buffers are keyed by PID rather than fd: on Windows the state
+        # channel is a socket.socket, whose handle is not a stable POSIX-style fd.
+        # IncrementalDecoder handles partial UTF-8 sequences that socket.recv() may return.
+        decoder = self.state_decoders[pid]
         try:
             # There might be more data than OUTPUT_BUFFER_SIZE, but we will read that in the next
             # iteration of the event loop to keep things responsive.
@@ -2557,16 +2570,30 @@ class PackageInstaller:
                 selector.unregister(key.fileobj)
             except (KeyError, OSError):
                 pass
+            final_text = decoder.decode(b"", final=True)
+            if final_text:
+                self._process_state_string(pid, child_info, final_text)
             self.state_buffers.pop(pid, None)
             return
 
-        # Append new data to the buffer for this fd and process it
-        buffer = self.state_buffers.get(pid, "") + data.decode(errors="replace")
-        lines = buffer.split("\n")
+        text = decoder.decode(data)
+        if text:
+            self._process_state_string(pid, child_info, text)
 
+    def _process_state_string(self, pid: int, child_info: ChildInfo, text: str) -> None:
+        buffer = self.state_buffers.get(pid, "") + text
+        lines = buffer.split("\n")
         # The last element of split() will be a partial line or an empty string.
         # We store it back in the buffer for the next read.
         self.state_buffers[pid] = lines.pop()
+
+        # Guard against unbounded buffer growth if a subprocess inherits the state fd and writes
+        # without newline terminators. Cap at 1 MB, keeping any partial in-progress line.
+        if len(self.state_buffers[pid]) > 1024 * 1024:
+            last_newline = self.state_buffers[pid].rfind("\n")
+            self.state_buffers[pid] = (
+                "" if last_newline < 0 else self.state_buffers[pid][last_newline + 1 :]
+            )
 
         for line in lines:
             if not line:

--- a/lib/spack/spack/new_installer.py
+++ b/lib/spack/spack/new_installer.py
@@ -92,8 +92,9 @@ if sys.platform == "win32":
     from spack.new_installer_base import NoopJobServer as JobServer
     from spack.new_installer_windows import WindowsTerminalState as TerminalState
 else:
-    from spack.new_installer_posix import PosixChildInfo, PosixTee
+    from spack.new_installer_posix import PosixChildInfo as ChildInfo
     from spack.new_installer_posix import PosixJobServer as JobServer
+    from spack.new_installer_posix import PosixTee as Tee
     from spack.new_installer_posix import PosixTerminalState as TerminalState
 
 if TYPE_CHECKING:
@@ -375,7 +376,7 @@ def worker_function(
     sys.stdin = open(os.devnull, "r", encoding=sys.stdin.encoding)
 
     # Start the tee thread to forward output to the log file and parent process.
-    tee = PosixTee(echo_control, parent, log_path)
+    tee = Tee(echo_control, parent, log_path)
 
     # Use closedfd=false because of the connection objects. Use line buffering.
     state_stream = os.fdopen(state.fileno(), "w", buffering=1, closefd=False)
@@ -703,7 +704,7 @@ def start_build(
     log_path: str,
     stop_before: Optional[str] = None,
     stop_at: Optional[str] = None,
-) -> PosixChildInfo:
+) -> ChildInfo:
     """Start a new build."""
     # Create pipes for the child's output, state reporting, and control.
     state_r_conn, state_w_conn = Pipe(duplex=False)
@@ -754,9 +755,7 @@ def start_build(
     os.set_blocking(output_r_conn.fileno(), False)
     os.set_blocking(state_r_conn.fileno(), False)
 
-    return PosixChildInfo(
-        proc, spec, output_r_conn, state_r_conn, control_w_conn, log_path, explicit
-    )
+    return ChildInfo(proc, spec, output_r_conn, state_r_conn, control_w_conn, log_path, explicit)
 
 
 class BuildInfo:
@@ -1858,7 +1857,7 @@ class NullReportData(ReportData):
         pass
 
 
-def _signal_children(running_builds: Dict[int, PosixChildInfo], sig: signal.Signals) -> None:
+def _signal_children(running_builds: Dict[int, ChildInfo], sig: signal.Signals) -> None:
     """Send a signal to the process group of each running build."""
     for child in running_builds.values():
         try:
@@ -1974,7 +1973,7 @@ class PackageInstaller:
         self.pending_expansions: List[str] = []
 
         self.verbose = verbose
-        self.running_builds: Dict[int, PosixChildInfo] = {}
+        self.running_builds: Dict[int, ChildInfo] = {}
         self.log_paths: Dict[str, str] = {}
         self.build_status = BuildStatus(
             len(self.build_graph.nodes),
@@ -2484,7 +2483,7 @@ class PackageInstaller:
         self.report_data.start_record(spec)
 
     def _handle_child_logs(
-        self, r_fd: int, child_info: PosixChildInfo, selector: selectors.BaseSelector
+        self, r_fd: int, child_info: ChildInfo, selector: selectors.BaseSelector
     ) -> None:
         """Handle reading output logs from a child process pipe."""
         try:
@@ -2505,24 +2504,20 @@ class PackageInstaller:
 
         self.build_status.print_logs(child_info.spec.dag_hash(), data)
 
-    def _drain_child_output(
-        self, child_info: PosixChildInfo, selector: selectors.BaseSelector
-    ) -> None:
+    def _drain_child_output(self, child_info: ChildInfo, selector: selectors.BaseSelector) -> None:
         """Read and print any remaining output from a finished child's pipe."""
         r_fd = child_info.output_r_conn.fileno()
         while r_fd in selector.get_map():
             self._handle_child_logs(r_fd, child_info, selector)
 
-    def _drain_child_state(
-        self, child_info: PosixChildInfo, selector: selectors.BaseSelector
-    ) -> None:
+    def _drain_child_state(self, child_info: ChildInfo, selector: selectors.BaseSelector) -> None:
         """Read and process any remaining state messages from a finished child's pipe."""
         r_fd = child_info.state_r_conn.fileno()
         while r_fd in selector.get_map():
             self._handle_child_state(r_fd, child_info, selector)
 
     def _handle_child_state(
-        self, r_fd: int, child_info: PosixChildInfo, selector: selectors.BaseSelector
+        self, r_fd: int, child_info: ChildInfo, selector: selectors.BaseSelector
     ) -> None:
         """Handle reading state updates from a child process pipe."""
         try:

--- a/lib/spack/spack/new_installer.py
+++ b/lib/spack/spack/new_installer.py
@@ -28,6 +28,7 @@ import selectors
 import shlex
 import shutil
 import signal
+import socket
 import sys
 import tempfile
 import time
@@ -90,12 +91,16 @@ from spack.util.path import padding_filter, padding_filter_bytes
 
 if sys.platform == "win32":
     from spack.new_installer_base import NoopJobServer as JobServer
+    from spack.new_installer_windows import WindowsChildInfo as ChildInfo
+    from spack.new_installer_windows import WindowsTee as Tee
     from spack.new_installer_windows import WindowsTerminalState as TerminalState
+    from spack.new_installer_windows import make_state_stream, read_connection, write_connection
 else:
     from spack.new_installer_posix import PosixChildInfo as ChildInfo
     from spack.new_installer_posix import PosixJobServer as JobServer
     from spack.new_installer_posix import PosixTee as Tee
     from spack.new_installer_posix import PosixTerminalState as TerminalState
+    from spack.new_installer_posix import make_state_stream, read_connection, write_connection
 
 if TYPE_CHECKING:
     import spack.package_base
@@ -379,7 +384,7 @@ def worker_function(
     tee = Tee(echo_control, parent, log_path)
 
     # Use closedfd=false because of the connection objects. Use line buffering.
-    state_stream = os.fdopen(state.fileno(), "w", buffering=1, closefd=False)
+    state_stream = make_state_stream(state)
     exit_code = ExitCode.SUCCESS
 
     try:
@@ -706,10 +711,24 @@ def start_build(
     stop_at: Optional[str] = None,
 ) -> ChildInfo:
     """Start a new build."""
-    # Create pipes for the child's output, state reporting, and control.
-    state_r_conn, state_w_conn = Pipe(duplex=False)
-    output_r_conn, output_w_conn = Pipe(duplex=False)
-    control_r_conn, control_w_conn = Pipe(duplex=False)
+    # Create IPC channels. On POSIX use Pipe() (anonymous pipe/fd); on Windows use socketpair()
+    # because anonymous pipes cannot be registered with the Windows selector.
+    state_r_conn: Union[Connection, socket.socket]
+    state_w_conn: Union[Connection, socket.socket]
+    output_r_conn: Union[Connection, socket.socket]
+    output_w_conn: Union[Connection, socket.socket]
+    # On Windows, use socketpair() for the control channel; anonymous pipes don't support the
+    # non-blocking I/O the Windows tee thread needs. On POSIX, use Pipe() like other channels.
+    control_r_conn: Union[Connection, socket.socket]
+    control_w_conn: Union[Connection, socket.socket]
+    if sys.platform == "win32":
+        state_r_conn, state_w_conn = socket.socketpair()
+        output_r_conn, output_w_conn = socket.socketpair()
+        control_r_conn, control_w_conn = socket.socketpair()
+    else:
+        state_r_conn, state_w_conn = Pipe(duplex=False)
+        output_r_conn, output_w_conn = Pipe(duplex=False)
+        control_r_conn, control_w_conn = Pipe(duplex=False)
 
     # Obtain the MAKEFLAGS to be set in the child process, and determine whether it's necessary
     # for the child process to inherit our jobserver fds.
@@ -751,9 +770,10 @@ def start_build(
     output_w_conn.close()
     control_r_conn.close()
 
-    # Set the read ends to non-blocking: in principle redundant with epoll/kqueue, but safer.
-    os.set_blocking(output_r_conn.fileno(), False)
-    os.set_blocking(state_r_conn.fileno(), False)
+    if sys.platform != "win32":
+        # Set the read ends to non-blocking: in principle redundant with epoll/kqueue, but safer.
+        os.set_blocking(output_r_conn.fileno(), False)
+        os.set_blocking(state_r_conn.fileno(), False)
 
     return ChildInfo(proc, spec, output_r_conn, state_r_conn, control_w_conn, log_path, explicit)
 
@@ -782,7 +802,7 @@ class BuildInfo:
         self,
         spec: spack.spec.Spec,
         explicit: bool,
-        control_w_conn: Optional[Connection],
+        control_w_conn: Optional[Union[Connection, socket.socket]],
         log_path: Optional[str] = None,
         start_time: float = 0.0,
     ) -> None:
@@ -864,7 +884,7 @@ class BuildStatus:
         self,
         spec: spack.spec.Spec,
         explicit: bool,
-        control_w_conn: Optional[Connection] = None,
+        control_w_conn: Optional[Union[Connection, socket.socket]] = None,
         log_path: Optional[str] = None,
     ) -> None:
         """Add a new build to the display and mark the display as dirty."""
@@ -876,7 +896,7 @@ class BuildStatus:
         if self.verbose and not self.tracked_build_id and control_w_conn is not None:
             self.tracked_build_id = spec.dag_hash()
             try:
-                os.write(control_w_conn.fileno(), b"1")
+                write_connection(control_w_conn, b"1")
             except OSError:
                 pass
 
@@ -905,7 +925,7 @@ class BuildStatus:
             try:
                 conn = self.builds[self.tracked_build_id].control_w_conn
                 if conn is not None:
-                    os.write(conn.fileno(), b"0")
+                    write_connection(conn, b"0")
             except (KeyError, OSError):
                 pass
             self.tracked_build_id = ""
@@ -970,7 +990,7 @@ class BuildStatus:
             try:
                 conn = self.builds[self.tracked_build_id].control_w_conn
                 if conn is not None:
-                    os.write(conn.fileno(), b"0")
+                    write_connection(conn, b"0")
             except (KeyError, OSError):
                 pass
 
@@ -1002,7 +1022,7 @@ class BuildStatus:
             try:
                 conn = new_build.control_w_conn
                 if conn is not None:
-                    os.write(conn.fileno(), b"1")
+                    write_connection(conn, b"1")
             except (KeyError, OSError):
                 pass
 
@@ -2085,9 +2105,9 @@ class PackageInstaller:
                         # Child output (logs and state updates)
                         child_info = self.running_builds[data.pid]
                         if data.name == "output":
-                            self._handle_child_logs(key.fd, child_info, selector)
+                            self._handle_child_logs(key, child_info, selector)
                         elif data.name == "state":
-                            self._handle_child_state(key.fd, child_info, selector)
+                            self._handle_child_state(key, child_info, selector)
                         elif data.name == "sentinel":
                             finished_pids.append(data.pid)
                     elif data == "stdin":
@@ -2483,13 +2503,13 @@ class PackageInstaller:
         self.report_data.start_record(spec)
 
     def _handle_child_logs(
-        self, r_fd: int, child_info: ChildInfo, selector: selectors.BaseSelector
+        self, key: selectors.SelectorKey, child_info: ChildInfo, selector: selectors.BaseSelector
     ) -> None:
         """Handle reading output logs from a child process pipe."""
         try:
             # There might be more data than OUTPUT_BUFFER_SIZE, but we will read that in the next
             # iteration of the event loop to keep things responsive.
-            data = os.read(r_fd, OUTPUT_BUFFER_SIZE)
+            data = read_connection(key, OUTPUT_BUFFER_SIZE)
         except BlockingIOError:
             return
         except OSError:
@@ -2497,8 +2517,8 @@ class PackageInstaller:
 
         if not data:  # EOF or error
             try:
-                selector.unregister(r_fd)
-            except KeyError:
+                selector.unregister(key.fileobj)
+            except (KeyError, OSError):
                 pass
             return
 
@@ -2506,24 +2526,27 @@ class PackageInstaller:
 
     def _drain_child_output(self, child_info: ChildInfo, selector: selectors.BaseSelector) -> None:
         """Read and print any remaining output from a finished child's pipe."""
-        r_fd = child_info.output_r_conn.fileno()
-        while r_fd in selector.get_map():
-            self._handle_child_logs(r_fd, child_info, selector)
+        obj = child_info.output_r_conn
+        while obj in selector.get_map():
+            self._handle_child_logs(selector.get_map()[obj], child_info, selector)
 
     def _drain_child_state(self, child_info: ChildInfo, selector: selectors.BaseSelector) -> None:
         """Read and process any remaining state messages from a finished child's pipe."""
-        r_fd = child_info.state_r_conn.fileno()
-        while r_fd in selector.get_map():
-            self._handle_child_state(r_fd, child_info, selector)
+        # Must drain before child.close() to consume any remaining data before bridges close.
+        obj = child_info.state_r_conn
+        while obj in selector.get_map():
+            self._handle_child_state(selector.get_map()[obj], child_info, selector)
 
     def _handle_child_state(
-        self, r_fd: int, child_info: ChildInfo, selector: selectors.BaseSelector
+        self, key: selectors.SelectorKey, child_info: ChildInfo, selector: selectors.BaseSelector
     ) -> None:
         """Handle reading state updates from a child process pipe."""
+        pid = child_info.proc.pid
+        assert pid is not None
         try:
             # There might be more data than OUTPUT_BUFFER_SIZE, but we will read that in the next
             # iteration of the event loop to keep things responsive.
-            data = os.read(r_fd, OUTPUT_BUFFER_SIZE)
+            data = read_connection(key, OUTPUT_BUFFER_SIZE)
         except BlockingIOError:
             return
         except OSError:
@@ -2531,19 +2554,19 @@ class PackageInstaller:
 
         if not data:  # EOF or error
             try:
-                selector.unregister(r_fd)
-            except KeyError:
+                selector.unregister(key.fileobj)
+            except (KeyError, OSError):
                 pass
-            self.state_buffers.pop(r_fd, None)
+            self.state_buffers.pop(pid, None)
             return
 
         # Append new data to the buffer for this fd and process it
-        buffer = self.state_buffers.get(r_fd, "") + data.decode(errors="replace")
+        buffer = self.state_buffers.get(pid, "") + data.decode(errors="replace")
         lines = buffer.split("\n")
 
         # The last element of split() will be a partial line or an empty string.
         # We store it back in the buffer for the next read.
-        self.state_buffers[r_fd] = lines.pop()
+        self.state_buffers[pid] = lines.pop()
 
         for line in lines:
             if not line:

--- a/lib/spack/spack/new_installer_base.py
+++ b/lib/spack/spack/new_installer_base.py
@@ -25,6 +25,9 @@ import spack.util.lock
 if TYPE_CHECKING:
     from spack.new_installer import BuildStatus
 
+# IPC state channel type: Connection on POSIX, socket on Windows
+StateChannel = Union[Connection, socket.socket]
+
 #: Size of the output buffer for child processes
 OUTPUT_BUFFER_SIZE = 32768
 
@@ -160,9 +163,9 @@ class ChildInfo(DatabaseAction):
         self,
         proc: Process,
         spec: spack.spec.Spec,
-        output_r_conn: Connection,
-        state_r_conn: Connection,
-        control_w_conn: Connection,
+        output_r_conn: Union[Connection, socket.socket],
+        state_r_conn: Union[Connection, socket.socket],
+        control_w_conn: Union[Connection, socket.socket],
         log_path: str,
         explicit: bool = False,
     ) -> None:
@@ -177,20 +180,23 @@ class ChildInfo(DatabaseAction):
 
     @property
     @abc.abstractmethod
-    def output_connection_handle(self):
-        """Accesor for underlying connection handle"""
+    def output_connection_handle(self) -> Union[int, socket.socket]:
+        """Accesor for underlying output connection handle.
+        fd on linux, socket on Windows"""
         pass
 
     @property
     @abc.abstractmethod
-    def state_connection_handle(self):
-        """Accesor for underlying connection handle"""
+    def state_connection_handle(self) -> Union[int, socket.socket]:
+        """Accesor for underlying process state connection handle.
+        fd on linux, socket on Windows"""
         pass
 
     @property
     @abc.abstractmethod
     def sentinel(self):
-        """Accessor for process sentinel"""
+        """Accessor for process sentinel
+        proc.sentinel on linux, WindowsSentinelBridge on Windows"""
         pass
 
     def _setup_handles(self) -> None:
@@ -328,7 +334,14 @@ class Tee(abc.ABC):
         self.tee_thread.start()
         for fd in fds:
             os.dup2(w, fd)
+        self._setup_handles()
         os.close(w)
+
+    def _setup_handles(self) -> None:
+        pass
+
+    def _restore_handles(self) -> None:
+        pass
 
     @abc.abstractmethod
     def run(self, log_r: int, log_file: io.BufferedWriter) -> None:
@@ -349,3 +362,4 @@ class Tee(abc.ABC):
         # Only then close the other fds.
         self.control.close()
         self.parent.close()
+        self._restore_handles()

--- a/lib/spack/spack/new_installer_base.py
+++ b/lib/spack/spack/new_installer_base.py
@@ -175,33 +175,60 @@ class ChildInfo(DatabaseAction):
         self.explicit = explicit
         self.prefix_lock: Optional[spack.util.lock.Lock] = None
 
+    @property
+    @abc.abstractmethod
+    def output_connection_handle(self):
+        """Accesor for underlying connection handle"""
+        pass
+
+    @property
+    @abc.abstractmethod
+    def state_connection_handle(self):
+        """Accesor for underlying connection handle"""
+        pass
+
+    @property
+    @abc.abstractmethod
+    def sentinel(self):
+        """Accessor for process sentinel"""
+        pass
+
+    def _setup_handles(self) -> None:
+        pass
+
+    def _cleanup_handles(self) -> None:
+        self.output_r_conn.close()
+        self.state_r_conn.close()
+        self.control_w_conn.close()
+
     def save_to_db(self, db: spack.database.Database) -> None:
         return db._add(self.spec, explicit=self.explicit)
 
     def register_with_selector(self, selector: selectors.BaseSelector, pid: int) -> None:
         """Register output, state, and sentinel channels with the selector."""
-        selector.register(self.output_r_conn.fileno(), selectors.EVENT_READ, FdInfo(pid, "output"))
-        selector.register(self.state_r_conn.fileno(), selectors.EVENT_READ, FdInfo(pid, "state"))
-        selector.register(self.proc.sentinel, selectors.EVENT_READ, FdInfo(pid, "sentinel"))
+        self._setup_handles()
+        selector.register(
+            self.output_connection_handle, selectors.EVENT_READ, FdInfo(pid, "output")
+        )
+        selector.register(self.state_connection_handle, selectors.EVENT_READ, FdInfo(pid, "state"))
+        selector.register(self.sentinel, selectors.EVENT_READ, FdInfo(pid, "sentinel"))
 
     def close(self, selector: selectors.BaseSelector) -> int:
         """Unregister and close file descriptors, and join the child process.
         Returns the exit code of the child process."""
         try:
-            selector.unregister(self.output_r_conn.fileno())
+            selector.unregister(self.output_connection_handle)
         except KeyError:
             pass
         try:
-            selector.unregister(self.state_r_conn.fileno())
+            selector.unregister(self.state_connection_handle)
         except KeyError:
             pass
         try:
-            selector.unregister(self.proc.sentinel)
+            selector.unregister(self.sentinel)
         except (KeyError, ValueError):
             pass
-        self.output_r_conn.close()
-        self.state_r_conn.close()
-        self.control_w_conn.close()
+        self._cleanup_handles()
         self.proc.join()
         exit_code = self.proc.exitcode
         assert exit_code is not None, "Finished build should have exit code set"

--- a/lib/spack/spack/new_installer_base.py
+++ b/lib/spack/spack/new_installer_base.py
@@ -2,18 +2,21 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-"""Abstract base classes for the new_installer TUI terminal state and stdin reading.
-
-Kept in a leaf module (no imports from new_installer.py or the platform modules) so that
-new_installer_posix and new_installer_windows can import from here without introducing a
-circular dependency."""
+"""Abstract base classes for new_installer:
+TUI terminal state, IPC channels, and job scheduling."""
 
 import abc
 import codecs
+import io
+import os
 import re
 import selectors
+import socket
 import sys
-from typing import TYPE_CHECKING, Any, Callable, Optional, Tuple
+import threading
+from multiprocessing import Process
+from multiprocessing.connection import Connection
+from typing import TYPE_CHECKING, Any, Callable, Optional, Tuple, Union
 
 import spack.database
 import spack.spec
@@ -21,6 +24,9 @@ import spack.util.lock
 
 if TYPE_CHECKING:
     from spack.new_installer import BuildStatus
+
+#: Size of the output buffer for child processes
+OUTPUT_BUFFER_SIZE = 32768
 
 
 class StdinReaderBase:
@@ -145,6 +151,65 @@ class FdInfo:
         self.name = name
 
 
+class ChildInfo(DatabaseAction):
+    """Base class for child process info. Subclassed per platform for IPC channel types."""
+
+    __slots__ = ("proc", "output_r_conn", "state_r_conn", "control_w_conn", "explicit", "log_path")
+
+    def __init__(
+        self,
+        proc: Process,
+        spec: spack.spec.Spec,
+        output_r_conn: Connection,
+        state_r_conn: Connection,
+        control_w_conn: Connection,
+        log_path: str,
+        explicit: bool = False,
+    ) -> None:
+        self.proc = proc
+        self.spec = spec
+        self.output_r_conn = output_r_conn
+        self.state_r_conn = state_r_conn
+        self.control_w_conn = control_w_conn
+        self.log_path = log_path
+        self.explicit = explicit
+        self.prefix_lock: Optional[spack.util.lock.Lock] = None
+
+    def save_to_db(self, db: spack.database.Database) -> None:
+        return db._add(self.spec, explicit=self.explicit)
+
+    def register_with_selector(self, selector: selectors.BaseSelector, pid: int) -> None:
+        """Register output, state, and sentinel channels with the selector."""
+        selector.register(self.output_r_conn.fileno(), selectors.EVENT_READ, FdInfo(pid, "output"))
+        selector.register(self.state_r_conn.fileno(), selectors.EVENT_READ, FdInfo(pid, "state"))
+        selector.register(self.proc.sentinel, selectors.EVENT_READ, FdInfo(pid, "sentinel"))
+
+    def close(self, selector: selectors.BaseSelector) -> int:
+        """Unregister and close file descriptors, and join the child process.
+        Returns the exit code of the child process."""
+        try:
+            selector.unregister(self.output_r_conn.fileno())
+        except KeyError:
+            pass
+        try:
+            selector.unregister(self.state_r_conn.fileno())
+        except KeyError:
+            pass
+        try:
+            selector.unregister(self.proc.sentinel)
+        except (KeyError, ValueError):
+            pass
+        self.output_r_conn.close()
+        self.state_r_conn.close()
+        self.control_w_conn.close()
+        self.proc.join()
+        exit_code = self.proc.exitcode
+        assert exit_code is not None, "Finished build should have exit code set"
+        if hasattr(self.proc, "close"):  # No known equivalent in Python 3.6
+            self.proc.close()
+        return exit_code
+
+
 class JobServerBase(abc.ABC):
     """Abstract base for controlling build concurrency."""
 
@@ -210,3 +275,50 @@ class NoopJobServer(JobServerBase):
     def release(self) -> None: ...
 
     def close(self) -> None: ...
+
+
+class Tee(abc.ABC):
+    """Emulates ./build 2>&1 | tee build.log. Output is sent to a log file and the parent
+    process (if echoing is enabled). The control socket is used to enable/disable echoing."""
+
+    def __init__(
+        self,
+        control: Union[Connection, socket.socket],
+        parent: Union[Connection, socket.socket],
+        log_path: str,
+    ) -> None:
+        self.control = control
+        self.parent = parent
+        # sys.stdout and sys.stderr may have been replaced with file objects under pytest, so
+        # redirect their file descriptors in addition to the original fds 1 and 2.
+        fds = {sys.stdout.fileno(), sys.stderr.fileno(), 1, 2}
+        self.saved_fds = {fd: os.dup(fd) for fd in fds}
+        #: The path of the log file
+        self.log_path = log_path
+        log_file = open(self.log_path, "ab")
+        r, w = os.pipe()
+        self.tee_thread = threading.Thread(target=self.run, args=(r, log_file), daemon=True)
+        self.tee_thread.start()
+        for fd in fds:
+            os.dup2(w, fd)
+        os.close(w)
+
+    @abc.abstractmethod
+    def run(self, log_r: int, log_file: io.BufferedWriter) -> None:
+        """Read from log_r, write to log_file; echo to parent when enabled. Runs in a thread."""
+        pass
+
+    def close(self) -> None:
+        # Closing stdout and stderr should close the last reference to the write end of the pipe,
+        # causing the tee thread to wake up, flush the last data, and exit. We restore stdout and
+        # stderr, because between sys.exit and the actual process exit buffers may be flushed, and
+        # can cause exit code 120 (witnessed under pytest+coverage on macOS).
+        sys.stdout.flush()
+        sys.stderr.flush()
+        for fd, saved_fd in self.saved_fds.items():
+            os.dup2(saved_fd, fd)
+            os.close(saved_fd)
+        self.tee_thread.join()
+        # Only then close the other fds.
+        self.control.close()
+        self.parent.close()

--- a/lib/spack/spack/new_installer_posix.py
+++ b/lib/spack/spack/new_installer_posix.py
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-"""POSIX-specific terminal state and stdin reader for the new_installer TUI."""
+"""POSIX-specific terminal state, stdin reader, IPC channels, and job scheduling."""
 
 import fcntl
 import io
@@ -13,25 +13,21 @@ import signal
 import sys
 import tempfile
 import termios
-import threading
 import tty
 import warnings
-from multiprocessing import Process
 from multiprocessing.connection import Connection
 from typing import TYPE_CHECKING, Any, Callable, Optional, Tuple, Union
 
-import spack.database
 import spack.llnl.util.tty
 import spack.spec
-import spack.util.lock
 from spack.llnl.util.tty.log import _is_background_tty, ignore_signal
 from spack.new_installer_base import (
     OUTPUT_BUFFER_SIZE,
     BaseTerminalState,
-    DatabaseAction,
-    FdInfo,
+    ChildInfo,
     JobServerBase,
     StdinReaderBase,
+    Tee,
 )
 
 if TYPE_CHECKING:
@@ -198,86 +194,11 @@ class PosixTerminalState(BaseTerminalState):
         return not _is_background_tty(sys.stdin)
 
 
-class PosixChildInfo(DatabaseAction):
-    """Information about a child process."""
-
-    __slots__ = ("proc", "output_r_conn", "state_r_conn", "control_w_conn", "explicit", "log_path")
-
-    def __init__(
-        self,
-        proc: Process,
-        spec: spack.spec.Spec,
-        output_r_conn: Connection,
-        state_r_conn: Connection,
-        control_w_conn: Connection,
-        log_path: str,
-        explicit: bool = False,
-    ) -> None:
-        self.proc = proc
-        self.spec = spec
-        self.output_r_conn = output_r_conn
-        self.state_r_conn = state_r_conn
-        self.control_w_conn = control_w_conn
-        self.log_path = log_path
-        self.explicit = explicit
-        self.prefix_lock: Optional[spack.util.lock.Lock] = None
-
-    def save_to_db(self, db: spack.database.Database) -> None:
-        return db._add(self.spec, explicit=self.explicit)
-
-    def register_with_selector(self, selector: selectors.BaseSelector, pid: int) -> None:
-        """Register output, state, and sentinel channels with the selector."""
-        selector.register(self.output_r_conn.fileno(), selectors.EVENT_READ, FdInfo(pid, "output"))
-        selector.register(self.state_r_conn.fileno(), selectors.EVENT_READ, FdInfo(pid, "state"))
-        selector.register(self.proc.sentinel, selectors.EVENT_READ, FdInfo(pid, "sentinel"))
-
-    def close(self, selector: selectors.BaseSelector) -> int:
-        """Unregister and close file descriptors, and join the child process.
-        Returns the exit code of the child process."""
-        try:
-            selector.unregister(self.output_r_conn.fileno())
-        except KeyError:
-            pass
-        try:
-            selector.unregister(self.state_r_conn.fileno())
-        except KeyError:
-            pass
-        try:
-            selector.unregister(self.proc.sentinel)
-        except (KeyError, ValueError):
-            pass
-        self.output_r_conn.close()
-        self.state_r_conn.close()
-        self.control_w_conn.close()
-        self.proc.join()
-        exit_code = self.proc.exitcode
-        assert exit_code is not None, "Finished build should have exit code set"
-        if hasattr(self.proc, "close"):  # No known equivalent in Python 3.6
-            self.proc.close()
-        return exit_code
+class PosixChildInfo(ChildInfo):
+    """Posix Compatible class for Child Information"""
 
 
-class PosixTee:
-    """Emulates ./build 2>&1 | tee build.log. The output is sent both to a log file and the parent
-    process (if echoing is enabled). The control_fd is used to enable/disable echoing."""
-
-    def __init__(self, control: Connection, parent: Connection, log_path: str) -> None:
-        self.control = control
-        self.parent = parent
-        # sys.stdout and sys.stderr may have been replaced with file objects under pytest, so
-        # redirect their file descriptors in addition to the original fds 1 and 2.
-        fds = {sys.stdout.fileno(), sys.stderr.fileno(), 1, 2}
-        self.saved_fds = {fd: os.dup(fd) for fd in fds}
-        #: The path of the log file
-        self.log_path = log_path
-        log_file = open(self.log_path, "ab")
-        r, w = os.pipe()
-        self.tee_thread = threading.Thread(target=self.run, args=(r, log_file), daemon=True)
-        self.tee_thread.start()
-        for fd in fds:
-            os.dup2(w, fd)
-        os.close(w)
-
+class PosixTee(Tee):
     def run(self, log_r: int, log_file: io.BufferedWriter) -> None:
         """Forward log_r to log_file and parent (if echoing is enabled).
         Echoing is enabled and disabled by reading from control."""
@@ -312,21 +233,6 @@ class PosixTee:
             pass
         finally:
             os.close(log_r)
-
-    def close(self) -> None:
-        # Closing stdout and stderr should close the last reference to the write end of the pipe,
-        # causing the tee thread to wake up, flush the last data, and exit. We restore stdout and
-        # stderr, because between sys.exit and the actual process exit buffers may be flushed, and
-        # can cause exit code 120 (witnessed under pytest+coverage on macOS).
-        sys.stdout.flush()
-        sys.stderr.flush()
-        for fd, saved_fd in self.saved_fds.items():
-            os.dup2(saved_fd, fd)
-            os.close(saved_fd)
-        self.tee_thread.join()
-        # Only then close the other fds.
-        self.control.close()
-        self.parent.close()
 
 
 class PosixJobServer(JobServerBase):

--- a/lib/spack/spack/new_installer_posix.py
+++ b/lib/spack/spack/new_installer_posix.py
@@ -197,6 +197,18 @@ class PosixTerminalState(BaseTerminalState):
 class PosixChildInfo(ChildInfo):
     """Posix Compatible class for Child Information"""
 
+    @property
+    def output_connection_handle(self):
+        return self.output_r_conn.fileno()
+
+    @property
+    def state_connection_handle(self):
+        return self.state_r_conn.fileno()
+
+    @property
+    def sentinel(self):
+        return self.proc.sentinel
+
 
 class PosixTee(Tee):
     def run(self, log_r: int, log_file: io.BufferedWriter) -> None:

--- a/lib/spack/spack/new_installer_posix.py
+++ b/lib/spack/spack/new_installer_posix.py
@@ -26,6 +26,7 @@ from spack.new_installer_base import (
     BaseTerminalState,
     ChildInfo,
     JobServerBase,
+    StateChannel,
     StdinReaderBase,
     Tee,
 )
@@ -445,3 +446,17 @@ def open_existing_jobserver_fifo(fifo_path: str) -> Optional[Tuple[int, int]]:
         return read_fd, write_fd
     except OSError:
         return None
+
+
+def make_state_stream(state: StateChannel) -> io.TextIOWrapper:
+    """Wrap the write end of the state Pipe as a line-buffered text stream."""
+    return os.fdopen(state.fileno(), "w", buffering=1, closefd=False)
+
+
+def read_connection(key: selectors.SelectorKey, max_size: int = 4096) -> bytes:
+    """Read from a selector key using os.read() on the key fd."""
+    return os.read(key.fd, max_size)
+
+
+def write_connection(conn: StateChannel, data: bytes) -> None:
+    os.write(conn.fileno(), data)

--- a/lib/spack/spack/new_installer_windows.py
+++ b/lib/spack/spack/new_installer_windows.py
@@ -2,22 +2,33 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-"""Windows-specific terminal state and stdin reader for the new_installer TUI."""
+"""Windows-specific terminal state, stdin reader, IPC channels, and job scheduling."""
 
 import ctypes
+import io
 import msvcrt
+import os
 import selectors
 import shutil
 import socket
 import threading
 import time
 from ctypes import wintypes
-from typing import TYPE_CHECKING, Callable, Optional
+from multiprocessing import Process
+from typing import TYPE_CHECKING, Callable, List, Optional, cast
 
-from spack.new_installer_base import BaseTerminalState, StdinReaderBase
+from spack.new_installer_base import (
+    OUTPUT_BUFFER_SIZE,
+    BaseTerminalState,
+    ChildInfo,
+    StateChannel,
+    StdinReaderBase,
+    Tee,
+)
 
 if TYPE_CHECKING:
     from spack.new_installer import BuildStatus
+    from spack.spec import Spec
 
 # Windows console mode flags
 ENABLE_LINE_INPUT = 0x0002
@@ -25,6 +36,8 @@ ENABLE_ECHO_INPUT = 0x0004
 ENABLE_QUICK_EDIT_MODE = 0x0040
 ENABLE_EXTENDED_FLAGS = 0x0080
 ENABLE_VIRTUAL_TERMINAL_PROCESSING = 0x0004  # for stdout handle
+WIN_STD_OUTPUT_HANDLE = -11
+WIN_STD_ERROR_HANDLE = -12
 
 
 class WindowsStdinReader(StdinReaderBase):
@@ -178,3 +191,157 @@ class WindowsTerminalState(BaseTerminalState):
                     self.sigwinch_w.sendall(b"\x00")
                 except OSError:
                     pass
+
+
+class WindowsSentinelBridge:
+    """Waits for a process to exit and sends a byte to a socket to wake the selector."""
+
+    def __init__(self, proc: Process) -> None:
+        self.rsock, self.wsock = socket.socketpair()
+        self.rsock.setblocking(False)
+        self.proc = proc
+        self.thread = threading.Thread(target=self._wait, daemon=True)
+        self.thread.start()
+
+    def _wait(self) -> None:
+        self.proc.join()
+        try:
+            self.wsock.sendall(b"x")
+        except OSError:
+            pass
+        self.wsock.close()
+
+    def fileno(self) -> int:
+        return self.rsock.fileno()
+
+    def recv(self, size: int) -> bytes:
+        try:
+            return self.rsock.recv(size)
+        except BlockingIOError:
+            return b""
+
+    def close(self) -> None:
+        self.rsock.close()
+
+
+class WindowsChildInfo(ChildInfo):
+    """ChildInfo for Windows: output and state use socket.socketpair(); sentinel via bridge."""
+
+    __slots__ = ("bridge",)
+
+    def __init__(
+        self,
+        proc: Process,
+        spec: "Spec",
+        output_r_conn: socket.socket,
+        state_r_conn: socket.socket,
+        control_w_conn: socket.socket,
+        log_path: str,
+        explicit: bool = False,
+    ) -> None:
+        super().__init__(
+            proc, spec, output_r_conn, state_r_conn, control_w_conn, log_path, explicit
+        )
+        self.bridge: Optional[WindowsSentinelBridge] = None
+
+    @property
+    def output_connection_handle(self):
+        return self.output_r_conn
+
+    @property
+    def state_connection_handle(self):
+        return self.state_r_conn
+
+    @property
+    def sentinel(self):
+        return self.bridge
+
+    def _setup_handles(self) -> None:
+        cast(socket.socket, self.output_r_conn).setblocking(False)
+        cast(socket.socket, self.state_r_conn).setblocking(False)
+        self.bridge = WindowsSentinelBridge(self.proc)
+
+    def _cleanup_handles(self) -> None:
+        if self.bridge is not None:
+            self.bridge.close()
+        super()._cleanup_handles()
+
+
+class WindowsTee(Tee):
+    """Tee for Windows: control and parent channels are sockets; stdout/stderr handles are
+    redirected via SetStdHandle so the child process inherits the write end of the pipe."""
+
+    def run(self, log_r: int, log_file: io.BufferedWriter) -> None:
+        _echo: List[bool] = [False]
+        control_r = cast(socket.socket, self.control)
+        parent_w = cast(socket.socket, self.parent)
+
+        def _control_reader() -> None:
+            nonlocal _echo
+            while True:
+                try:
+                    data = control_r.recv(1)
+                    if not data:
+                        break
+                    _echo[0] = data == b"1"
+                except OSError:
+                    break
+
+        threading.Thread(target=_control_reader, daemon=True).start()
+        try:
+            with log_file:
+                while True:
+                    try:
+                        data = os.read(log_r, OUTPUT_BUFFER_SIZE)
+                    except OSError:
+                        break
+                    if not data:
+                        break
+                    log_file.write(data)
+                    log_file.flush()
+                    if _echo[0]:
+                        try:
+                            parent_w.sendall(data)
+                        except OSError:
+                            pass
+        finally:
+            os.close(log_r)
+
+    def _setup_handles(self) -> None:
+        kernel32 = ctypes.windll.kernel32  # type: ignore[attr-defined]
+        self._saved_win32_stdout = kernel32.GetStdHandle(WIN_STD_OUTPUT_HANDLE)
+        self._saved_win32_stderr = kernel32.GetStdHandle(WIN_STD_ERROR_HANDLE)
+        h_write = msvcrt.get_osfhandle(1)  # type: ignore[attr-defined]
+        os.set_handle_inheritable(h_write, True)  # type: ignore[attr-defined]
+        kernel32.SetStdHandle(WIN_STD_OUTPUT_HANDLE, h_write)  # type: ignore[attr-defined]
+        kernel32.SetStdHandle(WIN_STD_ERROR_HANDLE, h_write)  # type: ignore[attr-defined]
+        self._h_write = h_write
+
+    def _restore_handles(self) -> None:
+        kernel32 = ctypes.windll.kernel32  # type: ignore[attr-defined]
+        kernel32.SetStdHandle(WIN_STD_OUTPUT_HANDLE, self._saved_win32_stdout)
+        kernel32.SetStdHandle(WIN_STD_ERROR_HANDLE, self._saved_win32_stderr)
+
+
+def make_state_stream(state: StateChannel) -> io.TextIOWrapper:
+    """Wrap the write end of the state socketpair as a line-buffered text stream."""
+    return cast(socket.socket, state).makefile("w", buffering=1, encoding="utf-8")
+
+
+def read_connection(key: selectors.SelectorKey, max_size: int = 4096) -> bytes:
+    """Read from a selector key using os.read() on the key fd."""
+    try:
+        return cast(socket.socket, key.fileobj).recv(max_size)
+    except BlockingIOError:
+        # caller handles: spurious wakeup, same on POSIX and Windows
+        # need to short circuit to prevent OS error from catching
+        raise
+    except (EOFError, OSError):
+        # normalize EOF/connection-closed to empty bytes
+        # aligns Windows socket behavior with posix pipe behavior
+        return b""
+
+
+def write_connection(conn: StateChannel, data: bytes) -> None:
+    """Write to a socket connection endpoint"""
+    cast(socket.socket, conn).sendall(data)


### PR DESCRIPTION
Based on #52482 

Facillitates IPC on Windows with the new installer via sockets

Breaks ChildInfo down into subclasses, with the posix side untouched and the windows side output/state use socket.socketpair().
Registers socket objects and a WindowsSentinelBridge.

WindowsSentinelBridge wraps a thread that calls proc.join() and writes a byte to a socket to wake the selector when the process exits (Windows cannot register process sentinels with a selector directly).

read_from_key() abstracts reads across fds and sockets: uses recv() when the selector key's fileobj has it, os.read() otherwise. This lets _handle_child_logs/state use one invocation for both platforms.

tee() is split into _tee_posix() (same as before) and _tee_windows() (thread-based control reader using sockets).

State buffer and decoder refactored to be keyed by pid rather than fd, and _handle_child_state extracts _process_state_string() for clarity.
Output is processed to support multibyte chars

JobServer is essentially disabled on Windows (to be done in later work, likely post release unless we get this in quickly somehow)