### PR TITLE
jobserver.py: fix parent fd validation

### DIFF
--- a/lib/spack/spack/new_installer_posix.py
+++ b/lib/spack/spack/new_installer_posix.py
@@ -361,9 +361,13 @@ class PosixJobServer(JobServerBase):
         elif type(fifo_config) is tuple:
             # Old style pipe-based jobserver. Validate the fds before using them.
             r, w = fifo_config
-            if fcntl.fcntl(r, fcntl.F_GETFD) != -1 and fcntl.fcntl(w, fcntl.F_GETFD) != -1:
+            try:
+                fcntl.fcntl(r, fcntl.F_GETFD)
+                fcntl.fcntl(w, fcntl.F_GETFD)
                 self.r, self.w = r, w
                 return
+            except OSError:  # raised if invalid
+                pass
 
         # No existing jobserver we can connect to: create a FIFO-based one.
         self.r, self.w, self.fifo_path = create_jobserver_fifo(self.num_jobs)

--- a/lib/spack/spack/test/jobserver.py
+++ b/lib/spack/spack/test/jobserver.py
@@ -69,8 +69,8 @@ class TestCreateJobserverFifo:
             assert os.path.exists(path)
             assert stat.S_ISFIFO(os.stat(path).st_mode)
             assert (os.stat(path).st_mode & 0o777) == 0o600
-            assert fcntl.fcntl(r, fcntl.F_GETFD) != -1
-            assert fcntl.fcntl(w, fcntl.F_GETFD) != -1
+            assert fcntl.fcntl(r, fcntl.F_GETFD) >= 0
+            assert fcntl.fcntl(w, fcntl.F_GETFD) >= 0
             assert fcntl.fcntl(r, fcntl.F_GETFL) & os.O_NONBLOCK
         finally:
             os.close(r)
@@ -114,8 +114,8 @@ class TestOpenExistingJobserverFifo:
         assert result is not None
 
         r, w = result
-        assert fcntl.fcntl(r, fcntl.F_GETFD) != -1
-        assert fcntl.fcntl(w, fcntl.F_GETFD) != -1
+        assert fcntl.fcntl(r, fcntl.F_GETFD) >= 0
+        assert fcntl.fcntl(w, fcntl.F_GETFD) >= 0
         assert fcntl.fcntl(r, fcntl.F_GETFL) & os.O_NONBLOCK
 
         os.close(r)
@@ -143,8 +143,8 @@ class TestJobServer:
             assert js.fifo_path is not None
             assert os.path.exists(js.fifo_path)
             assert js.tokens_acquired == 0
-            assert fcntl.fcntl(js.r, fcntl.F_GETFD) != -1
-            assert fcntl.fcntl(js.w, fcntl.F_GETFD) != -1
+            assert fcntl.fcntl(js.r, fcntl.F_GETFD) >= 0
+            assert fcntl.fcntl(js.w, fcntl.F_GETFD) >= 0
         finally:
             js.close()
 


### PR DESCRIPTION
The syscall returns `-1` if the fd is invalid, but Python intercepts and raises
`OSError: [Errno 9] Bad file descriptor` instead.