### PR TITLE
util.lang: add `ensure_unwrapped` free function

### DIFF
--- a/lib/spack/spack/config.py
+++ b/lib/spack/spack/config.py
@@ -526,10 +526,6 @@ class Configuration:
         self.scopes = lang.PriorityOrderedMapping()
         self.updated_scopes_by_section: Dict[str, List[ConfigScope]] = defaultdict(list)
 
-    def ensure_unwrapped(self) -> "Configuration":
-        """Ensure we unwrap this object from any dynamic wrapper (like Singleton)"""
-        return self
-
     def highest(self) -> ConfigScope:
         """Scope with the highest precedence"""
         return next(self.scopes.reversed_values())  # type: ignore

--- a/lib/spack/spack/detection/path.py
+++ b/lib/spack/spack/detection/path.py
@@ -435,7 +435,7 @@ def by_path(
     detected_specs_by_package: Dict[str, Tuple[concurrent.futures.Future, ...]] = {}
 
     result = collections.defaultdict(list)
-    repository = PATH.ensure_unwrapped()
+    repository = spack.llnl.util.lang.ensure_unwrapped(PATH)
 
     executor: concurrent.futures.Executor
     if max_workers == 1:

--- a/lib/spack/spack/llnl/util/lang.py
+++ b/lib/spack/spack/llnl/util/lang.py
@@ -787,6 +787,11 @@ class SingletonInstantiationError(Exception):
     """Error that indicates a singleton that cannot instantiate."""
 
 
+def ensure_unwrapped(obj):
+    """Returns the real object behind a Singleton"""
+    return obj.instance if isinstance(obj, Singleton) else obj
+
+
 def get_entry_points(*, group: str):
     """Wrapper for ``importlib.metadata.entry_points``
 

--- a/lib/spack/spack/repo.py
+++ b/lib/spack/spack/repo.py
@@ -58,7 +58,7 @@ import spack.util.naming as nm
 import spack.util.path
 import spack.util.spack_yaml as syaml
 from spack.llnl.util.filesystem import working_dir
-from spack.llnl.util.lang import Singleton, memoized
+from spack.llnl.util.lang import Singleton, ensure_unwrapped, memoized
 
 if TYPE_CHECKING:
     import spack.package_base
@@ -760,10 +760,6 @@ class RepoPath:
         for p in self.python_paths():
             if p in sys.path:
                 sys.path.remove(p)
-
-    def ensure_unwrapped(self) -> "RepoPath":
-        """Ensure we unwrap this object from any dynamic wrapper (like Singleton)"""
-        return self
 
     def put_first(self, repo: Union["Repo", "RepoPath"]) -> None:
         """Add repo first in the search path."""
@@ -2213,7 +2209,7 @@ class UnknownPackageError(UnknownEntityError):
                 long_msg = "Use 'spack create' to create a new package."
 
                 if not repo:
-                    repo = PATH.ensure_unwrapped()
+                    repo = ensure_unwrapped(PATH)
 
                 # We need to compare the base package name
                 pkg_name = name_from_fullname(name)

--- a/lib/spack/spack/subprocess_context.py
+++ b/lib/spack/spack/subprocess_context.py
@@ -21,6 +21,7 @@ from types import ModuleType
 from typing import TYPE_CHECKING, Optional
 
 import spack.config
+import spack.llnl.util.lang
 import spack.paths
 import spack.platforms
 import spack.repo
@@ -101,7 +102,7 @@ class GlobalStateMarshaler:
         if self.is_forked:
             return
 
-        self.config = spack.config.CONFIG.ensure_unwrapped()
+        self.config = spack.llnl.util.lang.ensure_unwrapped(spack.config.CONFIG)
         self.platform = spack.platforms.host
         self.store = spack.store.STORE
         self.test_patches = TestPatches.create()


### PR DESCRIPTION
Extracted from #52542 

Spack right now relies heavily on a few global objects. These objects are lazily initialized, to cut on import time, and are technically all of type `Singleton` - a wrapper class that calls a factory function on first access to an attribute or a method.

Sometimes though we need the wrapped object, and not just the `Singleton` wrapper. In these cases an `ensure_unwrapped` free function makes more sense than an `.ensure_unwrapped` method in the wrapped class - thus the PR.