### PR TITLE
Include matrix excludes when constructing the concretization group

### DIFF
--- a/lib/spack/spack/environment/environment.py
+++ b/lib/spack/spack/environment/environment.py
@@ -42,6 +42,7 @@ import spack.package_base
 import spack.paths
 import spack.repo
 import spack.schema.env
+import spack.schema.spec_list
 import spack.spec
 import spack.store
 import spack.user_environment as uenv
@@ -3228,7 +3229,13 @@ class EnvironmentManifestFile(collections.abc.Mapping):
 
                 if "matrix" in item:
                     # Short form if the group is composed of only one matrix
-                    self._user_specs[group].append({"matrix": item["matrix"]})
+                    self._user_specs[group].append(
+                        {
+                            key: item[key]
+                            for key in spack.schema.spec_list.spec_list_properties
+                            if key in item
+                        }
+                    )
                 elif "specs" in item:
                     self._user_specs[group].extend(item["specs"])
 

--- a/lib/spack/spack/test/env.py
+++ b/lib/spack/spack/test/env.py
@@ -1178,6 +1178,41 @@ spack:
     assert mpileaks_clang["mpich"].satisfies("%[virtuals=fortran] gcc")
 
 
+def test_toolchain_matrix_exclude_from_environment_manifest(
+    tmp_path: pathlib.Path, mutable_config
+):
+    """Tests that matrix excludes are preserved when the environment manifest is read."""
+    spack_yaml = """
+spack:
+  toolchains:
+    test_apple_clang:
+    - spec: "%c=apple-clang"
+      when: "%c"
+    - spec: "%cxx=apple-clang"
+      when: "%cxx"
+  definitions:
+  - packages: [zlib-ng, zlib]
+  - compilers: [test_apple_clang]
+  specs:
+  - matrix:
+    - [$packages]
+    - [$%compilers]
+    exclude:
+    - "zlib-ng %test_apple_clang"
+"""
+    manifest = tmp_path / "spack.yaml"
+    manifest.write_text(spack_yaml)
+
+    e = ev.Environment(tmp_path)
+
+    assert e.manifest.user_specs() == [
+        {"matrix": [["$packages"], ["$%compilers"]], "exclude": ["zlib-ng %test_apple_clang"]}
+    ]
+    assert e.user_specs.specs == [
+        spack.spec.Spec("zlib %[when='%c'] c=apple-clang %[when='%cxx'] cxx=apple-clang")
+    ]
+
+
 @pytest.mark.parametrize("unify", ["true", "false", "when_possible"])
 @pytest.mark.parametrize("requirement_type", ["require", "prefer"])
 def test_using_toolchain_as_requirement(

--- a/lib/spack/spack/test/env.py
+++ b/lib/spack/spack/test/env.py
@@ -1183,20 +1183,20 @@ def test_matrix_exclude_from_environment_manifest(tmp_path: pathlib.Path, mutabl
     spack_yaml = """
 spack:
   definitions:
-  - packages: [zlib-ng, zlib]
+  - packages: [foo, bar]
   specs:
   - matrix:
     - [$packages]
     exclude:
-    - "zlib-ng"
+    - "bar"
 """
     manifest = tmp_path / "spack.yaml"
     manifest.write_text(spack_yaml)
 
     e = ev.Environment(tmp_path)
 
-    assert e.manifest.user_specs() == [{"matrix": [["$packages"]], "exclude": ["zlib-ng"]}]
-    assert e.user_specs.specs == [spack.spec.Spec("zlib")]
+    assert e.manifest.user_specs() == [{"matrix": [["$packages"]], "exclude": ["bar"]}]
+    assert e.user_specs.specs == [spack.spec.Spec("foo")]
 
 
 @pytest.mark.parametrize("unify", ["true", "false", "when_possible"])

--- a/lib/spack/spack/test/env.py
+++ b/lib/spack/spack/test/env.py
@@ -1178,39 +1178,25 @@ spack:
     assert mpileaks_clang["mpich"].satisfies("%[virtuals=fortran] gcc")
 
 
-def test_toolchain_matrix_exclude_from_environment_manifest(
-    tmp_path: pathlib.Path, mutable_config
-):
+def test_matrix_exclude_from_environment_manifest(tmp_path: pathlib.Path, mutable_config):
     """Tests that matrix excludes are preserved when the environment manifest is read."""
     spack_yaml = """
 spack:
-  toolchains:
-    test_apple_clang:
-    - spec: "%c=apple-clang"
-      when: "%c"
-    - spec: "%cxx=apple-clang"
-      when: "%cxx"
   definitions:
   - packages: [zlib-ng, zlib]
-  - compilers: [test_apple_clang]
   specs:
   - matrix:
     - [$packages]
-    - [$%compilers]
     exclude:
-    - "zlib-ng %test_apple_clang"
+    - "zlib-ng"
 """
     manifest = tmp_path / "spack.yaml"
     manifest.write_text(spack_yaml)
 
     e = ev.Environment(tmp_path)
 
-    assert e.manifest.user_specs() == [
-        {"matrix": [["$packages"], ["$%compilers"]], "exclude": ["zlib-ng %test_apple_clang"]}
-    ]
-    assert e.user_specs.specs == [
-        spack.spec.Spec("zlib %[when='%c'] c=apple-clang %[when='%cxx'] cxx=apple-clang")
-    ]
+    assert e.manifest.user_specs() == [{"matrix": [["$packages"]], "exclude": ["zlib-ng"]}]
+    assert e.user_specs.specs == [spack.spec.Spec("zlib")]
 
 
 @pytest.mark.parametrize("unify", ["true", "false", "when_possible"])


### PR DESCRIPTION
Bug originally found by @white238.

After environment concretization groups it looks like we'd inadvertently dropped the `exclude` section. Thus when attempting to render a matrix with a set of excluded specs, all of the specs were always concretized instead of being filtered and dropped as expected.

**Reproducer**
```yaml
# This is a Spack Environment file.
#
# It describes a set of packages to be installed, along with
# configuration settings.
spack:
  definitions:
    - packages: [ "zlib-ng", "zlib" ]
  specs:
  - matrix:
    - [$packages]
    exclude:
      - "zlib-ng"
  view: false
  concretizer:
    unify: false
```