### PR TITLE
CI: Point at the latest hidden snapshot ref

### DIFF
--- a/.ci/gitlab-ci.yml
+++ b/.ci/gitlab-ci.yml
@@ -4,7 +4,7 @@ stages:
   - packages
 
 variables:
-  SPACK_PACKAGES_CHECKOUT_VERSION: develop
+  SPACK_PACKAGES_CHECKOUT_VERSION: refs/snapshots/develop-latest
 
 .clone_packages: &clone_packages
   - mkdir -p ${REPO_DESTINATION}


### PR DESCRIPTION
This should restrict running CI on only the latest snapshot ref.

This can merge now, but to continue to update the packages ref we need to also merge https://github.com/spack/spack-infrastructure/pull/867