### PR TITLE
New command: spack isolate

### DIFF
--- a/lib/spack/docs/configuration.rst
+++ b/lib/spack/docs/configuration.rst
@@ -699,6 +699,8 @@ It modifies the current Spack instance by setting the ``user`` scope to use ``IS
 This facilitates working with many independent Spack instances without worrying about overlapping configuration.
 ``spack isolate --undo`` reverts the changes to Spack made by ``spack isolate``.
 
+``spack isolate --self`` is a shortcut that isolates Spack to its own prefix.
+
 Currently, ``spack isolate`` is a best-effort approach to isolation of a Spack instance.
 The default location Spack uses for cloning Git based package repositories can only be configured by the ``SPACK_USER_CACHE_PATH`` environment variable (see :ref:`automatic-repo-cloning`).
 ``spack isolate --path ISO_PATH`` will explicitly set the destination of repositories that it knows about when invoked to a subdirectory of ``ISO_PATH``; however, newly added repositories without an explicit destination will be cloned to ``~/.spack``.
@@ -707,4 +709,3 @@ To avoid this, either explicitly set ``SPACK_USER_CACHE_PATH`` or explicitly set
   .. warning::
 
     This is an experimental feature that will be overhauled in v1.3, which will have big changes to how Spack is configured to store data and permit a more robust implementation.
-

--- a/lib/spack/docs/configuration.rst
+++ b/lib/spack/docs/configuration.rst
@@ -694,9 +694,15 @@ With these settings, if you want to isolate Spack in a CI environment, you can d
 ``spack isolate``
 ^^^^^^^^^^^^^^^^^^
 
-``spack isolate --path ISO_PATH`` provides a mechanism for isolating a single spack instance from ``~/.spack``. It modifies the current Spack instance by setting the ``user`` scope to use ``ISO_PATH`` and creating an ``isolate`` scope below the ``site`` scope that moves caches and stages that usually default to ``~/.spack`` to ``ISO_PATH`` instead. This facilitates working with many independent Spack instances without worrying about overlapping configuration. ``spack isolate --undo`` reverts the changes to Spack made by ``spack isolate``.
+``spack isolate --path ISO_PATH`` provides a mechanism for isolating a single spack instance from ``~/.spack``.
+It modifies the current Spack instance by setting the ``user`` scope to use ``ISO_PATH`` and creating an ``isolate`` scope below the ``site`` scope that moves caches and stages that usually default to ``~/.spack`` to ``ISO_PATH`` instead.
+This facilitates working with many independent Spack instances without worrying about overlapping configuration.
+``spack isolate --undo`` reverts the changes to Spack made by ``spack isolate``.
 
-Currently, ``spack isolate`` is a best-effort approach to isolation of a Spack instance. The default location Spack uses for cloning Git based package repositories can only be configured by the ``SPACK_USER_CACHE_PATH`` environment variable (see :ref:`automatic-repo-cloning`) . ``spack isolate --path ISO_PATH`` will explicitly set the destination of repositories that it knows about when invoked to a subdirectory of ``ISO_PATH``; however, newly added repositories without an explicit destination will be cloned to ``~/.spack``. To avoid this, either explicitly set ``SPACK_USER_CACHE_PATH`` or explicitly set the destination of newly added repositories to a different location (see :ref:`customizing-clone-location`).
+Currently, ``spack isolate`` is a best-effort approach to isolation of a Spack instance.
+The default location Spack uses for cloning Git based package repositories can only be configured by the ``SPACK_USER_CACHE_PATH`` environment variable (see :ref:`automatic-repo-cloning`).
+``spack isolate --path ISO_PATH`` will explicitly set the destination of repositories that it knows about when invoked to a subdirectory of ``ISO_PATH``; however, newly added repositories without an explicit destination will be cloned to ``~/.spack``.
+To avoid this, either explicitly set ``SPACK_USER_CACHE_PATH`` or explicitly set the destination of newly added repositories to a different location (see :ref:`customizing-clone-location`).
 
   .. warning::
 

--- a/lib/spack/docs/configuration.rst
+++ b/lib/spack/docs/configuration.rst
@@ -689,3 +689,16 @@ With these settings, if you want to isolate Spack in a CI environment, you can d
 
   $ export SPACK_DISABLE_LOCAL_CONFIG=true
   $ export SPACK_USER_CACHE_PATH=/tmp/spack
+
+
+``spack isolate``
+^^^^^^^^^^^^^^^^^^
+
+``spack isolate --path ISO_PATH`` provides a mechanism for isolating a single spack instance from ``~/.spack``. It modifies the current Spack instance by setting the ``user`` scope to use ``ISO_PATH`` and creating an ``isolate`` scope below the ``site`` scope that moves caches and stages that usually default to ``~/.spack`` to ``ISO_PATH`` instead. This facilitates working with many independent Spack instances without worrying about overlapping configuration. ``spack isolate --undo`` reverts the changes to Spack made by ``spack isolate``.
+
+Currently, ``spack isolate`` is a best-effort approach to isolation of a Spack instance. The default location Spack uses for cloning Git based package repositories can only be configured by the ``SPACK_USER_CACHE_PATH`` environment variable (see :ref:`automatic-repo-cloning`) . ``spack isolate --path ISO_PATH`` will explicitly set the destination of repositories that it knows about when invoked to a subdirectory of ``ISO_PATH``; however, newly added repositories without an explicit destination will be cloned to ``~/.spack``. To avoid this, either explicitly set ``SPACK_USER_CACHE_PATH`` or explicitly set the destination of newly added repositories to a different location (see :ref:`customizing-clone-location`).
+
+  .. warning::
+
+    This is an experimental feature that will be overhauled in v1.3, which will have big changes to how Spack is configured to store data and permit a more robust implementation.
+

--- a/lib/spack/docs/repositories.rst
+++ b/lib/spack/docs/repositories.rst
@@ -119,6 +119,8 @@ Spack can clone and use repositories directly from Git URLs:
    repos:
      my_remote_repo: https://github.com/myorg/spack-custom-pkgs.git
 
+.. _automatic-repo-cloning:
+
 Automatic Cloning
 """""""""""""""""
 
@@ -128,6 +130,8 @@ By default, these repositories are cloned into a subdirectory within ``~/.spack/
 To change directories to the package repository, you can use ``spack cd --repo [name]``.
 To find where a repository is cloned, you can use ``spack location --repo [name]`` or ``spack repo list``.
 The ``name`` argument is optional; if omitted, Spack will use the first package repository in configuration order.
+
+.. _customizing-clone-location:
 
 Customizing Clone Location
 """"""""""""""""""""""""""

--- a/lib/spack/spack/cmd/isolate.py
+++ b/lib/spack/spack/cmd/isolate.py
@@ -21,7 +21,7 @@ level = "long"
 
 INCLUDE_PATH = os.path.join(spack.paths.etc_path, "include.yaml")
 PRESERVED_INCLUDE_PATH = os.path.join(spack.paths.etc_path, ".isolate.include.yaml")
-ISOLATE_PATH = os.path.join(spack.paths.etc_path, "isolate")
+ISOLATE_SCOPE_PATH = os.path.join(spack.paths.etc_path, "isolate")
 
 
 def _get_scope_indices(included_scopes):
@@ -43,7 +43,7 @@ def _get_scope_indices(included_scopes):
 
 def _isolate_bootstrap_config(new_user_path):
     bootstrap_yaml = {"bootstrap": {"root": os.path.join(new_user_path, "bootstrap")}}
-    with open(os.path.join(ISOLATE_PATH, "bootstrap.yaml"), "w", encoding="utf-8") as f:
+    with open(os.path.join(ISOLATE_SCOPE_PATH, "bootstrap.yaml"), "w", encoding="utf-8") as f:
         syaml.dump(bootstrap_yaml, f)
 
 
@@ -58,7 +58,7 @@ def _isolate_config_config(new_user_path):
             "misc_cache:": misc_cache_dir,
         }
     }
-    with open(os.path.join(ISOLATE_PATH, "config.yaml"), "w", encoding="utf-8") as f:
+    with open(os.path.join(ISOLATE_SCOPE_PATH, "config.yaml"), "w", encoding="utf-8") as f:
         syaml.dump(config_yaml, f)
 
 
@@ -73,20 +73,20 @@ def _isolate_repos_config(new_user_path):
                 value["destination"] = os.path.join(new_user_path, "repos", key)
                 new_repos_config[key] = value
 
-    with open(os.path.join(ISOLATE_PATH, "repos.yaml"), "w", encoding="utf-8") as f:
+    with open(os.path.join(ISOLATE_SCOPE_PATH, "repos.yaml"), "w", encoding="utf-8") as f:
         syaml.dump({"repos": new_repos_config}, f)
 
 
 def _setup_isolate_scope(new_user_path, overwrite: bool):
-    if os.path.exists(ISOLATE_PATH):
+    if os.path.exists(ISOLATE_SCOPE_PATH):
         if overwrite:
-            shutil.rmtree(ISOLATE_PATH)
+            shutil.rmtree(ISOLATE_SCOPE_PATH)
         else:
             raise Exception("An isolation already exists for this Spack instance")
-    os.mkdir(ISOLATE_PATH)
+    os.mkdir(ISOLATE_SCOPE_PATH)
     isolate_dict = {}
     isolate_dict["name"] = "isolate"
-    isolate_dict["path"] = ISOLATE_PATH
+    isolate_dict["path"] = ISOLATE_SCOPE_PATH
     _isolate_bootstrap_config(new_user_path)
     _isolate_config_config(new_user_path)
     _isolate_repos_config(new_user_path)
@@ -140,11 +140,11 @@ def _do_isolate(args):
     isolate_scope = _setup_isolate_scope(destination, args.overwrite)
     # insert the isolate scope above the below user and site but above system
     if old_isolate_index is not None:  # first try the old isolate index (--overwrite)
-        include_config.insert(old_isolate_index, isolate_scope)
+        include_config[old_isolate_index] = isolate_scope
     elif site_index is not None:  # otherwise put it below the site scope
         include_config.insert(site_index + 1, isolate_scope)
     elif system_index is not None:  # if there is no site scope, put it above the system scope
-        include_config.insert(system_index - 1, isolate_scope)
+        include_config.insert(system_index, isolate_scope)
     elif user_index is not None:  # if there is no system scope, put it below the user scope
         include_config.insert(user_index + 1, isolate_scope)
     else:  # Strange changes have been made if there is no site, system, or user scope
@@ -161,9 +161,9 @@ def _do_isolate(args):
 
 
 def _undo_isolate():
-    assert os.path.exists(ISOLATE_PATH), "Cannot find isolation to undo"
+    assert os.path.exists(ISOLATE_SCOPE_PATH), "Cannot find isolation to undo"
     assert os.path.exists(PRESERVED_INCLUDE_PATH), "Cannot find pre-isolate include.yaml"
-    shutil.rmtree(ISOLATE_PATH)
+    shutil.rmtree(ISOLATE_SCOPE_PATH)
     shutil.copy(PRESERVED_INCLUDE_PATH, INCLUDE_PATH)
 
 

--- a/lib/spack/spack/cmd/isolate.py
+++ b/lib/spack/spack/cmd/isolate.py
@@ -60,7 +60,6 @@ def _isolate_config_config(new_user_path):
         syaml.dump(config_yaml, f)
 
 
-
 def _setup_isolate_scope(new_user_path, overwrite: bool):
     if os.path.exists(ISOLATE_PATH):
         if overwrite:
@@ -114,20 +113,17 @@ def _preserve_and_extract_include():
     )
     return include_config["include"]
 
+
 def _shim_user_path_in_exe(user_path):
     if_line = lambda var: f'if [[ -z "${{{var}}}" ]]; then'
     spaces = lambda n: f"{' ' * n}"
-    export_line = lambda var: f'export {var}={user_path}'
+    export_line = lambda var: f"export {var}={user_path}"
     with open(spack.paths.spack_script, "r", encoding="utf-8") as f:
         script_lines = f.read().split("\n")
     new_lines = []
     added_lines = []
-    for var in ('SPACK_USER_CONFIG_PATH', 'SPACK_USER_CACHE_PATH'):
-        added_lines += [
-            spaces(8) + if_line(var),
-            spaces(12) + export_line(var),
-            spaces(8) + "fi"
-        ]
+    for var in ("SPACK_USER_CONFIG_PATH", "SPACK_USER_CACHE_PATH"):
+        added_lines += [spaces(8) + if_line(var), spaces(12) + export_line(var), spaces(8) + "fi"]
     rest_ind = None
     for i, line in enumerate(script_lines):
         if line.strip() == if_line:
@@ -145,14 +141,12 @@ def _shim_user_path_in_exe(user_path):
         raise Exception("isolate: Failed to parse spack executable")
     with open(spack.paths.spack_script, "w", encoding="utf-8") as f:
         f.write("\n".join(new_lines + script_lines[rest_ind:]))
-        
-        
+
+
 def isolate(parser, args):
     destination = _ensure_destination_setup(args.destination, args.overwrite)
     include_config: list = _preserve_and_extract_include()
-    user_index, site_index, system_index, old_isolate_index = _get_scope_indices(
-        include_config
-    )
+    user_index, site_index, system_index, old_isolate_index = _get_scope_indices(include_config)
     isolate_scope = _setup_isolate_scope(destination, args.overwrite)
     # insert the isolate scope above the below user and site but above system
     if old_isolate_index is not None:

--- a/lib/spack/spack/cmd/isolate.py
+++ b/lib/spack/spack/cmd/isolate.py
@@ -22,7 +22,7 @@ INCLUDE_PATH = os.path.join(spack.paths.etc_path, "include.yaml")
 ISOLATE_PATH = os.path.join(spack.paths.etc_path, "isolate")
 
 
-def _get_scope_indices(included_scopes, destination):
+def _get_scope_indices(included_scopes):
     user_index = None
     site_index = None
     system_index = None
@@ -60,19 +60,6 @@ def _isolate_config_config(new_user_path):
         syaml.dump(config_yaml, f)
 
 
-def _isolate_repos_config(new_user_path):
-    current_repos_config = spack.config.get("repos")
-    new_repos_config = {}
-    for key, value in current_repos_config.items():
-        if isinstance(value, str):
-            new_repos_config[key] = value
-        if isinstance(value, dict):
-            if "destination" not in value:
-                value["destination"] = os.path.join(new_user_path, "repos", key)
-                new_repos_config[key] = value
-    with open(os.path.join(ISOLATE_PATH, "repos.yaml"), "w", encoding="utf-8") as f:
-        syaml.dump({"repos": new_repos_config}, f)
-
 
 def _setup_isolate_scope(new_user_path, overwrite: bool):
     if os.path.exists(ISOLATE_PATH):
@@ -86,7 +73,6 @@ def _setup_isolate_scope(new_user_path, overwrite: bool):
     isolate_dict["path"] = ISOLATE_PATH
     _isolate_bootstrap_config(new_user_path)
     _isolate_config_config(new_user_path)
-    _isolate_repos_config(new_user_path)
     return isolate_dict
 
 
@@ -117,7 +103,7 @@ def _ensure_destination_setup(destination: str, overwrite: bool):
         if overwrite:
             shutil.rmtree(destination)
         else:
-            raise Exception("Isolation destination already exists")
+            raise Exception(f"Isolation destination: {destination} already exists")
     os.mkdir(destination)
     return os.path.abspath(destination)
 
@@ -128,12 +114,44 @@ def _preserve_and_extract_include():
     )
     return include_config["include"]
 
-
+def _shim_user_path_in_exe(user_path):
+    if_line = lambda var: f'if [[ -z "${{{var}}}" ]]; then'
+    spaces = lambda n: f"{' ' * n}"
+    export_line = lambda var: f'export {var}={user_path}'
+    with open(spack.paths.spack_script, "r", encoding="utf-8") as f:
+        script_lines = f.read().split("\n")
+    new_lines = []
+    added_lines = []
+    for var in ('SPACK_USER_CONFIG_PATH', 'SPACK_USER_CACHE_PATH'):
+        added_lines += [
+            spaces(8) + if_line(var),
+            spaces(12) + export_line(var),
+            spaces(8) + "fi"
+        ]
+    rest_ind = None
+    for i, line in enumerate(script_lines):
+        if line.strip() == if_line:
+            new_lines += added_lines
+            rest_ind = i + len(added_lines)
+            break
+        elif line.strip().startswith("export SPACK_PYTHON"):
+            new_lines += added_lines
+            new_lines.append(line)
+            rest_ind = i + 1
+            break
+        else:
+            new_lines.append(line)
+    if rest_ind is None:
+        raise Exception("isolate: Failed to parse spack executable")
+    with open(spack.paths.spack_script, "w", encoding="utf-8") as f:
+        f.write("\n".join(new_lines + script_lines[rest_ind:]))
+        
+        
 def isolate(parser, args):
     destination = _ensure_destination_setup(args.destination, args.overwrite)
     include_config: list = _preserve_and_extract_include()
     user_index, site_index, system_index, old_isolate_index = _get_scope_indices(
-        include_config, destination
+        include_config
     )
     isolate_scope = _setup_isolate_scope(destination, args.overwrite)
     # insert the isolate scope above the below user and site but above system
@@ -157,6 +175,7 @@ def isolate(parser, args):
     with open(INCLUDE_PATH, "w", encoding="utf-8") as f:
         syaml.dump({"include": include_config}, f)
 
+    _shim_user_path_in_exe(destination)
     if args.bootstrap:
         del spack.config.CONFIG
         spack.config.CONFIG = spack.config.create()

--- a/lib/spack/spack/cmd/isolate.py
+++ b/lib/spack/spack/cmd/isolate.py
@@ -161,8 +161,10 @@ def _do_isolate(args):
 
 
 def _undo_isolate():
-    assert os.path.exists(ISOLATE_SCOPE_PATH), "Cannot find isolation to undo"
-    assert os.path.exists(PRESERVED_INCLUDE_PATH), "Cannot find pre-isolate include.yaml"
+    if not os.path.exists(ISOLATE_SCOPE_PATH):
+        raise RuntimeError("Cannot find isolation to undo")
+    if not os.path.exists(PRESERVED_INCLUDE_PATH):
+        raise RuntimeError("Cannot find pre-isolate include.yaml")
     shutil.rmtree(ISOLATE_SCOPE_PATH)
     shutil.copy(PRESERVED_INCLUDE_PATH, INCLUDE_PATH)
 

--- a/lib/spack/spack/cmd/isolate.py
+++ b/lib/spack/spack/cmd/isolate.py
@@ -3,12 +3,14 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 import os
 import shutil
+import textwrap
 from argparse import ArgumentParser
 from typing import cast
 
 from spack.vendor.ruamel.yaml.compat import ordereddict
 
 import spack.config
+import spack.llnl.util.tty as tty
 import spack.paths
 import spack.schema.include
 import spack.util.spack_yaml as syaml
@@ -18,6 +20,7 @@ section = "config"
 level = "long"
 
 INCLUDE_PATH = os.path.join(spack.paths.etc_path, "include.yaml")
+PRESERVED_INCLUDE_PATH = os.path.join(spack.paths.etc_path, ".isolate.include.yaml")
 ISOLATE_PATH = os.path.join(spack.paths.etc_path, "isolate")
 
 
@@ -59,6 +62,21 @@ def _isolate_config_config(new_user_path):
         syaml.dump(config_yaml, f)
 
 
+def _isolate_repos_config(new_user_path):
+    current_repos_config = spack.config.get("repos")
+    new_repos_config = {}
+    for key, value in current_repos_config.items():
+        if isinstance(value, str):
+            new_repos_config[key] = value
+        if isinstance(value, dict):
+            if "destination" not in value:
+                value["destination"] = os.path.join(new_user_path, "repos", key)
+                new_repos_config[key] = value
+
+    with open(os.path.join(ISOLATE_PATH, "repos.yaml"), "w", encoding="utf-8") as f:
+        syaml.dump({"repos": new_repos_config}, f)
+
+
 def _setup_isolate_scope(new_user_path, overwrite: bool):
     if os.path.exists(ISOLATE_PATH):
         if overwrite:
@@ -71,6 +89,7 @@ def _setup_isolate_scope(new_user_path, overwrite: bool):
     isolate_dict["path"] = ISOLATE_PATH
     _isolate_bootstrap_config(new_user_path)
     _isolate_config_config(new_user_path)
+    _isolate_repos_config(new_user_path)
     return isolate_dict
 
 
@@ -84,13 +103,6 @@ def _get_new_user_scope(new_user_path):
     }
 
 
-def setup_parser(subparser: ArgumentParser):
-    subparser.add_argument("destination", type=str, help="Path to data isolation directory")
-    subparser.add_argument(
-        "--overwrite", action="store_true", help="Overwrite existing isolation if necessary"
-    )
-
-
 def _ensure_destination_setup(destination: str, overwrite: bool):
     if os.path.exists(destination):
         if overwrite:
@@ -102,43 +114,27 @@ def _ensure_destination_setup(destination: str, overwrite: bool):
 
 
 def _preserve_and_extract_include():
+    if not os.path.exists(PRESERVED_INCLUDE_PATH):
+        shutil.copy(INCLUDE_PATH, PRESERVED_INCLUDE_PATH)
     include_config = cast(
         ordereddict, spack.config.read_config_file(INCLUDE_PATH, spack.schema.include.schema)
     )
     return include_config["include"]
 
 
-def _shim_user_path_in_exe(user_path):
-    if_line = lambda var: f'if [[ -z "${{{var}}}" ]]; then'
-    spaces = lambda n: f"{' ' * n}"
-    export_line = lambda var: f"export {var}={user_path}"
-    with open(spack.paths.spack_script, "r", encoding="utf-8") as f:
-        script_lines = f.read().split("\n")
-    new_lines = []
-    added_lines = []
-    for var in ("SPACK_USER_CONFIG_PATH", "SPACK_USER_CACHE_PATH"):
-        added_lines += [spaces(8) + if_line(var), spaces(12) + export_line(var), spaces(8) + "fi"]
-    rest_ind = None
-    for i, line in enumerate(script_lines):
-        if line.strip() == if_line:
-            new_lines += added_lines
-            rest_ind = i + len(added_lines)
-            break
-        elif line.strip().startswith("export SPACK_PYTHON"):
-            new_lines += added_lines
-            new_lines.append(line)
-            rest_ind = i + 1
-            break
-        else:
-            new_lines.append(line)
-    if rest_ind is None:
-        raise Exception("isolate: Failed to parse spack executable")
-    with open(spack.paths.spack_script, "w", encoding="utf-8") as f:
-        f.write("\n".join(new_lines + script_lines[rest_ind:]))
+def setup_parser(subparser: ArgumentParser):
+    isolate_group = subparser.add_mutually_exclusive_group()
+    isolate_group.add_argument("--path", type=str, help="Path to data isolation directory")
+    isolate_group.add_argument(
+        "--undo", action="store_true", help="Undo the result of calling isolate"
+    )
+    subparser.add_argument(
+        "--overwrite", action="store_true", help="Overwrite existing isolation if necessary"
+    )
 
 
-def isolate(parser, args):
-    destination = _ensure_destination_setup(args.destination, args.overwrite)
+def _do_isolate(args):
+    destination = _ensure_destination_setup(args.path, args.overwrite)
     include_config: list = _preserve_and_extract_include()
     user_index, site_index, system_index, old_isolate_index = _get_scope_indices(include_config)
     isolate_scope = _setup_isolate_scope(destination, args.overwrite)
@@ -163,4 +159,26 @@ def isolate(parser, args):
     with open(INCLUDE_PATH, "w", encoding="utf-8") as f:
         syaml.dump({"include": include_config}, f)
 
-    _shim_user_path_in_exe(destination)
+
+def _undo_isolate():
+    assert os.path.exists(ISOLATE_PATH), "Cannot find isolation to undo"
+    assert os.path.exists(PRESERVED_INCLUDE_PATH), "Cannot find pre-isolate include.yaml"
+    shutil.rmtree(ISOLATE_PATH)
+    shutil.copy(PRESERVED_INCLUDE_PATH, INCLUDE_PATH)
+
+
+def isolate(parser, args):
+    if args.undo:
+        _undo_isolate()
+    else:
+        assert args.path is not None, "Must provide an isolation destination"
+        _do_isolate(args)
+        tty.warn(
+            "\n".join(
+                textwrap.wrap(
+                    "Due to current limitations in Spack's configuration, adding repos without an"
+                    " explicit destination will default to $SPACK_USER_CACHE_PATH or ~/.spack."
+                    " This behavior will be fixed with shared spack in v1.3."
+                )
+            )
+        )

--- a/lib/spack/spack/cmd/isolate.py
+++ b/lib/spack/spack/cmd/isolate.py
@@ -124,12 +124,21 @@ def _preserve_and_extract_include():
 
 def setup_parser(subparser: ArgumentParser):
     isolate_group = subparser.add_mutually_exclusive_group()
-    isolate_group.add_argument("--path", type=str, help="Path to data isolation directory")
     isolate_group.add_argument(
-        "--undo", action="store_true", help="Undo the result of calling isolate"
+        "--path", dest="path", type=str, help="path to data isolation directory"
+    )
+    isolate_group.add_argument(
+        "--self",
+        dest="path",
+        action="store_const",
+        const=spack.paths.prefix,
+        help="use spack's own prefix as isolation directory",
+    )
+    isolate_group.add_argument(
+        "--undo", action="store_true", help="undo the result of calling isolate"
     )
     subparser.add_argument(
-        "--overwrite", action="store_true", help="Overwrite existing isolation if necessary"
+        "--overwrite", action="store_true", help="overwrite existing isolation if necessary"
     )
 
 

--- a/lib/spack/spack/cmd/isolate.py
+++ b/lib/spack/spack/cmd/isolate.py
@@ -1,0 +1,158 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+import os
+from argparse import ArgumentParser
+from pathlib import Path
+from typing import cast
+import shutil
+from spack import bootstrap
+import spack.config
+import spack.paths
+import spack.schema.include
+import spack.schema.repos
+import spack.util.spack_yaml as syaml
+import spack.concretize
+from spack.vendor.ruamel.yaml.compat import ordereddict
+description = "isolate the current spack instance from the home directory"
+section = "config"
+level = "long"
+
+INCLUDE_PATH = os.path.join(spack.paths.etc_path, "include.yaml")
+ISOLATE_PATH = os.path.join(spack.paths.etc_path, "isolate")
+
+def _get_scope_indices(included_scopes, destination):
+    user_index = None
+    site_index = None
+    system_index = None
+    iso_index = None
+    for i, entry in enumerate(included_scopes):
+        if entry['name'] == 'user':
+            user_index = i
+        elif entry['name'] == 'site':
+            site_index = i
+        elif entry['name'] == 'system':
+            system_index = i
+        elif entry['name'] == 'isolate':
+            iso_index = i
+    return user_index, site_index, system_index, iso_index
+
+def _isolate_bootstrap_config(new_user_path):
+    bootstrap_yaml = {"bootstrap": {"root": os.path.join(new_user_path, "bootstrap")}}
+    with open(os.path.join(ISOLATE_PATH, "bootstrap.yaml"), "w") as f:
+        syaml.dump(bootstrap_yaml, f)
+        
+def _isolate_config_config(new_user_path):
+    build_stage_dirs = ["$tempdir/$user/spack-stage", os.path.join(new_user_path, "stage")]
+    test_stage_dir = os.path.join(new_user_path, "test-stage")
+    misc_cache_dir = os.path.join(new_user_path, "cache")
+    config_yaml = {"config": {
+        "build_stage:": build_stage_dirs,
+        "test_stage:": test_stage_dir,
+        "misc_cache:": misc_cache_dir
+    }}
+    with open(os.path.join(ISOLATE_PATH, "config.yaml"), "w") as f:
+        syaml.dump(config_yaml, f)
+        
+def _isolate_repos_config(new_user_path):
+    current_repos_config = spack.config.get("repos")
+    new_repos_config = {}
+    for key, value in current_repos_config.items():
+        if isinstance(value, str):
+            new_repos_config[key] = value
+        if isinstance(value, dict):
+            if "destination" not in value:
+                value['destination'] = os.path.join(new_user_path, "repos", key)
+                new_repos_config[key] = value
+    with open(os.path.join(ISOLATE_PATH, "repos.yaml"), "w") as f:
+        syaml.dump({"repos": new_repos_config}, f)
+
+def _setup_isolate_scope(new_user_path, overwrite: bool):
+    if os.path.exists(ISOLATE_PATH):
+        if overwrite:
+            shutil.rmtree(ISOLATE_PATH)
+        else:
+            raise Exception("An isolation already exists for this Spack instance")
+    os.mkdir(ISOLATE_PATH)
+    isolate_dict = {}
+    isolate_dict['name'] = 'isolate'
+    isolate_dict['path'] = ISOLATE_PATH
+    _isolate_bootstrap_config(new_user_path)
+    _isolate_config_config(new_user_path)
+    _isolate_repos_config(new_user_path)
+    return isolate_dict
+
+def _get_new_user_scope(new_user_path):
+    return {
+        "name": 'user',
+        "path": new_user_path,
+        "optional": True,
+        "prefer_modify": True,
+        "when": '"SPACK_DISABLE_LOCAL_CONFIG" not in env'
+    }
+def setup_parser(subparser: ArgumentParser):
+    subparser.add_argument(
+        "destination",
+        type=str,
+        help="Path to data isolation directory"
+    )
+    subparser.add_argument(
+        "--overwrite",
+        action="store_true",
+        help="Overwrite existing isolation if necessary"
+    )
+    subparser.add_argument(
+        "--bootstrap",
+        action="store_true",
+        help="Bootstrap clingo, repos, and compiler config after isolation"
+    )
+
+def _ensure_destination_setup(destination: str, overwrite: bool):
+    if os.path.exists(destination):
+        if overwrite:
+            shutil.rmtree(destination)
+        else:
+            raise Exception("Isolation destination already exists")
+    os.mkdir(destination)
+    return os.path.abspath(destination)
+
+def _preserve_and_extract_include():
+    include_config = cast(ordereddict, spack.config.read_config_file(
+        INCLUDE_PATH,
+        spack.schema.include.schema
+    ))
+    return include_config['include']
+    
+def isolate(parser, args):
+    destination = _ensure_destination_setup(args.destination, args.overwrite)
+    include_config : list = _preserve_and_extract_include()
+    user_index, site_index, system_index, old_isolate_index = _get_scope_indices(
+        include_config,
+        destination
+    )
+    isolate_scope = _setup_isolate_scope(destination, args.overwrite)
+    # insert the isolate scope above the below user and site but above system
+    if old_isolate_index is not None:
+        include_config.insert(old_isolate_index, isolate_scope)
+    elif site_index is not None:
+        include_config.insert(site_index+1, isolate_scope)
+    elif system_index is not None:
+        include_config.insert(system_index-1, isolate_scope)
+    elif user_index is not None:
+        include_config.insert(user_index+1, isolate_scope)
+    else: # Strange changes have been made if there is no site, system, or user scope
+        include_config.append(isolate_scope)
+
+    new_user_scope = _get_new_user_scope(destination)
+    if user_index is not None:
+        include_config[user_index] = new_user_scope
+    else:
+        include_config.insert(0, new_user_scope)
+
+    with open(INCLUDE_PATH, "w") as f:
+        syaml.dump({"include": include_config}, f)
+
+    if args.bootstrap:
+        del spack.config.CONFIG
+        spack.config.CONFIG = spack.config.create()
+        spack.concretize.concretize_one("zlib")

--- a/lib/spack/spack/cmd/isolate.py
+++ b/lib/spack/spack/cmd/isolate.py
@@ -2,18 +2,18 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 import os
-from argparse import ArgumentParser
-from pathlib import Path
-from typing import cast
 import shutil
-from spack import bootstrap
+from argparse import ArgumentParser
+from typing import cast
+
+from spack.vendor.ruamel.yaml.compat import ordereddict
+
+import spack.concretize
 import spack.config
 import spack.paths
 import spack.schema.include
-import spack.schema.repos
 import spack.util.spack_yaml as syaml
-import spack.concretize
-from spack.vendor.ruamel.yaml.compat import ordereddict
+
 description = "isolate the current spack instance from the home directory"
 section = "config"
 level = "long"
@@ -21,39 +21,45 @@ level = "long"
 INCLUDE_PATH = os.path.join(spack.paths.etc_path, "include.yaml")
 ISOLATE_PATH = os.path.join(spack.paths.etc_path, "isolate")
 
+
 def _get_scope_indices(included_scopes, destination):
     user_index = None
     site_index = None
     system_index = None
     iso_index = None
     for i, entry in enumerate(included_scopes):
-        if entry['name'] == 'user':
+        if entry["name"] == "user":
             user_index = i
-        elif entry['name'] == 'site':
+        elif entry["name"] == "site":
             site_index = i
-        elif entry['name'] == 'system':
+        elif entry["name"] == "system":
             system_index = i
-        elif entry['name'] == 'isolate':
+        elif entry["name"] == "isolate":
             iso_index = i
     return user_index, site_index, system_index, iso_index
+
 
 def _isolate_bootstrap_config(new_user_path):
     bootstrap_yaml = {"bootstrap": {"root": os.path.join(new_user_path, "bootstrap")}}
     with open(os.path.join(ISOLATE_PATH, "bootstrap.yaml"), "w") as f:
         syaml.dump(bootstrap_yaml, f)
-        
+
+
 def _isolate_config_config(new_user_path):
     build_stage_dirs = ["$tempdir/$user/spack-stage", os.path.join(new_user_path, "stage")]
     test_stage_dir = os.path.join(new_user_path, "test-stage")
     misc_cache_dir = os.path.join(new_user_path, "cache")
-    config_yaml = {"config": {
-        "build_stage:": build_stage_dirs,
-        "test_stage:": test_stage_dir,
-        "misc_cache:": misc_cache_dir
-    }}
+    config_yaml = {
+        "config": {
+            "build_stage:": build_stage_dirs,
+            "test_stage:": test_stage_dir,
+            "misc_cache:": misc_cache_dir,
+        }
+    }
     with open(os.path.join(ISOLATE_PATH, "config.yaml"), "w") as f:
         syaml.dump(config_yaml, f)
-        
+
+
 def _isolate_repos_config(new_user_path):
     current_repos_config = spack.config.get("repos")
     new_repos_config = {}
@@ -62,10 +68,11 @@ def _isolate_repos_config(new_user_path):
             new_repos_config[key] = value
         if isinstance(value, dict):
             if "destination" not in value:
-                value['destination'] = os.path.join(new_user_path, "repos", key)
+                value["destination"] = os.path.join(new_user_path, "repos", key)
                 new_repos_config[key] = value
     with open(os.path.join(ISOLATE_PATH, "repos.yaml"), "w") as f:
         syaml.dump({"repos": new_repos_config}, f)
+
 
 def _setup_isolate_scope(new_user_path, overwrite: bool):
     if os.path.exists(ISOLATE_PATH):
@@ -75,37 +82,35 @@ def _setup_isolate_scope(new_user_path, overwrite: bool):
             raise Exception("An isolation already exists for this Spack instance")
     os.mkdir(ISOLATE_PATH)
     isolate_dict = {}
-    isolate_dict['name'] = 'isolate'
-    isolate_dict['path'] = ISOLATE_PATH
+    isolate_dict["name"] = "isolate"
+    isolate_dict["path"] = ISOLATE_PATH
     _isolate_bootstrap_config(new_user_path)
     _isolate_config_config(new_user_path)
     _isolate_repos_config(new_user_path)
     return isolate_dict
 
+
 def _get_new_user_scope(new_user_path):
     return {
-        "name": 'user',
+        "name": "user",
         "path": new_user_path,
         "optional": True,
         "prefer_modify": True,
-        "when": '"SPACK_DISABLE_LOCAL_CONFIG" not in env'
+        "when": '"SPACK_DISABLE_LOCAL_CONFIG" not in env',
     }
+
+
 def setup_parser(subparser: ArgumentParser):
+    subparser.add_argument("destination", type=str, help="Path to data isolation directory")
     subparser.add_argument(
-        "destination",
-        type=str,
-        help="Path to data isolation directory"
-    )
-    subparser.add_argument(
-        "--overwrite",
-        action="store_true",
-        help="Overwrite existing isolation if necessary"
+        "--overwrite", action="store_true", help="Overwrite existing isolation if necessary"
     )
     subparser.add_argument(
         "--bootstrap",
         action="store_true",
-        help="Bootstrap clingo, repos, and compiler config after isolation"
+        help="Bootstrap clingo, repos, and compiler config after isolation",
     )
+
 
 def _ensure_destination_setup(destination: str, overwrite: bool):
     if os.path.exists(destination):
@@ -116,31 +121,31 @@ def _ensure_destination_setup(destination: str, overwrite: bool):
     os.mkdir(destination)
     return os.path.abspath(destination)
 
+
 def _preserve_and_extract_include():
-    include_config = cast(ordereddict, spack.config.read_config_file(
-        INCLUDE_PATH,
-        spack.schema.include.schema
-    ))
-    return include_config['include']
-    
+    include_config = cast(
+        ordereddict, spack.config.read_config_file(INCLUDE_PATH, spack.schema.include.schema)
+    )
+    return include_config["include"]
+
+
 def isolate(parser, args):
     destination = _ensure_destination_setup(args.destination, args.overwrite)
-    include_config : list = _preserve_and_extract_include()
+    include_config: list = _preserve_and_extract_include()
     user_index, site_index, system_index, old_isolate_index = _get_scope_indices(
-        include_config,
-        destination
+        include_config, destination
     )
     isolate_scope = _setup_isolate_scope(destination, args.overwrite)
     # insert the isolate scope above the below user and site but above system
     if old_isolate_index is not None:
         include_config.insert(old_isolate_index, isolate_scope)
     elif site_index is not None:
-        include_config.insert(site_index+1, isolate_scope)
+        include_config.insert(site_index + 1, isolate_scope)
     elif system_index is not None:
-        include_config.insert(system_index-1, isolate_scope)
+        include_config.insert(system_index - 1, isolate_scope)
     elif user_index is not None:
-        include_config.insert(user_index+1, isolate_scope)
-    else: # Strange changes have been made if there is no site, system, or user scope
+        include_config.insert(user_index + 1, isolate_scope)
+    else:  # Strange changes have been made if there is no site, system, or user scope
         include_config.append(isolate_scope)
 
     new_user_scope = _get_new_user_scope(destination)

--- a/lib/spack/spack/cmd/isolate.py
+++ b/lib/spack/spack/cmd/isolate.py
@@ -41,7 +41,7 @@ def _get_scope_indices(included_scopes, destination):
 
 def _isolate_bootstrap_config(new_user_path):
     bootstrap_yaml = {"bootstrap": {"root": os.path.join(new_user_path, "bootstrap")}}
-    with open(os.path.join(ISOLATE_PATH, "bootstrap.yaml"), "w") as f:
+    with open(os.path.join(ISOLATE_PATH, "bootstrap.yaml"), "w", encoding="utf-8") as f:
         syaml.dump(bootstrap_yaml, f)
 
 
@@ -56,7 +56,7 @@ def _isolate_config_config(new_user_path):
             "misc_cache:": misc_cache_dir,
         }
     }
-    with open(os.path.join(ISOLATE_PATH, "config.yaml"), "w") as f:
+    with open(os.path.join(ISOLATE_PATH, "config.yaml"), "w", encoding="utf-8") as f:
         syaml.dump(config_yaml, f)
 
 
@@ -70,7 +70,7 @@ def _isolate_repos_config(new_user_path):
             if "destination" not in value:
                 value["destination"] = os.path.join(new_user_path, "repos", key)
                 new_repos_config[key] = value
-    with open(os.path.join(ISOLATE_PATH, "repos.yaml"), "w") as f:
+    with open(os.path.join(ISOLATE_PATH, "repos.yaml"), "w", encoding="utf-8") as f:
         syaml.dump({"repos": new_repos_config}, f)
 
 
@@ -154,7 +154,7 @@ def isolate(parser, args):
     else:
         include_config.insert(0, new_user_scope)
 
-    with open(INCLUDE_PATH, "w") as f:
+    with open(INCLUDE_PATH, "w", encoding="utf-8") as f:
         syaml.dump({"include": include_config}, f)
 
     if args.bootstrap:

--- a/lib/spack/spack/cmd/isolate.py
+++ b/lib/spack/spack/cmd/isolate.py
@@ -139,13 +139,13 @@ def _do_isolate(args):
     user_index, site_index, system_index, old_isolate_index = _get_scope_indices(include_config)
     isolate_scope = _setup_isolate_scope(destination, args.overwrite)
     # insert the isolate scope above the below user and site but above system
-    if old_isolate_index is not None:
+    if old_isolate_index is not None:  # first try the old isolate index (--overwrite)
         include_config.insert(old_isolate_index, isolate_scope)
-    elif site_index is not None:
+    elif site_index is not None:  # otherwise put it below the site scope
         include_config.insert(site_index + 1, isolate_scope)
-    elif system_index is not None:
+    elif system_index is not None:  # if there is no site scope, put it above the system scope
         include_config.insert(system_index - 1, isolate_scope)
-    elif user_index is not None:
+    elif user_index is not None:  # if there is no system scope, put it below the user scope
         include_config.insert(user_index + 1, isolate_scope)
     else:  # Strange changes have been made if there is no site, system, or user scope
         include_config.append(isolate_scope)

--- a/lib/spack/spack/cmd/isolate.py
+++ b/lib/spack/spack/cmd/isolate.py
@@ -181,8 +181,9 @@ def _undo_isolate():
 def isolate(parser, args):
     if args.undo:
         _undo_isolate()
+    elif args.path is None:
+        tty.die("Must provide one of --path, --self, or --undo")
     else:
-        assert args.path is not None, "Must provide an isolation destination"
         _do_isolate(args)
         tty.warn(
             "\n".join(

--- a/lib/spack/spack/cmd/isolate.py
+++ b/lib/spack/spack/cmd/isolate.py
@@ -8,7 +8,6 @@ from typing import cast
 
 from spack.vendor.ruamel.yaml.compat import ordereddict
 
-import spack.concretize
 import spack.config
 import spack.paths
 import spack.schema.include
@@ -90,11 +89,6 @@ def setup_parser(subparser: ArgumentParser):
     subparser.add_argument(
         "--overwrite", action="store_true", help="Overwrite existing isolation if necessary"
     )
-    subparser.add_argument(
-        "--bootstrap",
-        action="store_true",
-        help="Bootstrap clingo, repos, and compiler config after isolation",
-    )
 
 
 def _ensure_destination_setup(destination: str, overwrite: bool):
@@ -170,7 +164,3 @@ def isolate(parser, args):
         syaml.dump({"include": include_config}, f)
 
     _shim_user_path_in_exe(destination)
-    if args.bootstrap:
-        del spack.config.CONFIG
-        spack.config.CONFIG = spack.config.create()
-        spack.concretize.concretize_one("zlib")

--- a/lib/spack/spack/test/cmd/isolate.py
+++ b/lib/spack/spack/test/cmd/isolate.py
@@ -72,6 +72,15 @@ config:
 
 
 def test_isolate_overwrite_same_dir(mock_pre_isolate_config):
+    _, iso_root = mock_pre_isolate_config
+    isolated_path1 = iso_root / "test-isolation1"
+    sp_isolate("--path", str(isolated_path1))
+    with pytest.raises(Exception):
+        sp_isolate("--path", str(isolated_path1))
+    sp_isolate("--overwrite", "--path", str(isolated_path1))
+
+
+def test_isolate_overwrite_different_dir(mock_pre_isolate_config):
     cfg_dir, iso_root = mock_pre_isolate_config
     isolated_path1 = iso_root / "test-isolation"
     isolated_path2 = iso_root / "test-isolation"
@@ -85,16 +94,6 @@ def test_isolate_overwrite_same_dir(mock_pre_isolate_config):
 bootstrap:
   root: {isolated_path2 / "bootstrap"}"""
     assert text == expected_text
-
-
-def test_isolate_overwrite_different_dir(mock_pre_isolate_config):
-    _, iso_root = mock_pre_isolate_config
-    isolated_path1 = iso_root / "test-isolation1"
-    isolated_path2 = iso_root / "test-isolation2"
-    sp_isolate("--path", str(isolated_path1))
-    with pytest.raises(Exception):
-        sp_isolate("--path", str(isolated_path2))
-    sp_isolate("--overwrite", "--path", str(isolated_path2))
 
 
 def test_isolate_undo(mock_pre_isolate_config):

--- a/lib/spack/spack/test/cmd/isolate.py
+++ b/lib/spack/spack/test/cmd/isolate.py
@@ -56,6 +56,7 @@ def test_isolate_smoke_test(mock_pre_isolate_config):
     with spack.config.use_configuration(cfg_dir / "spack"):
         assert "isolate" in sp_config("scopes")
 
+
 def test_isolate_added_config(mock_pre_isolate_config):
     cfg_dir, iso_root = mock_pre_isolate_config
     isolated_path = iso_root / "test-isolation"

--- a/lib/spack/spack/test/cmd/isolate.py
+++ b/lib/spack/spack/test/cmd/isolate.py
@@ -1,0 +1,57 @@
+import pytest
+import shutil
+from spack.test.conftest import _create_mock_configuration_scopes
+import os
+import textwrap
+import spack.main
+import spack.config
+import spack.paths
+import spack.cmd.isolate
+
+sp_isolate = spack.main.SpackCommand("isolate")
+sp_config = spack.main.SpackCommand("config")
+@pytest.fixture(scope="function")
+def mutable_config_with_dir(tmp_path_factory: pytest.TempPathFactory, configuration_dir):
+    """Like config, but tests can modify the configuration."""
+    mutable_dir = tmp_path_factory.mktemp("mutable_config") / "tmp"
+    shutil.copytree(configuration_dir, mutable_dir)
+
+    scopes = _create_mock_configuration_scopes(mutable_dir)
+    with spack.config.use_configuration(*scopes) as cfg:
+        yield cfg, mutable_dir
+
+@pytest.fixture(scope="function")
+def mock_pre_isolate_config(mutable_config_with_dir, monkeypatch):
+    _, cfg_dir = mutable_config_with_dir
+    include_path = cfg_dir / "spack" / "include.yaml"
+    isolate_path = cfg_dir / "isolate"
+    user_path = cfg_dir / "user"
+    monkeypatch.setattr(spack.cmd.isolate, "INCLUDE_PATH", str(include_path))
+    monkeypatch.setattr(spack.cmd.isolate, "ISOLATE_PATH", str(isolate_path))
+    monkeypatch.setattr(spack.paths, "user_cache_path", user_path)
+    monkeypatch.setattr(spack.paths, "user_config_path", user_path)
+    yield cfg_dir
+
+
+def test_isolate_smoke_test(mock_pre_isolate_config, tmp_path):
+    cfg_dir = mock_pre_isolate_config
+    isolate_scope_path = cfg_dir / "isolate"
+    isolated_path = tmp_path / "test-isolation"
+    sp_isolate(str(isolated_path))
+    assert isolate_scope_path.exists()
+    assert isolated_path.exists()
+    assert (isolate_scope_path / "bootstrap.yaml").exists()
+    assert (isolate_scope_path / "config.yaml").exists()
+    # we reload the config after isolation
+    with spack.config.use_configuration(cfg_dir / "spack"):
+       assert "isolate" in sp_config("scopes")
+
+
+def test_isolate_added_config(mock_pre_isolate_config, tmp_path):
+    cfg_dir = mock_pre_isolate_config
+    isolated_path = tmp_path / "test-isolation"
+    sp_isolate(str(isolated_path))
+    with spack.config.use_configuration(cfg_dir / "spack"):
+        sp_config("add", "config:build_jobs:42")
+        assert (isolated_path / "config.yaml").exists()
+    

--- a/lib/spack/spack/test/cmd/isolate.py
+++ b/lib/spack/spack/test/cmd/isolate.py
@@ -83,7 +83,7 @@ def test_isolate_overwrite_same_dir(mock_pre_isolate_config):
         text = f.read().strip()
     expected_text = f"""\
 bootstrap:
-  root: {isolated_path2 / 'bootstrap'}"""
+  root: {isolated_path2 / "bootstrap"}"""
     assert text == expected_text
 
 

--- a/lib/spack/spack/test/cmd/isolate.py
+++ b/lib/spack/spack/test/cmd/isolate.py
@@ -36,7 +36,7 @@ def mock_pre_isolate_config(mutable_config_with_dir, monkeypatch, tmp_path):
     preserved_include_path = cfg_dir / "spack" / ".isolate.include.yaml"
     # These paths usually live in spack/etc/spack
     monkeypatch.setattr(spack.cmd.isolate, "INCLUDE_PATH", str(include_path))
-    monkeypatch.setattr(spack.cmd.isolate, "ISOLATE_PATH", str(isolate_path))
+    monkeypatch.setattr(spack.cmd.isolate, "ISOLATE_SCOPE_PATH", str(isolate_path))
     monkeypatch.setattr(spack.cmd.isolate, "PRESERVED_INCLUDE_PATH", str(preserved_include_path))
 
     yield cfg_dir, tmp_path
@@ -46,11 +46,11 @@ def test_isolate_smoke_test(mock_pre_isolate_config):
     cfg_dir, iso_root = mock_pre_isolate_config
     isolated_path = iso_root / "test-isolation"
     sp_isolate("--path", str(isolated_path))
-    assert os.path.exists(spack.cmd.isolate.ISOLATE_PATH)
+    assert os.path.exists(spack.cmd.isolate.ISOLATE_SCOPE_PATH)
     assert os.path.exists(spack.cmd.isolate.PRESERVED_INCLUDE_PATH)
     assert isolated_path.exists()
-    assert os.path.exists(os.path.join(spack.cmd.isolate.ISOLATE_PATH, "bootstrap.yaml"))
-    assert os.path.exists(os.path.join(spack.cmd.isolate.ISOLATE_PATH, "config.yaml"))
+    assert os.path.exists(os.path.join(spack.cmd.isolate.ISOLATE_SCOPE_PATH, "bootstrap.yaml"))
+    assert os.path.exists(os.path.join(spack.cmd.isolate.ISOLATE_SCOPE_PATH, "config.yaml"))
     # we reload the config after isolation
     with spack.config.use_configuration(cfg_dir / "spack"):
         assert "isolate" in sp_config("scopes")

--- a/lib/spack/spack/test/cmd/isolate.py
+++ b/lib/spack/spack/test/cmd/isolate.py
@@ -64,7 +64,7 @@ def test_isolate_added_config(mock_pre_isolate_config):
     with spack.config.use_configuration(cfg_dir / "spack"):
         sp_config("add", "config:build_jobs:42")
         assert (isolated_path / "config.yaml").exists()
-        with open(isolated_path / "config.yaml") as f:
+        with open(isolated_path / "config.yaml", "r", encoding="utf-8") as f:
             text = f.read()
         expected_text = """\
 config:

--- a/lib/spack/spack/test/cmd/isolate.py
+++ b/lib/spack/spack/test/cmd/isolate.py
@@ -71,3 +71,22 @@ config:
   build_jobs: 42
 """
         assert text == expected_text
+
+
+def test_isolate_overwrite_same_dir(mock_pre_isolate_config):
+    _, iso_root = mock_pre_isolate_config
+    isolated_path = iso_root / "test-isolation"
+    sp_isolate(str(isolated_path))
+    with pytest.raises(Exception):
+        sp_isolate(str(isolated_path))
+    sp_isolate("--overwrite", str(isolated_path))
+
+
+def test_isolate_overwrite_different_dir(mock_pre_isolate_config):
+    _, iso_root = mock_pre_isolate_config
+    isolated_path1 = iso_root / "test-isolation1"
+    isolated_path2 = iso_root / "test-isolation2"
+    sp_isolate(str(isolated_path1))
+    with pytest.raises(Exception):
+        sp_isolate(str(isolated_path2))
+    sp_isolate("--overwrite", str(isolated_path2))

--- a/lib/spack/spack/test/cmd/isolate.py
+++ b/lib/spack/spack/test/cmd/isolate.py
@@ -1,6 +1,7 @@
 # Copyright Spack Project Developers. See COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
+import os
 import shutil
 
 import pytest
@@ -8,7 +9,6 @@ import pytest
 import spack.cmd.isolate
 import spack.config
 import spack.main
-import spack.paths
 from spack.test.conftest import _create_mock_configuration_scopes
 
 sp_isolate = spack.main.SpackCommand("isolate")
@@ -31,27 +31,24 @@ def mock_pre_isolate_config(mutable_config_with_dir, monkeypatch, tmp_path):
     _, cfg_dir = mutable_config_with_dir
     include_path = cfg_dir / "spack" / "include.yaml"
     isolate_path = cfg_dir / "isolate"
-    user_path = cfg_dir / "user"
+    preserved_include_path = cfg_dir / "spack" / ".isolate.include.yaml"
     # These paths usually live in spack/etc/spack
     monkeypatch.setattr(spack.cmd.isolate, "INCLUDE_PATH", str(include_path))
     monkeypatch.setattr(spack.cmd.isolate, "ISOLATE_PATH", str(isolate_path))
-    # Unit tests shouldn't touch the spack exe
-    monkeypatch.setattr(spack.cmd.isolate, "_shim_user_path_in_exe", lambda _: None)
-    # These are the changes made by _shim_user_path_in_exe
-    monkeypatch.setattr(spack.paths, "user_cache_path", user_path)
-    monkeypatch.setattr(spack.paths, "user_config_path", user_path)
+    monkeypatch.setattr(spack.cmd.isolate, "PRESERVED_INCLUDE_PATH", str(preserved_include_path))
+
     yield cfg_dir, tmp_path
 
 
 def test_isolate_smoke_test(mock_pre_isolate_config):
     cfg_dir, iso_root = mock_pre_isolate_config
-    isolate_scope_path = cfg_dir / "isolate"
     isolated_path = iso_root / "test-isolation"
-    sp_isolate(str(isolated_path))
-    assert isolate_scope_path.exists()
+    sp_isolate("--path", str(isolated_path))
+    assert os.path.exists(spack.cmd.isolate.ISOLATE_PATH)
+    assert os.path.exists(spack.cmd.isolate.PRESERVED_INCLUDE_PATH)
     assert isolated_path.exists()
-    assert (isolate_scope_path / "bootstrap.yaml").exists()
-    assert (isolate_scope_path / "config.yaml").exists()
+    assert os.path.exists(os.path.join(spack.cmd.isolate.ISOLATE_PATH, "bootstrap.yaml"))
+    assert os.path.exists(os.path.join(spack.cmd.isolate.ISOLATE_PATH, "config.yaml"))
     # we reload the config after isolation
     with spack.config.use_configuration(cfg_dir / "spack"):
         assert "isolate" in sp_config("scopes")
@@ -60,7 +57,7 @@ def test_isolate_smoke_test(mock_pre_isolate_config):
 def test_isolate_added_config(mock_pre_isolate_config):
     cfg_dir, iso_root = mock_pre_isolate_config
     isolated_path = iso_root / "test-isolation"
-    sp_isolate(str(isolated_path))
+    sp_isolate("--path", str(isolated_path))
     with spack.config.use_configuration(cfg_dir / "spack"):
         sp_config("add", "config:build_jobs:42")
         assert (isolated_path / "config.yaml").exists()
@@ -76,17 +73,26 @@ config:
 def test_isolate_overwrite_same_dir(mock_pre_isolate_config):
     _, iso_root = mock_pre_isolate_config
     isolated_path = iso_root / "test-isolation"
-    sp_isolate(str(isolated_path))
+    sp_isolate("--path", str(isolated_path))
     with pytest.raises(Exception):
-        sp_isolate(str(isolated_path))
-    sp_isolate("--overwrite", str(isolated_path))
+        sp_isolate("--path", str(isolated_path))
+    sp_isolate("--overwrite", "--path", str(isolated_path))
 
 
 def test_isolate_overwrite_different_dir(mock_pre_isolate_config):
     _, iso_root = mock_pre_isolate_config
     isolated_path1 = iso_root / "test-isolation1"
     isolated_path2 = iso_root / "test-isolation2"
-    sp_isolate(str(isolated_path1))
+    sp_isolate("--path", str(isolated_path1))
     with pytest.raises(Exception):
-        sp_isolate(str(isolated_path2))
-    sp_isolate("--overwrite", str(isolated_path2))
+        sp_isolate("--path", str(isolated_path2))
+    sp_isolate("--overwrite", "--path", str(isolated_path2))
+
+
+def test_isolate_undo(mock_pre_isolate_config):
+    cfg_dir, iso_root = mock_pre_isolate_config
+    isolated_path = iso_root / "test-isolation"
+    sp_isolate("--path", str(isolated_path))
+    sp_isolate("--undo")
+    with spack.config.use_configuration(cfg_dir / "spack"):
+        assert "isolate" not in sp_config("scopes")

--- a/lib/spack/spack/test/cmd/isolate.py
+++ b/lib/spack/spack/test/cmd/isolate.py
@@ -1,3 +1,6 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
 import shutil
 
 import pytest
@@ -24,22 +27,26 @@ def mutable_config_with_dir(tmp_path_factory: pytest.TempPathFactory, configurat
 
 
 @pytest.fixture(scope="function")
-def mock_pre_isolate_config(mutable_config_with_dir, monkeypatch):
+def mock_pre_isolate_config(mutable_config_with_dir, monkeypatch, tmp_path):
     _, cfg_dir = mutable_config_with_dir
     include_path = cfg_dir / "spack" / "include.yaml"
     isolate_path = cfg_dir / "isolate"
     user_path = cfg_dir / "user"
+    # These paths usually live in spack/etc/spack
     monkeypatch.setattr(spack.cmd.isolate, "INCLUDE_PATH", str(include_path))
     monkeypatch.setattr(spack.cmd.isolate, "ISOLATE_PATH", str(isolate_path))
+    # Unit tests shouldn't touch the spack exe
+    monkeypatch.setattr(spack.cmd.isolate, "_shim_user_path_in_exe", lambda _: None)
+    # These are the changes made by _shim_user_path_in_exe
     monkeypatch.setattr(spack.paths, "user_cache_path", user_path)
     monkeypatch.setattr(spack.paths, "user_config_path", user_path)
-    yield cfg_dir
+    yield cfg_dir, tmp_path
 
 
-def test_isolate_smoke_test(mock_pre_isolate_config, tmp_path):
-    cfg_dir = mock_pre_isolate_config
+def test_isolate_smoke_test(mock_pre_isolate_config):
+    cfg_dir, iso_root = mock_pre_isolate_config
     isolate_scope_path = cfg_dir / "isolate"
-    isolated_path = tmp_path / "test-isolation"
+    isolated_path = iso_root / "test-isolation"
     sp_isolate(str(isolated_path))
     assert isolate_scope_path.exists()
     assert isolated_path.exists()
@@ -49,11 +56,17 @@ def test_isolate_smoke_test(mock_pre_isolate_config, tmp_path):
     with spack.config.use_configuration(cfg_dir / "spack"):
         assert "isolate" in sp_config("scopes")
 
-
-def test_isolate_added_config(mock_pre_isolate_config, tmp_path):
-    cfg_dir = mock_pre_isolate_config
-    isolated_path = tmp_path / "test-isolation"
+def test_isolate_added_config(mock_pre_isolate_config):
+    cfg_dir, iso_root = mock_pre_isolate_config
+    isolated_path = iso_root / "test-isolation"
     sp_isolate(str(isolated_path))
     with spack.config.use_configuration(cfg_dir / "spack"):
         sp_config("add", "config:build_jobs:42")
         assert (isolated_path / "config.yaml").exists()
+        with open(isolated_path / "config.yaml") as f:
+            text = f.read()
+        expected_text = """\
+config:
+  build_jobs: 42
+"""
+        assert text == expected_text

--- a/lib/spack/spack/test/cmd/isolate.py
+++ b/lib/spack/spack/test/cmd/isolate.py
@@ -17,7 +17,9 @@ sp_config = spack.main.SpackCommand("config")
 
 @pytest.fixture(scope="function")
 def mutable_config_with_dir(tmp_path_factory: pytest.TempPathFactory, configuration_dir):
-    """Like config, but tests can modify the configuration."""
+    """Like config, but tests can modify the configuration. This fixture also
+    yields the configuration directory, unlike conf_test.mutable_config
+    """
     mutable_dir = tmp_path_factory.mktemp("mutable_config") / "tmp"
     shutil.copytree(configuration_dir, mutable_dir)
 
@@ -62,21 +64,27 @@ def test_isolate_added_config(mock_pre_isolate_config):
         sp_config("add", "config:build_jobs:42")
         assert (isolated_path / "config.yaml").exists()
         with open(isolated_path / "config.yaml", "r", encoding="utf-8") as f:
-            text = f.read()
+            text = f.read().strip()
         expected_text = """\
 config:
-  build_jobs: 42
-"""
+  build_jobs: 42"""
         assert text == expected_text
 
 
 def test_isolate_overwrite_same_dir(mock_pre_isolate_config):
-    _, iso_root = mock_pre_isolate_config
-    isolated_path = iso_root / "test-isolation"
-    sp_isolate("--path", str(isolated_path))
+    cfg_dir, iso_root = mock_pre_isolate_config
+    isolated_path1 = iso_root / "test-isolation"
+    isolated_path2 = iso_root / "test-isolation"
+    sp_isolate("--path", str(isolated_path1))
     with pytest.raises(Exception):
-        sp_isolate("--path", str(isolated_path))
-    sp_isolate("--overwrite", "--path", str(isolated_path))
+        sp_isolate("--path", str(isolated_path1))
+    sp_isolate("--overwrite", "--path", str(isolated_path2))
+    with open(cfg_dir / "isolate" / "bootstrap.yaml", "r", encoding="utf-8") as f:
+        text = f.read().strip()
+    expected_text = f"""\
+bootstrap:
+  root: {isolated_path2}/bootstrap"""
+    assert text == expected_text
 
 
 def test_isolate_overwrite_different_dir(mock_pre_isolate_config):

--- a/lib/spack/spack/test/cmd/isolate.py
+++ b/lib/spack/spack/test/cmd/isolate.py
@@ -83,7 +83,7 @@ def test_isolate_overwrite_same_dir(mock_pre_isolate_config):
         text = f.read().strip()
     expected_text = f"""\
 bootstrap:
-  root: {isolated_path2}/bootstrap"""
+  root: {isolated_path2 / 'bootstrap'}"""
     assert text == expected_text
 
 

--- a/lib/spack/spack/test/cmd/isolate.py
+++ b/lib/spack/spack/test/cmd/isolate.py
@@ -1,15 +1,17 @@
-import pytest
 import shutil
-from spack.test.conftest import _create_mock_configuration_scopes
-import os
-import textwrap
-import spack.main
-import spack.config
-import spack.paths
+
+import pytest
+
 import spack.cmd.isolate
+import spack.config
+import spack.main
+import spack.paths
+from spack.test.conftest import _create_mock_configuration_scopes
 
 sp_isolate = spack.main.SpackCommand("isolate")
 sp_config = spack.main.SpackCommand("config")
+
+
 @pytest.fixture(scope="function")
 def mutable_config_with_dir(tmp_path_factory: pytest.TempPathFactory, configuration_dir):
     """Like config, but tests can modify the configuration."""
@@ -19,6 +21,7 @@ def mutable_config_with_dir(tmp_path_factory: pytest.TempPathFactory, configurat
     scopes = _create_mock_configuration_scopes(mutable_dir)
     with spack.config.use_configuration(*scopes) as cfg:
         yield cfg, mutable_dir
+
 
 @pytest.fixture(scope="function")
 def mock_pre_isolate_config(mutable_config_with_dir, monkeypatch):
@@ -44,7 +47,7 @@ def test_isolate_smoke_test(mock_pre_isolate_config, tmp_path):
     assert (isolate_scope_path / "config.yaml").exists()
     # we reload the config after isolation
     with spack.config.use_configuration(cfg_dir / "spack"):
-       assert "isolate" in sp_config("scopes")
+        assert "isolate" in sp_config("scopes")
 
 
 def test_isolate_added_config(mock_pre_isolate_config, tmp_path):
@@ -54,4 +57,3 @@ def test_isolate_added_config(mock_pre_isolate_config, tmp_path):
     with spack.config.use_configuration(cfg_dir / "spack"):
         sp_config("add", "config:build_jobs:42")
         assert (isolated_path / "config.yaml").exists()
-    

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -1376,7 +1376,7 @@ _spack_install() {
 _spack_isolate() {
     if $list_options
     then
-        SPACK_COMPREPLY="-h --help --overwrite --bootstrap"
+        SPACK_COMPREPLY="-h --help --overwrite"
     else
         SPACK_COMPREPLY=""
     fi

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -396,7 +396,7 @@ _spack() {
     then
         SPACK_COMPREPLY="--color -v --verbose -k --insecure -b --bootstrap -V --version -h --help -H --all-help -c --config -C --config-scope -e --env -D --env-dir -E --no-env --use-env-repo -d --debug -t --backtrace --pdb --timestamp -m --mock --print-shell-vars --stacktrace -l --enable-locks -L --disable-locks -p --profile --profile-file --sorted-profile --lines"
     else
-        SPACK_COMPREPLY="add arch audit blame bootstrap build-env buildcache cd change checksum ci clean commands compiler compilers concretize concretise config containerize containerise create debug deconcretize dependencies dependents deprecate dev-build develop diff docs edit env extensions external fetch find gc gpg graph help info install license list load location log-parse logs maintainers make-installer mark mirror module patch pkg providers pydoc python reindex remove rm repo resource restage solve spec stage style tags test test-env tutorial undevelop uninstall unit-test unload url verify versions view"
+        SPACK_COMPREPLY="add arch audit blame bootstrap build-env buildcache cd change checksum ci clean commands compiler compilers concretize concretise config containerize containerise create debug deconcretize dependencies dependents deprecate dev-build develop diff docs edit env extensions external fetch find gc gpg graph help info install isolate license list load location log-parse logs maintainers make-installer mark mirror module patch pkg providers pydoc python reindex remove rm repo resource restage solve spec stage style tags test test-env tutorial undevelop uninstall unit-test unload url verify versions view"
     fi
 }
 
@@ -1370,6 +1370,15 @@ _spack_install() {
         SPACK_COMPREPLY="-h --help --only -u --until -p --concurrent-packages -j --jobs --overwrite --fail-fast --keep-prefix --keep-stage --dont-restage --use-cache --no-cache --cache-only --use-buildcache --include-build-deps --no-check-signature --show-log-on-error --source -n --no-checksum -v --verbose --fake --only-concrete --add --no-add --clean --dirty --test --log-format --log-file --help-cdash --cdash-upload-url --cdash-build --cdash-site --cdash-track --cdash-buildstamp -y --yes-to-all -f --force -U --fresh --reuse --fresh-roots --reuse-deps --deprecated"
     else
         _all_packages
+    fi
+}
+
+_spack_isolate() {
+    if $list_options
+    then
+        SPACK_COMPREPLY="-h --help --overwrite --bootstrap"
+    else
+        SPACK_COMPREPLY=""
     fi
 }
 

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -1374,12 +1374,7 @@ _spack_install() {
 }
 
 _spack_isolate() {
-    if $list_options
-    then
-        SPACK_COMPREPLY="-h --help --overwrite"
-    else
-        SPACK_COMPREPLY=""
-    fi
+    SPACK_COMPREPLY="-h --help --path --undo --overwrite"
 }
 
 _spack_license() {

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -1374,7 +1374,7 @@ _spack_install() {
 }
 
 _spack_isolate() {
-    SPACK_COMPREPLY="-h --help --path --undo --overwrite"
+    SPACK_COMPREPLY="-h --help --path --self --undo --overwrite"
 }
 
 _spack_license() {

--- a/share/spack/spack-completion.fish
+++ b/share/spack/spack-completion.fish
@@ -2213,14 +2213,12 @@ complete -c spack -n '__fish_spack_using_command install' -l deprecated -f -a co
 complete -c spack -n '__fish_spack_using_command install' -l deprecated -d 'allow concretizer to select deprecated versions'
 
 # spack isolate
-set -g __fish_spack_optspecs_spack_isolate h/help overwrite bootstrap
+set -g __fish_spack_optspecs_spack_isolate h/help overwrite
 
 complete -c spack -n '__fish_spack_using_command isolate' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command isolate' -s h -l help -d 'show this help message and exit'
 complete -c spack -n '__fish_spack_using_command isolate' -l overwrite -f -a overwrite
 complete -c spack -n '__fish_spack_using_command isolate' -l overwrite -d 'Overwrite existing isolation if necessary'
-complete -c spack -n '__fish_spack_using_command isolate' -l bootstrap -f -a bootstrap
-complete -c spack -n '__fish_spack_using_command isolate' -l bootstrap -d 'Bootstrap clingo, repos, and compiler config after isolation'
 
 # spack license
 set -g __fish_spack_optspecs_spack_license h/help root=

--- a/share/spack/spack-completion.fish
+++ b/share/spack/spack-completion.fish
@@ -2213,15 +2213,17 @@ complete -c spack -n '__fish_spack_using_command install' -l deprecated -f -a co
 complete -c spack -n '__fish_spack_using_command install' -l deprecated -d 'allow concretizer to select deprecated versions'
 
 # spack isolate
-set -g __fish_spack_optspecs_spack_isolate h/help path= undo overwrite
+set -g __fish_spack_optspecs_spack_isolate h/help path= self undo overwrite
 complete -c spack -n '__fish_spack_using_command isolate' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command isolate' -s h -l help -d 'show this help message and exit'
 complete -c spack -n '__fish_spack_using_command isolate' -l path -r -f -a path
-complete -c spack -n '__fish_spack_using_command isolate' -l path -r -d 'Path to data isolation directory'
+complete -c spack -n '__fish_spack_using_command isolate' -l path -r -d 'path to data isolation directory'
+complete -c spack -n '__fish_spack_using_command isolate' -l self -f -a path
+complete -c spack -n '__fish_spack_using_command isolate' -l self -d 'use spack'"'"'s own prefix as isolation directory'
 complete -c spack -n '__fish_spack_using_command isolate' -l undo -f -a undo
-complete -c spack -n '__fish_spack_using_command isolate' -l undo -d 'Undo the result of calling isolate'
+complete -c spack -n '__fish_spack_using_command isolate' -l undo -d 'undo the result of calling isolate'
 complete -c spack -n '__fish_spack_using_command isolate' -l overwrite -f -a overwrite
-complete -c spack -n '__fish_spack_using_command isolate' -l overwrite -d 'Overwrite existing isolation if necessary'
+complete -c spack -n '__fish_spack_using_command isolate' -l overwrite -d 'overwrite existing isolation if necessary'
 
 # spack license
 set -g __fish_spack_optspecs_spack_license h/help root=

--- a/share/spack/spack-completion.fish
+++ b/share/spack/spack-completion.fish
@@ -389,6 +389,7 @@ complete -c spack -n '__fish_spack_using_command_pos 0 ' -f -a graph -d 'generat
 complete -c spack -n '__fish_spack_using_command_pos 0 ' -f -a help -d 'get help on spack and its commands'
 complete -c spack -n '__fish_spack_using_command_pos 0 ' -f -a info -d 'get detailed information on a particular package'
 complete -c spack -n '__fish_spack_using_command_pos 0 ' -f -a install -d 'build and install packages'
+complete -c spack -n '__fish_spack_using_command_pos 0 ' -f -a isolate -d 'isolate the current spack instance from the home directory'
 complete -c spack -n '__fish_spack_using_command_pos 0 ' -f -a license -d 'list and check license headers on files in spack'
 complete -c spack -n '__fish_spack_using_command_pos 0 ' -f -a list -d 'list and search available packages'
 complete -c spack -n '__fish_spack_using_command_pos 0 ' -f -a load -d 'add package to the user environment'
@@ -2210,6 +2211,16 @@ complete -c spack -n '__fish_spack_using_command install' -l fresh-roots -l reus
 complete -c spack -n '__fish_spack_using_command install' -l fresh-roots -l reuse-deps -d 'concretize with fresh roots and reused dependencies'
 complete -c spack -n '__fish_spack_using_command install' -l deprecated -f -a config_deprecated
 complete -c spack -n '__fish_spack_using_command install' -l deprecated -d 'allow concretizer to select deprecated versions'
+
+# spack isolate
+set -g __fish_spack_optspecs_spack_isolate h/help overwrite bootstrap
+
+complete -c spack -n '__fish_spack_using_command isolate' -s h -l help -f -a help
+complete -c spack -n '__fish_spack_using_command isolate' -s h -l help -d 'show this help message and exit'
+complete -c spack -n '__fish_spack_using_command isolate' -l overwrite -f -a overwrite
+complete -c spack -n '__fish_spack_using_command isolate' -l overwrite -d 'Overwrite existing isolation if necessary'
+complete -c spack -n '__fish_spack_using_command isolate' -l bootstrap -f -a bootstrap
+complete -c spack -n '__fish_spack_using_command isolate' -l bootstrap -d 'Bootstrap clingo, repos, and compiler config after isolation'
 
 # spack license
 set -g __fish_spack_optspecs_spack_license h/help root=

--- a/share/spack/spack-completion.fish
+++ b/share/spack/spack-completion.fish
@@ -2213,10 +2213,13 @@ complete -c spack -n '__fish_spack_using_command install' -l deprecated -f -a co
 complete -c spack -n '__fish_spack_using_command install' -l deprecated -d 'allow concretizer to select deprecated versions'
 
 # spack isolate
-set -g __fish_spack_optspecs_spack_isolate h/help overwrite
-
+set -g __fish_spack_optspecs_spack_isolate h/help path= undo overwrite
 complete -c spack -n '__fish_spack_using_command isolate' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command isolate' -s h -l help -d 'show this help message and exit'
+complete -c spack -n '__fish_spack_using_command isolate' -l path -r -f -a path
+complete -c spack -n '__fish_spack_using_command isolate' -l path -r -d 'Path to data isolation directory'
+complete -c spack -n '__fish_spack_using_command isolate' -l undo -f -a undo
+complete -c spack -n '__fish_spack_using_command isolate' -l undo -d 'Undo the result of calling isolate'
 complete -c spack -n '__fish_spack_using_command isolate' -l overwrite -f -a overwrite
 complete -c spack -n '__fish_spack_using_command isolate' -l overwrite -d 'Overwrite existing isolation if necessary'
 


### PR DESCRIPTION
`spack isolate` aims to keep a Spack instance from writing to `~/.spack`. This will become easier (and more complete) after shared Spack (#52443), but this PR serves as a stopgap before that feature is merged. 

`spack isolate ISO_PATH` does ~4~ 3 things:
1.  Changes the path of the `user` scope in `spack/etc/spack/include.yaml` to ISO_PATH and removes the `SPACK_USER_CONFIG_PATH` environment variable for configuring it. 
2. Creates an `isolate` scope below the `site` scope that moves the `bootstrap:root`, `config:misc_cache`, `config:test_stage`, and `config:build_stage` to subdirectories in ISO_PATH. 
3. Moves the existing repos with implicit destinations to a directory under ISO_PATH.
~4. Calling `spack isolate --bootstrap ISO_PATH` will also force a download of the package repo to its new location, a bootstrap build of clingo to its new location, and populate various caches (e.g. provider_cache).~ Bootstrapping should be done when needed, rather than by isolate. 

`spack isolate ISO_PATH` **does not**:
1. Move existing config out of `~/.spack` to the ISO_PATH or change the destination of explicitly set repos.
2. Change the default location where new git package repos are downloaded. This is a core limitation of Spack that this destination must be configured for each repo, and defaults to the environment variable `SPACK_USER_CACHE_PATH`. There is no config option that can be overridden.
3. Write `package_repository.lock` to `ISO_PATH/repos` for the same reason as 2. Both of these will be fixed by shared Spack.
4. Support multiple separate isolations. There is a single `isolate` scope that references the absolute path of the modified user scope. Users can use environments on top of isolate to get more separate isolation. 

Currently, this implementation is bare bones, since it will be rewritten for shared spack. For example, it does not currently preserve comments in `include.yaml`. 