### PR TITLE
new_installer: make StdinReader a concrete class

### DIFF
--- a/lib/spack/spack/new_installer.py
+++ b/lib/spack/spack/new_installer.py
@@ -83,7 +83,7 @@ from spack.new_installer_base import (
     IpcChannel,
     JobServerBase,
     ProcessExitNotifier,
-    StdinReaderBase,
+    StdinReader,
 )
 from spack.subprocess_context import GlobalStateMarshaler
 from spack.util.executable import ProcessError
@@ -2133,7 +2133,7 @@ class PackageInstaller:
 
         # Set up terminal handling (cbreak, signals, stdin registration)
         terminal: Optional[BaseTerminalState] = None
-        stdin_reader: Optional[StdinReaderBase] = None
+        stdin_reader: Optional[StdinReader] = None
         if TerminalState.stdin_is_interactive():
             terminal = TerminalState(
                 selector,

--- a/lib/spack/spack/new_installer_base.py
+++ b/lib/spack/spack/new_installer_base.py
@@ -32,15 +32,19 @@ else:
 OUTPUT_BUFFER_SIZE = 32768
 
 
-class StdinReaderBase:
-    """Base class for platform-specific non-blocking stdin reading with UTF-8 decoding.
+class StdinReader:
+    """Non-blocking stdin reading with UTF-8 decoding, on top of a platform-specific function
+    that reads raw bytes.
 
-    The input is the backing file descriptor for stdin (instead of the TextIOWrapper) to
-    avoid double buffering issues: the event loop triggers when the fd is ready to read, and if we
-    do a partial read from the TextIOWrapper, it will likely drain the fd and buffer the remainder
-    internally, which the event loop is not aware of, and user input doesn't come through."""
+    Raw bytes are read from the backing file descriptor or socket for stdin (instead of the
+    TextIOWrapper) to avoid double buffering issues: the event loop triggers when the fd is ready
+    to read, and if we do a partial read from the TextIOWrapper, it will likely drain the fd and
+    buffer the remainder internally, which the event loop is not aware of, and user input doesn't
+    come through."""
 
-    def __init__(self) -> None:
+    def __init__(self, read_raw: Callable[[], bytes]) -> None:
+        #: Platform-specific function that reads available raw bytes from stdin
+        self.read_raw = read_raw
         #: Handle multi-byte UTF-8 characters
         self.decoder = codecs.getincrementaldecoder("utf-8")(errors="replace")
         #: For stripping out arrow and navigation keys
@@ -50,7 +54,10 @@ class StdinReaderBase:
         return self.ansi_escape_re.sub("", self.decoder.decode(raw))
 
     def read(self) -> str:
-        raise NotImplementedError
+        try:
+            return self._decode(self.read_raw())
+        except OSError:
+            return ""
 
 
 class BaseTerminalState(abc.ABC):
@@ -77,7 +84,7 @@ class BaseTerminalState(abc.ABC):
         return sys.stdin.isatty()
 
     @abc.abstractmethod
-    def create_stdin_reader(self) -> StdinReaderBase:
+    def create_stdin_reader(self) -> StdinReader:
         pass
 
     @abc.abstractmethod

--- a/lib/spack/spack/new_installer_posix.py
+++ b/lib/spack/spack/new_installer_posix.py
@@ -5,6 +5,7 @@
 """POSIX-specific terminal state, stdin reader, IPC channels, and job scheduling."""
 
 import fcntl
+import functools
 import io
 import os
 import re
@@ -27,26 +28,12 @@ from spack.new_installer_base import (
     BaseTerminalState,
     JobServerBase,
     ProcessExitNotifier,
-    StdinReaderBase,
+    StdinReader,
     Tee,
 )
 
 if TYPE_CHECKING:
     from spack.new_installer import BuildStatus
-
-
-class PosixStdinReader(StdinReaderBase):
-    """Non-blocking stdin reader for POSIX"""
-
-    def __init__(self, fd: int) -> None:
-        super().__init__()
-        self.fd = fd
-
-    def read(self) -> str:
-        try:
-            return self._decode(os.read(self.fd, 1024))
-        except OSError:
-            return ""
 
 
 class PosixTerminalState(BaseTerminalState):
@@ -71,8 +58,8 @@ class PosixTerminalState(BaseTerminalState):
         self.sigwinch_r = -1
         self.sigwinch_w = -1
 
-    def create_stdin_reader(self) -> PosixStdinReader:
-        return PosixStdinReader(sys.stdin.fileno())
+    def create_stdin_reader(self) -> StdinReader:
+        return StdinReader(functools.partial(os.read, sys.stdin.fileno(), 1024))
 
     def setup(self) -> None:
         """Set cbreak mode, register stdin and signal pipes in the selector."""

--- a/lib/spack/spack/new_installer_windows.py
+++ b/lib/spack/spack/new_installer_windows.py
@@ -5,6 +5,7 @@
 """Windows-specific terminal state, stdin reader, IPC channels, and job scheduling."""
 
 import ctypes
+import functools
 import io
 import msvcrt
 import os
@@ -21,7 +22,7 @@ from spack.new_installer_base import (
     OUTPUT_BUFFER_SIZE,
     BaseTerminalState,
     ProcessExitNotifier,
-    StdinReaderBase,
+    StdinReader,
     Tee,
 )
 
@@ -36,21 +37,6 @@ ENABLE_EXTENDED_FLAGS = 0x0080
 ENABLE_VIRTUAL_TERMINAL_PROCESSING = 0x0004  # for stdout handle
 WIN_STD_OUTPUT_HANDLE = -11
 WIN_STD_ERROR_HANDLE = -12
-
-
-class WindowsStdinReader(StdinReaderBase):
-    """Non-blocking stdin reader for Windows using socket.recv() on the stdin socketpair."""
-
-    def __init__(self, fd: int, sock: socket.socket) -> None:
-        super().__init__()
-        self.fd = fd
-        self.sock = sock
-
-    def read(self) -> str:
-        try:
-            return self._decode(self.sock.recv(1024))
-        except OSError:
-            return ""
 
 
 class WindowsTerminalState(BaseTerminalState):
@@ -100,8 +86,8 @@ class WindowsTerminalState(BaseTerminalState):
         self.sigwinch_r, self.sigwinch_w = socket.socketpair()
         self.sigwinch_r.setblocking(False)
 
-    def create_stdin_reader(self) -> WindowsStdinReader:
-        return WindowsStdinReader(self.stdin_r.fileno(), sock=self.stdin_r)
+    def create_stdin_reader(self) -> StdinReader:
+        return StdinReader(functools.partial(self.stdin_r.recv, 1024))
 
     def setup(self) -> None:
         # Enable VT100 ANSI escapes on stdout

--- a/lib/spack/spack/test/installer_tui.py
+++ b/lib/spack/spack/test/installer_tui.py
@@ -11,6 +11,7 @@ if sys.platform == "win32":
     pytest.skip("No Windows support", allow_module_level=True)
 
 
+import functools
 import io
 import os
 from multiprocessing import Pipe
@@ -18,7 +19,12 @@ from typing import List, Optional, Tuple
 
 import spack.new_installer as inst
 from spack.new_installer import BuildStatus
-from spack.new_installer_posix import PosixStdinReader as StdinReader
+from spack.new_installer_base import StdinReader
+
+
+def _fd_reader(fd: int) -> StdinReader:
+    """StdinReader reading from a raw fd, as PosixTerminalState.create_stdin_reader does."""
+    return StdinReader(functools.partial(os.read, fd, 1024))
 
 
 class MockConnection:
@@ -1490,7 +1496,7 @@ class TestStdinReader:
     def test_basic_ascii(self):
         r, w = os.pipe()
         try:
-            reader = StdinReader(r)
+            reader = _fd_reader(r)
             os.write(w, b"abc")
             assert reader.read() == "abc"
         finally:
@@ -1500,7 +1506,7 @@ class TestStdinReader:
     def test_ansi_stripping(self):
         r, w = os.pipe()
         try:
-            reader = StdinReader(r)
+            reader = _fd_reader(r)
             os.write(w, b"hello\x1b[Aworld\x1b[B!")
             assert reader.read() == "helloworld!"
         finally:
@@ -1510,7 +1516,7 @@ class TestStdinReader:
     def test_multibyte_utf8(self):
         r, w = os.pipe()
         try:
-            reader = StdinReader(r)
+            reader = _fd_reader(r)
             encoded = "é".encode("utf-8")  # 0xc3 0xa9
             os.write(w, encoded[:1])
             # First read: incomplete char, decoder buffers it
@@ -1526,5 +1532,5 @@ class TestStdinReader:
         r, w = os.pipe()
         os.close(w)
         os.close(r)
-        reader = StdinReader(r)
+        reader = _fd_reader(r)
         assert reader.read() == ""

--- a/lib/spack/spack/test/windows_tui.py
+++ b/lib/spack/spack/test/windows_tui.py
@@ -9,6 +9,7 @@ into the selector-based event loop.  All tests here use pytest's monkeypatch and
 plain fake objects so that no real Win32 API calls are required.
 """
 
+import functools
 import os
 import selectors
 import shutil
@@ -24,6 +25,7 @@ if sys.platform != "win32":
 from ctypes import wintypes
 
 import spack.new_installer_windows as _niw
+from spack.new_installer_base import StdinReader
 from spack.new_installer_windows import (
     ENABLE_ECHO_INPUT,
     ENABLE_EXTENDED_FLAGS,
@@ -32,7 +34,6 @@ from spack.new_installer_windows import (
     ENABLE_VIRTUAL_TERMINAL_PROCESSING,
     WindowsTerminalState,
 )
-from spack.new_installer_windows import WindowsStdinReader as StdinReader
 
 
 class _FakeSelector:
@@ -468,7 +469,7 @@ class TestStdinReaderSocketPath:
         r, w = socket.socketpair()
         # Keep blocking so recv() returns data immediately, mirroring production behaviour
         # where read() is only called after the selector has already signalled data ready.
-        reader = StdinReader(r.fileno(), sock=r)
+        reader = StdinReader(functools.partial(r.recv, 1024))
         return reader, r, w
 
     def test_basic_ascii_via_socket(self):


### PR DESCRIPTION
PosixStdinReader and WindowsStdinReader differed from the base class in
a single expression (os.read on an fd vs socket.recv). Replace the
hierarchy with one concrete class that takes a partial wrapping the
platform-specific raw read call.

This is consistent with other composition > inheritance refactors done earlier.
