### PR TITLE
Docs: Update new installer limitation docs for new windows support

### DIFF
--- a/lib/spack/docs/installing.rst
+++ b/lib/spack/docs/installing.rst
@@ -19,9 +19,8 @@ This page covers the ``spack install`` experience in detail, including the inter
 Before diving in, ensure you are familiar with :doc:`package_fundamentals` for basic usage and spec syntax.
 
 .. versionadded:: 1.2
-   The TUI and POSIX jobserver are new in Spack 1.2.
-   The POSIX jobserver support in Spack requires a unix-like platform, Windows is currently unsupported.
-
+   The TUI and GNU Make jobserver support are new in Spack 1.2.
+   Spack supports the POSIX jobserver, Windows jobserver support will be added in a future release.
 
 Interactive terminal UI
 -----------------------

--- a/lib/spack/docs/installing.rst
+++ b/lib/spack/docs/installing.rst
@@ -20,7 +20,7 @@ Before diving in, ensure you are familiar with :doc:`package_fundamentals` for b
 
 .. versionadded:: 1.2
    The TUI and POSIX jobserver are new in Spack 1.2.
-   The POSIX jobserver requires a unix-like platform.
+   The POSIX jobserver support in Spack requires a unix-like platform, Windows is currently unsupported.
 
 
 Interactive terminal UI

--- a/lib/spack/docs/installing.rst
+++ b/lib/spack/docs/installing.rst
@@ -114,10 +114,10 @@ When a process encounters a prefix that was already installed, it simply skips i
 For best results on a cluster, it's recommended to limit per-process package-level parallelism (e.g., ``spack install -p2``) for better load balancing.
 
 
-.. note::
+.. admonition:: Windows Support
 
-   Due to a lack of file lock support, concurrent Spack processes are not guaranteed to function on Windows.
-   Due to a lack of jobserver support, jobserver orchestration and dynamic adjustment of build parallelism is not supported on Windows.
+   On Windows, due to a lack of file lock support, concurrent Spack processes are not guaranteed to function.
+   On Windows, due to a lack of jobserver support, jobserver orchestration and dynamic adjustment of build parallelism is not supported.
 
 Non-interactive mode
 --------------------

--- a/lib/spack/docs/installing.rst
+++ b/lib/spack/docs/installing.rst
@@ -19,7 +19,8 @@ This page covers the ``spack install`` experience in detail, including the inter
 Before diving in, ensure you are familiar with :doc:`package_fundamentals` for basic usage and spec syntax.
 
 .. versionadded:: 1.2
-   The TUI and POSIX jobserver are new in Spack 1.2 and require a Unix-like platform.
+   The TUI and POSIX jobserver are new in Spack 1.2.
+   The POSIX jobserver requires a unix-like platform.
 
 
 Interactive terminal UI
@@ -113,6 +114,11 @@ When a process encounters a prefix that was already installed, it simply skips i
 
 For best results on a cluster, it's recommended to limit per-process package-level parallelism (e.g., ``spack install -p2``) for better load balancing.
 
+
+.. note::
+
+   Due to a lack of file lock support, concurrent Spack processes are not guaranteed to function on Windows.
+   Due to a lack of jobserver support, jobserver orchestration and dynamic adjustment of build parallelism is not supported on Windows.
 
 Non-interactive mode
 --------------------


### PR DESCRIPTION
New installer works, jobserver and parallelism update UI elements do not. 

Notate a few more Windows limitations