### PR TITLE
(Feature/debuggable install) `--debuggable` flag for DWARF-correct source installs

### DIFF
--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -753,6 +753,118 @@ def get_cmake_prefix_path(pkg: spack.package_base.PackageBase) -> List[str]:
     )
 
 
+def _inject_debuggable_prefix_map(
+    pkg: "spack.package_base.PackageBase", env: EnvironmentModifications
+) -> None:
+    """Append ``-ffile-prefix-map`` flags so DWARF symbols embed permanent paths.
+
+    Called from :func:`setup_package` when ``pkg._debuggable_install`` is
+    ``True``. This runs inside the **child process**, after the stage has
+    been fully set up and after ``set_wrapper_variables()`` has already
+    populated the ``SPACK_CFLAGS`` and similar variables.
+
+    The approach:
+        At compile time, tell the compiler to rewrite any DWARF path
+        reference that starts with the staging directory to start with the
+        permanent install directory instead.  The installed binary's DWARF
+        therefore contains the correct permanent path from the moment the
+        object file is created — no post-install binary patching needed.
+
+    Flag used:
+        ``-ffile-prefix-map=OLD=NEW`` (GCC 8+, Clang 10+)
+        Remaps both DWARF references *and* ``__FILE__`` macro expansions.
+
+    Two path pairs are remapped:
+
+    1. ``staging_src``   ``<prefix>/share/<pkg>/src/``
+       Covers all source files that the compiler compiled from the
+       source tree.
+
+    2. ``build_dir``     ``<prefix>/share/<pkg>/build/``
+       Covers CMake out-of-tree builds where object files reference
+       the build directory (e.g. generated ``config.h`` paths).
+       Resolved via ``builder.build_directory`` — the authoritative API —
+       not by heuristic directory name inspection.
+
+    NVCC and HIP wrappers use ``-Xcompiler`` syntax to forward the flag
+    to the host compiler. Device-side PTX is not covered.
+
+    Coverage is best-effort. The post-install verification step
+    (:meth:`BuildProcessInstaller._verify_dwarf_coverage`) reports
+    any remaining staging-path references.
+
+    Args:
+        pkg: the package being compiled
+        env: the :class:`~spack.util.environment.EnvironmentModifications`
+             object to append flags into
+    """
+
+    try:
+        staging_src = pkg.stage.source_path
+    except Exception:
+        staging_src = str(pkg.stage.path)
+
+    permanent_src = os.path.join(str(pkg.spec.prefix), "share", pkg.name, "src")
+
+    # Collect all (old, new) path pairs we need to remap.
+    remap_pairs = [(staging_src, permanent_src)]
+
+    # Resolve the out-of-tree build directory via the builder API.
+    # Using the API (not heuristics like startswith("spack-build-"))
+    # ensures packages that override build_directory are handled correctly.
+    try:
+        builder = spack.builder.create(pkg)
+        build_dir = getattr(builder, "build_directory", None)
+        if build_dir and os.path.isabs(build_dir) and build_dir != staging_src:
+            permanent_build = os.path.join(str(pkg.spec.prefix), "share", pkg.name, "build")
+            remap_pairs.append((build_dir, permanent_build))
+    except Exception as e:
+        tty.debug(
+            f"[debuggable] Could not resolve build_directory for "
+            f"{pkg.name}: {e}. Only source tree paths will be remapped."
+        )
+
+    # Build the flag strings for each remap pair.
+    # -ffile-prefix-map is the preferred flag (GCC 8+ / Clang 10+).
+    # It remaps both DWARF references AND __FILE__ / __BASE_FILE__ macros.
+    ffile_flags = [f"-ffile-prefix-map={old}={new}" for old, new in remap_pairs]
+
+    # Inject into Spack's compiler wrapper injection variables.
+    # These variables are read by lib/spack/env/cc and prepended to every
+    # compiler invocation. We use append_flags so existing flags set by
+    # the package's flag_handler are preserved.
+
+    debug_flags = ["-g"] + ffile_flags
+
+    for spack_var in ("SPACK_CFLAGS", "SPACK_CXXFLAGS", "SPACK_FFLAGS", "SPACK_FCFLAGS"):
+        #    env.append_flags(spack_var, "-g") # NEW LINE
+        for flag in debug_flags:
+            env.append_flags(spack_var, flag)
+
+    for raw_var in ("CFLAGS", "CXXFLAGS", "FFLAGS", "FCFLAGS"):
+        for flag in debug_flags:
+            env.append_flags(raw_var, flag)
+
+    # NVCC and HIP use a wrapper syntax to forward flags to the host compiler.
+    # -Xcompiler passes flags through to the underlying gcc/clang invocation.
+    # Note: device-side PTX code does not use this DWARF format and is not
+    # covered by this flag injection.
+    #    nvcc_hip_flags = " ".join(f"-Xcompiler={flag}" for flag in ffile_flags)
+
+    # NVCC / HIP: forward both -g (host debug) and the remap flags
+    nvcc_hip_flags = "-Xcompiler=-g " + " ".join(f"-Xcompiler={flag}" for flag in ffile_flags)
+
+    if nvcc_hip_flags:
+        env.append_flags("CUDA_FLAGS", nvcc_hip_flags)
+        env.append_flags("NVCCFLAGS", nvcc_hip_flags)
+        env.append_flags("HIPFLAGS", nvcc_hip_flags)
+
+    # Log what we injected for debugging
+    tty.debug(f"[debuggable] injected DWARF prefix remapping for {pkg.name}:")
+    for old, new in remap_pairs:
+        tty.debug(f"[debuggable]   {old}    {new}")
+
+
 def setup_package(pkg, dirty, context: Context = Context.BUILD):
     """Execute all environment setup routines."""
     if context not in (Context.BUILD, Context.TEST):
@@ -768,12 +880,15 @@ def setup_package(pkg, dirty, context: Context = Context.BUILD):
     env_base = EnvironmentModifications() if dirty else clean_environment()
     env_mods = EnvironmentModifications()
 
-    # setup compilers for build contexts
     need_compiler = context == Context.BUILD or (
         context == Context.TEST and pkg.test_requires_compiler
     )
     if need_compiler:
         set_wrapper_variables(pkg, env_mods)
+        # Inject -ffile-prefix-map flags if this is a debuggable build.
+        # Must be called AFTER set_wrapper_variables() so we are appending
+        # to already-established SPACK_CFLAGS rather than overwriting them.
+        # Must only run in BUILD context — not TEST context.
 
     # Platform specific setup goes before package specific setup. This is for setting
     # defaults like MACOSX_DEPLOYMENT_TARGET on macOS.
@@ -811,6 +926,10 @@ def setup_package(pkg, dirty, context: Context = Context.BUILD):
             "A dependency has updated CPATH, this may lead pkg-config to assume that the package "
             "is part of the system includes and omit it when invoked with '--cflags'."
         )
+
+    # Inject debug flags LAST, after all other modifications, so nothing overwrites them.
+    if context == Context.BUILD and getattr(pkg, "_debuggable_install", False):
+        _inject_debuggable_prefix_map(pkg, env_mods)
 
     # First apply the clean environment changes
     env_base.apply_modifications()
@@ -1188,10 +1307,18 @@ def _setup_pkg_and_run(
         pkg = serialized_pkg.restore()
 
         if not kwargs.get("fake", False):
+            # Set _debuggable_install BEFORE setup_package() runs.
+            # setup_package() → _inject_debuggable_prefix_map() reads this attribute,
+            # but BuildProcessInstaller.run() (which used to set it) runs AFTER
+            # setup_package(). Moving the assignment here fixes the timing.
+            if kwargs.get("debuggable", False):
+                setattr(pkg, "_debuggable_install", True)
+
             kwargs["unmodified_env"] = os.environ.copy()
             kwargs["env_modifications"] = setup_package(
                 pkg, dirty=kwargs.get("dirty", False), context=Context.from_string(context)
             )
+
         return_value = function(pkg, kwargs)
         write_pipe.send(return_value)
 

--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -789,10 +789,6 @@ def _inject_debuggable_prefix_map(
     NVCC and HIP wrappers use ``-Xcompiler`` syntax to forward the flag
     to the host compiler. Device-side PTX is not covered.
 
-    Coverage is best-effort. The post-install verification step
-    (:meth:`BuildProcessInstaller._verify_dwarf_coverage`) reports
-    any remaining staging-path references.
-
     Args:
         pkg: the package being compiled
         env: the :class:`~spack.util.environment.EnvironmentModifications`
@@ -837,19 +833,12 @@ def _inject_debuggable_prefix_map(
     debug_flags = ["-g"] + ffile_flags
 
     for spack_var in ("SPACK_CFLAGS", "SPACK_CXXFLAGS", "SPACK_FFLAGS", "SPACK_FCFLAGS"):
-        #    env.append_flags(spack_var, "-g") # NEW LINE
         for flag in debug_flags:
             env.append_flags(spack_var, flag)
 
     for raw_var in ("CFLAGS", "CXXFLAGS", "FFLAGS", "FCFLAGS"):
         for flag in debug_flags:
             env.append_flags(raw_var, flag)
-
-    # NVCC and HIP use a wrapper syntax to forward flags to the host compiler.
-    # -Xcompiler passes flags through to the underlying gcc/clang invocation.
-    # Note: device-side PTX code does not use this DWARF format and is not
-    # covered by this flag injection.
-    #    nvcc_hip_flags = " ".join(f"-Xcompiler={flag}" for flag in ffile_flags)
 
     # NVCC / HIP: forward both -g (host debug) and the remap flags
     nvcc_hip_flags = "-Xcompiler=-g " + " ".join(f"-Xcompiler={flag}" for flag in ffile_flags)
@@ -1308,7 +1297,7 @@ def _setup_pkg_and_run(
 
         if not kwargs.get("fake", False):
             # Set _debuggable_install BEFORE setup_package() runs.
-            # setup_package() → _inject_debuggable_prefix_map() reads this attribute,
+            # setup_package(). _inject_debuggable_prefix_map() reads this attribute,
             # but BuildProcessInstaller.run() (which used to set it) runs AFTER
             # setup_package(). Moving the assignment here fixes the timing.
             if kwargs.get("debuggable", False):

--- a/lib/spack/spack/cmd/install.py
+++ b/lib/spack/spack/cmd/install.py
@@ -69,11 +69,11 @@ def install_kwargs_from_args(args):
         "keep_stage": args.keep_stage,
         "restage": not args.dont_restage,
         "install_source": args.install_source,
-        "debuggable": args.debuggable,  # NEW LINE
+        "debuggable": args.debuggable,
         "verbose": args.verbose or args.install_verbose,
         "fake": args.fake,
         "dirty": args.dirty,
-        "root_policy": root_policy,  # CHANGED
+        "root_policy": root_policy,
         "dependencies_policy": cache_opt(dep_use_bc, default),
         "include_build_deps": args.include_build_deps,
         "stop_at": args.until,
@@ -193,7 +193,6 @@ def setup_parser(subparser: argparse.ArgumentParser) -> None:
         help="install source files in prefix",
     )
 
-    # NEW FLAG
     subparser.add_argument(
         "--debuggable",
         action="store_true",

--- a/lib/spack/spack/cmd/install.py
+++ b/lib/spack/spack/cmd/install.py
@@ -48,16 +48,32 @@ def install_kwargs_from_args(args):
     else:
         default = "source_only"
 
+    # --debuggable requires compiling from source so that -ffile-prefix-map
+    # and -g are actually injected. A binary cache install produces binaries
+    # with wrong DWARF paths and no source files. Override root policy to
+    # source_only regardless of other cache flags. Dependencies may still
+    # come from cache since we are not trying to debug them.
+    if args.debuggable:
+        if args.cache_only or (pkg_use_bc == "only"):
+            tty.warn(
+                "--debuggable requires building from source; "
+                "overriding cache-only policy for the root package"
+            )
+        root_policy = "source_only"
+    else:
+        root_policy = cache_opt(pkg_use_bc, default)
+
     return {
         "fail_fast": args.fail_fast,
         "keep_prefix": args.keep_prefix,
         "keep_stage": args.keep_stage,
         "restage": not args.dont_restage,
         "install_source": args.install_source,
+        "debuggable": args.debuggable,  # NEW LINE
         "verbose": args.verbose or args.install_verbose,
         "fake": args.fake,
         "dirty": args.dirty,
-        "root_policy": cache_opt(pkg_use_bc, default),
+        "root_policy": root_policy,  # CHANGED
         "dependencies_policy": cache_opt(dep_use_bc, default),
         "include_build_deps": args.include_build_deps,
         "stop_at": args.until,
@@ -176,6 +192,16 @@ def setup_parser(subparser: argparse.ArgumentParser) -> None:
         dest="install_source",
         help="install source files in prefix",
     )
+
+    # NEW FLAG
+    subparser.add_argument(
+        "--debuggable",
+        action="store_true",
+        dest="debuggable",
+        default=False,
+        help="install source files in prefix AND remap DWARF debug symbols (implies --source)",
+    )
+
     arguments.add_common_arguments(subparser, ["no_checksum"])
     subparser.add_argument(
         "-v",

--- a/lib/spack/spack/debug_install.py
+++ b/lib/spack/spack/debug_install.py
@@ -1,0 +1,546 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+"""Install debug artifacts for packages built with ``--debuggable``.
+
+This module is called from both the old installer (``spack.installer``) and the
+new installer (``spack.new_installer``) after the real build completes and while
+the staging directory is still alive.
+
+Public entry point
+------------------
+install_debug_artifacts(pkg)
+    The single function callers should use.  Everything else is private.
+"""
+
+import enum
+import json
+import os
+import re
+import subprocess
+from typing import TYPE_CHECKING, Dict, Set
+
+import spack.builder
+import spack.error
+import spack.llnl.util.filesystem as fs
+import spack.llnl.util.tty as tty
+
+if TYPE_CHECKING:
+    import spack.package_base
+
+
+# ---------------------------------------------------------------------------
+# Failure policy machinery
+# ---------------------------------------------------------------------------
+
+
+class DebugInstallFailurePolicy(enum.Enum):
+    """Severity of failures during a debuggable installation.
+
+    FATAL:   Installation is aborted immediately via InstallError.
+             The debuggable install cannot proceed meaningfully.
+
+    WARNING: Installation continues but the user is notified.
+             Partial coverage is acceptable; user should know.
+
+    INFO:    Expected or benign condition; logged at debug level only.
+    """
+
+    FATAL = "fatal"
+    WARNING = "warning"
+    INFO = "info"
+
+
+#: Maps each known failure mode to its enforcement policy.
+#: Every failure that can occur during a debuggable install must be
+#: listed here. No failure is silently swallowed.
+_DEBUGGABLE_FAILURE_POLICIES: Dict[str, DebugInstallFailurePolicy] = {
+    # compile_commands.json absent or malformed.
+    # We fall back to DWARF-derived paths — not fatal.
+    "compile_commands_missing": DebugInstallFailurePolicy.INFO,
+    # A specific source file referenced in DWARF was not in staging.
+    # Happens for generated files cleaned up before install. Common.
+    "source_file_missing": DebugInstallFailurePolicy.INFO,
+    # Generated header installation failed for some files.
+    # Generated types may not resolve in debugger.
+    "generated_headers_partial": DebugInstallFailurePolicy.WARNING,
+}
+
+
+def _handle_debuggable_failure(failure_type: str, detail: str, pkg_id: str) -> None:
+    """Enforce the failure policy for a named failure mode.
+
+    Looks up ``failure_type`` in ``_DEBUGGABLE_FAILURE_POLICIES`` and
+    applies the corresponding action:
+
+    - FATAL    raises :exc:`spack.error.InstallError` immediately
+    - WARNING  calls ``tty.warn``
+    - INFO     calls ``tty.debug``
+
+    Unknown failure types default to WARNING so new failure modes added
+    during development are never silently swallowed.
+
+    Args:
+        failure_type: key into ``_DEBUGGABLE_FAILURE_POLICIES``
+        detail:       human-readable description of what went wrong
+        pkg_id:       package identifier string for the error message
+    """
+    policy = _DEBUGGABLE_FAILURE_POLICIES.get(failure_type, DebugInstallFailurePolicy.WARNING)
+    message = f"[debuggable:{failure_type}] {pkg_id}: {detail}"
+
+    if policy == DebugInstallFailurePolicy.FATAL:
+        raise spack.error.InstallError(message)
+    elif policy == DebugInstallFailurePolicy.WARNING:
+        tty.warn(message)
+    else:
+        tty.debug(message)
+
+
+# ---------------------------------------------------------------------------
+# ELF / DWARF inspection helpers
+# ---------------------------------------------------------------------------
+
+
+def _is_elf_with_debug_sections(filepath: str) -> bool:
+    """Return True if the file is an ELF binary containing DWARF debug sections.
+
+    Uses a two-stage check:
+
+    1. Read the first 4 bytes and verify ELF magic (``\\x7fELF``).
+       This is fast and avoids invoking readelf on every file.
+
+    2. If ELF magic matches, run ``readelf --sections --wide`` and check
+       for the presence of ``.debug_info`` or ``.debug_str`` sections.
+       Stripped binaries pass the magic check but have no DWARF and
+       should not be processed.
+
+    Args:
+        filepath: absolute path to the file to inspect
+
+    Returns:
+        True only if the file is ELF *and* has DWARF debug sections.
+        False for scripts, text files, stripped ELF, and unreadable files.
+    """
+    ELF_MAGIC = b"\x7fELF"
+    try:
+        with open(filepath, "rb") as f:
+            if f.read(4) != ELF_MAGIC:
+                return False
+
+        result = subprocess.run(
+            ["readelf", "--sections", "--wide", filepath],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        return ".debug_info" in result.stdout or ".debug_str" in result.stdout
+
+    except (IOError, OSError, subprocess.TimeoutExpired, FileNotFoundError):
+        return False
+
+
+def _parse_dwarf_comp_unit_paths(readelf_output: str, paths: Set[str]) -> None:
+    """Parse ``readelf --debug-dump=info`` output to extract source file paths.
+
+    Each compilation unit DIE in DWARF contains:
+
+    - ``DW_AT_comp_dir``: the working directory at compile time
+    - ``DW_AT_name``: the source filename (relative or absolute)
+
+    The full path is ``os.path.join(DW_AT_comp_dir, DW_AT_name)`` when
+    ``DW_AT_name`` is relative, or just ``DW_AT_name`` when absolute.
+
+    Args:
+        readelf_output: the full stdout from ``readelf --debug-dump=info``
+        paths:          set to update in place with discovered paths
+    """
+    comp_dir = None
+    for line in readelf_output.splitlines():
+        line = line.strip()
+        if "DW_AT_comp_dir" in line:
+            m = re.search(r"DW_AT_comp_dir\b.*:\s*(.+)$", line)
+            if m:
+                comp_dir = m.group(1).strip()
+        elif "DW_AT_name" in line and comp_dir is not None:
+            m = re.search(r"DW_AT_name\b.*:\s*(.+)$", line)
+            if m:
+                name = m.group(1).strip()
+                if os.path.isabs(name):
+                    paths.add(name)
+                else:
+                    paths.add(os.path.join(comp_dir, name))
+            comp_dir = None
+
+
+def _extract_compilation_unit_paths(pkg: "spack.package_base.PackageBase") -> Set[str]:
+    """Extract every source file path embedded in DWARF across all installed ELF binaries.
+
+    This is the authoritative source file list for deciding what to copy
+    during a debuggable installation. It works for any build system —
+    CMake, autotools, Make, raw Fortran, CUDA host code — because it reads
+    what the compiler actually embedded, not what a build manifest says.
+
+    Uses ``readelf --debug-dump=info --dwarf-depth=1`` which limits output
+    to top-level DIEs only (one per compilation unit). This is much faster
+    than a full DWARF dump and provides exactly what we need.
+
+    The ``share/<pkg>/`` subdirectory is excluded from the walk because it
+    contains the debug artifacts we are currently installing — we do not
+    want to re-scan our own output.
+
+    Args:
+        pkg: the package whose installed prefix to scan
+
+    Returns:
+        Set of absolute source file paths as embedded in DWARF.
+        If ``-ffile-prefix-map`` was injected correctly, these will be
+        permanent prefix paths, not staging paths.
+    """
+    prefix = str(pkg.spec.prefix)
+    share_dir = os.path.join(prefix, "share", pkg.name)
+    paths: Set[str] = set()
+
+    for root, _, files in os.walk(prefix):
+        if root.startswith(share_dir):
+            continue
+
+        for filename in files:
+            filepath = os.path.join(root, filename)
+
+            if os.path.islink(filepath):
+                continue
+
+            if not _is_elf_with_debug_sections(filepath):
+                continue
+
+            try:
+                result = subprocess.run(
+                    ["readelf", "--debug-dump=info", "--dwarf-depth=1", filepath],
+                    capture_output=True,
+                    text=True,
+                    timeout=60,
+                )
+                _parse_dwarf_comp_unit_paths(result.stdout, paths)
+
+            except subprocess.TimeoutExpired:
+                tty.debug(f"[debuggable] readelf timed out on {filepath}, skipping")
+            except FileNotFoundError:
+                tty.debug("[debuggable] readelf not found on this system")
+                return paths
+            except Exception as e:
+                tty.debug(f"[debuggable] readelf failed on {filepath}: {e}")
+
+    return paths
+
+
+# ---------------------------------------------------------------------------
+# Public entry point
+# ---------------------------------------------------------------------------
+
+
+def install_debug_artifacts(pkg: "spack.package_base.PackageBase") -> None:
+    """Install DWARF-filtered sources, generated headers, and compile_commands.json.
+
+    Must be called from within the child build process, after the real
+    install completes and while the staging directory is still present
+    (i.e. inside the ``with stage:`` context manager).
+
+    Args:
+        pkg:          the package that was just installed
+    """
+    pkg_id = f"{pkg.spec.name}-{pkg.spec.version}-{pkg.spec.dag_hash()}"
+    pre = f"{pkg.spec.name}:"
+
+    prefix = str(pkg.spec.prefix)
+    staging_src = pkg.stage.source_path
+    permanent_src = os.path.join(prefix, "share", pkg.name, "src")
+    share_base = os.path.join(prefix, "share", pkg.name)
+    build_target = os.path.join(share_base, "build")
+
+    fs.mkdirp(share_base)
+
+    # ── Step 1: get the authoritative source file list from DWARF ─────────
+    tty.debug(f"{pre} Extracting compilation unit paths from DWARF...")
+    dwarf_paths = _extract_compilation_unit_paths(pkg)
+    tty.debug(f"{pre} DWARF reported {len(dwarf_paths)} compilation units")
+
+    try:
+        builder = spack.builder.create(pkg)
+        staging_build_dir = getattr(builder, "build_directory", None)
+    except Exception:
+        staging_build_dir = None
+
+    files_to_copy: Set[str] = set()
+    build_files_to_copy: Set[str] = set()
+
+    for dwarf_path in dwarf_paths:
+        if dwarf_path.startswith(permanent_src):
+            rel = os.path.relpath(dwarf_path, permanent_src)
+            staging_file = os.path.join(staging_src, rel)
+            if os.path.isfile(staging_file):
+                files_to_copy.add(staging_file)
+            else:
+                _handle_debuggable_failure(
+                    "source_file_missing",
+                    f"DWARF references {dwarf_path} but {staging_file} not found in staging",
+                    pkg_id,
+                )
+        elif staging_build_dir and dwarf_path.startswith(staging_build_dir):
+            if os.path.isfile(dwarf_path):
+                build_files_to_copy.add(dwarf_path)
+        elif dwarf_path.startswith(staging_src):
+            if os.path.isfile(dwarf_path):
+                files_to_copy.add(dwarf_path)
+
+    # ── Fallback: compile_commands.json ───────────────────────────────────
+    if not files_to_copy:
+        tty.debug(f"{pre} DWARF yielded no files; falling back to compile_commands.json")
+        files_to_copy = _collect_from_compile_commands(pkg, pre)
+        if not files_to_copy:
+            _handle_debuggable_failure(
+                "compile_commands_missing",
+                "Neither DWARF introspection nor compile_commands.json "
+                "produced a source file list. "
+                "Install may lack debug sources.",
+                pkg_id,
+            )
+
+    # ── Collect headers from the staging source tree ──────────────────────
+    # Headers are referenced in DWARF DW_AT_decl_file entries for individual
+    # variables and types, but not as compilation unit roots, so they are
+    # invisible to _extract_compilation_unit_paths. Without them, debuggers
+    # cannot show inline code or type definitions from header files.
+    # Collect all headers from the staging source tree (but not docs, tests,
+    # build scripts, or other non-debugger-relevant files).
+    _HEADER_EXTENSIONS = {".h", ".hh", ".hpp", ".hxx", ".H", ".inl", ".f90", ".f", ".mod"}
+    if staging_src and os.path.isdir(staging_src):
+        for _root, _, _fnames in os.walk(staging_src):
+            for _fname in _fnames:
+                _, _ext = os.path.splitext(_fname)
+                if _ext in _HEADER_EXTENSIONS:
+                    _fpath = os.path.join(_root, _fname)
+                    if os.path.isfile(_fpath):
+                        files_to_copy.add(_fpath)
+        tty.debug(
+            f"{pre} After header scan: {len(files_to_copy)} files to copy to {permanent_src}"
+        )
+
+    if files_to_copy:
+        _install_sources_as_tree(pkg, files_to_copy, staging_src, permanent_src, pre)
+
+    # ── Step 2: install generated headers from build directory ────────────
+    if build_files_to_copy and staging_build_dir:
+        tty.debug(f"{pre} DWARF referenced {len(build_files_to_copy)} files from build directory")
+        _install_sources_as_tree(pkg, build_files_to_copy, staging_build_dir, build_target, pre)
+    elif staging_build_dir and os.path.isdir(staging_build_dir):
+        # Fallback: no DWARF refs into build dir, use extension filter
+        tty.debug(f"{pre} No DWARF refs into build dir; falling back to extension filter")
+        _install_generated_headers(pkg, build_target, pre, pkg_id)
+
+    # ── Step 3: install compile_commands.json for IDE tooling ─────────────
+    _install_compile_commands(pkg, build_target, pre)
+
+
+# ---------------------------------------------------------------------------
+# Private helpers
+# ---------------------------------------------------------------------------
+
+
+def _collect_from_compile_commands(pkg: "spack.package_base.PackageBase", pre: str) -> Set[str]:
+    """Parse ``compile_commands.json`` to get compiled source file paths.
+
+    This is a fallback when DWARF extraction yields nothing.  Only CMake
+    packages produce this file.
+
+    Returns:
+        Set of absolute staging paths, or empty set if not found/parseable.
+    """
+    try:
+        builder = spack.builder.create(pkg)
+        build_dir = getattr(builder, "build_directory", None)
+        if not build_dir:
+            return set()
+
+        cc_path = os.path.join(build_dir, "compile_commands.json")
+        if not os.path.isfile(cc_path):
+            tty.debug(f"{pre} compile_commands.json not found at {cc_path}")
+            return set()
+
+        with open(cc_path, "r", encoding="utf-8") as f:
+            entries = json.load(f)
+
+        result: Set[str] = set()
+        for entry in entries:
+            filepath = entry.get("file", "")
+            if filepath and os.path.isfile(filepath):
+                result.add(os.path.abspath(filepath))
+
+        tty.debug(f"{pre} compile_commands.json: found {len(result)} source files")
+        return result
+
+    except (json.JSONDecodeError, KeyError) as e:
+        tty.debug(f"{pre} Failed to parse compile_commands.json: {e}")
+        return set()
+    except Exception as e:
+        tty.debug(f"{pre} Unexpected error reading compile_commands: {e}")
+        return set()
+
+
+def _install_sources_as_tree(
+    pkg: "spack.package_base.PackageBase",
+    files: Set[str],
+    source_root: str,
+    dest_root: str,
+    pre: str,
+) -> None:
+    """Copy source files to a real directory tree in the install prefix.
+
+    Creates ``<prefix>/share/<pkg>/src/`` as a real filesystem directory
+    with the source files inside.  GDB can find these files immediately
+    without any extraction step because the paths in DWARF match the
+    filesystem paths exactly.
+
+    Args:
+        pkg:         the package being installed (used for logging only)
+        files:       absolute staging paths of source files to copy
+        source_root: staging source root for preserving directory structure
+        dest_root:   destination root directory in the install prefix
+        pre:         log prefix string
+    """
+    copied = 0
+    failed = 0
+
+    for staging_file in sorted(files):
+        if not os.path.isfile(staging_file):
+            continue
+        try:
+            try:
+                rel = os.path.relpath(staging_file, source_root)
+                rel = staging_file.lstrip("/") if rel.startswith("..") else rel
+            except ValueError:
+                rel = staging_file.lstrip("/")
+
+            dst = os.path.join(dest_root, rel)
+            fs.mkdirp(os.path.dirname(dst))
+            fs.install(staging_file, dst)
+            copied += 1
+
+        except Exception as e:
+            tty.debug(f"{pre} Could not copy {staging_file} to {dest_root}: {e}")
+            failed += 1
+
+    if copied > 0:
+        tty.msg(f"{pre} Installed {copied} source files to {dest_root}")
+    if failed > 0:
+        tty.debug(f"{pre} Failed to copy {failed} source files")
+
+
+def _install_generated_headers(
+    pkg: "spack.package_base.PackageBase", build_target: str, pre: str, pkg_id: str
+) -> None:
+    """Copy generated header files from the CMake build directory.
+
+    Installs ``config.h``, ``moc_*.cpp``, ``ui_*.h``, ``*.pb.h``, etc.
+    into ``<prefix>/share/<pkg>/build/``.
+    Only runs when ``builder.build_directory`` exists (CMake packages).
+    Makefile-based packages have no build directory and this is a no-op.
+
+    Args:
+        pkg:          the package being installed
+        build_target: destination directory in the install prefix
+        pre:          log prefix string
+        pkg_id:       package identifier string for error messages
+    """
+    HEADER_EXTENSIONS = {
+        ".h",
+        ".hh",
+        ".hpp",
+        ".hxx",
+        ".H",
+        ".f90",
+        ".f",
+        ".mod",
+        ".pb.h",
+        ".pb.cc",
+    }
+    GENERATED_SOURCE_PREFIXES = {"moc_", "ui_", "qrc_"}
+    EXCLUDED_DIRECTORY_NAMES = {"CMakeFiles", "Testing", "CTestFiles", ".cmake"}
+
+    try:
+        builder = spack.builder.create(pkg)
+        build_dir = getattr(builder, "build_directory", None)
+        if not build_dir or not os.path.isdir(build_dir):
+            tty.debug(f"{pre} No build directory found; skipping generated header installation")
+            return
+    except Exception as e:
+        tty.debug(f"{pre} Could not resolve build_directory: {e}")
+        return
+
+    copied = 0
+    errors = 0
+
+    for root, dirs, files in os.walk(build_dir):
+        dirs[:] = [d for d in dirs if d not in EXCLUDED_DIRECTORY_NAMES and not d.endswith(".dir")]
+
+        for filename in files:
+            _, ext = os.path.splitext(filename)
+            is_generated_header = ext in HEADER_EXTENSIONS
+            is_generated_source = any(
+                filename.startswith(prefix) for prefix in GENERATED_SOURCE_PREFIXES
+            )
+
+            if not (is_generated_header or is_generated_source):
+                continue
+
+            src_file = os.path.join(root, filename)
+            rel = os.path.relpath(src_file, build_dir)
+            dst_file = os.path.join(build_target, rel)
+
+            try:
+                fs.mkdirp(os.path.dirname(dst_file))
+                fs.install(src_file, dst_file)
+                copied += 1
+            except Exception as e:
+                _handle_debuggable_failure(
+                    "generated_headers_partial", f"Could not install {src_file}: {e}", pkg_id
+                )
+                errors += 1
+
+    if copied > 0:
+        tty.debug(f"{pre} Installed {copied} generated headers to {build_target}")
+    if errors > 0:
+        tty.debug(f"{pre} {errors} generated headers could not be installed")
+
+
+def _install_compile_commands(
+    pkg: "spack.package_base.PackageBase", build_target: str, pre: str
+) -> None:
+    """Copy ``compile_commands.json`` to the debug build directory.
+
+    Enables clangd, clang-tidy, and IDE tools to understand the package
+    source code.  Only runs when ``builder.build_directory`` exists.
+
+    Args:
+        pkg:          the package being installed
+        build_target: destination directory in the install prefix
+        pre:          log prefix string
+    """
+    try:
+        builder = spack.builder.create(pkg)
+        build_dir = getattr(builder, "build_directory", None)
+        if not build_dir:
+            return
+
+        cc_src = os.path.join(build_dir, "compile_commands.json")
+        if not os.path.isfile(cc_src):
+            tty.debug(f"{pre} compile_commands.json not found at {cc_src}, skipping")
+            return
+
+        fs.mkdirp(build_target)
+        cc_dst = os.path.join(build_target, "compile_commands.json")
+        fs.install(cc_src, cc_dst)
+        tty.debug(f"{pre} Installed compile_commands.json to {build_target}")
+
+    except Exception as e:
+        tty.debug(f"{pre} Could not install compile_commands.json: {e}")

--- a/lib/spack/spack/debug_install.py
+++ b/lib/spack/spack/debug_install.py
@@ -463,6 +463,10 @@ def _install_generated_headers(
         ".mod",
         ".pb.h",
         ".pb.cc",
+        ".c",
+        ".cc",
+        ".cpp",
+        ".cxx",
     }
     GENERATED_SOURCE_PREFIXES = {"moc_", "ui_", "qrc_"}
     EXCLUDED_DIRECTORY_NAMES = {"CMakeFiles", "Testing", "CTestFiles", ".cmake"}

--- a/lib/spack/spack/installer.py
+++ b/lib/spack/spack/installer.py
@@ -789,7 +789,7 @@ class BuildRequest:
             ("install_deps", True),
             ("install_package", True),
             ("install_source", False),
-            ("debuggable", False),  # NEW LINE
+            ("debuggable", False),
             ("root_policy", "auto"),
             ("keep_prefix", False),
             ("keep_stage", False),
@@ -1476,7 +1476,7 @@ class PackageInstaller:
         install_deps: bool = True,
         install_package: bool = True,
         install_source: bool = False,
-        debuggable: bool = False,  # NEW PARAMETER
+        debuggable: bool = False,
         keep_prefix: bool = False,
         keep_stage: bool = False,
         restage: bool = False,
@@ -1543,7 +1543,7 @@ class PackageInstaller:
             "install_deps": install_deps,
             "install_package": install_package,
             "install_source": install_source,
-            "debuggable": debuggable,  # NEW LINE
+            "debuggable": debuggable,
             "keep_prefix": keep_prefix,
             "keep_stage": keep_stage,
             "overwrite": overwrite or [],

--- a/lib/spack/spack/installer.py
+++ b/lib/spack/spack/installer.py
@@ -47,6 +47,7 @@ import spack.build_environment
 import spack.builder
 import spack.config
 import spack.database
+import spack.debug_install
 import spack.deptypes as dt
 import spack.error
 import spack.hooks
@@ -788,6 +789,7 @@ class BuildRequest:
             ("install_deps", True),
             ("install_package", True),
             ("install_source", False),
+            ("debuggable", False),  # NEW LINE
             ("root_policy", "auto"),
             ("keep_prefix", False),
             ("keep_stage", False),
@@ -1474,6 +1476,7 @@ class PackageInstaller:
         install_deps: bool = True,
         install_package: bool = True,
         install_source: bool = False,
+        debuggable: bool = False,  # NEW PARAMETER
         keep_prefix: bool = False,
         keep_stage: bool = False,
         restage: bool = False,
@@ -1540,6 +1543,7 @@ class PackageInstaller:
             "install_deps": install_deps,
             "install_package": install_package,
             "install_source": install_source,
+            "debuggable": debuggable,  # NEW LINE
             "keep_prefix": keep_prefix,
             "keep_stage": keep_stage,
             "overwrite": overwrite or [],
@@ -2597,6 +2601,13 @@ class BuildProcessInstaller:
         # whether to install source code with the package
         self.install_source = install_args.get("install_source", False)
 
+        # whether installation was explicitly requested by the user
+        self.explicit = pkg.spec.dag_hash() in install_args.get("explicit", [])
+
+        self.debuggable = install_args.get("debuggable", False) and self.explicit
+
+        self._install_args = install_args  # stored for delegation to spack.debug_install
+
         is_develop = pkg.spec.is_develop
         # whether to keep the build stage after installation
         # Note: user commands do not have an explicit choice to disable
@@ -2612,9 +2623,6 @@ class BuildProcessInstaller:
 
         # whether to enable echoing of build output initially or not
         self.verbose = bool(install_args.get("verbose", False))
-
-        # whether installation was explicitly requested by the user
-        self.explicit = pkg.spec.dag_hash() in install_args.get("explicit", [])
 
         # env before starting installation
         self.unmodified_env = install_args.get("unmodified_env", {})
@@ -2638,6 +2646,9 @@ class BuildProcessInstaller:
 
         stage = self.pkg.stage
         stage.keep = self.keep_stage
+
+        if self.debuggable:
+            setattr(self.pkg, "_debuggable_install", True)
 
         with stage:
             if self.restage:
@@ -2668,10 +2679,13 @@ class BuildProcessInstaller:
             if self.fake:
                 _do_fake_install(self.pkg)
             else:
-                if self.install_source:
-                    self._install_source()
-
-                self._real_install()
+                if self.debuggable:
+                    self._real_install()
+                    self._install_debuggable_sources()
+                else:
+                    if self.install_source:
+                        self._install_source()
+                    self._real_install()
 
             # Run post install hooks before build stage is removed.
             self.timer.start("post-install")
@@ -2769,6 +2783,47 @@ class BuildProcessInstaller:
         # After log, we can get all output/error files from the package stage
         combine_phase_logs(pkg.phase_log_files, pkg.log_path)
         log(pkg)
+
+    def _install_debuggable_sources(self) -> None:
+        """Install debug artifacts for a debuggable build.
+
+        Delegates to :func:`spack.debug_install.install_debug_artifacts`.
+        Called from :meth:`run` AFTER :meth:`_real_install` while the
+        staging directory is still present.
+        """
+        spack.debug_install.install_debug_artifacts(self.pkg)
+
+    def _collect_from_compile_commands(self) -> Set[str]:
+        """Parse compile_commands.json for source file paths.
+
+        Delegates to :func:`spack.debug_install._collect_from_compile_commands`.
+        """
+        return spack.debug_install._collect_from_compile_commands(self.pkg, self.pre)
+
+    def _install_sources_as_tree(self, files: Set[str], source_root: str, dest_root: str) -> None:
+        """Copy source files to a directory tree.
+
+        Delegates to :func:`spack.debug_install._install_sources_as_tree`.
+        """
+        spack.debug_install._install_sources_as_tree(
+            self.pkg, files, source_root, dest_root, self.pre
+        )
+
+    def _install_generated_headers(self, build_target: str) -> None:
+        """Copy generated headers from the CMake build directory.
+
+        Delegates to :func:`spack.debug_install._install_generated_headers`.
+        """
+        spack.debug_install._install_generated_headers(
+            self.pkg, build_target, self.pre, self.pkg_id
+        )
+
+    def _install_compile_commands(self, build_target: str) -> None:
+        """Copy compile_commands.json to the debug build directory.
+
+        Delegates to :func:`spack.debug_install._install_compile_commands`.
+        """
+        spack.debug_install._install_compile_commands(self.pkg, build_target, self.pre)
 
 
 def build_process(pkg: "spack.package_base.PackageBase", install_args: dict) -> bool:

--- a/lib/spack/spack/installer_dispatch.py
+++ b/lib/spack/spack/installer_dispatch.py
@@ -28,6 +28,7 @@ def create_installer(
     install_deps: bool = True,
     install_package: bool = True,
     install_source: bool = False,
+    debuggable: bool = False,  # NEW
     keep_prefix: bool = False,
     keep_stage: bool = False,
     restage: bool = True,
@@ -71,6 +72,7 @@ def create_installer(
         install_deps=install_deps,
         install_package=install_package,
         install_source=install_source,
+        debuggable=debuggable,  # NEW
         keep_prefix=keep_prefix,
         keep_stage=keep_stage,
         restage=restage,

--- a/lib/spack/spack/installer_dispatch.py
+++ b/lib/spack/spack/installer_dispatch.py
@@ -28,7 +28,7 @@ def create_installer(
     install_deps: bool = True,
     install_package: bool = True,
     install_source: bool = False,
-    debuggable: bool = False,  # NEW
+    debuggable: bool = False,
     keep_prefix: bool = False,
     keep_stage: bool = False,
     restage: bool = True,
@@ -72,7 +72,7 @@ def create_installer(
         install_deps=install_deps,
         install_package=install_package,
         install_source=install_source,
-        debuggable=debuggable,  # NEW
+        debuggable=debuggable,
         keep_prefix=keep_prefix,
         keep_stage=keep_stage,
         restage=restage,

--- a/lib/spack/spack/new_installer.py
+++ b/lib/spack/spack/new_installer.py
@@ -429,7 +429,7 @@ def worker_function(
     skip_patch: bool,
     fake: bool,
     install_source: bool,
-    debuggable: bool,  # NEW
+    debuggable: bool,
     run_tests: bool,
     state: Connection,
     parent: Connection,
@@ -540,7 +540,7 @@ def worker_function(
                 skip_patch,
                 fake,
                 install_source,
-                debuggable,  # NEW
+                debuggable,
                 state_stream,
                 log_path,
                 spack.store.STORE,
@@ -995,7 +995,7 @@ def start_build(
     skip_patch: bool,
     fake: bool,
     install_source: bool,
-    debuggable: bool,  # NEW
+    debuggable: bool,
     run_tests: bool,
     jobserver: JobServer,
     log_path: str,
@@ -1031,7 +1031,7 @@ def start_build(
             skip_patch,
             fake,
             install_source,
-            debuggable,  # NEW
+            debuggable,
             run_tests,
             state_w_conn,
             output_w_conn,
@@ -2242,7 +2242,7 @@ class PackageInstaller:
         install_deps: bool = True,
         install_package: bool = True,
         install_source: bool = False,
-        debuggable: bool = False,  # NEW
+        debuggable: bool = False,
         keep_prefix: bool = False,
         keep_stage: bool = False,
         restage: bool = True,
@@ -2260,7 +2260,7 @@ class PackageInstaller:
         assert install_package or install_deps, "Must install package, dependencies or both"
 
         self.install_source = install_source
-        self.debuggable = debuggable  # NEW
+        self.debuggable = debuggable
         self.stop_at = stop_at
         self.stop_before = stop_before
         self.tests: Union[bool, List[str], Set[str]] = tests
@@ -2826,7 +2826,7 @@ class PackageInstaller:
             skip_patch=self.skip_patch,
             fake=self.fake,
             install_source=self.install_source,
-            debuggable=self.debuggable and is_root,  # NEW
+            debuggable=self.debuggable and is_root,
             run_tests=run_tests,
             jobserver=jobserver,
             log_path=self.log_paths[dag_hash],

--- a/lib/spack/spack/new_installer.py
+++ b/lib/spack/spack/new_installer.py
@@ -59,6 +59,7 @@ import spack.build_environment
 import spack.builder
 import spack.config
 import spack.database
+import spack.debug_install
 import spack.deptypes as dt
 import spack.error
 import spack.hooks
@@ -428,6 +429,7 @@ def worker_function(
     skip_patch: bool,
     fake: bool,
     install_source: bool,
+    debuggable: bool,  # NEW
     run_tests: bool,
     state: Connection,
     parent: Connection,
@@ -538,6 +540,7 @@ def worker_function(
                 skip_patch,
                 fake,
                 install_source,
+                debuggable,  # NEW
                 state_stream,
                 log_path,
                 spack.store.STORE,
@@ -709,6 +712,7 @@ def _install(
     skip_patch: bool,
     fake: bool,
     install_source: bool,
+    debuggable: bool,
     state_stream: io.TextIOWrapper,
     log_path: str,
     store: spack.store.Store = spack.store.STORE,
@@ -746,6 +750,9 @@ def _install(
         # Binary cache was the only option; signal miss for force_source expansion.
         send_state("no binary available", state_stream)
         raise BinaryCacheMiss(f"No binary available for {spec}")
+
+    if debuggable:
+        setattr(pkg, "_debuggable_install", True)
 
     unmodified_env = os.environ.copy()
     env_mods = spack.build_environment.setup_package(pkg, dirty=dirty)
@@ -825,6 +832,10 @@ def _install(
                 raise spack.error.StopPhase(f"Stopping at '{stop_at}'")
 
         _archive_build_metadata(pkg)
+
+        if debuggable:
+            spack.debug_install.install_debug_artifacts(pkg)
+
         spack.hooks.post_install(spec, explicit)
 
 
@@ -984,6 +995,7 @@ def start_build(
     skip_patch: bool,
     fake: bool,
     install_source: bool,
+    debuggable: bool,  # NEW
     run_tests: bool,
     jobserver: JobServer,
     log_path: str,
@@ -1019,6 +1031,7 @@ def start_build(
             skip_patch,
             fake,
             install_source,
+            debuggable,  # NEW
             run_tests,
             state_w_conn,
             output_w_conn,
@@ -2229,6 +2242,7 @@ class PackageInstaller:
         install_deps: bool = True,
         install_package: bool = True,
         install_source: bool = False,
+        debuggable: bool = False,  # NEW
         keep_prefix: bool = False,
         keep_stage: bool = False,
         restage: bool = True,
@@ -2246,6 +2260,7 @@ class PackageInstaller:
         assert install_package or install_deps, "Must install package, dependencies or both"
 
         self.install_source = install_source
+        self.debuggable = debuggable  # NEW
         self.stop_at = stop_at
         self.stop_before = stop_before
         self.tests: Union[bool, List[str], Set[str]] = tests
@@ -2811,6 +2826,7 @@ class PackageInstaller:
             skip_patch=self.skip_patch,
             fake=self.fake,
             install_source=self.install_source,
+            debuggable=self.debuggable and is_root,  # NEW
             run_tests=run_tests,
             jobserver=jobserver,
             log_path=self.log_paths[dag_hash],


### PR DESCRIPTION
### Summary

Add `spack install --debuggable` flag that installs a package with DWARF debug symbols pointing to permanent, stable source paths rather than the ephemeral staging directory.

### Motivation

When debugging HPC packages with GDB or similar tools, the DWARF embedded in binaries typically contains staging-directory paths that are deleted after installation. This means `list`, `break <file>:<line>`, and inline expansion all fail. This feature makes debuggable installs a first-class operation in Spack.

### Related project

This PR is part of the CERN GSoC 2026 project **"Debuggable Installations for Spack Packages"**.
- GSoC project details (CERN-HSF page): https://hepsoftwarefoundation.org/gsoc/2026/proposal_Spack_DebuggableInstalls.html
- GSoC project summary (GSoC page): https://summerofcode.withgoogle.com/programs/2026/projects/gnBEsbW8

### What this PR does

**`--debuggable` flag in `spack install`**
- Forces `root_policy = "source_only"` so the package is always compiled from source (binary cache installs would have wrong DWARF paths).
- Only applies to the explicitly requested root package; dependencies may still come from cache.
- Warns the user if `--cache-only` is also specified and overrides it.

**DWARF path rewriting (`build_environment.py`)**
- Injects `-g` and `-ffile-prefix-map=<staging>=<prefix>/share/<pkg>/src/` into `SPACK_CFLAGS`, `SPACK_CXXFLAGS`, `SPACK_FFLAGS`, `SPACK_FCFLAGS`, and the raw `CFLAGS`/`CXXFLAGS`/etc. variables before every compilation.
- Also injects NVCC/HIP-compatible `-Xcompiler=` variants for GPU code.
- Resolves the out-of-tree build directory via `builder.build_directory` (the authoritative API) so packages that override it are handled correctly.
- Runs after `set_wrapper_variables()` so existing flags are preserved.

**Debug artifact installation (`debug_install.py`)**
- Scans installed ELF binaries with `readelf --debug-dump=info` to extract the authoritative DWARF-derived list of compiled source files.
- Copies those source files and headers to `<prefix>/share/<pkg>/src/`, exactly matching the permanent paths embedded in DWARF, so GDB's `DW_AT_name` references resolve immediately.
- Copies **generated headers** (e.g. CMake-generated `.h` and `.c` headers) to `<prefix>/share/<pkg>/build/`, matching the build-directory remap. These are also DWARF-referenced via the `-ffile-prefix-map=<build_dir>=...` injection. This covers `.h`, `.hpp`, `.hh`, `.hxx`, `.H`, `.f90`, `.f`, `.mod`, `.pb.h`, `.pb.cc`, `.c`, `.cc`, `.cpp` and `.cxx` formats.
- Copies `compile_commands.json` to `<prefix>/share/<pkg>/build/` as a bonus; this file is not DWARF-related but makes the installed package immediately usable as a project root in an IDE.
- Falls back to `compile_commands.json` source scanning if DWARF yields nothing.

**Wire-up**
- Both the old installer (`installer.py`) and new installer (`new_installer.py`) propagate `debuggable=True` down to the child build process.
- `installer_dispatch.py` forwards the flag to whichever installer is selected.
- `--debuggable` only applies to the root package (`is_root` check in `new_installer.py`); dependencies are unaffected.

### Verification (fmt@12.1.0)

```bash
$ cat binary_inspection.sh
#!/bin/bash

set -e

PKG=fmt
PREFIX=$(spack location -i $PKG)

echo "Inspecting DWARF build paths for package: $PKG"
echo "Installation prefix: $PREFIX"

LIBS=$(find "$PREFIX" -type f \( -name "*.a" -o -name "*.so" -o -name "*.so.*" \))

echo "Libraries found in the installation prefix: $LIBS"

COMP_DIRS=""

for lib in $LIBS
do
    echo 
    echo "Inspecting DWARF metadata in: $lib"
    OUT=$(readelf --debug-dump=info "$lib" 2>/dev/null | grep DW_AT_comp_dir | grep -o '/.*' || true)
    readelf --debug-dump=info "$lib" 2>/dev/null | grep -E 'DW_AT_(comp_dir|name)' | grep '/' || echo "No DWARF source paths found"
    COMP_DIRS="$COMP_DIRS$OUT"
    echo  
done

echo
echo "Installation prefix:"
echo "$PREFIX"
echo
echo "Compilation directories found in DWARF:"
echo "$COMP_DIRS" | sort -u


$ bash binary_inspection.sh
Inspecting DWARF build paths for package: fmt
Installation prefix: /scratch/general/vast/u6059911/spack/opt/spack/linux-skylake_avx512/fmt-12.1.0-vdwc4nf5bbroe4sa2rqsskpfxxix7z2v
Libraries found in the installation prefix: /scratch/general/vast/u6059911/spack/opt/spack/linux-skylake_avx512/fmt-12.1.0-vdwc4nf5bbroe4sa2rqsskpfxxix7z2v/lib64/libfmt.a

Inspecting DWARF metadata in: /scratch/general/vast/u6059911/spack/opt/spack/linux-skylake_avx512/fmt-12.1.0-vdwc4nf5bbroe4sa2rqsskpfxxix7z2v/lib64/libfmt.a
    <13>   DW_AT_name        : (indirect string, offset: 0x22f87): /scratch/general/vast/u6059911/spack/opt/spack/linux-skylake_avx512/fmt-12.1.0-vdwc4nf5bbroe4sa2rqsskpfxxix7z2v/share/fmt/src/src/format.cc
    <17>   DW_AT_comp_dir    : (indirect string, offset: 0x1ccae): /scratch/general/vast/u6059911/spack/opt/spack/linux-skylake_avx512/fmt-12.1.0-vdwc4nf5bbroe4sa2rqsskpfxxix7z2v/share/fmt/build
    <13>   DW_AT_name        : (indirect string, offset: 0x249): /scratch/general/vast/u6059911/spack/opt/spack/linux-skylake_avx512/fmt-12.1.0-vdwc4nf5bbroe4sa2rqsskpfxxix7z2v/share/fmt/src/src/os.cc
    <17>   DW_AT_comp_dir    : (indirect string, offset: 0xd31b): /scratch/general/vast/u6059911/spack/opt/spack/linux-skylake_avx512/fmt-12.1.0-vdwc4nf5bbroe4sa2rqsskpfxxix7z2v/share/fmt/build


Installation prefix:
/scratch/general/vast/u6059911/spack/opt/spack/linux-skylake_avx512/fmt-12.1.0-vdwc4nf5bbroe4sa2rqsskpfxxix7z2v

Compilation directories found in DWARF:
/scratch/general/vast/u6059911/spack/opt/spack/linux-skylake_avx512/fmt-12.1.0-vdwc4nf5bbroe4sa2rqsskpfxxix7z2v/share/fmt/build


$ ls $(spack location -i fmt)/share/fmt
build  src


$ ls $(spack location -i fmt)/share/fmt/*/*
/scratch/general/vast/u6059911/spack/opt/spack/linux-skylake_avx512/fmt-12.1.0-vdwc4nf5bbroe4sa2rqsskpfxxix7z2v/share/fmt/build/compile_commands.json

/scratch/general/vast/u6059911/spack/opt/spack/linux-skylake_avx512/fmt-12.1.0-vdwc4nf5bbroe4sa2rqsskpfxxix7z2v/share/fmt/src/include:
fmt

/scratch/general/vast/u6059911/spack/opt/spack/linux-skylake_avx512/fmt-12.1.0-vdwc4nf5bbroe4sa2rqsskpfxxix7z2v/share/fmt/src/src:
format.cc  os.cc

/scratch/general/vast/u6059911/spack/opt/spack/linux-skylake_avx512/fmt-12.1.0-vdwc4nf5bbroe4sa2rqsskpfxxix7z2v/share/fmt/src/test:
fuzzing  gtest  gtest-extra.h  mock-allocator.h  posix-mock.h  scan.h  test-assert.h  util.h
```

### Files changed

| File | Change |
|------|--------|
| `lib/spack/cmd/install.py` | `--debuggable` CLI flag |
| `lib/spack/spack/build_environment.py` | `-g` and `-ffile-prefix-map` injection |
| `lib/spack/spack/debug_install.py` | **new module** — DWARF scan + source copy |
| `lib/spack/spack/installer.py` | `debuggable` parameter plumbing |
| `lib/spack/spack/new_installer.py` | `debuggable` parameter plumbing |
| `lib/spack/spack/installer_dispatch.py` | `debuggable` parameter forwarding |