### PR TITLE
Resolve regression of commit lookup traversing the DAG

### DIFF
--- a/lib/spack/spack/stage.py
+++ b/lib/spack/spack/stage.py
@@ -71,6 +71,7 @@ def compute_stage_name(spec):
         stage_name_structure = spack.config.get("config:stage_name", default=spec_stage_structure)
     else:
         spec_stage_structure += "{name}-{version}"
+        stage_name_structure = spec_stage_structure
     
     return spec.format_path(format_string=stage_name_structure)
 

--- a/lib/spack/spack/stage.py
+++ b/lib/spack/spack/stage.py
@@ -63,16 +63,15 @@ stage_prefix = "spack-stage-"
 def compute_stage_name(spec):
     """Determine stage name given a spec"""
     spec_stage_structure = stage_prefix
+    # only use config for concrete specs since these are going to be actual stages
+    # non-concrete stages are persistent, but psuedo-temp because they are used to resolve
+    # commit values for git versions when using source mirrors
     if spec.concrete:
         spec_stage_structure += "{name}-{version}-{hash}"
-        # TODO (psakiev, scheibelp) Technically a user could still reintroduce a hash via
-        # config:stage_name. This is a fix for how to handle staging an abstract spec (see #51305)
-        # only do this for concrete specs since these are going to be actual stages
         stage_name_structure = spack.config.get("config:stage_name", default=spec_stage_structure)
     else:
-        spec_stage_structure += "{name}-{version}"
-        stage_name_structure = spec_stage_structure
-    return spec.format_path(format_string=stage_name_structure)
+        stage_name_structure = spec_stage_structure + "{name}-{version}"
+        return spec.format_path(format_string=stage_name_structure)
 
 
 def create_stage_root(path: str) -> None:

--- a/lib/spack/spack/stage.py
+++ b/lib/spack/spack/stage.py
@@ -72,7 +72,6 @@ def compute_stage_name(spec):
     else:
         spec_stage_structure += "{name}-{version}"
         stage_name_structure = spec_stage_structure
-    
     return spec.format_path(format_string=stage_name_structure)
 
 

--- a/lib/spack/spack/stage.py
+++ b/lib/spack/spack/stage.py
@@ -65,11 +65,13 @@ def compute_stage_name(spec):
     spec_stage_structure = stage_prefix
     if spec.concrete:
         spec_stage_structure += "{name}-{version}-{hash}"
+        # TODO (psakiev, scheibelp) Technically a user could still reintroduce a hash via
+        # config:stage_name. This is a fix for how to handle staging an abstract spec (see #51305)
+        # only do this for concrete specs since these are going to be actual stages
+        stage_name_structure = spack.config.get("config:stage_name", default=spec_stage_structure)
     else:
         spec_stage_structure += "{name}-{version}"
-    # TODO (psakiev, scheibelp) Technically a user could still reintroduce a hash via
-    # config:stage_name. This is a fix for how to handle staging an abstract spec (see #51305)
-    stage_name_structure = spack.config.get("config:stage_name", default=spec_stage_structure)
+    
     return spec.format_path(format_string=stage_name_structure)
 
 

--- a/lib/spack/spack/stage.py
+++ b/lib/spack/spack/stage.py
@@ -71,7 +71,7 @@ def compute_stage_name(spec):
         stage_name_structure = spack.config.get("config:stage_name", default=spec_stage_structure)
     else:
         stage_name_structure = spec_stage_structure + "{name}-{version}"
-        return spec.format_path(format_string=stage_name_structure)
+    return spec.format_path(format_string=stage_name_structure)
 
 
 def create_stage_root(path: str) -> None:


### PR DESCRIPTION
https://github.com/spack/spack/pull/52220 add a permanent config value which undoes the fix in https://github.com/spack/spack/pull/51305

This PR moves the config evaluation under the concrete spec check. The non-concrete version is only for finding git commit values from a source mirror and doesn't need to respect the config since it is not ever intended to be a build stage.