### PR TITLE
noop jobserver: initialize to 1 job by default

### DIFF
--- a/lib/spack/spack/new_installer_base.py
+++ b/lib/spack/spack/new_installer_base.py
@@ -200,6 +200,10 @@ class JobServerBase(abc.ABC):
 class NoopJobServer(JobServerBase):
     """Dummy jobserver for platforms lacking jobserver support."""
 
+    def __init__(self, num_jobs: int) -> None:
+        """Always initialize jobs to one, dummy jobserver cannot have multiple jobs"""
+        super(NoopJobServer, self).__init__(1)
+
     def makeflags_and_data(self, gmake: Optional[spack.spec.Spec]) -> Tuple[Optional[str], Any]:
         return (None, None)
 


### PR DESCRIPTION
The noop jobserver is a dummy jobserver that does not allow for the concurrent build of packages. Reflect that in its internal job counts.