### PR TITLE
new_installer.py: no terminal title while headless

### DIFF
--- a/lib/spack/spack/new_installer.py
+++ b/lib/spack/spack/new_installer.py
@@ -1127,7 +1127,7 @@ class BuildStatus:
         self.dirty = True
 
     def _update_terminal_title(self, clear: bool = False) -> None:
-        if not self.term_title:
+        if not self.term_title or self.headless:
             return
 
         term_title = ""


### PR DESCRIPTION
Avoid a SIGTTOU when backgrounded. In practice I couldn't trigger it, but it should be there nonetheless, might depend on the terminal if it's problematic or not.