### PR TITLE
modules: refactor classes and clean-up code

### DIFF
--- a/lib/spack/docs/conf.py
+++ b/lib/spack/docs/conf.py
@@ -370,6 +370,7 @@ nitpick_ignore = [
     ("py:class", "spack.vendor.archspec.cpu.microarchitecture.Microarchitecture"),
     ("py:class", "spack.vendor.jinja2.Environment"),
     ("py:class", "SpecFiltersFactory"),
+    ('py:exc', 'CoreCompilersNotFoundError'),
     # TypeVar that is not handled correctly
     ("py:class", "spack.util.lang.ClassPropertyType"),
     ("py:class", "spack.util.lang.K"),

--- a/lib/spack/docs/conf.py
+++ b/lib/spack/docs/conf.py
@@ -370,7 +370,7 @@ nitpick_ignore = [
     ("py:class", "spack.vendor.archspec.cpu.microarchitecture.Microarchitecture"),
     ("py:class", "spack.vendor.jinja2.Environment"),
     ("py:class", "SpecFiltersFactory"),
-    ('py:exc', 'CoreCompilersNotFoundError'),
+    ("py:exc", "CoreCompilersNotFoundError"),
     # TypeVar that is not handled correctly
     ("py:class", "spack.util.lang.ClassPropertyType"),
     ("py:class", "spack.util.lang.K"),

--- a/lib/spack/spack/cmd/modules/__init__.py
+++ b/lib/spack/spack/cmd/modules/__init__.py
@@ -14,6 +14,7 @@ import spack.config
 import spack.error
 import spack.modules
 import spack.modules.common
+import spack.modules.error
 import spack.repo
 from spack.cmd import MultipleSpecsMatch, NoSpecMatches
 from spack.cmd.common import arguments
@@ -229,7 +230,7 @@ def find(module_type, specs, args):
                 required=True,
             )
         )
-    except spack.modules.common.ModuleNotFoundError as e:
+    except spack.modules.error.ModuleNotFoundError as e:
         tty.die(e.message)
 
     if not all(modules):

--- a/lib/spack/spack/cmd/modules/__init__.py
+++ b/lib/spack/spack/cmd/modules/__init__.py
@@ -246,11 +246,13 @@ def rm(module_type, specs, args):
     check_module_set_name(args.module_set_name)
 
     module_cls = spack.modules.module_types[module_type]
-    module_exist = lambda x: os.path.exists(module_cls(x, args.module_set_name).layout.filename)
+    module_exist = lambda x: os.path.exists(
+        module_cls.from_spec(x, args.module_set_name).layout.filename
+    )
 
     specs_with_modules = [spec for spec in specs if module_exist(spec)]
 
-    modules = [module_cls(spec, args.module_set_name) for spec in specs_with_modules]
+    modules = [module_cls.from_spec(spec, args.module_set_name) for spec in specs_with_modules]
 
     if not modules:
         tty.die("No module file matches your query")
@@ -299,7 +301,9 @@ def refresh(module_type, specs, args):
 
     # Skip unknown packages.
     writers = [
-        cls(spec, args.module_set_name) for spec in specs if spack.repo.PATH.exists(spec.name)
+        cls.from_spec(spec, args.module_set_name)
+        for spec in specs
+        if spack.repo.PATH.exists(spec.name)
     ]
 
     # Filter excluded packages early

--- a/lib/spack/spack/cmd/modules/lmod.py
+++ b/lib/spack/spack/cmd/modules/lmod.py
@@ -42,5 +42,5 @@ def setdefault(module_type, specs, args):
     spack.modules.lmod.LmodConfiguration._registry = {}
     scope = spack.config.InternalConfigScope("lmod-setdefault", data)
     with spack.config.override(scope):
-        writer = spack.modules.module_types["lmod"](spec, args.module_set_name)
+        writer = spack.modules.module_types["lmod"].from_spec(spec, args.module_set_name)
         writer.update_module_defaults()

--- a/lib/spack/spack/cmd/modules/tcl.py
+++ b/lib/spack/spack/cmd/modules/tcl.py
@@ -37,5 +37,5 @@ def setdefault(module_type, specs, args):
     spack.modules.tcl.TclConfiguration._registry = {}
     scope = spack.config.InternalConfigScope("tcl-setdefault", data)
     with spack.config.override(scope):
-        writer = spack.modules.module_types["tcl"](spec, args.module_set_name)
+        writer = spack.modules.module_types["tcl"].from_spec(spec, args.module_set_name)
         writer.update_module_defaults()

--- a/lib/spack/spack/hooks/module_file_generation.py
+++ b/lib/spack/spack/hooks/module_file_generation.py
@@ -22,7 +22,7 @@ def _for_each_enabled(
             continue
 
         for module_type in enabled:
-            generator = spack.modules.module_types[module_type](spec, name, explicit)
+            generator = spack.modules.module_types[module_type].from_spec(spec, name, explicit)
             try:
                 getattr(generator, method_name)()
             except RuntimeError as e:

--- a/lib/spack/spack/modules/__init__.py
+++ b/lib/spack/spack/modules/__init__.py
@@ -16,6 +16,7 @@ import spack.store
 
 from . import common
 from .common import BaseModuleFileWriter, disable_modules
+from .error import ModuleNotFoundError
 from .lmod import LmodModulefileWriter
 from .tcl import TclModulefileWriter
 
@@ -74,7 +75,7 @@ def get_module(
         if not os.path.isfile(writer.layout.filename):
             fmt_str = "{name}{@version}{/hash:7}"
             if not writer.conf.excluded:
-                raise common.ModuleNotFoundError(
+                raise ModuleNotFoundError(
                     "The module for package {} should be at {}, but it does not exist".format(
                         spec.format(fmt_str), writer.layout.filename
                     )

--- a/lib/spack/spack/modules/__init__.py
+++ b/lib/spack/spack/modules/__init__.py
@@ -71,7 +71,7 @@ def get_module(
         else:
             return module.use_name
     else:
-        writer = module_types[module_type](spec, module_set_name)
+        writer = module_types[module_type].from_spec(spec, module_set_name)
         if not os.path.isfile(writer.layout.filename):
             fmt_str = "{name}{@version}{/hash:7}"
             if not writer.conf.excluded:

--- a/lib/spack/spack/modules/common.py
+++ b/lib/spack/spack/modules/common.py
@@ -362,6 +362,7 @@ class BaseConfiguration:
         self._config: dict = _set_cfg.get(self.module_system, {})
         self.hierarchical: bool = self._config.get("hierarchical", self._default_hierarchical)
         self.arch_folder: bool = _set_cfg.get("arch_folder", True)
+        self.root: str = root_path(self.module_system, module_set_name)
         self.use_view: Union[bool, str] = _set_cfg.get("use_view", False)
         self.prefix_inspections: dict = syaml.syaml_dict()
         spack.schema.merge_yaml(
@@ -704,7 +705,7 @@ class FileLayout:
 
     def dirname(self) -> str:
         """Root folder for module files of this type."""
-        return root_path(self.conf.module_system, self.conf.name)
+        return self.conf.root
 
     @property
     def use_name(self) -> str:
@@ -1156,15 +1157,6 @@ class ModuleContext(tengine.Context):
         """Returns the list of paths that are unlocked unconditionally."""
         return [os.path.join(*parts) for parts in self.layout.unlocked_paths[None]]
 
-    def _manipulate_path(self, token: str) -> str:
-        return self.conf._manipulate_path(token)
-
-    def _format_condition(self, services_needed: Tuple[str, ...]) -> str:
-        return self.conf._format_condition(services_needed)
-
-    def _join_path(self, parts: Tuple[str, ...]) -> str:
-        return self.conf._join_path(parts)
-
     @tengine.context_property
     def conditionally_unlocked_paths(self) -> List[Tuple[str, str]]:
         """Returns the list of paths that are unlocked conditionally.
@@ -1174,9 +1166,9 @@ class ModuleContext(tengine.Context):
         for services_needed, list_of_path_parts in self.layout.unlocked_paths.items():
             if services_needed is None:
                 continue
-            condition = self._format_condition(services_needed)
+            condition = self.conf.format_condition(services_needed)
             for parts in list_of_path_parts:
-                value.append((condition, self._join_path(parts)))
+                value.append((condition, self.conf.join_path(parts)))
         return value
 
 
@@ -1205,11 +1197,13 @@ class BaseModuleFileWriter:
     def __init__(
         self, spec: spack.spec.Spec, module_set_name: str, explicit: Optional[bool] = None
     ) -> None:
-        self.spec = spec
-
         self.conf = self.configuration_class.make_configuration(spec, module_set_name, explicit)
         self.layout = FileLayout(self.conf)
         self.context = ModuleContext(self.conf, self.layout)
+
+    @property
+    def spec(self) -> spack.spec.Spec:
+        return self.conf.spec
 
     def _get_template(self) -> str:
         """Gets the template that will be rendered for this spec."""

--- a/lib/spack/spack/modules/common.py
+++ b/lib/spack/spack/modules/common.py
@@ -324,11 +324,16 @@ class BaseConfiguration:
     #: Default for the ``hierarchical`` config key when it is absent. Subclasses may override.
     _default_hierarchical: bool = False
 
-    #: Per-subclass cache: must be assigned as ClassVar[Dict] = {} in each concrete subclass
     _registry: ClassVar[Dict[Tuple[str, str, bool], "BaseConfiguration"]]
 
     #: File extension for module files (empty string means no extension)
     file_extension: ClassVar[str] = ""
+
+    def __init_subclass__(cls, **kwargs: object) -> None:
+        super().__init_subclass__(**kwargs)
+        if not hasattr(cls, "module_system"):
+            raise AttributeError(f"'{cls.__name__}' must define a 'module_system' class attribute")
+        cls._registry = {}
 
     @classmethod
     def configuration(cls, module_set_name: str) -> dict:
@@ -353,17 +358,6 @@ class BaseConfiguration:
     ) -> "FileLayout":
         return FileLayout(cls.make_configuration(spec, module_set_name, explicit))
 
-    @classmethod
-    def make_context(
-        cls,
-        spec: spack.spec.Spec,
-        module_set_name: str,
-        *,
-        explicit: Optional[bool] = None,
-        layout: "FileLayout",
-    ) -> "ModuleContext":
-        return ModuleContext(cls.make_configuration(spec, module_set_name, explicit), layout)
-
     def __init__(self, spec: spack.spec.Spec, module_set_name: str, explicit: bool) -> None:
         # Spec for which we want to generate a module file
         self.spec = spec
@@ -372,6 +366,7 @@ class BaseConfiguration:
         # Cache once — configuration() traverses all config scopes on every call
         self._config = self.configuration(self.name)
         self.hierarchical: bool = self._config.get("hierarchical", self._default_hierarchical)
+        self.arch_folder: bool = spack.config.get(f"modules:{module_set_name}:arch_folder", True)
         # Dictionary of configuration options that should be applied to the spec
         self.conf = merge_config_rules(self._config, self.spec)
 
@@ -732,10 +727,7 @@ class FileLayout:
     @property
     def arch_dirname(self) -> str:
         """Returns the root folder for THIS architecture"""
-        # Architecture sub-folder
-        arch_folder_conf = spack.config.get("modules:%s:arch_folder" % self.conf.name, True)
-        if arch_folder_conf:
-            # include an arch specific folder between root and filename
+        if self.conf.arch_folder:
             if self.conf.hierarchical:
                 arch_folder = "-".join(
                     [str(self.spec.platform), str(self.spec.os), str(self.spec.target.family)]
@@ -1224,12 +1216,9 @@ class BaseModuleFileWriter:
     ) -> None:
         self.spec = spec
 
-        # Create the triplet of configuration/layout/context
         self.conf = self.configuration_class.make_configuration(spec, module_set_name, explicit)
-        self.layout = self.conf.make_layout(spec, module_set_name, explicit)
-        self.context = self.conf.make_context(
-            spec, module_set_name, explicit=explicit, layout=self.layout
-        )
+        self.layout = FileLayout(self.conf)
+        self.context = ModuleContext(self.conf, self.layout)
 
     def _get_template(self) -> str:
         """Gets the template that will be rendered for this spec."""

--- a/lib/spack/spack/modules/common.py
+++ b/lib/spack/spack/modules/common.py
@@ -320,8 +320,6 @@ class BaseConfiguration:
 
     #: Layout class must be set on each concrete subclass
     layout_class: ClassVar[Type["BaseFileLayout"]]
-    #: Context class must be set on each concrete subclass
-    context_class: ClassVar[Type["BaseContext"]]
 
     @classmethod
     def configuration(cls, module_set_name: str) -> dict:
@@ -355,7 +353,7 @@ class BaseConfiguration:
         explicit: Optional[bool] = None,
         layout: "BaseFileLayout",
     ) -> "BaseContext":
-        return cls.context_class(cls.make_configuration(spec, module_set_name, explicit), layout)
+        return BaseContext(cls.make_configuration(spec, module_set_name, explicit), layout)
 
     def __init__(self, spec: spack.spec.Spec, module_set_name: str, explicit: bool) -> None:
         # Spec for which we want to generate a module file
@@ -693,7 +691,11 @@ class BaseFileLayout:
 
     @property
     def modulerc(self) -> str:
-        raise NotImplementedError
+        """Returns the modulerc file for this module file."""
+        dirname = os.path.dirname(self.filename)
+        if self.extension:
+            return os.path.join(dirname, f".modulerc.{self.extension}")
+        return os.path.join(dirname, ".modulerc")
 
     @property
     def spec(self) -> spack.spec.Spec:
@@ -962,6 +964,11 @@ class BaseContext(tengine.Context):
         # the configure option section
         return None
 
+    @tengine.context_property
+    def prerequisites(self) -> List[str]:
+        """List of modules that must be loaded before this one."""
+        return self._create_module_list_of("specs_to_prereq")
+
     def modification_needs_formatting(
         self,
         modification: Union[
@@ -1170,13 +1177,13 @@ class BaseContext(tengine.Context):
         return [os.path.join(*parts) for parts in self.layout.unlocked_paths[None]]
 
     def _manipulate_path(self, token: str) -> str:
-        raise NotImplementedError
+        return self.conf._manipulate_path(token)
 
     def _format_condition(self, services_needed: Tuple[str, ...]) -> str:
-        raise NotImplementedError
+        return self.conf._format_condition(services_needed)
 
     def _join_path(self, parts: Tuple[str, ...]) -> str:
-        raise NotImplementedError
+        return self.conf._join_path(parts)
 
     @tengine.context_property
     def conditionally_unlocked_paths(self) -> List[Tuple[str, str]]:

--- a/lib/spack/spack/modules/common.py
+++ b/lib/spack/spack/modules/common.py
@@ -63,6 +63,15 @@ from spack.aliases import BUILTIN_TO_LEGACY_COMPILER
 from spack.enums import Context
 from spack.util.lang import Singleton, dedupe, memoized
 
+from .error import (
+    CoreCompilersNotFoundError,
+    DefaultTemplateNotDefined,
+    HideCmdFormatNotDefined,
+    ModulercHeaderNotDefined,
+    ModulesError,
+    ModulesTemplateNotFoundError,
+)
+
 #: Valid tokens for naming scheme and env variable names
 _valid_tokens = (
     "name",
@@ -1193,32 +1202,6 @@ class ModuleContext(tengine.Context):
         return value
 
 
-class ModulesError(spack.error.SpackError):
-    """Base error for modules."""
-
-
-class ModuleNotFoundError(ModulesError):
-    """Raised when a module cannot be found for a spec"""
-
-
-class DefaultTemplateNotDefined(AttributeError, ModulesError):
-    """Raised if the attribute ``default_template`` has not been specified
-    in the derived classes.
-    """
-
-
-class HideCmdFormatNotDefined(AttributeError, ModulesError):
-    """Raised if the attribute ``hide_cmd_format`` has not been specified
-    in the derived classes.
-    """
-
-
-class ModulercHeaderNotDefined(AttributeError, ModulesError):
-    """Raised if the attribute ``modulerc_header`` has not been specified
-    in the derived classes.
-    """
-
-
 class BaseModuleFileWriter:
     default_template: str
     hide_cmd_format: str
@@ -1445,13 +1428,3 @@ def disable_modules() -> Iterator[None]:
     disable_scope = spack.config.InternalConfigScope("disable_modules", data=data)
     with spack.config.override(disable_scope):
         yield
-
-
-class ModulesTemplateNotFoundError(ModulesError, RuntimeError):
-    """Raised if the template for a module file was not found."""
-
-
-class CoreCompilersNotFoundError(spack.error.SpackError, KeyError):
-    """Error raised if the key ``core_compilers`` has not been specified
-    in the configuration file.
-    """

--- a/lib/spack/spack/modules/common.py
+++ b/lib/spack/spack/modules/common.py
@@ -1,27 +1,16 @@
 # Copyright Spack Project Developers. See COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
-"""Here we consolidate the logic for creating an abstract description
-of the information that module systems need.
+"""This module contains the logic for generating environment module files for each installed spec.
 
-This information maps **a single spec** to:
+The logic is split across four classes:
 
-* a unique module filename
-* the module file content
+* ``BaseConfiguration``: queries the ``modules.yaml`` configuration for a given spec.
+* ``FileLayout``: derives the on-disk path and the *use name* of a module file.
+* ``ModuleContext``: builds the Jinja2 template context dictionary.
+* ``BaseModuleFileWriter``: uses the three classes above to write, update, and remove module files.
 
-and is divided among four classes:
-
-* a configuration class that provides a convenient interface to query
-  details about the configuration for the spec under consideration.
-* a layout class that provides the information associated with module
-  file names and directories
-* a context class that provides the dictionary used by the template engine
-  to generate the module file
-* a writer that collects and uses the information above to either write
-  or remove the module file
-
-Each of the four classes needs to be sub-classed when implementing a new
-module type.
+To add a new module type, subclass ``BaseConfiguration`` and ``BaseModuleFileWriter``.
 """
 
 import collections
@@ -307,8 +296,8 @@ class UpstreamModuleIndex:
 
 
 class BaseConfiguration:
-    """Manipulates the information needed to generate a module file to make
-    querying easier. It needs to be sub-classed for specific module types.
+    """Reads the ``modules`` section of the configuration for a given spec and exposes it as a
+    set of properties used by ``FileLayout``, ``ModuleContext``, and ``BaseModuleFileWriter``.
     """
 
     default_projections: Dict[str, str]
@@ -544,9 +533,7 @@ class BaseConfiguration:
 
     @property
     def verbose(self) -> Optional[bool]:
-        """Returns True if the module file needs to be verbose, False
-        otherwise
-        """
+        """Returns the verbosity setting, or None if not configured."""
         return self.conf.get("verbose")
 
     @property
@@ -704,10 +691,7 @@ class FileLayout:
 
     @property
     def use_name(self) -> str:
-        """Returns the 'use' name of the module i.e. the name you have to type
-        to console to use it. This implementation fits the needs of most
-        non-hierarchical layouts.
-        """
+        """Returns the name used to load the module (e.g. with ``module load``)."""
         projection = proj.get_projection(self.conf.projections, self.spec)
         if not projection:
             projection = self.conf.default_projections["all"]
@@ -723,7 +707,7 @@ class FileLayout:
 
     @property
     def arch_dirname(self) -> str:
-        """Returns the root folder for THIS architecture"""
+        """Returns the root folder for this architecture."""
         if self.conf.arch_folder:
             if self.conf.hierarchical:
                 arch_folder = "-".join(
@@ -736,7 +720,7 @@ class FileLayout:
 
     @property
     def filename(self) -> str:
-        """Name of the module file for the current spec."""
+        """Absolute path to the module file for the current spec."""
         # Just the name of the file
         filename = self.use_name
         if self.conf.file_extension:
@@ -1091,7 +1075,7 @@ class ModuleContext(tengine.Context):
 
     @tengine.context_property
     def autoload(self) -> List[str]:
-        """List of modules that needs to be loaded automatically."""
+        """List of modules that need to be loaded automatically."""
         # From 'autoload' configuration option
         specs = self._create_module_list_of("specs_to_load")
         # From 'load' configuration option

--- a/lib/spack/spack/modules/common.py
+++ b/lib/spack/spack/modules/common.py
@@ -23,7 +23,19 @@ import pathlib
 import re
 import string
 import warnings
-from typing import IO, ClassVar, Dict, Iterator, List, NamedTuple, Optional, Tuple, Type, Union
+from typing import (
+    IO,
+    Any,
+    ClassVar,
+    Dict,
+    Iterator,
+    List,
+    NamedTuple,
+    Optional,
+    Tuple,
+    Type,
+    Union,
+)
 
 import spack.vendor.jinja2
 
@@ -50,7 +62,7 @@ import spack.util.path
 import spack.util.spack_yaml as syaml
 from spack.aliases import BUILTIN_TO_LEGACY_COMPILER
 from spack.enums import Context
-from spack.util.lang import Singleton, dedupe, memoized
+from spack.util.lang import Singleton, dedupe
 
 from .error import (
     CoreCompilersNotFoundError,
@@ -60,6 +72,10 @@ from .error import (
     ModulesError,
     ModulesTemplateNotFoundError,
 )
+
+EnvironmentModification = Tuple[
+    str, Union[spack.util.environment.NameModifier, spack.util.environment.NameValueModifier]
+]
 
 #: Valid tokens for naming scheme and env variable names
 _valid_tokens = (
@@ -343,6 +359,7 @@ class BaseConfiguration:
         self.spec = spec
         self.name = module_set_name
         self.explicit = explicit
+        self._cache: Dict[str, Any] = {}
         _modules_cfg = spack.config.CONFIG.get_config("modules")
         _set_cfg = _modules_cfg.get(module_set_name, {})
         self._config: dict = _set_cfg.get(self.module_system, {})
@@ -575,16 +592,19 @@ class BaseConfiguration:
         return self._config.get("filter_hierarchy_specs", {})
 
     @property
-    @memoized
     def hierarchy_tokens(self) -> List[str]:
         """Returns the list of tokens that are part of the modulefile
         hierarchy. ``compiler`` is always present.
         """
+        if "hierarchy_tokens" not in self._cache:
+            self._cache["hierarchy_tokens"] = self._compute_hierarchy_tokens()
+        return self._cache["hierarchy_tokens"]
+
+    def _compute_hierarchy_tokens(self) -> List[str]:
         configured = self._config.get("hierarchy", [])
         return list(dedupe(itertools.chain(configured, ["compiler"])))
 
     @property
-    @memoized
     def requires(self) -> Dict[str, spack.spec.Spec]:
         """Returns a dictionary mapping all the requirements of this spec to the actual provider.
 
@@ -592,6 +612,11 @@ class BaseConfiguration:
 
         Returns an empty dictionary if hierarchical mode is disabled.
         """
+        if "requires" not in self._cache:
+            self._cache["requires"] = self._compute_requires()
+        return self._cache["requires"]
+
+    def _compute_requires(self) -> Dict[str, spack.spec.Spec]:
         if not self.hierarchical:
             return {}
 
@@ -621,13 +646,17 @@ class BaseConfiguration:
         return requirements
 
     @property
-    @memoized
     def provides(self) -> Dict[str, spack.spec.Spec]:
         """Returns a dictionary mapping all the services provided by this
         spec to the spec itself.
 
         Returns an empty dictionary if hierarchical mode is disabled.
         """
+        if "provides" not in self._cache:
+            self._cache["provides"] = self._compute_provides()
+        return self._cache["provides"]
+
+    def _compute_provides(self) -> Dict[str, spack.spec.Spec]:
         if not self.hierarchical:
             return {}
 
@@ -660,9 +689,13 @@ class BaseConfiguration:
         return {**self.requires, **self.provides}
 
     @property
-    @memoized
     def missing(self) -> List[str]:
         """Returns the list of tokens that are not available."""
+        if "missing" not in self._cache:
+            self._cache["missing"] = self._compute_missing()
+        return self._cache["missing"]
+
+    def _compute_missing(self) -> List[str]:
         return [x for x in self.hierarchy_tokens if x not in self.available]
 
 
@@ -671,6 +704,9 @@ class FileLayout:
 
     def __init__(self, configuration):
         self.conf = configuration
+        self._unlocked_paths: Optional[Dict[Optional[Tuple[str, ...]], List[Tuple[str, ...]]]] = (
+            None
+        )
 
     @property
     def modulerc(self) -> str:
@@ -797,7 +833,6 @@ class FileLayout:
         return parts
 
     @property
-    @memoized
     def unlocked_paths(self) -> Dict[Optional[Tuple[str, ...]], List[Tuple[str, ...]]]:
         """Returns a dictionary mapping conditions to a list of unlocked
         paths.
@@ -806,7 +841,11 @@ class FileLayout:
         key 'None'. The other keys represent the list of services you need
         loaded to unlock the corresponding paths.
         """
+        if self._unlocked_paths is None:
+            self._unlocked_paths = self._compute_unlocked_paths()
+        return self._unlocked_paths
 
+    def _compute_unlocked_paths(self) -> Dict[Optional[Tuple[str, ...]], List[Tuple[str, ...]]]:
         unlocked: Dict[Optional[Tuple[str, ...]], List[Tuple[str, ...]]] = collections.defaultdict(
             list
         )
@@ -874,6 +913,7 @@ class ModuleContext(tengine.Context):
     def __init__(self, configuration, layout: "FileLayout") -> None:
         self.conf = configuration
         self.layout = layout
+        self._environment_modifications: Optional[List[EnvironmentModification]] = None
 
     @tengine.context_property
     def spec(self) -> spack.spec.Spec:
@@ -949,16 +989,13 @@ class ModuleContext(tengine.Context):
         )
 
     @tengine.context_property
-    @memoized
-    def environment_modifications(
-        self,
-    ) -> List[
-        Tuple[
-            str,
-            Union[spack.util.environment.NameModifier, spack.util.environment.NameValueModifier],
-        ]
-    ]:
+    def environment_modifications(self) -> List[EnvironmentModification]:
         """List of environment modifications to be processed."""
+        if self._environment_modifications is None:
+            self._environment_modifications = self._compute_environment_modifications()
+        return self._environment_modifications
+
+    def _compute_environment_modifications(self) -> List[EnvironmentModification]:
         use_view = self.conf.use_view
         assert isinstance(use_view, (bool, str))
 

--- a/lib/spack/spack/modules/common.py
+++ b/lib/spack/spack/modules/common.py
@@ -1194,12 +1194,17 @@ class BaseModuleFileWriter:
                     "Did you forget to define it in the class?"
                 )
 
-    def __init__(
-        self, spec: spack.spec.Spec, module_set_name: str, explicit: Optional[bool] = None
-    ) -> None:
-        self.conf = self.configuration_class.make_configuration(spec, module_set_name, explicit)
-        self.layout = FileLayout(self.conf)
-        self.context = ModuleContext(self.conf, self.layout)
+    def __init__(self, conf: "BaseConfiguration") -> None:
+        self.conf = conf
+        self.layout = FileLayout(conf)
+        self.context = ModuleContext(conf, self.layout)
+
+    @classmethod
+    def from_spec(
+        cls, spec: spack.spec.Spec, module_set_name: str, explicit: Optional[bool] = None
+    ) -> "BaseModuleFileWriter":
+        conf = cls.configuration_class.make_configuration(spec, module_set_name, explicit)
+        return cls(conf)
 
     @property
     def spec(self) -> spack.spec.Spec:

--- a/lib/spack/spack/modules/common.py
+++ b/lib/spack/spack/modules/common.py
@@ -117,7 +117,7 @@ def _check_tokens_are_valid(format_string: str, error_message: str) -> None:
 def update_dictionary_extending_lists(target: dict, update: dict) -> None:
     """Updates a dictionary, but extends lists instead of overriding them."""
     for key in update:
-        value = target.get(key, None)
+        value = target.get(key)
         if isinstance(value, list):
             target[key].extend(update[key])
         elif isinstance(value, dict):
@@ -249,14 +249,11 @@ def _read_module_index(str_or_file: IO[str]) -> Dict[str, ModuleIndexEntry]:
     """Read in the mapping of spec hash to module location/name. For a given
     Spack installation there is assumed to be (at most) one such mapping
     per module type."""
-    yaml_content = syaml.load(str_or_file)
-    index = {}
-    yaml_index = yaml_content["module_index"]
-    for dag_hash, module_properties in yaml_index.items():
-        index[dag_hash] = ModuleIndexEntry(
-            module_properties["path"], module_properties["use_name"]
-        )
-    return index
+    yaml_index = syaml.load(str_or_file)["module_index"]
+    return {
+        dag_hash: ModuleIndexEntry(props["path"], props["use_name"])
+        for dag_hash, props in yaml_index.items()
+    }
 
 
 def read_module_indices() -> List[Dict[str, Dict[str, ModuleIndexEntry]]]:
@@ -265,11 +262,12 @@ def read_module_indices() -> List[Dict[str, Dict[str, ModuleIndexEntry]]]:
     module_indices = []
 
     for install_properties in other_spack_instances.values():
-        module_type_to_index = {}
-        module_type_to_root = install_properties.get("modules", {})
-        for module_type, root in module_type_to_root.items():
-            module_type_to_index[module_type] = read_module_index(root)
-        module_indices.append(module_type_to_index)
+        module_indices.append(
+            {
+                module_type: read_module_index(root)
+                for module_type, root in install_properties.get("modules", {}).items()
+            }
+        )
 
     return module_indices
 
@@ -302,11 +300,10 @@ class UpstreamModuleIndex:
                 f"where {spec} is installed"
             )
             return None
-        if spec.dag_hash() in module_type_index:
-            return module_type_index[spec.dag_hash()]
-        else:
+        entry = module_type_index.get(spec.dag_hash())
+        if entry is None:
             tty.debug(f"No module is available for upstream package {spec}")
-            return None
+        return entry
 
 
 class BaseConfiguration:
@@ -539,11 +536,11 @@ class BaseConfiguration:
         return filter_subsection.get("exclude_env_vars", [])
 
     def _create_list_for(self, what: str) -> List[spack.spec.Spec]:
-        include = []
-        for item in self.conf[what]:
-            if not self.make_configuration(item, self.name).excluded:
-                include.append(item)
-        return include
+        return [
+            item
+            for item in self.conf[what]
+            if not self.make_configuration(item, self.name).excluded
+        ]
 
     @property
     def verbose(self) -> Optional[bool]:
@@ -637,6 +634,7 @@ class BaseConfiguration:
         return requirements
 
     @property
+    @memoized
     def provides(self) -> Dict[str, spack.spec.Spec]:
         """Returns a dictionary mapping all the services provided by this
         spec to the spec itself.
@@ -670,12 +668,9 @@ class BaseConfiguration:
         """Returns a dictionary of the services that are currently
         available.
         """
-        available = {}
         # What is available is what I require plus what I provide.
         # 'compiler' is the only key that may be overridden.
-        available.update(self.requires)
-        available.update(self.provides)
-        return available
+        return {**self.requires, **self.provides}
 
     @property
     @memoized
@@ -752,8 +747,7 @@ class FileLayout:
             # list of the path parts
             requires = self.conf.requires
             hierarchy = self.conf.hierarchy_tokens
-            path_parts = lambda x: self.token_to_path(x, requires[x])
-            parts = [path_parts(x) for x in hierarchy if x in requires]
+            parts = [self.token_to_path(x, requires[x]) for x in hierarchy if x in requires]
 
             if not parts:
                 raise ModulesError(
@@ -852,10 +846,10 @@ class FileLayout:
 
         # Compute the paths that are unconditionally added
         # and append them to the dictionary (key = None)
+        hierarchy = self.conf.hierarchy_tokens
+        available = self.conf.available
         available_combination = []
         for item in to_be_processed:
-            hierarchy = self.conf.hierarchy_tokens
-            available = self.conf.available
             ac = [x for x in hierarchy if x in item]
             available_combination.append(tuple(ac))
             parts = [self.token_to_path(x, available[x]) for x in ac]
@@ -872,13 +866,12 @@ class FileLayout:
         for ii in range(len(missing)):
             missing_combinations += itertools.combinations(missing, ii + 1)
 
+        token2path = lambda x: self.token_to_path(x, available[x])
+
         # Attach the services required to each combination
         for m in missing_combinations:
             to_be_processed = [m + x for x in available_combination]
             for item in to_be_processed:
-                hierarchy = self.conf.hierarchy_tokens
-                available = self.conf.available
-                token2path = lambda x: self.token_to_path(x, available[x])
                 parts = []
                 for x in hierarchy:
                     if x not in item:
@@ -1140,7 +1133,7 @@ class ModuleContext(tengine.Context):
     def version_part(self) -> str:
         """Version of this provider."""
         s = self.spec
-        return "-".join([str(s.version), s.dag_hash(length=7)])
+        return f"{s.version}-{s.dag_hash(length=7)}"
 
     @tengine.context_property
     def provides(self) -> Dict[str, spack.spec.Spec]:
@@ -1217,11 +1210,7 @@ class BaseModuleFileWriter:
         # 2. template specified in a package directly
         # 3. default template (must be defined, check in __init__)
         package_attribute = f"{self.conf.module_system}_template"
-        for candidate in [
-            self.conf.template,
-            getattr(self.spec.package, package_attribute, None),
-            self.default_template,  # This is always defined at this point
-        ]:
+        for candidate in [self.conf.template, getattr(self.spec.package, package_attribute, None)]:
             if candidate:
                 return candidate
         return self.default_template
@@ -1339,7 +1328,7 @@ class BaseModuleFileWriter:
 
             # add hide command if module is hidden
             elif not already_hidden and hidden:
-                if len(content) == 0:
+                if not content:
                     content = self.modulerc_header.copy()
                 content.append(hide_module_cmd)
                 updated = True
@@ -1351,12 +1340,12 @@ class BaseModuleFileWriter:
 
         # no modulerc file change if no content update
         if updated:
-            is_empty = content == self.modulerc_header or len(content) == 0
+            is_empty = content == self.modulerc_header or not content
             # remove existing modulerc if empty
             if modulerc_exists and is_empty:
                 os.remove(modulerc_path)
             # create or update modulerc
-            elif content != self.modulerc_header:
+            elif not is_empty:
                 # ensure file ends with a newline character
                 content.append("")
                 with open(modulerc_path, "w", encoding="utf-8") as f:

--- a/lib/spack/spack/modules/common.py
+++ b/lib/spack/spack/modules/common.py
@@ -336,15 +336,6 @@ class BaseConfiguration:
         cls._registry = {}
 
     @classmethod
-    def configuration(cls, module_set_name: str) -> dict:
-        """Returns the raw configuration dict for this module system."""
-        return (
-            spack.config.CONFIG.get_config("modules")
-            .get(module_set_name, {})
-            .get(cls.module_system, {})
-        )
-
-    @classmethod
     def make_configuration(
         cls, spec: spack.spec.Spec, module_set_name: str, explicit: Optional[bool] = None
     ) -> "BaseConfiguration":
@@ -368,7 +359,7 @@ class BaseConfiguration:
         self.explicit = explicit
         _modules_cfg = spack.config.CONFIG.get_config("modules")
         _set_cfg = _modules_cfg.get(module_set_name, {})
-        self._config: dict = self.configuration(module_set_name)
+        self._config: dict = _set_cfg.get(self.module_system, {})
         self.hierarchical: bool = self._config.get("hierarchical", self._default_hierarchical)
         self.arch_folder: bool = _set_cfg.get("arch_folder", True)
         self.use_view: Union[bool, str] = _set_cfg.get("use_view", False)

--- a/lib/spack/spack/modules/common.py
+++ b/lib/spack/spack/modules/common.py
@@ -352,8 +352,8 @@ class BaseConfiguration:
         *,
         explicit: Optional[bool] = None,
         layout: "BaseFileLayout",
-    ) -> "BaseContext":
-        return BaseContext(cls.make_configuration(spec, module_set_name, explicit), layout)
+    ) -> "ModuleContext":
+        return ModuleContext(cls.make_configuration(spec, module_set_name, explicit), layout)
 
     def __init__(self, spec: spack.spec.Spec, module_set_name: str, explicit: bool) -> None:
         # Spec for which we want to generate a module file
@@ -893,15 +893,8 @@ class BaseFileLayout:
         return unlocked
 
 
-class BaseContext(tengine.Context):
-    """Provides the base context needed for template rendering.
-
-    This class needs to be sub-classed for specific module types. The
-    following attributes need to be implemented:
-
-    - fields
-
-    """
+class ModuleContext(tengine.Context):
+    """Provides the context dictionary used by the template engine to render a module file."""
 
     def __init__(self, configuration, layout: "BaseFileLayout") -> None:
         self.conf = configuration

--- a/lib/spack/spack/modules/common.py
+++ b/lib/spack/spack/modules/common.py
@@ -327,8 +327,8 @@ class BaseConfiguration:
     #: Per-subclass cache: must be assigned as ClassVar[Dict] = {} in each concrete subclass
     _registry: ClassVar[Dict[Tuple[str, str, bool], "BaseConfiguration"]]
 
-    #: Layout class must be set on each concrete subclass
-    layout_class: ClassVar[Type["BaseFileLayout"]]
+    #: File extension for module files (empty string means no extension)
+    file_extension: ClassVar[str] = ""
 
     @classmethod
     def configuration(cls, module_set_name: str) -> dict:
@@ -350,8 +350,8 @@ class BaseConfiguration:
     @classmethod
     def make_layout(
         cls, spec: spack.spec.Spec, module_set_name: str, explicit: Optional[bool] = None
-    ) -> "BaseFileLayout":
-        return cls.layout_class(cls.make_configuration(spec, module_set_name, explicit))
+    ) -> "FileLayout":
+        return FileLayout(cls.make_configuration(spec, module_set_name, explicit))
 
     @classmethod
     def make_context(
@@ -360,7 +360,7 @@ class BaseConfiguration:
         module_set_name: str,
         *,
         explicit: Optional[bool] = None,
-        layout: "BaseFileLayout",
+        layout: "FileLayout",
     ) -> "ModuleContext":
         return ModuleContext(cls.make_configuration(spec, module_set_name, explicit), layout)
 
@@ -687,13 +687,8 @@ class BaseConfiguration:
         return [x for x in self.hierarchy_tokens if x not in self.available]
 
 
-class BaseFileLayout:
-    """Provides information on the layout of module files. Needs to be
-    sub-classed for specific module types.
-    """
-
-    #: This needs to be redefined
-    extension: Optional[str] = None
+class FileLayout:
+    """Provides information on the layout of module files."""
 
     def __init__(self, configuration):
         self.conf = configuration
@@ -702,8 +697,8 @@ class BaseFileLayout:
     def modulerc(self) -> str:
         """Returns the modulerc file for this module file."""
         dirname = os.path.dirname(self.filename)
-        if self.extension:
-            return os.path.join(dirname, f".modulerc.{self.extension}")
+        if self.conf.file_extension:
+            return os.path.join(dirname, f".modulerc.{self.conf.file_extension}")
         return os.path.join(dirname, ".modulerc")
 
     @property
@@ -755,8 +750,8 @@ class BaseFileLayout:
         """Name of the module file for the current spec."""
         # Just the name of the file
         filename = self.use_name
-        if self.extension:
-            filename = f"{self.use_name}.{self.extension}"
+        if self.conf.file_extension:
+            filename = f"{self.use_name}.{self.conf.file_extension}"
 
         if self.conf.hierarchical:
             # Get the list of requirements and build an **ordered**
@@ -905,7 +900,7 @@ class BaseFileLayout:
 class ModuleContext(tengine.Context):
     """Provides the context dictionary used by the template engine to render a module file."""
 
-    def __init__(self, configuration, layout: "BaseFileLayout") -> None:
+    def __init__(self, configuration, layout: "FileLayout") -> None:
         self.conf = configuration
         self.layout = layout
 

--- a/lib/spack/spack/modules/common.py
+++ b/lib/spack/spack/modules/common.py
@@ -338,7 +338,11 @@ class BaseConfiguration:
     @classmethod
     def configuration(cls, module_set_name: str) -> dict:
         """Returns the raw configuration dict for this module system."""
-        return spack.config.get(f"modules:{module_set_name}:{cls.module_system}", {})
+        return (
+            spack.config.CONFIG.get_config("modules")
+            .get(module_set_name, {})
+            .get(cls.module_system, {})
+        )
 
     @classmethod
     def make_configuration(
@@ -359,14 +363,20 @@ class BaseConfiguration:
         return FileLayout(cls.make_configuration(spec, module_set_name, explicit))
 
     def __init__(self, spec: spack.spec.Spec, module_set_name: str, explicit: bool) -> None:
-        # Spec for which we want to generate a module file
         self.spec = spec
         self.name = module_set_name
         self.explicit = explicit
-        # Cache once — configuration() traverses all config scopes on every call
-        self._config = self.configuration(self.name)
+        _modules_cfg = spack.config.CONFIG.get_config("modules")
+        _set_cfg = _modules_cfg.get(module_set_name, {})
+        self._config: dict = self.configuration(module_set_name)
         self.hierarchical: bool = self._config.get("hierarchical", self._default_hierarchical)
-        self.arch_folder: bool = spack.config.get(f"modules:{module_set_name}:arch_folder", True)
+        self.arch_folder: bool = _set_cfg.get("arch_folder", True)
+        self.use_view: Union[bool, str] = _set_cfg.get("use_view", False)
+        self.prefix_inspections: dict = syaml.syaml_dict()
+        spack.schema.merge_yaml(
+            self.prefix_inspections, _modules_cfg.get("prefix_inspections", {})
+        )
+        spack.schema.merge_yaml(self.prefix_inspections, _set_cfg.get("prefix_inspections", {}))
         # Dictionary of configuration options that should be applied to the spec
         self.conf = merge_config_rules(self._config, self.spec)
 
@@ -980,18 +990,7 @@ class ModuleContext(tengine.Context):
         ]
     ]:
         """List of environment modifications to be processed."""
-        # Modifications guessed by inspecting the spec prefix
-        prefix_inspections = syaml.syaml_dict()
-        spack.schema.merge_yaml(
-            prefix_inspections, spack.config.get("modules:prefix_inspections", {})
-        )
-        spack.schema.merge_yaml(
-            prefix_inspections,
-            spack.config.get(f"modules:{self.conf.name}:prefix_inspections", {}),
-        )
-
-        use_view = spack.config.get(f"modules:{self.conf.name}:use_view", False)
-
+        use_view = self.conf.use_view
         assert isinstance(use_view, (bool, str))
 
         if use_view:
@@ -1014,7 +1013,9 @@ class ModuleContext(tengine.Context):
             view = None
 
         env = spack.util.environment.inspect_path(
-            self.spec.prefix, prefix_inspections, exclude=spack.util.environment.is_system_path
+            self.spec.prefix,
+            self.conf.prefix_inspections,
+            exclude=spack.util.environment.is_system_path,
         )
 
         # Let the extendee/dependency modify their extensions/dependencies
@@ -1071,8 +1072,7 @@ class ModuleContext(tengine.Context):
                 continue
             if cmd.name == "MANPATH":
                 return True
-        else:
-            return False
+        return False
 
     @tengine.context_property
     def conflicts(self) -> List[str]:
@@ -1338,13 +1338,8 @@ class BaseModuleFileWriter:
         updated = False
 
         if modulerc_exists:
-            # retrieve modulerc content
             with open(modulerc_path, encoding="utf-8") as f:
-                content = f.readlines()
-                content = "".join(content).split("\n")
-                # remove last empty item if any
-                if len(content[-1]) == 0:
-                    del content[-1]
+                content = f.read().splitlines()
             already_hidden = hide_module_cmd in content
 
             # remove hide command if module not hidden

--- a/lib/spack/spack/modules/error.py
+++ b/lib/spack/spack/modules/error.py
@@ -1,0 +1,35 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+"""Errors and exceptions for the modules package."""
+
+import spack.error
+
+
+class ModulesError(spack.error.SpackError):
+    """Base error for modules."""
+
+
+class ModuleNotFoundError(ModulesError):
+    """Raised when a module cannot be found for a spec"""
+
+
+class DefaultTemplateNotDefined(AttributeError, ModulesError):
+    """Raised if ``default_template`` has not been specified in the derived class."""
+
+
+class HideCmdFormatNotDefined(AttributeError, ModulesError):
+    """Raised if ``hide_cmd_format`` has not been specified in the derived class."""
+
+
+class ModulercHeaderNotDefined(AttributeError, ModulesError):
+    """Raised if ``modulerc_header`` has not been specified in the derived class."""
+
+
+class ModulesTemplateNotFoundError(ModulesError, RuntimeError):
+    """Raised if the template for a module file was not found."""
+
+
+class CoreCompilersNotFoundError(spack.error.SpackError, KeyError):
+    """Raised if ``core_compilers`` has not been specified in the configuration file."""

--- a/lib/spack/spack/modules/lmod.py
+++ b/lib/spack/spack/modules/lmod.py
@@ -14,16 +14,16 @@ class LmodConfiguration(BaseConfiguration):
     _default_hierarchical = True
     file_extension = "lua"
 
-    def _manipulate_path(self, token: str) -> str:
+    def manipulate_path(self, token: str) -> str:
         if token in self.hierarchy_tokens:
             return "{0}_name, {0}_version".format(token)
         return '"' + token + '"'
 
-    def _format_condition(self, services_needed: Tuple[str, ...]) -> str:
+    def format_condition(self, services_needed: Tuple[str, ...]) -> str:
         return " and ".join([x + "_name" for x in services_needed])
 
-    def _join_path(self, parts: Tuple[str, ...]) -> str:
-        return ", ".join([self._manipulate_path(token) for token in parts])
+    def join_path(self, parts: Tuple[str, ...]) -> str:
+        return ", ".join([self.manipulate_path(token) for token in parts])
 
 
 class LmodModulefileWriter(BaseModuleFileWriter):

--- a/lib/spack/spack/modules/lmod.py
+++ b/lib/spack/spack/modules/lmod.py
@@ -2,10 +2,9 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-import os
 from typing import ClassVar, Dict, Tuple
 
-from .common import BaseConfiguration, BaseContext, BaseFileLayout, BaseModuleFileWriter
+from .common import BaseConfiguration, BaseFileLayout, BaseModuleFileWriter
 
 
 class LmodFileLayout(BaseFileLayout):
@@ -13,26 +12,6 @@ class LmodFileLayout(BaseFileLayout):
 
     #: file extension of lua module files
     extension = "lua"
-
-    @property
-    def modulerc(self) -> str:
-        """Returns the modulerc file associated with current module file"""
-        return os.path.join(os.path.dirname(self.filename), f".modulerc.{self.extension}")
-
-
-class LmodContext(BaseContext):
-    """Context class for lmod module files."""
-
-    def _manipulate_path(self, token: str) -> str:
-        if token in self.conf.hierarchy_tokens:
-            return "{0}_name, {0}_version".format(token)
-        return '"' + token + '"'
-
-    def _format_condition(self, services_needed: Tuple[str, ...]) -> str:
-        return " and ".join([x + "_name" for x in services_needed])
-
-    def _join_path(self, parts: Tuple[str, ...]) -> str:
-        return ", ".join([self._manipulate_path(x) for x in parts])
 
 
 class LmodConfiguration(BaseConfiguration):
@@ -42,7 +21,17 @@ class LmodConfiguration(BaseConfiguration):
     _default_hierarchical = True
     _registry: ClassVar[Dict] = {}
     layout_class = LmodFileLayout
-    context_class = LmodContext
+
+    def _manipulate_path(self, token: str) -> str:
+        if token in self.hierarchy_tokens:
+            return "{0}_name, {0}_version".format(token)
+        return '"' + token + '"'
+
+    def _format_condition(self, services_needed: Tuple[str, ...]) -> str:
+        return " and ".join([x + "_name" for x in services_needed])
+
+    def _join_path(self, parts: Tuple[str, ...]) -> str:
+        return ", ".join([self._manipulate_path(token) for token in parts])
 
 
 class LmodModulefileWriter(BaseModuleFileWriter):

--- a/lib/spack/spack/modules/lmod.py
+++ b/lib/spack/spack/modules/lmod.py
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-from typing import ClassVar, Dict, Tuple
+from typing import Tuple
 
 from .common import BaseConfiguration, BaseModuleFileWriter
 
@@ -12,7 +12,6 @@ class LmodConfiguration(BaseConfiguration):
 
     module_system = "lmod"
     _default_hierarchical = True
-    _registry: ClassVar[Dict] = {}
     file_extension = "lua"
 
     def _manipulate_path(self, token: str) -> str:

--- a/lib/spack/spack/modules/lmod.py
+++ b/lib/spack/spack/modules/lmod.py
@@ -4,14 +4,7 @@
 
 from typing import ClassVar, Dict, Tuple
 
-from .common import BaseConfiguration, BaseFileLayout, BaseModuleFileWriter
-
-
-class LmodFileLayout(BaseFileLayout):
-    """File layout for lmod module files."""
-
-    #: file extension of lua module files
-    extension = "lua"
+from .common import BaseConfiguration, BaseModuleFileWriter
 
 
 class LmodConfiguration(BaseConfiguration):
@@ -20,7 +13,7 @@ class LmodConfiguration(BaseConfiguration):
     module_system = "lmod"
     _default_hierarchical = True
     _registry: ClassVar[Dict] = {}
-    layout_class = LmodFileLayout
+    file_extension = "lua"
 
     def _manipulate_path(self, token: str) -> str:
         if token in self.hierarchy_tokens:

--- a/lib/spack/spack/modules/tcl.py
+++ b/lib/spack/spack/modules/tcl.py
@@ -14,16 +14,16 @@ class TclConfiguration(BaseConfiguration):
 
     module_system = "tcl"
 
-    def _manipulate_path(self, token: str) -> str:
+    def manipulate_path(self, token: str) -> str:
         if token in self.hierarchy_tokens:
             return "${{{0}_name}} ${{{0}_version}}".format(token)
         return '"' + token + '"'
 
-    def _format_condition(self, services_needed: Tuple[str, ...]) -> str:
+    def format_condition(self, services_needed: Tuple[str, ...]) -> str:
         return " && ".join(["[string length $" + x + "_name]" for x in services_needed])
 
-    def _join_path(self, parts: Tuple[str, ...]) -> str:
-        return " ".join([self._manipulate_path(token) for token in parts])
+    def join_path(self, parts: Tuple[str, ...]) -> str:
+        return " ".join([self.manipulate_path(token) for token in parts])
 
 
 class TclModulefileWriter(BaseModuleFileWriter):

--- a/lib/spack/spack/modules/tcl.py
+++ b/lib/spack/spack/modules/tcl.py
@@ -4,7 +4,7 @@
 
 """This module implements the classes necessary to generate Tcl modules."""
 
-from typing import ClassVar, Dict, Tuple
+from typing import Tuple
 
 from .common import BaseConfiguration, BaseModuleFileWriter
 
@@ -13,7 +13,6 @@ class TclConfiguration(BaseConfiguration):
     """Configuration class for tcl module files."""
 
     module_system = "tcl"
-    _registry: ClassVar[Dict] = {}
 
     def _manipulate_path(self, token: str) -> str:
         if token in self.hierarchy_tokens:

--- a/lib/spack/spack/modules/tcl.py
+++ b/lib/spack/spack/modules/tcl.py
@@ -6,11 +6,7 @@
 
 from typing import ClassVar, Dict, Tuple
 
-from .common import BaseConfiguration, BaseFileLayout, BaseModuleFileWriter
-
-
-class TclFileLayout(BaseFileLayout):
-    """File layout for tcl module files."""
+from .common import BaseConfiguration, BaseModuleFileWriter
 
 
 class TclConfiguration(BaseConfiguration):
@@ -18,7 +14,6 @@ class TclConfiguration(BaseConfiguration):
 
     module_system = "tcl"
     _registry: ClassVar[Dict] = {}
-    layout_class = TclFileLayout
 
     def _manipulate_path(self, token: str) -> str:
         if token in self.hierarchy_tokens:

--- a/lib/spack/spack/modules/tcl.py
+++ b/lib/spack/spack/modules/tcl.py
@@ -4,41 +4,13 @@
 
 """This module implements the classes necessary to generate Tcl modules."""
 
-import os
-from typing import ClassVar, Dict, List, Tuple
+from typing import ClassVar, Dict, Tuple
 
-import spack.tengine as tengine
-
-from .common import BaseConfiguration, BaseContext, BaseFileLayout, BaseModuleFileWriter
+from .common import BaseConfiguration, BaseFileLayout, BaseModuleFileWriter
 
 
 class TclFileLayout(BaseFileLayout):
     """File layout for tcl module files."""
-
-    @property
-    def modulerc(self) -> str:
-        """Returns the modulerc file associated with current module file"""
-        return os.path.join(os.path.dirname(self.filename), ".modulerc")
-
-
-class TclContext(BaseContext):
-    """Context class for tcl module files."""
-
-    @tengine.context_property
-    def prerequisites(self) -> List[str]:
-        """List of modules that needs to be loaded automatically."""
-        return self._create_module_list_of("specs_to_prereq")
-
-    def _manipulate_path(self, token: str) -> str:
-        if token in self.conf.hierarchy_tokens:
-            return "${{{0}_name}} ${{{0}_version}}".format(token)
-        return '"' + token + '"'
-
-    def _format_condition(self, services_needed: Tuple[str, ...]) -> str:
-        return " && ".join(["[string length $" + x + "_name]" for x in services_needed])
-
-    def _join_path(self, parts: Tuple[str, ...]) -> str:
-        return " ".join([self._manipulate_path(x) for x in parts])
 
 
 class TclConfiguration(BaseConfiguration):
@@ -47,7 +19,17 @@ class TclConfiguration(BaseConfiguration):
     module_system = "tcl"
     _registry: ClassVar[Dict] = {}
     layout_class = TclFileLayout
-    context_class = TclContext
+
+    def _manipulate_path(self, token: str) -> str:
+        if token in self.hierarchy_tokens:
+            return "${{{0}_name}} ${{{0}_version}}".format(token)
+        return '"' + token + '"'
+
+    def _format_condition(self, services_needed: Tuple[str, ...]) -> str:
+        return " && ".join(["[string length $" + x + "_name]" for x in services_needed])
+
+    def _join_path(self, parts: Tuple[str, ...]) -> str:
+        return " ".join([self._manipulate_path(token) for token in parts])
 
 
 class TclModulefileWriter(BaseModuleFileWriter):

--- a/lib/spack/spack/test/cmd/module.py
+++ b/lib/spack/spack/test/cmd/module.py
@@ -35,7 +35,7 @@ def ensure_module_files_are_there(mock_packages_repo, mock_store, mock_configura
 def _module_files(module_type, *specs):
     specs = [spack.concretize.concretize_one(x) for x in specs]
     writer_cls = spack.modules.module_types[module_type]
-    return [writer_cls(spec, "default").layout.filename for spec in specs]
+    return [writer_cls.from_spec(spec, "default").layout.filename for spec in specs]
 
 
 @pytest.fixture(
@@ -191,8 +191,8 @@ def test_setdefault_command(mutable_database, mutable_config):
     PackageInstaller([s.package for s in specs], explicit=True, fake=True).install()
 
     writers = {
-        preferred: writer_cls(specs[1], "default"),
-        other_spec: writer_cls(specs[0], "default"),
+        preferred: writer_cls.from_spec(specs[1], "default"),
+        other_spec: writer_cls.from_spec(specs[0], "default"),
     }
 
     # Create two module files for the same software

--- a/lib/spack/spack/test/conftest.py
+++ b/lib/spack/spack/test/conftest.py
@@ -1353,18 +1353,6 @@ def gen_mock_layout(tmp_path: Path):
     yield create_layout
 
 
-class MockConfig:
-    def __init__(self, configuration, writer_key):
-        self._configuration = configuration
-        self.writer_key = writer_key
-
-    def configuration(self, module_set_name):
-        return self._configuration
-
-    def writer_configuration(self, module_set_name):
-        return self.configuration(module_set_name)[self.writer_key]
-
-
 class ConfigUpdate:
     def __init__(self, root_for_conf, writer_mod, writer_key, monkeypatch):
         self.root_for_conf = root_for_conf
@@ -1377,12 +1365,8 @@ class ConfigUpdate:
         with open(file, encoding="utf-8") as f:
             config_settings = syaml.load_config(f)
         spack.config.set("modules:default", config_settings)
-        mock_config = MockConfig(config_settings, self.writer_key)
 
         conf_cls = getattr(self.writer_mod, self.writer_key.capitalize() + "Configuration")
-        self.monkeypatch.setattr(
-            conf_cls, "configuration", staticmethod(mock_config.writer_configuration)
-        )
         self.monkeypatch.setattr(conf_cls, "_registry", {})
 
 

--- a/lib/spack/spack/test/modules/common.py
+++ b/lib/spack/spack/test/modules/common.py
@@ -63,7 +63,7 @@ def test_modules_written_with_proper_permissions(
 
     # The code tested is common to all module types, but has to be tested from
     # one. Tcl picked at random
-    generator = spack.modules.tcl.TclModulefileWriter(spec, "default")
+    generator = spack.modules.tcl.TclModulefileWriter.from_spec(spec, "default")
     generator.write()
 
     assert mock_package_perms & os.stat(mock_module_filename).st_mode == mock_package_perms
@@ -77,7 +77,7 @@ def test_modules_default_symlink(
     mock_module_defaults(spec.format("{name}{@version}"), True)
 
     generator_cls = spack.modules.module_types[module_type]
-    generator = generator_cls(spec, "default")
+    generator = generator_cls.from_spec(spec, "default")
     generator.write()
 
     link_path = os.path.join(os.path.dirname(mock_module_filename), "default")
@@ -177,7 +177,7 @@ def test_load_installed_package_not_in_repo(install_mockery, mock_fetch, monkeyp
     """Test that installed packages that have been removed are still loadable"""
     spec = spack.concretize.concretize_one("trivial-install-test-package")
     PackageInstaller([spec.package], explicit=True).install()
-    spack.modules.module_types["tcl"](spec, "default", True).write()
+    spack.modules.module_types["tcl"].from_spec(spec, "default", True).write()
 
     def find_nothing(*args):
         raise spack.repo.UnknownPackageError("Repo package access is disabled for test")
@@ -224,5 +224,5 @@ def test_check_module_set_name(mutable_config):
 @pytest.mark.parametrize("module_type", ["tcl", "lmod"])
 def test_module_writers_are_pickleable(default_mock_concretization, module_type):
     s = default_mock_concretization("mpileaks")
-    writer = spack.modules.module_types[module_type](s, "default")
+    writer = spack.modules.module_types[module_type].from_spec(s, "default")
     assert pickle.loads(pickle.dumps(writer)).spec == s

--- a/lib/spack/spack/test/modules/conftest.py
+++ b/lib/spack/spack/test/modules/conftest.py
@@ -19,7 +19,7 @@ def modulefile_content(request):
         if isinstance(spec_like, str):
             spec_like = spack.spec.Spec(spec_like)
         spec = spack.concretize.concretize_one(spec_like)
-        generator = writer_cls(spec, module_set_name, explicit)
+        generator = writer_cls.from_spec(spec, module_set_name, explicit)
         generator.write(overwrite=True)
         written_module = pathlib.Path(generator.layout.filename)
         content = written_module.read_text(encoding="utf-8").splitlines()
@@ -36,7 +36,7 @@ def factory(request, mock_modules_root):
 
     def _mock(spec_string, module_set_name="default", explicit=True):
         spec = spack.concretize.concretize_one(spec_string)
-        return writer_cls(spec, module_set_name, explicit), spec
+        return writer_cls.from_spec(spec, module_set_name, explicit), spec
 
     return _mock
 

--- a/lib/spack/spack/test/modules/conftest.py
+++ b/lib/spack/spack/test/modules/conftest.py
@@ -6,8 +6,7 @@ import pathlib
 import pytest
 
 import spack.concretize
-import spack.modules.lmod
-import spack.modules.tcl
+import spack.modules.common
 import spack.spec
 
 
@@ -45,7 +44,5 @@ def factory(request, mock_modules_root):
 @pytest.fixture()
 def mock_module_filename(monkeypatch, tmp_path: pathlib.Path):
     filename = tmp_path / "module"
-    # Set for both module types so we can test both
-    monkeypatch.setattr(spack.modules.lmod.LmodFileLayout, "filename", str(filename))
-    monkeypatch.setattr(spack.modules.tcl.TclFileLayout, "filename", str(filename))
+    monkeypatch.setattr(spack.modules.common.FileLayout, "filename", str(filename))
     yield str(filename)

--- a/lib/spack/spack/test/modules/lmod.py
+++ b/lib/spack/spack/test/modules/lmod.py
@@ -13,7 +13,7 @@ import spack.concretize
 import spack.config
 import spack.environment as ev
 import spack.main
-import spack.modules.common
+import spack.modules.error
 import spack.modules.lmod
 import spack.spec
 import spack.util.environment
@@ -335,14 +335,14 @@ class TestLmod:
         module_configuration("missing_core_compilers")
 
         module, spec = factory(mpileaks_spec_string)
-        with pytest.raises(spack.modules.common.CoreCompilersNotFoundError):
+        with pytest.raises(spack.modules.error.CoreCompilersNotFoundError):
             module.write()
 
         # Here we have an empty list
         module_configuration("core_compilers_empty")
 
         module, spec = factory(mpileaks_spec_string)
-        with pytest.raises(spack.modules.common.CoreCompilersNotFoundError):
+        with pytest.raises(spack.modules.error.CoreCompilersNotFoundError):
             module.write()
 
     def test_conflicts(self, modulefile_content, module_configuration):
@@ -362,7 +362,7 @@ class TestLmod:
 
         # This configuration is inconsistent, check an error is raised
         module_configuration("wrong_conflicts")
-        with pytest.raises(spack.modules.common.ModulesError):
+        with pytest.raises(spack.modules.error.ModulesError):
             modulefile_content("mpileaks")
 
     def test_override_template_in_package(self, modulefile_content, module_configuration):

--- a/lib/spack/spack/test/modules/lmod.py
+++ b/lib/spack/spack/test/modules/lmod.py
@@ -491,7 +491,7 @@ class TestLmod:
         spec = spack.concretize.concretize_one("mpileaks@2.3")
 
         # mpileaks is defined as implicit, thus hide command should appear in modulerc
-        writer = writer_cls(spec, "default", False)
+        writer = writer_cls.from_spec(spec, "default", False)
         writer.write()
         assert os.path.exists(writer.layout.modulerc)
         with open(writer.layout.modulerc, encoding="utf-8") as f:
@@ -513,7 +513,7 @@ class TestLmod:
 
         # when mpileaks becomes explicit, its file name changes (hash_length = 0), meaning an
         # extra module file is created; the old one still exists and remains hidden.
-        writer = writer_cls(spec, "default", True)
+        writer = writer_cls.from_spec(spec, "default", True)
         writer.write()
         assert os.path.exists(writer.layout.modulerc)
         with open(writer.layout.modulerc, encoding="utf-8") as f:
@@ -523,13 +523,13 @@ class TestLmod:
 
         # after removing both the implicit and explicit module, the modulerc file would be empty
         # and should be removed.
-        writer_cls(spec, "default", False).remove()
-        writer_cls(spec, "default", True).remove()
+        writer_cls.from_spec(spec, "default", False).remove()
+        writer_cls.from_spec(spec, "default", True).remove()
         assert not os.path.exists(writer.layout.modulerc)
         assert not os.path.exists(writer.layout.filename)
 
         # implicit module is removed
-        writer = writer_cls(spec, "default", False)
+        writer = writer_cls.from_spec(spec, "default", False)
         writer.write()
         assert os.path.exists(writer.layout.filename)
         assert os.path.exists(writer.layout.modulerc)
@@ -538,13 +538,13 @@ class TestLmod:
         assert not os.path.exists(writer.layout.filename)
 
         # three versions of mpileaks are implicit
-        writer = writer_cls(spec, "default", False)
+        writer = writer_cls.from_spec(spec, "default", False)
         writer.write(overwrite=True)
         spec_alt1 = spack.concretize.concretize_one("mpileaks@2.2")
         spec_alt2 = spack.concretize.concretize_one("mpileaks@2.1")
-        writer_alt1 = writer_cls(spec_alt1, "default", False)
+        writer_alt1 = writer_cls.from_spec(spec_alt1, "default", False)
         writer_alt1.write(overwrite=True)
-        writer_alt2 = writer_cls(spec_alt2, "default", False)
+        writer_alt2 = writer_cls.from_spec(spec_alt2, "default", False)
         writer_alt2.write(overwrite=True)
         assert os.path.exists(writer.layout.modulerc)
         with open(writer.layout.modulerc, encoding="utf-8") as f:

--- a/lib/spack/spack/test/modules/tcl.py
+++ b/lib/spack/spack/test/modules/tcl.py
@@ -11,6 +11,7 @@ import spack.vendor.archspec.cpu
 import spack.concretize
 import spack.config
 import spack.modules.common
+import spack.modules.error
 import spack.modules.tcl
 import spack.spec
 import spack.util.environment
@@ -357,7 +358,7 @@ class TestTcl:
 
         # This configuration is inconsistent, check an error is raised
         module_configuration("wrong_conflicts")
-        with pytest.raises(spack.modules.common.ModulesError):
+        with pytest.raises(spack.modules.error.ModulesError):
             modulefile_content("mpileaks")
 
     def test_module_index(
@@ -731,14 +732,14 @@ class TestTcl:
         module_configuration("missing_core_compilers")
 
         module, spec = factory(mpileaks_spec_string)
-        with pytest.raises(spack.modules.common.CoreCompilersNotFoundError):
+        with pytest.raises(spack.modules.error.CoreCompilersNotFoundError):
             module.write()
 
         # Here we have an empty list
         module_configuration("core_compilers_empty")
 
         module, spec = factory(mpileaks_spec_string)
-        with pytest.raises(spack.modules.common.CoreCompilersNotFoundError):
+        with pytest.raises(spack.modules.error.CoreCompilersNotFoundError):
             module.write()
 
     def test_guess_core_compilers(self, factory, module_configuration, monkeypatch):

--- a/lib/spack/spack/test/modules/tcl.py
+++ b/lib/spack/spack/test/modules/tcl.py
@@ -485,14 +485,14 @@ class TestTcl:
         # the tests database
         mpileaks_specs = mutable_database.query("mpileaks")
         for item in mpileaks_specs:
-            writer = writer_cls(item, "default")
+            writer = writer_cls.from_spec(item, "default")
             assert not writer.conf.excluded
 
         # callpath is a dependency of mpileaks, and has been pulled
         # in implicitly
         callpath_specs = mutable_database.query("callpath")
         for item in callpath_specs:
-            writer = writer_cls(item, "default")
+            writer = writer_cls.from_spec(item, "default")
             assert writer.conf.excluded
 
     @pytest.mark.regression("12105")
@@ -501,12 +501,12 @@ class TestTcl:
 
         # mpileaks is defined as explicit with explicit argument set on writer
         mpileaks_spec = spack.concretize.concretize_one("mpileaks")
-        writer = writer_cls(mpileaks_spec, "default", True)
+        writer = writer_cls.from_spec(mpileaks_spec, "default", True)
         assert not writer.conf.excluded
 
         # callpath is defined as implicit with explicit argument set on writer
         callpath_spec = spack.concretize.concretize_one("callpath")
-        writer = writer_cls(callpath_spec, "default", False)
+        writer = writer_cls.from_spec(callpath_spec, "default", False)
         assert writer.conf.excluded
 
     @pytest.mark.regression("9624")
@@ -543,7 +543,7 @@ class TestTcl:
         spec = spack.concretize.concretize_one("mpileaks@2.3")
 
         # mpileaks is defined as implicit, thus hide command should appear in modulerc
-        writer = writer_cls(spec, "default", False)
+        writer = writer_cls.from_spec(spec, "default", False)
         writer.write()
         assert os.path.exists(writer.layout.modulerc)
         with open(writer.layout.modulerc, encoding="utf-8") as f:
@@ -560,7 +560,7 @@ class TestTcl:
 
         # when mpileaks becomes explicit, its file name changes (hash_length = 0), meaning an
         # extra module file is created; the old one still exists and remains hidden.
-        writer = writer_cls(spec, "default", True)
+        writer = writer_cls.from_spec(spec, "default", True)
         writer.write()
         assert os.path.exists(writer.layout.modulerc)
         with open(writer.layout.modulerc, encoding="utf-8") as f:
@@ -570,13 +570,13 @@ class TestTcl:
 
         # after removing both the implicit and explicit module, the modulerc file would be empty
         # and should be removed.
-        writer_cls(spec, "default", False).remove()
-        writer_cls(spec, "default", True).remove()
+        writer_cls.from_spec(spec, "default", False).remove()
+        writer_cls.from_spec(spec, "default", True).remove()
         assert not os.path.exists(writer.layout.modulerc)
         assert not os.path.exists(writer.layout.filename)
 
         # implicit module is removed
-        writer = writer_cls(spec, "default", False)
+        writer = writer_cls.from_spec(spec, "default", False)
         writer.write()
         assert os.path.exists(writer.layout.filename)
         assert os.path.exists(writer.layout.modulerc)
@@ -585,13 +585,13 @@ class TestTcl:
         assert not os.path.exists(writer.layout.filename)
 
         # three versions of mpileaks are implicit
-        writer = writer_cls(spec, "default", False)
+        writer = writer_cls.from_spec(spec, "default", False)
         writer.write(overwrite=True)
         spec_alt1 = spack.concretize.concretize_one("mpileaks@2.2")
         spec_alt2 = spack.concretize.concretize_one("mpileaks@2.1")
-        writer_alt1 = writer_cls(spec_alt1, "default", False)
+        writer_alt1 = writer_cls.from_spec(spec_alt1, "default", False)
         writer_alt1.write(overwrite=True)
-        writer_alt2 = writer_cls(spec_alt2, "default", False)
+        writer_alt2 = writer_cls.from_spec(spec_alt2, "default", False)
         writer_alt2.write(overwrite=True)
         assert os.path.exists(writer.layout.modulerc)
         with open(writer.layout.modulerc, encoding="utf-8") as f:


### PR DESCRIPTION
Modifications:

* Eliminated subclasses for `FileLayout` and `ModuleContext`
* Reduced the number of time we re-read configuration (less `spack.config.get` calls in favor of `get_config` and reading from the stored dict)
* Configuration caches are per-class, not per module
* `*ModuleFileWriter` takes a configuration object during construction (a `from_spec()` classmethod replaces the old constructor)
* Errors have been extracted to `spack.modules.error`
