### PR TITLE
new_installer.py: no jobserver on windows

### DIFF
--- a/lib/spack/spack/new_installer.py
+++ b/lib/spack/spack/new_installer.py
@@ -37,6 +37,7 @@ from multiprocessing import Pipe, Process
 from multiprocessing.connection import Connection
 from typing import (
     TYPE_CHECKING,
+    Any,
     Callable,
     Dict,
     FrozenSet,
@@ -79,6 +80,7 @@ from spack.new_installer_base import (
     BaseTerminalState,
     DatabaseAction,
     FdInfo,
+    JobServerBase,
     StdinReaderBase,
 )
 from spack.subprocess_context import GlobalStateMarshaler
@@ -87,9 +89,11 @@ from spack.util.log_parse import make_log_context, parse_log_events
 from spack.util.path import padding_filter, padding_filter_bytes
 
 if sys.platform == "win32":
+    from spack.new_installer_base import NoopJobServer as JobServer
     from spack.new_installer_windows import WindowsTerminalState as TerminalState
 else:
-    from spack.new_installer_posix import PosixChildInfo, PosixJobServer, PosixTee
+    from spack.new_installer_posix import PosixChildInfo, PosixTee
+    from spack.new_installer_posix import PosixJobServer as JobServer
     from spack.new_installer_posix import PosixTerminalState as TerminalState
 
 if TYPE_CHECKING:
@@ -285,9 +289,7 @@ def worker_function(
     state: Connection,
     parent: Connection,
     echo_control: Connection,
-    makeflags: str,
-    js1: Optional[Connection],
-    js2: Optional[Connection],
+    jobserver_info: Tuple[Optional[str], Any],
     log_path: str,
     global_state: GlobalStateMarshaler,
     stop_before: Optional[str] = None,
@@ -312,9 +314,9 @@ def worker_function(
         state: Connection to send state updates to
         parent: Connection to send build output to
         echo_control: Connection to receive echo control messages from
-        makeflags: MAKEFLAGS to set, so that the build process uses the POSIX jobserver
-        js1: Connection for old style jobserver read fd (if any). Unused, just to inherit fd.
-        js2: Connection for old style jobserver write fd (if any). Unused, just to inherit fd.
+        jobserver_info: MAKEFLAGS to set, so that the build process uses the POSIX jobserver, and
+            opaque data only to be serialized (e.g. old style jobserver r/w pipes, only to be
+            inherited in the build process)
         log_path: Path to the log file to write build output to
         global_state: Global state to restore
     """
@@ -351,7 +353,9 @@ def worker_function(
 
     signal.signal(signal.SIGTERM, handle_sigterm)
 
-    os.environ["MAKEFLAGS"] = makeflags
+    makeflags, _ = jobserver_info
+    if makeflags is not None:
+        os.environ["MAKEFLAGS"] = makeflags
 
     # Force line buffering for Python's textio wrappers of stdout/stderr. We're not going to print
     # much ourselves, but what we print should appear before output from `make` and other build
@@ -695,7 +699,7 @@ def start_build(
     fake: bool,
     install_source: bool,
     run_tests: bool,
-    jobserver: PosixJobServer,
+    jobserver: JobServerBase,
     log_path: str,
     stop_before: Optional[str] = None,
     stop_at: Optional[str] = None,
@@ -709,8 +713,7 @@ def start_build(
     # Obtain the MAKEFLAGS to be set in the child process, and determine whether it's necessary
     # for the child process to inherit our jobserver fds.
     gmake = next(iter(spec.dependencies("gmake")), None)
-    makeflags = jobserver.makeflags(gmake)
-    fifo = "--jobserver-auth=fifo:" in makeflags
+    jobserver_details = jobserver.makeflags_and_data(gmake)
 
     # As a performance optimization, we do not serialize the environment which
     # is slow to serialize and not needed in the build job
@@ -733,9 +736,7 @@ def start_build(
             state_w_conn,
             output_w_conn,
             control_r_conn,
-            makeflags,
-            None if fifo else jobserver.r_conn,
-            None if fifo else jobserver.w_conn,
+            jobserver_details,
             log_path,
             GlobalStateMarshaler(serialize_env=False),
             stop_before,
@@ -1605,7 +1606,7 @@ def schedule_builds(
     overwrite_time: float,
     capacity: int,
     needs_jobserver_token: bool,
-    jobserver: PosixJobServer,
+    jobserver: JobServerBase,
     explicit: Set[str],
 ) -> ScheduleResult:
     """Try to schedule as many pending builds as possible.
@@ -2009,7 +2010,7 @@ class PackageInstaller:
 
     def _installer(self) -> None:
         spack.store.STORE.install_sbang()
-        jobserver = PosixJobServer(self.jobs)
+        jobserver = JobServer(self.jobs)
         selector = selectors.DefaultSelector()
 
         # Set up terminal handling (cbreak, signals, stdin registration)
@@ -2050,16 +2051,13 @@ class PackageInstaller:
                 # Monitor the jobserver when we have pending builds, capacity, and at least one
                 # spec is not locked by another process. Also listen if the target parallelism is
                 # reduced.
-                wake_on_jobserver = (
+                wake_on_jobserver = bool(
                     self.pending_builds
                     and self.capacity
                     and not blocked
                     or not jobserver.has_target_parallelism()
                 )
-                if wake_on_jobserver and jobserver.r not in selector.get_map():
-                    selector.register(jobserver.r, selectors.EVENT_READ, "jobserver")
-                elif not wake_on_jobserver and jobserver.r in selector.get_map():
-                    selector.unregister(jobserver.r)
+                jobserver.update_selector(selector, wake_on_jobserver)
 
                 stdin_ready = False
 
@@ -2100,7 +2098,7 @@ class PackageInstaller:
                         terminal.drain_sigwinch()
                         self.build_status.on_resize()
                     elif data == "jobserver" and not jobserver.has_target_parallelism():
-                        jobserver.maybe_discard_tokens()
+                        jobserver._maybe_discard_tokens()
                         self.build_status.set_jobs(jobserver.num_jobs, jobserver.target_jobs)
 
                 current_time = time.monotonic()
@@ -2261,7 +2259,7 @@ class PackageInstaller:
         self,
         pid: int,
         current_time: float,
-        jobserver: PosixJobServer,
+        jobserver: JobServerBase,
         selector: selectors.BaseSelector,
         failures: List[spack.spec.Spec],
         database_actions: List[DatabaseAction],
@@ -2368,7 +2366,7 @@ class PackageInstaller:
     def _schedule_builds(
         self,
         selector: selectors.BaseSelector,
-        jobserver: PosixJobServer,
+        jobserver: JobServerBase,
         retained_read_locks: List[spack.util.lock.Lock],
         database_actions: List[DatabaseAction],
     ) -> bool:
@@ -2428,7 +2426,7 @@ class PackageInstaller:
     def _start(
         self,
         selector: selectors.BaseSelector,
-        jobserver: PosixJobServer,
+        jobserver: JobServerBase,
         dag_hash: str,
         prefix_lock: spack.util.lock.Lock,
     ) -> None:

--- a/lib/spack/spack/new_installer_base.py
+++ b/lib/spack/spack/new_installer_base.py
@@ -13,9 +13,10 @@ import codecs
 import re
 import selectors
 import sys
-from typing import TYPE_CHECKING, Callable, Optional
+from typing import TYPE_CHECKING, Any, Callable, Optional, Tuple
 
 import spack.database
+import spack.spec
 import spack.util.lock
 
 if TYPE_CHECKING:
@@ -120,7 +121,7 @@ class DatabaseAction:
 
     __slots__ = ("spec", "prefix_lock")
 
-    spec: "spack.spec.Spec"
+    spec: spack.spec.Spec
     prefix_lock: Optional[spack.util.lock.Lock]
 
     def save_to_db(self, db: spack.database.Database) -> None: ...
@@ -142,3 +143,70 @@ class FdInfo:
     def __init__(self, pid: int, name: str) -> None:
         self.pid = pid
         self.name = name
+
+
+class JobServerBase(abc.ABC):
+    """Abstract base for controlling build concurrency."""
+
+    def __init__(self, num_jobs: int) -> None:
+        #: The number of jobs to run concurrently
+        self.num_jobs = num_jobs
+        #: The target number of jobs to run concurrently, which may differ from num_jobs if the
+        #: user has requested a decrease in parallelism, but we haven't consumed enough tokens to
+        #: reflect that yet. This value is used in the UI. The value self.target_jobs can only be
+        #: modified if Spack owns the jobserver, and not when it's attached to a parent jobserver.
+        self.target_jobs = num_jobs
+
+    def has_target_parallelism(self) -> bool:
+        return self.num_jobs == self.target_jobs
+
+    @abc.abstractmethod
+    def makeflags_and_data(self, gmake: Optional[spack.spec.Spec]) -> Tuple[Optional[str], Any]:
+        """Return a tuple of (makeflags, data) to be passed to the child process. The makeflags are
+        meant to be set in the child process's environment, and the data is implementation specific
+        data serialized and sent to the child process for jobserver support."""
+
+    @abc.abstractmethod
+    def update_selector(self, selector: selectors.BaseSelector, wake: bool) -> None:
+        """Listen or stop listening for jobserver events on the given selector."""
+
+    @abc.abstractmethod
+    def increase_parallelism(self) -> None:
+        """Increase the target parallelism by one."""
+
+    @abc.abstractmethod
+    def decrease_parallelism(self) -> None:
+        """Decrease the target parallelism by one."""
+
+    @abc.abstractmethod
+    def acquire(self, jobs: int) -> int:
+        """Try and acquire at most 'jobs' tokens from the jobserver. Returns the number of tokens
+        actually acquired (may be less than requested, or zero)."""
+
+    @abc.abstractmethod
+    def release(self) -> None:
+        """Release a token back to the jobserver."""
+
+    @abc.abstractmethod
+    def close(self) -> None:
+        """Close any resources associated with the jobserver."""
+
+
+class NoopJobServer(JobServerBase):
+    """Dummy jobserver for platforms lacking jobserver support."""
+
+    def makeflags_and_data(self, gmake: Optional[spack.spec.Spec]) -> Tuple[Optional[str], Any]:
+        return (None, None)
+
+    def update_selector(self, selector: selectors.BaseSelector, wake: bool) -> None: ...
+
+    def increase_parallelism(self) -> None: ...
+
+    def decrease_parallelism(self) -> None: ...
+
+    def acquire(self, jobs: int) -> int:
+        return 0
+
+    def release(self) -> None: ...
+
+    def close(self) -> None: ...

--- a/lib/spack/spack/new_installer_posix.py
+++ b/lib/spack/spack/new_installer_posix.py
@@ -18,7 +18,7 @@ import tty
 import warnings
 from multiprocessing import Process
 from multiprocessing.connection import Connection
-from typing import TYPE_CHECKING, Callable, Optional, Tuple, Union
+from typing import TYPE_CHECKING, Any, Callable, Optional, Tuple, Union
 
 import spack.database
 import spack.llnl.util.tty
@@ -30,6 +30,7 @@ from spack.new_installer_base import (
     BaseTerminalState,
     DatabaseAction,
     FdInfo,
+    JobServerBase,
     StdinReaderBase,
 )
 
@@ -328,20 +329,13 @@ class PosixTee:
         self.parent.close()
 
 
-class PosixJobServer:
+class PosixJobServer(JobServerBase):
     """Attach to an existing POSIX jobserver or create a FIFO-based one."""
 
     def __init__(self, num_jobs: int) -> None:
+        super().__init__(num_jobs)
         #: Keep track of how many tokens Spack itself has acquired, which is used to release them.
         self.tokens_acquired = 0
-        #: The number of jobs to run concurrently. This translates to `num_jobs - 1` tokens in the
-        #: jobserver.
-        self.num_jobs = num_jobs
-        #: The target number of jobs to run concurrently, which may differ from num_jobs if the
-        #: user has requested a decrease in parallelism, but we haven't consumed enough tokens to
-        #: reflect that yet. This value is used in the UI. The invariant is that self.target_jobs
-        #: can only be modified if self.created is True.
-        self.target_jobs = num_jobs
         self.fifo_path: Optional[str] = None
         self.created = False
         self._setup()
@@ -375,20 +369,23 @@ class PosixJobServer:
         self.r, self.w, self.fifo_path = create_jobserver_fifo(self.num_jobs)
         self.created = True
 
-    def makeflags(self, gmake: Optional[spack.spec.Spec]) -> str:
-        """Return the MAKEFLAGS for a build process, depending on its gmake build dependency."""
+    def makeflags_and_data(self, gmake: Optional[spack.spec.Spec]) -> Tuple[Optional[str], Any]:
         if self.fifo_path and (not gmake or gmake.satisfies("@4.4:")):
-            return f" -j{self.num_jobs} --jobserver-auth=fifo:{self.fifo_path}"
-        elif not gmake or gmake.satisfies("@4.0:"):
-            return f" -j{self.num_jobs} --jobserver-auth={self.r},{self.w}"
+            return f" -j{self.num_jobs} --jobserver-auth=fifo:{self.fifo_path}", None
+        # For non-FIFO jobservers, ensure the pipes are inherited by the child process
+        pipes = (self.r_conn, self.w_conn)
+        if not gmake or gmake.satisfies("@4.0:"):
+            return f" -j{self.num_jobs} --jobserver-auth={self.r},{self.w}", pipes
         else:
-            return f" -j{self.num_jobs} --jobserver-fds={self.r},{self.w}"
+            return f" -j{self.num_jobs} --jobserver-fds={self.r},{self.w}", pipes
 
-    def has_target_parallelism(self) -> bool:
-        return self.num_jobs == self.target_jobs
+    def update_selector(self, selector: selectors.BaseSelector, wake: bool) -> None:
+        if wake and self.r not in selector.get_map():
+            selector.register(self.r, selectors.EVENT_READ, "jobserver")
+        elif not wake and self.r in selector.get_map():
+            selector.unregister(self.r)
 
     def increase_parallelism(self) -> None:
-        """Add one token to the jobserver to increase parallelism; this should always work."""
         if not self.created:
             return
         self.target_jobs += 1
@@ -399,13 +396,12 @@ class PosixJobServer:
         self.num_jobs += 1
 
     def decrease_parallelism(self) -> None:
-        """Request an eventual concurrency decrease by 1."""
         if not self.created or self.target_jobs <= 1:
             return
         self.target_jobs -= 1
-        self.maybe_discard_tokens()
+        self._maybe_discard_tokens()
 
-    def maybe_discard_tokens(self) -> None:
+    def _maybe_discard_tokens(self) -> None:
         """Try to get reduce parallelism by discarding tokens."""
         to_discard = self.num_jobs - self.target_jobs
         if to_discard <= 0:
@@ -417,8 +413,6 @@ class PosixJobServer:
             pass
 
     def acquire(self, jobs: int) -> int:
-        """Try and acquire at most 'jobs' tokens from the jobserver. Returns the number of
-        tokens actually acquired (may be less than requested, or zero)."""
         try:
             num_acquired = len(os.read(self.r, jobs))
             self.tokens_acquired += num_acquired
@@ -427,7 +421,6 @@ class PosixJobServer:
             return 0
 
     def release(self) -> None:
-        """Release a token back to the jobserver."""
         # The last job to quit has an implicit token, so don't release if we have none.
         if self.tokens_acquired == 0:
             return

--- a/lib/spack/spack/test/jobserver.py
+++ b/lib/spack/spack/test/jobserver.py
@@ -14,8 +14,8 @@ import os
 import pathlib
 import stat
 
-from spack.new_installer import PosixJobServer
 from spack.new_installer_posix import (
+    PosixJobServer,
     create_jobserver_fifo,
     get_jobserver_config,
     open_existing_jobserver_fifo,
@@ -217,8 +217,9 @@ class TestJobServer:
         js = PosixJobServer(8)
 
         try:
-            flags = js.makeflags(Spec("gmake@=4.4"))
+            flags, data = js.makeflags_and_data(Spec("gmake@=4.4"))
             assert flags == f" -j8 --jobserver-auth=fifo:{js.fifo_path}"
+            assert data is None
         finally:
             js.close()
 
@@ -227,8 +228,9 @@ class TestJobServer:
         js = PosixJobServer(8)
 
         try:
-            flags = js.makeflags(Spec("gmake@=4.0"))
+            flags, data = js.makeflags_and_data(Spec("gmake@=4.0"))
             assert flags == f" -j8 --jobserver-auth={js.r},{js.w}"
+            assert data == (js.r_conn, js.w_conn)
         finally:
             js.close()
 
@@ -237,8 +239,9 @@ class TestJobServer:
         js = PosixJobServer(8)
 
         try:
-            flags = js.makeflags(Spec("gmake@=3.9"))
+            flags, data = js.makeflags_and_data(Spec("gmake@=3.9"))
             assert flags == f" -j8 --jobserver-fds={js.r},{js.w}"
+            assert data == (js.r_conn, js.w_conn)
         finally:
             js.close()
 
@@ -247,8 +250,9 @@ class TestJobServer:
         js = PosixJobServer(6)
 
         try:
-            flags = js.makeflags(None)
+            flags, data = js.makeflags_and_data(None)
             assert flags == f" -j6 --jobserver-auth=fifo:{js.fifo_path}"
+            assert data is None
         finally:
             js.close()
 
@@ -389,7 +393,7 @@ class TestJobServer:
         js = PosixJobServer(3)
         try:
             original_num = js.num_jobs
-            js.maybe_discard_tokens()  # to_discard == 0
+            js._maybe_discard_tokens()  # to_discard == 0
             assert js.num_jobs == original_num
         finally:
             js.close()
@@ -401,7 +405,7 @@ class TestJobServer:
             # Manually set target lower to create a discard requirement.
             js.target_jobs = js.num_jobs - 2
             original_num = js.num_jobs
-            js.maybe_discard_tokens()
+            js._maybe_discard_tokens()
             assert js.num_jobs < original_num
         finally:
             js.close()
@@ -415,7 +419,7 @@ class TestJobServer:
             original_num = js.num_jobs
             # Artificially lower target so a discard is requested, but pipe is empty.
             js.target_jobs = js.num_jobs - 1
-            js.maybe_discard_tokens()  # Should not raise; num_jobs unchanged.
+            js._maybe_discard_tokens()  # Should not raise; num_jobs unchanged.
             assert js.num_jobs == original_num
         finally:
             js.close()

--- a/lib/spack/spack/test/new_installer.py
+++ b/lib/spack/spack/test/new_installer.py
@@ -18,11 +18,11 @@ from spack.new_installer import (
     BinaryCacheMiss,
     BuildGraph,
     PackageInstaller,
-    PosixJobServer,
     PrefixPivoter,
     _node_to_roots,
     schedule_builds,
 )
+from spack.new_installer_posix import PosixJobServer
 from spack.test.traverse import create_dag
 
 


### PR DESCRIPTION
Add a base class for the JobServer, and add a no-op implementation for Windows.

Prereq for #52483 to make that focused on Windows support.