### PR TITLE
noopjobserver: return jobs from acquire

### DIFF
--- a/etc/spack/defaults/windows/config.yaml
+++ b/etc/spack/defaults/windows/config.yaml
@@ -3,3 +3,4 @@ config:
   build_stage::
     - '$user_cache_path/stage'
   stage_name: '{name}-{version}-{hash:7}'
+  concurrent_packages: 1

--- a/lib/spack/spack/new_installer_base.py
+++ b/lib/spack/spack/new_installer_base.py
@@ -210,7 +210,7 @@ class NoopJobServer(JobServerBase):
     def decrease_parallelism(self) -> None: ...
 
     def acquire(self, jobs: int) -> int:
-        return 0
+        return jobs
 
     def release(self) -> None: ...
 


### PR DESCRIPTION
Previously `NoopJobserver.acquire` returned 0, which prevented the dispatch of parallel package builds on platform using the noop jobserver (Windows).

Instead return jobs, which accurately reflects the requested levels of package parallelism.