### PR TITLE
new_installer_windows.py: fix line-buffering

### DIFF
--- a/lib/spack/spack/new_installer_windows.py
+++ b/lib/spack/spack/new_installer_windows.py
@@ -275,7 +275,8 @@ class WindowsTee(Tee):
 
 def make_state_stream(state: socket.socket) -> io.TextIOWrapper:
     """Wrap the write end of the state socketpair as a line-buffered text stream."""
-    return state.makefile("w", buffering=1, encoding="utf-8", newline="\n")
+    buffer = state.makefile("wb")
+    return io.TextIOWrapper(buffer, encoding="utf-8", newline="\n", line_buffering=True)
 
 
 def read_connection(conn: socket.socket, max_size: int = 4096) -> bytes:


### PR DESCRIPTION
`makefile(..., buffering=1)` sets the internal buffer size of
BufferedWriter to 1; it is different from `fdopen(..., buffering=1)`
which means "line buffering".

Fix by using binary mode for socket.makefile, with an explicitly line
buffered TextIOWrapper.
