### PR TITLE
locks.py: composition over inheritance for dummy lock

### DIFF
--- a/lib/spack/spack/llnl/util/lock.py
+++ b/lib/spack/spack/llnl/util/lock.py
@@ -376,6 +376,7 @@ class Lock:
         default_timeout: Optional[float] = None,
         debug: bool = False,
         desc: str = "",
+        enable: bool = True,
     ) -> None:
         """Construct a new lock on the file at ``path``.
 
@@ -396,6 +397,8 @@ class Lock:
             debug: debug mode specific to locking
             desc: optional debug message lock description, which is helpful for distinguishing
                 between different Spack locks.
+            enable: when False, swap in a no-op backend so all lock operations succeed
+                without acquiring a real filesystem lock. Always disabled on Windows.
         """
         self.path = path
         self._reads = 0
@@ -416,7 +419,7 @@ class Lock:
         # user sets a timeout for each attempt)
         self.default_timeout = default_timeout or None
 
-        if sys.platform != "win32":
+        if sys.platform != "win32" and enable:
             self.backend: Union[PosixBackend, DummyBackend] = PosixBackend(
                 path, start, length, debug=debug
             )

--- a/lib/spack/spack/llnl/util/lock.py
+++ b/lib/spack/spack/llnl/util/lock.py
@@ -402,10 +402,11 @@ class Lock:
             if self.debug:
                 # All locks read the owner PID and host
                 self._read_log_debug_data()
-                self._log_debug(
+                tty.debug(
                     "{0} locked {1} [{2}:{3}] (owner={4})".format(
                         LockType.to_str(op), self.path, self._start, self._length, self.pid
-                    )
+                    ),
+                    level=2,
                 )
 
                 # Exclusive locks write their PID/host

--- a/lib/spack/spack/llnl/util/lock.py
+++ b/lib/spack/spack/llnl/util/lock.py
@@ -359,12 +359,7 @@ class Lock:
         self._log_acquiring("{0} LOCK".format(op_str))
         timeout = timeout or self.default_timeout
 
-        fh = self._ensure_valid_handle()
-
-        if LockType.to_module(op) == fcntl.LOCK_EX and fh.mode == "rb":
-            # Attempt to upgrade to write lock w/a read-only file.
-            # If the file were writable, we'd have opened it rb+
-            raise LockROFileError(self.path)
+        self.prepare(op)
 
         self._log_debug(
             "{} locking [{}:{}]: timeout {}".format(
@@ -378,7 +373,7 @@ class Lock:
         poll_intervals = Lock._poll_interval_generator()
 
         while True:
-            if self._poll_lock(op):
+            if self.poll(op):
                 return time.monotonic() - start_time, num_attempts
             if time.monotonic() >= end_time:
                 break
@@ -387,7 +382,13 @@ class Lock:
 
         raise LockTimeoutError(op, self.path, time.monotonic() - start_time, num_attempts)
 
-    def _poll_lock(self, op: int) -> bool:
+    def prepare(self, op: int) -> None:
+        """Ensure the lock file is open; raise if a write lock is requested on a read-only file."""
+        fh = self._ensure_valid_handle()
+        if LockType.to_module(op) == fcntl.LOCK_EX and fh.mode == "rb":
+            raise LockROFileError(self.path)
+
+    def poll(self, op: int) -> bool:
         """Attempt to acquire the lock in a non-blocking manner. Return whether
         the locking attempt succeeds
         """
@@ -452,7 +453,7 @@ class Lock:
         self._file_ref.fh.flush()
         os.fsync(self._file_ref.fh.fileno())
 
-    def _unlock(self) -> None:
+    def release(self) -> None:
         """Releases a lock using POSIX locks (``fcntl.lockf``)
 
         Releases the lock regardless of mode. Note that read locks may be masquerading as write
@@ -529,8 +530,8 @@ class Lock:
             op = LockType.READ
         else:
             return
-        self._ensure_valid_handle()
-        if not self._poll_lock(op):
+        self.prepare(op)
+        if not self.poll(op):
             raise LockTimeoutError(op, self.path, time=0, attempts=1)
 
     def try_acquire_read(self) -> bool:
@@ -539,8 +540,8 @@ class Lock:
         Returns True if the lock was acquired, False if it would block.
         """
         if self._reads == 0 and self._writes == 0:
-            self._ensure_valid_handle()
-            if not self._poll_lock(LockType.READ):
+            self.prepare(LockType.READ)
+            if not self.poll(LockType.READ):
                 return False
             self._reads += 1
             self._log_acquired("READ LOCK", 0, 1)
@@ -556,10 +557,8 @@ class Lock:
         Returns True if the lock was acquired, False if it would block.
         """
         if self._writes == 0:
-            fh = self._ensure_valid_handle()
-            if LockType.to_module(LockType.WRITE) == fcntl.LOCK_EX and fh.mode == "rb":
-                raise LockROFileError(self.path)
-            if not self._poll_lock(LockType.WRITE):
+            self.prepare(LockType.WRITE)
+            if not self.poll(LockType.WRITE):
                 return False
             self._writes += 1
             self._log_acquired("WRITE LOCK", 0, 1)
@@ -644,7 +643,7 @@ class Lock:
             release_fn = release_fn or true_fn
             result = release_fn()
 
-            self._unlock()  # can raise LockError.
+            self.release()  # can raise LockError.
             self._reads = 0
             self._log_released(locktype)
             return bool(result)
@@ -679,7 +678,7 @@ class Lock:
             if self._reads > 0:
                 self._lock(LockType.READ)
             else:
-                self._unlock()  # can raise LockError.
+                self.release()  # can raise LockError.
 
             self._writes = 0
             self._log_released(locktype)

--- a/lib/spack/spack/llnl/util/lock.py
+++ b/lib/spack/spack/llnl/util/lock.py
@@ -9,7 +9,7 @@ import sys
 import time
 from datetime import datetime
 from types import TracebackType
-from typing import IO, Callable, Dict, Generator, Optional, Tuple, Type
+from typing import IO, Callable, Dict, Generator, Optional, Tuple, Type, Union
 
 from spack.llnl.util import lang, tty
 
@@ -31,6 +31,8 @@ __all__ = [
     "LockPermissionError",
     "LockROFileError",
     "CantCreateLockError",
+    "PosixBackend",
+    "DummyBackend",
 ]
 
 
@@ -70,7 +72,7 @@ class OpenFileTracker:
     no ``Lock`` in this process still needs it).
 
     Descriptors are *not* released on unlock; they are kept alive across lock/unlock cycles so that
-    the next lock operation can skip re-opening the file. ``Lock._ensure_valid_handle``
+    the next lock operation can skip re-opening the file. ``PosixBackend._ensure_valid_handle``
     re-validates the on-disk inode before each lock operation and drops a stale descriptor when
     the file was deleted and replaced.
     """
@@ -173,75 +175,32 @@ class LockType:
         return op == LockType.READ or op == LockType.WRITE
 
 
-class Lock:
-    """This is an implementation of a filesystem lock using Python's lockf.
+class PosixBackend:
+    """fcntl-based lock backend for POSIX systems."""
 
-    In Python, ``lockf`` actually calls ``fcntl``, so this should work with any filesystem
-    implementation that supports locking through the fcntl calls. This includes distributed
-    filesystems like Lustre (when flock is enabled) and recent NFS versions.
-
-    Note that this is for managing contention over resources *between* processes and not for
-    managing contention between threads in a process: the functions of this object are not
-    thread-safe. A process also must not maintain multiple locks on the same file (or, more
-    specifically, on overlapping byte ranges in the same file).
-    """
-
-    def __init__(
-        self,
-        path: str,
-        *,
-        start: int = 0,
-        length: int = 0,
-        default_timeout: Optional[float] = None,
-        debug: bool = False,
-        desc: str = "",
-    ) -> None:
-        """Construct a new lock on the file at ``path``.
-
-        By default, the lock applies to the whole file.  Optionally, caller can specify a byte
-        range beginning ``start`` bytes from the start of the file and extending ``length`` bytes
-        from there.
-
-        This exposes a subset of fcntl locking functionality.  It does not currently expose the
-        ``whence`` parameter -- ``whence`` is always ``os.SEEK_SET`` and ``start`` is always
-        evaluated from the beginning of the file.
-
-        Args:
-            path: path to the lock
-            start: optional byte offset at which the lock starts
-            length: optional number of bytes to lock
-            default_timeout: seconds to wait for lock attempts, where None means to wait
-                indefinitely
-            debug: debug mode specific to locking
-            desc: optional debug message lock description, which is helpful for distinguishing
-                between different Spack locks.
-        """
+    def __init__(self, path: str, start: int, length: int, debug: bool = False) -> None:
         self.path = path
-        self._reads = 0
-        self._writes = 0
-        self._file_ref: Optional[OpenFile] = None
-        self._cached_key: Optional[DevIno] = None
-
-        # byte range parameters
         self._start = start
         self._length = length
-
-        # enable debug mode
         self.debug = debug
-
-        # optional debug description
-        self.desc = f" ({desc})" if desc else ""
-
-        # If the user doesn't set a default timeout, or if they choose
-        # None, 0, etc. then lock attempts will not time out (unless the
-        # user sets a timeout for each attempt)
-        self.default_timeout = default_timeout or None
-
-        # PID and host of lock holder (only used in debug mode)
+        self._file_ref: Optional[OpenFile] = None
+        self._cached_key: Optional[DevIno] = None
+        # PID and host of the lock holder (only used in debug mode)
         self.pid: Optional[int] = None
         self.old_pid: Optional[int] = None
         self.host: Optional[str] = None
         self.old_host: Optional[str] = None
+
+    def __getstate__(self):
+        state = self.__dict__.copy()
+        del state["_file_ref"]
+        del state["_cached_key"]
+        return state
+
+    def __setstate__(self, state):
+        self.__dict__.update(state)
+        self._file_ref = None
+        self._cached_key = None
 
     def _ensure_valid_handle(self) -> IO[bytes]:
         """Return a valid file handle for the lock file, opening or re-opening as needed.
@@ -291,96 +250,6 @@ class Lock:
         self._cached_key = self._file_ref.key
 
         return self._file_ref.fh
-
-    @staticmethod
-    def _poll_interval_generator(
-        _wait_times: Optional[Tuple[float, float, float]] = None,
-    ) -> Generator[float, None, None]:
-        """This implements a backoff scheme for polling a contended resource by suggesting a
-        succession of wait times between polls.
-
-        It suggests a poll interval of .1s until 2 seconds have passed, then a poll interval of
-        .2s until 10 seconds have passed, and finally (for all requests after 10s) suggests a poll
-        interval of .5s.
-
-        This doesn't actually track elapsed time, it estimates the waiting time as though the
-        caller always waits for the full length of time suggested by this function.
-        """
-        num_requests = 0
-        stage1, stage2, stage3 = _wait_times or (1e-1, 2e-1, 5e-1)
-        wait_time = stage1
-        while True:
-            if num_requests >= 60:  # 40 * .2 = 8
-                wait_time = stage3
-            elif num_requests >= 20:  # 20 * .1 = 2
-                wait_time = stage2
-            num_requests += 1
-            yield wait_time
-
-    def __repr__(self) -> str:
-        """Formal representation of the lock."""
-        rep = f"{self.__class__.__name__}("
-        for attr, value in self.__dict__.items():
-            rep += f"{attr}={value.__repr__()}, "
-        return f"{rep.strip(', ')})"
-
-    def __str__(self) -> str:
-        """Readable string (with key fields) of the lock."""
-        location = f"{self.path}[{self._start}:{self._length}]"
-        timeout = f"timeout={self.default_timeout}"
-        activity = f"#reads={self._reads}, #writes={self._writes}"
-        return f"({location}, {timeout}, {activity})"
-
-    def __getstate__(self):
-        """Don't include file handles or counts in pickled state."""
-        state = self.__dict__.copy()
-        del state["_file_ref"]
-        del state["_reads"]
-        del state["_writes"]
-        return state
-
-    def __setstate__(self, state):
-        self.__dict__.update(state)
-        self._file_ref = None
-        self._reads = 0
-        self._writes = 0
-
-    def _lock(self, op: int, timeout: Optional[float] = None) -> Tuple[float, int]:
-        """This takes a lock using POSIX locks (``fcntl.lockf``).
-
-        The lock is implemented as a spin lock using a nonblocking call to ``lockf()``.
-
-        If the lock times out, it raises a ``LockError``. If the lock is successfully acquired, the
-        total wait time and the number of attempts is returned.
-        """
-        assert LockType.is_valid(op)
-        op_str = LockType.to_str(op)
-
-        self._log_acquiring("{0} LOCK".format(op_str))
-        timeout = timeout or self.default_timeout
-
-        self.prepare(op)
-
-        self._log_debug(
-            "{} locking [{}:{}]: timeout {}".format(
-                op_str.lower(), self._start, self._length, lang.pretty_seconds(timeout or 0)
-            )
-        )
-
-        start_time = time.monotonic()
-        end_time = float("inf") if not timeout else start_time + timeout
-        num_attempts = 1
-        poll_intervals = Lock._poll_interval_generator()
-
-        while True:
-            if self.poll(op):
-                return time.monotonic() - start_time, num_attempts
-            if time.monotonic() >= end_time:
-                break
-            time.sleep(next(poll_intervals))
-            num_attempts += 1
-
-        raise LockTimeoutError(op, self.path, time.monotonic() - start_time, num_attempts)
 
     def prepare(self, op: int) -> None:
         """Ensure the lock file is open; raise if a write lock is requested on a read-only file."""
@@ -463,8 +332,184 @@ class Lock:
         fcntl.lockf(
             self._file_ref.fh.fileno(), fcntl.LOCK_UN, self._length, self._start, os.SEEK_SET
         )
+
+    def cleanup(self, path: str) -> None:
+        """Remove the lock file."""
+        os.unlink(path)
+
+
+class DummyBackend:
+    """No-op lock backend: all operations succeed without acquiring any real locks."""
+
+    def prepare(self, op: int) -> None:
+        pass
+
+    def poll(self, op: int) -> bool:
+        return True
+
+    def release(self) -> None:
+        pass
+
+    def cleanup(self, path: str) -> None:
+        pass
+
+
+class Lock:
+    """This is an implementation of a filesystem lock using Python's lockf.
+
+    In Python, ``lockf`` actually calls ``fcntl``, so this should work with any filesystem
+    implementation that supports locking through the fcntl calls. This includes distributed
+    filesystems like Lustre (when flock is enabled) and recent NFS versions.
+
+    Note that this is for managing contention over resources *between* processes and not for
+    managing contention between threads in a process: the functions of this object are not
+    thread-safe. A process also must not maintain multiple locks on the same file (or, more
+    specifically, on overlapping byte ranges in the same file).
+    """
+
+    def __init__(
+        self,
+        path: str,
+        *,
+        start: int = 0,
+        length: int = 0,
+        default_timeout: Optional[float] = None,
+        debug: bool = False,
+        desc: str = "",
+    ) -> None:
+        """Construct a new lock on the file at ``path``.
+
+        By default, the lock applies to the whole file.  Optionally, caller can specify a byte
+        range beginning ``start`` bytes from the start of the file and extending ``length`` bytes
+        from there.
+
+        This exposes a subset of fcntl locking functionality.  It does not currently expose the
+        ``whence`` parameter -- ``whence`` is always ``os.SEEK_SET`` and ``start`` is always
+        evaluated from the beginning of the file.
+
+        Args:
+            path: path to the lock
+            start: optional byte offset at which the lock starts
+            length: optional number of bytes to lock
+            default_timeout: seconds to wait for lock attempts, where None means to wait
+                indefinitely
+            debug: debug mode specific to locking
+            desc: optional debug message lock description, which is helpful for distinguishing
+                between different Spack locks.
+        """
+        self.path = path
         self._reads = 0
         self._writes = 0
+
+        # byte range parameters
+        self._start = start
+        self._length = length
+
+        # enable debug mode
+        self.debug = debug
+
+        # optional debug description
+        self.desc = f" ({desc})" if desc else ""
+
+        # If the user doesn't set a default timeout, or if they choose
+        # None, 0, etc. then lock attempts will not time out (unless the
+        # user sets a timeout for each attempt)
+        self.default_timeout = default_timeout or None
+
+        if sys.platform != "win32":
+            self.backend: Union[PosixBackend, DummyBackend] = PosixBackend(
+                path, start, length, debug=debug
+            )
+        else:
+            self.backend = DummyBackend()
+
+    @staticmethod
+    def _poll_interval_generator(
+        _wait_times: Optional[Tuple[float, float, float]] = None,
+    ) -> Generator[float, None, None]:
+        """This implements a backoff scheme for polling a contended resource by suggesting a
+        succession of wait times between polls.
+
+        It suggests a poll interval of .1s until 2 seconds have passed, then a poll interval of
+        .2s until 10 seconds have passed, and finally (for all requests after 10s) suggests a poll
+        interval of .5s.
+
+        This doesn't actually track elapsed time, it estimates the waiting time as though the
+        caller always waits for the full length of time suggested by this function.
+        """
+        num_requests = 0
+        stage1, stage2, stage3 = _wait_times or (1e-1, 2e-1, 5e-1)
+        wait_time = stage1
+        while True:
+            if num_requests >= 60:  # 40 * .2 = 8
+                wait_time = stage3
+            elif num_requests >= 20:  # 20 * .1 = 2
+                wait_time = stage2
+            num_requests += 1
+            yield wait_time
+
+    def __repr__(self) -> str:
+        """Formal representation of the lock."""
+        rep = f"{self.__class__.__name__}("
+        for attr, value in self.__dict__.items():
+            rep += f"{attr}={value.__repr__()}, "
+        return f"{rep.strip(', ')})"
+
+    def __str__(self) -> str:
+        """Readable string (with key fields) of the lock."""
+        location = f"{self.path}[{self._start}:{self._length}]"
+        timeout = f"timeout={self.default_timeout}"
+        activity = f"#reads={self._reads}, #writes={self._writes}"
+        return f"({location}, {timeout}, {activity})"
+
+    def __getstate__(self):
+        """Don't include counts in pickled state (backend handles its own file handles)."""
+        state = self.__dict__.copy()
+        del state["_reads"]
+        del state["_writes"]
+        return state
+
+    def __setstate__(self, state):
+        self.__dict__.update(state)
+        self._reads = 0
+        self._writes = 0
+
+    def _lock(self, op: int, timeout: Optional[float] = None) -> Tuple[float, int]:
+        """This takes a lock using POSIX locks (``fcntl.lockf``).
+
+        The lock is implemented as a spin lock using a nonblocking call to ``lockf()``.
+
+        If the lock times out, it raises a ``LockError``. If the lock is successfully acquired, the
+        total wait time and the number of attempts is returned.
+        """
+        assert LockType.is_valid(op)
+        op_str = LockType.to_str(op)
+
+        self._log_acquiring("{0} LOCK".format(op_str))
+        timeout = timeout or self.default_timeout
+
+        self.backend.prepare(op)
+
+        self._log_debug(
+            "{} locking [{}:{}]: timeout {}".format(
+                op_str.lower(), self._start, self._length, lang.pretty_seconds(timeout or 0)
+            )
+        )
+
+        start_time = time.monotonic()
+        end_time = float("inf") if not timeout else start_time + timeout
+        num_attempts = 1
+        poll_intervals = Lock._poll_interval_generator()
+
+        while True:
+            if self.backend.poll(op):
+                return time.monotonic() - start_time, num_attempts
+            if time.monotonic() >= end_time:
+                break
+            time.sleep(next(poll_intervals))
+            num_attempts += 1
+
+        raise LockTimeoutError(op, self.path, time.monotonic() - start_time, num_attempts)
 
     def acquire_read(self, timeout: Optional[float] = None) -> bool:
         """Acquires a recursive, shared lock for reading.
@@ -530,8 +575,8 @@ class Lock:
             op = LockType.READ
         else:
             return
-        self.prepare(op)
-        if not self.poll(op):
+        self.backend.prepare(op)
+        if not self.backend.poll(op):
             raise LockTimeoutError(op, self.path, time=0, attempts=1)
 
     def try_acquire_read(self) -> bool:
@@ -540,8 +585,8 @@ class Lock:
         Returns True if the lock was acquired, False if it would block.
         """
         if self._reads == 0 and self._writes == 0:
-            self.prepare(LockType.READ)
-            if not self.poll(LockType.READ):
+            self.backend.prepare(LockType.READ)
+            if not self.backend.poll(LockType.READ):
                 return False
             self._reads += 1
             self._log_acquired("READ LOCK", 0, 1)
@@ -557,8 +602,8 @@ class Lock:
         Returns True if the lock was acquired, False if it would block.
         """
         if self._writes == 0:
-            self.prepare(LockType.WRITE)
-            if not self.poll(LockType.WRITE):
+            self.backend.prepare(LockType.WRITE)
+            if not self.backend.poll(LockType.WRITE):
                 return False
             self._writes += 1
             self._log_acquired("WRITE LOCK", 0, 1)
@@ -643,7 +688,7 @@ class Lock:
             release_fn = release_fn or true_fn
             result = release_fn()
 
-            self.release()  # can raise LockError.
+            self.backend.release()  # can raise LockError.
             self._reads = 0
             self._log_released(locktype)
             return bool(result)
@@ -678,7 +723,7 @@ class Lock:
             if self._reads > 0:
                 self._lock(LockType.READ)
             else:
-                self.release()  # can raise LockError.
+                self.backend.release()  # can raise LockError.
 
             self._writes = 0
             self._log_released(locktype)
@@ -689,7 +734,7 @@ class Lock:
 
     def cleanup(self) -> None:
         if self._reads == 0 and self._writes == 0:
-            os.unlink(self.path)
+            self.backend.cleanup(self.path)
         else:
             raise LockError("Attempting to cleanup active lock.")
 

--- a/lib/spack/spack/test/llnl/util/lock.py
+++ b/lib/spack/spack/test/llnl/util/lock.py
@@ -1245,10 +1245,10 @@ def test_poll_lock_exception(tmp_path: pathlib.Path, monkeypatch, err_num, err_m
         monkeypatch.setattr(fcntl, "lockf", _lockf)
 
         if err_num in [errno.EAGAIN, errno.EACCES]:
-            assert not lock._poll_lock(fcntl.LOCK_EX)
+            assert not lock.poll(fcntl.LOCK_EX)
         else:
             with pytest.raises(OSError, match=err_msg):
-                lock._poll_lock(fcntl.LOCK_EX)
+                lock.poll(fcntl.LOCK_EX)
 
         monkeypatch.undo()
         lock.release_read()

--- a/lib/spack/spack/test/llnl/util/lock.py
+++ b/lib/spack/spack/test/llnl/util/lock.py
@@ -631,22 +631,22 @@ def test_upgrade_read_to_write(private_lock_path):
     lock.acquire_read()
     assert lock._reads == 1
     assert lock._writes == 0
-    assert lock._file_ref.fh.mode == "rb+"
+    assert lock.backend._file_ref.fh.mode == "rb+"
 
     lock.acquire_write()
     assert lock._reads == 1
     assert lock._writes == 1
-    assert lock._file_ref.fh.mode == "rb+"
+    assert lock.backend._file_ref.fh.mode == "rb+"
 
     lock.release_write()
     assert lock._reads == 1
     assert lock._writes == 0
-    assert lock._file_ref.fh.mode == "rb+"
+    assert lock.backend._file_ref.fh.mode == "rb+"
 
     lock.release_read()
     assert lock._reads == 0
     assert lock._writes == 0
-    assert not lock._file_ref.fh.closed  # recycle the file handle for next lock
+    assert not lock.backend._file_ref.fh.closed  # recycle the file handle for next lock
 
 
 def test_release_write_downgrades_to_shared(private_lock_path):
@@ -694,7 +694,7 @@ def test_upgrade_read_to_write_fails_with_readonly_file(private_lock_path):
         lock.acquire_read()
         assert lock._reads == 1
         assert lock._writes == 0
-        assert lock._file_ref.fh.mode == "rb"
+        assert lock.backend._file_ref.fh.mode == "rb"
 
         # upgrade to write here
         with pytest.raises(lk.LockROFileError):
@@ -1101,8 +1101,8 @@ class LockDebugOutput:
             # p1 takes write lock and writes pid/host to file
             barrier.wait()  # ------------------------------------ 1
 
-        assert lock.pid == p1_pid
-        assert lock.host == self.host
+        assert lock.backend.pid == p1_pid
+        assert lock.backend.host == self.host
 
         # wait for p2 to verify contents of file
         barrier.wait()  # ---------------------------------------- 2
@@ -1112,11 +1112,11 @@ class LockDebugOutput:
 
         # verify pid/host info again
         with lk.ReadTransaction(lock):
-            assert lock.old_pid == p1_pid
-            assert lock.old_host == self.host
+            assert lock.backend.old_pid == p1_pid
+            assert lock.backend.old_host == self.host
 
-            assert lock.pid == p2_pid
-            assert lock.host == self.host
+            assert lock.backend.pid == p2_pid
+            assert lock.backend.host == self.host
 
         barrier.wait()  # ---------------------------------------- 4
 
@@ -1134,18 +1134,18 @@ class LockDebugOutput:
 
         # verify that p1 wrote information to lock file
         with lk.ReadTransaction(lock):
-            assert lock.pid == p1_pid
-            assert lock.host == self.host
+            assert lock.backend.pid == p1_pid
+            assert lock.backend.host == self.host
 
         barrier.wait()  # ---------------------------------------- 2
 
         # take a write lock on the file and verify pid/host info
         with lk.WriteTransaction(lock):
-            assert lock.old_pid == p1_pid
-            assert lock.old_host == self.host
+            assert lock.backend.old_pid == p1_pid
+            assert lock.backend.old_host == self.host
 
-            assert lock.pid == p2_pid
-            assert lock.host == self.host
+            assert lock.backend.pid == p2_pid
+            assert lock.backend.host == self.host
 
             barrier.wait()  # ------------------------------------ 3
 
@@ -1245,10 +1245,10 @@ def test_poll_lock_exception(tmp_path: pathlib.Path, monkeypatch, err_num, err_m
         monkeypatch.setattr(fcntl, "lockf", _lockf)
 
         if err_num in [errno.EAGAIN, errno.EACCES]:
-            assert not lock.poll(fcntl.LOCK_EX)
+            assert not lock.backend.poll(fcntl.LOCK_EX)
         else:
             with pytest.raises(OSError, match=err_msg):
-                lock.poll(fcntl.LOCK_EX)
+                lock.backend.poll(fcntl.LOCK_EX)
 
         monkeypatch.undo()
         lock.release_read()

--- a/lib/spack/spack/util/lock.py
+++ b/lib/spack/spack/util/lock.py
@@ -7,9 +7,10 @@
 import os
 import stat
 import sys
-from typing import Optional, Tuple
+from typing import Optional
 
 import spack.error
+from spack.llnl.util.lock import DummyBackend
 from spack.llnl.util.lock import Lock as Llnl_lock
 from spack.llnl.util.lock import (
     LockError,
@@ -23,9 +24,8 @@ from spack.llnl.util.lock import (
 class Lock(Llnl_lock):
     """Lock that can be disabled.
 
-    This overrides the ``_lock()`` and ``release()`` methods from
-    ``spack.llnl.util.lock`` so that all the lock API calls will succeed, but
-    the actual locking mechanism can be disabled via ``_enable_locks``.
+    Swaps in a ``DummyBackend`` when ``enable`` is False (or on Windows), so all the lock API
+    calls will succeed without performing real filesystem locks.
     """
 
     def __init__(
@@ -39,7 +39,6 @@ class Lock(Llnl_lock):
         desc: str = "",
         enable: bool = True,
     ) -> None:
-        self._enable = sys.platform != "win32" and enable
         super().__init__(
             path,
             start=start,
@@ -48,39 +47,8 @@ class Lock(Llnl_lock):
             debug=debug,
             desc=desc,
         )
-
-    def _reaffirm_lock(self) -> None:
-        if self._enable:
-            super()._reaffirm_lock()
-
-    def _lock(self, op: int, timeout: Optional[float] = 0.0) -> Tuple[float, int]:
-        if self._enable:
-            return super()._lock(op, timeout)
-        return 0.0, 0
-
-    def poll(self, op: int) -> bool:
-        if self._enable:
-            return super().poll(op)
-        return True
-
-    def release(self) -> None:
-        """Unlock call that always succeeds."""
-        if self._enable:
-            super().release()
-
-    def try_acquire_read(self) -> bool:
-        if self._enable:
-            return super().try_acquire_read()
-        return True
-
-    def try_acquire_write(self) -> bool:
-        if self._enable:
-            return super().try_acquire_write()
-        return True
-
-    def cleanup(self, *args) -> None:
-        if self._enable:
-            super().cleanup(*args)
+        if sys.platform == "win32" or not enable:
+            self.backend = DummyBackend()
 
 
 def check_lock_safety(path: str) -> None:

--- a/lib/spack/spack/util/lock.py
+++ b/lib/spack/spack/util/lock.py
@@ -10,6 +10,7 @@ import stat
 import spack.error
 from spack.llnl.util.lock import (
     Lock,
+    LockDowngradeError,
     LockError,
     LockTimeoutError,
     LockUpgradeError,
@@ -51,11 +52,12 @@ def check_lock_safety(path: str) -> None:
 
 
 __all__ = [
+    "check_lock_safety",
+    "Lock",
+    "LockDowngradeError",
     "LockError",
     "LockTimeoutError",
     "LockUpgradeError",
     "ReadTransaction",
     "WriteTransaction",
-    "Lock",
-    "check_lock_safety",
 ]

--- a/lib/spack/spack/util/lock.py
+++ b/lib/spack/spack/util/lock.py
@@ -2,53 +2,20 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-"""Wrapper for ``spack.llnl.util.lock`` allows locking to be enabled/disabled."""
+"""Re-exports of :mod:`spack.llnl.util.lock` along with :func:`check_lock_safety`."""
 
 import os
 import stat
-import sys
-from typing import Optional
 
 import spack.error
-from spack.llnl.util.lock import DummyBackend
-from spack.llnl.util.lock import Lock as Llnl_lock
 from spack.llnl.util.lock import (
+    Lock,
     LockError,
     LockTimeoutError,
     LockUpgradeError,
     ReadTransaction,
     WriteTransaction,
 )
-
-
-class Lock(Llnl_lock):
-    """Lock that can be disabled.
-
-    Swaps in a ``DummyBackend`` when ``enable`` is False (or on Windows), so all the lock API
-    calls will succeed without performing real filesystem locks.
-    """
-
-    def __init__(
-        self,
-        path: str,
-        *,
-        start: int = 0,
-        length: int = 0,
-        default_timeout: Optional[float] = None,
-        debug: bool = False,
-        desc: str = "",
-        enable: bool = True,
-    ) -> None:
-        super().__init__(
-            path,
-            start=start,
-            length=length,
-            default_timeout=default_timeout,
-            debug=debug,
-            desc=desc,
-        )
-        if sys.platform == "win32" or not enable:
-            self.backend = DummyBackend()
 
 
 def check_lock_safety(path: str) -> None:

--- a/lib/spack/spack/util/lock.py
+++ b/lib/spack/spack/util/lock.py
@@ -23,7 +23,7 @@ from spack.llnl.util.lock import (
 class Lock(Llnl_lock):
     """Lock that can be disabled.
 
-    This overrides the ``_lock()`` and ``_unlock()`` methods from
+    This overrides the ``_lock()`` and ``release()`` methods from
     ``spack.llnl.util.lock`` so that all the lock API calls will succeed, but
     the actual locking mechanism can be disabled via ``_enable_locks``.
     """
@@ -58,15 +58,15 @@ class Lock(Llnl_lock):
             return super()._lock(op, timeout)
         return 0.0, 0
 
-    def _poll_lock(self, op: int) -> bool:
+    def poll(self, op: int) -> bool:
         if self._enable:
-            return super()._poll_lock(op)
+            return super().poll(op)
         return True
 
-    def _unlock(self) -> None:
+    def release(self) -> None:
         """Unlock call that always succeeds."""
         if self._enable:
-            super()._unlock()
+            super().release()
 
     def try_acquire_read(self) -> bool:
         if self._enable:


### PR DESCRIPTION
Replaces #52488 and #52479.

Condense the `if self._enabled` branches into a single one in the constructor, instead of sprinkling them in every method. It works by extracting the syscalls to a backend class in a composition over inheritance style. On Windows the backend is a no-op version.

This is best reviewed commit by commit, with `git show --color-moved=dimmed-zebra c94402845c6eda4fb9a36108a6037a68880a9507` for the commit that moves code.

In a follow-up PR we could use a mock backend in tests to drop `fcntl` monkeypatching.

