### PR TITLE
new_installer.py: fix fail-fast dynamic scheduling

### DIFF
--- a/lib/spack/spack/new_installer.py
+++ b/lib/spack/spack/new_installer.py
@@ -2228,6 +2228,7 @@ class PackageInstaller:
                     for child in self.running_builds.values():
                         child.proc.terminate()
                     self.pending_builds.clear()
+                    self.pending_expansions.clear()
 
                 if stdin_ready and stdin_reader is not None:
                     for char in stdin_reader.read():


### PR DESCRIPTION
Fix a minor issue where on failure with fail-fast `pending_expansions` was
not cleared. A build that exited with a binary cache miss in the same
batch where another fatally failed would have its build deps expanded
later in the same loop iteration, repopulating `pending_builds` and
launching new builds after other builds were already terminated.

