### PR TITLE
fix: install missing upstream packages in local store (new installer)

### DIFF
--- a/lib/spack/spack/new_installer.py
+++ b/lib/spack/spack/new_installer.py
@@ -1827,8 +1827,15 @@ def schedule_builds(
                 continue
 
             # Write lock acquired: proceed with scheduling.
-            # Don't schedule builds for specs from upstream databases.
-            if upstream and record and not record.installed:
+            # Don't schedule builds for specs from upstream databases, unless this is a
+            # build-only dependency that can be rebuilt locally when missing upstream.
+            rebuild_locally = (
+                upstream
+                and record
+                and not record.installed
+                and not spec.dependents(deptype=dt.LINK | dt.RUN)
+            )
+            if upstream and record and not record.installed and not rebuild_locally:
                 lock.release_write()
                 raise spack.error.InstallError(
                     f"Cannot install {spec}: it is uninstalled in an upstream database."

--- a/lib/spack/spack/new_installer.py
+++ b/lib/spack/spack/new_installer.py
@@ -1497,8 +1497,15 @@ class BuildGraph:
         with database.read_transaction():
             # Set the install prefix for each spec based on the db record or store layout
             for s in spack.traverse.traverse_nodes(specs):
-                _, record = database.query_by_spec_hash(s.dag_hash())
-                if record and record.path:
+                upstream, record = database.query_by_spec_hash(s.dag_hash())
+                # Missing upstream build deps may be rebuilt locally
+                rebuild_locally = (
+                    upstream
+                    and record
+                    and not record.installed
+                    and not s.dependents(deptype=dt.LINK | dt.RUN)
+                )
+                if record and record.path and not rebuild_locally:
                     s.set_prefix(record.path)
                 else:
                     s.set_prefix(spack.store.STORE.layout.path_for_spec(s))

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -2219,8 +2219,8 @@ class Spec:
         if self._prefix is None:
             from spack.store import STORE
 
-            upstream, record = STORE.db.query_by_spec_hash(self.dag_hash())
-            if record and record.path and (not upstream or record.installed):
+            _, record = STORE.db.query_by_spec_hash(self.dag_hash())
+            if record and record.path:
                 self.set_prefix(record.path)
             else:
                 self.set_prefix(STORE.layout.path_for_spec(self))

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -2219,8 +2219,8 @@ class Spec:
         if self._prefix is None:
             from spack.store import STORE
 
-            _, record = STORE.db.query_by_spec_hash(self.dag_hash())
-            if record and record.path:
+            upstream, record = STORE.db.query_by_spec_hash(self.dag_hash())
+            if record and record.path and (not upstream or record.installed):
                 self.set_prefix(record.path)
             else:
                 self.set_prefix(STORE.layout.path_for_spec(self))

--- a/lib/spack/spack/test/new_installer.py
+++ b/lib/spack/spack/test/new_installer.py
@@ -682,7 +682,9 @@ class TestScheduleBuilds:
 
         # Case 1: dep_d is upstream-uninstalled with no LINK|RUN dependents → scheduled.
         monkeypatch.setattr(
-            temporary_store.db, "query_by_spec_hash", partial(fake_query, target_hash=dep_d.dag_hash())
+            temporary_store.db,
+            "query_by_spec_hash",
+            partial(fake_query, target_hash=dep_d.dag_hash()),
         )
         jobserver = PosixJobServer(num_jobs=2)
         pending = [dep_d.dag_hash()]
@@ -709,7 +711,9 @@ class TestScheduleBuilds:
 
         # Case 2: dep_e is upstream-uninstalled with a LINK dependent → raises.
         monkeypatch.setattr(
-            temporary_store.db, "query_by_spec_hash", partial(fake_query, target_hash=dep_e.dag_hash())
+            temporary_store.db,
+            "query_by_spec_hash",
+            partial(fake_query, target_hash=dep_e.dag_hash()),
         )
         jobserver2 = PosixJobServer(num_jobs=2)
         pending2 = [dep_e.dag_hash()]

--- a/lib/spack/spack/test/new_installer.py
+++ b/lib/spack/spack/test/new_installer.py
@@ -661,7 +661,6 @@ class TestScheduleBuilds:
         )
         for s in dag.values():
             s._mark_concrete()
-        spec_c = dag["installed-deps-c"]
         dep_d = dag["installed-deps-d"]  # build-only dep
         dep_e = dag["installed-deps-e"]  # build+link dep
 

--- a/lib/spack/spack/test/new_installer.py
+++ b/lib/spack/spack/test/new_installer.py
@@ -6,12 +6,17 @@
 import pathlib
 import sys
 import time
+from functools import partial
+from types import SimpleNamespace
 
 import pytest
+
+import spack.deptypes as dt
 
 if sys.platform == "win32":
     pytest.skip("No Windows support", allow_module_level=True)
 
+import spack.error
 import spack.spec
 from spack.new_installer import (
     OVERWRITE_GARBAGE_SUFFIX,
@@ -637,6 +642,93 @@ class TestScheduleBuilds:
             for _, _, lock in result.newly_installed:
                 lock.release_read()
             jobserver.close()
+
+    def test_upstream_uninstalled_build_dep_only_is_scheduled(
+        self, temporary_store, mock_packages, monkeypatch
+    ):
+        """Build-only upstream deps are rebuilt locally; link/run upstream deps raise.
+
+        Uses the installed-deps-c package topology:
+          c --> d  (build only)
+          c --> e  (build + link)
+        """
+        dag = create_dag(
+            nodes=["installed-deps-c", "installed-deps-d", "installed-deps-e"],
+            edges=[
+                ("installed-deps-c", "installed-deps-d", "build"),
+                ("installed-deps-c", "installed-deps-e", ("build", "link")),
+            ],
+        )
+        for s in dag.values():
+            s._mark_concrete()
+        spec_c = dag["installed-deps-c"]
+        dep_d = dag["installed-deps-d"]  # build-only dep
+        dep_e = dag["installed-deps-e"]  # build+link dep
+
+        # Confirm the deptype structure the production code relies on.
+        assert not dep_d.dependents(deptype=dt.LINK | dt.RUN)
+        assert dep_e.dependents(deptype=dt.LINK | dt.RUN)
+
+        upstream_record = SimpleNamespace(
+            installed=False, path="/opt/upstream/missing", installation_time=0.0, explicit=False
+        )
+        original_query = temporary_store.db.query_by_spec_hash
+        bg = _FakeBuildGraph(list(dag.values()))
+
+        def fake_query(dag_hash, *, target_hash):
+            if dag_hash == target_hash:
+                return True, upstream_record
+            return original_query(dag_hash)
+
+        # Case 1: dep_d is upstream-uninstalled with no LINK|RUN dependents → scheduled.
+        monkeypatch.setattr(
+            temporary_store.db, "query_by_spec_hash", partial(fake_query, target_hash=dep_d.dag_hash())
+        )
+        jobserver = PosixJobServer(num_jobs=2)
+        pending = [dep_d.dag_hash()]
+        try:
+            result = schedule_builds(
+                pending,
+                bg,
+                temporary_store.db,
+                temporary_store.prefix_locker,
+                overwrite=set(),
+                overwrite_time=0.0,
+                capacity=1,
+                needs_jobserver_token=False,
+                jobserver=jobserver,
+                explicit=set(),
+            )
+            assert len(result.to_start) == 1
+            assert result.to_start[0][0] == dep_d.dag_hash()
+            assert not pending
+        finally:
+            for _, lock in result.to_start:
+                lock.release_write()
+            jobserver.close()
+
+        # Case 2: dep_e is upstream-uninstalled with a LINK dependent → raises.
+        monkeypatch.setattr(
+            temporary_store.db, "query_by_spec_hash", partial(fake_query, target_hash=dep_e.dag_hash())
+        )
+        jobserver2 = PosixJobServer(num_jobs=2)
+        pending2 = [dep_e.dag_hash()]
+        try:
+            with pytest.raises(spack.error.InstallError, match="uninstalled in an upstream"):
+                schedule_builds(
+                    pending2,
+                    bg,
+                    temporary_store.db,
+                    temporary_store.prefix_locker,
+                    overwrite=set(),
+                    overwrite_time=0.0,
+                    capacity=1,
+                    needs_jobserver_token=False,
+                    jobserver=jobserver2,
+                    explicit=set(),
+                )
+        finally:
+            jobserver2.close()
 
 
 def test_nodes_to_roots():


### PR DESCRIPTION
We provide upstreams for our users, but garbage collect build-only dependencies. This means that e.g. `compile-wrapper` is missing. However, when attempting to install something, `compiler-wrapper` is attempted to be installed in the upstream location which is read-only.

This PR modifies the logic to only use the upstream path as prefix when the upstream is still installed.