### PR TITLE
Windows: update installer config to reflect general spack defaults

### DIFF
--- a/etc/spack/defaults/windows/config.yaml
+++ b/etc/spack/defaults/windows/config.yaml
@@ -3,4 +3,3 @@ config:
   build_stage::
     - '$user_cache_path/stage'
   stage_name: '{name}-{version}-{hash:7}'
-  installer: old


### PR DESCRIPTION
Updates Windows installer config, no special `config:installer` setting, just use the general spack default (new installer! woo!)