### PR TITLE
move spack.llnl.util.lang to spack.util.lang

### DIFF
--- a/lib/spack/docs/conf.py
+++ b/lib/spack/docs/conf.py
@@ -129,7 +129,7 @@ class CustomPygmentsBridge(PygmentsBridge):
 PygmentsBridge.html_formatter = NoWhitespaceHtmlFormatter
 
 
-from spack.llnl.util.lang import classproperty
+from spack.util.lang import classproperty
 from spack.spec_parser import SpecTokens
 
 # replace classproperty.__get__ to return `self` so Sphinx can document it correctly. Otherwise
@@ -371,17 +371,17 @@ nitpick_ignore = [
     ("py:class", "spack.vendor.jinja2.Environment"),
     ("py:class", "SpecFiltersFactory"),
     # TypeVar that is not handled correctly
-    ("py:class", "spack.llnl.util.lang.ClassPropertyType"),
-    ("py:class", "spack.llnl.util.lang.K"),
-    ("py:class", "spack.llnl.util.lang.KT"),
-    ("py:class", "spack.llnl.util.lang.T"),
-    ("py:class", "spack.llnl.util.lang.V"),
-    ("py:class", "spack.llnl.util.lang.VT"),
-    ("py:obj", "spack.llnl.util.lang.ClassPropertyType"),
-    ("py:obj", "spack.llnl.util.lang.K"),
-    ("py:obj", "spack.llnl.util.lang.KT"),
-    ("py:obj", "spack.llnl.util.lang.V"),
-    ("py:obj", "spack.llnl.util.lang.VT"),
+    ("py:class", "spack.util.lang.ClassPropertyType"),
+    ("py:class", "spack.util.lang.K"),
+    ("py:class", "spack.util.lang.KT"),
+    ("py:class", "spack.util.lang.T"),
+    ("py:class", "spack.util.lang.V"),
+    ("py:class", "spack.util.lang.VT"),
+    ("py:obj", "spack.util.lang.ClassPropertyType"),
+    ("py:obj", "spack.util.lang.K"),
+    ("py:obj", "spack.util.lang.KT"),
+    ("py:obj", "spack.util.lang.V"),
+    ("py:obj", "spack.util.lang.VT"),
     ("py:class", "_P"),
     ("py:class", "spack.util.web._R"),
 ]

--- a/lib/spack/spack/audit.py
+++ b/lib/spack/spack/audit.py
@@ -54,11 +54,11 @@ import spack.builder
 import spack.config
 import spack.enums
 import spack.fetch_strategy
-import spack.llnl.util.lang
 import spack.patch
 import spack.repo
 import spack.spec
 import spack.util.crypto
+import spack.util.lang
 import spack.util.spack_yaml as syaml
 import spack.variant
 from spack.util.string import plural
@@ -917,7 +917,7 @@ def _linting_package_file(pkgs, error_cls):
                 errors.append(error_cls(msg.format(pkg_cls.name), [str(e)]))
                 continue
 
-    return spack.llnl.util.lang.dedupe(errors)
+    return spack.util.lang.dedupe(errors)
 
 
 @package_directives
@@ -1009,7 +1009,7 @@ def _variant_issues_in_directives(pkgs, error_cls):
                 )
             )
 
-    return spack.llnl.util.lang.dedupe(errors)
+    return spack.util.lang.dedupe(errors)
 
 
 @package_directives
@@ -1350,7 +1350,7 @@ def _named_specs_in_when_arguments(pkgs, error_cls):
                 error_cls(f"{pkg_name}: wrong 'when=' condition in 'resource' directives", details)
             )
 
-    return spack.llnl.util.lang.dedupe(errors)
+    return spack.util.lang.dedupe(errors)
 
 
 #: Sanity checks on package directives

--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -50,7 +50,6 @@ import spack.error
 import spack.hash_types as ht
 import spack.hooks
 import spack.hooks.sbang
-import spack.llnl.util.lang
 import spack.llnl.util.tty as tty
 import spack.mirrors.mirror
 import spack.oci.image
@@ -68,6 +67,7 @@ import spack.util.crypto
 import spack.util.file_cache as file_cache
 import spack.util.filesystem as fsys
 import spack.util.gpg
+import spack.util.lang
 import spack.util.parallel
 import spack.util.path
 import spack.util.spack_json as sjson
@@ -126,8 +126,8 @@ class BuildCacheDatabase(spack.database.Database):
 
     def __init__(self, root):
         super().__init__(root, lock_cfg=spack.database.NO_LOCK, layout=None)
-        self._write_transaction_impl = spack.llnl.util.lang.nullcontext
-        self._read_transaction_impl = spack.llnl.util.lang.nullcontext
+        self._write_transaction_impl = spack.util.lang.nullcontext
+        self._read_transaction_impl = spack.util.lang.nullcontext
 
     def _handle_old_db_versions_read(self, check, db, *, reindex: bool):
         if not self.is_readable():
@@ -522,7 +522,7 @@ def binary_index_location():
 
 
 #: Default binary cache index instance
-BINARY_INDEX = cast(BinaryIndexCache, spack.llnl.util.lang.Singleton(BinaryIndexCache))
+BINARY_INDEX = cast(BinaryIndexCache, spack.util.lang.Singleton(BinaryIndexCache))
 
 
 def compute_hash(data):
@@ -542,7 +542,7 @@ def read_buildinfo_file(prefix):
         return syaml.load(f)
 
 
-def file_matches(f: IO[bytes], regex: spack.llnl.util.lang.PatternBytes) -> bool:
+def file_matches(f: IO[bytes], regex: spack.util.lang.PatternBytes) -> bool:
     try:
         return bool(regex.search(f.read()))
     finally:
@@ -560,7 +560,7 @@ def specs_to_relocate(spec: spack.spec.Spec) -> List[spack.spec.Spec]:
         )
         if not s.external
     ]
-    return list(spack.llnl.util.lang.dedupe(specs, key=lambda s: s.dag_hash()))
+    return list(spack.util.lang.dedupe(specs, key=lambda s: s.dag_hash()))
 
 
 def get_buildinfo_dict(spec):
@@ -618,7 +618,7 @@ def buildcache_relative_index_url(layout_version: int = CURRENT_BUILD_CACHE_LAYO
     return url_util.join(*cache_class.get_relative_path_components(BuildcacheComponent.INDEX))
 
 
-@spack.llnl.util.lang.memoized
+@spack.util.lang.memoized
 def warn_v2_layout(mirror_url: str, action: str) -> bool:
     lines = textwrap.wrap(
         f"{action} from a v2 binary mirror layout, located at "

--- a/lib/spack/spack/bootstrap/core.py
+++ b/lib/spack/spack/bootstrap/core.py
@@ -45,7 +45,7 @@ import spack.util.spack_yaml
 import spack.util.url
 import spack.version
 from spack.llnl.util import tty
-from spack.llnl.util.lang import GroupedExceptionHandler
+from spack.util.lang import GroupedExceptionHandler
 
 from ._common import (
     QueryInfo,

--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -84,7 +84,6 @@ from spack import traverse
 from spack.enums import Context
 from spack.error import InstallError, NoHeadersError, NoLibrariesError
 from spack.install_test import spack_install_test_log
-from spack.llnl.util.lang import dedupe, stable_partition
 from spack.llnl.util.tty.color import cescape, colorize
 from spack.util.environment import (
     SYSTEM_DIR_CASE_ENTRY,
@@ -99,6 +98,7 @@ from spack.util.environment import (
 )
 from spack.util.executable import Executable
 from spack.util.filesystem import join_path, symlink
+from spack.util.lang import dedupe, stable_partition
 from spack.util.log_parse import make_log_context, parse_log_events
 from spack.util.string import plural
 

--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -99,6 +99,7 @@ from spack.util.environment import (
 from spack.util.executable import Executable
 from spack.util.filesystem import join_path, symlink
 from spack.util.lang import dedupe, stable_partition
+from spack.util.lang import dedupe, stable_partition
 from spack.util.log_parse import make_log_context, parse_log_events
 from spack.util.string import plural
 

--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -99,7 +99,6 @@ from spack.util.environment import (
 from spack.util.executable import Executable
 from spack.util.filesystem import join_path, symlink
 from spack.util.lang import dedupe, stable_partition
-from spack.util.lang import dedupe, stable_partition
 from spack.util.log_parse import make_log_context, parse_log_events
 from spack.util.string import plural
 

--- a/lib/spack/spack/caches.py
+++ b/lib/spack/spack/caches.py
@@ -8,9 +8,9 @@ from typing import cast
 
 import spack.config
 import spack.fetch_strategy
-import spack.llnl.util.lang
 import spack.paths
 import spack.util.file_cache
+import spack.util.lang
 
 
 def misc_cache_location():
@@ -29,7 +29,7 @@ def _misc_cache():
 
 
 #: Spack's cache for small data
-MISC_CACHE = cast(spack.util.file_cache.FileCache, spack.llnl.util.lang.Singleton(_misc_cache))
+MISC_CACHE = cast(spack.util.file_cache.FileCache, spack.util.lang.Singleton(_misc_cache))
 
 
 def fetch_cache_location():
@@ -64,4 +64,4 @@ class MirrorCache(spack.fetch_strategy.FsCacheBase):
 
 
 #: Spack's local cache for downloaded source archives
-FETCH_CACHE = cast(spack.fetch_strategy.FsCache, spack.llnl.util.lang.Singleton(_fetch_cache))
+FETCH_CACHE = cast(spack.fetch_strategy.FsCache, spack.util.lang.Singleton(_fetch_cache))

--- a/lib/spack/spack/ci/common.py
+++ b/lib/spack/spack/ci/common.py
@@ -30,11 +30,11 @@ import spack.util.compression as compression
 import spack.util.filesystem as fs
 import spack.util.web as web_util
 from spack import traverse
-from spack.llnl.util.lang import memoized
 from spack.reporters import CDash, CDashConfiguration
 from spack.reporters.cdash import SPACK_CDASH_TIMEOUT
 from spack.reporters.cdash import build_stamp as cdash_build_stamp
 from spack.url_buildcache import get_url_buildcache_class
+from spack.util.lang import memoized
 
 IS_WINDOWS = sys.platform == "win32"
 SPACK_RESERVED_TAGS = ["public", "protected", "notary"]

--- a/lib/spack/spack/cmd/__init__.py
+++ b/lib/spack/spack/cmd/__init__.py
@@ -30,10 +30,10 @@ import spack.user_environment as uenv
 import spack.util.spack_json as sjson
 import spack.util.spack_yaml as syaml
 import spack.util.string
-from spack.llnl.util.lang import attr_setdefault, index_by
 from spack.llnl.util.tty.colify import colify
 from spack.llnl.util.tty.color import colorize
 from spack.util.filesystem import join_path
+from spack.util.lang import attr_setdefault, index_by
 
 from ..enums import InstallRecordStatus
 

--- a/lib/spack/spack/cmd/blame.py
+++ b/lib/spack/spack/cmd/blame.py
@@ -15,10 +15,10 @@ import spack.repo
 import spack.util.git
 import spack.util.spack_json as sjson
 from spack.cmd import spack_is_git_repo
-from spack.llnl.util.lang import pretty_date
 from spack.llnl.util.tty.colify import colify_table
 from spack.util.executable import ProcessError
 from spack.util.filesystem import working_dir
+from spack.util.lang import pretty_date
 
 description = "show contributors to packages"
 section = "query"

--- a/lib/spack/spack/cmd/buildcache.py
+++ b/lib/spack/spack/cmd/buildcache.py
@@ -31,9 +31,9 @@ from spack.binary_distribution import BINARY_INDEX
 from spack.cmd import display_specs
 from spack.cmd.common import arguments
 from spack.llnl.util import tty
-from spack.llnl.util.lang import elide_list, stable_partition
 from spack.llnl.util.tty import colify
 from spack.spec import Spec, save_dependency_specfiles
+from spack.util.lang import elide_list, stable_partition
 from spack.util.string import plural
 
 from ..buildcache_migrate import migrate

--- a/lib/spack/spack/cmd/checksum.py
+++ b/lib/spack/spack/cmd/checksum.py
@@ -7,10 +7,10 @@ import re
 import sys
 from typing import Dict, Optional, Tuple
 
-import spack.llnl.util.lang
 import spack.repo
 import spack.spec
 import spack.stage
+import spack.util.lang
 import spack.util.string
 import spack.util.web as web_util
 from spack.cmd.common import arguments
@@ -223,10 +223,7 @@ def print_checksum_status(pkg: PackageBase, version_hashes: dict):
 
     # Display table of checksum results.
     tty.msg(
-        f"Verified {num_verified} of {num_total}",
-        "",
-        *spack.llnl.util.lang.elide_list(results),
-        "",
+        f"Verified {num_verified} of {num_total}", "", *spack.util.lang.elide_list(results), ""
     )
 
     # Terminate at the end of function to prevent additional output.

--- a/lib/spack/spack/cmd/common/arguments.py
+++ b/lib/spack/spack/cmd/common/arguments.py
@@ -17,7 +17,7 @@ import spack.mirrors.utils
 import spack.reporters
 import spack.spec
 import spack.store
-from spack.llnl.util.lang import stable_partition
+from spack.util.lang import stable_partition
 from spack.util.pattern import Args
 
 __all__ = ["add_common_arguments"]

--- a/lib/spack/spack/cmd/compiler.py
+++ b/lib/spack/spack/cmd/compiler.py
@@ -14,10 +14,10 @@ import spack.llnl.util.tty as tty
 import spack.spec
 import spack.store
 from spack.cmd.common import arguments
-from spack.llnl.util.lang import index_by
 from spack.llnl.util.tty.colify import colify
 from spack.llnl.util.tty.color import colorize
 from spack.spec import Spec
+from spack.util.lang import index_by
 
 description = "manage compilers"
 section = "config"

--- a/lib/spack/spack/cmd/find.py
+++ b/lib/spack/spack/cmd/find.py
@@ -11,13 +11,13 @@ import spack.binary_distribution
 import spack.cmd as cmd
 import spack.config
 import spack.environment as ev
-import spack.llnl.util.lang
 import spack.llnl.util.tty as tty
 import spack.llnl.util.tty.color as color
 import spack.repo
 import spack.solver.reuse
 import spack.spec
 import spack.store
+import spack.util.lang
 from spack.cmd.common import arguments
 from spack.externals_config import create_external_parser, external_config_with_implicit_externals
 from spack.llnl.util.tty.color import colorize
@@ -229,7 +229,7 @@ def query_arguments(args):
     for attribute in ("start_date", "end_date"):
         date = getattr(args, attribute)
         if date:
-            q_args[attribute] = spack.llnl.util.lang.pretty_string_to_date(date)
+            q_args[attribute] = spack.util.lang.pretty_string_to_date(date)
 
     return q_args
 

--- a/lib/spack/spack/cmd/mirror.py
+++ b/lib/spack/spack/cmd/mirror.py
@@ -11,13 +11,13 @@ import spack.cmd
 import spack.concretize
 import spack.config
 import spack.environment as ev
-import spack.llnl.util.lang as lang
 import spack.llnl.util.tty as tty
 import spack.llnl.util.tty.colify as colify
 import spack.mirrors.mirror
 import spack.mirrors.utils
 import spack.repo
 import spack.spec
+import spack.util.lang as lang
 import spack.util.parallel
 import spack.util.web as web_util
 from spack.cmd.common import arguments

--- a/lib/spack/spack/cmd/spec.py
+++ b/lib/spack/spack/cmd/spec.py
@@ -17,6 +17,9 @@ import spack.llnl.util.tty.color as color
 import spack.package_base
 import spack.solver.asp as asp
 import spack.spec
+import spack.store
+import spack.traverse
+import spack.util.lang as lang
 from spack.cmd.common import arguments
 
 description = "show what would be installed, given a spec"

--- a/lib/spack/spack/cmd/spec.py
+++ b/lib/spack/spack/cmd/spec.py
@@ -17,9 +17,6 @@ import spack.llnl.util.tty.color as color
 import spack.package_base
 import spack.solver.asp as asp
 import spack.spec
-import spack.store
-import spack.traverse
-import spack.util.lang as lang
 from spack.cmd.common import arguments
 
 description = "show what would be installed, given a spec"

--- a/lib/spack/spack/compilers/adaptor.py
+++ b/lib/spack/spack/compilers/adaptor.py
@@ -5,7 +5,7 @@ import enum
 from typing import Dict, List
 
 import spack.spec
-from spack.llnl.util import lang
+from spack.util import lang
 
 from .libraries import CompilerPropertyDetector
 

--- a/lib/spack/spack/compilers/config.py
+++ b/lib/spack/spack/compilers/config.py
@@ -15,12 +15,12 @@ import spack.config
 import spack.detection
 import spack.detection.path
 import spack.error
-import spack.llnl.util.lang
 import spack.llnl.util.tty as tty
 import spack.platforms
 import spack.repo
 import spack.spec
 import spack.util.filesystem as fs
+import spack.util.lang
 from spack.externals import ExternalSpecsParser, external_spec, extract_dicts_from_configuration
 from spack.operating_systems import windows_os
 from spack.util.environment import get_path
@@ -197,7 +197,7 @@ class CompilerRemover:
                 def _partition_match(external_yaml):
                     return not external_spec(external_yaml).satisfies(match)
 
-                to_keep, to_remove = spack.llnl.util.lang.stable_partition(
+                to_keep, to_remove = spack.util.lang.stable_partition(
                     externals_config, _partition_match
                 )
                 if not to_remove:

--- a/lib/spack/spack/compilers/libraries.py
+++ b/lib/spack/spack/compilers/libraries.py
@@ -13,10 +13,10 @@ import tempfile
 from typing import Dict, List, Optional, Set, Tuple, cast
 
 import spack.caches
-import spack.llnl.util.lang
 import spack.schema.environment
 import spack.spec
 import spack.util.executable
+import spack.util.lang
 import spack.util.libc
 import spack.util.module_cmd
 import spack.util.path
@@ -443,4 +443,4 @@ def _make_compiler_cache():
     return FileCompilerCache(spack.caches.MISC_CACHE)
 
 
-COMPILER_CACHE = cast(CompilerCache, spack.llnl.util.lang.Singleton(_make_compiler_cache))
+COMPILER_CACHE = cast(CompilerCache, spack.util.lang.Singleton(_make_compiler_cache))

--- a/lib/spack/spack/config.py
+++ b/lib/spack/spack/config.py
@@ -72,8 +72,8 @@ import spack.util.hash
 import spack.util.remote_file_cache as rfc_util
 import spack.util.spack_json as sjson
 import spack.util.spack_yaml as syaml
-from spack.llnl.util import lang, tty
-from spack.util import filesystem
+from spack.llnl.util import tty
+from spack.util import filesystem, lang
 from spack.util.cpus import cpus_available
 from spack.util.spack_yaml import get_mark_from_yaml_data
 

--- a/lib/spack/spack/detection/path.py
+++ b/lib/spack/spack/detection/path.py
@@ -16,13 +16,13 @@ import warnings
 from typing import Dict, Iterable, List, Optional, Set, Tuple, Type
 
 import spack.error
-import spack.llnl.util.lang
 import spack.llnl.util.tty
 import spack.spec
 import spack.util.elf as elf_utils
 import spack.util.environment
 import spack.util.environment as environment
 import spack.util.filesystem
+import spack.util.lang
 import spack.util.ld_so_conf
 import spack.util.parallel
 
@@ -271,7 +271,7 @@ class Finder:
         result = []
         resolved_specs: Dict[spack.spec.Spec, str] = {}  # spec -> prefix of first detection
         for candidate_path, items_in_prefix in _group_by_prefix(
-            spack.llnl.util.lang.dedupe(paths)
+            spack.util.lang.dedupe(paths)
         ).items():
             # TODO: multiple instances of a package can live in the same
             # prefix, and a package implementation can return multiple specs
@@ -435,7 +435,7 @@ def by_path(
     detected_specs_by_package: Dict[str, Tuple[concurrent.futures.Future, ...]] = {}
 
     result = collections.defaultdict(list)
-    repository = spack.llnl.util.lang.ensure_unwrapped(PATH)
+    repository = spack.util.lang.ensure_unwrapped(PATH)
 
     executor: concurrent.futures.Executor
     if max_workers == 1:

--- a/lib/spack/spack/directives_meta.py
+++ b/lib/spack/spack/directives_meta.py
@@ -11,7 +11,7 @@ from spack.vendor.typing_extensions import ParamSpec
 import spack.error
 import spack.repo
 import spack.spec
-from spack.llnl.util.lang import dedupe
+from spack.util.lang import dedupe
 
 P = ParamSpec("P")
 R = TypeVar("R")

--- a/lib/spack/spack/environment/environment.py
+++ b/lib/spack/spack/environment/environment.py
@@ -55,11 +55,11 @@ import spack.variant as vt
 from spack import traverse
 from spack.config import substitute_path_variables
 from spack.enums import ConfigScopePriority
-from spack.llnl.util.lang import stable_partition
 from spack.schema.env import TOP_LEVEL_KEY
 from spack.spec import Spec
 from spack.spec_filter import SpecFilter
 from spack.util.filesystem import copy_tree, islink, readlink
+from spack.util.lang import stable_partition
 from spack.util.link_tree import ConflictingSpecsError
 
 from .list import SpecList, SpecListError, SpecListParser

--- a/lib/spack/spack/environment/environment.py
+++ b/lib/spack/spack/environment/environment.py
@@ -61,8 +61,6 @@ from spack.spec_filter import SpecFilter
 from spack.util.filesystem import copy_tree, islink, readlink
 from spack.util.lang import stable_partition
 from spack.util.link_tree import ConflictingSpecsError
-from spack.util.lang import stable_partition
-from spack.util.path import substitute_path_variables
 
 from .list import SpecList, SpecListError, SpecListParser
 

--- a/lib/spack/spack/environment/environment.py
+++ b/lib/spack/spack/environment/environment.py
@@ -61,6 +61,8 @@ from spack.spec_filter import SpecFilter
 from spack.util.filesystem import copy_tree, islink, readlink
 from spack.util.lang import stable_partition
 from spack.util.link_tree import ConflictingSpecsError
+from spack.util.lang import stable_partition
+from spack.util.path import substitute_path_variables
 
 from .list import SpecList, SpecListError, SpecListParser
 

--- a/lib/spack/spack/extensions.py
+++ b/lib/spack/spack/extensions.py
@@ -16,7 +16,7 @@ from typing import List
 
 import spack.config
 import spack.error
-import spack.llnl.util.lang
+import spack.util.lang
 
 _extension_regexp = re.compile(r"spack-(\w[-\w]*)$")
 
@@ -89,7 +89,7 @@ def ensure_extension_loaded(extension, *, path):
         parts = [path] + name.split(".") + ["__init__.py"]
         init_file = os.path.join(*parts)
         if os.path.exists(init_file):
-            m = spack.llnl.util.lang.load_module_from_file(package_name, init_file)
+            m = spack.util.lang.load_module_from_file(package_name, init_file)
         else:
             m = types.ModuleType(package_name)
 
@@ -132,7 +132,7 @@ def get_extension_paths():
     return paths
 
 
-@spack.llnl.util.lang.memoized
+@spack.util.lang.memoized
 def extension_paths_from_entry_points() -> List[str]:
     """Load extensions from a Python package's entry points.
 
@@ -151,7 +151,7 @@ def extension_paths_from_entry_points() -> List[str]:
     called. E.g., it doesn't support any new installation of packages between two calls.
     """
     extension_paths: List[str] = []
-    for entry_point in spack.llnl.util.lang.get_entry_points(group="spack.extensions"):
+    for entry_point in spack.util.lang.get_entry_points(group="spack.extensions"):
         hook = entry_point.load()
         if callable(hook):
             paths = hook() or []

--- a/lib/spack/spack/filesystem_view.py
+++ b/lib/spack/spack/filesystem_view.py
@@ -24,7 +24,6 @@ import spack.util.spack_json as s_json
 import spack.util.spack_yaml as s_yaml
 from spack.error import SpackError
 from spack.llnl.util import tty
-from spack.llnl.util.lang import index_by, match_predicate
 from spack.llnl.util.tty.color import colorize
 from spack.util.filesystem import (
     mkdirp,
@@ -33,6 +32,7 @@ from spack.util.filesystem import (
     symlink,
     visit_directory_tree,
 )
+from spack.util.lang import index_by, match_predicate
 from spack.util.link_tree import (
     ConflictingSpecsError,
     DestinationMergeVisitor,

--- a/lib/spack/spack/hooks/absolutify_elf_sonames.py
+++ b/lib/spack/spack/hooks/absolutify_elf_sonames.py
@@ -8,9 +8,9 @@ import spack.bootstrap
 import spack.config
 import spack.llnl.util.tty as tty
 import spack.relocate
-from spack.llnl.util.lang import elide_list
 from spack.util.elf import ElfParsingError, parse_elf
 from spack.util.filesystem import BaseDirectoryVisitor, visit_directory_tree
+from spack.util.lang import elide_list
 
 
 def is_shared_library_elf(filepath):

--- a/lib/spack/spack/install_test.py
+++ b/lib/spack/spack/install_test.py
@@ -26,9 +26,9 @@ import spack.util.executable
 import spack.util.filesystem as fs
 import spack.util.spack_json as sjson
 from spack.error import InstallError
-from spack.llnl.util.lang import nullcontext
 from spack.llnl.util.tty.color import colorize
 from spack.spec import Spec
+from spack.util.lang import nullcontext
 from spack.util.prefix import Prefix
 from spack.util.string import plural
 

--- a/lib/spack/spack/installer.py
+++ b/lib/spack/spack/installer.py
@@ -62,11 +62,11 @@ import spack.store
 import spack.util.filesystem as fs
 import spack.util.path
 import spack.util.timer as timer
-from spack.llnl.util.lang import pretty_seconds
 from spack.llnl.util.tty.color import colorize
 from spack.llnl.util.tty.log import log_output, preserve_terminal_settings
 from spack.url_buildcache import BuildcacheEntryError
 from spack.util.environment import EnvironmentModifications, dump_environment
+from spack.util.lang import pretty_seconds
 from spack.util.string import ordinal
 
 if TYPE_CHECKING:

--- a/lib/spack/spack/llnl/util/lock.py
+++ b/lib/spack/spack/llnl/util/lock.py
@@ -11,7 +11,8 @@ from datetime import datetime
 from types import TracebackType
 from typing import IO, Callable, Dict, Generator, Optional, Tuple, Type, Union
 
-from spack.llnl.util import lang, tty
+from spack.llnl.util import tty
+from spack.util import lang
 from spack.util.string import plural
 
 if sys.platform != "win32":

--- a/lib/spack/spack/main.py
+++ b/lib/spack/spack/main.py
@@ -35,7 +35,6 @@ import spack.environment
 import spack.environment as ev
 import spack.environment.environment
 import spack.error
-import spack.llnl.util.lang
 import spack.llnl.util.tty as tty
 import spack.llnl.util.tty.colify
 import spack.llnl.util.tty.color as color
@@ -44,6 +43,7 @@ import spack.platforms
 import spack.solver.asp
 import spack.spec
 import spack.util.environment
+import spack.util.lang
 import spack.util.lock
 
 from .enums import ConfigScopePriority
@@ -767,7 +767,7 @@ def _profile_wrapper(command, main_args, parser, args, unknown_args):
         stats.print_stats(nlines)
 
 
-@spack.llnl.util.lang.memoized
+@spack.util.lang.memoized
 def _compatible_sys_types():
     """Return a list of all the platform-os-target tuples compatible
     with the current host.
@@ -1037,7 +1037,7 @@ def _main(argv=None):
     # set up a bootstrap context, if asked.
     # bootstrap context needs to include parsing the command, b/c things
     # like `ConstraintAction` and `ConfigSetAction` happen at parse time.
-    bootstrap_context = spack.llnl.util.lang.nullcontext()
+    bootstrap_context = spack.util.lang.nullcontext()
     if args.bootstrap:
         import spack.bootstrap as bootstrap  # avoid circular imports
 

--- a/lib/spack/spack/modules/common.py
+++ b/lib/spack/spack/modules/common.py
@@ -61,7 +61,7 @@ import spack.util.path
 import spack.util.spack_yaml as syaml
 from spack.aliases import BUILTIN_TO_LEGACY_COMPILER
 from spack.enums import Context
-from spack.llnl.util.lang import Singleton, dedupe, memoized
+from spack.util.lang import Singleton, dedupe, memoized
 
 #: Valid tokens for naming scheme and env variable names
 _valid_tokens = (

--- a/lib/spack/spack/new_installer.py
+++ b/lib/spack/spack/new_installer.py
@@ -75,7 +75,6 @@ import spack.util.environment
 import spack.util.filesystem as fs
 import spack.util.lock
 from spack.installer import _do_fake_install, dump_packages
-from spack.llnl.util.lang import pretty_duration
 from spack.new_installer_base import (
     OUTPUT_BUFFER_SIZE,
     BaseTerminalState,
@@ -87,6 +86,7 @@ from spack.new_installer_base import (
 )
 from spack.subprocess_context import GlobalStateMarshaler
 from spack.util.executable import ProcessError
+from spack.util.lang import pretty_duration
 from spack.util.log_parse import make_log_context, parse_log_events
 from spack.util.path import padding_filter, padding_filter_bytes
 

--- a/lib/spack/spack/oci/opener.py
+++ b/lib/spack/spack/oci/opener.py
@@ -16,9 +16,9 @@ from typing import Callable, Dict, Iterable, List, NamedTuple, Optional, Tuple
 from urllib.request import Request
 
 import spack.config
-import spack.llnl.util.lang
 import spack.mirrors.mirror
 import spack.tokenize
+import spack.util.lang
 import spack.util.web
 
 from .image import ImageReference
@@ -38,7 +38,7 @@ OpenType = Callable[..., HTTPResponse]
 MaybeOpen = Optional[OpenType]
 
 #: Opener that automatically uses OCI authentication based on mirror config
-urlopen: OpenType = spack.llnl.util.lang.Singleton(_urlopen)
+urlopen: OpenType = spack.util.lang.Singleton(_urlopen)
 
 
 SP = r" "

--- a/lib/spack/spack/operating_systems/_operating_system.py
+++ b/lib/spack/spack/operating_systems/_operating_system.py
@@ -1,10 +1,10 @@
 # Copyright Spack Project Developers. See COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
-import spack.llnl.util.lang
+import spack.util.lang
 
 
-@spack.llnl.util.lang.lazy_lexicographic_ordering
+@spack.util.lang.lazy_lexicographic_ordering
 class OperatingSystem:
     """Base class for all the Operating Systems.
 

--- a/lib/spack/spack/operating_systems/mac_os.py
+++ b/lib/spack/spack/operating_systems/mac_os.py
@@ -6,14 +6,14 @@ import os
 import platform as py_platform
 import re
 
-import spack.llnl.util.lang
+import spack.util.lang
 from spack.util.executable import Executable
 from spack.version import StandardVersion, Version
 
 from ._operating_system import OperatingSystem
 
 
-@spack.llnl.util.lang.memoized
+@spack.util.lang.memoized
 def macos_version() -> StandardVersion:
     """Get the current macOS version as a version object.
 
@@ -60,7 +60,7 @@ def macos_version() -> StandardVersion:
     return StandardVersion.from_string(py_platform.mac_ver()[0])
 
 
-@spack.llnl.util.lang.memoized
+@spack.util.lang.memoized
 def macos_cltools_version():
     """Find the last installed version of the CommandLineTools.
 
@@ -84,7 +84,7 @@ def macos_cltools_version():
     return None
 
 
-@spack.llnl.util.lang.memoized
+@spack.util.lang.memoized
 def macos_sdk_path():
     """Return path to the active macOS SDK."""
     xcrun = Executable("xcrun")

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -71,7 +71,6 @@ from spack.install_test import (
     install_test_root,
     test_part,
 )
-from spack.llnl.util.lang import ClassProperty, classproperty, dedupe, memoized
 from spack.mixins import filter_compiler_wrappers
 from spack.multimethod import default_args, when
 from spack.operating_systems.linux_distro import kernel_version
@@ -136,6 +135,7 @@ from spack.util.filesystem import (
     windows_sfn,
     working_dir,
 )
+from spack.util.lang import ClassProperty, classproperty, dedupe, memoized
 from spack.util.libc import libc_from_dynamic_linker, parse_dynamic_linker
 from spack.util.link_tree import LinkTree
 from spack.util.module_cmd import get_path_args_from_module_line

--- a/lib/spack/spack/package_base.py
+++ b/lib/spack/spack/package_base.py
@@ -53,9 +53,9 @@ import spack.variant
 from spack.compilers.adaptor import DeprecatedCompiler
 from spack.error import InstallError, NoURLError, PackageError
 from spack.filesystem_view import YamlFilesystemView
-from spack.llnl.util.lang import ClassProperty, classproperty, dedupe, memoized
 from spack.resource import Resource
 from spack.util.filesystem import AlreadyExistsError, find_all_shared_libraries, islink, symlink
+from spack.util.lang import ClassProperty, classproperty, dedupe, memoized
 from spack.util.package_hash import package_hash
 from spack.util.typing import SupportsRichComparison
 from spack.version import GitVersion, StandardVersion, VersionError, is_git_version

--- a/lib/spack/spack/phase_callbacks.py
+++ b/lib/spack/spack/phase_callbacks.py
@@ -5,7 +5,7 @@
 import collections
 from typing import Optional
 
-import spack.llnl.util.lang as lang
+import spack.util.lang as lang
 
 #: An object of this kind is a shared global state used to collect callbacks during
 #: class definition time, and is flushed when the class object is created at the end

--- a/lib/spack/spack/platforms/_functions.py
+++ b/lib/spack/spack/platforms/_functions.py
@@ -1,7 +1,7 @@
 # Copyright Spack Project Developers. See COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
-import spack.llnl.util.lang
+import spack.util.lang
 
 from .darwin import Darwin
 from .freebsd import FreeBSD
@@ -13,7 +13,7 @@ from .windows import Windows
 platforms = [Darwin, Linux, Windows, FreeBSD, Test]
 
 
-@spack.llnl.util.lang.memoized
+@spack.util.lang.memoized
 def _host():
     """Detect and return the platform for this machine or None if detection fails."""
     for platform_cls in sorted(platforms, key=lambda plt: plt.priority):
@@ -29,7 +29,7 @@ def reset():
     _host.cache_clear()
 
 
-@spack.llnl.util.lang.memoized
+@spack.util.lang.memoized
 def cls_by_name(name):
     """Return a platform class that corresponds to the given name or None
     if there is no match.

--- a/lib/spack/spack/platforms/_platform.py
+++ b/lib/spack/spack/platforms/_platform.py
@@ -6,10 +6,10 @@ from typing import Optional
 
 import spack.vendor.archspec.cpu
 
-import spack.llnl.util.lang
+import spack.util.lang
 
 
-@spack.llnl.util.lang.lazy_lexicographic_ordering
+@spack.util.lang.lazy_lexicographic_ordering
 class Platform:
     """Platform is an abstract class extended by subclasses.
 

--- a/lib/spack/spack/relocate.py
+++ b/lib/spack/spack/relocate.py
@@ -11,14 +11,14 @@ from typing import Dict, Iterable, List, Optional
 import spack.vendor.macholib.mach_o
 import spack.vendor.macholib.MachO
 
-import spack.llnl.util.lang
 import spack.llnl.util.tty as tty
 import spack.store
 import spack.util.elf as elf
 import spack.util.executable as executable
 import spack.util.filesystem as fs
-from spack.llnl.util.lang import memoized
+import spack.util.lang
 from spack.util.filesystem import readlink, symlink
+from spack.util.lang import memoized
 
 from .relocate_text import BinaryFilePrefixReplacer, PrefixToPrefix, TextFilePrefixReplacer
 
@@ -120,7 +120,7 @@ def _modify_macho_object(cur_path, rpaths, deps, idpath, paths_to_paths):
                 new_rpaths.append(new_rpath)
 
     # Deduplicate and flatten
-    args = list(itertools.chain.from_iterable(spack.llnl.util.lang.dedupe(args)))
+    args = list(itertools.chain.from_iterable(spack.util.lang.dedupe(args)))
     install_name_tool = executable.Executable("install_name_tool")
     if args:
         with fs.edit_in_place_through_temporary_file(cur_path) as temp_path:
@@ -308,7 +308,7 @@ def is_binary(filename: str) -> bool:
 
 
 # Memoize this due to repeated calls to libraries in the same directory.
-@spack.llnl.util.lang.memoized
+@spack.util.lang.memoized
 def _exists_dir(dirname):
     return os.path.isdir(dirname)
 

--- a/lib/spack/spack/relocate_text.py
+++ b/lib/spack/spack/relocate_text.py
@@ -9,7 +9,7 @@ import re
 from typing import IO, Dict, Iterable, List, Union
 
 import spack.error
-from spack.llnl.util.lang import PatternBytes
+from spack.util.lang import PatternBytes
 
 Prefix = Union[str, bytes]
 PrefixToPrefix = Union[Dict[str, str], Dict[bytes, bytes]]

--- a/lib/spack/spack/repo.py
+++ b/lib/spack/spack/repo.py
@@ -56,8 +56,8 @@ import spack.util.lock
 import spack.util.naming as nm
 import spack.util.path
 import spack.util.spack_yaml as syaml
-from spack.llnl.util.lang import Singleton, ensure_unwrapped, memoized
 from spack.util.filesystem import working_dir
+from spack.util.lang import Singleton, ensure_unwrapped, memoized
 
 if TYPE_CHECKING:
     import spack.package_base

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -49,7 +49,6 @@ import spack.error
 import spack.externals_config
 import spack.hash_lookup
 import spack.hash_types as ht
-import spack.llnl.util.lang
 import spack.llnl.util.tty as tty
 import spack.package_base
 import spack.package_prefs
@@ -61,6 +60,7 @@ import spack.store
 import spack.traverse
 import spack.util.crypto
 import spack.util.hash
+import spack.util.lang
 import spack.util.module_cmd as md
 import spack.util.timer
 import spack.variant as vt
@@ -68,8 +68,8 @@ import spack.version as vn
 import spack.version.git_ref_lookup
 from spack import traverse
 from spack.compilers.libraries import CompilerPropertyDetector
-from spack.llnl.util.lang import elide_list
 from spack.spec import EMPTY_SPEC
+from spack.util.lang import elide_list
 
 from .compat import default_clingo_control, make_error_control
 from .core import AspFunction, AspVar, NodeId, SourceContext, extract_args, fn
@@ -952,7 +952,7 @@ class PyclingoDriver:
                 finished = handle.wait(1.0)
 
             if not finished:
-                specs_str = ", ".join(spack.llnl.util.lang.elide_list([str(s) for s in specs], 4))
+                specs_str = ", ".join(spack.util.lang.elide_list([str(s) for s in specs], 4))
                 header = f"Spack is taking more than {time_limit} seconds to solve for {specs_str}"
                 if error_on_timeout:
                     raise UnsatisfiableSpecError(f"{header}, stopping concretization")
@@ -1361,7 +1361,7 @@ class SpackSolverSetup:
         # Account for preferences in packages.yaml, if any
         if pkg.name in self.versions_from_yaml:
             ordered_versions = list(
-                spack.llnl.util.lang.dedupe(self.versions_from_yaml[pkg.name] + ordered_versions)
+                spack.util.lang.dedupe(self.versions_from_yaml[pkg.name] + ordered_versions)
             )
 
         # Set the deprecation penalty, according to the package. This should be enough to move the
@@ -1945,7 +1945,7 @@ class SpackSolverSetup:
 
             current_preferences = required + preferred + virtual_preferences.get(virtual_str, [])
             current_preferences = [x for x in current_preferences if x not in removed]
-            for i, provider in enumerate(spack.llnl.util.lang.dedupe(current_preferences)):
+            for i, provider in enumerate(spack.util.lang.dedupe(current_preferences)):
                 provider_name = spack.spec.Spec(provider).name
                 self.gen.fact(fn.provider_weight_from_config(virtual_str, provider_name, i))
             self.gen.newline()
@@ -2454,7 +2454,7 @@ class SpackSolverSetup:
                         )
                     from_packages_yaml.extend(matches)
 
-            from_packages_yaml = list(spack.llnl.util.lang.dedupe(from_packages_yaml))
+            from_packages_yaml = list(spack.util.lang.dedupe(from_packages_yaml))
             for v in from_packages_yaml:
                 provenance = Provenance.PACKAGES_YAML
                 if isinstance(v, vn.GitVersion):

--- a/lib/spack/spack/solver/core.py
+++ b/lib/spack/spack/solver/core.py
@@ -5,7 +5,7 @@
 
 from typing import Any, NamedTuple, Optional, Tuple
 
-from spack.llnl.util import lang
+from spack.util import lang
 
 from .compat import symbol_name, symbol_string
 

--- a/lib/spack/spack/solver/input_analysis.py
+++ b/lib/spack/spack/solver/input_analysis.py
@@ -17,8 +17,9 @@ import spack.repo
 import spack.spec
 import spack.store
 from spack.error import SpackError
-from spack.llnl.util import lang, tty
+from spack.llnl.util import tty
 from spack.spec import EMPTY_SPEC
+from spack.util import lang
 
 
 class PossibleGraph(NamedTuple):

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -86,7 +86,6 @@ import spack.compilers.flags
 import spack.deptypes as dt
 import spack.error
 import spack.hash_types as ht
-import spack.llnl.util.lang as lang
 import spack.llnl.util.tty as tty
 import spack.llnl.util.tty.color as clr
 import spack.patch
@@ -99,6 +98,7 @@ import spack.traverse
 import spack.util.filesystem as fs
 import spack.util.gpg
 import spack.util.hash
+import spack.util.lang as lang
 import spack.util.path
 import spack.util.prefix
 import spack.util.spack_json as sjson

--- a/lib/spack/spack/stage.py
+++ b/lib/spack/spack/stage.py
@@ -17,12 +17,12 @@ from typing import TYPE_CHECKING, Callable, Dict, Generator, Iterable, List, Opt
 import spack.caches
 import spack.config
 import spack.error
-import spack.llnl.util.lang
 import spack.llnl.util.tty as tty
 import spack.oci.image
 import spack.resource
 import spack.spec
 import spack.util.crypto
+import spack.util.lang
 import spack.util.lock
 import spack.util.parallel
 import spack.util.path as sup
@@ -1119,7 +1119,7 @@ def interactive_version_filter(
                 )
                 for v in sorted_and_filtered
             ]
-            tty.msg(". ".join(header), *spack.llnl.util.lang.elide_list(version_with_url))
+            tty.msg(". ".join(header), *spack.util.lang.elide_list(version_with_url))
             print()
 
         print_header = True

--- a/lib/spack/spack/store.py
+++ b/lib/spack/spack/store.py
@@ -31,10 +31,10 @@ import spack.config
 import spack.database
 import spack.directory_layout
 import spack.error
-import spack.llnl.util.lang
 import spack.package_prefs
 import spack.paths
 import spack.spec
+import spack.util.lang
 import spack.util.path
 from spack.llnl.util import tty
 from spack.util import filesystem as fs
@@ -296,7 +296,7 @@ def _create_global() -> Store:
 
 
 #: Singleton store instance
-STORE = cast(Store, spack.llnl.util.lang.Singleton(_create_global))
+STORE = cast(Store, spack.util.lang.Singleton(_create_global))
 
 
 def reinitialize():
@@ -306,7 +306,7 @@ def reinitialize():
     global STORE
 
     token = STORE
-    STORE = cast(Store, spack.llnl.util.lang.Singleton(_create_global))
+    STORE = cast(Store, spack.util.lang.Singleton(_create_global))
 
     return token
 

--- a/lib/spack/spack/subprocess_context.py
+++ b/lib/spack/spack/subprocess_context.py
@@ -21,12 +21,12 @@ from types import ModuleType
 from typing import TYPE_CHECKING, Optional
 
 import spack.config
-import spack.llnl.util.lang
 import spack.paths
 import spack.platforms
 import spack.repo
 import spack.store
 import spack.util.gpg
+import spack.util.lang
 
 if TYPE_CHECKING:
     import spack.package_base
@@ -102,7 +102,7 @@ class GlobalStateMarshaler:
         if self.is_forked:
             return
 
-        self.config = spack.llnl.util.lang.ensure_unwrapped(spack.config.CONFIG)
+        self.config = spack.util.lang.ensure_unwrapped(spack.config.CONFIG)
         self.platform = spack.platforms.host
         self.store = spack.store.STORE
         self.test_patches = TestPatches.create()

--- a/lib/spack/spack/tengine.py
+++ b/lib/spack/spack/tengine.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple
 
 import spack.config
 import spack.extensions
-import spack.llnl.util.lang
+import spack.util.lang
 from spack.config import canonicalize_path
 
 if TYPE_CHECKING:
@@ -30,7 +30,7 @@ class ContextMeta(type):
                 context_properties.extend(x.context_properties)
             except AttributeError:
                 pass
-        context_properties = list(spack.llnl.util.lang.dedupe(context_properties))
+        context_properties = list(spack.util.lang.dedupe(context_properties))
 
         # Flush the list
         cls._new_context_properties = []
@@ -73,7 +73,7 @@ def make_environment(dirs: Optional[Tuple[str, ...]] = None) -> "spack.vendor.ji
     return make_environment_from_dirs(dirs)
 
 
-@spack.llnl.util.lang.memoized
+@spack.util.lang.memoized
 def make_environment_from_dirs(dirs: Tuple[str, ...]) -> "spack.vendor.jinja2.Environment":
     # Import at this scope to avoid slowing Spack startup down
     import spack.vendor.jinja2

--- a/lib/spack/spack/test/cmd/buildcache.py
+++ b/lib/spack/spack/test/cmd/buildcache.py
@@ -26,7 +26,6 @@ import spack.spec
 import spack.util.url as url_util
 import spack.util.web as web_util
 from spack.installer import PackageInstaller
-from spack.llnl.util.lang import nullcontext
 from spack.paths import test_path
 from spack.url_buildcache import (
     BuildcacheComponent,
@@ -36,6 +35,7 @@ from spack.url_buildcache import (
     get_url_buildcache_class,
 )
 from spack.util.filesystem import copy_tree, find, getuid
+from spack.util.lang import nullcontext
 
 buildcache = spack.main.SpackCommand("buildcache")
 install = spack.main.SpackCommand("install")

--- a/lib/spack/spack/test/cmd/env.py
+++ b/lib/spack/spack/test/cmd/env.py
@@ -39,7 +39,6 @@ import spack.util.spack_yaml
 from spack.cmd.env import _env_create
 from spack.config import substitute_path_variables
 from spack.installer import PackageInstaller
-from spack.llnl.util.lang import dedupe
 from spack.main import SpackCommand, SpackCommandError
 from spack.spec import Spec
 from spack.stage import stage_prefix
@@ -47,6 +46,7 @@ from spack.test.conftest import RepoBuilder
 from spack.traverse import traverse_nodes
 from spack.util.executable import Executable
 from spack.util.filesystem import readlink
+from spack.util.lang import dedupe
 from spack.version import Version
 
 # TODO-27021

--- a/lib/spack/spack/test/concretization/core.py
+++ b/lib/spack/spack/test/concretization/core.py
@@ -28,7 +28,6 @@ import spack.environment as ev
 import spack.error
 import spack.externals_config
 import spack.hash_types as ht
-import spack.llnl.util.lang
 import spack.package_base
 import spack.paths
 import spack.platforms
@@ -43,6 +42,7 @@ import spack.spec_filter
 import spack.traverse
 import spack.util.file_cache
 import spack.util.hash
+import spack.util.lang
 import spack.util.spack_yaml as syaml
 import spack.variant as vt
 from spack.externals import ExternalDependencyError
@@ -1049,15 +1049,15 @@ spack:
         s = Spec("mpileaks")
         s = spack.concretize.concretize_one(s)
 
-        assert spack.llnl.util.lang.ObjectWrapper not in s.__class__.__mro__
+        assert spack.util.lang.ObjectWrapper not in s.__class__.__mro__
 
         # Spec wrapped in a build interface
         build_interface = s["mpileaks"]
-        assert spack.llnl.util.lang.ObjectWrapper in build_interface.__class__.__mro__
+        assert spack.util.lang.ObjectWrapper in build_interface.__class__.__mro__
 
         # Mimics asking the build interface from a build interface
         build_interface = s["mpileaks"]["mpileaks"]
-        assert spack.llnl.util.lang.ObjectWrapper in build_interface.__class__.__mro__
+        assert spack.util.lang.ObjectWrapper in build_interface.__class__.__mro__
 
     @pytest.mark.regression("7705")
     def test_regression_issue_7705(self):
@@ -1766,7 +1766,7 @@ spack:
         config = {"externals": [{"spec": spec, "prefix": "/fake/path"}], "buildable": False}
         spack.config.set("packages:sticky-variant", config)
 
-        maybe = spack.llnl.util.lang.nullcontext if allow_gcc else pytest.raises
+        maybe = spack.util.lang.nullcontext if allow_gcc else pytest.raises
         with maybe(spack.error.SpackError):
             s = spack.concretize.concretize_one("sticky-variant-dependent%gcc")
 
@@ -1799,7 +1799,7 @@ spack:
     def test_conditional_values_in_variants(self, spec_str, valid):
         s = Spec(spec_str)
         raises = pytest.raises((RuntimeError, spack.error.UnsatisfiableSpecError))
-        with spack.llnl.util.lang.nullcontext() if valid else raises:
+        with spack.util.lang.nullcontext() if valid else raises:
             s = spack.concretize.concretize_one(s)
 
     def test_conditional_values_in_conditional_variant(self):
@@ -3430,7 +3430,7 @@ def test_spec_unification(unify, mutable_config, mock_packages):
     b_concrete_unrestricted = [s for s in unrestricted if s.name == "pkg-b"][0]
     assert (a_concrete_unrestricted["pkg-b"] == b_concrete_unrestricted) == (unify is not False)
 
-    maybe_fails = pytest.raises if unify is True else spack.llnl.util.lang.nullcontext
+    maybe_fails = pytest.raises if unify is True else spack.util.lang.nullcontext
     with maybe_fails(spack.solver.asp.UnsatisfiableSpecError):
         _ = spack.cmd.parse_specs([a_restricted, b], concretize=True)
 

--- a/lib/spack/spack/test/conftest.py
+++ b/lib/spack/spack/test/conftest.py
@@ -41,7 +41,6 @@ import spack.environment as ev
 import spack.error
 import spack.extensions
 import spack.hash_types
-import spack.llnl.util.lang
 import spack.llnl.util.lock
 import spack.llnl.util.tty as tty
 import spack.llnl.util.tty.color
@@ -61,6 +60,7 @@ import spack.util.executable
 import spack.util.file_cache
 import spack.util.git
 import spack.util.gpg
+import spack.util.lang
 import spack.util.naming
 import spack.util.parallel
 import spack.util.spack_yaml as syaml
@@ -2097,7 +2097,7 @@ def inode_cache():
 @pytest.fixture(autouse=True)
 def brand_new_binary_cache():
     yield
-    spack.binary_distribution.BINARY_INDEX = spack.llnl.util.lang.Singleton(
+    spack.binary_distribution.BINARY_INDEX = spack.util.lang.Singleton(
         spack.binary_distribution.BinaryIndexCache
     )
 

--- a/lib/spack/spack/test/entry_points.py
+++ b/lib/spack/spack/test/entry_points.py
@@ -10,7 +10,7 @@ import pytest
 
 import spack.config
 import spack.extensions
-import spack.llnl.util.lang
+import spack.util.lang
 
 
 class MockConfigEntryPoint:
@@ -67,7 +67,7 @@ def entry_points_factory(tmp_path: pathlib.Path):
 @pytest.fixture()
 def mock_get_entry_points(tmp_path: pathlib.Path, reset_extension_paths, monkeypatch):
     entry_points = entry_points_factory(tmp_path)
-    monkeypatch.setattr(spack.llnl.util.lang, "get_entry_points", entry_points)
+    monkeypatch.setattr(spack.util.lang, "get_entry_points", entry_points)
 
 
 def test_spack_entry_point_config(tmp_path: pathlib.Path, mock_get_entry_points):
@@ -106,8 +106,8 @@ def test_llnl_util_lang_get_entry_points(tmp_path: pathlib.Path, monkeypatch):
 
     monkeypatch.setattr(importlib.metadata, "entry_points", entry_points_factory(tmp_path))
 
-    entry_points = list(spack.llnl.util.lang.get_entry_points(group="spack.config"))
+    entry_points = list(spack.util.lang.get_entry_points(group="spack.config"))
     assert isinstance(entry_points[0], MockConfigEntryPoint)
 
-    entry_points = list(spack.llnl.util.lang.get_entry_points(group="spack.extensions"))
+    entry_points = list(spack.util.lang.get_entry_points(group="spack.extensions"))
     assert isinstance(entry_points[0], MockExtensionsEntryPoint)

--- a/lib/spack/spack/test/schema.py
+++ b/lib/spack/spack/test/schema.py
@@ -12,7 +12,7 @@ from spack.vendor import jsonschema
 import spack.schema
 import spack.schema.env
 import spack.util.spack_yaml as syaml
-from spack.llnl.util.lang import list_modules
+from spack.util.lang import list_modules
 
 _draft_07_with_spack_extensions = {
     "$schema": "http://json-schema.org/draft-07/schema#",

--- a/lib/spack/spack/test/spec_semantics.py
+++ b/lib/spack/spack/test/spec_semantics.py
@@ -9,7 +9,6 @@ import pytest
 import spack.concretize
 import spack.deptypes as dt
 import spack.directives
-import spack.llnl.util.lang
 import spack.package_base
 import spack.paths
 import spack.repo
@@ -17,6 +16,7 @@ import spack.solver.asp
 import spack.spec
 import spack.spec_parser
 import spack.store
+import spack.util.lang
 import spack.variant
 import spack.version as vn
 from spack.enums import PropagationPolicy
@@ -2311,7 +2311,7 @@ EMPTY_FLG = Spec().compiler_flags
 )
 def test_spec_canonical_comparison_form(spec, expected_tuplified):
     """Tests a few expected canonical comparison form of specs"""
-    assert spack.llnl.util.lang.tuplify(Spec(spec)._cmp_iter) == expected_tuplified
+    assert spack.util.lang.tuplify(Spec(spec)._cmp_iter) == expected_tuplified
 
 
 def test_comparison_after_breaking_hash_change():

--- a/lib/spack/spack/test/util/lang.py
+++ b/lib/spack/spack/test/util/lang.py
@@ -10,8 +10,8 @@ from datetime import datetime, timedelta
 
 import pytest
 
-import spack.llnl.util.lang
-from spack.llnl.util.lang import (
+import spack.util.lang
+from spack.util.lang import (
     Singleton,
     SingletonInstantiationError,
     dedupe,
@@ -105,7 +105,7 @@ def test_pretty_date():
 )
 def test_pretty_string_to_date_delta(now, delta, pretty_string):
     t1 = now - delta
-    t2 = spack.llnl.util.lang.pretty_string_to_date(pretty_string, now)
+    t2 = spack.util.lang.pretty_string_to_date(pretty_string, now)
     assert t1 == t2
 
 
@@ -121,25 +121,25 @@ def test_pretty_string_to_date_delta(now, delta, pretty_string):
 )
 def test_pretty_string_to_date(format, pretty_string):
     t1 = datetime.strptime(pretty_string, format)
-    t2 = spack.llnl.util.lang.pretty_string_to_date(pretty_string, now)
+    t2 = spack.util.lang.pretty_string_to_date(pretty_string, now)
     assert t1 == t2
 
 
 def test_pretty_seconds():
-    assert spack.llnl.util.lang.pretty_seconds(2.1) == "2.100s"
-    assert spack.llnl.util.lang.pretty_seconds(2.1 / 1000) == "2.100ms"
-    assert spack.llnl.util.lang.pretty_seconds(2.1 / 1000 / 1000) == "2.100us"
-    assert spack.llnl.util.lang.pretty_seconds(2.1 / 1000 / 1000 / 1000) == "2.100ns"
-    assert spack.llnl.util.lang.pretty_seconds(2.1 / 1000 / 1000 / 1000 / 10) == "0.210ns"
+    assert spack.util.lang.pretty_seconds(2.1) == "2.100s"
+    assert spack.util.lang.pretty_seconds(2.1 / 1000) == "2.100ms"
+    assert spack.util.lang.pretty_seconds(2.1 / 1000 / 1000) == "2.100us"
+    assert spack.util.lang.pretty_seconds(2.1 / 1000 / 1000 / 1000) == "2.100ns"
+    assert spack.util.lang.pretty_seconds(2.1 / 1000 / 1000 / 1000 / 10) == "0.210ns"
 
 
 def test_pretty_duration():
-    assert spack.llnl.util.lang.pretty_duration(0) == "0s"
-    assert spack.llnl.util.lang.pretty_duration(45) == "45s"
-    assert spack.llnl.util.lang.pretty_duration(60) == "1m00s"
-    assert spack.llnl.util.lang.pretty_duration(125) == "2m05s"
-    assert spack.llnl.util.lang.pretty_duration(3600) == "1h00m"
-    assert spack.llnl.util.lang.pretty_duration(3661) == "1h01m"
+    assert spack.util.lang.pretty_duration(0) == "0s"
+    assert spack.util.lang.pretty_duration(45) == "45s"
+    assert spack.util.lang.pretty_duration(60) == "1m00s"
+    assert spack.util.lang.pretty_duration(125) == "2m05s"
+    assert spack.util.lang.pretty_duration(3600) == "1h00m"
+    assert spack.util.lang.pretty_duration(3661) == "1h01m"
 
 
 def test_match_predicate():
@@ -168,24 +168,24 @@ def test_load_modules_from_file(module_path):
     assert "foo" not in sys.modules
 
     # Check that the module is loaded correctly from file
-    foo = spack.llnl.util.lang.load_module_from_file("foo", module_path)
+    foo = spack.util.lang.load_module_from_file("foo", module_path)
     assert "foo" in sys.modules
     assert foo.value == 1
     assert foo.path == os.path.join("/usr", "bin")
 
     # Check that the module is not reloaded a second time on subsequent calls
     foo.value = 2
-    foo = spack.llnl.util.lang.load_module_from_file("foo", module_path)
+    foo = spack.util.lang.load_module_from_file("foo", module_path)
     assert "foo" in sys.modules
     assert foo.value == 2
     assert foo.path == os.path.join("/usr", "bin")
 
 
 def test_uniq():
-    assert [1, 2, 3] == spack.llnl.util.lang.uniq([1, 2, 3])
-    assert [1, 2, 3] == spack.llnl.util.lang.uniq([1, 1, 1, 1, 2, 2, 2, 3, 3])
-    assert [1, 2, 1] == spack.llnl.util.lang.uniq([1, 1, 1, 1, 2, 2, 2, 1, 1])
-    assert [] == spack.llnl.util.lang.uniq([])
+    assert [1, 2, 3] == spack.util.lang.uniq([1, 2, 3])
+    assert [1, 2, 3] == spack.util.lang.uniq([1, 1, 1, 1, 2, 2, 2, 3, 3])
+    assert [1, 2, 1] == spack.util.lang.uniq([1, 1, 1, 1, 2, 2, 2, 1, 1])
+    assert [] == spack.util.lang.uniq([])
 
 
 def test_key_ordering():
@@ -193,12 +193,12 @@ def test_key_ordering():
 
     with pytest.raises(TypeError):
 
-        @spack.llnl.util.lang.key_ordering
+        @spack.util.lang.key_ordering
         class ClassThatHasNoCmpKeyMethod:
             # this will raise b/c it does not define _cmp_key
             pass
 
-    @spack.llnl.util.lang.key_ordering
+    @spack.util.lang.key_ordering
     class KeyComparable:
         def __init__(self, t):
             self.t = t
@@ -268,7 +268,7 @@ def test_dedupe():
 
 
 def test_grouped_exception():
-    h = spack.llnl.util.lang.GroupedExceptionHandler()
+    h = spack.util.lang.GroupedExceptionHandler()
 
     def inner():
         raise ValueError("wow!")
@@ -281,7 +281,7 @@ def test_grouped_exception():
 
 
 def test_grouped_exception_base_type():
-    h = spack.llnl.util.lang.GroupedExceptionHandler()
+    h = spack.util.lang.GroupedExceptionHandler()
 
     with h.forward("catch-runtime-error", RuntimeError):
         raise NotImplementedError()
@@ -299,7 +299,7 @@ def test_class_level_constant_value():
     """Tests that the Const descriptor does not allow overwriting the value from an instance"""
 
     class _SomeClass:
-        CONST_VALUE = spack.llnl.util.lang.Const(10)
+        CONST_VALUE = spack.util.lang.Const(10)
 
     with pytest.raises(TypeError, match="not support assignment"):
         _SomeClass().CONST_VALUE = 11
@@ -310,7 +310,7 @@ def test_deprecated_property():
     deprecating an attribute.
     """
 
-    class _Deprecated(spack.llnl.util.lang.DeprecatedProperty):
+    class _Deprecated(spack.util.lang.DeprecatedProperty):
         def factory(self, instance, owner):
             return 46
 
@@ -334,7 +334,7 @@ def test_deprecated_property():
 
 def test_fnmatch_multiple():
     named_patterns = {"a": "libf*o.so", "b": "libb*r.so"}
-    regex = re.compile(spack.llnl.util.lang.fnmatch_translate_multiple(named_patterns))
+    regex = re.compile(spack.util.lang.fnmatch_translate_multiple(named_patterns))
 
     a = regex.match("libfoo.so")
     assert a and a.group("a") == "libfoo.so"
@@ -391,14 +391,14 @@ class TestPriorityOrderedMapping:
     )
     def test_iteration_order(self, elements, expected):
         """Tests that the iteration order respects priorities, no matter the insertion order."""
-        m = spack.llnl.util.lang.PriorityOrderedMapping()
+        m = spack.util.lang.PriorityOrderedMapping()
         for key, priority in elements:
             m.add(key, value=None, priority=priority)
         assert list(m) == expected
 
     def test_reverse_iteration(self):
         """Tests that we can conveniently use reverse iteration"""
-        m = spack.llnl.util.lang.PriorityOrderedMapping()
+        m = spack.util.lang.PriorityOrderedMapping()
         for key, value in [("a", 1), ("b", 2), ("c", 3)]:
             m.add(key, value=value)
 

--- a/lib/spack/spack/util/ctest_log_parser.py
+++ b/lib/spack/spack/util/ctest_log_parser.py
@@ -75,7 +75,7 @@ import time
 from collections import deque
 from typing import Dict, Iterable, List, Optional, TextIO, Tuple, Union
 
-from spack.llnl.util.lang import PatternStr
+from spack.util.lang import PatternStr
 
 _error_matches = [
     "^FAIL: ",

--- a/lib/spack/spack/util/environment.py
+++ b/lib/spack/spack/util/environment.py
@@ -19,7 +19,7 @@ from typing import Any, Callable, Dict, Iterable, List, MutableMapping, Optional
 
 import spack.error
 from spack.llnl.util import tty
-from spack.llnl.util.lang import dedupe
+from spack.util.lang import dedupe
 from spack.util.path import path_to_os_path, system_path_filter
 
 # List is invariant, so List[str] is not a subtype of List[Union[str, pathlib.PurePath]].

--- a/lib/spack/spack/util/filesystem.py
+++ b/lib/spack/spack/util/filesystem.py
@@ -38,9 +38,10 @@ from typing import (
     Union,
 )
 
-from spack.llnl.util import lang, tty
-from spack.llnl.util.lang import dedupe, fnmatch_translate_multiple, memoized
+from spack.llnl.util import tty
+from spack.util import lang
 from spack.util.executable import Executable
+from spack.util.lang import dedupe, fnmatch_translate_multiple, memoized
 from spack.util.path import path_to_os_path, sanitize_win_longpath, system_path_filter
 
 if sys.platform == "win32":

--- a/lib/spack/spack/util/git.py
+++ b/lib/spack/spack/util/git.py
@@ -11,9 +11,9 @@ from typing import List, Optional, overload
 
 from spack.vendor.typing_extensions import Literal
 
-import spack.llnl.util.lang
 import spack.util.executable as exe
 import spack.util.filesystem as fs
+import spack.util.lang
 from spack.util.environment import EnvironmentModifications
 
 # regex for a commit version
@@ -27,7 +27,7 @@ def is_git_commit_sha(string: str) -> bool:
     return len(string) == 40 and bool(COMMIT_VERSION.match(string))
 
 
-@spack.llnl.util.lang.memoized
+@spack.util.lang.memoized
 def _find_git() -> Optional[str]:
     """Find the git executable in the system path."""
     return exe.which_string("git", required=False)

--- a/lib/spack/spack/util/lang.py
+++ b/lib/spack/spack/util/lang.py
@@ -511,7 +511,7 @@ def dedupe(sequence, key=None):
 
             [x for x in dedupe([1, 2, 1, 3, 2])] == [1, 2, 3]
 
-            [x for x in spack.llnl.util.lang.dedupe([1,-2,1,3,2], key=abs)] == [1, -2, 3]
+            [x for x in spack.util.lang.dedupe([1,-2,1,3,2], key=abs)] == [1, -2, 3]
     """
     seen = set()
     for x in sequence:

--- a/lib/spack/spack/util/ld_so_conf.py
+++ b/lib/spack/spack/util/ld_so_conf.py
@@ -8,7 +8,7 @@ import re
 import sys
 
 import spack.util.elf as elf_utils
-from spack.llnl.util.lang import dedupe
+from spack.util.lang import dedupe
 
 
 def parse_ld_so_conf(conf_file="/etc/ld.so.conf"):

--- a/lib/spack/spack/util/libc.py
+++ b/lib/spack/spack/util/libc.py
@@ -11,7 +11,7 @@ from typing import Dict, List, Optional
 
 import spack.spec
 import spack.util.elf
-from spack.llnl.util.lang import memoized
+from spack.util.lang import memoized
 
 #: Pattern to distinguish glibc from other libc implementations
 GLIBC_PATTERN = r"\b(?:Free Software Foundation|Roland McGrath|Ulrich Depper)\b"

--- a/lib/spack/spack/util/path.py
+++ b/lib/spack/spack/util/path.py
@@ -17,7 +17,7 @@ from typing import List, Optional, Union
 from urllib.parse import urlparse
 
 import spack.llnl.util.tty as tty
-from spack.llnl.util.lang import memoized
+from spack.util.lang import memoized
 
 __all__ = []
 

--- a/lib/spack/spack/util/socket.py
+++ b/lib/spack/spack/util/socket.py
@@ -5,10 +5,10 @@
 
 import socket
 
-import spack.llnl.util.lang
+import spack.util.lang
 
 
-@spack.llnl.util.lang.memoized
+@spack.util.lang.memoized
 def _gethostname():
     """Memoized version of `getfqdn()`.
 

--- a/lib/spack/spack/util/timer.py
+++ b/lib/spack/spack/util/timer.py
@@ -16,7 +16,7 @@ from contextlib import contextmanager
 from typing import Callable, Dict, List
 
 import spack.util.spack_json as sjson
-from spack.llnl.util.lang import pretty_seconds_formatter
+from spack.util.lang import pretty_seconds_formatter
 
 TimerEvent = collections.namedtuple("TimerEvent", ("time", "running", "label"))
 TimeTracker = collections.namedtuple("TimeTracker", ("total", "start", "count", "path"))

--- a/lib/spack/spack/util/web.py
+++ b/lib/spack/spack/util/web.py
@@ -34,7 +34,8 @@ import spack.util.executable
 import spack.util.parallel
 import spack.util.url
 import spack.util.url as url_util
-from spack.llnl.util import lang, tty
+from spack.llnl.util import tty
+from spack.util import lang
 from spack.util.filesystem import mkdirp, working_dir
 
 from .executable import CommandNotFoundError, Executable

--- a/lib/spack/spack/util/web.py
+++ b/lib/spack/spack/util/web.py
@@ -35,8 +35,8 @@ import spack.util.parallel
 import spack.util.url
 import spack.util.url as url_util
 from spack.llnl.util import tty
-from spack.util import lang
 from spack.util.filesystem import mkdirp, working_dir
+from spack.util import lang
 
 from .executable import CommandNotFoundError, Executable
 from .gcs import GCSBlob, GCSBucket, GCSHandler

--- a/lib/spack/spack/util/web.py
+++ b/lib/spack/spack/util/web.py
@@ -35,8 +35,8 @@ import spack.util.parallel
 import spack.util.url
 import spack.util.url as url_util
 from spack.llnl.util import tty
-from spack.util.filesystem import mkdirp, working_dir
 from spack.util import lang
+from spack.util.filesystem import mkdirp, working_dir
 
 from .executable import CommandNotFoundError, Executable
 from .gcs import GCSBlob, GCSBucket, GCSHandler

--- a/lib/spack/spack/variant.py
+++ b/lib/spack/spack/variant.py
@@ -26,9 +26,9 @@ from typing import (
 )
 
 import spack.error
-import spack.llnl.util.lang as lang
 import spack.llnl.util.tty.color
 import spack.spec_parser
+import spack.util.lang as lang
 
 if TYPE_CHECKING:
     import spack.package_base

--- a/lib/spack/spack/verify_libraries.py
+++ b/lib/spack/spack/verify_libraries.py
@@ -8,8 +8,8 @@ import re
 from typing import IO, Dict, List
 
 import spack.util.elf as elf
-from spack.llnl.util.lang import stable_partition
 from spack.util.filesystem import BaseDirectoryVisitor
+from spack.util.lang import stable_partition
 
 #: Patterns for names of libraries that are allowed to be unresolved when *just* looking at RPATHs
 #: added by Spack. These are libraries outside of Spack's control, and assumed to be located in

--- a/var/spack/test_repos/spack_repo/builtin_mock/build_systems/compiler.py
+++ b/var/spack/test_repos/spack_repo/builtin_mock/build_systems/compiler.py
@@ -12,8 +12,8 @@ import spack
 import spack.llnl.util.tty as tty
 import spack.package_base
 import spack.util.executable
-from spack.llnl.util.lang import classproperty, memoized
 from spack.package import CompilerError
+from spack.util.lang import classproperty, memoized
 
 # Local "type" for type hints
 Path = Union[str, pathlib.Path]

--- a/var/spack/test_repos/spack_repo/builtin_mock/packages/compiler_wrapper/package.py
+++ b/var/spack/test_repos/spack_repo/builtin_mock/packages/compiler_wrapper/package.py
@@ -12,8 +12,8 @@ import spack.vendor.archspec.cpu
 
 import spack.compilers.libraries
 import spack.package_base
-from spack.llnl.util import lang
 from spack.package import *
+from spack.util import lang
 
 
 class CompilerWrapper(Package):


### PR DESCRIPTION
I am working on combining the spack.llnl and spack.util.llnl modules into the spack.util module. The abstraction is leaky, the distinction between the two is weak, and I don't think it's serving us anymore.

I'm going to try to keep these PRs small and separate. They'll probably conflict with each other, but I expect the rebasing to be trivial.