### PR TITLE
new_installer.py: non-blocking DB transaction API

### DIFF
--- a/lib/spack/spack/database.py
+++ b/lib/spack/spack/database.py
@@ -662,14 +662,16 @@ class Database:
         the write lock was acquired (the database is re-read from disk on entry and written back on
         exit, unless an exception occurred), or False if acquiring the lock would block, in which
         case the body must skip its work."""
-        assert isinstance(self.lock, lk.Lock), "not supported for upstream databases"
+        if not isinstance(self.lock, lk.Lock):
+            raise ForbiddenLockError("Cannot acquire a write lock on an upstream database")
         return lk.TryWriteTransaction(self.lock, acquire=self._read, release=self._write)
 
     def try_read_transaction(self) -> lk.TryReadTransaction:
         """Non-blocking variant of :meth:`read_transaction`: the context manager yields True if the
         read lock was acquired (the database is re-read from disk on entry), or False if acquiring
         the lock would block, in which case the body must skip its work."""
-        assert isinstance(self.lock, lk.Lock), "not supported for upstream databases"
+        if not isinstance(self.lock, lk.Lock):
+            raise ForbiddenLockError("Cannot acquire a read lock on an upstream database")
         return lk.TryReadTransaction(self.lock, acquire=self._read)
 
     def _write_to_file(self, stream):

--- a/lib/spack/spack/database.py
+++ b/lib/spack/spack/database.py
@@ -657,6 +657,21 @@ class Database:
         """Get a read lock context manager for use in a ``with`` block."""
         return self._read_transaction_impl(self.lock, acquire=self._read)
 
+    def try_write_transaction(self) -> lk.TryWriteTransaction:
+        """Non-blocking variant of :meth:`write_transaction`: the context manager yields True if
+        the write lock was acquired (the database is re-read from disk on entry and written back on
+        exit, unless an exception occurred), or False if acquiring the lock would block, in which
+        case the body must skip its work."""
+        assert isinstance(self.lock, lk.Lock), "not supported for upstream databases"
+        return lk.TryWriteTransaction(self.lock, acquire=self._read, release=self._write)
+
+    def try_read_transaction(self) -> lk.TryReadTransaction:
+        """Non-blocking variant of :meth:`read_transaction`: the context manager yields True if the
+        read lock was acquired (the database is re-read from disk on entry), or False if acquiring
+        the lock would block, in which case the body must skip its work."""
+        assert isinstance(self.lock, lk.Lock), "not supported for upstream databases"
+        return lk.TryReadTransaction(self.lock, acquire=self._read)
+
     def _write_to_file(self, stream):
         """Write out the database in JSON format to the stream passed
         as argument.

--- a/lib/spack/spack/llnl/util/lock.py
+++ b/lib/spack/spack/llnl/util/lock.py
@@ -869,7 +869,15 @@ class TryReadTransaction(ReadTransaction):
             ...
     """
 
-    _acquired = False
+    def __init__(
+        self,
+        lock: Lock,
+        acquire: Optional[Callable[[], None]] = None,
+        release: Optional[ExitFnType] = None,
+        timeout: Optional[float] = None,
+    ) -> None:
+        super().__init__(lock, acquire=acquire, release=release, timeout=timeout)
+        self._acquired = False
 
     def __enter__(self) -> bool:
         # The acquire function must only run on the outermost acquisition
@@ -902,7 +910,15 @@ class TryWriteTransaction(WriteTransaction):
             ...
     """
 
-    _acquired = False
+    def __init__(
+        self,
+        lock: Lock,
+        acquire: Optional[Callable[[], None]] = None,
+        release: Optional[ExitFnType] = None,
+        timeout: Optional[float] = None,
+    ) -> None:
+        super().__init__(lock, acquire=acquire, release=release, timeout=timeout)
+        self._acquired = False
 
     def __enter__(self) -> bool:
         # The acquire function must only run on the outermost acquisition

--- a/lib/spack/spack/llnl/util/lock.py
+++ b/lib/spack/spack/llnl/util/lock.py
@@ -859,6 +859,72 @@ class WriteTransaction(LockTransaction):
         return self._lock.release_write(release_fn)
 
 
+class TryReadTransaction(ReadTransaction):
+    """Non-blocking ReadTransaction: yields True if the lock was acquired, and False if acquiring
+    it would block, in which case the body must skip its work::
+
+        with TryReadTransaction(lock, acquire=...) as acquired:
+            if not acquired:
+                return
+            ...
+    """
+
+    _acquired = False
+
+    def __enter__(self) -> bool:
+        # The acquire function must only run on the outermost acquisition
+        outermost = self._lock._reads == 0 and self._lock._writes == 0
+        if not self._lock.try_acquire_read():
+            return False
+        self._acquired = True
+        if outermost and self._acquire_fn:
+            self._acquire_fn()
+        return True
+
+    def __exit__(
+        self,
+        exc_type: Optional[Type[BaseException]],
+        exc_value: Optional[BaseException],
+        traceback: Optional[TracebackType],
+    ) -> bool:
+        if not self._acquired:
+            return False
+        return super().__exit__(exc_type, exc_value, traceback)
+
+
+class TryWriteTransaction(WriteTransaction):
+    """Non-blocking WriteTransaction: yields True if the lock was acquired, and False if acquiring
+    it would block, in which case the body must skip its work::
+
+        with TryWriteTransaction(lock, acquire=..., release=...) as acquired:
+            if not acquired:
+                return
+            ...
+    """
+
+    _acquired = False
+
+    def __enter__(self) -> bool:
+        # The acquire function must only run on the outermost acquisition
+        outermost = self._lock._writes == 0
+        if not self._lock.try_acquire_write():
+            return False
+        self._acquired = True
+        if outermost and self._acquire_fn:
+            self._acquire_fn()
+        return True
+
+    def __exit__(
+        self,
+        exc_type: Optional[Type[BaseException]],
+        exc_value: Optional[BaseException],
+        traceback: Optional[TracebackType],
+    ) -> bool:
+        if not self._acquired:
+            return False
+        return super().__exit__(exc_type, exc_value, traceback)
+
+
 class LockError(Exception):
     """Raised for any errors related to locks."""
 

--- a/lib/spack/spack/new_installer.py
+++ b/lib/spack/spack/new_installer.py
@@ -1758,11 +1758,9 @@ def schedule_builds(
 
     # Acquire the DB read lock non-blocking; hold it throughout the loop so the in-memory snapshot
     # stays consistent while we acquire per-spec prefix locks.
-    if not db.lock.try_acquire_read():
-        return ScheduleResult(blocked, to_start, newly_installed, to_mark_explicit)
-
-    try:
-        db._read()  # refresh in-memory snapshot under the read lock
+    with db.try_read_transaction() as acquired:
+        if not acquired:
+            return ScheduleResult(blocked, to_start, newly_installed, to_mark_explicit)
 
         idx = 0
         while capacity and idx < len(pending):
@@ -1846,9 +1844,6 @@ def schedule_builds(
             to_start.append((dag_hash, lock))
             capacity -= 1
             needs_jobserver_token = True  # all subsequent jobs need a token
-
-    finally:
-        db.lock.release_read()
 
     return ScheduleResult(blocked, to_start, newly_installed, to_mark_explicit)
 
@@ -2428,10 +2423,9 @@ class PackageInstaller:
     def _try_expand_build_deps(self) -> None:
         """Try to expand build deps for specs with cache misses. Non-blocking: returns immediately
         if the DB read lock is unavailable."""
-        if not self.db.lock.try_acquire_read():
-            return
-        try:
-            self.db._read()
+        with self.db.try_read_transaction() as acquired:
+            if not acquired:
+                return
             dep_policy = (
                 "source_only"
                 if (self.dependencies_policy == "auto" and not self.has_mirrors)
@@ -2446,22 +2440,17 @@ class PackageInstaller:
                 )
             self.build_status.total += len(newly_added)
             self.pending_expansions.clear()
-        finally:
-            self.db.lock.release_read()
 
     def _save_to_db(
         self,
         database_actions: List[DatabaseAction],
         retained_read_locks: List[spack.util.lock.Lock],
     ) -> bool:
-        if not self.db.lock.try_acquire_write():
-            return False
-        try:
-            self.db._read()
+        with self.db.try_write_transaction() as acquired:
+            if not acquired:
+                return False
             for action in database_actions:
                 action.save_to_db(self.db)
-        finally:
-            self.db.lock.release_write(self.db._write)
 
         # DB has been written and flushed; downgrade per-spec prefix write locks to read locks so
         # other processes can see the specs are installed, while preventing concurrent uninstalls.

--- a/lib/spack/spack/test/database.py
+++ b/lib/spack/spack/test/database.py
@@ -626,6 +626,53 @@ def test_017_write_and_read_without_uuid(mutable_database, monkeypatch):
         assert new_rec.installed == rec.installed
 
 
+def test_try_write_transaction(mutable_database, monkeypatch):
+    """try_write_transaction persists changes on success and yields False without doing anything
+    when acquiring the lock would block."""
+    db = spack.store.STORE.db
+
+    spec = db.query_one("mpileaks ^zmpi")
+    with db.try_write_transaction() as acquired:
+        assert acquired
+        db._remove(spec)
+
+    db._state_is_inconsistent = True  # force re-read from disk
+    with db.read_transaction():
+        assert db.query_local_by_spec_hash(spec.dag_hash()) is None
+
+    monkeypatch.setattr(db.lock, "try_acquire_write", lambda: False)
+    with db.try_write_transaction() as acquired:
+        assert not acquired
+
+
+def test_try_write_transaction_does_not_flush_on_exception(mutable_database):
+    """Regression test: an exception inside try_write_transaction must not flush the possibly
+    inconsistent in-memory database to disk; the next transaction re-reads it instead."""
+    db = spack.store.STORE.db
+
+    with pytest.raises(ValueError):
+        with db.try_write_transaction() as acquired:
+            assert acquired
+            db._data.clear()
+            db._installed_prefixes.clear()
+            raise ValueError("interrupted transaction")
+
+    with db.read_transaction():
+        assert db.query("mpileaks")
+
+
+def test_try_read_transaction(mutable_database, monkeypatch):
+    db = spack.store.STORE.db
+
+    with db.try_read_transaction() as acquired:
+        assert acquired
+        assert db.query("mpileaks")
+
+    monkeypatch.setattr(db.lock, "try_acquire_read", lambda: False)
+    with db.try_read_transaction() as acquired:
+        assert not acquired
+
+
 def test_020_db_sanity(database):
     """Make sure query() returns what's actually in the db."""
     _check_db_sanity(database)

--- a/lib/spack/spack/test/llnl/util/lock.py
+++ b/lib/spack/spack/test/llnl/util/lock.py
@@ -1083,6 +1083,109 @@ def test_nested_reads(lock_path):
                     assert vals["read"] == 1
 
 
+@pytest.mark.parametrize(
+    "transaction,type", [(lk.TryReadTransaction, "read"), (lk.TryWriteTransaction, "write")]
+)
+def test_try_transaction(lock_path, transaction, type):
+    """When uncontended, try-transactions yield True and behave like blocking transactions."""
+
+    def enter_fn():
+        vals["entered_fn"] = True
+
+    def exit_fn(t, v, tb):
+        vals["exited_fn"] = True
+        vals["exception"] = t or v or tb
+
+    vals = collections.defaultdict(lambda: False)
+    lock = AssertLock(lock_path, vals)
+
+    with transaction(lock, acquire=enter_fn, release=exit_fn) as acquired:
+        assert acquired
+        assert vals["entered_fn"]
+        assert not vals["released_%s" % type]
+
+    assert vals["exited_fn"]
+    assert vals["released_%s" % type]
+    assert not vals["exception"]
+
+
+@pytest.mark.parametrize(
+    "transaction,attr",
+    [(lk.TryReadTransaction, "try_acquire_read"), (lk.TryWriteTransaction, "try_acquire_write")],
+)
+def test_try_transaction_blocked(lock_path, transaction, attr, monkeypatch):
+    """When the lock would block, try-transactions yield False and call no functions on exit."""
+
+    def enter_fn():
+        vals["entered_fn"] = True
+
+    def exit_fn(t, v, tb):
+        vals["exited_fn"] = True
+
+    vals = collections.defaultdict(lambda: False)
+    lock = AssertLock(lock_path, vals)
+    monkeypatch.setattr(lock, attr, lambda: False)
+
+    with transaction(lock, acquire=enter_fn, release=exit_fn) as acquired:
+        assert not acquired
+
+    assert not vals["entered_fn"]
+    assert not vals["exited_fn"]
+    assert lock._reads == 0 and lock._writes == 0
+
+    # exceptions raised in the body still propagate
+    with pytest.raises(ValueError):
+        with transaction(lock, acquire=enter_fn, release=exit_fn) as acquired:
+            assert not acquired
+            raise ValueError()
+
+
+def test_try_transaction_with_exception(lock_path):
+    """An exception in the body propagates and is forwarded to the release function."""
+
+    def exit_fn(t, v, tb):
+        vals["exception"] = t or v or tb
+
+    vals = collections.defaultdict(lambda: False)
+    lock = AssertLock(lock_path, vals)
+
+    with pytest.raises(ValueError):
+        with lk.TryWriteTransaction(lock, release=exit_fn) as acquired:
+            assert acquired
+            raise ValueError()
+
+    assert vals["exception"]
+    assert vals["released_write"]
+    assert lock._reads == 0 and lock._writes == 0
+
+
+def test_try_transaction_nested(lock_path):
+    """Nested try-transactions acquire, but do not re-run the acquire function, and the release
+    function only runs when the outermost write lock is released."""
+
+    def read():
+        vals["read"] += 1
+
+    def write(t, v, tb):
+        vals["wrote"] += 1
+
+    vals = collections.defaultdict(lambda: 0)
+    lock = AssertLock(lock_path, vals)
+
+    with lk.WriteTransaction(lock, acquire=read, release=write):
+        assert vals["read"] == 1
+        with lk.TryWriteTransaction(lock, acquire=read, release=write) as acquired:
+            assert acquired
+            assert vals["read"] == 1
+        assert vals["wrote"] == 0
+        with lk.TryReadTransaction(lock, acquire=read) as acquired:
+            assert acquired
+            assert vals["read"] == 1
+        assert lock._writes == 1
+    assert vals["wrote"] == 1
+    assert lock._reads == 0 and lock._writes == 0
+
+
 class LockDebugOutput:
     def __init__(self, lock_path):
         self.lock_path = lock_path

--- a/lib/spack/spack/util/lock.py
+++ b/lib/spack/spack/util/lock.py
@@ -15,6 +15,8 @@ from spack.llnl.util.lock import (
     LockTimeoutError,
     LockUpgradeError,
     ReadTransaction,
+    TryReadTransaction,
+    TryWriteTransaction,
     WriteTransaction,
 )
 
@@ -59,5 +61,7 @@ __all__ = [
     "LockTimeoutError",
     "LockUpgradeError",
     "ReadTransaction",
+    "TryReadTransaction",
+    "TryWriteTransaction",
     "WriteTransaction",
 ]


### PR DESCRIPTION
Add `TryReadTransaction` and `TryWriteTransaction`: non-blocking variants of the
existing transaction context managers that yield whether the lock was acquired.
The call site is responsible for early exit when no lock was acquired.

Use them in the installer event loop, which previously hand-rolled non-blocking
transactions against Database internals. This also fixes a bug in
`_save_to_db`: when an exception interrupted a database update, the possibly
inconsistent in-memory database was still flushed to disk. The transaction's
exit now forwards exception info to `Database._write`, which skips the flush
and re-reads the database in the next transaction.

