### PR TITLE
new_installer.py: extract get_log_summary

### DIFF
--- a/lib/spack/spack/new_installer.py
+++ b/lib/spack/spack/new_installer.py
@@ -1150,11 +1150,13 @@ class BuildStatus:
         self.dirty = True
         self._update_terminal_title()
 
-    def update_state(self, build_id: str, state: str) -> None:
+    def update_state(self, build_id: str, state: str, log_summary: Optional[str] = None) -> None:
         """Update the state of a package and mark the display as dirty."""
         build_info = self.builds[build_id]
         build_info.state = state
         build_info.progress_percent = None
+        if log_summary is not None:
+            build_info.log_summary = log_summary
 
         if state in ("finished", "failed"):
             self.completed += 1
@@ -1179,18 +1181,6 @@ class BuildStatus:
             )
             self.stdout.write(line + "\n")
             self.stdout.flush()
-
-    def parse_log_summary(self, build_id: str) -> None:
-        """Parse the build log for errors/warnings and store the summary."""
-        build_info = self.builds[build_id]
-        if not build_info.log_path or not os.path.exists(build_info.log_path):
-            return
-        errors, warnings, tail_event = parse_log_events(build_info.log_path, tail=20)
-        events = [*errors, *warnings]
-        if tail_event is not None:
-            events.append(tail_event)
-        if events:
-            build_info.log_summary = make_log_context(events)
 
     def update_progress(self, build_id: str, current: int, total: int) -> None:
         """Update the progress of a package and mark the display as dirty."""
@@ -1443,6 +1433,19 @@ class BuildStatus:
             yield f" ({pretty_duration(elapsed)})"
             if self.color:
                 yield "\033[0m"
+
+
+def get_log_summary(log_path: Optional[str]) -> Optional[str]:
+    """Parse the build log for errors/warnings and return a summary string."""
+    if not log_path or not os.path.exists(log_path):
+        return None
+    errors, warnings, tail_event = parse_log_events(log_path, tail=20)
+    events = [*errors, *warnings]
+    if tail_event is not None:
+        events.append(tail_event)
+    if events:
+        return make_log_context(events)
+    return None
 
 
 Nodes = Dict[str, spack.spec.Spec]
@@ -2421,8 +2424,8 @@ class PackageInstaller:
             # Record a failure. In fail-fast mode, only record the first failure; subsequent
             # failures may be a consequence of us terminating other builds.
             failures.append(build.spec)
-            self.build_status.update_state(dag_hash, "failed")
-            self.build_status.parse_log_summary(dag_hash)
+            summary = get_log_summary(build.log_path)
+            self.build_status.update_state(dag_hash, "failed", summary)
 
     def _try_expand_build_deps(self) -> None:
         """Try to expand build deps for specs with cache misses. Non-blocking: returns immediately

--- a/lib/spack/spack/test/installer_tui.py
+++ b/lib/spack/spack/test/installer_tui.py
@@ -210,39 +210,32 @@ class TestBasicStateManagement:
         assert status.tracked_build_id == ""
         assert status.overview_mode is True
 
-    def test_parse_log_summary(self, tmp_path):
-        """Test that parse_log_summary parses the build log and stores the summary."""
-        status, _, _ = create_build_status()
-        (spec,) = add_mock_builds(status, 1)
-        build_id = spec.dag_hash()
-
+    def test_get_log_summary(self, tmp_path):
+        """Test that get_log_summary parses the build log and returns the summary."""
         # Create a fake log file with an error
         log_file = tmp_path / "build.log"
         log_file.write_text("error: something went wrong\n")
 
-        status.builds[build_id].log_path = str(log_file)
-        status.parse_log_summary(build_id)
-        assert status.builds[build_id].log_summary is not None
-        assert "error" in status.builds[build_id].log_summary.lower()
+        summary = inst.get_log_summary(str(log_file))
+        assert summary is not None
+        assert "error" in summary.lower()
 
-    def test_parse_log_summary_no_log_path(self):
-        """Test that parse_log_summary is a no-op when log_path is not set."""
+    def test_get_log_summary_no_log_path(self):
+        """Test that get_log_summary returns None when log_path is not set."""
+        assert inst.get_log_summary(None) is None
+
+    def test_get_log_summary_missing_file(self, tmp_path):
+        """Test that get_log_summary returns None when the log file doesn't exist."""
+        assert inst.get_log_summary(str(tmp_path / "nonexistent.log")) is None
+
+    def test_update_state_stores_log_summary(self):
+        """Test that update_state stores a passed log_summary on the build."""
         status, _, _ = create_build_status()
         (spec,) = add_mock_builds(status, 1)
         build_id = spec.dag_hash()
 
-        status.parse_log_summary(build_id)
-        assert status.builds[build_id].log_summary is None
-
-    def test_parse_log_summary_missing_file(self, tmp_path):
-        """Test that parse_log_summary is a no-op when log file doesn't exist."""
-        status, _, _ = create_build_status()
-        (spec,) = add_mock_builds(status, 1)
-        build_id = spec.dag_hash()
-
-        status.builds[build_id].log_path = str(tmp_path / "nonexistent.log")
-        status.parse_log_summary(build_id)
-        assert status.builds[build_id].log_summary is None
+        status.update_state(build_id, "failed", "Error: boom\n")
+        assert status.builds[build_id].log_summary == "Error: boom\n"
 
     def test_update_progress(self):
         """Test that update_progress updates percentages"""


### PR DESCRIPTION
The BuildStatus class is doing I/O for logs. That's more controller than
model logic in MVC-speak, so inject it instead of computing it.

It simplifies the tests a bit, meaning it pays off.

