### PR TITLE
Concretizer: Add prefer_oldest option to test oldest dependencies

### DIFF
--- a/etc/spack/defaults/base/concretizer.yaml
+++ b/etc/spack/defaults/base/concretizer.yaml
@@ -94,6 +94,11 @@ concretizer:
   # cases where there are requirements that prevent part of the search space to be explored.
   static_analysis: false
 
+  # If true, prefer the oldest version of packages during concretization instead
+  # of the newest. This is useful for CI testing against the oldest supported
+  # versions of dependencies.
+  prefer_oldest: false
+
   # If enabled, concretizations are cached in the misc_cache. The cache is keyed by the hash
   # of solver inputs, so we only need to run setup (not solve) if there is a cache hit.
   # Feature is experimental: enabling may result in potentially invalid concretizations

--- a/lib/spack/spack/cmd/common/arguments.py
+++ b/lib/spack/spack/cmd/common/arguments.py
@@ -684,6 +684,14 @@ def add_concretizer_args(subparser):
         default=None,
         help="allow concretizer to select deprecated versions",
     )
+    subgroup.add_argument(
+        "--prefer-oldest",
+        action=ConfigSetAction,
+        dest="concretizer:prefer_oldest",
+        const=True,
+        default=None,
+        help="prefer the oldest version of each package during concretization",
+    )
 
 
 def add_connection_args(subparser, add_help):

--- a/lib/spack/spack/schema/concretizer.py
+++ b/lib/spack/spack/schema/concretizer.py
@@ -255,6 +255,13 @@ properties: Dict[str, Any] = {
                     },
                 },
             },
+            "prefer_oldest": {
+                "type": "boolean",
+                "default": False,
+                "description": "If true, prefer the oldest version of packages during "
+                "concretization instead of the newest. Useful for CI testing against "
+                "the oldest supported versions of dependencies.",
+            },
             "externals": {
                 "type": "object",
                 "description": "Configuration for how Spack handles external packages during "

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -1306,7 +1306,7 @@ class SpackSolverSetup:
     gen: "ProblemInstanceBuilder"
     possible_versions: Dict[str, Dict[GitOrStandardVersion, List[Provenance]]]
 
-    def __init__(self, tests: spack.concretize.TestsType = False):
+    def __init__(self, tests: spack.concretize.TestsType = False, prefer_oldest: bool = False):
         self.possible_graph = create_graph_analyzer()
 
         # these are all initialized in setup()
@@ -1357,6 +1357,9 @@ class SpackSolverSetup:
         # If true, we have to load the code for synthesizing splices
         self.enable_splicing: bool = spack.config.CONFIG.get("concretizer:splice:automatic")
 
+        # If true, prefer oldest versions instead of newest during concretization
+        self.prefer_oldest: bool = prefer_oldest
+
     def pkg_version_rules(self, pkg: Type[spack.package_base.PackageBase]) -> None:
         """Declares known versions, their origins, and their weights."""
         version_provenance = self.possible_versions[pkg.name]
@@ -1376,7 +1379,10 @@ class SpackSolverSetup:
                 fn.pkg_fact(pkg.name, fn.version_deprecation_penalty(len(ordered_versions)))
             )
 
-        for weight, declared_version in enumerate(ordered_versions):
+        # If prefer_oldest is enabled, reverse the version order so that the oldest
+        # versions get the lowest weights in the optimization.
+        version_order = list(reversed(ordered_versions)) if self.prefer_oldest else ordered_versions
+        for weight, declared_version in enumerate(version_order):
             self.gen.fact(fn.pkg_fact(pkg.name, fn.version_declared(declared_version, weight)))
             for origin in version_provenance[declared_version]:
                 self.gen.fact(
@@ -3923,6 +3929,8 @@ class Solver:
             packages_with_externals=self.packages_with_externals,
         )
 
+        self.prefer_oldest: bool = spack.config.get("concretizer:prefer_oldest", False)
+
     @staticmethod
     def _extract_concrete_specs(specs: Sequence[spack.spec.Spec]) -> List[spack.spec.Spec]:
         return [s for s in spack.traverse.traverse_nodes(specs) if s.concrete]
@@ -3954,7 +3962,7 @@ class Solver:
         specs = [s.lookup_hash() for s in specs]
         reusable_specs = self._extract_concrete_specs(specs)
         reusable_specs.extend(self.selector.reusable_specs(specs))
-        setup = SpackSolverSetup(tests=tests)
+        setup = SpackSolverSetup(tests=tests, prefer_oldest=self.prefer_oldest)
         output = OutputConfiguration(timers=timers, stats=stats, out=out, setup_only=setup_only)
 
         result = self.driver.solve(
@@ -4005,7 +4013,7 @@ class Solver:
         specs = [s.lookup_hash() for s in specs]
         reusable_specs = self._extract_concrete_specs(specs)
         reusable_specs.extend(self.selector.reusable_specs(specs))
-        setup = SpackSolverSetup(tests=tests)
+        setup = SpackSolverSetup(tests=tests, prefer_oldest=self.prefer_oldest)
 
         # Tell clingo that we don't have to solve all the inputs at once
         setup.concretize_everything = False


### PR DESCRIPTION
Closes #24995

By default, Spack installs the latest stable release of a package. This PR introduces a new concretizer option "prefer_oldest", which allows users to install the oldest release that Spack knows about for each package.

This enables testing against the oldest supported versions of dependencies to ensure backward compatibility.

Key Features:
- concretizer.yaml: Added prefer_oldest: false to the base concretizer.yaml defaults.
- arguments.py: Added `--prefer-oldest` CLI flag to the common concretizer arguments.
- asp.py: When enabled, the concretizer reverses the ordered list of known versions in asp.py.
- concretizer.py: Schema modify for concretizer.yaml

Using CLI:
```
$ spack spec --prefer-oldest zlib-ng
```

Using spack.yaml:
```
spack:
  specs:
  - zlib-ng
  concretizer:
    prefer_oldest: true
```

