### PR TITLE
new_installer.py: no echo logic in BuildStatus

### DIFF
--- a/lib/spack/spack/new_installer.py
+++ b/lib/spack/spack/new_installer.py
@@ -887,7 +887,6 @@ class BuildInfo:
         "start_time",
         "duration",
         "progress_percent",
-        "control_w_conn",
         "log_path",
         "log_summary",
     )
@@ -896,7 +895,6 @@ class BuildInfo:
         self,
         spec: spack.spec.Spec,
         explicit: bool,
-        control_w_conn: Optional[IpcChannel],
         log_path: Optional[str] = None,
         start_time: float = 0.0,
     ) -> None:
@@ -911,7 +909,6 @@ class BuildInfo:
         self.start_time: float = start_time
         self.duration: Optional[float] = None
         self.progress_percent: Optional[int] = None
-        self.control_w_conn = control_w_conn
         self.log_path = log_path
         self.log_summary: Optional[str] = None
 
@@ -977,38 +974,38 @@ class BuildStatus:
         self.dirty = True
 
     def add_build(
-        self,
-        spec: spack.spec.Spec,
-        explicit: bool,
-        control_w_conn: Optional[IpcChannel] = None,
-        log_path: Optional[str] = None,
-    ) -> None:
-        """Add a new build to the display and mark the display as dirty."""
-        build_info = BuildInfo(spec, explicit, control_w_conn, log_path, int(self.get_time()))
+        self, spec: spack.spec.Spec, explicit: bool, log_path: Optional[str] = None
+    ) -> bool:
+        """Add a new build to the display and mark the display as dirty. Returns True if the caller
+        should start echoing this build's logs."""
+        build_info = BuildInfo(spec, explicit, log_path, int(self.get_time()))
         self.builds[spec.dag_hash()] = build_info
         self.dirty = True
         # Track the new build's logs when we're not already following another build. This applies
         # only in non-TTY verbose mode.
-        if self.verbose and not self.tracked_build_id and control_w_conn is not None:
+        if self.verbose and not self.tracked_build_id:
             self.tracked_build_id = spec.dag_hash()
-            try:
-                write_connection(control_w_conn, b"1")
-            except OSError:
-                pass
+            return True
+        return False
 
-    def remove_build(self, build_id: str) -> None:
-        """Remove a build from the display (e.g. after a binary cache miss before retry)."""
+    def remove_build(self, build_id: str) -> Optional[str]:
+        """Remove a build from the display (e.g. after a binary cache miss before retry). Returns
+        the build ID to stop echoing if the removed build was being followed."""
         self.builds.pop(build_id, None)
+        untracked_id = None
         if self.tracked_build_id == build_id:
             self.tracked_build_id = ""
+            untracked_id = build_id
             if not self.overview_mode:
                 self.overview_mode = True
         self.dirty = True
+        return untracked_id
 
-    def toggle(self) -> None:
-        """Toggle between overview mode and following a specific build."""
+    def toggle(self) -> Tuple[Optional[str], Optional[str]]:
+        """Toggle between overview mode and following a specific build. Returns the
+        (stop_echoing, start_echoing) build IDs the caller should apply."""
         if self.overview_mode:
-            self.next()
+            return self.next()
         else:
             if not self.log_ends_with_newline:
                 self.stdout.buffer.write(b"\n")
@@ -1018,13 +1015,9 @@ class BuildStatus:
             self.search_mode = False
             self.overview_mode = True
             self.dirty = True
-            try:
-                conn = self.builds[self.tracked_build_id].control_w_conn
-                if conn is not None:
-                    write_connection(conn, b"0")
-            except (KeyError, OSError):
-                pass
+            old_id = self.tracked_build_id
             self.tracked_build_id = ""
+            return old_id or None, None
 
     def search_input(self, input: str) -> None:
         """Handle keyboard input when in search mode"""
@@ -1069,12 +1062,13 @@ class BuildStatus:
 
         return matching[(idx + direction) % len(matching)]
 
-    def next(self, direction: int = 1) -> None:
-        """Follow the logs of the next build in the list."""
+    def next(self, direction: int = 1) -> Tuple[Optional[str], Optional[str]]:
+        """Follow the logs of the next build in the list. Returns the (stop_echoing, start_echoing)
+        build IDs the caller should apply."""
         new_build_id = self._get_next(direction)
 
         if not new_build_id or self.tracked_build_id == new_build_id:
-            return
+            return None, None
 
         new_build = self.builds[new_build_id]
 
@@ -1082,14 +1076,7 @@ class BuildStatus:
             self.overview_mode = False
 
         # Stop following the previous and start following the new build.
-        if self.tracked_build_id:
-            try:
-                conn = self.builds[self.tracked_build_id].control_w_conn
-                if conn is not None:
-                    write_connection(conn, b"0")
-            except (KeyError, OSError):
-                pass
-
+        old_id = self.tracked_build_id or None
         self.tracked_build_id = new_build_id
 
         version_str = (
@@ -1110,17 +1097,14 @@ class BuildStatus:
                     self.stdout.write("Full log: ")
                 self.stdout.write(f"{new_build.log_path}\n")
             self.stdout.flush()
-        else:
-            # Tell the user we're following new logs, and instruct the child to start sending.
-            self.stdout.write(f"{prefix}==> Following logs of {new_build.name}{version_str}\n")
-            self.log_ends_with_newline = True
-            self.stdout.flush()
-            try:
-                conn = new_build.control_w_conn
-                if conn is not None:
-                    write_connection(conn, b"1")
-            except (KeyError, OSError):
-                pass
+            # No live logs to follow for a failed build; only stop echoing the old one.
+            return old_id, None
+
+        # Tell the user we're following new logs, and instruct the caller to start echoing.
+        self.stdout.write(f"{prefix}==> Following logs of {new_build.name}{version_str}\n")
+        self.log_ends_with_newline = True
+        self.stdout.flush()
+        return old_id, new_build_id
 
     def set_blocked(self, blocked: bool) -> None:
         """Set whether all pending builds are blocked by another Spack process."""
@@ -1150,14 +1134,18 @@ class BuildStatus:
         self.dirty = True
         self._update_terminal_title()
 
-    def update_state(self, build_id: str, state: str, log_summary: Optional[str] = None) -> None:
-        """Update the state of a package and mark the display as dirty."""
+    def update_state(
+        self, build_id: str, state: str, log_summary: Optional[str] = None
+    ) -> Optional[str]:
+        """Update the state of a package and mark the display as dirty. Returns the build ID to
+        stop echoing if a tracked build reached a terminal state."""
         build_info = self.builds[build_id]
         build_info.state = state
         build_info.progress_percent = None
         if log_summary is not None:
             build_info.log_summary = log_summary
 
+        untracked_id = None
         if state in ("finished", "failed"):
             self.completed += 1
             now = self.get_time()
@@ -1167,9 +1155,10 @@ class BuildStatus:
             # Stop tracking the finished build's logs.
             if build_id == self.tracked_build_id:
                 if not self.overview_mode:
-                    self.toggle()
-                if self.verbose:
+                    untracked_id, _ = self.toggle()
+                elif self.verbose:
                     self.tracked_build_id = ""
+                    untracked_id = build_id
 
         self.dirty = True
         self._update_terminal_title()
@@ -1181,6 +1170,8 @@ class BuildStatus:
             )
             self.stdout.write(line + "\n")
             self.stdout.flush()
+
+        return untracked_id
 
     def update_progress(self, build_id: str, current: int, total: int) -> None:
         """Update the progress of a package and mark the display as dirty."""
@@ -2124,6 +2115,23 @@ class PackageInstaller:
     def install(self) -> None:
         self._installer()
 
+    def _set_echo(self, dag_hash: Optional[str], enable: bool) -> None:
+        """Signal the child process handling a build to start or stop streaming live logs."""
+        if not dag_hash:
+            return
+        for child in self.running_builds.values():
+            if child.spec.dag_hash() == dag_hash:
+                try:
+                    write_connection(child.control_w_conn, b"1" if enable else b"0")
+                except OSError:
+                    pass
+                break
+
+    def _apply_echo(self, stop_id: Optional[str], start_id: Optional[str]) -> None:
+        """Stop echoing one build and start echoing another, as requested by the display."""
+        self._set_echo(stop_id, False)
+        self._set_echo(start_id, True)
+
     def _installer(self) -> None:
         spack.store.STORE.install_sbang()
         jobserver = JobServer(self.jobs)
@@ -2238,12 +2246,12 @@ class PackageInstaller:
                             self.build_status.search_input(char)
                         elif overview and char == "/":
                             self.build_status.enter_search()
-                        elif char == "v" or char in ("q", "\x1b") and not overview:
-                            self.build_status.toggle()
+                        elif char == "v" or (char in ("q", "\x1b") and not overview):
+                            self._apply_echo(*self.build_status.toggle())
                         elif char == "n":
-                            self.build_status.next(1)
+                            self._apply_echo(*self.build_status.next(1))
                         elif char == "p" or char == "N":
-                            self.build_status.next(-1)
+                            self._apply_echo(*self.build_status.next(-1))
                         elif char == "+":
                             jobserver.increase_parallelism()
                             self.build_status.set_jobs(jobserver.num_jobs, jobserver.target_jobs)
@@ -2586,12 +2594,10 @@ class PackageInstaller:
         assert type(pid) is int
         self.running_builds[pid] = child_info
         child_info.register_with_selector(selector, pid)
-        self.build_status.add_build(
-            child_info.spec,
-            explicit=explicit,
-            control_w_conn=child_info.control_w_conn,
-            log_path=child_info.log_path,
-        )
+        if self.build_status.add_build(
+            child_info.spec, explicit=explicit, log_path=child_info.log_path
+        ):
+            self._set_echo(dag_hash, True)
         self.report_data.start_record(spec)
 
     def _handle_child_logs(self, child_info: ChildInfo, selector: selectors.BaseSelector) -> bool:

--- a/lib/spack/spack/new_installer.py
+++ b/lib/spack/spack/new_installer.py
@@ -1150,11 +1150,13 @@ class BuildStatus:
         self.dirty = True
         self._update_terminal_title()
 
-    def update_state(self, build_id: str, state: str) -> None:
+    def update_state(self, build_id: str, state: str, log_summary: Optional[str] = None) -> None:
         """Update the state of a package and mark the display as dirty."""
         build_info = self.builds[build_id]
         build_info.state = state
         build_info.progress_percent = None
+        if log_summary is not None:
+            build_info.log_summary = log_summary
 
         if state in ("finished", "failed"):
             self.completed += 1
@@ -1179,18 +1181,6 @@ class BuildStatus:
             )
             self.stdout.write(line + "\n")
             self.stdout.flush()
-
-    def parse_log_summary(self, build_id: str) -> None:
-        """Parse the build log for errors/warnings and store the summary."""
-        build_info = self.builds[build_id]
-        if not build_info.log_path or not os.path.exists(build_info.log_path):
-            return
-        errors, warnings, tail_event = parse_log_events(build_info.log_path, tail=20)
-        events = [*errors, *warnings]
-        if tail_event is not None:
-            events.append(tail_event)
-        if events:
-            build_info.log_summary = make_log_context(events)
 
     def update_progress(self, build_id: str, current: int, total: int) -> None:
         """Update the progress of a package and mark the display as dirty."""
@@ -1443,6 +1433,19 @@ class BuildStatus:
             yield f" ({pretty_duration(elapsed)})"
             if self.color:
                 yield "\033[0m"
+
+
+def get_log_summary(log_path: Optional[str]) -> Optional[str]:
+    """Parse the build log for errors/warnings and return a summary string."""
+    if not log_path or not os.path.exists(log_path):
+        return None
+    errors, warnings, tail_event = parse_log_events(log_path, tail=20)
+    events = [*errors, *warnings]
+    if tail_event is not None:
+        events.append(tail_event)
+    if events:
+        return make_log_context(events)
+    return None
 
 
 Nodes = Dict[str, spack.spec.Spec]
@@ -2421,8 +2424,8 @@ class PackageInstaller:
             # Record a failure. In fail-fast mode, only record the first failure; subsequent
             # failures may be a consequence of us terminating other builds.
             failures.append(build.spec)
-            self.build_status.update_state(dag_hash, "failed")
-            self.build_status.parse_log_summary(dag_hash)
+            summary = get_log_summary(build.log_path)
+            self.build_status.update_state(dag_hash, "failed", summary)
 
     def _try_expand_build_deps(self) -> None:
         """Try to expand build deps for specs with cache misses. Non-blocking: returns immediately

--- a/lib/spack/spack/test/installer_tui.py
+++ b/lib/spack/spack/test/installer_tui.py
@@ -14,7 +14,6 @@ if sys.platform == "win32":
 import functools
 import io
 import os
-from multiprocessing import Pipe
 from typing import List, Optional, Tuple
 
 import spack.new_installer as inst
@@ -25,13 +24,6 @@ from spack.new_installer_base import StdinReader
 def _fd_reader(fd: int) -> StdinReader:
     """StdinReader reading from a raw fd, as PosixTerminalState.create_stdin_reader does."""
     return StdinReader(functools.partial(os.read, fd, 1024))
-
-
-class MockConnection:
-    """Mock multiprocessing.Connection for testing"""
-
-    def fileno(self):
-        return -1
 
 
 class MockSpec:
@@ -111,7 +103,7 @@ def add_mock_builds(status: BuildStatus, count: int) -> List[MockSpec]:
     """Helper function to add builds to a BuildStatus instance"""
     specs = [MockSpec(f"pkg{i}", f"{i}.0") for i in range(count)]
     for spec in specs:
-        status.add_build(spec, explicit=True, control_w_conn=MockConnection())  # type: ignore
+        status.add_build(spec, explicit=True)  # type: ignore
     return specs
 
 
@@ -145,14 +137,14 @@ class TestBasicStateManagement:
         spec1 = MockSpec("pkg1", "1.0")
         spec2 = MockSpec("pkg2", "2.0")
 
-        status.add_build(spec1, explicit=True, control_w_conn=MockConnection())
+        status.add_build(spec1, explicit=True)
         assert len(status.builds) == 1
         assert spec1.dag_hash() in status.builds
         assert status.builds[spec1.dag_hash()].name == "pkg1"
         assert status.builds[spec1.dag_hash()].explicit is True
         assert status.dirty is True
 
-        status.add_build(spec2, explicit=False, control_w_conn=MockConnection())
+        status.add_build(spec2, explicit=False)
         assert len(status.builds) == 2
         assert spec2.dag_hash() in status.builds
         assert status.builds[spec2.dag_hash()].explicit is False
@@ -283,7 +275,7 @@ class TestOutputRendering:
         status, _, fake_stdout = create_build_status(is_tty=False)
         spec = MockSpec("mypackage", "1.0")
 
-        status.add_build(spec, explicit=True, control_w_conn=MockConnection())
+        status.add_build(spec, explicit=True)
         build_id = spec.dag_hash()
 
         status.update_state(build_id, "finished")
@@ -375,8 +367,8 @@ class TestOutputRendering:
 
         spec4 = MockSpec("pkg3", "3.0")
         spec5 = MockSpec("pkg4", "4.0")
-        status.add_build(spec4, explicit=True, control_w_conn=MockConnection())
-        status.add_build(spec5, explicit=True, control_w_conn=MockConnection())
+        status.add_build(spec4, explicit=True)
+        status.add_build(spec5, explicit=True)
 
         # Second update: finished builds persist (newlines), active area updates (cursor moves)
         status.update()
@@ -514,9 +506,9 @@ class TestSearchAndFilter:
         spec2 = MockSpec("package-bar", "1.0")
         spec3 = MockSpec("other", "1.0")
 
-        status.add_build(spec1, explicit=True, control_w_conn=MockConnection())
-        status.add_build(spec2, explicit=True, control_w_conn=MockConnection())
-        status.add_build(spec3, explicit=True, control_w_conn=MockConnection())
+        status.add_build(spec1, explicit=True)
+        status.add_build(spec2, explicit=True)
+        status.add_build(spec3, explicit=True)
 
         build1 = status.builds[spec1.dag_hash()]
         build2 = status.builds[spec2.dag_hash()]
@@ -549,8 +541,8 @@ class TestSearchAndFilter:
         spec2 = MockSpec("pkg2", "1.0")
         spec2._hash = "def456"
 
-        status.add_build(spec1, explicit=True, control_w_conn=MockConnection())
-        status.add_build(spec2, explicit=True, control_w_conn=MockConnection())
+        status.add_build(spec1, explicit=True)
+        status.add_build(spec2, explicit=True)
 
         build1 = status.builds[spec1.dag_hash()]
         build2 = status.builds[spec2.dag_hash()]
@@ -620,7 +612,7 @@ class TestNavigation:
             MockSpec("package-d", "1.0"),
         ]
         for spec in specs:
-            status.add_build(spec, explicit=True, control_w_conn=MockConnection())
+            status.add_build(spec, explicit=True)
 
         # Filter to only "package-*"
         status.search_term = "package"
@@ -675,7 +667,7 @@ class TestNavigation:
             MockSpec("other-c", "1.0"),
         ]
         for spec in specs:
-            status.add_build(spec, explicit=True, control_w_conn=MockConnection())
+            status.add_build(spec, explicit=True)
 
         # Start tracking "other-c"
         status.tracked_build_id = specs[2].dag_hash()
@@ -744,7 +736,7 @@ class TestBuildInfo:
         """Test that BuildInfo is created correctly"""
         spec = MockSpec("mypackage", "1.0")
 
-        build_info = inst.BuildInfo(spec, explicit=True, control_w_conn=MockConnection())
+        build_info = inst.BuildInfo(spec, explicit=True)
 
         assert build_info.name == "mypackage"
         assert build_info.version == "1.0"
@@ -758,7 +750,7 @@ class TestBuildInfo:
         """Test BuildInfo for external package"""
         spec = MockSpec("external-pkg", "1.0", external=True)
 
-        build_info = inst.BuildInfo(spec, explicit=False, control_w_conn=MockConnection())
+        build_info = inst.BuildInfo(spec, explicit=False)
 
         assert build_info.external is True
 
@@ -924,6 +916,41 @@ class TestNavigationIntegration:
         status.next(-1)
         assert status.tracked_build_id == specs[1].dag_hash()
 
+    def test_next_returns_echo_intents(self):
+        """next() returns (stop_echoing, start_echoing) IDs for the controller to apply."""
+        status, _, _ = create_build_status(total=3)
+        specs = add_mock_builds(status, 3)
+
+        # From overview: nothing to stop, start echoing the first build.
+        stop_id, start_id = status.next(1)
+        assert stop_id is None
+        assert start_id == specs[0].dag_hash()
+
+        # Moving on: stop the previous, start the next.
+        stop_id, start_id = status.next(1)
+        assert stop_id == specs[0].dag_hash()
+        assert start_id == specs[1].dag_hash()
+
+    def test_next_to_failed_build_has_no_start_intent(self):
+        """Navigating to a failed build shows its summary but returns no start-echoing intent."""
+        status, _, _ = create_build_status(total=2)
+        specs = add_mock_builds(status, 2)
+
+        status.next(1)  # follow specs[0]
+        status.update_state(specs[1].dag_hash(), "failed")
+
+        stop_id, start_id = status.next(1)
+        assert stop_id == specs[0].dag_hash()
+        assert start_id is None  # failed build shows a summary, not live logs
+        assert status.tracked_build_id == specs[1].dag_hash()
+
+    def test_next_no_eligible_build_returns_none_none(self):
+        """next() returns (None, None) when there is no build to follow."""
+        status, _, _ = create_build_status(total=1)
+        (spec,) = add_mock_builds(status, 1)
+        status.update_state(spec.dag_hash(), "finished")
+        assert status.next(1) == (None, None)
+
     def test_next_does_nothing_when_no_builds(self):
         """Test that next() does nothing when no unfinished builds exist"""
         status, _, _ = create_build_status(total=1)
@@ -979,6 +1006,34 @@ class TestToggle:
         assert status.overview_mode is False
         assert status.tracked_build_id != ""
         assert "Following logs of" in fake_stdout.getvalue()
+
+    def test_toggle_returns_echo_intents(self):
+        """toggle() returns (stop_echoing, start_echoing) IDs for the controller to apply."""
+        status, _, _ = create_build_status(total=2)
+        specs = add_mock_builds(status, 2)
+
+        # From overview, toggle delegates to next(): start echoing the first build.
+        stop_id, start_id = status.toggle()
+        assert stop_id is None
+        assert start_id == specs[0].dag_hash()
+
+        # From log-following, toggle returns to overview and stops echoing the tracked build.
+        stop_id, start_id = status.toggle()
+        assert stop_id == specs[0].dag_hash()
+        assert start_id is None
+
+    def test_remove_build_returns_untracked_id(self):
+        """remove_build() returns the build ID to stop echoing when its tracked build is gone."""
+        status, _, _ = create_build_status(total=2)
+        specs = add_mock_builds(status, 2)
+
+        # Removing an untracked build returns nothing to untrack.
+        assert status.remove_build(specs[1].dag_hash()) is None
+
+        # Removing the tracked build returns its ID.
+        status.next(1)
+        tracked = status.tracked_build_id
+        assert status.remove_build(tracked) == tracked
 
     def test_toggle_from_logs_returns_to_overview(self):
         """Test that toggle() from log-following mode returns to overview"""
@@ -1076,7 +1131,7 @@ class TestToggle:
         padded_prefix = "/base/__spack_path_placeholder__/__spack_path_placeholder__/mypackage"
         status, _, fake_stdout = create_build_status(is_tty=False, filter_padding=filter_padding)
         spec = MockSpec("mypackage", "1.0", prefix=padded_prefix)
-        status.add_build(spec, explicit=True, control_w_conn=MockConnection())
+        status.add_build(spec, explicit=True)
         build_id = spec.dag_hash()
         status.update_state(build_id, "finished")
         output = fake_stdout.getvalue()
@@ -1101,7 +1156,7 @@ class TestSearchFilteringIntegration:
             MockSpec("package-baz", "4.0"),
         ]
         for spec in specs:
-            status.add_build(spec, explicit=True, control_w_conn=MockConnection())
+            status.add_build(spec, explicit=True)
 
         # Enter search mode and search for "package"
         status.enter_search()
@@ -1138,7 +1193,7 @@ class TestSearchFilteringIntegration:
             MockSpec("other-d", "4.0"),
         ]
         for spec in specs:
-            status.add_build(spec, explicit=True, control_w_conn=MockConnection())
+            status.add_build(spec, explicit=True)
 
         # Set search term to filter for "package"
         status.search_term = "package"
@@ -1182,7 +1237,7 @@ class TestSearchFilteringIntegration:
             MockSpec("package-c", "3.0"),
         ]
         for spec in specs:
-            status.add_build(spec, explicit=True, control_w_conn=MockConnection())
+            status.add_build(spec, explicit=True)
 
         # Enter search and type something
         status.enter_search()
@@ -1273,68 +1328,69 @@ class TestEdgeCases:
 
 
 class TestBuildStatusVerbose:
-    """Tests for verbose non-TTY log tracking in BuildStatus."""
+    """Tests for verbose non-TTY log tracking in BuildStatus.
+
+    The display no longer touches IPC channels: add_build/toggle/next/update_state return the
+    build IDs to start/stop echoing, and the controller (PackageInstaller) performs the writes.
+    These tests therefore assert on the returned intents and tracking state directly, with no OS
+    pipes involved.
+    """
 
     def test_verbose_tracks_first_build(self):
-        """First add_build() in verbose non-TTY mode sets tracked_build_id and enables echoing."""
+        """First add_build() in verbose non-TTY mode tracks the build and asks to start echoing."""
         bs, _, _ = create_build_status(is_tty=False, verbose=True, total=4)
         spec = MockSpec("trivial-install-test-package", "1.0")
 
-        r_conn, w_conn = Pipe(duplex=False)
-
-        with r_conn, w_conn:
-            bs.add_build(spec, explicit=True, control_w_conn=w_conn)
-
-            assert bs.tracked_build_id == spec.dag_hash()
-            written = os.read(r_conn.fileno(), 1)
-            assert written == b"1"
+        assert bs.add_build(spec, explicit=True) is True
+        assert bs.tracked_build_id == spec.dag_hash()
 
     def test_verbose_does_not_track_when_already_tracking(self):
-        """Second add_build() while already tracking does not switch tracking."""
+        """Second add_build() while already tracking does not switch tracking or ask to echo."""
         bs, _, _ = create_build_status(is_tty=False, verbose=True, total=4)
         spec1 = MockSpec("pkg1", "1.0")
         spec2 = MockSpec("pkg2", "1.0")
 
-        r1, w1 = Pipe(duplex=False)
-        r2, w2 = Pipe(duplex=False)
-        with r1, w1, r2, w2:
-            bs.add_build(spec1, explicit=True, control_w_conn=w1)
-            first_tracked = bs.tracked_build_id
+        assert bs.add_build(spec1, explicit=True) is True
+        first_tracked = bs.tracked_build_id
 
-            bs.add_build(spec2, explicit=False, control_w_conn=w2)
-            assert bs.tracked_build_id == first_tracked
-            assert bs.tracked_build_id == spec1.dag_hash()
-
-            # Second build should not have received b"1"
-            assert not r2.poll(), "Second build should not be enabled"
+        assert bs.add_build(spec2, explicit=False) is False
+        assert bs.tracked_build_id == first_tracked == spec1.dag_hash()
 
     def test_verbose_switches_on_finish(self):
-        """After the tracked build finishes, tracked_build_id is cleared."""
+        """When the tracked build finishes, tracking is cleared and its ID is returned."""
         bs, _, _ = create_build_status(is_tty=False, verbose=True, total=4)
         spec = MockSpec("trivial-install-test-package", "1.0")
 
-        r_conn, w_conn = Pipe(duplex=False)
+        bs.add_build(spec, explicit=True)
+        assert bs.tracked_build_id == spec.dag_hash()
 
-        with r_conn, w_conn:
-            bs.add_build(spec, explicit=True, control_w_conn=w_conn)
-            assert bs.tracked_build_id == spec.dag_hash()
+        untracked = bs.update_state(spec.dag_hash(), "finished")
+        assert untracked == spec.dag_hash()
+        assert bs.tracked_build_id == ""
 
-            bs.update_state(spec.dag_hash(), "finished")
-            assert bs.tracked_build_id == ""
+    def test_verbose_externally_installed_spec_leaves_no_stale_tracking(self):
+        """An externally-installed spec (no live child) added in verbose mode is briefly tracked
+        but is immediately cleared by the following finished update_state, leaving no stale
+        tracking that could suppress a real build's logs."""
+        bs, _, _ = create_build_status(is_tty=False, verbose=True, total=2)
+        ext = MockSpec("external-pkg", "1.0", external=True)
+
+        bs.add_build(ext, explicit=True)
+        untracked = bs.update_state(ext.dag_hash(), "finished")
+
+        assert untracked == ext.dag_hash()
+        assert bs.tracked_build_id == ""
 
     def test_verbose_print_logs_tracked(self):
         """print_logs() for the tracked build writes to stdout."""
         bs, _, stdout = create_build_status(is_tty=False, verbose=True, total=1)
         spec = MockSpec("trivial-install-test-package", "1.0")
 
-        r_conn, w_conn = Pipe(duplex=False)
+        bs.add_build(spec, explicit=True)
+        bs.print_logs(spec.dag_hash(), b"hello log\n")
 
-        with r_conn, w_conn:
-            bs.add_build(spec, explicit=True, control_w_conn=w_conn)
-            bs.print_logs(spec.dag_hash(), b"hello log\n")
-
-            stdout.flush()
-            assert stdout.buffer.getvalue() == b"hello log\n"
+        stdout.flush()
+        assert stdout.buffer.getvalue() == b"hello log\n"
 
     def test_verbose_print_logs_untracked(self):
         """print_logs() for an untracked build discards data."""
@@ -1342,28 +1398,22 @@ class TestBuildStatusVerbose:
         spec1 = MockSpec("pkg1", "1.0")
         spec2 = MockSpec("pkg2", "1.0")
 
-        r1, w1 = Pipe(duplex=False)
+        bs.add_build(spec1, explicit=True)
+        bs.add_build(spec2, explicit=False)
 
-        with r1, w1:
-            bs.add_build(spec1, explicit=True, control_w_conn=w1)
-            bs.add_build(spec2, explicit=False, control_w_conn=None)
+        # Only spec1 is tracked; spec2 logs should be discarded
+        bs.print_logs(spec2.dag_hash(), b"ignored\n")
 
-            # Only spec1 is tracked; spec2 logs should be discarded
-            bs.print_logs(spec2.dag_hash(), b"ignored\n")
-
-            stdout.flush()
-            assert stdout.buffer.getvalue() == b""
+        stdout.flush()
+        assert stdout.buffer.getvalue() == b""
 
     def test_verbose_tty_no_effect(self):
-        """In TTY mode, add_build() does not set tracked_build_id automatically."""
+        """In TTY mode, add_build() does not set tracked_build_id or ask to echo automatically."""
         bs, _, _ = create_build_status(is_tty=True, verbose=True, total=4)
         spec = MockSpec("trivial-install-test-package", "1.0")
 
-        r_conn, w_conn = Pipe(duplex=False)
-
-        with r_conn, w_conn:
-            bs.add_build(spec, explicit=True, control_w_conn=w_conn)
-            assert bs.tracked_build_id == ""
+        assert bs.add_build(spec, explicit=True) is False
+        assert bs.tracked_build_id == ""
 
 
 class TestBuildStatusColor:

--- a/lib/spack/spack/test/installer_tui.py
+++ b/lib/spack/spack/test/installer_tui.py
@@ -210,39 +210,32 @@ class TestBasicStateManagement:
         assert status.tracked_build_id == ""
         assert status.overview_mode is True
 
-    def test_parse_log_summary(self, tmp_path):
-        """Test that parse_log_summary parses the build log and stores the summary."""
-        status, _, _ = create_build_status()
-        (spec,) = add_mock_builds(status, 1)
-        build_id = spec.dag_hash()
-
+    def test_get_log_summary(self, tmp_path):
+        """Test that get_log_summary parses the build log and returns the summary."""
         # Create a fake log file with an error
         log_file = tmp_path / "build.log"
         log_file.write_text("error: something went wrong\n")
 
-        status.builds[build_id].log_path = str(log_file)
-        status.parse_log_summary(build_id)
-        assert status.builds[build_id].log_summary is not None
-        assert "error" in status.builds[build_id].log_summary.lower()
+        summary = inst.get_log_summary(str(log_file))
+        assert summary is not None
+        assert "error" in summary.lower()
 
-    def test_parse_log_summary_no_log_path(self):
-        """Test that parse_log_summary is a no-op when log_path is not set."""
+    def test_get_log_summary_no_log_path(self):
+        """Test that get_log_summary returns None when log_path is not set."""
+        assert inst.get_log_summary(None) is None
+
+    def test_get_log_summary_missing_file(self, tmp_path):
+        """Test that get_log_summary returns None when the log file doesn't exist."""
+        assert inst.get_log_summary(str(tmp_path / "nonexistent.log")) is None
+
+    def test_update_state_stores_log_summary(self):
+        """Test that update_state stores a passed log_summary on the build."""
         status, _, _ = create_build_status()
         (spec,) = add_mock_builds(status, 1)
         build_id = spec.dag_hash()
 
-        status.parse_log_summary(build_id)
-        assert status.builds[build_id].log_summary is None
-
-    def test_parse_log_summary_missing_file(self, tmp_path):
-        """Test that parse_log_summary is a no-op when log file doesn't exist."""
-        status, _, _ = create_build_status()
-        (spec,) = add_mock_builds(status, 1)
-        build_id = spec.dag_hash()
-
-        status.builds[build_id].log_path = str(tmp_path / "nonexistent.log")
-        status.parse_log_summary(build_id)
-        assert status.builds[build_id].log_summary is None
+        status.update_state(build_id, "failed", "Error: boom\n")
+        assert status.builds[build_id].log_summary == "Error: boom\n"
 
     def test_update_progress(self):
         """Test that update_progress updates percentages"""


### PR DESCRIPTION
On top of #52546 

BuildStatus holds a reference to `control_w_conn` which is used to
enable/disable log following by sending a byte. That's not the best
design, because BuildStatus lives longer than ChildInfo (which is the
owner of the pipe) and is meant to be a model rather than a controller
in MVC-speak.

Instead, move the communication logic to PackageInstaller, and let
BuildStatus just tell what logs to stop and start following.

This way, there's a single owner of the pipe, and the tests are
simplified.

