### PR TITLE
Respect no_cache for git sources

### DIFF
--- a/lib/spack/spack/fetch_strategy.py
+++ b/lib/spack/spack/fetch_strategy.py
@@ -917,6 +917,26 @@ class GitFetchStrategy(VCSFetchStrategy):
                 sparse_string = "_".join(sparse_paths)
                 sparse_hash = hashlib.sha1(sparse_string.encode("utf-8")).hexdigest()
                 provenance_id = f"{provenance_id}_{sparse_hash}"
+            cache_options = []
+            submodules = self.submodules
+            if callable(submodules):
+                submodules = submodules(self.package) if self.package else True
+            if isinstance(submodules, str):
+                submodules = [submodules]
+            if submodules:
+                if isinstance(submodules, (list, tuple)):
+                    submodules = sorted(submodules)
+                cache_options.append(("submodules", submodules))
+            if self.submodules_delete:
+                cache_options.append(("submodules_delete", sorted(self.submodules_delete)))
+            if self.get_full_repo:
+                cache_options.append(("get_full_repo", True))
+            if self.skip_checkout:
+                cache_options.append(("skip_checkout", True))
+            if cache_options:
+                options_string = repr(cache_options)
+                options_hash = hashlib.sha1(options_string.encode("utf-8")).hexdigest()
+                provenance_id = f"{provenance_id}_{options_hash}"
             result = os.path.sep.join(["git", repo_path, provenance_id])
             return result
 
@@ -934,8 +954,12 @@ class GitFetchStrategy(VCSFetchStrategy):
     @_needs_stage
     def fetch(self):
         if self.stage.expanded:
-            tty.debug(f"Already fetched {self.stage.source_path}")
-            return
+            if not self.cache_enabled:
+                tty.debug(f"Removing cached git source from {self.stage.source_path}")
+                fs.remove_linked_tree(self.stage.source_path)
+            else:
+                tty.debug(f"Already fetched {self.stage.source_path}")
+                return
 
         self._clone_src()
         self.submodule_operations()
@@ -1649,7 +1673,11 @@ def _for_package_version(pkg, version=None):
                 commit = version_meta_data.get("commit")
             tag = version_meta_data.get("tag") or version_meta_data.get("branch")
 
-        kwargs = {"commit": commit, "tag": tag, "no_cache": bool(not commit)}
+        no_cache = bool(not commit)
+        if version_meta_data and "no_cache" in version_meta_data:
+            no_cache = version_meta_data["no_cache"]
+
+        kwargs = {"commit": commit, "tag": tag, "no_cache": no_cache}
         kwargs["git"] = git_url
         kwargs["submodules"] = pkg.version_or_package_attr("submodules", version, False)
         kwargs["git_sparse_paths"] = pkg.version_or_package_attr("git_sparse_paths", version, None)
@@ -1661,6 +1689,7 @@ def _for_package_version(pkg, version=None):
         if ref_version:
             kwargs["git"] = pkg.version_or_package_attr("git", ref_version)
             kwargs["submodules"] = pkg.version_or_package_attr("submodules", ref_version, False)
+            kwargs["no_cache"] = pkg.version_or_package_attr("no_cache", ref_version, no_cache)
 
         fetcher = GitFetchStrategy(**kwargs)
         return fetcher

--- a/lib/spack/spack/test/git_fetch.py
+++ b/lib/spack/spack/test/git_fetch.py
@@ -359,6 +359,62 @@ def test_gitsubmodule(
 
 
 @pytest.mark.disable_clean_stage_check
+def test_git_no_cache_refetches_existing_stage(mock_git_repository, tmp_path: pathlib.Path):
+    testpath = str(tmp_path / "stage")
+    submodule_file = os.path.join(
+        "third_party",
+        "submodule0",
+        "r0_file_0",
+    )
+
+    first_fetcher = GitFetchStrategy(git=mock_git_repository.url)
+    with Stage(first_fetcher, path=testpath) as stage:
+        stage.fetch()
+        assert not os.path.isfile(os.path.join(stage.source_path, submodule_file))
+
+        no_cache_fetcher = GitFetchStrategy(
+            git=mock_git_repository.url, no_cache=True, submodules=True
+        )
+        stage.fetcher = stage.default_fetcher = no_cache_fetcher
+        no_cache_fetcher.stage = stage
+
+        stage.fetch()
+        assert os.path.isfile(os.path.join(stage.source_path, submodule_file))
+
+
+def test_git_commit_variant_preserves_no_cache(
+    mock_git_repository, mutable_mock_repo, monkeypatch
+):
+    t = mock_git_repository.checks["commit"]
+
+    pkg_class = spack.repo.PATH.get_pkg_class("git-test")
+    monkeypatch.setitem(
+        pkg_class.versions,
+        Version("git"),
+        {"git": mock_git_repository.url, "no_cache": True},
+    )
+    pkg = pkg_class(Spec("git-test"))
+    pkg.spec.variants["commit"] = SingleValuedVariant("commit", t.args["commit"])
+
+    fetcher = spack.fetch_strategy.for_package_version(pkg, Version("git"))
+
+    assert fetcher.commit == t.args["commit"]
+    assert not fetcher.cache_enabled
+    assert not fetcher.cachable
+
+
+def test_gitsubmodule_cache_key_changes_with_submodules(mock_git_repository):
+    t = mock_git_repository.checks["commit"]
+
+    fetcher_without_submodules = GitFetchStrategy(**t.args)
+    args_with_submodules = copy.copy(t.args)
+    args_with_submodules["submodules"] = True
+    fetcher_with_submodules = GitFetchStrategy(**args_with_submodules)
+
+    assert fetcher_without_submodules.mirror_id() != fetcher_with_submodules.mirror_id()
+
+
+@pytest.mark.disable_clean_stage_check
 def test_gitsubmodules_callable(
     mock_git_repository, default_mock_concretization, mutable_mock_repo, monkeypatch
 ):


### PR DESCRIPTION
Fixes #52349

### Summary

This fixes git source fetching so `no_cache=True` is honored when a package changes git fetch options such as `submodules=True`.

### Changes

- Preserve explicit `no_cache=True` when constructing git fetchers for commit-based versions
- Re-fetch an existing expanded git stage when caching is disabled instead of reusing stale staged sources
- Include submodule-related git fetch options in the source-cache key so cached archives with different submodule behavior do not collide
- Add regression tests for stale git stages, commit variants with `no_cache=True`, and submodule-sensitive cache keys