### PR TITLE
autopush: only push non-redistributable packages to private mirrors

### DIFF
--- a/lib/spack/docs/binary_caches.rst
+++ b/lib/spack/docs/binary_caches.rst
@@ -395,6 +395,15 @@ will have the same effect as
 .. note::
 
     Packages are automatically pushed to a build cache only if they are built from source.
+    Packages that may not be redistributed (see the ``redistribute()`` directive) are only pushed to mirrors marked private:
+
+    .. code-block:: yaml
+
+        mirrors:
+          <name>:
+            url: <url>
+            autopush: true
+            private: true  # also autopush non-redistributable packages
 
 .. index::
    single: buildcache; OCI registries

--- a/lib/spack/spack/hooks/autopush.py
+++ b/lib/spack/spack/hooks/autopush.py
@@ -27,6 +27,9 @@ def post_install(spec, explicit):
             )
             continue
 
+        # Non-redistributable packages may only be pushed to private mirrors
+        if not mirror.private and not pkg.redistribute_binary:
+            continue
         signing_key = spack.binary_distribution.select_signing_key() if mirror.signed else None
         with spack.binary_distribution.make_uploader(
             mirror=mirror, force=True, signing_key=signing_key

--- a/lib/spack/spack/mirrors/mirror.py
+++ b/lib/spack/spack/mirrors/mirror.py
@@ -168,6 +168,12 @@ class Mirror:
         )
 
     @property
+    def private(self) -> bool:
+        if isinstance(self._data, str):
+            return False
+        return self._data.get("private", False)
+
+    @property
     def fetch_url(self) -> str:
         """Get the valid, canonicalized fetch URL"""
         return self.get_url("fetch")

--- a/lib/spack/spack/schema/mirrors.py
+++ b/lib/spack/spack/schema/mirrors.py
@@ -126,6 +126,11 @@ mirror_entry = {
             "description": "Automatically push packages to this build cache immediately after "
             "they are installed locally",
         },
+        "private": {
+            "type": "boolean",
+            "description": "Whether this mirror is private; non-redistributable packages may "
+            "be pushed to private mirrors",
+        },
         **overridable_per_direction,
     },
 }

--- a/lib/spack/spack/test/cmd/buildcache.py
+++ b/lib/spack/spack/test/cmd/buildcache.py
@@ -18,6 +18,7 @@ import spack.buildcache_migrate as migrate
 import spack.buildcache_prune
 import spack.cmd.buildcache
 import spack.concretize
+import spack.config
 import spack.environment as ev
 import spack.error
 import spack.main
@@ -196,6 +197,32 @@ def test_buildcache_autopush(tmp_path: pathlib.Path, install_mockery, mock_fetch
 
     assert not (mirror_dir / specs_dirs / manifest_file).exists()
     assert (mirror_autopush_dir / specs_dirs / manifest_file).exists()
+
+
+def test_buildcache_autopush_skips_non_redistributable(
+    tmp_path: pathlib.Path, install_mockery, mock_fetch
+):
+    """Specs with redistribute(binary=False) are only pushed to private autopush mirrors"""
+    mirror_autopush_dir = tmp_path / "mirror_autopush"
+    mirror_private_dir = tmp_path / "mirror_autopush_private"
+
+    mirror("add", "--autopush", "--unsigned", "mirror-autopush", mirror_autopush_dir.as_uri())
+    spack.config.set(
+        "mirrors:mirror-autopush-private",
+        {"url": mirror_private_dir.as_uri(), "autopush": True, "signed": False, "private": True},
+    )
+
+    s = spack.concretize.concretize_one("no-redistribute")
+
+    PackageInstaller([s.package], fake=True, explicit=True).install()
+
+    manifest_file = URLBuildcacheEntry.get_manifest_filename(s)
+    specs_dirs = os.path.join(
+        *URLBuildcacheEntry.get_relative_path_components(BuildcacheComponent.SPEC), s.name
+    )
+
+    assert not (mirror_autopush_dir / specs_dirs / manifest_file).exists()
+    assert (mirror_private_dir / specs_dirs / manifest_file).exists()
 
 
 def test_buildcache_sync(


### PR DESCRIPTION
The `autopush` hook pushed every freshly built spec unconditionally, while `buildcache push` filters `redistribute(binary=False)` specs unless `--private` is given. A mirror with `autopush: true` would therefore mirror packages whose license forbids it, e.g. all of `IntelOneApiPackage`, where only mirroring within an organization is permitted.

autopush has no CLI invocation to hang `--private` off, so add a `private` setting to the mirror config and have the hook push non-redistributable specs only to private mirrors. This keeps the legitimate use case, autopushing to an organization-internal cache, while applying the same default as `buildcache push`.