### PR TITLE
Add [b] support to `spack concretize` and other commands

### DIFF
--- a/lib/spack/spack/cmd/compiler.py
+++ b/lib/spack/spack/cmd/compiler.py
@@ -7,6 +7,7 @@ import sys
 from typing import List, Optional
 
 import spack.binary_distribution
+import spack.cmd
 import spack.compilers.config
 import spack.config
 import spack.llnl.util.tty as tty
@@ -185,6 +186,12 @@ def compiler_list(args):
             print(c.format("{name}@{version}"))
         return
 
+    status_fn = (
+        spack.cmd.buildcache_status_fn(spack.binary_distribution.BINARY_INDEX)
+        if args.remote
+        else spack.spec.Spec.install_status
+    )
+
     # If there are no compilers in any scope, and we're outputting to a tty, give a
     # hint to the user.
     if len(compilers) == 0:
@@ -216,9 +223,7 @@ def compiler_list(args):
             os_str += f"-{target}"
         cname = f"{spack.spec.COMPILER_COLOR}{{{name}}} {os_str}"
         tty.hline(colorize(cname), char="-")
-        result = {
-            colorize(c.install_status().value) + c.format("{name}@{version}") for c in compilers
-        }
+        result = {colorize(status_fn(c).value) + c.format("{name}@{version}") for c in compilers}
         colify(reversed(sorted(result)))
 
 

--- a/lib/spack/spack/cmd/concretize.py
+++ b/lib/spack/spack/cmd/concretize.py
@@ -4,6 +4,7 @@
 
 import argparse
 
+import spack.binary_distribution
 import spack.cmd
 import spack.cmd.common.arguments
 import spack.environment as ev
@@ -45,9 +46,12 @@ def concretize(parser, args):
         if not args.quiet:
             if concretized_specs:
                 tty.msg(f"Concretized {plural(len(concretized_specs), 'spec')}:")
+                spack.binary_distribution.load_buildcache_index()
+                status_fn = spack.cmd.buildcache_status_fn(spack.binary_distribution.BINARY_INDEX)
                 ev.display_specs(
                     [concrete for _, concrete in concretized_specs],
                     highlight_non_defaults=args.non_defaults,
+                    status_fn=status_fn,
                 )
             else:
                 tty.msg("No new specs to concretize.")

--- a/lib/spack/spack/cmd/find.py
+++ b/lib/spack/spack/cmd/find.py
@@ -252,7 +252,7 @@ def make_env_decorator(env):
     return decorator
 
 
-def display_env(env, args, decorator, results):
+def display_env(env, args, decorator, results, status_fn=None):
     """Display extra find output when running in an environment.
 
     In an environment, ``spack find`` outputs a preliminary section
@@ -264,12 +264,13 @@ def display_env(env, args, decorator, results):
     tty.msg(f"In environment {env.name} ({root_spec_str})")
 
     concrete_specs = {x.root: env.specs_by_hash[x.hash] for x in env.concretized_roots}
+    _status_fn = status_fn if status_fn is not None else spack.spec.Spec.install_status
 
     def root_decorator(spec, string):
         """Decorate root specs with their install status if needed"""
         concrete = concrete_specs.get(spec)
         if concrete:
-            status = color.colorize(concrete.install_status().value)
+            status = color.colorize(_status_fn(concrete).value)
             hash = concrete.dag_hash()
         else:
             status = color.colorize(spack.spec.InstallStatus.absent.value)
@@ -430,7 +431,7 @@ def find(parser, args):
 
         if not args.format:
             if env:
-                display_env(env, args, decorator, results)
+                display_env(env, args, decorator, results, status_fn=status_fn)
 
         if not args.only_roots:
             display_results = list(results)

--- a/lib/spack/spack/cmd/install.py
+++ b/lib/spack/spack/cmd/install.py
@@ -8,6 +8,7 @@ import shutil
 import sys
 from typing import List
 
+import spack.binary_distribution
 import spack.cmd
 import spack.config
 import spack.environment as ev
@@ -359,7 +360,9 @@ def _maybe_add_and_concretize(args, env, specs):
         concretized_specs = env.concretize(tests=tests)
         if concretized_specs:
             tty.msg(f"Concretized {plural(len(concretized_specs), 'spec')}")
-            ev.display_specs([concrete for _, concrete in concretized_specs])
+            spack.binary_distribution.load_buildcache_index()
+            status_fn = spack.cmd.buildcache_status_fn(spack.binary_distribution.BINARY_INDEX)
+            ev.display_specs([concrete for _, concrete in concretized_specs], status_fn=status_fn)
 
         # save view regeneration for later, so that we only do it
         # once, as it can be slow.

--- a/lib/spack/spack/environment/environment.py
+++ b/lib/spack/spack/environment/environment.py
@@ -2894,20 +2894,27 @@ def _equiv_dict(first, second):
     return same_values and same_keys_with_same_overrides
 
 
-def display_specs(specs: List[spack.spec.Spec], *, highlight_non_defaults: bool = False) -> None:
+def display_specs(
+    specs: List[spack.spec.Spec],
+    *,
+    highlight_non_defaults: bool = False,
+    status_fn: Optional[Callable[["spack.spec.Spec"], "spack.spec.InstallStatus"]] = None,
+) -> None:
     """Displays a list of specs traversed breadth-first, covering nodes, with install status.
 
     Args:
         specs: list of specs to be displayed
         highlight_non_defaults: if True, highlights non-default versions and variants in the specs
             being displayed
+        status_fn: callable mapping a spec to its InstallStatus; defaults to
+            ``spack.spec.Spec.install_status``
     """
     tree_string = spack.spec.tree(
         specs,
         format=spack.spec.DISPLAY_FORMAT,
         hashes=True,
         hashlen=7,
-        status_fn=spack.spec.Spec.install_status,
+        status_fn=status_fn if status_fn is not None else spack.spec.Spec.install_status,
         highlight_version_fn=(
             spack.package_base.non_preferred_version if highlight_non_defaults else None
         ),


### PR DESCRIPTION
In #52471 support for `spack concretize` (and for a few other commands)  was missed because the status function was not tied to a `-I` argument. Fix it in this PR by adding `[b]` support to all commands that use the status function implicitly.