### PR TITLE
Add `when=` clause to `version()` directive

### DIFF
--- a/lib/spack/spack/audit.py
+++ b/lib/spack/spack/audit.py
@@ -47,7 +47,7 @@ import pathlib
 import pickle
 import re
 import warnings
-from typing import Iterable, List, Set, Tuple
+from typing import Iterable, List, Sequence, Set, Tuple, Type
 from urllib.request import urlopen
 
 import spack.builder
@@ -593,15 +593,20 @@ def _ensure_packages_are_unparseable(pkgs, error_cls):
 
 
 @package_properties
-def _ensure_all_versions_can_produce_a_fetcher(pkgs, error_cls):
+def _ensure_all_versions_can_produce_a_fetcher(
+    pkgs: Sequence[str], error_cls: Type[Error]
+) -> List[Error]:
     """Ensure all versions in a package can produce a fetcher"""
     errors = []
     for pkg_name in pkgs:
         pkg_cls = spack.repo.PATH.get_pkg_class(pkg_name)
-        pkg = pkg_cls(spack.spec.Spec(pkg_name))
+
+        versions = pkg_cls.all_versions()
+        spec = spack.spec.Spec(pkg_name)
         try:
-            spack.fetch_strategy.check_pkg_attributes(pkg)
-            for version in pkg.versions:
+            spack.fetch_strategy.check_pkg_attributes(pkg_cls)
+            # TODO: needs to be modified for fetch_strategy.for_spec()
+            for version in versions:
                 assert spack.fetch_strategy.for_package_version(pkg, version)
         except Exception as e:
             error_msg = "The package '{}' cannot produce a fetcher for some of its versions"

--- a/lib/spack/spack/cmd/url.py
+++ b/lib/spack/spack/cmd/url.py
@@ -5,6 +5,7 @@
 import argparse
 import urllib.parse
 from collections import defaultdict
+from typing import Dict
 
 import spack.fetch_strategy as fs
 import spack.llnl.util.tty.color as color
@@ -173,7 +174,7 @@ def url_list(args):
     return len(urls)
 
 
-def url_summary(args):
+def url_summary(args: Dict):
     # Collect statistics on how many URLs were correctly parsed
     total_urls = 0
     correct_names = 0

--- a/lib/spack/spack/cmd/versions.py
+++ b/lib/spack/spack/cmd/versions.py
@@ -4,6 +4,7 @@
 
 import argparse
 import sys
+from typing import Dict
 
 import spack.llnl.util.tty as tty
 import spack.repo
@@ -34,7 +35,7 @@ def setup_parser(subparser: argparse.ArgumentParser) -> None:
     arguments.add_common_arguments(subparser, ["package", "jobs"])
 
 
-def versions(parser, args):
+def versions(parser: argparse.ArgumentParser, args: Dict):
     spec = spack.spec.Spec(args.package)
     pkg_cls = spack.repo.PATH.get_pkg_class(spec.name)
     pkg = pkg_cls(spec)

--- a/lib/spack/spack/directives.py
+++ b/lib/spack/spack/directives.py
@@ -62,6 +62,7 @@ from spack.directives_meta import DirectiveError, directive, get_spec
 from spack.resource import Resource
 from spack.spec import EMPTY_SPEC
 from spack.version import StandardVersion, VersionChecksumError, VersionError
+from spack.version_def import VersionDefinition
 
 __all__ = [
     "DirectiveError",
@@ -154,7 +155,7 @@ def _make_when_spec(value: Union[WhenType, Tuple[str, ...]]) -> Optional[spack.s
 SubmoduleCallback = Callable[[spack.package_base.PackageBase], Union[str, List[str], bool]]
 
 
-@directive("versions", supports_when=False)
+@directive(("versions", "when_versions"), supports_when=False)
 def version(
     ver: Union[str, int],
     # this positional argument is deprecated, use sha256=... instead
@@ -193,6 +194,8 @@ def version(
     cvs: Optional[str] = None,
     revision: Optional[str] = None,
     date: Optional[str] = None,
+    # condition defining when this version exists
+    when: WhenType = None,
 ):
     """Declare a version for a package with optional metadata for fetching its code.
 
@@ -238,10 +241,16 @@ def version(
         )
         if value is not None
     }
-    return partial(_execute_version, ver=ver, kwargs=kwargs)
+    return partial(_execute_version, ver=ver, when=when, kwargs=kwargs)
 
 
-def _execute_version(pkg: PackageType, ver: Union[str, int], kwargs: dict):
+def _execute_version(
+    pkg: Type[spack.package_base.PackageBase], ver: Union[str, int], when: WhenType, kwargs: dict
+):
+    when_spec = _make_when_spec(when)
+    if not when_spec:  # ignore if when was False
+        return
+
     if (
         (any(s in kwargs for s in spack.util.crypto.hashes) or "checksum" in kwargs)
         and hasattr(pkg, "has_code")
@@ -258,8 +267,16 @@ def _execute_version(pkg: PackageType, ver: Union[str, int], kwargs: dict):
 
     version = StandardVersion.from_string(str(ver))
 
-    # Store kwargs for the package to later with a fetch_strategy.
+    # Add version to deprecated versions dictionary on the package (for backward compatibility)
+    # TODO: we should likely have a convention for *which* of the conditional versions to add,
+    # TODO: e.g., we probably want to choose the one for the current platform if we can.
     pkg.versions[version] = kwargs
+
+    # Store a version definition for this directive invocation
+    when_versions = pkg.when_versions.setdefault(when_spec, {})
+    when_versions[version] = VersionDefinition(
+        version, precedence=pkg.num_version_definitions(), kwargs=kwargs
+    )
 
 
 @directive("conflicts")

--- a/lib/spack/spack/fetch_strategy.py
+++ b/lib/spack/spack/fetch_strategy.py
@@ -39,7 +39,7 @@ import time
 import urllib.parse
 import urllib.request
 from pathlib import PurePath
-from typing import Callable, List, Mapping, Optional, Type
+from typing import Any, Callable, Dict, List, Mapping, Optional, Type
 
 import spack.config
 import spack.error
@@ -47,6 +47,7 @@ import spack.llnl.url
 import spack.llnl.util.filesystem as fs
 import spack.llnl.util.tty as tty
 import spack.oci.opener
+import spack.spec
 import spack.util.archive
 import spack.util.crypto as crypto
 import spack.util.executable
@@ -54,6 +55,8 @@ import spack.util.git
 import spack.util.url as url_util
 import spack.util.web as web_util
 import spack.version
+import spack.version.git_ref_lookup
+import spack.version_def
 from spack.llnl.string import comma_and, quote
 from spack.llnl.util.filesystem import get_single_file, mkdirp, symlink, temp_cwd, working_dir
 from spack.util.compression import decompressor_for
@@ -95,7 +98,7 @@ class FetchStrategy:
     #: The URL attribute must be specified either at the package class
     #: level, or as a keyword argument to ``version()``.  It is used to
     #: distinguish fetchers for different versions in the package DSL.
-    url_attr: Optional[str] = None
+    url_attr: str
 
     #: Optional attributes can be used to distinguish fetchers when :
     #: classes have multiple ``url_attrs`` at the top-level.
@@ -201,11 +204,6 @@ class BundleFetchStrategy(FetchStrategy):
     TODO: Remove this class by refactoring resource handling and the link
     between composite stages and composite fetch strategies (see #11981).
     """
-
-    #: There is no associated URL keyword in ``version()`` for no-code
-    #: packages but this property is required for some strategy-related
-    #: functions (e.g., check_pkg_attributes).
-    url_attr = ""
 
     def fetch(self):
         """Simply report success -- there is no code to fetch."""
@@ -1500,7 +1498,7 @@ def from_kwargs(**kwargs) -> FetchStrategy:
     raise InvalidArgsError(**kwargs)
 
 
-def check_pkg_attributes(pkg):
+def check_pkg_attributes(pkg: Type["spack.package_base.PackageBase"]):
     """Find ambiguous top-level fetch attributes in a package.
 
     Currently this only ensures that two or more VCS fetch strategies are
@@ -1520,15 +1518,19 @@ def check_pkg_attributes(pkg):
         )
 
 
-def _check_version_attributes(fetcher, pkg, version):
+def _check_version_attributes(
+    fetcher: FetchStrategy, spec: "spack.spec.Spec", version: spack.version.ConcreteVersion
+):
     """Ensure that the fetcher for a version is not ambiguous.
 
     This assumes that we have already determined the fetcher for the
-    specific version using ``for_package_version()``
+    specific version using ``for_spec()``
+
+    Helper for ``for_spec()``.
     """
     all_optionals = set(a for s in all_strategies for a in s.optional_attrs)
 
-    args = pkg.versions[version]
+    args = spec.package_class.version_def_for_spec(spec).kwargs
     extra = set(args) - set(fetcher.optional_attrs) - set([fetcher.url_attr, "no_cache"])
     extra.intersection_update(all_optionals)
 
@@ -1536,14 +1538,17 @@ def _check_version_attributes(fetcher, pkg, version):
         legal_attrs = [fetcher.url_attr] + list(fetcher.optional_attrs)
         raise FetcherConflict(
             "%s version '%s' has extra arguments: %s"
-            % (pkg.name, version, comma_and(quote(extra))),
+            % (spec.name, spec.version, comma_and(quote(extra))),
             "Valid arguments for a %s fetcher are: \n    %s"
             % (fetcher.url_attr, comma_and(quote(legal_attrs))),
         )
 
 
 def _extrapolate(pkg, version):
-    """Create a fetcher from an extrapolated URL for this version."""
+    """Create a fetcher from an extrapolated URL for this version.
+
+    Helper for ``for_spec()``.
+    """
     try:
         return URLFetchStrategy(url=pkg.url_for_version(version), fetch_options=pkg.fetch_options)
     except spack.error.NoURLError:
@@ -1553,10 +1558,19 @@ def _extrapolate(pkg, version):
         )
 
 
-def _from_merged_attrs(fetcher, pkg, version):
-    """Create a fetcher from merged package and version attributes."""
+def _from_merged_attrs(
+    fetcher: Type[FetchStrategy],
+    pkg: "spack.package_base.PackageBase",
+    version_def: spack.version_def.VersionDefinition,
+) -> FetchStrategy:
+    """Create a fetcher from merged package and version attributes.
+
+    Helper for ``for_spec()``.
+    """
+    attrs: Dict[str, Any]
+
     if fetcher.url_attr == "url":
-        mirrors = pkg.all_urls_for_version(version)
+        mirrors = pkg.all_urls_for_version(version_def.version)
         url = mirrors[0]
         mirrors = mirrors[1:]
         attrs = {fetcher.url_attr: url, "mirrors": mirrors}
@@ -1565,7 +1579,7 @@ def _from_merged_attrs(fetcher, pkg, version):
         attrs = {fetcher.url_attr: url}
 
     attrs["fetch_options"] = pkg.fetch_options
-    attrs.update(pkg.versions[version])
+    attrs.update(version_def.kwargs)
 
     if fetcher.url_attr == "git":
         pkg_attr_list = ["submodules", "git_sparse_paths"]
@@ -1576,41 +1590,37 @@ def _from_merged_attrs(fetcher, pkg, version):
     return fetcher(**attrs)
 
 
-def for_package_version(pkg, version=None):
-    saved_versions = None
-    if version is not None:
-        saved_versions = pkg.spec.versions
+def for_spec(spec: "spack.spec.Spec"):
+    # TODO: remove this method when we understand why _for_spec modifies packages.
+    # See 52ac1b09c9ed3eee6489b33665beb1255c893068.
+    saved_versions = pkg.spec.versions
+    saved_when_versions = pkg.spec.when_versions
 
     try:
-        return _for_package_version(pkg, version)
+        return _for_spec(spec)
     finally:
-        if saved_versions is not None:
-            pkg.spec.versions = saved_versions
+        spec.versions = saved_versions
+        spec.when_versions = saved_when_versions
 
 
-def _for_package_version(pkg, version=None):
-    """Determine a fetch strategy based on the arguments supplied to
-    version() in the package description."""
+def _for_spec(spec: "spack.spec.Spec") -> FetchStrategy:
+    """Determine a fetch strategy from an abstract or concrete spec."""
 
     # No-code packages have a custom fetch strategy to work around issues
     # with resource staging.
-    if not pkg.has_code:
+    pkg_class = spec.package_class
+    if not pkg_class.has_code:
         return BundleFetchStrategy()
 
-    check_pkg_attributes(pkg)
+    # ensure package doesn't have ambiguous attributes
+    check_pkg_attributes(pkg_class)
 
-    if version is not None:
-        assert not pkg.spec.concrete, "concrete specs should not pass the 'version=' argument"
-        # Specs are initialized with the universe range, if no version information is given,
-        # so here we make sure we always match the version passed as argument
-        if not isinstance(version, spack.version.StandardVersion):
-            version = spack.version.Version(version)
+    # TODO: Having to get a package instance here is awkward, but we need to use
+    # TODO: methods and properties that may be overridden by package authors.
+    pkg = pkg_class(spec)
 
-        version_list = spack.version.VersionList()
-        version_list.add(version)
-        pkg.spec.versions = version_list
-    else:
-        version = pkg.version
+    # specs must have a concrete version for this to work.
+    version = spec.version
 
     # if it's a commit, we must use a GitFetchStrategy
     commit_var = pkg.spec.variants.get("commit", None)
@@ -1662,22 +1672,22 @@ def _for_package_version(pkg, version=None):
             kwargs["git"] = pkg.version_or_package_attr("git", ref_version)
             kwargs["submodules"] = pkg.version_or_package_attr("submodules", ref_version, False)
 
-        fetcher = GitFetchStrategy(**kwargs)
-        return fetcher
+        return GitFetchStrategy(**kwargs)
 
     # If it's not a known version, try to extrapolate one by URL
-    if version not in pkg.versions:
+    version_def = pkg.version_def_for_spec(spec)
+    if not version_def:
         return _extrapolate(pkg, version)
 
     # Set package args first so version args can override them
     args = {"fetch_options": pkg.fetch_options}
     # Grab a dict of args out of the package version dict
-    args.update(pkg.versions[version])
+    args.update(version_def.kwargs)
 
     # If the version specifies a `url_attr` directly, use that.
     for fetcher in all_strategies:
         if fetcher.url_attr in args:
-            _check_version_attributes(fetcher, pkg, version)
+            _check_version_attributes(fetcher, spec, version)
             if fetcher.url_attr == "git" and hasattr(pkg, "submodules"):
                 args.setdefault("submodules", pkg.submodules)
             return fetcher(**args)
@@ -1688,16 +1698,16 @@ def _for_package_version(pkg, version=None):
         if hasattr(pkg, fetcher.url_attr) or fetcher.url_attr == "url":
             optionals = fetcher.optional_attrs
             if optionals and any(a in args for a in optionals):
-                _check_version_attributes(fetcher, pkg, version)
-                return _from_merged_attrs(fetcher, pkg, version)
+                _check_version_attributes(fetcher, spec, version)
+                return _from_merged_attrs(fetcher, pkg, version_def)
 
     # if the optional attributes tell us nothing, then use any `url_attr`
     # on the package.  This prefers URL vs. VCS, b/c URLFetchStrategy is
     # defined first in this file.
     for fetcher in all_strategies:
         if hasattr(pkg, fetcher.url_attr):
-            _check_version_attributes(fetcher, pkg, version)
-            return _from_merged_attrs(fetcher, pkg, version)
+            _check_version_attributes(fetcher, spec, version)
+            return _from_merged_attrs(fetcher, pkg, version_def)
 
     raise InvalidArgsError(pkg, version, **args)
 
@@ -1726,11 +1736,10 @@ def from_url_scheme(url: str, **kwargs) -> FetchStrategy:
     raise ValueError(f'No FetchStrategy found for url with scheme: "{parsed_url.scheme}"')
 
 
-def from_list_url(pkg):
-    """If a package provides a URL which lists URLs for resources by
-    version, this can can create a fetcher for a URL discovered for
-    the specified package's version."""
-
+def from_list_url(pkg: "spack.package_base.PackageBase"):
+    """If a package provides a URL that lists URLs for resources by version, this can
+    can create a fetcher for a URL discovered for the specified package's version.
+    """
     if pkg.list_url:
         try:
             versions = pkg.fetch_remote_versions()
@@ -1741,11 +1750,11 @@ def from_list_url(pkg):
 
                 # try to find a known checksum for version, from the package
                 version = pkg.version
-                if version in pkg.versions:
-                    args = pkg.versions[version]
-                    checksum = next(
-                        (v for k, v in args.items() if k in crypto.hashes), args.get("checksum")
-                    )
+                defs = pkg.version_definitions(version)
+                for when, vdef in defs:
+                    if pkg.spec.satisfies(when):
+                        checksum = vdef.get_checksum()
+                        break
 
                 # construct a fetcher
                 return URLFetchStrategy(

--- a/lib/spack/spack/llnl/string.py
+++ b/lib/spack/spack/llnl/string.py
@@ -5,7 +5,7 @@
 standard library
 """
 
-from typing import Any, Sequence, List, Optional
+from typing import Any, List, Optional, Sequence
 
 
 def comma_list(sequence: Sequence[Any], article: str = "") -> str:

--- a/lib/spack/spack/llnl/string.py
+++ b/lib/spack/spack/llnl/string.py
@@ -5,10 +5,18 @@
 standard library
 """
 
-from typing import List, Optional, Sequence
+from typing import Any, Sequence, List, Optional
 
 
-def comma_list(sequence: Sequence[str], article: str = "") -> str:
+def comma_list(sequence: Sequence[Any], article: str = "") -> str:
+    """Create a comma-separated list out of a sequence of stringifiable objects.
+
+    Arguments:
+        sequence: objects to be stringified
+        article: optionally use an article (e.g., 'and' or 'or' to separate the last two elements).
+            With two elements, only the article is used as a separator. With three or more, use
+            an Oxford comma (as everyone should).
+    """
     if type(sequence) is not list:
         sequence = list(sequence)
 
@@ -27,16 +35,20 @@ def comma_list(sequence: Sequence[str], article: str = "") -> str:
     return out
 
 
-def comma_or(sequence: Sequence[str]) -> str:
-    """Return a string with all the elements of the input joined by comma, but the last
-    one (which is joined by ``"or"``).
+def comma_or(sequence: Sequence[Any]) -> str:
+    """Create a comma-separated list with a final ``"or"`` (foo, bar, or baz).
+
+    Arguments:
+        sequence: objects in the list
     """
     return comma_list(sequence, "or")
 
 
-def comma_and(sequence: List[str]) -> str:
-    """Return a string with all the elements of the input joined by comma, but the last
-    one (which is joined by ``"and"``).
+def comma_and(sequence: Sequence[Any]) -> str:
+    """Create a comma-separated list with a final ``"and"`` (foo, bar, and baz).
+
+    Arguments:
+        sequence: objects in the list
     """
     return comma_list(sequence, "and")
 
@@ -55,8 +67,13 @@ def ordinal(number: int) -> str:
     return f"{number}{suffix}"
 
 
-def quote(sequence: List[str], q: str = "'") -> List[str]:
-    """Quotes each item in the input list with the quote character passed as second argument."""
+def quote(sequence: Sequence[Any], q: str = "'") -> List[str]:
+    """Returns a list of quoted strings made from each item in the input list.
+
+    Arguments:
+        sequence: a sequence of anything that can be turned into a string
+        q: quote character to use
+    """
     return [f"{q}{e}{q}" for e in sequence]
 
 

--- a/lib/spack/spack/mirrors/layout.py
+++ b/lib/spack/spack/mirrors/layout.py
@@ -118,27 +118,29 @@ def default_mirror_layout(
     per_package_ref: str,
     spec: Optional["spack.spec.Spec"] = None,
 ) -> MirrorLayout:
-    """Returns a ``MirrorReference`` object which keeps track of the relative
+    """Returns a ``MirrorLayout`` object which keeps track of the relative
     storage path of the resource associated with the specified ``fetcher``."""
-    ext = None
+
     if spec:
         pkg_cls = spack.repo.PATH.get_pkg_class(spec.name)
-        versions = pkg_cls.versions.get(spec.version, {})
-        ext = versions.get("extension", None)
-    # If the spec does not explicitly specify an extension (the default case),
-    # then try to determine it automatically. An extension can only be
+        when_versions = pkg_cls.version_definitions(spec.version)
+        version_args = next((v.kwargs for when, v in when_versions if spec.satisfies(when)), {})
+        ext = version_args.get("extension", None)
+
+    # If the version as defined in the package does not explicitly specify
+    # an extension, try to determine one automatically. An extension can only be
     # specified for the primary source of the package (e.g. the source code
     # identified in the 'version' declaration). Resources/patches don't have
     # an option to specify an extension, so it must be inferred for those.
     ext = ext or _determine_extension(fetcher)
 
     if ext:
-        per_package_ref += ".%s" % ext
+        per_package_ref += f".{ext}"
 
     global_ref = fetcher.mirror_id()
     if global_ref:
         global_ref = os.path.join("_source-cache", global_ref)
     if global_ref and ext:
-        global_ref += ".%s" % ext
+        global_ref += f".{ext}"
 
     return DefaultLayout(per_package_ref, global_ref)

--- a/lib/spack/spack/package_base.py
+++ b/lib/spack/spack/package_base.py
@@ -50,6 +50,7 @@ import spack.util.naming
 import spack.util.path
 import spack.util.web
 import spack.variant
+import spack.version_def
 from spack.compilers.adaptor import DeprecatedCompiler
 from spack.error import InstallError, NoURLError, PackageError
 from spack.filesystem_view import YamlFilesystemView
@@ -63,7 +64,15 @@ from spack.llnl.util.lang import ClassProperty, classproperty, dedupe, memoized
 from spack.resource import Resource
 from spack.util.package_hash import package_hash
 from spack.util.typing import SupportsRichComparison
-from spack.version import GitVersion, StandardVersion, VersionError, is_git_version
+from spack.version import (
+    ConcreteVersion,
+    GitVersion,
+    StandardVersion,
+    Version,
+    VersionError,
+    is_git_version,
+)
+from spack.version_def import VersionDefinition
 
 FLAG_HANDLER_RETURN_TYPE = Tuple[
     Optional[Iterable[str]], Optional[Iterable[str]], Optional[Iterable[str]]
@@ -320,7 +329,7 @@ def on_package_attributes(**attr_dict):
             has_all_attributes = all([hasattr(instance, key) for key in attr_dict])
             if has_all_attributes:
                 has_the_right_values = all(
-                    [getattr(instance, key) == value for key, value in attr_dict.items()]  # NOQA: ignore=E501
+                    [getattr(instance, key) == value for key, value in attr_dict.items()]
                 )
                 if has_the_right_values:
                     func(instance, *args, **kwargs)
@@ -471,6 +480,8 @@ def _remove_overridden_defs(defs: List[Tuple[spack.spec.Spec, Any]]) -> None:
     ``when="+rocm"``, but we can't guarantee that will always happen when a vdef is
     overridden. So we use this method to remove any overrides we can know statically.
 
+    Version dictionaries act similarly.
+
     """
     i = 0
     while i < len(defs):
@@ -498,6 +509,19 @@ def _definitions(
         _remove_overridden_defs(defs)
 
     return defs
+
+
+def _get_def(
+    when_indexed_dictionary: Dict[spack.spec.Spec, Dict[K, V]], spec: spack.spec.Spec, key: K
+) -> Optional[V]:
+    """Get highest precedence definition from a dictionary, given a spec and a subkey."""
+    assert spec.concrete
+
+    try:
+        high_to_low = reversed(_definitions(when_indexed_dictionary, key))
+        return next(definition for when, definition in high_to_low if spec.satisfies(when))
+    except StopIteration:
+        return None
 
 
 #: Store whether a given Spec source/binary should not be redistributed.
@@ -546,8 +570,13 @@ class PackageBase(WindowsRPath, PackageViewMixin, metaclass=PackageMeta):
 
     compiler = DeprecatedCompiler()
 
-    #: Class level dictionary populated by :func:`~spack.directives.version` directives
+    #: DEPRECATED Class level dictionary populated by :func:`~spack.directives.version` directives
+    #: This is here for backward compatibility - some packages use it, but we will warn if they do.
+    #: This loses information about conditional versions and has been Superseded by when_versions.
     versions: Dict[StandardVersion, Dict[str, Any]]
+    #: Class level dictionary populated by :func:`~spack.directives.version` directives.
+    #: Added in package API v2.6 to support conditional versions.
+    when_versions: Dict[spack.spec.Spec, Dict[StandardVersion, VersionDefinition]]
     #: Class level dictionary populated by :func:`~spack.directives.resource` directives
     resources: Dict[spack.spec.Spec, List[Resource]]
     #: Class level dictionary populated by :func:`~spack.directives.depends_on` and
@@ -733,6 +762,27 @@ class PackageBase(WindowsRPath, PackageViewMixin, metaclass=PackageMeta):
     def dependencies_by_name(cls, when: bool = False):
         return _by_subkey(cls.dependencies, when=when)
 
+    # Accessors for versions
+    # External code working with Versions should go through the methods below
+    @classmethod
+    def all_versions(cls) -> List[ConcreteVersion]:
+        return _subkeys(cls.when_versions)
+
+    @classmethod
+    def has_version(cls, version: ConcreteVersion) -> bool:
+        return _has_subkey(cls.when_versions, version)
+
+    @classmethod
+    def num_version_definitions(cls) -> int:
+        return _num_definitions(cls.when_versions)
+
+    @classmethod
+    def version_definitions(
+        cls, version: ConcreteVersion
+    ) -> List[Tuple[spack.spec.Spec, VersionDefinition]]:
+        """Iterator over (when_spec, VersionDefinition) for all definitions of a version."""
+        return _definitions(cls.when_versions, version)
+
     # Accessors for variants
     # External code working with Variants should go through the methods below
 
@@ -773,17 +823,21 @@ class PackageBase(WindowsRPath, PackageViewMixin, metaclass=PackageMeta):
             if filtered_variants_by_name:
                 yield when, filtered_variants_by_name
 
+    @classmethod
+    def version_def_for_spec(cls, spec) -> Optional[spack.version_def.VersionDefinition]:
+        """Get the highest precedence version definition matching this package's spec."""
+        return _get_def(cls.versions, spec, spec.version)
+
     def get_variant(self, name: str) -> spack.variant.Variant:
         """Get the highest precedence variant definition matching this package's spec.
 
         Arguments:
             name: name of the variant definition to get
         """
-        try:
-            highest_to_lowest = reversed(self.variant_definitions(name))
-            return next(vdef for when, vdef in highest_to_lowest if self.spec.satisfies(when))
-        except StopIteration:
+        vdef = _get_def(self.variants, self.spec, name)
+        if not vdef:
             raise ValueError(f"No variant '{name}' on spec: {self.spec}")
+        return vdef
 
     @classmethod
     def validate_variant_names(self, spec: spack.spec.Spec):
@@ -928,16 +982,21 @@ class PackageBase(WindowsRPath, PackageViewMixin, metaclass=PackageMeta):
 
     @classmethod
     @memoized
-    def version_urls(cls) -> Dict[StandardVersion, str]:
+    def version_urls(cls) -> Dict[ConcreteVersion, str]:
         """Dict of explicitly defined URLs for versions of this package.
 
         Return:
-           An dict mapping version to url, ordered by version.
+           A dict mapping version to url, ordered by version.
 
         A version's URL only appears in the result if it has an an explicitly defined ``url``
         argument. So, this list may be empty if a package only defines ``url`` at the top level.
         """
-        return {v: args["url"] for v, args in sorted(cls.versions.items()) if "url" in args}
+        return {
+            v: version_def.kwargs["url"]
+            for v in cls.all_versions()
+            for when, version_def in cls.version_definitions(v)
+            if "url" in version_def.kwargs
+        }
 
     def nearest_url(self, version):
         """Finds the URL with the "closest" version to ``version``.
@@ -1071,7 +1130,7 @@ class PackageBase(WindowsRPath, PackageViewMixin, metaclass=PackageMeta):
         """
         self._resolve_git_provenance(self.spec)
 
-    def all_urls_for_version(self, version: StandardVersion) -> List[str]:
+    def all_urls_for_version(self, version: ConcreteVersion) -> List[str]:
         """Return all URLs derived from version_urls(), url, urls, and
         list_url (if it contains a version) in a package in that order.
 
@@ -1085,8 +1144,8 @@ class PackageBase(WindowsRPath, PackageViewMixin, metaclass=PackageMeta):
 
     def _implement_all_urls_for_version(
         self,
-        version: Union[str, StandardVersion],
-        custom_url_for_version: Optional[Callable[[StandardVersion], Optional[str]]] = None,
+        version: Union[str, ConcreteVersion],
+        custom_url_for_version: Optional[Callable[[ConcreteVersion], Optional[str]]] = None,
     ) -> List[str]:
         version = StandardVersion.from_string(version) if isinstance(version, str) else version
 
@@ -1849,7 +1908,7 @@ class PackageBase(WindowsRPath, PackageViewMixin, metaclass=PackageMeta):
         # TODO: resources
         if self.spec.versions.concrete:
             try:
-                source_id = fs.for_package_version(self).source_id()
+                source_id = fs.for_spec(self).source_id()
             except (fs.ExtrapolationError, fs.InvalidArgsError, spack.error.NoURLError):
                 # ExtrapolationError happens if the package has no fetchers defined.
                 # InvalidArgsError happens when there are version directives with args,
@@ -2301,9 +2360,10 @@ class PackageBase(WindowsRPath, PackageViewMixin, metaclass=PackageMeta):
         if hasattr(self, "urls") and self.urls:
             urls.append(self.urls[0])
 
-        for args in self.versions.values():
-            if "url" in args:
-                urls.append(args["url"])
+        for v in self.all_versions():
+            for _, vdef in self.version_definitions(v):
+                if "url" in vdef.kwargs:
+                    urls.append(vdef.kwargs["url"])
         return urls
 
     def fetch_remote_versions(
@@ -2571,18 +2631,18 @@ def make_package_test_rpath(pkg: PackageBase, test_dir: Union[str, pathlib.Path]
     mini_rpath.establish_link()
 
 
-def deprecated_version(pkg: PackageBase, version: Union[str, StandardVersion]) -> bool:
+def deprecated_version(pkg: PackageBase, version: Union[str, ConcreteVersion]) -> bool:
     """Return True iff the version is deprecated.
 
     Arguments:
         pkg: The package whose version is to be checked.
         version: The version being checked
     """
-    if not isinstance(version, StandardVersion):
-        version = StandardVersion.from_string(version)
+    if not isinstance(version, ConcreteVersion):
+        version = Version(version)
 
-    details = pkg.versions.get(version)
-    return details is not None and details.get("deprecated", False)
+    definitions = pkg.version_definitions(version)
+    return any(vdef.kwargs.get("deprecated", False) for _, vdef in definitions)
 
 
 def preferred_version(
@@ -2597,13 +2657,13 @@ def preferred_version(
         pkg: The package whose versions are to be assessed.
     """
 
-    def _version_order(version_info):
-        version, info = version_info
-        deprecated_key = not info.get("deprecated", False)
-        return (deprecated_key, *concretization_version_order(version_info))
+    def _version_order(vdef):
+        deprecated_key = not vdef.kwargs.get("deprecated", False)
+        return (deprecated_key, *concretization_version_order(vdef))
 
-    version, _ = max(pkg.versions.items(), key=_version_order)
-    return version
+    vdefs = [vdef for v in pkg.all_versions() for _, vdef in pkg.version_definitions(v)]
+    vdef = max(vdefs, key=_version_order)
+    return vdef.version
 
 
 def non_preferred_version(node: spack.spec.Spec) -> bool:
@@ -2639,22 +2699,19 @@ def sort_by_pkg_preference(
     return [v for v, _ in sorted(s, reverse=True, key=concretization_version_order)]
 
 
-def concretization_version_order(
-    version_info: Tuple[Union[GitVersion, StandardVersion], dict],
-) -> Tuple[bool, bool, bool, bool, Union[GitVersion, StandardVersion]]:
+def concretization_version_order(vdef: VersionDefinition):
     """Version order key for concretization, where preferred > not preferred,
     finite > any infinite component; only if all are the same, do we use default version
     ordering.
 
     Version deprecation needs to be accounted for separately.
     """
-    version, info = version_info
     return (
-        info.get("preferred", False),
-        not isinstance(version, GitVersion),
-        not version.isdevelop(),
-        not version.is_prerelease(),
-        version,
+        vdef.kwargs.get("preferred", False),
+        not isinstance(vdef.version, GitVersion),
+        not vdef.version.isdevelop(),
+        not vdef.version.is_prerelease(),
+        vdef.version,
     )
 
 

--- a/lib/spack/spack/version/git_ref_lookup.py
+++ b/lib/spack/spack/version/git_ref_lookup.py
@@ -114,7 +114,7 @@ class GitRefLookup(AbstractRefLookup):
 
         return self.data[ref]
 
-    def lookup_ref(self, ref) -> Tuple[Optional[str], int]:
+    def lookup_ref(self, ref: str) -> Tuple[Optional[str], int]:
         """Lookup the previous version and distance for a given commit.
 
         We use git to compare the known versions from package to the git tags,

--- a/lib/spack/spack/version/version_types.py
+++ b/lib/spack/spack/version/version_types.py
@@ -203,6 +203,12 @@ class ConcreteVersion(VersionType):
 
     __slots__ = ()
 
+    def is_develop(self):
+        raise NotImplementedError
+
+    def is_prerelease(self) -> bool:
+        raise NotImplementedError
+
 
 def _stringify_version(versions: VersionTuple, separators: Tuple[str, ...]) -> str:
     """Create a string representation from version components."""

--- a/lib/spack/spack/version_def.py
+++ b/lib/spack/spack/version_def.py
@@ -1,0 +1,31 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+"""Version definitions as represented on a package class."""
+
+from typing import Dict, Optional
+
+import spack.util.crypto as crypto
+from spack.version import ConcreteVersion
+
+
+class VersionDefinition:
+    """Class representing a version definition.
+
+    Includes the version and all of the arguments provided with it in its package definition.
+    """
+
+    version: ConcreteVersion
+    precedence: int
+    kwargs: Dict
+
+    def __init__(self, version: ConcreteVersion, precedence: int, kwargs: Dict):
+        self.version = version
+        self.precedence = precedence
+        self.kwargs = kwargs
+
+    def get_checksum(self) -> Optional[str]:
+        """Get the checksum for this version def, if one exists in the kwargs."""
+        return next(
+            (v for k, v in self.kwargs.items() if k in crypto.hashes), self.kwargs.get("checksum")
+        )


### PR DESCRIPTION
Closes #51771.

Enables `when` with `version()`, so that we can have multiple downloads for versions, e.g.:

## Problem

### Expressiveness in packages 

```python
class Foo(Package):
    version("1.0.0", url="...", sha256="...", when="platform=linux")
    version("1.0.0", url="...", sha256="...", when="platform=darwin")
    version("1.0.0", url="...", sha256="...", when="platform=windows")
```

Nearly all of the metadata on `PackageBase` is conditional, *except* versions.  Spack assumes a single source (or single binary installer) for all versions of a package, and packages (like most of the vendor compilers, CUDA, etc.) that are only available as binaries work around this in weird ways. For example, CUDA has a big `_versions` dictionary like this:

```python
_versions = {
    "13.3.0": {
        "Linux-aarch64": (
            "94ec4572197b65532dcf3d327460417c6527fa42ded9d5010e06ddb89e878d4c",
            "https://developer.download.nvidia.com/compute/cuda/13.3.0/local_installers/cuda_13.3.0_610.43.02_linux_sbsa.run",
        ),
        "Linux-x86_64": (
            "5f79488b57fe6936bc95a56f9b7e2838ab2f2ee3313b1008942206eebe06352d",
            "https://developer.download.nvidia.com/compute/cuda/13.3.0/local_installers/cuda_13.3.0_610.43.02_linux.run",
        ),
    },
}

class Cuda(Package):
    for ver, packages in _versions.items():
        pkg = packages.get(f"{platform.system()}-{platform.machine()}")
        if pkg:
            version(ver, sha256=pkg[0], url=pkg[1], expand=False)
```

And `arm-forge` has conditionally *executed* `version()` directives like this:

```python
class ArmForge(Package):
    if platform.machine() in ["aarch64", "arm64"]:
        version("22.1.3", sha256="131884f998b82673e885a7b42cc883210e3a0229b50af374092140cdfd42a408")
    elif platform.machine() == "ppc64le":
        version("22.1.3", sha256="6479c3a4ae6ce6648c37594eb0266161f06d9f89010fca9299855848661dda49")
    elif platform.machine() == "x86_64":
        version("22.1.3", sha256="4f8a8b1df6ad712e89c82eedf4bd85b93b57b3c8d5b37d13480ff058fa8f4467")        ...
```

### Metadata & Mirroring

This is a problem for commands like `spack info` and `spack mirror` that need to access version metadata.  With package like the above, `spack info` can currently only see version downloads for the *current* platform/target/os, and `spack mirror is similar, so we cannot easily mirror all available versions for all platforms (#51771 attempts to address this).

Similarly, the automatic upload logic in https://github.com/spack/spack-packages/pull/4373 will only show new downloads for the current platform, and will miss downloads added for non-linux machines because GitHub actions runs on linux.

We need a way to *declaratively* specify versions for multiple platforms (and potentially other scenarios), and `when=` is the way we do that for other Spack directives.


## Implementation

Versions are unfortunately somewhat fundamental for Spack, so this refactor is large. This PR:

1. Introduces a `when_versions` dictionary on `PackageBase` to store `version()` metadata keyed by `when=` specs, the same way we store metadata for other directives. 
2. Keeps a `versions` dictionary on `PackageBase` to ensure backward compatibility with the v2.2 [Package API](https://spack.readthedocs.io/en/latest/package_api.html) (the API used in Spack v1.0) (see [here](https://spack.readthedocs.io/en/latest/package_api.html#spack.package.PackageBase.versions) -- `versions` is unfortunately in the API)
3. Refactors the `spack.fetch_strategy.for_package_version()` method to take a `Spec` (e.g., from `when`) so that we can get fetchers not just for a specific version, but for a specific package configuration when needed.


## Things left to do
This is currently a draft so that @alstar555 can pick up where I left off.  I have tried to enumerate what is left to do below.

- [x] Introduce a VersionDefinition class so that we can record all version definitions and store them on `PackageBase`
- [x] Add conditional version accessor functions to PackageBase, similar to those for variants

TBD on `FetchStrategy`
- [ ] Figure out why `_for_package_version` (now `_for_spec`) modified packages and get rid of wrapper `for_spec` method.
- [ ] `for_spec` likely needs to return a `List[FetchStrategy]`, as a spec may match more than one fetch strategy.
      - think about how callers should handle this
      - Think about introducing `single_fetcher_for_spec()` that returns a single `FetchStrategy` and fails if the spec is ambiguous.
      - Callsites probably need to be refactored so that concrete specs are passed to `for_spec` so that most calls to this can use `single_fetcher_for_spec()`. Callsites like `spack mirror` that enumerate versions likely should got through `PackageBase` methods to enumerate conditions and/or get all version definitions -- not just ask for a single fetch strategy.
- [ ] Finish refactor of `spack.fetch_strategy._for_package_version` -> `_for_spec`

TBD on `PackageBase`
- [ ] Make `PackageBase.versions` into a deprecated `@classproperty`, have it warn when accessed.
- [ ] Rework `find_valid_url_for_version` (see commands like `spack ci that use this)
- [ ] Ensure all internal code uses new `PackageBase` version accessors

Commands
- [ ] `spack ci`: validate_stanadard_versions() and `validate_git_versions()`
- [ ] `spack info`: Modify `print_versions` to show conditional versions, similar to variants
- [ ] `spack url` update to use `for_spec()`
- [ ] `spack audit`: Update `audit.py` checks to use `for_spec` instead of `for_package_version`
- [ ] `spack mirror`: Make mirroring code iterate over all versions for all platforms using new methods
- [ ] `spack checksum`: update to use `for_spec()`

Solver
- [ ] Make solver work with conditional versions
      - look at how variants are done
      - possibly optimize case where versions are platform-specific
      - we likely know statically in most cases which conditional versions are needed.

Tests
- [ ] Update tests that use `fetch_strategy.for_package_version()`
- [ ] Add tests for conditional versions

Package API
- [ ] Bump package API version for Spack

Docs
- [ ] Update package API docs for `PackageBase.versions` and `PackageBase.when_versions`

Once this PR is merged and once we decide to bump the package API on `builtin`, we can do a PR to refactor all packages to use `when=` instead of complicated package logic.


