### PR TITLE
Windows CI: no git bash tools

### DIFF
--- a/.github/workflows/unit_tests.yaml
+++ b/.github/workflows/unit_tests.yaml
@@ -294,6 +294,9 @@ jobs:
       run: |
           Remove-Item -Path (Get-Command gpg).Path
           Remove-Item -Path (Get-Command file).Path
+    - name: Bootstrap Gpg + File for unit tests
+      run: |
+          spack bootstrap now
     - name: Unit Test
       env:
         COVERAGE_FILE: coverage/.coverage-windows

--- a/.github/workflows/unit_tests.yaml
+++ b/.github/workflows/unit_tests.yaml
@@ -290,6 +290,10 @@ jobs:
     - name: Create local develop
       run: |
         ./.github/workflows/bin/setup_git.ps1
+    - name: Remove Spack Bootstrap Requirements
+      run: |
+          Remove-Item -Path (Get-Command gpg).Path
+          Remove-Item -Path (Get-Command file).Path
     - name: Unit Test
       env:
         COVERAGE_FILE: coverage/.coverage-windows


### PR DESCRIPTION
Git on Windows vendors a functional bash, and associated suite of tools. These tools work great, when used with git bash. When called by native programs with Windows path, they almost universally fail, leading to hard to diagnose, obtuse failures

Remove the git bash tools when running unit tests and bootstrapping

Previously bootstrap ci checks on WIndows just removed file and gpg directly, this check removes the entire git bash tool suite.