### PR TITLE
new_installer_*.py: terminal state simplifications

### DIFF
--- a/lib/spack/spack/new_installer_base.py
+++ b/lib/spack/spack/new_installer_base.py
@@ -89,10 +89,8 @@ class BaseTerminalState(abc.ABC):
         """Restore input settings and signal handlers. Called before the final UI render."""
         pass
 
-    @abc.abstractmethod
     def teardown_output(self) -> None:
         """Restore output settings. Called after the final UI render."""
-        pass
 
     def teardown(self) -> None:
         self.teardown_input()
@@ -103,22 +101,24 @@ class BaseTerminalState(abc.ABC):
         pass
 
     @abc.abstractmethod
-    def enter_background(self) -> None:
-        pass
-
-    @abc.abstractmethod
-    def handle_continue(self) -> None:
-        pass
-
-    @abc.abstractmethod
     def drain_sigwinch(self) -> None:
         """Drain the platform-specific sigwinch notification channel."""
         pass
 
-    @abc.abstractmethod
+    # The methods below are job-control hooks: a platform with suspend/resume support (SIGTSTP/
+    # SIGCONT on POSIX) overrides them to transition between foreground and headless mode. The
+    # defaults are for platforms without job control, where the process never goes headless after
+    # setup().
+
+    def enter_background(self) -> None:
+        pass
+
+    def handle_continue(self) -> None:
+        pass
+
     def should_enter_foreground(self) -> bool:
         """Return True if the process should switch from headless to foreground mode."""
-        pass
+        return False
 
 
 class FdInfo:

--- a/lib/spack/spack/new_installer_posix.py
+++ b/lib/spack/spack/new_installer_posix.py
@@ -119,9 +119,6 @@ class PosixTerminalState(BaseTerminalState):
             except Exception as e:
                 spack.llnl.util.tty.debug(f"Failed to close sigwinch pipe {fd}: {e}")
 
-    def teardown_output(self) -> None:
-        pass
-
     def _handle_sigtstp(self, signum: int, frame: object) -> None:
         """Restore terminal before suspending, then re-install handler after resume."""
 

--- a/lib/spack/spack/new_installer_windows.py
+++ b/lib/spack/spack/new_installer_windows.py
@@ -147,19 +147,8 @@ class WindowsTerminalState(BaseTerminalState):
         self.build_status.headless = False
         self.build_status.dirty = True
 
-    def enter_background(self) -> None:
-        if self.stdin_r.fileno() in self.selector.get_map():
-            self.selector.unregister(self.stdin_r)
-        self.build_status.headless = True
-
-    def handle_continue(self) -> None:
-        self.enter_foreground()
-
     def drain_sigwinch(self) -> None:
         self.sigwinch_r.recv(64)
-
-    def should_enter_foreground(self) -> bool:
-        return True
 
     def _input_thread(self) -> None:
         while self._running:

--- a/lib/spack/spack/test/windows_tui.py
+++ b/lib/spack/spack/test/windows_tui.py
@@ -10,7 +10,6 @@ plain fake objects so that no real Win32 API calls are required.
 """
 
 import os
-import selectors
 import shutil
 import socket
 import sys
@@ -302,16 +301,6 @@ class TestForegroundBackground:
 
         tags = [data for _, _, data in sel.register_calls]
         assert "stdin" not in tags
-
-    def test_enter_background_unregisters_stdin_and_sets_headless(self):
-        """enter_background() unregisters stdin_r and sets headless=True."""
-        state, sel, bs, k32 = _make_state(headless=False)
-        sel._reg[state.stdin_r.fileno()] = (state.stdin_r, selectors.EVENT_READ, "stdin")
-
-        state.enter_background()
-
-        assert sel.unregister_calls
-        assert bs.headless is True
 
 
 class TestInputThread:


### PR DESCRIPTION
`enter_background`, `handle_continue`, and `should_enter_foreground`
exist for POSIX job control: the first two are only reachable from the
`SIGTSTP` handler, and the third only applies while headless, which
cannot be triggered on Windows.

The abstract methods forced `WindowsTerminalState` to implement dead
code. Give them no-op defaults and drop the Windows overrides, along
with the empty POSIX `teardown_output`.
