### PR TITLE
Gpg: prevent bad split on carriage return

### DIFF
--- a/lib/spack/spack/util/gpg.py
+++ b/lib/spack/spack/util/gpg.py
@@ -862,7 +862,7 @@ def _parse_gpg_output(output: str) -> List[GpgKey]:
     current_key: Optional[GpgKey] = None
     current_subkey: Optional[GpgKey] = None
     keys = []
-    for line in output.split("\n"):
+    for line in output.splitlines():
         # Only parse lines with colons
         if ":" not in line:
             continue


### PR DESCRIPTION
splitting on `\n` can break on windows when programs emit carriage returns. Evidently, gpg is one of those programs. `splitlines` handles carriage returns correctly while preserveing the newline split everywhere else.