### PR TITLE
Revert "environment.py: remove `._view/hash` indirection (#52158)"

### DIFF
--- a/lib/spack/spack/environment/environment.py
+++ b/lib/spack/spack/environment/environment.py
@@ -4,13 +4,13 @@
 import collections
 import collections.abc
 import contextlib
+import errno
 import glob
 import os
 import pathlib
 import re
 import shutil
 import stat
-import uuid
 import warnings
 from collections.abc import KeysView
 from itertools import zip_longest
@@ -55,7 +55,7 @@ import spack.util.spack_yaml as syaml
 import spack.variant as vt
 from spack import traverse
 from spack.enums import ConfigScopePriority
-from spack.llnl.util.filesystem import copy_tree, islink, readlink
+from spack.llnl.util.filesystem import copy_tree, islink, readlink, symlink
 from spack.llnl.util.lang import stable_partition
 from spack.llnl.util.link_tree import ConflictingSpecsError
 from spack.schema.env import TOP_LEVEL_KEY
@@ -97,9 +97,6 @@ lockfile_name = "spack.lock"
 
 #: Name of the directory where environments store repos, logs, views, configs
 env_subdir_name = ".spack-env"
-
-#: Name of the file inside the view to mark it as Spack-owned with content hash for currency checks
-MARKER_FILE = ".spack-view"
 
 
 def env_root_path() -> str:
@@ -678,6 +675,30 @@ def _is_dev_spec_and_has_changed(spec):
     return spec.package.detect_dev_src_change()
 
 
+def _error_on_nonempty_view_dir(new_root):
+    """Defensively error when the target view path already exists and is not an
+    empty directory. This usually happens when the view symlink was removed, but
+    not the directory it points to. In those cases, it's better to just error when
+    the new view dir is non-empty, since it indicates the user removed part but not
+    all of the view, and it likely in an inconsistent state."""
+    # Check if the target path lexists
+    try:
+        st = os.lstat(new_root)
+    except OSError:
+        return
+
+    # Empty directories are fine
+    if stat.S_ISDIR(st.st_mode) and len(os.listdir(new_root)) == 0:
+        return
+
+    # Anything else is an error
+    raise SpackEnvironmentViewError(
+        "Failed to generate environment view, because the target {} already "
+        "exists or is not empty. To update the view, remove this path, and run "
+        "`spack env view regenerate`".format(new_root)
+    )
+
+
 class ViewDescriptor:
     def __init__(
         self,
@@ -769,42 +790,11 @@ class ViewDescriptor:
         root_dir = os.path.dirname(self.root)
         return os.path.join(root_dir, root)
 
-    def _is_up_to_date(self, content_hash: str) -> bool:
-        # Old format: self.root is a symlink to ._<basename>/<hash>/
-        if os.path.islink(self.root):
-            old_root = self._current_root
-            if old_root and os.path.basename(old_root) == content_hash:
-                return True
-        # New format: check the marker file inside the view itself
-        try:
-            with open(self.marker_path, "r", encoding="utf-8") as f:
-                return f.read().strip() == content_hash
-        except OSError:
-            return False
-
-    @property
-    def marker_path(self) -> str:
-        return os.path.join(self.root, MARKER_FILE)
-
-    def _ensure_safe_to_replace(self):
-        """Prevents Spack from deleting non-Spack owned user directories like /usr/local if users
-        accidentally map a view to an existing path."""
-        try:
-            lstat = os.lstat(self.root)
-        except OSError:
-            return  # non-existent path is fine to put a view
-
-        if stat.S_ISLNK(lstat.st_mode):
-            return  # symlinks are fine to replace
-        if stat.S_ISDIR(lstat.st_mode) and (
-            os.path.exists(self.marker_path) or not os.listdir(self.root)
-        ):
-            return  # Spack-owned and empty directories are fine to replace
-
-        raise SpackEnvironmentViewError(
-            f"The environment view at {self.root} cannot be updated because it is a non-empty "
-            "directory or file not managed by Spack. Please remove it manually to update the view."
-        )
+    def _next_root(self, specs):
+        content_hash = self.content_hash(specs)
+        root_dir = os.path.dirname(self.root)
+        root_name = os.path.basename(self.root)
+        return os.path.join(root_dir, "._%s" % root_name, content_hash)
 
     def content_hash(self, specs):
         d = syaml.syaml_dict(
@@ -833,15 +823,9 @@ class ViewDescriptor:
             new: If a string, create a FilesystemView rooted at that path. Default None. This
                 should only be used to regenerate the view, and cannot be used to access specs.
         """
-        if new:
-            return self._view(new)
-        if os.path.islink(self.root):
-            path: Optional[str] = self._current_root  # old format: follow symlink
-        elif os.path.isdir(self.root):
-            path = self.root  # new format: use directly
-        else:
-            path = None
+        path = new if new else self._current_root
         if not path:
+            # This can only be hit if we write a future bug
             raise SpackEnvironmentViewError(
                 f"Attempting to get nonexistent view from environment. View root is at {self.root}"
             )
@@ -902,46 +886,75 @@ class ViewDescriptor:
             concrete_roots = [c for g in self.groups for _, c in env.concretized_specs_by(group=g)]
 
         specs = self.specs_for_view(concrete_roots)
-        content_hash = self.content_hash(specs)
 
-        if self._is_up_to_date(content_hash):
+        # To ensure there are no conflicts with packages being installed
+        # that cannot be resolved or have repos that have been removed
+        # we always regenerate the view from scratch.
+        # We will do this by hashing the view contents and putting the view
+        # in a directory by hash, and then having a symlink to the real
+        # view in the root. The real root for a view at /dirname/basename
+        # will be /dirname/._basename_<hash>.
+        # This allows for atomic swaps when we update the view
+
+        # cache the roots because the way we determine which is which does
+        # not work while we are updating
+        new_root = self._next_root(specs)
+        old_root = self._current_root
+
+        if new_root == old_root:
             tty.debug(f"View at {self.root} does not need regeneration.")
             return
 
-        self._ensure_safe_to_replace()
+        _error_on_nonempty_view_dir(new_root)
 
+        # construct view at new_root
         if specs:
             tty.msg(f"Updating view at {self.root}")
 
-        root_parent = os.path.dirname(self.root)
-        root_basename = os.path.basename(self.root)
-        suffix = uuid.uuid4().hex[:8]
-        # Working directory for the new view
-        new_root = os.path.join(root_parent, f"{root_basename}.new.{suffix}")
-        # Temporary location for the old view in case we need to roll back
-        old_root = os.path.join(root_parent, f"{root_basename}.old.{suffix}")
+        view = self.view(new=new_root)
 
+        root_dirname = os.path.dirname(self.root)
+        tmp_symlink_name = os.path.join(root_dirname, "._view_link")
+
+        # Remove self.root if is it an empty dir, since we need a symlink there. Note that rmdir
+        # fails if self.root is a symlink.
+        try:
+            os.rmdir(self.root)
+        except (FileNotFoundError, NotADirectoryError):
+            pass
+        except OSError as e:
+            if e.errno == errno.ENOTEMPTY:
+                msg = "it is a non-empty directory"
+            elif e.errno == errno.EACCES:
+                msg = "of insufficient permissions"
+            else:
+                raise
+            raise SpackEnvironmentViewError(
+                f"The environment view in {self.root} cannot not be created because {msg}."
+            ) from e
+
+        # Create a new view
         try:
             fs.mkdirp(new_root)
-            self.view(new=new_root).add_specs(*specs)
+            view.add_specs(*specs)
 
-            # Claim ownership of the view by dropping a marker file with the content hash.
-            with open(os.path.join(new_root, MARKER_FILE), "x", encoding="utf-8") as f:
-                f.write(content_hash)
+            # create symlink from tmp_symlink_name to new_root
+            if os.path.exists(tmp_symlink_name):
+                os.unlink(tmp_symlink_name)
+            symlink(new_root, tmp_symlink_name)
 
-            # Rename self.root -> <root>.old (if it exists), then .new -> self.root
-            if os.path.lexists(self.root):
-                os.rename(self.root, old_root)
-            os.rename(new_root, self.root)
-
+            # mv symlink atomically over root symlink to old_root
+            fs.rename(tmp_symlink_name, self.root)
         except Exception as e:
-            # Restore self.root if the rename sequence left it missing
-            if not os.path.lexists(self.root) and os.path.lexists(old_root):
-                try:
-                    os.rename(old_root, self.root)
-                except OSError:
-                    pass
+            # Clean up new view and temporary symlink on any failure.
+            try:
+                shutil.rmtree(new_root, ignore_errors=True)
+                os.unlink(tmp_symlink_name)
+            except OSError:
+                pass
 
+            # Give an informative error message for the typical error case: two specs, same package
+            # project to same prefix.
             if isinstance(e, ConflictingSpecsError):
                 spec_a = e.args[0].format(color=clr.get_color_when())
                 spec_b = e.args[1].format(color=clr.get_color_when())
@@ -958,26 +971,20 @@ class ViewDescriptor:
                 ) from e
             raise
 
-        finally:
-            if os.path.lexists(new_root):
-                shutil.rmtree(new_root, ignore_errors=True)
-
-        # Clean up old view
-        if os.path.islink(old_root):
-            # Old format: only remove symlink target if it lives inside ._<name>/
-            target = os.path.realpath(old_root)
-            old_view_container = os.path.join(root_parent, "._%s" % root_basename)
-            if target.startswith(old_view_container + os.sep):
-                try:
-                    shutil.rmtree(target)
-                except OSError as exc:
-                    tty.warn(f"Failed to remove old view at {target}\n{exc}")
-            os.unlink(old_root)
-        elif os.path.isdir(old_root):
+        # Remove the old root when it's in the same folder as the new root. This guards
+        # against removal of an arbitrary path when the original symlink in self.root
+        # was not created by the environment, but by the user.
+        if (
+            old_root
+            and os.path.exists(old_root)
+            and os.path.samefile(os.path.dirname(new_root), os.path.dirname(old_root))
+        ):
             try:
                 shutil.rmtree(old_root)
-            except OSError as exc:
-                tty.warn(f"Failed to remove old view at {old_root}\n{exc}")
+            except OSError as e:
+                msg = "Failed to remove old view at %s\n" % old_root
+                msg += str(e)
+                tty.warn(msg)
 
     def _exclude_duplicate_runtimes(self, specs: List[Spec]) -> List[Spec]:
         """Stably filter out duplicates of "runtime" tagged packages, keeping only latest."""
@@ -1860,15 +1867,13 @@ class Environment:
         if default_view_name not in self.views:
             return
 
-        view_path = pathlib.Path(self.default_view.root)
         try:
-            if view_path.is_symlink():
-                shutil.rmtree(view_path.resolve())  # old format: remove hash dir
-                view_path.unlink()
-            else:
-                shutil.rmtree(view_path)  # new format: remove real dir
+            view = pathlib.Path(self.default_view.root)
+            shutil.rmtree(view.resolve())
+            view.unlink()
         except FileNotFoundError as e:
-            tty.debug(f"[ENVIRONMENT] error trying to delete the default view: {e}")
+            msg = f"[ENVIRONMENT] error trying to delete the default view: {str(e)}"
+            tty.debug(msg)
 
     def regenerate_views(self):
         if not self.views:

--- a/lib/spack/spack/test/cmd/env.py
+++ b/lib/spack/spack/test/cmd/env.py
@@ -3909,36 +3909,6 @@ def test_env_view_fail_if_symlink_points_elsewhere(
     assert os.path.isdir(non_view_dir)
 
 
-def test_env_view_backward_compat_old_symlink_format(
-    tmp_path: pathlib.Path, mock_stage, mock_fetch, install_mockery
-):
-    """An old-style symlink view pointing to ._view/<hash>/ is recognized as up-to-date."""
-    view = str(tmp_path / "view")
-    env("create", "--with-view={0}".format(view), "test")
-    with ev.read("test") as e:
-        add("libelf")
-        install("--fake")
-        view_desc = e.default_view
-        specs = view_desc.specs_for_view(e.concrete_roots())
-        content_hash = view_desc.content_hash(specs)
-
-    # Simulate old format: remove the real view dir and replace with a symlink
-    root_name = os.path.basename(view)
-    root_dir = os.path.dirname(view)
-    old_hash_dir = os.path.join(root_dir, "._%s" % root_name, content_hash)
-    shutil.rmtree(view)
-    os.makedirs(old_hash_dir, exist_ok=True)
-    os.symlink(old_hash_dir, view)
-
-    # Regeneration should detect the old symlink is up-to-date and be a no-op
-    with ev.read("test"):
-        env("view", "regenerate")
-
-    # The symlink was not touched (still points to the old hash dir)
-    assert os.path.islink(view)
-    assert os.path.realpath(view) == old_hash_dir
-
-
 def test_failed_view_cleanup(tmp_path: pathlib.Path, mock_stage, mock_fetch, install_mockery):
     """Tests whether Spack cleans up after itself when a view fails to create"""
     view_dir = tmp_path / "view"
@@ -3946,7 +3916,10 @@ def test_failed_view_cleanup(tmp_path: pathlib.Path, mock_stage, mock_fetch, ins
         add("libelf")
         install("--fake")
 
-    assert view_dir.is_dir() and not view_dir.is_symlink()
+    # Save the current view directory.
+    resolved_view = view_dir.resolve(strict=True)
+    all_views = resolved_view.parent
+    views_before = list(all_views.iterdir())
 
     # Add a spec that results in view clash when creating a view
     with ev.read("env"):
@@ -3954,39 +3927,48 @@ def test_failed_view_cleanup(tmp_path: pathlib.Path, mock_stage, mock_fetch, ins
         with pytest.raises(ev.SpackEnvironmentViewError):
             install("--fake")
 
-    # The view is still a real directory; no .new or .old leftovers.
-    assert view_dir.is_dir() and not view_dir.is_symlink()
-    assert not list(tmp_path.glob("view.new.*"))
-    assert not list(tmp_path.glob("view.old.*"))
+    # Make sure there is no broken view in the views directory, and the current
+    # view is the original view from before the failed regenerate attempt.
+    views_after = list(all_views.iterdir())
+    assert views_before == views_after
+    assert view_dir.samefile(resolved_view), view_dir
 
 
 def test_environment_view_target_already_exists(
     tmp_path: pathlib.Path, mock_stage, mock_fetch, install_mockery
 ):
-    """The view is a real directory; an orphaned ._view/<hash>/ from the old
-    symlink format does not prevent regeneration."""
+    """When creating a new view, Spack should check whether
+    the new view dir already exists. If so, it should not be
+    removed or modified."""
 
+    # Create a new environment
     view = str(tmp_path / "view")
     env("create", "--with-view={0}".format(view), "test")
     with ev.read("test"):
         add("libelf")
         install("--fake")
 
-    # view is a real directory in the new format
-    assert os.path.isdir(view) and not os.path.islink(view)
-    assert os.listdir(view)  # has some contents
+    # Empty the underlying view
+    real_view = os.path.realpath(view)
+    assert os.listdir(real_view)  # make sure it had *some* contents
+    shutil.rmtree(real_view)
 
-    # Simulate an orphaned old-format hash dir sitting next to the view
-    orphan_dir = os.path.join(str(tmp_path), "._view", "someoldhash")
-    os.makedirs(orphan_dir)
-    fs.touch(os.path.join(orphan_dir, "orphan_file"))
+    # Replace it with something new.
+    os.mkdir(real_view)
+    fs.touch(os.path.join(real_view, "file"))
 
-    # Regeneration should succeed; the orphaned dir is not touched
+    # Remove the symlink so Spack can't know about the "previous root"
+    os.unlink(view)
+
+    # Regenerate the view, which should realize it can't write into the same dir.
+    msg = "Failed to generate environment view"
     with ev.read("test"):
-        env("view", "regenerate")
+        with pytest.raises(ev.SpackEnvironmentViewError, match=msg):
+            env("view", "regenerate")
 
-    assert os.path.isdir(view) and not os.path.islink(view)
-    assert os.path.isfile(os.path.join(orphan_dir, "orphan_file"))
+    # Make sure the dir was left untouched.
+    assert not os.path.lexists(view)
+    assert os.listdir(real_view) == ["file"]
 
 
 def test_environment_query_spec_by_hash(mock_stage, mock_fetch, install_mockery):

--- a/lib/spack/spack/test/env.py
+++ b/lib/spack/spack/test/env.py
@@ -20,7 +20,11 @@ import spack.spec
 import spack.spec_parser
 from spack.enums import ConfigScopePriority
 from spack.environment import SpackEnvironmentConfigError
-from spack.environment.environment import EnvironmentManifestFile
+from spack.environment.environment import (
+    EnvironmentManifestFile,
+    SpackEnvironmentViewError,
+    _error_on_nonempty_view_dir,
+)
 from spack.environment.list import UndefinedReferenceError
 from spack.traverse import traverse_nodes
 
@@ -356,6 +360,34 @@ def test_environment_pickle(tmp_path: pathlib.Path):
     obj = pickle.dumps(env1)
     env2 = pickle.loads(obj)
     assert isinstance(env2, ev.Environment)
+
+
+def test_error_on_nonempty_view_dir(tmp_path: pathlib.Path):
+    """Error when the target is not an empty dir"""
+    with fs.working_dir(str(tmp_path)):
+        os.mkdir("empty_dir")
+        os.mkdir("nonempty_dir")
+        with open(os.path.join("nonempty_dir", "file"), "wb"):
+            pass
+        os.symlink("empty_dir", "symlinked_empty_dir")
+        os.symlink("does_not_exist", "broken_link")
+        os.symlink("broken_link", "file")
+
+        # This is OK.
+        _error_on_nonempty_view_dir("empty_dir")
+
+        # This is not OK.
+        with pytest.raises(SpackEnvironmentViewError):
+            _error_on_nonempty_view_dir("nonempty_dir")
+
+        with pytest.raises(SpackEnvironmentViewError):
+            _error_on_nonempty_view_dir("symlinked_empty_dir")
+
+        with pytest.raises(SpackEnvironmentViewError):
+            _error_on_nonempty_view_dir("broken_link")
+
+        with pytest.raises(SpackEnvironmentViewError):
+            _error_on_nonempty_view_dir("file")
 
 
 def test_can_add_specs_to_environment_without_specs_attribute(tmp_path: pathlib.Path, config):
@@ -855,20 +887,14 @@ def test_env_view_on_empty_dir_is_fine(tmp_path: pathlib.Path, config, temporary
     env.concretize()
     env.install_all(fake=True)
     env.regenerate_views()
-    assert list(view_dir.iterdir())  # view dir should not be empty after regeneration
+    assert view_dir.is_symlink()
 
 
-@pytest.mark.parametrize("as_file", [False, True], ids=["non_empty_dir", "plain_file"])
-def test_env_view_on_non_empty_dir_errors(
-    tmp_path: pathlib.Path, config, temporary_store, as_file: bool
-):
-    """Tests that creating a view pointing to a non-empty dir or plain file errors."""
+def test_env_view_on_non_empty_dir_errors(tmp_path: pathlib.Path, config, temporary_store):
+    """Tests that creating a view pointing to a non-empty dir errors."""
     view_dir = tmp_path / "view"
-    if as_file:
-        view_dir.write_text("")
-    else:
-        view_dir.mkdir()
-        (view_dir / "file").write_text("")
+    view_dir.mkdir()
+    (view_dir / "file").write_text("")
     env = ev.create_in_dir(tmp_path, with_view="view")
     env.add("mpileaks")
     env.concretize()


### PR DESCRIPTION
This reverts commit a8be776a329ec735fd9709016fdade8f4c567380.
