### PR TITLE
Bugfix: Add missing config view to Mirror update

### DIFF
--- a/lib/spack/spack/cmd/mirror.py
+++ b/lib/spack/spack/cmd/mirror.py
@@ -143,6 +143,7 @@ def setup_parser(subparser: argparse.ArgumentParser) -> None:
         dest="signed",
     )
     add_parser.add_argument(
+        "--view",
         "--name",
         "-n",
         action="store",
@@ -238,6 +239,14 @@ def setup_parser(subparser: argparse.ArgumentParser) -> None:
         action=arguments.ConfigScope,
         default=lambda: spack.config.CONFIG.default_modify_scope(),
         help="configuration scope to modify",
+    )
+    set_parser.add_argument(
+        "--view",
+        "--name",
+        "-n",
+        action="store",
+        dest="view_name",
+        help="Name of the index view for a binary mirror",
     )
     arguments.add_connection_args(set_parser, False)
 
@@ -421,9 +430,9 @@ def _configure_mirror(args):
         changes["signed"] = args.signed
     if getattr(args, "autopush", None) is not None:
         changes["autopush"] = args.autopush
+    if getattr(args, "view_name", None):
+        changes["view"] = args.view_name
 
-    # argparse cannot distinguish between --binary and --no-binary when same dest :(
-    # notice that set-url does not have these args, so getattr
     if getattr(args, "type", None):
         changes["binary"] = "binary" in args.type
         changes["source"] = "source" in args.type

--- a/lib/spack/spack/cmd/mirror.py
+++ b/lib/spack/spack/cmd/mirror.py
@@ -142,13 +142,16 @@ def setup_parser(subparser: argparse.ArgumentParser) -> None:
         default=None,
         dest="signed",
     )
-    add_parser.add_argument(
+    add_parser_view = add_parser.add_mutually_exclusive_group(required=False)
+    add_parser_view.add_argument(
         "--view",
-        "--name",
-        "-n",
         action="store",
         dest="view_name",
         help="Name of the index view for a binary mirror",
+    )
+    # This option name is deprecated, use --view
+    add_parser_view.add_argument(
+        "--name", "-n", action="store", dest="view_name", help=argparse.SUPPRESS
     )
     arguments.add_connection_args(add_parser, False)
     # Remove
@@ -242,8 +245,6 @@ def setup_parser(subparser: argparse.ArgumentParser) -> None:
     )
     set_parser.add_argument(
         "--view",
-        "--name",
-        "-n",
         action="store",
         dest="view_name",
         help="Name of the index view for a binary mirror",

--- a/lib/spack/spack/mirrors/mirror.py
+++ b/lib/spack/spack/mirrors/mirror.py
@@ -122,6 +122,9 @@ class Mirror:
 
     def display(self, max_len: int = 0) -> None:
         fetch, push = self.fetch_url, self.push_url
+        fetch_view, push_view = self.fetch_view, self.push_view
+        fetch = ":".join([fetch, fetch_view]) if fetch_view else fetch
+        push = ":".join([push, push_view]) if push_view else push
         # don't print the same URL twice
         url = fetch if fetch == push else f"fetch: {fetch} push: {push}"
         source = "s" if self.source else " "
@@ -260,14 +263,15 @@ class Mirror:
             )
 
         keys = [
-            "url",
             "access_pair",
             "access_token",
             "access_token_variable",
-            "profile",
             "endpoint_url",
-            "select",
             "exclude",
+            "profile",
+            "select",
+            "url",
+            "view",
         ]
         if top_level:
             keys += ["binary", "source", "signed", "autopush"]

--- a/lib/spack/spack/mirrors/mirror.py
+++ b/lib/spack/spack/mirrors/mirror.py
@@ -123,8 +123,8 @@ class Mirror:
     def display(self, max_len: int = 0) -> None:
         fetch, push = self.fetch_url, self.push_url
         fetch_view, push_view = self.fetch_view, self.push_view
-        fetch = ":".join([fetch, fetch_view]) if fetch_view else fetch
-        push = ":".join([push, push_view]) if push_view else push
+        fetch = f"{fetch}:{fetch_view}" if fetch_view else fetch
+        push = f"{push}:{push_view}" if push_view else push
         # don't print the same URL twice
         url = fetch if fetch == push else f"fetch: {fetch} push: {push}"
         source = "s" if self.source else " "

--- a/lib/spack/spack/test/cmd/mirror.py
+++ b/lib/spack/spack/test/cmd/mirror.py
@@ -475,6 +475,18 @@ def test_mirror_crud(mutable_config):
     assert "No mirrors configured" in output
 
 
+def test_mirror_set_view(mutable_config):
+    mirror("add", "mirror", "http://spack.io")
+    output = mirror("list")
+    assert "https://spack.io" in output
+    assert "https://spack.io:someview" not in output
+
+    mirror("set", "--name", "someview")
+
+    output = mirror("list")
+    assert "https://spack.io:someview" in output
+
+
 def test_mirror_nonexisting(mutable_config):
     with pytest.raises(SpackCommandError):
         mirror("remove", "not-a-mirror")

--- a/lib/spack/spack/test/cmd/mirror.py
+++ b/lib/spack/spack/test/cmd/mirror.py
@@ -478,13 +478,13 @@ def test_mirror_crud(mutable_config):
 def test_mirror_set_view(mutable_config):
     mirror("add", "mirror", "http://spack.io")
     output = mirror("list")
-    assert "https://spack.io" in output
-    assert "https://spack.io:someview" not in output
+    assert "http://spack.io" in output
+    assert "http://spack.io:someview" not in output
 
-    mirror("set", "--name", "someview")
+    mirror("set", "--view", "someview", "mirror")
 
     output = mirror("list")
-    assert "https://spack.io:someview" in output
+    assert "http://spack.io:someview" in output
 
 
 def test_mirror_nonexisting(mutable_config):

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -1491,7 +1491,7 @@ _spack_mirror_destroy() {
 _spack_mirror_add() {
     if $list_options
     then
-        SPACK_COMPREPLY="-h --help --scope --type --autopush --unsigned --signed --name -n --s3-access-key-id --s3-access-key-id-variable --s3-access-key-secret-variable --s3-access-token-variable --s3-profile --s3-endpoint-url --oci-username --oci-username-variable --oci-password-variable"
+        SPACK_COMPREPLY="-h --help --scope --type --autopush --unsigned --signed --view --name -n --s3-access-key-id --s3-access-key-id-variable --s3-access-key-secret-variable --s3-access-token-variable --s3-profile --s3-endpoint-url --oci-username --oci-username-variable --oci-password-variable"
     else
         _mirrors
     fi
@@ -1527,7 +1527,7 @@ _spack_mirror_set_url() {
 _spack_mirror_set() {
     if $list_options
     then
-        SPACK_COMPREPLY="-h --help --push --fetch --type --url --autopush --no-autopush --unsigned --signed --scope --s3-access-key-id --s3-access-key-id-variable --s3-access-key-secret-variable --s3-access-token-variable --s3-profile --s3-endpoint-url --oci-username --oci-username-variable --oci-password-variable"
+        SPACK_COMPREPLY="-h --help --push --fetch --type --url --autopush --no-autopush --unsigned --signed --scope --view --name -n --s3-access-key-id --s3-access-key-id-variable --s3-access-key-secret-variable --s3-access-token-variable --s3-profile --s3-endpoint-url --oci-username --oci-username-variable --oci-password-variable"
     else
         _mirrors
     fi

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -1527,7 +1527,7 @@ _spack_mirror_set_url() {
 _spack_mirror_set() {
     if $list_options
     then
-        SPACK_COMPREPLY="-h --help --push --fetch --type --url --autopush --no-autopush --unsigned --signed --scope --view --name -n --s3-access-key-id --s3-access-key-id-variable --s3-access-key-secret-variable --s3-access-token-variable --s3-profile --s3-endpoint-url --oci-username --oci-username-variable --oci-password-variable"
+        SPACK_COMPREPLY="-h --help --push --fetch --type --url --autopush --no-autopush --unsigned --signed --scope --view --s3-access-key-id --s3-access-key-id-variable --s3-access-key-secret-variable --s3-access-token-variable --s3-profile --s3-endpoint-url --oci-username --oci-username-variable --oci-password-variable"
     else
         _mirrors
     fi

--- a/share/spack/spack-completion.fish
+++ b/share/spack/spack-completion.fish
@@ -2440,7 +2440,7 @@ complete -c spack -n '__fish_spack_using_command mirror destroy' -l mirror-url -
 complete -c spack -n '__fish_spack_using_command mirror destroy' -l mirror-url -r -d 'find mirror to destroy by url'
 
 # spack mirror add
-set -g __fish_spack_optspecs_spack_mirror_add h/help scope= type= autopush unsigned signed n/name= s3-access-key-id= s3-access-key-id-variable= s3-access-key-secret-variable= s3-access-token-variable= s3-profile= s3-endpoint-url= oci-username= oci-username-variable= oci-password-variable=
+set -g __fish_spack_optspecs_spack_mirror_add h/help scope= type= autopush unsigned signed view= s3-access-key-id= s3-access-key-id-variable= s3-access-key-secret-variable= s3-access-token-variable= s3-profile= s3-endpoint-url= oci-username= oci-username-variable= oci-password-variable=
 complete -c spack -n '__fish_spack_using_command_pos 0 mirror add' -f
 complete -c spack -n '__fish_spack_using_command mirror add' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command mirror add' -s h -l help -d 'show this help message and exit'
@@ -2454,8 +2454,8 @@ complete -c spack -n '__fish_spack_using_command mirror add' -l unsigned -f -a s
 complete -c spack -n '__fish_spack_using_command mirror add' -l unsigned -d 'do not require signing and signature verification when pushing and installing from this build cache'
 complete -c spack -n '__fish_spack_using_command mirror add' -l signed -f -a signed
 complete -c spack -n '__fish_spack_using_command mirror add' -l signed -d 'require signing and signature verification when pushing and installing from this build cache'
-complete -c spack -n '__fish_spack_using_command mirror add' -l name -s n -r -f -a view_name
-complete -c spack -n '__fish_spack_using_command mirror add' -l name -s n -r -d 'Name of the index view for a binary mirror'
+complete -c spack -n '__fish_spack_using_command mirror add' -l view -l name -s n -r -f -a view_name
+complete -c spack -n '__fish_spack_using_command mirror add' -l view -l name -s n -r -d 'Name of the index view for a binary mirror'
 complete -c spack -n '__fish_spack_using_command mirror add' -l s3-access-key-id -r -f -a s3_access_key_id
 complete -c spack -n '__fish_spack_using_command mirror add' -l s3-access-key-id -r -d 'ID string to use to connect to this S3 mirror'
 complete -c spack -n '__fish_spack_using_command mirror add' -l s3-access-key-id-variable -r -f -a s3_access_key_id_variable
@@ -2526,7 +2526,7 @@ complete -c spack -n '__fish_spack_using_command mirror set-url' -l oci-password
 complete -c spack -n '__fish_spack_using_command mirror set-url' -l oci-password-variable -r -d 'environment variable containing password to use to connect to this OCI mirror'
 
 # spack mirror set
-set -g __fish_spack_optspecs_spack_mirror_set h/help push fetch type= url= autopush no-autopush unsigned signed scope= s3-access-key-id= s3-access-key-id-variable= s3-access-key-secret-variable= s3-access-token-variable= s3-profile= s3-endpoint-url= oci-username= oci-username-variable= oci-password-variable=
+set -g __fish_spack_optspecs_spack_mirror_set h/help push fetch type= url= autopush no-autopush unsigned signed scope= view= s3-access-key-id= s3-access-key-id-variable= s3-access-key-secret-variable= s3-access-token-variable= s3-profile= s3-endpoint-url= oci-username= oci-username-variable= oci-password-variable=
 complete -c spack -n '__fish_spack_using_command_pos 0 mirror set' -f -a '(__fish_spack_mirrors)'
 complete -c spack -n '__fish_spack_using_command mirror set' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command mirror set' -s h -l help -d 'show this help message and exit'
@@ -2548,6 +2548,8 @@ complete -c spack -n '__fish_spack_using_command mirror set' -l signed -f -a sig
 complete -c spack -n '__fish_spack_using_command mirror set' -l signed -d 'require signing and signature verification when pushing and installing from this build cache'
 complete -c spack -n '__fish_spack_using_command mirror set' -l scope -r -f -a '_builtin defaults:base defaults system site user spack command_line'
 complete -c spack -n '__fish_spack_using_command mirror set' -l scope -r -d 'configuration scope to modify'
+complete -c spack -n '__fish_spack_using_command mirror set' -l view -l name -s n -r -f -a view_name
+complete -c spack -n '__fish_spack_using_command mirror set' -l view -l name -s n -r -d 'Name of the index view for a binary mirror'
 complete -c spack -n '__fish_spack_using_command mirror set' -l s3-access-key-id -r -f -a s3_access_key_id
 complete -c spack -n '__fish_spack_using_command mirror set' -l s3-access-key-id -r -d 'ID string to use to connect to this S3 mirror'
 complete -c spack -n '__fish_spack_using_command mirror set' -l s3-access-key-id-variable -r -f -a s3_access_key_id_variable

--- a/share/spack/spack-completion.fish
+++ b/share/spack/spack-completion.fish
@@ -2440,7 +2440,7 @@ complete -c spack -n '__fish_spack_using_command mirror destroy' -l mirror-url -
 complete -c spack -n '__fish_spack_using_command mirror destroy' -l mirror-url -r -d 'find mirror to destroy by url'
 
 # spack mirror add
-set -g __fish_spack_optspecs_spack_mirror_add h/help scope= type= autopush unsigned signed view= s3-access-key-id= s3-access-key-id-variable= s3-access-key-secret-variable= s3-access-token-variable= s3-profile= s3-endpoint-url= oci-username= oci-username-variable= oci-password-variable=
+set -g __fish_spack_optspecs_spack_mirror_add h/help scope= type= autopush unsigned signed view= n/name= s3-access-key-id= s3-access-key-id-variable= s3-access-key-secret-variable= s3-access-token-variable= s3-profile= s3-endpoint-url= oci-username= oci-username-variable= oci-password-variable=
 complete -c spack -n '__fish_spack_using_command_pos 0 mirror add' -f
 complete -c spack -n '__fish_spack_using_command mirror add' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command mirror add' -s h -l help -d 'show this help message and exit'
@@ -2454,8 +2454,9 @@ complete -c spack -n '__fish_spack_using_command mirror add' -l unsigned -f -a s
 complete -c spack -n '__fish_spack_using_command mirror add' -l unsigned -d 'do not require signing and signature verification when pushing and installing from this build cache'
 complete -c spack -n '__fish_spack_using_command mirror add' -l signed -f -a signed
 complete -c spack -n '__fish_spack_using_command mirror add' -l signed -d 'require signing and signature verification when pushing and installing from this build cache'
-complete -c spack -n '__fish_spack_using_command mirror add' -l view -l name -s n -r -f -a view_name
-complete -c spack -n '__fish_spack_using_command mirror add' -l view -l name -s n -r -d 'Name of the index view for a binary mirror'
+complete -c spack -n '__fish_spack_using_command mirror add' -l view -r -f -a view_name
+complete -c spack -n '__fish_spack_using_command mirror add' -l view -r -d 'Name of the index view for a binary mirror'
+complete -c spack -n '__fish_spack_using_command mirror add' -l name -s n -r -f -a view_name
 complete -c spack -n '__fish_spack_using_command mirror add' -l s3-access-key-id -r -f -a s3_access_key_id
 complete -c spack -n '__fish_spack_using_command mirror add' -l s3-access-key-id -r -d 'ID string to use to connect to this S3 mirror'
 complete -c spack -n '__fish_spack_using_command mirror add' -l s3-access-key-id-variable -r -f -a s3_access_key_id_variable
@@ -2548,8 +2549,8 @@ complete -c spack -n '__fish_spack_using_command mirror set' -l signed -f -a sig
 complete -c spack -n '__fish_spack_using_command mirror set' -l signed -d 'require signing and signature verification when pushing and installing from this build cache'
 complete -c spack -n '__fish_spack_using_command mirror set' -l scope -r -f -a '_builtin defaults:base defaults system site user spack command_line'
 complete -c spack -n '__fish_spack_using_command mirror set' -l scope -r -d 'configuration scope to modify'
-complete -c spack -n '__fish_spack_using_command mirror set' -l view -l name -s n -r -f -a view_name
-complete -c spack -n '__fish_spack_using_command mirror set' -l view -l name -s n -r -d 'Name of the index view for a binary mirror'
+complete -c spack -n '__fish_spack_using_command mirror set' -l view -r -f -a view_name
+complete -c spack -n '__fish_spack_using_command mirror set' -l view -r -d 'Name of the index view for a binary mirror'
 complete -c spack -n '__fish_spack_using_command mirror set' -l s3-access-key-id -r -f -a s3_access_key_id
 complete -c spack -n '__fish_spack_using_command mirror set' -l s3-access-key-id -r -d 'ID string to use to connect to this S3 mirror'
 complete -c spack -n '__fish_spack_using_command mirror set' -l s3-access-key-id-variable -r -f -a s3_access_key_id_variable


### PR DESCRIPTION
The key `view` was missing from the update connection key list. This would result in changes to view being ignored.