### PR TITLE
Add support for macOS 27: Golden Gate

### DIFF
--- a/lib/spack/spack/operating_systems/mac_os.py
+++ b/lib/spack/spack/operating_systems/mac_os.py
@@ -130,6 +130,7 @@ mac_releases = {
     "14": "sonoma",
     "15": "sequoia",
     "26": "tahoe",
+    "27": "goldengate",
 }
 
 

--- a/lib/spack/spack/solver/os_compatibility.lp
+++ b/lib/spack/spack/solver/os_compatibility.lp
@@ -11,6 +11,7 @@
 %=============================================================================
 
 % macOS
+os_compatible("goldengate", "tahoe").
 os_compatible("tahoe", "sequoia").
 os_compatible("sequoia", "sonoma").
 os_compatible("sonoma", "ventura").


### PR DESCRIPTION
@becker33 this may be small and innocuous enough to sneak into 1.2.

Reference: https://en.wikipedia.org/wiki/MacOS_Golden_Gate