### PR TITLE
gpg: fix trust() silently dropping secret-key files

### DIFF
--- a/lib/spack/spack/test/util/util_gpg.py
+++ b/lib/spack/spack/test/util/util_gpg.py
@@ -161,6 +161,7 @@ def test_gpg_key_algorithm():
 
 
 @pytest.mark.maybeslow
+@pytest.mark.not_on_windows("does not run on windows")
 def test_trust_secret_key_file(tmp_path: pathlib.Path, mock_gnupghome):
     """Verify that `spack gpg trust` can import secret keys from a keyfile."""
     # Create a signing key in the current homedir.

--- a/lib/spack/spack/test/util/util_gpg.py
+++ b/lib/spack/spack/test/util/util_gpg.py
@@ -164,7 +164,7 @@ def test_gpg_key_algorithm():
 @pytest.mark.not_on_windows("does not run on windows")
 def test_trust_secret_key_file(tmp_path: pathlib.Path, mock_gnupghome):
     """Verify that `spack gpg trust` can import secret keys from a keyfile."""
-    # Create a signing key in the current homedir.
+    # Create a signing key.
     spack.util.gpg.create(
         name="Spack CI test", email="ci@spack.io", comment="regression test key", expires="0"
     )
@@ -172,19 +172,16 @@ def test_trust_secret_key_file(tmp_path: pathlib.Path, mock_gnupghome):
     assert len(signing) == 1, "expected exactly one signing key after create"
     original_fpr = signing[0].fpr
 
-    # Export the *secret* key to a file – this is the format used in our
-    # GitLab CI pipelines.
+    # Export it to file.
     secret_keyfile = str(tmp_path / "secret.gpg")
     spack.util.gpg.export_keys(secret_keyfile, signing, secret=True)
 
-    # Delete the key so the keyring is empty, then re-import via trust().
+    # Use gpg.untrust() to remove the key from the keyring.
     spack.util.gpg.untrust(True, original_fpr)
     assert spack.util.gpg.signing_keys() == [], "keyring should be empty after untrust"
 
-    # trust() on a file containing a secret key can import it so signing_keys()
-    # can find it afterward.
+    # Use gpg.trust() to re-import the key.
     spack.util.gpg.trust(secret_keyfile, yes_to_all=True)
-
     restored = spack.util.gpg.signing_keys()
     assert len(restored) == 1, "signing key should be restored after trusting secret key file"
     assert restored[0].fpr == original_fpr, "restored key fingerprint should match original"

--- a/lib/spack/spack/test/util/util_gpg.py
+++ b/lib/spack/spack/test/util/util_gpg.py
@@ -160,6 +160,35 @@ def test_gpg_key_algorithm():
         assert "2048" in f"{e:2048}"
 
 
+@pytest.mark.maybeslow
+def test_trust_secret_key_file(tmp_path: pathlib.Path, mock_gnupghome):
+    """Verify that `spack gpg trust` can import secret keys from a keyfile."""
+    # Create a signing key in the current homedir.
+    spack.util.gpg.create(
+        name="Spack CI test", email="ci@spack.io", comment="regression test key", expires="0"
+    )
+    signing = spack.util.gpg.signing_keys()
+    assert len(signing) == 1, "expected exactly one signing key after create"
+    original_fpr = signing[0].fpr
+
+    # Export the *secret* key to a file – this is the format used in our
+    # GitLab CI pipelines.
+    secret_keyfile = str(tmp_path / "secret.gpg")
+    spack.util.gpg.export_keys(secret_keyfile, signing, secret=True)
+
+    # Delete the key so the keyring is empty, then re-import via trust().
+    spack.util.gpg.untrust(True, original_fpr)
+    assert spack.util.gpg.signing_keys() == [], "keyring should be empty after untrust"
+
+    # trust() on a file containing a secret key can import it so signing_keys()
+    # can find it afterward.
+    spack.util.gpg.trust(secret_keyfile, yes_to_all=True)
+
+    restored = spack.util.gpg.signing_keys()
+    assert len(restored) == 1, "signing key should be restored after trusting secret key file"
+    assert restored[0].fpr == original_fpr, "restored key fingerprint should match original"
+
+
 def test_gpg_key_type():
     str_to_type = [
         ("pub", spack.util.gpg.GpgKeyType.PUBLIC),

--- a/lib/spack/spack/util/gpg.py
+++ b/lib/spack/spack/util/gpg.py
@@ -620,16 +620,19 @@ class Gpg:
         ownertrust: GpgKeyTrust = GpgKeyTrust.ULTIMATE,
         yes_to_all: bool = False,
     ):
-        """Import a public key from a file and trust it.
+        """Import a key from a file and trust it.
+
+        The keyfile may contain public keys, secret keys (which embed public
+        key material), or both.
 
         Args:
-            keyfile: file with the public key
+            keyfile: file with the public or secret key(s)
             fprs: list of fingerprints to trust, if provided, then yes_to_all is ignored
             ownertrust: level of trust to assign to the key(s)
             yes_to_all: trust all keys in the file if True, otherwise ask for each key
         """
 
-        # This global method is safe to use to list keys in a file
+        # This global method is safe to use to list keys in a file without importing them
         imported_keys = extract_public_keys(keyfile)
         if not imported_keys:
             tty.info(f"No keys to trust in {keyfile}")
@@ -935,15 +938,31 @@ def export_keys(location: str, keys: List[GpgKey], secret: bool = False):
 
 @_autoinit
 def extract_public_keys(keyfile: str):
-    """Extract the public key ids from a file
+    """Extract the key ids from a file, including keys stored as secret keys.
+
+    A secret-key export contains both the private and public key material and
+    has the same fingerprint as the corresponding public key, so secret-key
+    files are valid input for trust operations.
 
     Args:
-        keyfile: file with the public key
+        keyfile: file with the public or secret key(s)
     """
     assert GPG
-    # Get the public keys we are about to import
-    output = GPG("--with-colons", "--with-fingerprint", keyfile, output=str, error=str)
-    return [k for k in _parse_gpg_output(output) if k.type == GpgKeyType.PUBLIC]
+    # Use --import-options show-only --import to list keys from a file without
+    # importing them.
+    output = GPG(
+        "--with-colons",
+        "--with-fingerprint",
+        "--import-options",
+        "show-only",
+        "--import",
+        keyfile,
+        output=str,
+        error=str,
+    )
+    return [
+        k for k in _parse_gpg_output(output) if k.type in (GpgKeyType.PUBLIC, GpgKeyType.SECRET)
+    ]
 
 
 @_autoinit

--- a/lib/spack/spack/util/gpg.py
+++ b/lib/spack/spack/util/gpg.py
@@ -593,8 +593,9 @@ class Gpg:
             gpg_args.append("--show-keys")
         elif self._version >= spack.version.Version("2.1.23"):
             gpg_args.extend(["--import-options", "show-only", "--import"])
-        else:
+        elif self._version >= spack.version.Version("2.1.14"):
             gpg_args.extend(["--import-options", "import-show", "--dry-run", "--import"])
+        # For older versions of gpg we fall back to using keyfile as a bare positional argument.
 
         output = self.gpg(*gpg_args, keyfile, output=str, error=str)
         return [k for k in _parse_gpg_output(output) if k.type in ktypes]

--- a/lib/spack/spack/util/gpg.py
+++ b/lib/spack/spack/util/gpg.py
@@ -10,7 +10,8 @@ import os
 import pathlib
 import re
 import sys
-from typing import Any, Callable, Dict, List, Optional, Union
+import warnings
+from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 
 import spack.error
 import spack.llnl.util.filesystem
@@ -294,7 +295,7 @@ class GpgUserId:
         self.type = data["type"]
         self.trust = GpgKeyTrust(data.get("trust", ""))
         if "created_at" not in data:
-            tty.warn("GPG Key User ID has no creation date")
+            warnings.warn("GPG Key User ID has no creation date")
             self.created_at = None
         else:
             self.created_at = datetime.datetime.fromtimestamp(int(data["created_at"]))
@@ -487,6 +488,7 @@ class Gpg:
 
         self._gpg: Optional[Executable] = None
         self._gpgconf: Optional[Executable] = None
+        self._version: Optional[spack.version.VersionType] = None
         self._socket_dir: Optional[pathlib.Path] = None
 
     @staticmethod
@@ -520,16 +522,29 @@ class Gpg:
 
         return gnupghome
 
-    def _create_gpgfn(self, finder: Callable[..., Optional[Executable]]) -> Optional[Executable]:
+    def _create_gpgfn(
+        self, finder: Callable[..., Optional[Tuple[Executable, spack.version.VersionType]]]
+    ) -> Optional[Executable]:
         """Create a GPG function wrapper"""
         import spack.bootstrap
 
         with spack.bootstrap.ensure_bootstrap_configuration():
             spack.bootstrap.ensure_gpg_in_path_or_raise()
-            gpgfn = finder()
+            result = finder()
 
-        if gpgfn:
-            gpgfn.add_default_env("GNUPGHOME", str(self.home))
+        if result is None:
+            return None
+
+        gpgfn, version = result
+
+        if self._version and version != self._version:
+            warnings.warn(
+                "Version mismatch between gpg and gpgconf. This may lead to unexpected behavior"
+            )
+        else:
+            self._version = version
+
+        gpgfn.add_default_env("GNUPGHOME", str(self.home))
 
         return gpgfn
 
@@ -565,6 +580,24 @@ class Gpg:
                 self.conf("--create-socketdir")
 
         return self._socket_dir
+
+    def list_keyfile(
+        self, keyfile: str, ktype: Union[GpgKeyType, List[GpgKeyType]] = GpgKeyType.PUBLIC
+    ) -> List[GpgKey]:
+        """List keys in a keyfile"""
+        assert self._version is not None, "GPG version is not set; ensure GPG is initialized"
+        ktypes = {ktype} if isinstance(ktype, GpgKeyType) else set(ktype)
+
+        gpg_args = ["--with-colons", "--with-fingerprint"]
+        if self._version >= spack.version.Version("2.2.8"):
+            gpg_args.append("--show-keys")
+        elif self._version >= spack.version.Version("2.1.23"):
+            gpg_args.extend(["--import-options", "show-only", "--import"])
+        else:
+            gpg_args.extend(["--import-options", "import-show", "--dry-run", "--import"])
+
+        output = self.gpg(*gpg_args, keyfile, output=str, error=str)
+        return [k for k in _parse_gpg_output(output) if k.type in ktypes]
 
     def _list_keys(self, *fprs, colons: bool = True, ktype: GpgKeyType = GpgKeyType.PUBLIC) -> str:
         gpg_args = []
@@ -633,7 +666,7 @@ class Gpg:
         """
 
         # This global method is safe to use to list keys in a file without importing them
-        imported_keys = extract_public_keys(keyfile)
+        imported_keys = self.list_keyfile(keyfile, ktype=[GpgKeyType.PUBLIC, GpgKeyType.SECRET])
         if not imported_keys:
             tty.info(f"No keys to trust in {keyfile}")
             return
@@ -938,31 +971,13 @@ def export_keys(location: str, keys: List[GpgKey], secret: bool = False):
 
 @_autoinit
 def extract_public_keys(keyfile: str):
-    """Extract the key ids from a file, including keys stored as secret keys.
-
-    A secret-key export contains both the private and public key material and
-    has the same fingerprint as the corresponding public key, so secret-key
-    files are valid input for trust operations.
+    """Extract the key ids from a file
 
     Args:
-        keyfile: file with the public or secret key(s)
+        keyfile: file with the public key
     """
     assert GPG
-    # Use --import-options show-only --import to list keys from a file without
-    # importing them.
-    output = GPG(
-        "--with-colons",
-        "--with-fingerprint",
-        "--import-options",
-        "show-only",
-        "--import",
-        keyfile,
-        output=str,
-        error=str,
-    )
-    return [
-        k for k in _parse_gpg_output(output) if k.type in (GpgKeyType.PUBLIC, GpgKeyType.SECRET)
-    ]
+    return GPG.list_keyfile(keyfile, ktype=GpgKeyType.PUBLIC)
 
 
 @_autoinit
@@ -1048,7 +1063,7 @@ def glist(trusted: bool, signing: bool, fmt: str = "default"):
         print(GPG.list_keys(ktype=GpgKeyType.SECRET, fmt=fmt))
 
 
-def _verify_exe_or_raise(exe):
+def _verify_exe_or_raise(exe) -> spack.version.VersionType:
     """Verify that the gpg executable is a new enough version."""
 
     msg = (
@@ -1066,11 +1081,14 @@ def _verify_exe_or_raise(exe):
     if not match:
         raise SpackGPGError('Could not determine "{0}" version'.format(exe.name))
 
-    if spack.version.Version(match.group(2)) < spack.version.Version("2"):
+    gpg_version = spack.version.Version(match.group(2))
+    if gpg_version < spack.version.Version("2"):
         raise SpackGPGError(msg)
 
+    return gpg_version
 
-def _gpgconf() -> Optional[Executable]:
+
+def _gpgconf() -> Optional[Tuple[Executable, spack.version.VersionType]]:
     """Get executable for gpgconf if it exists"""
     # ensure that the gpgconf we found can run "gpgconf --create-socketdir"
     exe = spack.util.executable.which(*GPGCONF_NAMES)
@@ -1078,19 +1096,19 @@ def _gpgconf() -> Optional[Executable]:
         return None
 
     try:
-        _verify_exe_or_raise(exe)
+        version = _verify_exe_or_raise(exe)
         exe("--dry-run", "--create-socketdir", output=os.devnull, error=os.devnull)
-        return exe
+        return exe, version
     except spack.util.executable.ProcessError:
         # no dice
         return None
 
 
-def _gpg() -> Executable:
+def _gpg() -> Tuple[Executable, spack.version.VersionType]:
     """Get executable for gpg"""
     exe = spack.util.executable.which(*GPG_NAMES, required=True)
-    _verify_exe_or_raise(exe)
-    return exe
+    version = _verify_exe_or_raise(exe)
+    return exe, version
 
 
 def _socket_dir(gpgconf: Optional[Executable]) -> Optional[pathlib.Path]:


### PR DESCRIPTION
Prior to this commit, `gpg.trust()` would sometimes fail to import a signing key. The underlying issue is that the gpg command-line invocation for inspecting keys stored in a file is version-dependent:

* gpg >= 2.2.8: `--show-keys`
* gpg >= 2.1.23: `--import-options show-only --import`
* gpg >= 2.1.14: `--import-options import-show --dry-run --import`
* older versions: specify keyfile as a bare positional argument

The previous code used `gpg --with-colons --with-fingerprint <keyfile>` (the bare positional argument form)  unconditionally, which would silently fail for newer gpg versions and cause `extract_public_keys()` to return an empty list.

This bug was masked prior to #52430 because we unconditionally called `GPG("--batch", "--import", keyfile)` regardless of what the inspection step returned. The refactor made the import conditional on `extract_public_keys()` returning a non-empty list, exposing the latent bug.

This commit fixes the issue by storing the gpg version on the `Gpg` instance and selecting the appropriate CLI arguments in a `new list_keyfile()` method. `trust()` is also updated to handle keyfiles containing secret keys (e.g. CI signing key exports), which produce `sec` records rather than `pub` records when inspected.

A regression test is added that exports a secret key to a file, clears the keyring, calls `spack.util.gpg.trust()` on the file, and asserts the secret key is restored.