### PR TITLE
lock.py: "forbidden" as backend

### DIFF
--- a/lib/spack/spack/database.py
+++ b/lib/spack/spack/database.py
@@ -257,18 +257,6 @@ class InstallRecord:
         return InstallRecord(spec, **d)
 
 
-class ForbiddenLockError(SpackError):
-    """Raised when an upstream DB attempts to acquire a lock"""
-
-
-class ForbiddenLock:
-    def __getattr__(self, name):
-        raise ForbiddenLockError(f"Cannot access attribute '{name}' of lock")
-
-    def __reduce__(self):
-        return ForbiddenLock, tuple()
-
-
 class LockConfiguration(NamedTuple):
     """Data class to configure locks in Database objects
 
@@ -613,9 +601,10 @@ class Database:
         self.db_lock_timeout = lock_cfg.database_timeout
         tty.debug(f"DATABASE LOCK TIMEOUT: {str(self.db_lock_timeout)}s")
 
-        self.lock: Union[ForbiddenLock, lk.Lock]
         if self.is_upstream:
-            self.lock = ForbiddenLock()
+            self.lock = lk.Lock.forbidden(
+                str(self._lock_path), "Cannot lock an upstream database", desc="database"
+            )
         else:
             self.lock = lk.Lock(
                 str(self._lock_path),
@@ -664,16 +653,12 @@ class Database:
         the write lock was acquired (the database is re-read from disk on entry and written back on
         exit, unless an exception occurred), or False if acquiring the lock would block, in which
         case the body must skip its work."""
-        if not isinstance(self.lock, lk.Lock):
-            raise ForbiddenLockError("Cannot acquire a write lock on an upstream database")
         return lk.TryWriteTransaction(self.lock, acquire=self._read, release=self._write)
 
     def try_read_transaction(self) -> lk.TryReadTransaction:
         """Non-blocking variant of :meth:`read_transaction`: the context manager yields True if the
         read lock was acquired (the database is re-read from disk on entry), or False if acquiring
         the lock would block, in which case the body must skip its work."""
-        if not isinstance(self.lock, lk.Lock):
-            raise ForbiddenLockError("Cannot acquire a read lock on an upstream database")
         return lk.TryReadTransaction(self.lock, acquire=self._read)
 
     def _write_to_file(self, stream):

--- a/lib/spack/spack/test/database.py
+++ b/lib/spack/spack/test/database.py
@@ -99,7 +99,7 @@ def test_installed_upstream(upstream_and_downstream_db, repo_builder: RepoBuilde
         for dep in spec.traverse(root=False):
             record = downstream_db.get_by_hash(dep.dag_hash())
             assert record is not None
-            with pytest.raises(spack.database.ForbiddenLockError):
+            with pytest.raises(lk.ForbiddenLockError):
                 upstream_db.get_by_hash(dep.dag_hash())
 
         new_spec = spack.concretize.concretize_one("w")
@@ -242,7 +242,7 @@ def test_cannot_write_upstream(tmp_path: pathlib.Path, mock_packages, config):
     # Create it as an upstream
     db = Database(str(tmp_path), is_upstream=True)
 
-    with pytest.raises(spack.database.ForbiddenLockError):
+    with pytest.raises(lk.ForbiddenLockError):
         db.add(spack.concretize.concretize_one("pkg-a"))
 
 

--- a/lib/spack/spack/util/lock.py
+++ b/lib/spack/spack/util/lock.py
@@ -24,6 +24,8 @@ __all__ = [
     "check_lock_safety",
     "CantCreateLockError",
     "DummyBackend",
+    "ForbiddenBackend",
+    "ForbiddenLockError",
     "Lock",
     "LockDowngradeError",
     "LockError",
@@ -358,6 +360,26 @@ class DummyBackend:
         pass
 
 
+class ForbiddenBackend:
+    """Lock backend that refuses every operation, for resources that must never be locked
+    (e.g. a read-only upstream database)."""
+
+    def __init__(self, message: str) -> None:
+        self._message = message
+
+    def prepare(self, op: int) -> None:
+        raise ForbiddenLockError(self._message)
+
+    def poll(self, op: int) -> bool:
+        raise ForbiddenLockError(self._message)
+
+    def release(self) -> None:
+        raise ForbiddenLockError(self._message)
+
+    def cleanup(self, path: str) -> None:
+        raise ForbiddenLockError(self._message)
+
+
 class Lock:
     """This is an implementation of a filesystem lock using Python's lockf.
 
@@ -424,7 +446,7 @@ class Lock:
         self.default_timeout = default_timeout or None
 
         if sys.platform != "win32" and enable:
-            self.backend: Union[PosixBackend, DummyBackend] = PosixBackend(
+            self.backend: Union[PosixBackend, DummyBackend, ForbiddenBackend] = PosixBackend(
                 path, start, length, debug=debug
             )
         else:
@@ -434,6 +456,13 @@ class Lock:
     def enabled(self) -> bool:
         """True if this lock actually takes OS locks (False for the no-op backend)."""
         return not isinstance(self.backend, DummyBackend)
+
+    @classmethod
+    def forbidden(cls, path: str, message: str, *, desc: str = "") -> "Lock":
+        """A lock that refuses every acquisition by raising a ForbiddenLockError."""
+        lock = cls(path, desc=desc, enable=False)
+        lock.backend = ForbiddenBackend(message)
+        return lock
 
     @staticmethod
     def _poll_interval_generator(
@@ -984,6 +1013,11 @@ class TryWriteTransaction(WriteTransaction):
 
 class LockError(Exception):
     """Raised for any errors related to locks."""
+
+
+class ForbiddenLockError(LockError):
+    """Raised when acquiring a lock that is explicitly forbidden, e.g. on a read-only upstream
+    database."""
 
 
 class LockDowngradeError(LockError):


### PR DESCRIPTION
Make "forbidden" a lock backend (`ForbiddenBackend`, constructed via
`Lock.forbidden(...)`) instead of a separate `ForbiddenLock` type. Call sites now
always deal with a plain `Lock`, so we drop the `Union[ForbiddenLock, Lock]`
annotations and `isinstance` checks. Used for read-only upstream databases, which
still raise `ForbiddenLockError` on any lock attempt.