### PR TITLE
Windows IPC v2

### DIFF
--- a/lib/spack/spack/new_installer.py
+++ b/lib/spack/spack/new_installer.py
@@ -2023,8 +2023,11 @@ class PackageInstaller:
         self.keep_prefix = keep_prefix
         self.fail_fast = fail_fast
 
-        # Buffer for incoming, partially received state data from child processes
-        self.state_buffers: Dict[int, str] = {}
+        # Buffer for incoming, partially received state data from child processes. Kept as raw
+        # bytes and split on b"\n": the newline byte cannot occur inside a multi-byte UTF-8
+        # sequence, so framing is safe without decoding partial reads. Keyed by PID rather than fd
+        # because on Windows the state channel is a socket whose handle is not a stable POSIX fd.
+        self.state_buffers: Dict[int, bytes] = {}
 
         if explicit is True:
             self.explicit = {spec.dag_hash() for spec in specs}
@@ -2623,7 +2626,8 @@ class PackageInstaller:
         """Handle reading state updates from a child process pipe. Returns False once the channel
         has reached EOF and was unregistered, True while it remains open."""
         conn = child_info.state_r_conn
-        fd = conn.fileno()
+        pid = child_info.proc.pid
+        assert pid is not None
         try:
             # There might be more data than OUTPUT_BUFFER_SIZE, but we will read that in the next
             # iteration of the event loop to keep things responsive.
@@ -2638,23 +2642,23 @@ class PackageInstaller:
                 selector.unregister(conn)
             except (KeyError, OSError):
                 pass
-            self.state_buffers.pop(fd, None)
+            self.state_buffers.pop(pid, None)
             return False
 
-        # Append new data to the buffer for this fd and process it
-        buffer = self.state_buffers.get(fd, "") + data.decode(errors="replace")
-        lines = buffer.split("\n")
-
+        # Accumulate raw bytes and split on the newline byte. We never decode a partial read; only
+        # complete lines are handed to json.loads(), which decodes the (UTF-8) bytes itself.
+        buffer = self.state_buffers.get(pid, b"") + data
+        lines = buffer.split(b"\n")
         # The last element of split() will be a partial line or an empty string.
         # We store it back in the buffer for the next read.
-        self.state_buffers[fd] = lines.pop()
+        self.state_buffers[pid] = lines.pop()
 
         for line in lines:
             if not line:
                 continue
             try:
                 message = json.loads(line)
-            except json.JSONDecodeError:
+            except ValueError:
                 continue
             if "state" in message:
                 self.build_status.update_state(child_info.spec.dag_hash(), message["state"])

--- a/lib/spack/spack/new_installer.py
+++ b/lib/spack/spack/new_installer.py
@@ -34,7 +34,6 @@ import time
 import traceback
 from gzip import GzipFile
 from multiprocessing import Pipe, Process
-from multiprocessing.connection import Connection
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -79,7 +78,9 @@ from spack.new_installer_base import (
     OUTPUT_BUFFER_SIZE,
     BaseTerminalState,
     FdInfo,
+    IpcChannel,
     JobServerBase,
+    ProcessExitNotifier,
     StdinReaderBase,
 )
 from spack.subprocess_context import GlobalStateMarshaler
@@ -91,6 +92,7 @@ if sys.platform == "win32":
     from spack.new_installer_base import NoopJobServer as JobServer
     from spack.new_installer_windows import WindowsTerminalState as TerminalState
 else:
+    from spack.new_installer_posix import PosixExitNotifier as ExitNotifier
     from spack.new_installer_posix import PosixJobServer as JobServer
     from spack.new_installer_posix import PosixTee
     from spack.new_installer_posix import PosixTerminalState as TerminalState
@@ -166,15 +168,24 @@ class MarkExplicitAction(DatabaseAction):
 class ChildInfo(DatabaseAction):
     """Information about a child process."""
 
-    __slots__ = ("proc", "output_r_conn", "state_r_conn", "control_w_conn", "explicit", "log_path")
+    __slots__ = (
+        "proc",
+        "output_r_conn",
+        "state_r_conn",
+        "control_w_conn",
+        "notifier",
+        "explicit",
+        "log_path",
+    )
 
     def __init__(
         self,
         proc: Process,
         spec: spack.spec.Spec,
-        output_r_conn: Connection,
-        state_r_conn: Connection,
-        control_w_conn: Connection,
+        output_r_conn: IpcChannel,
+        state_r_conn: IpcChannel,
+        control_w_conn: IpcChannel,
+        notifier: ProcessExitNotifier,
         log_path: str,
         explicit: bool = False,
     ) -> None:
@@ -183,6 +194,7 @@ class ChildInfo(DatabaseAction):
         self.output_r_conn = output_r_conn
         self.state_r_conn = state_r_conn
         self.control_w_conn = control_w_conn
+        self.notifier = notifier
         self.log_path = log_path
         self.explicit = explicit
         self.prefix_lock: Optional[spack.util.lock.Lock] = None
@@ -192,28 +204,29 @@ class ChildInfo(DatabaseAction):
 
     def register_with_selector(self, selector: selectors.BaseSelector, pid: int) -> None:
         """Register output, state, and sentinel channels with the selector."""
-        selector.register(self.output_r_conn.fileno(), selectors.EVENT_READ, FdInfo(pid, "output"))
-        selector.register(self.state_r_conn.fileno(), selectors.EVENT_READ, FdInfo(pid, "state"))
-        selector.register(self.proc.sentinel, selectors.EVENT_READ, FdInfo(pid, "sentinel"))
+        selector.register(self.output_r_conn, selectors.EVENT_READ, FdInfo(pid, "output"))
+        selector.register(self.state_r_conn, selectors.EVENT_READ, FdInfo(pid, "state"))
+        selector.register(self.notifier.fileobj, selectors.EVENT_READ, FdInfo(pid, "sentinel"))
 
     def close(self, selector: selectors.BaseSelector) -> int:
         """Unregister and close file descriptors, and join the child process.
         Returns the exit code of the child process."""
         try:
-            selector.unregister(self.output_r_conn.fileno())
-        except KeyError:
+            selector.unregister(self.output_r_conn)
+        except (KeyError, OSError):
             pass
         try:
-            selector.unregister(self.state_r_conn.fileno())
-        except KeyError:
+            selector.unregister(self.state_r_conn)
+        except (KeyError, OSError):
             pass
         try:
-            selector.unregister(self.proc.sentinel)
-        except (KeyError, ValueError):
+            selector.unregister(self.notifier.fileobj)
+        except (KeyError, ValueError, OSError):
             pass
         self.output_r_conn.close()
         self.state_r_conn.close()
         self.control_w_conn.close()
+        self.notifier.close()
         self.proc.join()
         exit_code = self.proc.exitcode
         assert exit_code is not None, "Finished build should have exit code set"
@@ -363,9 +376,9 @@ def worker_function(
     fake: bool,
     install_source: bool,
     run_tests: bool,
-    state: Connection,
-    parent: Connection,
-    echo_control: Connection,
+    state: IpcChannel,
+    parent: IpcChannel,
+    echo_control: IpcChannel,
     jobserver_info: Tuple[Optional[str], Any],
     log_path: str,
     global_state: GlobalStateMarshaler,
@@ -831,7 +844,16 @@ def start_build(
     os.set_blocking(output_r_conn.fileno(), False)
     os.set_blocking(state_r_conn.fileno(), False)
 
-    return ChildInfo(proc, spec, output_r_conn, state_r_conn, control_w_conn, log_path, explicit)
+    return ChildInfo(
+        proc,
+        spec,
+        output_r_conn,
+        state_r_conn,
+        control_w_conn,
+        ExitNotifier(proc),
+        log_path,
+        explicit,
+    )
 
 
 class BuildInfo:
@@ -858,7 +880,7 @@ class BuildInfo:
         self,
         spec: spack.spec.Spec,
         explicit: bool,
-        control_w_conn: Optional[Connection],
+        control_w_conn: Optional[IpcChannel],
         log_path: Optional[str] = None,
         start_time: float = 0.0,
     ) -> None:
@@ -940,7 +962,7 @@ class BuildStatus:
         self,
         spec: spack.spec.Spec,
         explicit: bool,
-        control_w_conn: Optional[Connection] = None,
+        control_w_conn: Optional[IpcChannel] = None,
         log_path: Optional[str] = None,
     ) -> None:
         """Add a new build to the display and mark the display as dirty."""

--- a/lib/spack/spack/new_installer.py
+++ b/lib/spack/spack/new_installer.py
@@ -94,7 +94,12 @@ if sys.platform == "win32":
 else:
     from spack.new_installer_posix import PosixExitNotifier as ExitNotifier
     from spack.new_installer_posix import PosixJobServer as JobServer
-    from spack.new_installer_posix import PosixTee
+    from spack.new_installer_posix import (
+        PosixTee,
+        make_state_stream,
+        read_connection,
+        write_connection,
+    )
     from spack.new_installer_posix import PosixTerminalState as TerminalState
 
 if TYPE_CHECKING:
@@ -468,7 +473,7 @@ def worker_function(
     tee = PosixTee(echo_control, parent, log_path)
 
     # Use closedfd=false because of the connection objects. Use line buffering.
-    state_stream = os.fdopen(state.fileno(), "w", buffering=1, closefd=False)
+    state_stream = make_state_stream(state)
     exit_code = ExitCode.SUCCESS
 
     try:
@@ -974,7 +979,7 @@ class BuildStatus:
         if self.verbose and not self.tracked_build_id and control_w_conn is not None:
             self.tracked_build_id = spec.dag_hash()
             try:
-                os.write(control_w_conn.fileno(), b"1")
+                write_connection(control_w_conn, b"1")
             except OSError:
                 pass
 
@@ -1003,7 +1008,7 @@ class BuildStatus:
             try:
                 conn = self.builds[self.tracked_build_id].control_w_conn
                 if conn is not None:
-                    os.write(conn.fileno(), b"0")
+                    write_connection(conn, b"0")
             except (KeyError, OSError):
                 pass
             self.tracked_build_id = ""
@@ -1068,7 +1073,7 @@ class BuildStatus:
             try:
                 conn = self.builds[self.tracked_build_id].control_w_conn
                 if conn is not None:
-                    os.write(conn.fileno(), b"0")
+                    write_connection(conn, b"0")
             except (KeyError, OSError):
                 pass
 
@@ -1100,7 +1105,7 @@ class BuildStatus:
             try:
                 conn = new_build.control_w_conn
                 if conn is not None:
-                    os.write(conn.fileno(), b"1")
+                    write_connection(conn, b"1")
             except (KeyError, OSError):
                 pass
 
@@ -2183,9 +2188,9 @@ class PackageInstaller:
                         # Child output (logs and state updates)
                         child_info = self.running_builds[data.pid]
                         if data.name == "output":
-                            self._handle_child_logs(key.fd, child_info, selector)
+                            self._handle_child_logs(child_info, selector)
                         elif data.name == "state":
-                            self._handle_child_state(key.fd, child_info, selector)
+                            self._handle_child_state(child_info, selector)
                         elif data.name == "sentinel":
                             finished_pids.append(data.pid)
                     elif data == "stdin":
@@ -2580,68 +2585,69 @@ class PackageInstaller:
         )
         self.report_data.start_record(spec)
 
-    def _handle_child_logs(
-        self, r_fd: int, child_info: ChildInfo, selector: selectors.BaseSelector
-    ) -> None:
-        """Handle reading output logs from a child process pipe."""
+    def _handle_child_logs(self, child_info: ChildInfo, selector: selectors.BaseSelector) -> bool:
+        """Handle reading output logs from a child process pipe. Returns False once the channel
+        has reached EOF and was unregistered, True while it remains open."""
+        conn = child_info.output_r_conn
         try:
             # There might be more data than OUTPUT_BUFFER_SIZE, but we will read that in the next
             # iteration of the event loop to keep things responsive.
-            data = os.read(r_fd, OUTPUT_BUFFER_SIZE)
+            data = read_connection(conn, OUTPUT_BUFFER_SIZE)
         except BlockingIOError:
-            return
+            return True
         except OSError:
             data = None
 
         if not data:  # EOF or error
             try:
-                selector.unregister(r_fd)
-            except KeyError:
+                selector.unregister(conn)
+            except (KeyError, OSError):
                 pass
-            return
+            return False
 
         self.build_status.print_logs(child_info.spec.dag_hash(), data)
+        return True
 
     def _drain_child_output(self, child_info: ChildInfo, selector: selectors.BaseSelector) -> None:
         """Read and print any remaining output from a finished child's pipe."""
-        r_fd = child_info.output_r_conn.fileno()
-        while r_fd in selector.get_map():
-            self._handle_child_logs(r_fd, child_info, selector)
+        while self._handle_child_logs(child_info, selector):
+            pass
 
     def _drain_child_state(self, child_info: ChildInfo, selector: selectors.BaseSelector) -> None:
         """Read and process any remaining state messages from a finished child's pipe."""
-        r_fd = child_info.state_r_conn.fileno()
-        while r_fd in selector.get_map():
-            self._handle_child_state(r_fd, child_info, selector)
+        # Must drain before child.close() to consume any remaining data before bridges close.
+        while self._handle_child_state(child_info, selector):
+            pass
 
-    def _handle_child_state(
-        self, r_fd: int, child_info: ChildInfo, selector: selectors.BaseSelector
-    ) -> None:
-        """Handle reading state updates from a child process pipe."""
+    def _handle_child_state(self, child_info: ChildInfo, selector: selectors.BaseSelector) -> bool:
+        """Handle reading state updates from a child process pipe. Returns False once the channel
+        has reached EOF and was unregistered, True while it remains open."""
+        conn = child_info.state_r_conn
+        fd = conn.fileno()
         try:
             # There might be more data than OUTPUT_BUFFER_SIZE, but we will read that in the next
             # iteration of the event loop to keep things responsive.
-            data = os.read(r_fd, OUTPUT_BUFFER_SIZE)
+            data = read_connection(conn, OUTPUT_BUFFER_SIZE)
         except BlockingIOError:
-            return
+            return True
         except OSError:
             data = None
 
         if not data:  # EOF or error
             try:
-                selector.unregister(r_fd)
-            except KeyError:
+                selector.unregister(conn)
+            except (KeyError, OSError):
                 pass
-            self.state_buffers.pop(r_fd, None)
-            return
+            self.state_buffers.pop(fd, None)
+            return False
 
         # Append new data to the buffer for this fd and process it
-        buffer = self.state_buffers.get(r_fd, "") + data.decode(errors="replace")
+        buffer = self.state_buffers.get(fd, "") + data.decode(errors="replace")
         lines = buffer.split("\n")
 
         # The last element of split() will be a partial line or an empty string.
         # We store it back in the buffer for the next read.
-        self.state_buffers[r_fd] = lines.pop()
+        self.state_buffers[fd] = lines.pop()
 
         for line in lines:
             if not line:
@@ -2658,6 +2664,8 @@ class PackageInstaller:
                 )
             elif "installed_from_binary_cache" in message:
                 child_info.spec.package.installed_from_binary_cache = True
+
+        return True
 
 
 class BinaryCacheMiss(spack.error.SpackError):

--- a/lib/spack/spack/new_installer.py
+++ b/lib/spack/spack/new_installer.py
@@ -358,7 +358,7 @@ class PrefixPivoter:
         return os.path.lexists(path)
 
     def _rename(self, src: str, dst: str) -> None:
-        os.rename(src, dst)
+        fs.rename(src, dst)
 
     def _mkdtemp(self, dir: str, prefix: str, suffix: str) -> str:
         return tempfile.mkdtemp(dir=dir, prefix=prefix, suffix=suffix)

--- a/lib/spack/spack/new_installer.py
+++ b/lib/spack/spack/new_installer.py
@@ -28,6 +28,7 @@ import selectors
 import shlex
 import shutil
 import signal
+import socket
 import sys
 import tempfile
 import time
@@ -90,17 +91,16 @@ from spack.util.path import padding_filter, padding_filter_bytes
 
 if sys.platform == "win32":
     from spack.new_installer_base import NoopJobServer as JobServer
+    from spack.new_installer_windows import WindowsSentinelBridge as ExitNotifier
+    from spack.new_installer_windows import WindowsTee as Tee
     from spack.new_installer_windows import WindowsTerminalState as TerminalState
+    from spack.new_installer_windows import make_state_stream, read_connection, write_connection
 else:
     from spack.new_installer_posix import PosixExitNotifier as ExitNotifier
     from spack.new_installer_posix import PosixJobServer as JobServer
-    from spack.new_installer_posix import (
-        PosixTee,
-        make_state_stream,
-        read_connection,
-        write_connection,
-    )
+    from spack.new_installer_posix import PosixTee as Tee
     from spack.new_installer_posix import PosixTerminalState as TerminalState
+    from spack.new_installer_posix import make_state_stream, read_connection, write_connection
 
 if TYPE_CHECKING:
     import spack.package_base
@@ -119,7 +119,6 @@ CLEANUP_TIMEOUT = 2.0
 
 #: How often to flush completed builds to the database
 DATABASE_WRITE_INTERVAL = 5.0
-
 
 #: Suffix for temporary backup during overwrite install
 OVERWRITE_BACKUP_SUFFIX = ".old"
@@ -470,7 +469,7 @@ def worker_function(
     sys.stdin = open(os.devnull, "r", encoding=sys.stdin.encoding)
 
     # Start the tee thread to forward output to the log file and parent process.
-    tee = PosixTee(echo_control, parent, log_path)
+    tee = Tee(echo_control, parent, log_path)
 
     # Use closedfd=false because of the connection objects. Use line buffering.
     state_stream = make_state_stream(state)
@@ -800,10 +799,19 @@ def start_build(
     stop_at: Optional[str] = None,
 ) -> ChildInfo:
     """Start a new build."""
-    # Create pipes for the child's output, state reporting, and control.
-    state_r_conn, state_w_conn = Pipe(duplex=False)
-    output_r_conn, output_w_conn = Pipe(duplex=False)
-    control_r_conn, control_w_conn = Pipe(duplex=False)
+    # Set the read ends non-blocking so the selector-based loop never blocks.
+    if sys.platform == "win32":
+        state_r_conn, state_w_conn = socket.socketpair()
+        output_r_conn, output_w_conn = socket.socketpair()
+        control_r_conn, control_w_conn = socket.socketpair()
+        output_r_conn.setblocking(False)
+        state_r_conn.setblocking(False)
+    else:
+        state_r_conn, state_w_conn = Pipe(duplex=False)
+        output_r_conn, output_w_conn = Pipe(duplex=False)
+        control_r_conn, control_w_conn = Pipe(duplex=False)
+        os.set_blocking(output_r_conn.fileno(), False)
+        os.set_blocking(state_r_conn.fileno(), False)
 
     # Obtain the MAKEFLAGS to be set in the child process, and determine whether it's necessary
     # for the child process to inherit our jobserver fds.
@@ -844,10 +852,6 @@ def start_build(
     state_w_conn.close()
     output_w_conn.close()
     control_r_conn.close()
-
-    # Set the read ends to non-blocking: in principle redundant with epoll/kqueue, but safer.
-    os.set_blocking(output_r_conn.fileno(), False)
-    os.set_blocking(state_r_conn.fileno(), False)
 
     return ChildInfo(
         proc,

--- a/lib/spack/spack/new_installer.py
+++ b/lib/spack/spack/new_installer.py
@@ -78,7 +78,6 @@ from spack.llnl.util.lang import pretty_duration
 from spack.new_installer_base import (
     OUTPUT_BUFFER_SIZE,
     BaseTerminalState,
-    DatabaseAction,
     FdInfo,
     JobServerBase,
     StdinReaderBase,
@@ -92,8 +91,8 @@ if sys.platform == "win32":
     from spack.new_installer_base import NoopJobServer as JobServer
     from spack.new_installer_windows import WindowsTerminalState as TerminalState
 else:
-    from spack.new_installer_posix import PosixChildInfo, PosixTee
     from spack.new_installer_posix import PosixJobServer as JobServer
+    from spack.new_installer_posix import PosixTee
     from spack.new_installer_posix import PosixTerminalState as TerminalState
 
 if TYPE_CHECKING:
@@ -131,9 +130,28 @@ class ExitCode:
     BUILD_CACHE_MISS = 4
 
 
+class DatabaseAction:
+    """Base class for objects that need to be persisted to the database."""
+
+    __slots__ = ("spec", "prefix_lock")
+
+    spec: spack.spec.Spec
+    prefix_lock: Optional[spack.util.lock.Lock]
+
+    def save_to_db(self, db: spack.database.Database) -> None: ...
+
+    def release_prefix_lock(self) -> None:
+        if self.prefix_lock is not None:
+            try:
+                self.prefix_lock.release_write()
+            except Exception:
+                pass
+        self.prefix_lock = None
+
+
 class MarkExplicitAction(DatabaseAction):
-    """Action to mark an already installed spec as explicitly installed. Similar to PosixChildInfo,
-    but used when no build process was needed."""
+    """Action to mark an already installed spec as explicitly installed. Similar to ChildInfo, but
+    used when no build process was needed."""
 
     __slots__ = ()
 
@@ -143,6 +161,65 @@ class MarkExplicitAction(DatabaseAction):
 
     def save_to_db(self, db: spack.database.Database) -> None:
         db._mark(self.spec, "explicit", True)
+
+
+class ChildInfo(DatabaseAction):
+    """Information about a child process."""
+
+    __slots__ = ("proc", "output_r_conn", "state_r_conn", "control_w_conn", "explicit", "log_path")
+
+    def __init__(
+        self,
+        proc: Process,
+        spec: spack.spec.Spec,
+        output_r_conn: Connection,
+        state_r_conn: Connection,
+        control_w_conn: Connection,
+        log_path: str,
+        explicit: bool = False,
+    ) -> None:
+        self.proc = proc
+        self.spec = spec
+        self.output_r_conn = output_r_conn
+        self.state_r_conn = state_r_conn
+        self.control_w_conn = control_w_conn
+        self.log_path = log_path
+        self.explicit = explicit
+        self.prefix_lock: Optional[spack.util.lock.Lock] = None
+
+    def save_to_db(self, db: spack.database.Database) -> None:
+        return db._add(self.spec, explicit=self.explicit)
+
+    def register_with_selector(self, selector: selectors.BaseSelector, pid: int) -> None:
+        """Register output, state, and sentinel channels with the selector."""
+        selector.register(self.output_r_conn.fileno(), selectors.EVENT_READ, FdInfo(pid, "output"))
+        selector.register(self.state_r_conn.fileno(), selectors.EVENT_READ, FdInfo(pid, "state"))
+        selector.register(self.proc.sentinel, selectors.EVENT_READ, FdInfo(pid, "sentinel"))
+
+    def close(self, selector: selectors.BaseSelector) -> int:
+        """Unregister and close file descriptors, and join the child process.
+        Returns the exit code of the child process."""
+        try:
+            selector.unregister(self.output_r_conn.fileno())
+        except KeyError:
+            pass
+        try:
+            selector.unregister(self.state_r_conn.fileno())
+        except KeyError:
+            pass
+        try:
+            selector.unregister(self.proc.sentinel)
+        except (KeyError, ValueError):
+            pass
+        self.output_r_conn.close()
+        self.state_r_conn.close()
+        self.control_w_conn.close()
+        self.proc.join()
+        exit_code = self.proc.exitcode
+        assert exit_code is not None, "Finished build should have exit code set"
+        if hasattr(self.proc, "close"):  # No known equivalent in Python 3.6
+            self.proc.close()
+        return exit_code
 
 
 def send_state(state: str, state_pipe: io.TextIOWrapper) -> None:
@@ -703,7 +780,7 @@ def start_build(
     log_path: str,
     stop_before: Optional[str] = None,
     stop_at: Optional[str] = None,
-) -> PosixChildInfo:
+) -> ChildInfo:
     """Start a new build."""
     # Create pipes for the child's output, state reporting, and control.
     state_r_conn, state_w_conn = Pipe(duplex=False)
@@ -754,9 +831,7 @@ def start_build(
     os.set_blocking(output_r_conn.fileno(), False)
     os.set_blocking(state_r_conn.fileno(), False)
 
-    return PosixChildInfo(
-        proc, spec, output_r_conn, state_r_conn, control_w_conn, log_path, explicit
-    )
+    return ChildInfo(proc, spec, output_r_conn, state_r_conn, control_w_conn, log_path, explicit)
 
 
 class BuildInfo:
@@ -1858,7 +1933,7 @@ class NullReportData(ReportData):
         pass
 
 
-def _signal_children(running_builds: Dict[int, PosixChildInfo], sig: signal.Signals) -> None:
+def _signal_children(running_builds: Dict[int, ChildInfo], sig: signal.Signals) -> None:
     """Send a signal to the process group of each running build."""
     for child in running_builds.values():
         try:
@@ -1974,7 +2049,7 @@ class PackageInstaller:
         self.pending_expansions: List[str] = []
 
         self.verbose = verbose
-        self.running_builds: Dict[int, PosixChildInfo] = {}
+        self.running_builds: Dict[int, ChildInfo] = {}
         self.log_paths: Dict[str, str] = {}
         self.build_status = BuildStatus(
             len(self.build_graph.nodes),
@@ -2484,7 +2559,7 @@ class PackageInstaller:
         self.report_data.start_record(spec)
 
     def _handle_child_logs(
-        self, r_fd: int, child_info: PosixChildInfo, selector: selectors.BaseSelector
+        self, r_fd: int, child_info: ChildInfo, selector: selectors.BaseSelector
     ) -> None:
         """Handle reading output logs from a child process pipe."""
         try:
@@ -2505,24 +2580,20 @@ class PackageInstaller:
 
         self.build_status.print_logs(child_info.spec.dag_hash(), data)
 
-    def _drain_child_output(
-        self, child_info: PosixChildInfo, selector: selectors.BaseSelector
-    ) -> None:
+    def _drain_child_output(self, child_info: ChildInfo, selector: selectors.BaseSelector) -> None:
         """Read and print any remaining output from a finished child's pipe."""
         r_fd = child_info.output_r_conn.fileno()
         while r_fd in selector.get_map():
             self._handle_child_logs(r_fd, child_info, selector)
 
-    def _drain_child_state(
-        self, child_info: PosixChildInfo, selector: selectors.BaseSelector
-    ) -> None:
+    def _drain_child_state(self, child_info: ChildInfo, selector: selectors.BaseSelector) -> None:
         """Read and process any remaining state messages from a finished child's pipe."""
         r_fd = child_info.state_r_conn.fileno()
         while r_fd in selector.get_map():
             self._handle_child_state(r_fd, child_info, selector)
 
     def _handle_child_state(
-        self, r_fd: int, child_info: PosixChildInfo, selector: selectors.BaseSelector
+        self, r_fd: int, child_info: ChildInfo, selector: selectors.BaseSelector
     ) -> None:
         """Handle reading state updates from a child process pipe."""
         try:

--- a/lib/spack/spack/new_installer.py
+++ b/lib/spack/spack/new_installer.py
@@ -421,12 +421,13 @@ def worker_function(
 
     global_state.restore()
 
-    # Isolate the process group to shield against Ctrl+C and enable safe killpg() cleanup. In
-    # constrast to setsid(), this keeps a neat process group hierarchy for utils like pstree.
-    os.setpgid(0, 0)
+    if sys.platform != "win32":
+        # Isolate the process group to shield against Ctrl+C and enable safe killpg() cleanup. In
+        # constrast to setsid(), this keeps a neat process group hierarchy for utils like pstree.
+        os.setpgid(0, 0)
 
-    # Reset SIGTSTP to default in case the parent had a custom handler.
-    signal.signal(signal.SIGTSTP, signal.SIG_DFL)
+        # Reset SIGTSTP to default in case the parent had a custom handler.
+        signal.signal(signal.SIGTSTP, signal.SIG_DFL)
 
     def handle_sigterm(signum, frame):
         # This SIGTERM handler forwards the signal to child processes (cmake, make, etc). We wait
@@ -435,13 +436,13 @@ def worker_function(
         # get to clean up the prefix without risking that the child process writes to it
         # afterwards.
         signal.signal(signal.SIGTERM, signal.SIG_IGN)
-        os.killpg(0, signal.SIGTERM)
-
-        try:
-            while True:
-                os.waitpid(-1, 0)
-        except ChildProcessError:
-            pass
+        if sys.platform != "win32":
+            os.killpg(0, signal.SIGTERM)
+            try:
+                while True:
+                    os.waitpid(-1, 0)
+            except ChildProcessError:
+                pass
 
         raise KeyboardInterrupt("Installation interrupted")
 
@@ -451,15 +452,10 @@ def worker_function(
     if makeflags is not None:
         os.environ["MAKEFLAGS"] = makeflags
 
-    # Force line buffering for Python's textio wrappers of stdout/stderr. We're not going to print
-    # much ourselves, but what we print should appear before output from `make` and other build
-    # tools.
-    sys.stdout = os.fdopen(
-        sys.stdout.fileno(), "w", buffering=1, encoding=sys.stdout.encoding, closefd=False
-    )
-    sys.stderr = os.fdopen(
-        sys.stderr.fileno(), "w", buffering=1, encoding=sys.stderr.encoding, closefd=False
-    )
+    # Save encodings before the Tee redirects fds 1/2 to the pipe. We need them to create the
+    # line-buffered wrappers after the Tee starts.
+    _stdout_enc = sys.stdout.encoding or "utf-8"
+    _stderr_enc = sys.stderr.encoding or "utf-8"
 
     # Detach stdin from the terminal like `./build < /dev/null`. This would not be necessary if we
     # used os.setsid() instead of os.setpgid(), but that would "break" pstree output.
@@ -472,6 +468,16 @@ def worker_function(
     tee = Tee(echo_control, parent, log_path)
 
     # Use closedfd=false because of the connection objects. Use line buffering.
+    # Replace sys.stdout/stderr AFTER Tee.dup2() so Python creates FileIO (WriteFile) rather
+    # than ConsoleIO (WriteConsoleW). On Windows, if fds 1/2 are still console handles when
+    # os.fdopen() is called, Python picks ConsoleIO; WriteConsoleW on a pipe handle returns
+    # ERROR_INVALID_FUNCTION. Post-dup2 the fds are pipe handles, so FileIO is chosen.
+    sys.stdout = os.fdopen(
+        sys.stdout.fileno(), "w", buffering=1, encoding=_stdout_enc, closefd=False
+    )
+    sys.stderr = os.fdopen(
+        sys.stderr.fileno(), "w", buffering=1, encoding=_stderr_enc, closefd=False
+    )
     state_stream = make_state_stream(state)
     exit_code = ExitCode.SUCCESS
 

--- a/lib/spack/spack/new_installer_base.py
+++ b/lib/spack/spack/new_installer_base.py
@@ -2,23 +2,34 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-"""Abstract base classes for the new_installer TUI terminal state and stdin reading.
-
-Kept in a leaf module (no imports from new_installer.py or the platform modules) so that
-new_installer_posix and new_installer_windows can import from here without introducing a
-circular dependency."""
+"""Abstract base classes for new_installer:
+TUI terminal state, IPC channels, and job scheduling."""
 
 import abc
 import codecs
+import io
+import os
 import re
 import selectors
+import socket
 import sys
-from typing import TYPE_CHECKING, Any, Callable, Optional, Tuple
+import threading
+from multiprocessing.connection import Connection
+from typing import TYPE_CHECKING, Any, Callable, Optional, Tuple, Union
 
 import spack.spec
 
 if TYPE_CHECKING:
     from spack.new_installer import BuildStatus
+
+# Inter-process communication type
+if sys.platform == "win32":
+    IpcChannel = socket.socket
+else:
+    IpcChannel = Connection
+
+#: Size of the output buffer for child processes
+OUTPUT_BUFFER_SIZE = 32768
 
 
 class StdinReaderBase:
@@ -110,10 +121,6 @@ class BaseTerminalState(abc.ABC):
         pass
 
 
-#: Size of the output buffer for child processes
-OUTPUT_BUFFER_SIZE = 32768
-
-
 class FdInfo:
     """Information about a file descriptor mapping."""
 
@@ -122,6 +129,18 @@ class FdInfo:
     def __init__(self, pid: int, name: str) -> None:
         self.pid = pid
         self.name = name
+
+
+class ProcessExitNotifier(abc.ABC):
+    """Selector-watchable handle that becomes readable when the child process exits."""
+
+    @property
+    @abc.abstractmethod
+    def fileobj(self) -> Union[int, socket.socket]:
+        """Object/fd to register with the selector to detect process exit."""
+
+    def close(self) -> None:
+        """Release any resources. Default: nothing to release."""
 
 
 class JobServerBase(abc.ABC):
@@ -189,3 +208,53 @@ class NoopJobServer(JobServerBase):
     def release(self) -> None: ...
 
     def close(self) -> None: ...
+
+
+class Tee(abc.ABC):
+    """Emulates ./build 2>&1 | tee build.log. Output is sent to a log file and the parent
+    process (if echoing is enabled). The control socket is used to enable/disable echoing."""
+
+    def __init__(self, control: IpcChannel, parent: IpcChannel, log_path: str) -> None:
+        self.control = control
+        self.parent = parent
+        # sys.stdout and sys.stderr may have been replaced with file objects under pytest, so
+        # redirect their file descriptors in addition to the original fds 1 and 2.
+        fds = {sys.stdout.fileno(), sys.stderr.fileno(), 1, 2}
+        self.saved_fds = {fd: os.dup(fd) for fd in fds}
+        #: The path of the log file
+        self.log_path = log_path
+        log_file = open(self.log_path, "ab")
+        r, w = os.pipe()
+        self.tee_thread = threading.Thread(target=self.run, args=(r, log_file), daemon=True)
+        self.tee_thread.start()
+        for fd in fds:
+            os.dup2(w, fd)
+        self._setup_handles()
+        os.close(w)
+
+    def _setup_handles(self) -> None:
+        pass
+
+    def _restore_handles(self) -> None:
+        pass
+
+    @abc.abstractmethod
+    def run(self, log_r: int, log_file: io.BufferedWriter) -> None:
+        """Read from log_r, write to log_file; echo to parent when enabled. Runs in a thread."""
+        pass
+
+    def close(self) -> None:
+        # Closing stdout and stderr should close the last reference to the write end of the pipe,
+        # causing the tee thread to wake up, flush the last data, and exit. We restore stdout and
+        # stderr, because between sys.exit and the actual process exit buffers may be flushed, and
+        # can cause exit code 120 (witnessed under pytest+coverage on macOS).
+        sys.stdout.flush()
+        sys.stderr.flush()
+        for fd, saved_fd in self.saved_fds.items():
+            os.dup2(saved_fd, fd)
+            os.close(saved_fd)
+        self.tee_thread.join()
+        # Only then close the other fds.
+        self.control.close()
+        self.parent.close()
+        self._restore_handles()

--- a/lib/spack/spack/new_installer_base.py
+++ b/lib/spack/spack/new_installer_base.py
@@ -15,9 +15,7 @@ import selectors
 import sys
 from typing import TYPE_CHECKING, Any, Callable, Optional, Tuple
 
-import spack.database
 import spack.spec
-import spack.util.lock
 
 if TYPE_CHECKING:
     from spack.new_installer import BuildStatus
@@ -114,25 +112,6 @@ class BaseTerminalState(abc.ABC):
 
 #: Size of the output buffer for child processes
 OUTPUT_BUFFER_SIZE = 32768
-
-
-class DatabaseAction:
-    """Base class for objects that need to be persisted to the database."""
-
-    __slots__ = ("spec", "prefix_lock")
-
-    spec: spack.spec.Spec
-    prefix_lock: Optional[spack.util.lock.Lock]
-
-    def save_to_db(self, db: spack.database.Database) -> None: ...
-
-    def release_prefix_lock(self) -> None:
-        if self.prefix_lock is not None:
-            try:
-                self.prefix_lock.release_write()
-            except Exception:
-                pass
-        self.prefix_lock = None
 
 
 class FdInfo:

--- a/lib/spack/spack/new_installer_posix.py
+++ b/lib/spack/spack/new_installer_posix.py
@@ -16,20 +16,15 @@ import termios
 import threading
 import tty
 import warnings
-from multiprocessing import Process
 from multiprocessing.connection import Connection
 from typing import TYPE_CHECKING, Any, Callable, Optional, Tuple, Union
 
-import spack.database
 import spack.llnl.util.tty
 import spack.spec
-import spack.util.lock
 from spack.llnl.util.tty.log import _is_background_tty, ignore_signal
 from spack.new_installer_base import (
     OUTPUT_BUFFER_SIZE,
     BaseTerminalState,
-    DatabaseAction,
-    FdInfo,
     JobServerBase,
     StdinReaderBase,
 )
@@ -196,65 +191,6 @@ class PosixTerminalState(BaseTerminalState):
 
     def should_enter_foreground(self) -> bool:
         return not _is_background_tty(sys.stdin)
-
-
-class PosixChildInfo(DatabaseAction):
-    """Information about a child process."""
-
-    __slots__ = ("proc", "output_r_conn", "state_r_conn", "control_w_conn", "explicit", "log_path")
-
-    def __init__(
-        self,
-        proc: Process,
-        spec: spack.spec.Spec,
-        output_r_conn: Connection,
-        state_r_conn: Connection,
-        control_w_conn: Connection,
-        log_path: str,
-        explicit: bool = False,
-    ) -> None:
-        self.proc = proc
-        self.spec = spec
-        self.output_r_conn = output_r_conn
-        self.state_r_conn = state_r_conn
-        self.control_w_conn = control_w_conn
-        self.log_path = log_path
-        self.explicit = explicit
-        self.prefix_lock: Optional[spack.util.lock.Lock] = None
-
-    def save_to_db(self, db: spack.database.Database) -> None:
-        return db._add(self.spec, explicit=self.explicit)
-
-    def register_with_selector(self, selector: selectors.BaseSelector, pid: int) -> None:
-        """Register output, state, and sentinel channels with the selector."""
-        selector.register(self.output_r_conn.fileno(), selectors.EVENT_READ, FdInfo(pid, "output"))
-        selector.register(self.state_r_conn.fileno(), selectors.EVENT_READ, FdInfo(pid, "state"))
-        selector.register(self.proc.sentinel, selectors.EVENT_READ, FdInfo(pid, "sentinel"))
-
-    def close(self, selector: selectors.BaseSelector) -> int:
-        """Unregister and close file descriptors, and join the child process.
-        Returns the exit code of the child process."""
-        try:
-            selector.unregister(self.output_r_conn.fileno())
-        except KeyError:
-            pass
-        try:
-            selector.unregister(self.state_r_conn.fileno())
-        except KeyError:
-            pass
-        try:
-            selector.unregister(self.proc.sentinel)
-        except (KeyError, ValueError):
-            pass
-        self.output_r_conn.close()
-        self.state_r_conn.close()
-        self.control_w_conn.close()
-        self.proc.join()
-        exit_code = self.proc.exitcode
-        assert exit_code is not None, "Finished build should have exit code set"
-        if hasattr(self.proc, "close"):  # No known equivalent in Python 3.6
-            self.proc.close()
-        return exit_code
 
 
 class PosixTee:

--- a/lib/spack/spack/new_installer_posix.py
+++ b/lib/spack/spack/new_installer_posix.py
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-"""POSIX-specific terminal state and stdin reader for the new_installer TUI."""
+"""POSIX-specific terminal state, stdin reader, IPC channels, and job scheduling."""
 
 import fcntl
 import io
@@ -13,9 +13,9 @@ import signal
 import sys
 import tempfile
 import termios
-import threading
 import tty
 import warnings
+from multiprocessing import Process
 from multiprocessing.connection import Connection
 from typing import TYPE_CHECKING, Any, Callable, Optional, Tuple, Union
 
@@ -26,7 +26,9 @@ from spack.new_installer_base import (
     OUTPUT_BUFFER_SIZE,
     BaseTerminalState,
     JobServerBase,
+    ProcessExitNotifier,
     StdinReaderBase,
+    Tee,
 )
 
 if TYPE_CHECKING:
@@ -193,27 +195,18 @@ class PosixTerminalState(BaseTerminalState):
         return not _is_background_tty(sys.stdin)
 
 
-class PosixTee:
-    """Emulates ./build 2>&1 | tee build.log. The output is sent both to a log file and the parent
-    process (if echoing is enabled). The control_fd is used to enable/disable echoing."""
+class PosixExitNotifier(ProcessExitNotifier):
+    """Process-exit notifier for POSIX: the multiprocessing sentinel fd is selector-watchable."""
 
-    def __init__(self, control: Connection, parent: Connection, log_path: str) -> None:
-        self.control = control
-        self.parent = parent
-        # sys.stdout and sys.stderr may have been replaced with file objects under pytest, so
-        # redirect their file descriptors in addition to the original fds 1 and 2.
-        fds = {sys.stdout.fileno(), sys.stderr.fileno(), 1, 2}
-        self.saved_fds = {fd: os.dup(fd) for fd in fds}
-        #: The path of the log file
-        self.log_path = log_path
-        log_file = open(self.log_path, "ab")
-        r, w = os.pipe()
-        self.tee_thread = threading.Thread(target=self.run, args=(r, log_file), daemon=True)
-        self.tee_thread.start()
-        for fd in fds:
-            os.dup2(w, fd)
-        os.close(w)
+    def __init__(self, proc: Process) -> None:
+        self.proc = proc
 
+    @property
+    def fileobj(self) -> int:
+        return self.proc.sentinel
+
+
+class PosixTee(Tee):
     def run(self, log_r: int, log_file: io.BufferedWriter) -> None:
         """Forward log_r to log_file and parent (if echoing is enabled).
         Echoing is enabled and disabled by reading from control."""
@@ -248,21 +241,6 @@ class PosixTee:
             pass
         finally:
             os.close(log_r)
-
-    def close(self) -> None:
-        # Closing stdout and stderr should close the last reference to the write end of the pipe,
-        # causing the tee thread to wake up, flush the last data, and exit. We restore stdout and
-        # stderr, because between sys.exit and the actual process exit buffers may be flushed, and
-        # can cause exit code 120 (witnessed under pytest+coverage on macOS).
-        sys.stdout.flush()
-        sys.stderr.flush()
-        for fd, saved_fd in self.saved_fds.items():
-            os.dup2(saved_fd, fd)
-            os.close(saved_fd)
-        self.tee_thread.join()
-        # Only then close the other fds.
-        self.control.close()
-        self.parent.close()
 
 
 class PosixJobServer(JobServerBase):

--- a/lib/spack/spack/new_installer_posix.py
+++ b/lib/spack/spack/new_installer_posix.py
@@ -445,3 +445,16 @@ def open_existing_jobserver_fifo(fifo_path: str) -> Optional[Tuple[int, int]]:
         return read_fd, write_fd
     except OSError:
         return None
+
+
+def make_state_stream(state: Connection) -> io.TextIOWrapper:
+    """Wrap the write end of the state Pipe as a line-buffered text stream."""
+    return os.fdopen(state.fileno(), "w", buffering=1, closefd=False)
+
+
+def read_connection(conn: Connection, max_size: int = 4096) -> bytes:
+    return os.read(conn.fileno(), max_size)
+
+
+def write_connection(conn: Connection, data: bytes) -> None:
+    os.write(conn.fileno(), data)

--- a/lib/spack/spack/new_installer_windows.py
+++ b/lib/spack/spack/new_installer_windows.py
@@ -2,19 +2,28 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-"""Windows-specific terminal state and stdin reader for the new_installer TUI."""
+"""Windows-specific terminal state, stdin reader, IPC channels, and job scheduling."""
 
 import ctypes
+import io
 import msvcrt
+import os
 import selectors
 import shutil
 import socket
 import threading
 import time
 from ctypes import wintypes
-from typing import TYPE_CHECKING, Callable, Optional
+from multiprocessing import Process
+from typing import TYPE_CHECKING, Callable, Optional, cast
 
-from spack.new_installer_base import BaseTerminalState, StdinReaderBase
+from spack.new_installer_base import (
+    OUTPUT_BUFFER_SIZE,
+    BaseTerminalState,
+    ProcessExitNotifier,
+    StdinReaderBase,
+    Tee,
+)
 
 if TYPE_CHECKING:
     from spack.new_installer import BuildStatus
@@ -25,6 +34,8 @@ ENABLE_ECHO_INPUT = 0x0004
 ENABLE_QUICK_EDIT_MODE = 0x0040
 ENABLE_EXTENDED_FLAGS = 0x0080
 ENABLE_VIRTUAL_TERMINAL_PROCESSING = 0x0004  # for stdout handle
+WIN_STD_OUTPUT_HANDLE = -11
+WIN_STD_ERROR_HANDLE = -12
 
 
 class WindowsStdinReader(StdinReaderBase):
@@ -178,3 +189,98 @@ class WindowsTerminalState(BaseTerminalState):
                     self.sigwinch_w.sendall(b"\x00")
                 except OSError:
                     pass
+
+
+class WindowsSentinelBridge(ProcessExitNotifier):
+    """Process-exit notifier for Windows: a thread joins the process and pokes a socket so the
+    selector wakes up (Windows process handles cannot be registered with the selector directly)."""
+
+    def __init__(self, proc: Process) -> None:
+        self.rsock, self.wsock = socket.socketpair()
+        self.rsock.setblocking(False)
+        self.proc = proc
+        self.thread = threading.Thread(target=self._wait, daemon=True)
+        self.thread.start()
+
+    def _wait(self) -> None:
+        self.proc.join()
+        try:
+            self.wsock.sendall(b"x")
+        except OSError:
+            pass
+        self.wsock.close()
+
+    @property
+    def fileobj(self) -> socket.socket:
+        return self.rsock
+
+    def close(self) -> None:
+        self.rsock.close()
+
+
+class WindowsTee(Tee):
+    """Tee for Windows: control and parent channels are sockets; stdout/stderr handles are
+    redirected via SetStdHandle so the child process inherits the write end of the pipe."""
+
+    def run(self, log_r: int, log_file: io.BufferedWriter) -> None:
+        _echo = False
+        control_r = cast(socket.socket, self.control)
+        parent_w = cast(socket.socket, self.parent)
+
+        def _control_reader() -> None:
+            nonlocal _echo
+            while True:
+                try:
+                    data = control_r.recv(1)
+                    if not data:
+                        break
+                    _echo = data == b"1"
+                except OSError:
+                    break
+
+        threading.Thread(target=_control_reader, daemon=True).start()
+        try:
+            with log_file:
+                while True:
+                    try:
+                        data = os.read(log_r, OUTPUT_BUFFER_SIZE)
+                    except OSError:
+                        break
+                    if not data:
+                        break
+                    log_file.write(data)
+                    log_file.flush()
+                    if _echo:
+                        try:
+                            parent_w.sendall(data)
+                        except OSError:
+                            pass
+        finally:
+            os.close(log_r)
+
+    def _setup_handles(self) -> None:
+        kernel32 = ctypes.windll.kernel32  # type: ignore[attr-defined]
+        self._saved_win32_stdout = kernel32.GetStdHandle(WIN_STD_OUTPUT_HANDLE)
+        self._saved_win32_stderr = kernel32.GetStdHandle(WIN_STD_ERROR_HANDLE)
+        h_write = msvcrt.get_osfhandle(1)  # type: ignore[attr-defined]
+        os.set_handle_inheritable(h_write, True)  # type: ignore[attr-defined]
+        kernel32.SetStdHandle(WIN_STD_OUTPUT_HANDLE, h_write)  # type: ignore[attr-defined]
+        kernel32.SetStdHandle(WIN_STD_ERROR_HANDLE, h_write)  # type: ignore[attr-defined]
+
+    def _restore_handles(self) -> None:
+        kernel32 = ctypes.windll.kernel32  # type: ignore[attr-defined]
+        kernel32.SetStdHandle(WIN_STD_OUTPUT_HANDLE, self._saved_win32_stdout)
+        kernel32.SetStdHandle(WIN_STD_ERROR_HANDLE, self._saved_win32_stderr)
+
+
+def make_state_stream(state: socket.socket) -> io.TextIOWrapper:
+    """Wrap the write end of the state socketpair as a line-buffered text stream."""
+    return state.makefile("w", buffering=1, encoding="utf-8", newline="\n")
+
+
+def read_connection(conn: socket.socket, max_size: int = 4096) -> bytes:
+    return conn.recv(max_size)
+
+
+def write_connection(conn: socket.socket, data: bytes) -> None:
+    conn.sendall(data)


### PR DESCRIPTION
This is similar to #52483 but has a couple changes:

* I realized that ChildInfo was not a good candidate for a base class, since the only difference between posix and windows is how the event loop is notified about process exit. The selectors support both Connection and socket objects already. So, move ChildInfo and DatabaseAction back where they came from.
* Removes defensive large buffer checks for tiny messages `{"state": "configure"}\n` introduced in #52483
* Avoids dealing with UTF-8 decoding correctness, which #52483 introduced, but redundantly so, since the message are guaranteed pure-ascii JSON separated by `\n`; so work with bytes instead and let json.loads do decoding. (If in the future there is any UTF-8, it is encoded as ASCII in the message as `\u...`, so nothing to worry about.) Also avoids the decoder-dictionary "leak" from 52483.
* Simplifies exception handling of IPC reads that had two layers in #52483 where BlockingIOError was re-raised. Since we use low-level IO, the EOFError exception is never raised, so original error handling was already fine.
* `nonlocal` fixup (52483 used the keyword, but still had a redundant list to hold a value)
* Improved readability of IPC bits
