### PR TITLE
environment.py: construct view in final location

### DIFF
--- a/lib/spack/spack/environment/environment.py
+++ b/lib/spack/spack/environment/environment.py
@@ -821,20 +821,14 @@ class ViewDescriptor:
         to exist on the filesystem."""
         return self._view(self.root).get_projection_for_spec(spec)
 
-    def view(self, new: Optional[str] = None) -> fsv.SimpleFilesystemView:
+    def view(self) -> fsv.SimpleFilesystemView:
         """
         Returns a view object for the *underlying* view directory. This means that the
-        self.root symlink is followed, and that the view has to exist on the filesystem
-        (unless ``new``). This function is useful when writing to the view.
+        self.root symlink is followed, and that the view has to exist on the filesystem.
+        This function is useful when writing to the view.
 
-        Raise if new is None and there is no current view
-
-        Arguments:
-            new: If a string, create a FilesystemView rooted at that path. Default None. This
-                should only be used to regenerate the view, and cannot be used to access specs.
+        Raise if there is no current view.
         """
-        if new:
-            return self._view(new)
         if os.path.islink(self.root):
             path: Optional[str] = self._current_root  # old format: follow symlink
         elif os.path.isdir(self.root):
@@ -916,27 +910,29 @@ class ViewDescriptor:
         root_parent = os.path.dirname(self.root)
         root_basename = os.path.basename(self.root)
         suffix = uuid.uuid4().hex[:8]
-        # Working directory for the new view
-        new_root = os.path.join(root_parent, f"{root_basename}.new.{suffix}")
         # Temporary location for the old view in case we need to roll back
         old_root = os.path.join(root_parent, f"{root_basename}.old.{suffix}")
 
+        # The view is built *in place* at self.root: packages bake the projection path
+        # (e.g. shebangs, pyvenv.cfg) into file contents, and that path has to be the
+        # final view location, not a temporary build directory that's renamed afterwards.
+        # To stay able to roll back, move an existing view aside first.
+        moved_old = os.path.lexists(self.root)
+        if moved_old:
+            os.rename(self.root, old_root)
+
         try:
-            fs.mkdirp(new_root)
-            self.view(new=new_root).add_specs(*specs)
+            fs.mkdirp(self.root)
+            self._view(self.root).add_specs(*specs)
 
             # Claim ownership of the view by dropping a marker file with the content hash.
-            with open(os.path.join(new_root, MARKER_FILE), "x", encoding="utf-8") as f:
+            with open(self.marker_path, "x", encoding="utf-8") as f:
                 f.write(content_hash)
 
-            # Rename self.root -> <root>.old (if it exists), then .new -> self.root
-            if os.path.lexists(self.root):
-                os.rename(self.root, old_root)
-            os.rename(new_root, self.root)
-
         except Exception as e:
-            # Restore self.root if the rename sequence left it missing
-            if not os.path.lexists(self.root) and os.path.lexists(old_root):
+            # Roll back to the previous view (if any).
+            shutil.rmtree(self.root, ignore_errors=True)
+            if moved_old:
                 try:
                     os.rename(old_root, self.root)
                 except OSError:
@@ -958,9 +954,8 @@ class ViewDescriptor:
                 ) from e
             raise
 
-        finally:
-            if os.path.lexists(new_root):
-                shutil.rmtree(new_root, ignore_errors=True)
+        if not moved_old:
+            return
 
         # Clean up old view
         if os.path.islink(old_root):

--- a/lib/spack/spack/test/env.py
+++ b/lib/spack/spack/test/env.py
@@ -14,6 +14,7 @@ import pytest
 import spack.config
 import spack.environment as ev
 import spack.llnl.util.filesystem as fs
+import spack.package_base
 import spack.platforms
 import spack.solver.asp
 import spack.spec
@@ -856,6 +857,42 @@ def test_env_view_on_empty_dir_is_fine(tmp_path: pathlib.Path, config, temporary
     env.install_all(fake=True)
     env.regenerate_views()
     assert list(view_dir.iterdir())  # view dir should not be empty after regeneration
+
+
+def test_view_projection_path_is_final_after_regenerate(
+    tmp_path: pathlib.Path, config, temporary_store, monkeypatch
+):
+    """Paths embedded into file *contents* by ``add_files_to_view`` (e.g. shebangs,
+    ``pyvenv.cfg``) must reference the final view directory, not the temporary directory
+    the view is built in. Regression test for views being built in a sibling staging dir
+    and renamed into place, which left dangling staging paths baked into files."""
+
+    original = spack.package_base.PackageBase.add_files_to_view
+
+    def add_files_to_view(self, view, merge_map, skip_if_exists=True):
+        original(self, view, merge_map, skip_if_exists=skip_if_exists)
+        # Emulate packages like python that bake the projection into file contents.
+        projection = view.get_projection_for_spec(self.spec)
+        with open(os.path.join(projection, f"{self.name}.projection"), "w", encoding="utf-8") as f:
+            f.write(projection)
+
+    monkeypatch.setattr(spack.package_base.PackageBase, "add_files_to_view", add_files_to_view)
+
+    view_dir = tmp_path / "view"
+    env = ev.create_in_dir(tmp_path, with_view="view")
+    env.add("mpileaks")
+    env.concretize()
+    env.install_all(fake=True)
+    env.regenerate_views()
+
+    recorded = list(view_dir.glob("*.projection"))
+    assert recorded, "expected add_files_to_view to have written marker files"
+    for marker in recorded:
+        assert marker.read_text() == str(view_dir)
+
+    # No staging/backup siblings should be left behind after a successful regeneration.
+    assert not list(tmp_path.glob("view.new.*"))
+    assert not list(tmp_path.glob("view.old.*"))
 
 
 @pytest.mark.parametrize("as_file", [False, True], ids=["non_empty_dir", "plain_file"])


### PR DESCRIPTION
PR #52158 introduced a regression where shebangs could point to
`view.new.random/bin/pyton3` instead of `view/bin/python3`

Unfortunately that cannot be fixed other than constructing the view in the
target location, or restoring the symlink indirection; I don't immediately
see an alternative that would make `python/package.py` work across
Spack versions.

So, this PR definitively drops atomicity of view updates. Reviewers have
to judge whether dropping the `view -> ._view/<hash>` indirection with
its associated problem of going stale is better/worse than a longer wait
between old and new view.

