### PR TITLE
Locks: Complete higher level lock interface

### DIFF
--- a/lib/spack/spack/database.py
+++ b/lib/spack/spack/database.py
@@ -361,7 +361,9 @@ class SpecLocker:
 
         return self.locks[key]
 
-    def raw_lock(self, spec: "spack.spec.Spec", timeout: Optional[float] = None) -> lk.LockInterface:
+    def raw_lock(
+        self, spec: "spack.spec.Spec", timeout: Optional[float] = None
+    ) -> lk.LockInterface:
         """Returns a raw lock for a Spec, but doesn't keep track of it."""
         return lk.lock(
             str(self.lock_path),

--- a/lib/spack/spack/database.py
+++ b/lib/spack/spack/database.py
@@ -337,9 +337,9 @@ class SpecLocker:
         self.default_timeout = default_timeout
 
         # Maps (spec.dag_hash(), spec.name) to the corresponding lock object
-        self.locks: Dict[Tuple[str, str], lk.Lock] = {}
+        self.locks: Dict[Tuple[str, str], lk.LockInterface] = {}
 
-    def lock(self, spec: "spack.spec.Spec", timeout: Optional[float] = None) -> lk.Lock:
+    def lock(self, spec: "spack.spec.Spec", timeout: Optional[float] = None) -> lk.LockInterface:
         """Returns a lock on a concrete spec.
 
         The lock is a byte range lock on the nth byte of a file.
@@ -361,9 +361,9 @@ class SpecLocker:
 
         return self.locks[key]
 
-    def raw_lock(self, spec: "spack.spec.Spec", timeout: Optional[float] = None) -> lk.Lock:
+    def raw_lock(self, spec: "spack.spec.Spec", timeout: Optional[float] = None) -> lk.LockInterface:
         """Returns a raw lock for a Spec, but doesn't keep track of it."""
-        return lk.Lock(
+        return lk.lock(
             str(self.lock_path),
             start=spec.dag_hash_bit_prefix(bit_length(sys.maxsize)),
             length=1,
@@ -395,12 +395,12 @@ class SpecLocker:
         else:
             lock.release_write()
 
-    def clear(self, spec: "spack.spec.Spec") -> Tuple[bool, Optional[lk.Lock]]:
+    def clear(self, spec: "spack.spec.Spec") -> Tuple[bool, Optional[lk.LockInterface]]:
         key = self._lock_key(spec)
         lock = self.locks.pop(key, None)
         return bool(lock), lock
 
-    def clear_all(self, clear_fn: Optional[Callable[[lk.Lock], Any]] = None) -> None:
+    def clear_all(self, clear_fn: Optional[Callable[[lk.LockInterface], Any]] = None) -> None:
         if clear_fn is not None:
             for lock in self.locks.values():
                 clear_fn(lock)
@@ -496,7 +496,7 @@ class FailureTracker:
             except OSError as exc:
                 tty.warn(f"Unable to remove failure marking file {fail_mark}: {str(exc)}")
 
-    def mark(self, spec: "spack.spec.Spec") -> lk.Lock:
+    def mark(self, spec: "spack.spec.Spec") -> lk.LockInterface:
         """Marks a spec as failing to install.
 
         Args:
@@ -611,11 +611,11 @@ class Database:
         self.db_lock_timeout = lock_cfg.database_timeout
         tty.debug(f"DATABASE LOCK TIMEOUT: {str(self.db_lock_timeout)}s")
 
-        self.lock: Union[ForbiddenLock, lk.Lock]
+        self.lock: Union[ForbiddenLock, lk.LockInterface]
         if self.is_upstream:
             self.lock = ForbiddenLock()
         else:
-            self.lock = lk.Lock(
+            self.lock = lk.lock(
                 str(self._lock_path),
                 default_timeout=self.db_lock_timeout,
                 desc="database",

--- a/lib/spack/spack/environment/environment.py
+++ b/lib/spack/spack/environment/environment.py
@@ -1055,7 +1055,7 @@ class Environment:
         self.name = environment_name(self.path)
         self.env_subdir_path = env_subdir_path(self.path)
 
-        self.txlock = lk.Lock(self._transaction_lock_path)
+        self.txlock = lk.lock(self._transaction_lock_path)
 
         self._unify = None
         self.views: Dict[str, ViewDescriptor] = {}
@@ -1129,7 +1129,7 @@ class Environment:
 
     def __setstate__(self, state):
         self.__dict__.update(state)
-        self.txlock = lk.Lock(self._transaction_lock_path)
+        self.txlock = lk.lock(self._transaction_lock_path)
         self._repo = None
 
     def _re_read(self):

--- a/lib/spack/spack/installer.py
+++ b/lib/spack/spack/installer.py
@@ -1569,7 +1569,7 @@ class PackageInstaller:
         self.build_tasks: Dict[str, Task] = {}
 
         # Cache of package locks for failed packages, keyed on package's ids
-        self.failed: Dict[str, Optional[lk.Lock]] = {}
+        self.failed: Dict[str, Optional[lk.LockInterface]] = {}
 
         # Cache the PID for distributed build messaging
         self.pid: int = os.getpid()
@@ -1581,7 +1581,7 @@ class PackageInstaller:
         self.layout = spack.store.STORE.layout
 
         # Locks on specs being built, keyed on the package's unique id
-        self.locks: Dict[str, Tuple[str, Optional[lk.Lock]]] = {}
+        self.locks: Dict[str, Tuple[str, Optional[lk.LockInterface]]] = {}
 
         # Cache fail_fast option to ensure if one build request asks to fail
         # fast then that option applies to all build requests.
@@ -1821,7 +1821,7 @@ class PackageInstaller:
 
     def _ensure_locked(
         self, lock_type: str, pkg: "spack.package_base.PackageBase"
-    ) -> Tuple[str, Optional[lk.Lock]]:
+    ) -> Tuple[str, Optional[lk.LockInterface]]:
         """
         Add a prefix lock of the specified type for the package spec
 

--- a/lib/spack/spack/llnl/util/lock.py
+++ b/lib/spack/spack/llnl/util/lock.py
@@ -21,6 +21,7 @@ if sys.platform != "win32":
 
 __all__ = [
     "Lock",
+    "LockInterface",
     "LockDowngradeError",
     "LockUpgradeError",
     "LockTransaction",
@@ -173,7 +174,85 @@ class LockType:
         return op == LockType.READ or op == LockType.WRITE
 
 
-class Lock:
+class LockInterface:
+    """Base class / no-op implementation of the lock interface.
+
+    All methods are no-ops that return default values. ``release_read`` and
+    ``release_write`` still invoke ``release_fn`` so that ``LockTransaction``
+    teardown callbacks are invoked even when locking is disabled.
+
+    Used when locking is disabled.
+    """
+
+    def __init__(
+        self,
+        path: str,
+        *,
+        start: int = 0,
+        length: int = 0,
+        default_timeout: Optional[float] = None,
+        debug: bool = False,
+        desc: str = "",
+    ) -> None:
+        self.path = path
+
+        # byte range parameters
+        self._start = start
+        self._length = length
+
+        # enable debug mode
+        self.debug = debug
+
+        # optional debug description
+        self.desc = f" ({desc})" if desc else ""
+
+        # If the user doesn't set a default timeout, or if they choose
+        # None, 0, etc. then lock attempts will not time out (unless the
+        # user sets a timeout for each attempt)
+        self.default_timeout = default_timeout or None
+
+        # PID and host of lock holder (only used in debug mode)
+        self.pid: Optional[int] = None
+        self.old_pid: Optional[int] = None
+        self.host: Optional[str] = None
+        self.old_host: Optional[str] = None
+
+    def acquire_read(self, timeout: Optional[float] = None) -> bool:
+        return True
+
+    def acquire_write(self, timeout: Optional[float] = None) -> bool:
+        return True
+
+    def try_acquire_read(self) -> bool:
+        return True
+
+    def try_acquire_write(self) -> bool:
+        return True
+
+    def is_write_locked(self) -> bool:
+        return False
+
+    def downgrade_write_to_read(self, timeout: Optional[float] = None) -> None:
+        pass
+
+    def upgrade_read_to_write(self, timeout: Optional[float] = None) -> None:
+        pass
+
+    def release_read(self, release_fn: ReleaseFnType = None) -> bool:
+        if release_fn is not None:
+            return bool(release_fn())
+        return True
+
+    def release_write(self, release_fn: ReleaseFnType = None) -> bool:
+        if release_fn is not None:
+            return bool(release_fn())
+        return True
+
+    def cleanup(self) -> None:
+        pass
+
+
+class Lock(LockInterface):
     """This is an implementation of a filesystem lock using Python's lockf.
 
     In Python, ``lockf`` actually calls ``fcntl``, so this should work with any filesystem
@@ -216,32 +295,18 @@ class Lock:
             desc: optional debug message lock description, which is helpful for distinguishing
                 between different Spack locks.
         """
-        self.path = path
+        super().__init__(
+            path,
+            start=start,
+            length=length,
+            default_timeout=default_timeout,
+            debug=debug,
+            desc=desc,
+        )
         self._reads = 0
         self._writes = 0
         self._file_ref: Optional[OpenFile] = None
         self._cached_key: Optional[DevIno] = None
-
-        # byte range parameters
-        self._start = start
-        self._length = length
-
-        # enable debug mode
-        self.debug = debug
-
-        # optional debug description
-        self.desc = f" ({desc})" if desc else ""
-
-        # If the user doesn't set a default timeout, or if they choose
-        # None, 0, etc. then lock attempts will not time out (unless the
-        # user sets a timeout for each attempt)
-        self.default_timeout = default_timeout or None
-
-        # PID and host of lock holder (only used in debug mode)
-        self.pid: Optional[int] = None
-        self.old_pid: Optional[int] = None
-        self.host: Optional[str] = None
-        self.old_host: Optional[str] = None
 
     def _ensure_valid_handle(self) -> IO[bytes]:
         """Return a valid file handle for the lock file, opening or re-opening as needed.
@@ -758,7 +823,7 @@ class LockTransaction:
 
     def __init__(
         self,
-        lock: Lock,
+        lock: LockInterface,
         acquire: Optional[Callable[[], None]] = None,
         release: Optional[ExitFnType] = None,
         timeout: Optional[float] = None,

--- a/lib/spack/spack/new_installer.py
+++ b/lib/spack/spack/new_installer.py
@@ -130,7 +130,7 @@ class DatabaseAction:
     __slots__ = ("spec", "prefix_lock")
 
     spec: "spack.spec.Spec"
-    prefix_lock: Optional[spack.util.lock.Lock]
+    prefix_lock: Optional[spack.util.lock.LockInterface]
 
     def save_to_db(self, db: spack.database.Database) -> None: ...
 
@@ -179,7 +179,7 @@ class ChildInfo(DatabaseAction):
         self.control_w_conn = control_w_conn
         self.log_path = log_path
         self.explicit = explicit
-        self.prefix_lock: Optional[spack.util.lock.Lock] = None
+        self.prefix_lock: Optional[spack.util.lock.LockInterface] = None
 
     def save_to_db(self, db: spack.database.Database) -> None:
         return db._add(self.spec, explicit=self.explicit)
@@ -1930,10 +1930,10 @@ class ScheduleResult(NamedTuple):
     blocked: bool
     #: ``(dag_hash, lock)`` pairs where the write lock is held and the caller must start the build
     #: and eventually release the lock.
-    to_start: List[Tuple[str, spack.util.lock.Lock]]
+    to_start: List[Tuple[str, spack.util.lock.LockInterface]]
     #: ``(dag_hash, spec, lock)`` triples found already installed by another process; the read lock
     #: is held and the caller must add it to retained_read_locks.
-    newly_installed: List[Tuple[str, spack.spec.Spec, spack.util.lock.Lock]]
+    newly_installed: List[Tuple[str, spack.spec.Spec, spack.util.lock.LockInterface]]
     #: Actions to mark already installed specs explicit in the DB.
     to_mark_explicit: List[MarkExplicitAction]
 
@@ -1980,8 +1980,8 @@ def schedule_builds(
         A :class:`ScheduleResult` with ``blocked``, ``to_start``, and ``newly_installed``
         fields; see :class:`ScheduleResult` for field semantics.
     """
-    to_start: List[Tuple[str, spack.util.lock.Lock]] = []
-    newly_installed: List[Tuple[str, spack.spec.Spec, spack.util.lock.Lock]] = []
+    to_start: List[Tuple[str, spack.util.lock.LockInterface]] = []
+    newly_installed: List[Tuple[str, spack.spec.Spec, spack.util.lock.LockInterface]] = []
     to_mark_explicit: List[MarkExplicitAction] = []
     blocked = True
 
@@ -2528,7 +2528,7 @@ class PackageInstaller:
         # Finished builds that have not yet been written to the database.
         database_actions: List[DatabaseAction] = []
         # Prefix read locks retained after DB flush (downgraded from write locks in _save_to_db).
-        retained_read_locks: List[spack.util.lock.Lock] = []
+        retained_read_locks: List[spack.util.lock.LockInterface] = []
 
         failures: List[spack.spec.Spec] = []
         finished_pids: List[int] = []
@@ -2832,7 +2832,7 @@ class PackageInstaller:
     def _save_to_db(
         self,
         database_actions: List[DatabaseAction],
-        retained_read_locks: List[spack.util.lock.Lock],
+        retained_read_locks: List[spack.util.lock.LockInterface],
     ) -> bool:
         if not self.db.lock.try_acquire_write():
             return False
@@ -2862,7 +2862,7 @@ class PackageInstaller:
         self,
         selector: selectors.BaseSelector,
         jobserver: JobServer,
-        retained_read_locks: List[spack.util.lock.Lock],
+        retained_read_locks: List[spack.util.lock.LockInterface],
         database_actions: List[DatabaseAction],
     ) -> bool:
         """Try to schedule as many pending builds as possible.
@@ -2923,7 +2923,7 @@ class PackageInstaller:
         selector: selectors.BaseSelector,
         jobserver: JobServer,
         dag_hash: str,
-        prefix_lock: spack.util.lock.Lock,
+        prefix_lock: spack.util.lock.LockInterface,
     ) -> None:
         self.capacity -= 1
         explicit = dag_hash in self.explicit

--- a/lib/spack/spack/repo.py
+++ b/lib/spack/spack/repo.py
@@ -72,9 +72,9 @@ _API_REGEX = re.compile(r"^v(\d+)\.(\d+)$")
 SPACK_REPO_INDEX_FILE_NAME = "spack-repo-index.yaml"
 
 
-def package_repository_lock() -> spack.util.lock.Lock:
+def package_repository_lock() -> spack.util.lock.LockInterface:
     """Lock for process safety when cloning remote package repositories"""
-    return spack.util.lock.Lock(
+    return spack.util.lock.lock(
         os.path.join(spack.paths.user_cache_path, "package-repository.lock")
     )
 
@@ -1741,7 +1741,7 @@ class RemoteRepoDescriptor(RepoDescriptor):
         tag: Optional[str],
         destination: str,
         relative_paths: Optional[List[str]],
-        lock: spack.util.lock.Lock,
+        lock: spack.util.lock.LockInterface,
     ) -> None:
         super().__init__(name)
         self.repository = repository
@@ -1982,7 +1982,7 @@ class RepoDescriptors(Mapping[str, RepoDescriptor]):
 
     @staticmethod
     def from_config(
-        lock: spack.util.lock.Lock, config: spack.config.Configuration, scope=None
+        lock: spack.util.lock.LockInterface, config: spack.config.Configuration, scope=None
     ) -> "RepoDescriptors":
         return RepoDescriptors(
             {
@@ -2027,7 +2027,7 @@ class RepoDescriptors(Mapping[str, RepoDescriptor]):
 
 
 def parse_config_descriptor(
-    name: Optional[str], descriptor: Any, lock: spack.util.lock.Lock
+    name: Optional[str], descriptor: Any, lock: spack.util.lock.LockInterface
 ) -> RepoDescriptor:
     """Parse a repository descriptor from validated configuration. This does not instantiate Repo
     objects, but merely turns the config into a more useful RepoDescriptor instance.

--- a/lib/spack/spack/stage.py
+++ b/lib/spack/spack/stage.py
@@ -265,7 +265,7 @@ class AbstractStage(abc.ABC):
             sha1 = hashlib.sha1(self.name.encode("utf-8")).digest()
             lock_id = prefix_bits(sha1, bit_length(sys.maxsize))
             stage_lock_path = os.path.join(get_stage_root(), ".lock")
-            self._lock = spack.util.lock.Lock(
+            self._lock = spack.util.lock.lock(
                 stage_lock_path, start=lock_id, length=1, desc=self.name
             )
         return self._lock

--- a/lib/spack/spack/test/database.py
+++ b/lib/spack/spack/test/database.py
@@ -59,7 +59,7 @@ def writable(database):
 
     try:
         # this is safe on all platforms during tests (tests get their own tmpdirs)
-        database.lock = spack.util.lock.Lock(str(database._lock_path), enable=False)
+        database.lock = spack.util.lock.lock(str(database._lock_path), enable=False)
         database.is_upstream = False
         db_root.chmod(mode=0o755)
         with database.write_transaction():
@@ -1007,11 +1007,12 @@ def test_clear_failure_forced(mutable_database, monkeypatch, capfd):
     assert "Unable to remove failure marking" in out
 
 
+@pytest.mark.skipif(sys.platform == "win32", reason="Locking currently unsupported on Windows")
 @pytest.mark.db
 def test_mark_failed(mutable_database, monkeypatch, tmp_path: pathlib.Path, capfd):
     """Add coverage to mark_failed."""
 
-    def _raise_exc(lock):
+    def _raise_exc(lock, timeout=None):
         raise lk.LockTimeoutError(lk.LockType.WRITE, "/mock-lock", 1.234, 10)
 
     with fs.working_dir(str(tmp_path)):
@@ -1052,7 +1053,7 @@ def test_prefix_failed(mutable_database, monkeypatch):
 def test_prefix_write_lock_error(mutable_database, monkeypatch):
     """Cover the prefix write lock exception."""
 
-    def _raise(db, spec):
+    def _raise(lock, timeout=None):
         raise lk.LockError("Mock lock error")
 
     s = spack.concretize.concretize_one("pkg-a")

--- a/lib/spack/spack/test/installer.py
+++ b/lib/spack/spack/test/installer.py
@@ -932,10 +932,10 @@ def test_cleanup_failed_err(install_mockery, tmp_path: pathlib.Path, monkeypatch
 
     installer = create_installer(["trivial-install-test-package"], {})
 
-    monkeypatch.setattr(ulk.LockInterface, "release_write", _raise_except)
     pkg_id = "test"
     with fs.working_dir(str(tmp_path)):
         lock = lk.lock("./test", default_timeout=1e-9, desc="test")
+        monkeypatch.setattr(type(lock), "release_write", _raise_except)
         installer.failed[pkg_id] = lock
 
         installer._cleanup_failed(pkg_id)

--- a/lib/spack/spack/test/installer.py
+++ b/lib/spack/spack/test/installer.py
@@ -386,7 +386,7 @@ def test_ensure_locked_new_lock(install_mockery, tmp_path: pathlib.Path, lock_ty
     with fs.working_dir(str(tmp_path)):
         ltype, lock = installer._ensure_locked(lock_type, spec.package)
         assert ltype == lock_type
-        assert lock is not None
+        assert isinstance(lock, lk.Lock)
         assert lock._reads == reads
         assert lock._writes == writes
 

--- a/lib/spack/spack/test/installer.py
+++ b/lib/spack/spack/test/installer.py
@@ -321,6 +321,7 @@ def test_installer_ensure_ready_errors(install_mockery, monkeypatch):
         installer._ensure_install_ready(spec.package)
 
 
+@pytest.mark.skipif(sys.platform == "win32", reason="locks are no-ops on Windows")
 def test_ensure_locked_err(install_mockery, monkeypatch, tmp_path: pathlib.Path, capfd):
     """Test _ensure_locked when a non-lock exception is raised."""
     mock_err_msg = "Mock exception error"
@@ -341,6 +342,7 @@ def test_ensure_locked_err(install_mockery, monkeypatch, tmp_path: pathlib.Path,
         assert mock_err_msg in out
 
 
+@pytest.mark.skipif(sys.platform == "win32", reason="locks are no-ops on Windows")
 def test_ensure_locked_have(install_mockery, tmp_path: pathlib.Path, capfd):
     """Test _ensure_locked when already have lock."""
     installer = create_installer(["trivial-install-test-package"], {})
@@ -349,7 +351,7 @@ def test_ensure_locked_have(install_mockery, tmp_path: pathlib.Path, capfd):
 
     with fs.working_dir(str(tmp_path)):
         # Test "downgrade" of a read lock (to a read lock)
-        lock = lk.Lock("./test", default_timeout=1e-9, desc="test")
+        lock = lk.lock("./test", default_timeout=1e-9, desc="test")
         lock_type = "read"
         tpl = (lock_type, lock)
         installer.locks[pkg_id] = tpl
@@ -366,7 +368,7 @@ def test_ensure_locked_have(install_mockery, tmp_path: pathlib.Path, capfd):
         assert "exception when releasing read lock" in out
 
         # Test "upgrade" of the read lock *with* read count to a write
-        lock._reads = 1
+        lock._reads = 1  # type: ignore[attr-defined]
         tpl = (lock_type, lock)
         assert installer._ensure_locked(lock_type, spec.package) == tpl
 
@@ -376,6 +378,7 @@ def test_ensure_locked_have(install_mockery, tmp_path: pathlib.Path, capfd):
         assert installer._ensure_locked(lock_type, spec.package) == tpl
 
 
+@pytest.mark.skipif(sys.platform == "win32", reason="locks are no-ops on Windows")
 @pytest.mark.parametrize("lock_type,reads,writes", [("read", 1, 0), ("write", 0, 1)])
 def test_ensure_locked_new_lock(install_mockery, tmp_path: pathlib.Path, lock_type, reads, writes):
     installer = create_installer(["pkg-a"], {})
@@ -803,15 +806,16 @@ def test_install_task_requeue_build_specs(install_mockery, monkeypatch):
     assert inst.package_id(popped_task.pkg.spec) in installer.build_tasks
 
 
+@pytest.mark.skipif(sys.platform == "win32", reason="locks are no-ops on Windows")
 def test_release_lock_write_n_exception(install_mockery, tmp_path: pathlib.Path, capfd):
     """Test _release_lock for supposed write lock with exception."""
     installer = create_installer(["trivial-install-test-package"], {})
 
     pkg_id = "test"
     with fs.working_dir(str(tmp_path)):
-        lock = lk.Lock("./test", default_timeout=1e-9, desc="test")
+        lock = lk.lock("./test", default_timeout=1e-9, desc="test")
         installer.locks[pkg_id] = ("write", lock)
-        assert lock._writes == 0
+        assert lock._writes == 0  # type: ignore[attr-defined]
 
         installer._release_lock(pkg_id)
         out = str(capfd.readouterr()[1])
@@ -923,15 +927,15 @@ def test_cleanup_failed_err(install_mockery, tmp_path: pathlib.Path, monkeypatch
     """Test _cleanup_failed exception path."""
     msg = "Fake release_write exception"
 
-    def _raise_except(lock):
+    def _raise_except(lock, release_fn=None):
         raise RuntimeError(msg)
 
     installer = create_installer(["trivial-install-test-package"], {})
 
-    monkeypatch.setattr(lk.Lock, "release_write", _raise_except)
+    monkeypatch.setattr(ulk.LockInterface, "release_write", _raise_except)
     pkg_id = "test"
     with fs.working_dir(str(tmp_path)):
-        lock = lk.Lock("./test", default_timeout=1e-9, desc="test")
+        lock = lk.lock("./test", default_timeout=1e-9, desc="test")
         installer.failed[pkg_id] = lock
 
         installer._cleanup_failed(pkg_id)

--- a/lib/spack/spack/test/repo.py
+++ b/lib/spack/spack/test/repo.py
@@ -603,7 +603,7 @@ def test_parse_config_descriptor_git_1(tmp_path: pathlib.Path):
             "git": str(tmp_path / "repo.git"),
             "destination": str(tmp_path / "some/destination"),
         },
-        lock=spack.util.lock.Lock(str(tmp_path / "x"), enable=False),
+        lock=spack.util.lock.lock(str(tmp_path / "x"), enable=False),
     )
 
     assert isinstance(descriptor, spack.repo.RemoteRepoDescriptor)
@@ -617,7 +617,7 @@ def test_parse_config_descriptor_git_2(tmp_path: pathlib.Path):
     descriptor = spack.repo.parse_config_descriptor(
         name="name",
         descriptor={"git": str(tmp_path / "repo.git"), "paths": ["some/path"]},
-        lock=spack.util.lock.Lock(str(tmp_path / "x"), enable=False),
+        lock=spack.util.lock.lock(str(tmp_path / "x"), enable=False),
     )
     assert isinstance(descriptor, spack.repo.RemoteRepoDescriptor)
     assert descriptor.relative_paths == ["some/path"]
@@ -631,7 +631,7 @@ def test_remote_descriptor_no_git(tmp_path: pathlib.Path):
             "git": str(tmp_path / "repo.git"),
             "destination": str(tmp_path / "some/destination"),
         },
-        lock=spack.util.lock.Lock(str(tmp_path / "x"), enable=False),
+        lock=spack.util.lock.lock(str(tmp_path / "x"), enable=False),
     )
 
     descriptor.initialize(fetch=True, git=None)
@@ -648,7 +648,7 @@ def test_remote_descriptor_update_no_git(tmp_path: pathlib.Path):
             "git": str(tmp_path / "repo.git"),
             "destination": str(tmp_path / "some/destination"),
         },
-        lock=spack.util.lock.Lock(str(tmp_path / "x"), enable=False),
+        lock=spack.util.lock.lock(str(tmp_path / "x"), enable=False),
     )
 
     assert isinstance(descriptor, spack.repo.RemoteRepoDescriptor)
@@ -661,7 +661,7 @@ def test_parse_config_descriptor_local(tmp_path: pathlib.Path):
     descriptor = spack.repo.parse_config_descriptor(
         name="name",
         descriptor=str(tmp_path / "local_repo"),
-        lock=spack.util.lock.Lock(str(tmp_path / "x"), enable=False),
+        lock=spack.util.lock.lock(str(tmp_path / "x"), enable=False),
     )
     assert isinstance(descriptor, spack.repo.LocalRepoDescriptor)
     assert descriptor.name == "name"
@@ -674,7 +674,7 @@ def test_parse_config_descriptor_no_git(tmp_path: pathlib.Path):
         spack.repo.parse_config_descriptor(
             name="name",
             descriptor={"destination": str(tmp_path / "some/destination"), "paths": ["some/path"]},
-            lock=spack.util.lock.Lock(str(tmp_path / "x"), enable=False),
+            lock=spack.util.lock.lock(str(tmp_path / "x"), enable=False),
         )
 
 
@@ -683,7 +683,7 @@ def test_repo_descriptors_construct(tmp_path: pathlib.Path):
     construct a Repo instance, e.g. due to missing repo.yaml file. Check that it parses the
     spack-repo-index.yaml file both when newly initialized and when already cloned."""
 
-    lock = spack.util.lock.Lock(str(tmp_path / "x"), enable=False)
+    lock = spack.util.lock.lock(str(tmp_path / "x"), enable=False)
     cache = spack.util.file_cache.FileCache(str(tmp_path / "cache"))
 
     # Construct 3 identical descriptors
@@ -776,7 +776,7 @@ def test_repo_descriptors_update(tmp_path: pathlib.Path):
     construct a Repo instance, e.g. due to missing repo.yaml file. Check that it parses the
     spack-repo-index.yaml file both when newly initialized and when already cloned."""
 
-    lock = spack.util.lock.Lock(str(tmp_path / "x"), enable=False)
+    lock = spack.util.lock.lock(str(tmp_path / "x"), enable=False)
     cache = spack.util.file_cache.FileCache(str(tmp_path / "cache"))
 
     # Construct 3 identical descriptors
@@ -874,7 +874,7 @@ def test_repo_descriptors_update_invalid(tmp_path: pathlib.Path):
     construct a Repo instance, e.g. due to missing repo.yaml file. Check that it parses the
     spack-repo-index.yaml file both when newly initialized and when already cloned."""
 
-    lock = spack.util.lock.Lock(str(tmp_path / "x"), enable=False)
+    lock = spack.util.lock.lock(str(tmp_path / "x"), enable=False)
     cache = spack.util.file_cache.FileCache(str(tmp_path / "cache"))
 
     # Construct 3 identical descriptors

--- a/lib/spack/spack/test/util/spack_lock_wrapper.py
+++ b/lib/spack/spack/test/util/spack_lock_wrapper.py
@@ -17,7 +17,7 @@ from spack.llnl.util.filesystem import getuid, group_ids
 def test_disable_locking(tmp_path: pathlib.Path):
     """Ensure that locks do no real locking when disabled."""
     lock_path = str(tmp_path / "lockfile")
-    lock = lk.Lock(lock_path, enable=False)
+    lock = lk.lock(lock_path, enable=False)
 
     lock.acquire_read()
     assert not os.path.exists(lock_path)

--- a/lib/spack/spack/util/file_cache.py
+++ b/lib/spack/spack/util/file_cache.py
@@ -12,7 +12,7 @@ from typing import IO, Dict, Iterator, Optional, Tuple, Union
 
 from spack.error import SpackError
 from spack.llnl.util.filesystem import rename
-from spack.util.lock import Lock
+from spack.util.lock import LockInterface, lock
 
 
 def _maybe_open(path: Union[str, pathlib.Path]) -> Optional[IO[str]]:
@@ -114,7 +114,7 @@ class FileCache:
         self.root.mkdir(parents=True, exist_ok=True)
 
         self.lock_path = self.root / ".lock"
-        self._locks: Dict[str, Lock] = {}
+        self._locks: Dict[str, LockInterface] = {}
         self.lock_timeout = timeout
 
     def destroy(self):
@@ -143,7 +143,7 @@ class FileCache:
 
         if key_str not in self._locks:
             start, length = self._get_lock_offsets(key_str)
-            self._locks[key_str] = Lock(
+            self._locks[key_str] = lock(
                 str(self.lock_path),
                 start=start,
                 length=length,

--- a/lib/spack/spack/util/lock.py
+++ b/lib/spack/spack/util/lock.py
@@ -7,11 +7,13 @@
 import os
 import stat
 import sys
-from typing import Optional, Tuple
+from typing import Optional
 
 import spack.error
-from spack.llnl.util.lock import Lock as Llnl_lock
 from spack.llnl.util.lock import (
+    Lock,
+    LockInterface,
+    LockDowngradeError,
     LockError,
     LockTimeoutError,
     LockUpgradeError,
@@ -20,27 +22,19 @@ from spack.llnl.util.lock import (
 )
 
 
-class Lock(Llnl_lock):
-    """Lock that can be disabled.
+def lock(
+    path: str,
+    *,
+    start: int = 0,
+    length: int = 0,
+    default_timeout: Optional[float] = None,
+    debug: bool = False,
+    desc: str = "",
+    enable: bool = True,
+) -> LockInterface:
 
-    This overrides the ``_lock()`` and ``_unlock()`` methods from
-    ``spack.llnl.util.lock`` so that all the lock API calls will succeed, but
-    the actual locking mechanism can be disabled via ``_enable_locks``.
-    """
-
-    def __init__(
-        self,
-        path: str,
-        *,
-        start: int = 0,
-        length: int = 0,
-        default_timeout: Optional[float] = None,
-        debug: bool = False,
-        desc: str = "",
-        enable: bool = True,
-    ) -> None:
-        self._enable = sys.platform != "win32" and enable
-        super().__init__(
+    if sys.platform != "win32" and enable:
+        return Lock(
             path,
             start=start,
             length=length,
@@ -48,39 +42,9 @@ class Lock(Llnl_lock):
             debug=debug,
             desc=desc,
         )
-
-    def _reaffirm_lock(self) -> None:
-        if self._enable:
-            super()._reaffirm_lock()
-
-    def _lock(self, op: int, timeout: Optional[float] = 0.0) -> Tuple[float, int]:
-        if self._enable:
-            return super()._lock(op, timeout)
-        return 0.0, 0
-
-    def _poll_lock(self, op: int) -> bool:
-        if self._enable:
-            return super()._poll_lock(op)
-        return True
-
-    def _unlock(self) -> None:
-        """Unlock call that always succeeds."""
-        if self._enable:
-            super()._unlock()
-
-    def try_acquire_read(self) -> bool:
-        if self._enable:
-            return super().try_acquire_read()
-        return True
-
-    def try_acquire_write(self) -> bool:
-        if self._enable:
-            return super().try_acquire_write()
-        return True
-
-    def cleanup(self, *args) -> None:
-        if self._enable:
-            super().cleanup(*args)
+    return LockInterface(
+        path, start=start, length=length, default_timeout=default_timeout, debug=debug, desc=desc
+    )
 
 
 def check_lock_safety(path: str) -> None:
@@ -116,11 +80,13 @@ def check_lock_safety(path: str) -> None:
 
 
 __all__ = [
+    "LockDowngradeError",
     "LockError",
     "LockTimeoutError",
     "LockUpgradeError",
     "ReadTransaction",
     "WriteTransaction",
     "Lock",
+    "LockInterface",
     "check_lock_safety",
 ]

--- a/lib/spack/spack/util/lock.py
+++ b/lib/spack/spack/util/lock.py
@@ -12,9 +12,9 @@ from typing import Optional
 import spack.error
 from spack.llnl.util.lock import (
     Lock,
-    LockInterface,
     LockDowngradeError,
     LockError,
+    LockInterface,
     LockTimeoutError,
     LockUpgradeError,
     ReadTransaction,


### PR DESCRIPTION
https://github.com/spack/spack/pull/52479 expanded some of the higher level locking interface in `spack.util.lock.Lock` which wraps `spack.llnl.util.lock.Lock`. 

We need to finish expanding that wrapping to the locking api the rest of Spack actually uses to obtain and free locks.

Motivation:

Locks in spack are taken via `spack.util.lock.Lock`, which has special handling for disabled locking in Spack, which is configurable everywhere, and the default/mandatory on Windows (not for much longer, but for right now). 

Anywhere locking is disabled, we don't descend into the `spack.llnl.util.lock.Lock` class, we short circuit at `spack.util.lock.Lock`. This works when taking locks (as those are the calls we intercept) but when releasing, upgrading, or downgrading locks, prior to this PR, we were not intercepting those methods, which means `spack.llnl.util.lock.Lock` was being invoked directly. `spack.llnl.util.lock.Lock` involves manual counting of the number of read/write locks we currently hold. The lock freeing methods take this into account when deciding whether to free a lock, but if we're not properly incrementing the lock tracking with `acquire_*`, when we go to free the count is off and we can hit errors.

This PR solves that by ensuring the rest of the interface considers whether locking has been disabled, and avoids counting when locking is disabled.