### PR TITLE
modules: consolidate per-module boilerplate into base classes

### DIFF
--- a/lib/spack/spack/cmd/modules/lmod.py
+++ b/lib/spack/spack/cmd/modules/lmod.py
@@ -39,7 +39,7 @@ def setdefault(module_type, specs, args):
     spec = specs[0]
     data = {"modules": {args.module_set_name: {"lmod": {"defaults": [str(spec)]}}}}
     # Need to clear the cache if a SpackCommand is called during scripting
-    spack.modules.lmod.configuration_registry = {}
+    spack.modules.lmod.LmodConfiguration._registry = {}
     scope = spack.config.InternalConfigScope("lmod-setdefault", data)
     with spack.config.override(scope):
         writer = spack.modules.module_types["lmod"](spec, args.module_set_name)

--- a/lib/spack/spack/cmd/modules/tcl.py
+++ b/lib/spack/spack/cmd/modules/tcl.py
@@ -34,7 +34,7 @@ def setdefault(module_type, specs, args):
     spack.cmd.modules.one_spec_or_raise(specs)
     spec = specs[0]
     data = {"modules": {args.module_set_name: {"tcl": {"defaults": [str(spec)]}}}}
-    spack.modules.tcl.configuration_registry = {}
+    spack.modules.tcl.TclConfiguration._registry = {}
     scope = spack.config.InternalConfigScope("tcl-setdefault", data)
     with spack.config.override(scope):
         writer = spack.modules.module_types["tcl"](spec, args.module_set_name)

--- a/lib/spack/spack/modules/common.py
+++ b/lib/spack/spack/modules/common.py
@@ -28,11 +28,10 @@ import collections
 import contextlib
 import copy
 import datetime
-import inspect
 import os
 import re
 import string
-from typing import List, Optional
+from typing import Callable, ClassVar, List, Optional
 
 import spack.vendor.jinja2
 
@@ -57,13 +56,6 @@ import spack.util.path
 import spack.util.spack_yaml as syaml
 from spack.context import Context
 from spack.llnl.util.lang import Singleton, dedupe, memoized
-
-
-#: config section for this file
-def configuration(module_set_name):
-    config_path = f"modules:{module_set_name}"
-    return spack.config.get(config_path, {})
-
 
 #: Valid tokens for naming scheme and env variable names
 _valid_tokens = (
@@ -328,23 +320,27 @@ class BaseConfiguration:
 
     default_projections = {"all": "{name}/{version}-{compiler.name}-{compiler.version}"}
 
+    #: Name of the module system (must be set by each subclass)
+    module_system: str
+
+    #: Module-level helpers — each subclass assigns these as staticmethod(...)
+    configuration: ClassVar[Callable[..., dict]]
+    make_configuration: ClassVar[Callable[..., "BaseConfiguration"]]
+    make_layout: ClassVar[Callable[..., "BaseFileLayout"]]
+
     def __init__(self, spec: spack.spec.Spec, module_set_name: str, explicit: bool) -> None:
         # Spec for which we want to generate a module file
         self.spec = spec
         self.name = module_set_name
         self.explicit = explicit
         # Dictionary of configuration options that should be applied to the spec
-        self.conf = merge_config_rules(self.module.configuration(self.name), self.spec)
-
-    @property
-    def module(self):
-        return inspect.getmodule(self)
+        self.conf = merge_config_rules(self.configuration(self.name), self.spec)
 
     @property
     def projections(self):
         """Projection from specs to module names"""
         # backwards compatibility for naming_scheme key
-        conf = self.module.configuration(self.name)
+        conf = self.configuration(self.name)
         if "naming_scheme" in conf:
             default = {"all": conf["naming_scheme"]}
         else:
@@ -415,7 +411,7 @@ class BaseConfiguration:
 
         # A few variables for convenience of writing the method
         spec = self.spec
-        conf = self.module.configuration(self.name)
+        conf = self.configuration(self.name)
 
         # Compute the list of matching include / exclude rules, and whether excluded as implicit
         include_matches = [x for x in conf.get("include", []) if spec.satisfies(x)]
@@ -440,7 +436,7 @@ class BaseConfiguration:
     def hidden(self):
         """Returns True if the module has been hidden, False otherwise."""
 
-        conf = self.module.configuration(self.name)
+        conf = self.configuration(self.name)
 
         hidden_as_implicit = not self.explicit and conf.get("hide_implicits", False)
 
@@ -477,7 +473,7 @@ class BaseConfiguration:
     def _create_list_for(self, what):
         include = []
         for item in self.conf[what]:
-            if not self.module.make_configuration(item, self.name).excluded:
+            if not self.make_configuration(item, self.name).excluded:
                 include.append(item)
         return include
 
@@ -507,8 +503,7 @@ class BaseFileLayout:
 
     def dirname(self):
         """Root folder for module files of this type."""
-        module_system = str(self.conf.module.__name__).split(".")[-1]
-        return root_path(module_system, self.conf.name)
+        return root_path(self.conf.module_system, self.conf.name)
 
     @property
     def use_name(self):
@@ -759,9 +754,8 @@ class BaseContext(tengine.Context):
         return specs + literals
 
     def _create_module_list_of(self, what):
-        m = self.conf.module
         name = self.conf.name
-        return [m.make_layout(x, name).use_name for x in getattr(self.conf, what)]
+        return [self.conf.make_layout(x, name).use_name for x in getattr(self.conf, what)]
 
     @tengine.context_property
     def verbose(self):
@@ -774,17 +768,19 @@ class BaseModuleFileWriter:
     hide_cmd_format: str
     modulerc_header: List[str]
 
+    make_configuration: ClassVar[Callable[..., "BaseConfiguration"]]
+    make_layout: ClassVar[Callable[..., "BaseFileLayout"]]
+    make_context: ClassVar[Callable[..., "BaseContext"]]
+
     def __init__(
         self, spec: spack.spec.Spec, module_set_name: str, explicit: Optional[bool] = None
     ) -> None:
         self.spec = spec
 
-        m = self.module
-
         # Create the triplet of configuration/layout/context
-        self.conf = m.make_configuration(spec, module_set_name, explicit)
-        self.layout = m.make_layout(spec, module_set_name, explicit)
-        self.context = m.make_context(spec, module_set_name, explicit)
+        self.conf = self.make_configuration(spec, module_set_name, explicit)
+        self.layout = self.make_layout(spec, module_set_name, explicit)
+        self.context = self.make_context(spec, module_set_name, explicit)
 
         # Check if a default template has been defined,
         # throw if not found
@@ -816,18 +812,13 @@ class BaseModuleFileWriter:
             name = type(self).__name__
             raise ModulercHeaderNotDefined(msg.format(name))
 
-    @property
-    def module(self):
-        return inspect.getmodule(self)
-
     def _get_template(self):
         """Gets the template that will be rendered for this spec."""
         # Get templates and put them in the order of importance:
         # 1. template specified in "modules.yaml"
         # 2. template specified in a package directly
         # 3. default template (must be defined, check in __init__)
-        module_system_name = str(self.module.__name__).split(".")[-1]
-        package_attribute = f"{module_system_name}_template"
+        package_attribute = f"{self.conf.module_system}_template"
         choices = [
             self.conf.template,
             getattr(self.spec.package, package_attribute, None),
@@ -891,8 +882,7 @@ class BaseModuleFileWriter:
         context = self.context.to_dict()
 
         # Attribute from package
-        module_name = str(self.module.__name__).split(".")[-1]
-        attr_name = f"{module_name}_context"
+        attr_name = f"{self.conf.module_system}_context"
         pkg_update = getattr(self.spec.package, attr_name, {})
         context.update(pkg_update)
 

--- a/lib/spack/spack/modules/common.py
+++ b/lib/spack/spack/modules/common.py
@@ -469,7 +469,7 @@ class BaseConfiguration:
     def exclude_env_vars(self):
         """List of variables that should be left unmodified."""
         filter_subsection = self.conf.get("filter", {})
-        return filter_subsection.get("exclude_env_vars", {})
+        return filter_subsection.get("exclude_env_vars", [])
 
     def _create_list_for(self, what):
         include = []

--- a/lib/spack/spack/modules/common.py
+++ b/lib/spack/spack/modules/common.py
@@ -327,6 +327,7 @@ class BaseConfiguration:
     configuration: ClassVar[Callable[..., dict]]
     make_configuration: ClassVar[Callable[..., "BaseConfiguration"]]
     make_layout: ClassVar[Callable[..., "BaseFileLayout"]]
+    make_context: ClassVar[Callable[..., "BaseContext"]]
 
     def __init__(self, spec: spack.spec.Spec, module_set_name: str, explicit: bool) -> None:
         # Spec for which we want to generate a module file
@@ -551,8 +552,9 @@ class BaseContext(tengine.Context):
 
     """
 
-    def __init__(self, configuration):
+    def __init__(self, configuration, layout: "BaseFileLayout") -> None:
         self.conf = configuration
+        self.layout = layout
 
     @tengine.context_property
     def spec(self):
@@ -769,8 +771,6 @@ class BaseModuleFileWriter:
     modulerc_header: List[str]
 
     make_configuration: ClassVar[Callable[..., "BaseConfiguration"]]
-    make_layout: ClassVar[Callable[..., "BaseFileLayout"]]
-    make_context: ClassVar[Callable[..., "BaseContext"]]
 
     def __init__(
         self, spec: spack.spec.Spec, module_set_name: str, explicit: Optional[bool] = None
@@ -779,8 +779,8 @@ class BaseModuleFileWriter:
 
         # Create the triplet of configuration/layout/context
         self.conf = self.make_configuration(spec, module_set_name, explicit)
-        self.layout = self.make_layout(spec, module_set_name, explicit)
-        self.context = self.make_context(spec, module_set_name, explicit)
+        self.layout = self.conf.make_layout(spec, module_set_name, explicit)
+        self.context = self.conf.make_context(spec, module_set_name, explicit, self.layout)
 
         # Check if a default template has been defined,
         # throw if not found

--- a/lib/spack/spack/modules/common.py
+++ b/lib/spack/spack/modules/common.py
@@ -323,11 +323,14 @@ class BaseConfiguration:
     #: Name of the module system (must be set by each subclass)
     module_system: str
 
-    #: Module-level helpers — each subclass assigns these as staticmethod(...)
-    configuration: ClassVar[Callable[..., dict]]
     make_configuration: ClassVar[Callable[..., "BaseConfiguration"]]
     make_layout: ClassVar[Callable[..., "BaseFileLayout"]]
     make_context: ClassVar[Callable[..., "BaseContext"]]
+
+    @classmethod
+    def configuration(cls, module_set_name: str) -> dict:
+        """Returns the raw configuration dict for this module system."""
+        return spack.config.get(f"modules:{module_set_name}:{cls.module_system}", {})
 
     def __init__(self, spec: spack.spec.Spec, module_set_name: str, explicit: bool) -> None:
         # Spec for which we want to generate a module file

--- a/lib/spack/spack/modules/common.py
+++ b/lib/spack/spack/modules/common.py
@@ -31,7 +31,7 @@ import datetime
 import os
 import re
 import string
-from typing import Callable, ClassVar, List, Optional
+from typing import Callable, ClassVar, Dict, List, Optional, Tuple, Type
 
 import spack.vendor.jinja2
 
@@ -323,7 +323,9 @@ class BaseConfiguration:
     #: Name of the module system (must be set by each subclass)
     module_system: str
 
-    make_configuration: ClassVar[Callable[..., "BaseConfiguration"]]
+    #: Per-subclass cache: must be assigned as ClassVar[Dict] = {} in each concrete subclass
+    _registry: ClassVar[Dict[Tuple[str, str, bool], "BaseConfiguration"]]
+
     make_layout: ClassVar[Callable[..., "BaseFileLayout"]]
     make_context: ClassVar[Callable[..., "BaseContext"]]
 
@@ -331,6 +333,18 @@ class BaseConfiguration:
     def configuration(cls, module_set_name: str) -> dict:
         """Returns the raw configuration dict for this module system."""
         return spack.config.get(f"modules:{module_set_name}:{cls.module_system}", {})
+
+    @classmethod
+    def make_configuration(
+        cls, spec: spack.spec.Spec, module_set_name: str, explicit: Optional[bool] = None
+    ) -> "BaseConfiguration":
+        """Returns the cached configuration object for spec."""
+        explicit = bool(spec._installed_explicitly()) if explicit is None else explicit
+        key = (spec.dag_hash(), module_set_name, explicit)
+        try:
+            return cls._registry[key]
+        except KeyError:
+            return cls._registry.setdefault(key, cls(spec, module_set_name, explicit))
 
     def __init__(self, spec: spack.spec.Spec, module_set_name: str, explicit: bool) -> None:
         # Spec for which we want to generate a module file
@@ -773,7 +787,7 @@ class BaseModuleFileWriter:
     hide_cmd_format: str
     modulerc_header: List[str]
 
-    make_configuration: ClassVar[Callable[..., "BaseConfiguration"]]
+    configuration_class: ClassVar[Type["BaseConfiguration"]]
 
     def __init__(
         self, spec: spack.spec.Spec, module_set_name: str, explicit: Optional[bool] = None
@@ -781,7 +795,7 @@ class BaseModuleFileWriter:
         self.spec = spec
 
         # Create the triplet of configuration/layout/context
-        self.conf = self.make_configuration(spec, module_set_name, explicit)
+        self.conf = self.configuration_class.make_configuration(spec, module_set_name, explicit)
         self.layout = self.conf.make_layout(spec, module_set_name, explicit)
         self.context = self.conf.make_context(
             spec, module_set_name, explicit=explicit, layout=self.layout

--- a/lib/spack/spack/modules/common.py
+++ b/lib/spack/spack/modules/common.py
@@ -780,7 +780,9 @@ class BaseModuleFileWriter:
         # Create the triplet of configuration/layout/context
         self.conf = self.make_configuration(spec, module_set_name, explicit)
         self.layout = self.conf.make_layout(spec, module_set_name, explicit)
-        self.context = self.conf.make_context(spec, module_set_name, explicit, self.layout)
+        self.context = self.conf.make_context(
+            spec, module_set_name, explicit=explicit, layout=self.layout
+        )
 
         # Check if a default template has been defined,
         # throw if not found

--- a/lib/spack/spack/modules/lmod.py
+++ b/lib/spack/spack/modules/lmod.py
@@ -55,14 +55,12 @@ def make_layout(
 def make_context(
     spec: spack.spec.Spec,
     module_set_name: str,
+    *,
     explicit: Optional[bool] = None,
-    layout: Optional[BaseFileLayout] = None,
+    layout: BaseFileLayout,
 ) -> BaseContext:
     """Returns the context information for spec"""
-    conf = make_configuration(spec, module_set_name, explicit)
-    if layout is None:
-        layout = make_layout(spec, module_set_name, explicit)
-    return LmodContext(conf, layout)
+    return LmodContext(make_configuration(spec, module_set_name, explicit), layout)
 
 
 def guess_core_compilers(name, store=False) -> List[spack.spec.Spec]:

--- a/lib/spack/spack/modules/lmod.py
+++ b/lib/spack/spack/modules/lmod.py
@@ -21,12 +21,6 @@ from spack.aliases import BUILTIN_TO_LEGACY_COMPILER
 
 from .common import BaseConfiguration, BaseContext, BaseFileLayout, BaseModuleFileWriter
 
-
-#: lmod specific part of the configuration
-def configuration(module_set_name: str) -> dict:
-    return spack.config.get(f"modules:{module_set_name}:lmod", {})
-
-
 # Caches the configuration {spec_hash: configuration}
 configuration_registry: Dict[Tuple[str, str, bool], BaseConfiguration] = {}
 
@@ -83,7 +77,6 @@ class LmodConfiguration(BaseConfiguration):
     """Configuration class for lmod module files."""
 
     module_system = "lmod"
-    configuration = staticmethod(configuration)
     make_configuration = staticmethod(make_configuration)
 
     @staticmethod
@@ -137,7 +130,7 @@ class LmodConfiguration(BaseConfiguration):
                 the sequence is empty
         """
         compilers = []
-        for c in configuration(self.name).get("core_compilers", []):
+        for c in self.configuration(self.name).get("core_compilers", []):
             compilers.extend(spack.spec.Spec(f"%{c}").dependencies())
 
         if not compilers:
@@ -152,12 +145,12 @@ class LmodConfiguration(BaseConfiguration):
     @property
     def core_specs(self):
         """Returns the list of "Core" specs"""
-        return configuration(self.name).get("core_specs", [])
+        return self.configuration(self.name).get("core_specs", [])
 
     @property
     def filter_hierarchy_specs(self):
         """Returns the dict of specs with modified hierarchies"""
-        return configuration(self.name).get("filter_hierarchy_specs", {})
+        return self.configuration(self.name).get("filter_hierarchy_specs", {})
 
     @property
     @lang.memoized
@@ -165,7 +158,7 @@ class LmodConfiguration(BaseConfiguration):
         """Returns the list of tokens that are part of the modulefile
         hierarchy. ``compiler`` is always present.
         """
-        tokens = configuration(self.name).get("hierarchy", [])
+        tokens = self.configuration(self.name).get("hierarchy", [])
 
         # Append 'compiler' which is always implied
         tokens.append("compiler")

--- a/lib/spack/spack/modules/lmod.py
+++ b/lib/spack/spack/modules/lmod.py
@@ -77,13 +77,14 @@ def guess_core_compilers(name, store=False) -> List[spack.spec.Spec]:
     """
     core_compilers = []
     for compiler in spack.compilers.config.all_compilers(init_config=False):
-        try:
-            cc_dir = pathlib.Path(compiler.package.cc).parent
-            is_system_compiler = str(cc_dir) in spack.util.environment.SYSTEM_DIRS
-            if is_system_compiler:
-                core_compilers.append(compiler)
-        except (KeyError, TypeError, AttributeError):
-            continue
+        for attr in ("cc", "cxx", "fc"):
+            try:
+                path = getattr(compiler.package, attr)
+                if path and str(pathlib.Path(path).parent) in spack.util.environment.SYSTEM_DIRS:
+                    core_compilers.append(compiler)
+                    break
+            except (KeyError, TypeError, AttributeError):
+                continue
 
     if store and core_compilers:
         # If we asked to store core compilers, update the entry

--- a/lib/spack/spack/modules/lmod.py
+++ b/lib/spack/spack/modules/lmod.py
@@ -7,7 +7,7 @@ import itertools
 import os
 import pathlib
 import warnings
-from typing import Dict, List, Optional, Tuple
+from typing import ClassVar, Dict, List, Optional
 
 import spack.compilers.config
 import spack.config
@@ -20,23 +20,6 @@ import spack.util.environment
 from spack.aliases import BUILTIN_TO_LEGACY_COMPILER
 
 from .common import BaseConfiguration, BaseContext, BaseFileLayout, BaseModuleFileWriter
-
-# Caches the configuration {spec_hash: configuration}
-configuration_registry: Dict[Tuple[str, str, bool], BaseConfiguration] = {}
-
-
-def make_configuration(
-    spec: spack.spec.Spec, module_set_name: str, explicit: Optional[bool] = None
-) -> BaseConfiguration:
-    """Returns the lmod configuration for spec"""
-    explicit = bool(spec._installed_explicitly()) if explicit is None else explicit
-    key = (spec.dag_hash(), module_set_name, explicit)
-    try:
-        return configuration_registry[key]
-    except KeyError:
-        return configuration_registry.setdefault(
-            key, LmodConfiguration(spec, module_set_name, explicit)
-        )
 
 
 def guess_core_compilers(name, store=False) -> List[spack.spec.Spec]:
@@ -77,13 +60,14 @@ class LmodConfiguration(BaseConfiguration):
     """Configuration class for lmod module files."""
 
     module_system = "lmod"
-    make_configuration = staticmethod(make_configuration)
+    _registry: ClassVar[Dict] = {}
 
     @staticmethod
     def make_layout(
         spec: spack.spec.Spec, module_set_name: str, explicit: Optional[bool] = None
     ) -> BaseFileLayout:
-        return LmodFileLayout(make_configuration(spec, module_set_name, explicit))
+        configuration = LmodConfiguration.make_configuration(spec, module_set_name, explicit)
+        return LmodFileLayout(configuration)
 
     @staticmethod
     def make_context(
@@ -93,7 +77,8 @@ class LmodConfiguration(BaseConfiguration):
         explicit: Optional[bool] = None,
         layout: BaseFileLayout,
     ) -> BaseContext:
-        return LmodContext(make_configuration(spec, module_set_name, explicit), layout)
+        configuration = LmodConfiguration.make_configuration(spec, module_set_name, explicit)
+        return LmodContext(configuration, layout)
 
     default_projections = {"all": "{name}/{version}"}
 
@@ -484,7 +469,7 @@ class LmodContext(BaseContext):
 class LmodModulefileWriter(BaseModuleFileWriter):
     """Writer class for lmod module files."""
 
-    make_configuration = staticmethod(make_configuration)
+    configuration_class = LmodConfiguration
 
     default_template = "modules/modulefile.lua"
 

--- a/lib/spack/spack/modules/lmod.py
+++ b/lib/spack/spack/modules/lmod.py
@@ -45,24 +45,6 @@ def make_configuration(
         )
 
 
-def make_layout(
-    spec: spack.spec.Spec, module_set_name: str, explicit: Optional[bool] = None
-) -> BaseFileLayout:
-    """Returns the layout information for spec"""
-    return LmodFileLayout(make_configuration(spec, module_set_name, explicit))
-
-
-def make_context(
-    spec: spack.spec.Spec,
-    module_set_name: str,
-    *,
-    explicit: Optional[bool] = None,
-    layout: BaseFileLayout,
-) -> BaseContext:
-    """Returns the context information for spec"""
-    return LmodContext(make_configuration(spec, module_set_name, explicit), layout)
-
-
 def guess_core_compilers(name, store=False) -> List[spack.spec.Spec]:
     """Guesses the list of core compilers installed in the system.
 
@@ -103,8 +85,22 @@ class LmodConfiguration(BaseConfiguration):
     module_system = "lmod"
     configuration = staticmethod(configuration)
     make_configuration = staticmethod(make_configuration)
-    make_layout = staticmethod(make_layout)
-    make_context = staticmethod(make_context)
+
+    @staticmethod
+    def make_layout(
+        spec: spack.spec.Spec, module_set_name: str, explicit: Optional[bool] = None
+    ) -> BaseFileLayout:
+        return LmodFileLayout(make_configuration(spec, module_set_name, explicit))
+
+    @staticmethod
+    def make_context(
+        spec: spack.spec.Spec,
+        module_set_name: str,
+        *,
+        explicit: Optional[bool] = None,
+        layout: BaseFileLayout,
+    ) -> BaseContext:
+        return LmodContext(make_configuration(spec, module_set_name, explicit), layout)
 
     default_projections = {"all": "{name}/{version}"}
 

--- a/lib/spack/spack/modules/lmod.py
+++ b/lib/spack/spack/modules/lmod.py
@@ -53,10 +53,16 @@ def make_layout(
 
 
 def make_context(
-    spec: spack.spec.Spec, module_set_name: str, explicit: Optional[bool] = None
+    spec: spack.spec.Spec,
+    module_set_name: str,
+    explicit: Optional[bool] = None,
+    layout: Optional[BaseFileLayout] = None,
 ) -> BaseContext:
     """Returns the context information for spec"""
-    return LmodContext(make_configuration(spec, module_set_name, explicit))
+    conf = make_configuration(spec, module_set_name, explicit)
+    if layout is None:
+        layout = make_layout(spec, module_set_name, explicit)
+    return LmodContext(conf, layout)
 
 
 def guess_core_compilers(name, store=False) -> List[spack.spec.Spec]:
@@ -99,6 +105,7 @@ class LmodConfiguration(BaseConfiguration):
     configuration = staticmethod(configuration)
     make_configuration = staticmethod(make_configuration)
     make_layout = staticmethod(make_layout)
+    make_context = staticmethod(make_context)
 
     default_projections = {"all": "{name}/{version}"}
 
@@ -462,19 +469,17 @@ class LmodContext(BaseContext):
     @lang.memoized
     def unlocked_paths(self):
         """Returns the list of paths that are unlocked unconditionally."""
-        layout = make_layout(self.spec, self.conf.name)
-        return [os.path.join(*parts) for parts in layout.unlocked_paths[None]]
+        return [os.path.join(*parts) for parts in self.layout.unlocked_paths[None]]
 
     @tengine.context_property
     def conditionally_unlocked_paths(self):
         """Returns the list of paths that are unlocked conditionally.
         Each item in the list is a tuple with the structure (condition, path).
         """
-        layout = make_layout(self.spec, self.conf.name)
         value = []
-        conditional_paths = layout.unlocked_paths
-        conditional_paths.pop(None)
-        for services_needed, list_of_path_parts in conditional_paths.items():
+        for services_needed, list_of_path_parts in self.layout.unlocked_paths.items():
+            if services_needed is None:
+                continue
             condition = " and ".join([x + "_name" for x in services_needed])
             for parts in list_of_path_parts:
 
@@ -484,7 +489,6 @@ class LmodContext(BaseContext):
                     return '"' + token + '"'
 
                 path = ", ".join([manipulate_path(x) for x in parts])
-
                 value.append((condition, path))
         return value
 
@@ -493,8 +497,6 @@ class LmodModulefileWriter(BaseModuleFileWriter):
     """Writer class for lmod module files."""
 
     make_configuration = staticmethod(make_configuration)
-    make_layout = staticmethod(make_layout)
-    make_context = staticmethod(make_context)
 
     default_template = "modules/modulefile.lua"
 

--- a/lib/spack/spack/modules/lmod.py
+++ b/lib/spack/spack/modules/lmod.py
@@ -95,6 +95,11 @@ def guess_core_compilers(name, store=False) -> List[spack.spec.Spec]:
 class LmodConfiguration(BaseConfiguration):
     """Configuration class for lmod module files."""
 
+    module_system = "lmod"
+    configuration = staticmethod(configuration)
+    make_configuration = staticmethod(make_configuration)
+    make_layout = staticmethod(make_layout)
+
     default_projections = {"all": "{name}/{version}"}
 
     compiler: Optional[spack.spec.Spec]
@@ -486,6 +491,10 @@ class LmodContext(BaseContext):
 
 class LmodModulefileWriter(BaseModuleFileWriter):
     """Writer class for lmod module files."""
+
+    make_configuration = staticmethod(make_configuration)
+    make_layout = staticmethod(make_layout)
+    make_context = staticmethod(make_context)
 
     default_template = "modules/modulefile.lua"
 

--- a/lib/spack/spack/modules/tcl.py
+++ b/lib/spack/spack/modules/tcl.py
@@ -39,32 +39,28 @@ def make_configuration(
         )
 
 
-def make_layout(
-    spec: spack.spec.Spec, module_set_name: str, explicit: Optional[bool] = None
-) -> BaseFileLayout:
-    """Returns the layout information for spec"""
-    return TclFileLayout(make_configuration(spec, module_set_name, explicit))
-
-
-def make_context(
-    spec: spack.spec.Spec,
-    module_set_name: str,
-    *,
-    explicit: Optional[bool] = None,
-    layout: BaseFileLayout,
-) -> BaseContext:
-    """Returns the context information for spec"""
-    return TclContext(make_configuration(spec, module_set_name, explicit), layout)
-
-
 class TclConfiguration(BaseConfiguration):
     """Configuration class for tcl module files."""
 
     module_system = "tcl"
     configuration = staticmethod(configuration)
     make_configuration = staticmethod(make_configuration)
-    make_layout = staticmethod(make_layout)
-    make_context = staticmethod(make_context)
+
+    @staticmethod
+    def make_layout(
+        spec: spack.spec.Spec, module_set_name: str, explicit: Optional[bool] = None
+    ) -> BaseFileLayout:
+        return TclFileLayout(make_configuration(spec, module_set_name, explicit))
+
+    @staticmethod
+    def make_context(
+        spec: spack.spec.Spec,
+        module_set_name: str,
+        *,
+        explicit: Optional[bool] = None,
+        layout: BaseFileLayout,
+    ) -> BaseContext:
+        return TclContext(make_configuration(spec, module_set_name, explicit), layout)
 
 
 class TclFileLayout(BaseFileLayout):

--- a/lib/spack/spack/modules/tcl.py
+++ b/lib/spack/spack/modules/tcl.py
@@ -49,14 +49,12 @@ def make_layout(
 def make_context(
     spec: spack.spec.Spec,
     module_set_name: str,
+    *,
     explicit: Optional[bool] = None,
-    layout: Optional[BaseFileLayout] = None,
+    layout: BaseFileLayout,
 ) -> BaseContext:
     """Returns the context information for spec"""
-    conf = make_configuration(spec, module_set_name, explicit)
-    if layout is None:
-        layout = make_layout(spec, module_set_name, explicit)
-    return TclContext(conf, layout)
+    return TclContext(make_configuration(spec, module_set_name, explicit), layout)
 
 
 class TclConfiguration(BaseConfiguration):

--- a/lib/spack/spack/modules/tcl.py
+++ b/lib/spack/spack/modules/tcl.py
@@ -7,42 +7,25 @@ non-hierarchical modules.
 """
 
 import os
-from typing import Dict, Optional, Tuple
+from typing import ClassVar, Dict, Optional
 
 import spack.spec
 import spack.tengine as tengine
 
 from .common import BaseConfiguration, BaseContext, BaseFileLayout, BaseModuleFileWriter
 
-# Caches the configuration {spec_hash: configuration}
-configuration_registry: Dict[Tuple[str, str, bool], BaseConfiguration] = {}
-
-
-def make_configuration(
-    spec: spack.spec.Spec, module_set_name: str, explicit: Optional[bool] = None
-) -> BaseConfiguration:
-    """Returns the tcl configuration for spec"""
-    explicit = bool(spec._installed_explicitly()) if explicit is None else explicit
-    key = (spec.dag_hash(), module_set_name, explicit)
-    try:
-        return configuration_registry[key]
-    except KeyError:
-        return configuration_registry.setdefault(
-            key, TclConfiguration(spec, module_set_name, explicit)
-        )
-
 
 class TclConfiguration(BaseConfiguration):
     """Configuration class for tcl module files."""
 
     module_system = "tcl"
-    make_configuration = staticmethod(make_configuration)
+    _registry: ClassVar[Dict] = {}
 
     @staticmethod
     def make_layout(
         spec: spack.spec.Spec, module_set_name: str, explicit: Optional[bool] = None
     ) -> BaseFileLayout:
-        return TclFileLayout(make_configuration(spec, module_set_name, explicit))
+        return TclFileLayout(TclConfiguration.make_configuration(spec, module_set_name, explicit))
 
     @staticmethod
     def make_context(
@@ -52,7 +35,8 @@ class TclConfiguration(BaseConfiguration):
         explicit: Optional[bool] = None,
         layout: BaseFileLayout,
     ) -> BaseContext:
-        return TclContext(make_configuration(spec, module_set_name, explicit), layout)
+        configuration = TclConfiguration.make_configuration(spec, module_set_name, explicit)
+        return TclContext(configuration, layout)
 
 
 class TclFileLayout(BaseFileLayout):
@@ -76,7 +60,7 @@ class TclContext(BaseContext):
 class TclModulefileWriter(BaseModuleFileWriter):
     """Writer class for tcl module files."""
 
-    make_configuration = staticmethod(make_configuration)
+    configuration_class = TclConfiguration
 
     default_template = "modules/modulefile.tcl"
 

--- a/lib/spack/spack/modules/tcl.py
+++ b/lib/spack/spack/modules/tcl.py
@@ -47,10 +47,16 @@ def make_layout(
 
 
 def make_context(
-    spec: spack.spec.Spec, module_set_name: str, explicit: Optional[bool] = None
+    spec: spack.spec.Spec,
+    module_set_name: str,
+    explicit: Optional[bool] = None,
+    layout: Optional[BaseFileLayout] = None,
 ) -> BaseContext:
     """Returns the context information for spec"""
-    return TclContext(make_configuration(spec, module_set_name, explicit))
+    conf = make_configuration(spec, module_set_name, explicit)
+    if layout is None:
+        layout = make_layout(spec, module_set_name, explicit)
+    return TclContext(conf, layout)
 
 
 class TclConfiguration(BaseConfiguration):
@@ -60,6 +66,7 @@ class TclConfiguration(BaseConfiguration):
     configuration = staticmethod(configuration)
     make_configuration = staticmethod(make_configuration)
     make_layout = staticmethod(make_layout)
+    make_context = staticmethod(make_context)
 
 
 class TclFileLayout(BaseFileLayout):
@@ -84,8 +91,6 @@ class TclModulefileWriter(BaseModuleFileWriter):
     """Writer class for tcl module files."""
 
     make_configuration = staticmethod(make_configuration)
-    make_layout = staticmethod(make_layout)
-    make_context = staticmethod(make_context)
 
     default_template = "modules/modulefile.tcl"
 

--- a/lib/spack/spack/modules/tcl.py
+++ b/lib/spack/spack/modules/tcl.py
@@ -56,6 +56,11 @@ def make_context(
 class TclConfiguration(BaseConfiguration):
     """Configuration class for tcl module files."""
 
+    module_system = "tcl"
+    configuration = staticmethod(configuration)
+    make_configuration = staticmethod(make_configuration)
+    make_layout = staticmethod(make_layout)
+
 
 class TclFileLayout(BaseFileLayout):
     """File layout for tcl module files."""
@@ -77,6 +82,10 @@ class TclContext(BaseContext):
 
 class TclModulefileWriter(BaseModuleFileWriter):
     """Writer class for tcl module files."""
+
+    make_configuration = staticmethod(make_configuration)
+    make_layout = staticmethod(make_layout)
+    make_context = staticmethod(make_context)
 
     default_template = "modules/modulefile.tcl"
 

--- a/lib/spack/spack/modules/tcl.py
+++ b/lib/spack/spack/modules/tcl.py
@@ -9,17 +9,10 @@ non-hierarchical modules.
 import os
 from typing import Dict, Optional, Tuple
 
-import spack.config
 import spack.spec
 import spack.tengine as tengine
 
 from .common import BaseConfiguration, BaseContext, BaseFileLayout, BaseModuleFileWriter
-
-
-#: Tcl specific part of the configuration
-def configuration(module_set_name: str) -> dict:
-    return spack.config.get(f"modules:{module_set_name}:tcl", {})
-
 
 # Caches the configuration {spec_hash: configuration}
 configuration_registry: Dict[Tuple[str, str, bool], BaseConfiguration] = {}
@@ -43,7 +36,6 @@ class TclConfiguration(BaseConfiguration):
     """Configuration class for tcl module files."""
 
     module_system = "tcl"
-    configuration = staticmethod(configuration)
     make_configuration = staticmethod(make_configuration)
 
     @staticmethod

--- a/lib/spack/spack/test/cmd/env.py
+++ b/lib/spack/spack/test/cmd/env.py
@@ -3653,7 +3653,7 @@ spack:
 
 def test_modules_exist_after_env_install(installed_environment, monkeypatch):
     # Some caching issue
-    monkeypatch.setattr(spack.modules.tcl, "configuration_registry", {})
+    monkeypatch.setattr(spack.modules.tcl.TclConfiguration, "_registry", {})
     with installed_environment(
         """
 spack:

--- a/lib/spack/spack/test/conftest.py
+++ b/lib/spack/spack/test/conftest.py
@@ -1379,7 +1379,6 @@ class ConfigUpdate:
         spack.config.set("modules:default", config_settings)
         mock_config = MockConfig(config_settings, self.writer_key)
 
-        self.monkeypatch.setattr(spack.modules.common, "configuration", mock_config.configuration)
         self.monkeypatch.setattr(
             self.writer_mod, "configuration", mock_config.writer_configuration
         )

--- a/lib/spack/spack/test/conftest.py
+++ b/lib/spack/spack/test/conftest.py
@@ -1379,8 +1379,9 @@ class ConfigUpdate:
         spack.config.set("modules:default", config_settings)
         mock_config = MockConfig(config_settings, self.writer_key)
 
+        conf_cls = getattr(self.writer_mod, self.writer_key.capitalize() + "Configuration")
         self.monkeypatch.setattr(
-            self.writer_mod, "configuration", mock_config.writer_configuration
+            conf_cls, "configuration", staticmethod(mock_config.writer_configuration)
         )
         self.monkeypatch.setattr(self.writer_mod, "configuration_registry", {})
 

--- a/lib/spack/spack/test/conftest.py
+++ b/lib/spack/spack/test/conftest.py
@@ -1383,7 +1383,7 @@ class ConfigUpdate:
         self.monkeypatch.setattr(
             conf_cls, "configuration", staticmethod(mock_config.writer_configuration)
         )
-        self.monkeypatch.setattr(self.writer_mod, "configuration_registry", {})
+        self.monkeypatch.setattr(conf_cls, "_registry", {})
 
 
 @pytest.fixture()


### PR DESCRIPTION
Extracted (and extended) from #52024

Modifications:
- Replace `inspect.getmodule()` calls with explicit `ClassVar` attributes
- Consolidate factories into `BaseConfiguration`, so each writer subclass only declares `configuration_class`
- `exclude_env_vars` returned `{}` instead of `[]`. Now fixed
- `guess_core_compilers` only checked `cc`. Now checks `cxx` and `fc` too
