### PR TITLE
solver: speed-up setup phase

### DIFF
--- a/lib/spack/spack/solver/core.py
+++ b/lib/spack/spack/solver/core.py
@@ -63,8 +63,7 @@ class AspFunction:
         parts = []
         for arg in self.args:
             if type(arg) is str:
-                if "\\" in arg or "\n" in arg or '"' in arg:
-                    arg = arg.replace("\\", r"\\").replace("\n", r"\n").replace('"', r"\"")
+                arg = arg.replace("\\", r"\\").replace("\n", r"\n").replace('"', r"\"")
                 parts.append(f'"{arg}"')
             elif type(arg) is AspFunction or type(arg) is int or type(arg) is AspVar:
                 parts.append(str(arg))

--- a/lib/spack/spack/solver/core.py
+++ b/lib/spack/spack/solver/core.py
@@ -57,7 +57,7 @@ class AspFunction:
             attr("version", "foo", "bar")
 
         """
-        return AspFunction(self.name, self.args + args)
+        return AspFunction(self.name, args if not self.args else self.args + args)
 
     def __str__(self) -> str:
         parts = []

--- a/lib/spack/spack/solver/core.py
+++ b/lib/spack/spack/solver/core.py
@@ -77,7 +77,9 @@ class AspFunction:
 
 class _AspFunctionBuilder:
     def __getattr__(self, name: str) -> AspFunction:
-        # This is safe to do because AspFunction objects are never mutated
+        # Writing to __dict__ directly caches the result so repeated access to the
+        # same name bypasses __getattr__ and hits the instance dict instead.
+        # Safe because AspFunction objects are never mutated.
         f = AspFunction(name)
         self.__dict__[name] = f
         return f

--- a/lib/spack/spack/solver/core.py
+++ b/lib/spack/spack/solver/core.py
@@ -63,7 +63,8 @@ class AspFunction:
         parts = []
         for arg in self.args:
             if type(arg) is str:
-                arg = arg.replace("\\", r"\\").replace("\n", r"\n").replace('"', r"\"")
+                if '\\' in arg or '\n' in arg or '"' in arg:
+                    arg = arg.replace("\\", r"\\").replace("\n", r"\n").replace('"', r"\"")
                 parts.append(f'"{arg}"')
             elif type(arg) is AspFunction or type(arg) is int or type(arg) is AspVar:
                 parts.append(str(arg))
@@ -77,7 +78,10 @@ class AspFunction:
 
 class _AspFunctionBuilder:
     def __getattr__(self, name: str) -> AspFunction:
-        return AspFunction(name)
+        # This is safe to do because AspFunction objects are never mutated
+        f = AspFunction(name)
+        self.__dict__[name] = f
+        return f
 
 
 #: Global AspFunction builder

--- a/lib/spack/spack/solver/core.py
+++ b/lib/spack/spack/solver/core.py
@@ -63,7 +63,7 @@ class AspFunction:
         parts = []
         for arg in self.args:
             if type(arg) is str:
-                if '\\' in arg or '\n' in arg or '"' in arg:
+                if "\\" in arg or "\n" in arg or '"' in arg:
                     arg = arg.replace("\\", r"\\").replace("\n", r"\n").replace('"', r"\"")
                 parts.append(f'"{arg}"')
             elif type(arg) is AspFunction or type(arg) is int or type(arg) is AspVar:

--- a/lib/spack/spack/solver/input_analysis.py
+++ b/lib/spack/spack/solver/input_analysis.py
@@ -246,7 +246,6 @@ class NoStaticAnalysis(PossibleDependencyGraph):
             dep.depflag & allowed_deps for deplist in dependencies.values() for dep in deplist
         )
 
-    @lang.memoized
     def _is_possible(self, *, pkg_name):
         try:
             return self.is_allowed_on_this_platform(pkg_name=pkg_name) and self.can_be_installed(

--- a/lib/spack/spack/solver/input_analysis.py
+++ b/lib/spack/spack/solver/input_analysis.py
@@ -246,6 +246,7 @@ class NoStaticAnalysis(PossibleDependencyGraph):
             dep.depflag & allowed_deps for deplist in dependencies.values() for dep in deplist
         )
 
+    @lang.memoized
     def _is_possible(self, *, pkg_name):
         try:
             return self.is_allowed_on_this_platform(pkg_name=pkg_name) and self.can_be_installed(
@@ -459,9 +460,9 @@ class MinimalDuplicatesCounter(NoDuplicatesCounter):
         )
         self._possible_virtuals.update(virtuals)
         self._link_run_virtuals.update(virtuals)
-        for x in self._link_run:
+        if self._link_run:
             reals, virtuals, _ = self.possible_graph.possible_dependencies(
-                x, allowed_deps=dt.BUILD, transitive=False, strict_depflag=True
+                *self._link_run, allowed_deps=dt.BUILD, transitive=False, strict_depflag=True
             )
             self._possible_virtuals.update(virtuals)
             self._direct_build.update(reals)

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -6012,6 +6012,7 @@ class _ImmutableSpec(Spec):
     """An immutable Spec that prevents a class of accidental mutations."""
 
     _mutable: bool
+    _str_cache: str
 
     def __init__(self, spec_like: Optional[str] = None) -> None:
         object.__setattr__(self, "_mutable", True)
@@ -6030,6 +6031,15 @@ class _ImmutableSpec(Spec):
     def add_dependency_edge(self, *args, **kwargs):
         assert self._mutable
         return super().add_dependency_edge(*args, **kwargs)
+
+    def __str__(self) -> str:
+        # Cache the str value of immutable specs as an optimization
+        try:
+            return self._str_cache
+        except AttributeError:
+            s = self._str(color=False)
+            object.__setattr__(self, "_str_cache", s)
+            return s
 
     def __setattr__(self, name, value) -> None:
         assert self._mutable

--- a/lib/spack/spack/variant.py
+++ b/lib/spack/spack/variant.py
@@ -598,6 +598,9 @@ class DisjointSetsOfValues(collections.abc.Sequence):
         )
         return object_without_empty_set
 
+    def __iter__(self):
+        return itertools.chain.from_iterable(self.sets)
+
     def __getitem__(self, idx):
         return tuple(itertools.chain.from_iterable(self.sets))[idx]
 


### PR DESCRIPTION
Modifications:
- Skip the triple `str.replace()` in `AspFunction.__str__` when the argument contains no characters that need escaping.
- Cache base `AspFunction` instances in `_AspFunctionBuilder` so repeated use of `fn.some_name` reuse the same object. This is safe because `__call__` always returns a new instance.
- Add `__iter__` to `DisjointSetOfValues`
- Cache `__str__` for `ImmutableSpec`

<img width="2000" height="1000" alt="comparison" src="https://github.com/user-attachments/assets/6130ff90-6718-466c-9b38-ca1cc3cd049b" />
