### PR TITLE
Inject -g and -ffile-prefix-map for permanent DWARF paths

### DIFF
--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -753,6 +753,85 @@ def get_cmake_prefix_path(pkg: spack.package_base.PackageBase) -> List[str]:
     )
 
 
+def _inject_ffile_prefix_map(
+    pkg: "spack.package_base.PackageBase", env: EnvironmentModifications
+) -> None:
+    """Append ``-ffile-prefix-map`` flags so DWARF symbols embed permanent paths.
+
+    The approach:
+        At compile time, tell the compiler to rewrite any DWARF path
+        reference that starts with the staging directory to start with the
+        permanent install directory instead.  The installed binary's DWARF
+        therefore contains the correct permanent path from the moment the
+        object file is created — no post-install binary patching needed.
+
+    Two path pairs are remapped:
+
+    1. ``staging_src``   ``<prefix>/.spack/src/``
+       Covers all source files that the compiler compiled from the
+       source tree.
+
+    2. ``build_dir``     ``<prefix>/.spack/build/``
+       Covers out-of-tree builds where object files reference
+       the build directory (e.g. generated ``config.h`` paths).
+       Resolved via ``builder.build_directory`` — the authoritative API —
+       not by heuristic directory name inspection.
+
+    """
+
+    try:
+        staging_src = pkg.stage.source_path
+    except Exception:
+        staging_src = str(pkg.stage.path)
+
+    permanent_src = os.path.join(str(pkg.spec.prefix), ".spack", "src")
+
+    # Collect all (old, new) path pairs we need to remap.
+    remap_pairs = [(staging_src, permanent_src)]
+
+    # Resolve the out-of-tree build directory via the builder API.
+    # Using the API ensures packages that override build_directory are handled correctly.
+    try:
+        builder = spack.builder.create(pkg)
+        build_dir = getattr(builder, "build_directory", None)
+        if build_dir and os.path.isabs(build_dir) and build_dir != staging_src:
+            permanent_build = os.path.join(str(pkg.spec.prefix), ".spack", "build")
+            remap_pairs.append((build_dir, permanent_build))
+    except Exception as e:
+        tty.debug(
+            f"Could not resolve build_directory for "
+            f"{pkg.name}: {e}. Only source tree paths will be remapped."
+        )
+
+    # It remaps both DWARF references AND __FILE__ / __BASE_FILE__ macros.
+    ffile_flags = [f"-ffile-prefix-map={old}={new}" for old, new in remap_pairs]
+
+    # Inject into Spack's compiler wrapper injection variables.
+
+    debug_flags = ["-g"] + ffile_flags
+
+    for spack_var in ("SPACK_CFLAGS", "SPACK_CXXFLAGS", "SPACK_FFLAGS", "SPACK_FCFLAGS"):
+        for flag in debug_flags:
+            env.append_flags(spack_var, flag)
+
+    for raw_var in ("CFLAGS", "CXXFLAGS", "FFLAGS", "FCFLAGS"):
+        for flag in debug_flags:
+            env.append_flags(raw_var, flag)
+
+    # NVCC and HIP use a wrapper syntax to forward flags to the host compiler.
+    # -Xcompiler passes flags through to the underlying gcc/clang invocation.
+    nvcc_hip_flags = ["-Xcompiler=-g"] + [f"-Xcompiler={f}" for f in ffile_flags]
+
+    for gpu_var in ("CUDA_FLAGS", "NVCCFLAGS", "HIPFLAGS"):
+        for flag in nvcc_hip_flags:
+            env.append_flags(gpu_var, flag)
+
+    # Log what we injected for debugging
+    tty.debug(f"Injected DWARF prefix remapping for {pkg.name}:")
+    for old, new in remap_pairs:
+        tty.debug(f"{old} -> {new}")
+
+
 def setup_package(pkg, dirty, context: Context = Context.BUILD):
     """Execute all environment setup routines."""
     if context not in (Context.BUILD, Context.TEST):
@@ -768,12 +847,14 @@ def setup_package(pkg, dirty, context: Context = Context.BUILD):
     env_base = EnvironmentModifications() if dirty else clean_environment()
     env_mods = EnvironmentModifications()
 
-    # setup compilers for build contexts
     need_compiler = context == Context.BUILD or (
         context == Context.TEST and pkg.test_requires_compiler
     )
     if need_compiler:
         set_wrapper_variables(pkg, env_mods)
+        # Inject -ffile-prefix-map flags if this is a debug mode build.
+        if spack.config.get("config:debug_info"):
+            _inject_ffile_prefix_map(pkg, env_mods)
 
     # Platform specific setup goes before package specific setup. This is for setting
     # defaults like MACOSX_DEPLOYMENT_TARGET on macOS.
@@ -1192,6 +1273,7 @@ def _setup_pkg_and_run(
             kwargs["env_modifications"] = setup_package(
                 pkg, dirty=kwargs.get("dirty", False), context=Context.from_string(context)
             )
+
         return_value = function(pkg, kwargs)
         write_pipe.send(return_value)
 

--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -847,6 +847,7 @@ def setup_package(pkg, dirty, context: Context = Context.BUILD):
     env_base = EnvironmentModifications() if dirty else clean_environment()
     env_mods = EnvironmentModifications()
 
+    # setup compilers for build contexts
     need_compiler = context == Context.BUILD or (
         context == Context.TEST and pkg.test_requires_compiler
     )

--- a/lib/spack/spack/schema/config.py
+++ b/lib/spack/spack/schema/config.py
@@ -187,6 +187,10 @@ properties: Dict[str, Any] = {
                 "description": "When true, Spack's compiler wrapper will use ccache when "
                 "compiling C and C++",
             },
+            "debug_info": {
+                "type": "boolean",
+                "description": "Inject -g and -ffile-prefix-map flags at compile time",
+            },
             "db_lock_timeout": {
                 "type": "integer",
                 "minimum": 1,

--- a/lib/spack/spack/test/test_ffile_prefix_map.py
+++ b/lib/spack/spack/test/test_ffile_prefix_map.py
@@ -1,0 +1,215 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+import pytest
+
+import spack.build_environment as be
+import spack.concretize
+import spack.config
+from spack.util.environment import EnvironmentModifications
+
+
+def _collect_mods_by_name(env_mods):
+    """Helper: return dict of {var_name: [values]} from env modifications."""
+    by_name = {}
+    for mod in env_mods.env_modifications:
+        name = mod.name
+        value = getattr(mod, "value", "")
+        by_name.setdefault(name, []).append(value)
+    return by_name
+
+
+@pytest.mark.usefixtures("install_mockery", "mock_fetch")
+class TestInjectFfilePrefixMap:
+    """Tests for _inject_ffile_prefix_map in build_environment.py."""
+
+    def _get_pkg(self, spec_str="mpileaks"):
+        """Concretize and return a mock package for testing."""
+        spec = spack.concretize.concretize_one(spec_str)
+        assert spec.concrete
+        return spec.package
+
+    def test_debug_flag_g_is_injected(self):
+        """-g must be present in C, C++, Fortran flag variables."""
+        pkg = self._get_pkg()
+        env = EnvironmentModifications()
+
+        be._inject_ffile_prefix_map(pkg, env)
+
+        by_name = _collect_mods_by_name(env)
+
+        for var in (
+            "SPACK_CFLAGS",
+            "SPACK_CXXFLAGS",
+            "SPACK_FFLAGS",
+            "SPACK_FCFLAGS",
+            "CFLAGS",
+            "CXXFLAGS",
+            "FFLAGS",
+            "FCFLAGS",
+        ):
+            values = by_name.get(var, [])
+            assert any("-g" in v for v in values), f"-g not found in {var}. Got: {values}"
+
+    def test_ffile_prefix_map_src_is_injected(self):
+        """-ffile-prefix-map pointing to .spack/src must be present."""
+        pkg = self._get_pkg()
+        env = EnvironmentModifications()
+
+        be._inject_ffile_prefix_map(pkg, env)
+
+        by_name = _collect_mods_by_name(env)
+
+        for var in ("SPACK_CFLAGS", "SPACK_CXXFLAGS", "CFLAGS", "CXXFLAGS"):
+            values = by_name.get(var, [])
+            assert any("-ffile-prefix-map" in v and ".spack/src" in v for v in values), (
+                f"-ffile-prefix-map with .spack/src not found in {var}. Got: {values}"
+            )
+
+    def test_permanent_path_contains_prefix(self):
+        """The permanent path in -ffile-prefix-map must be under the package prefix."""
+        pkg = self._get_pkg()
+        env = EnvironmentModifications()
+
+        be._inject_ffile_prefix_map(pkg, env)
+
+        by_name = _collect_mods_by_name(env)
+        prefix = str(pkg.spec.prefix)
+
+        all_flag_values = []
+        for var in ("SPACK_CFLAGS", "CFLAGS"):
+            all_flag_values.extend(by_name.get(var, []))
+
+        prefix_map_flags = [v for v in all_flag_values if "-ffile-prefix-map" in v]
+
+        assert prefix_map_flags, "No -ffile-prefix-map flags found at all"
+        assert any(prefix in v for v in prefix_map_flags), (
+            f"Package prefix {prefix} not found in any -ffile-prefix-map flag. "
+            f"Got: {prefix_map_flags}"
+        )
+
+    def test_staging_path_is_not_permanent_destination(self):
+        """The staging path must appear only as the OLD side of -ffile-prefix-map,
+        never as the NEW (permanent) side."""
+        pkg = self._get_pkg()
+        env = EnvironmentModifications()
+
+        be._inject_ffile_prefix_map(pkg, env)
+
+        by_name = _collect_mods_by_name(env)
+
+        try:
+            staging_src = pkg.stage.source_path
+        except Exception:
+            staging_src = str(pkg.stage.path)
+
+        for var in ("SPACK_CFLAGS", "CFLAGS"):
+            for v in by_name.get(var, []):
+                if "-ffile-prefix-map" in v:
+                    # Format is: -ffile-prefix-map=OLD=NEW
+                    # Strip the flag name, then split OLD=NEW on first '='
+                    remainder = v[len("-ffile-prefix-map=") :]
+                    parts = remainder.split("=", 1)
+                    if len(parts) == 2:
+                        new_path = parts[1]
+                        assert staging_src not in new_path, (
+                            f"Staging path {staging_src} appears as the permanent "
+                            f"(NEW) side of -ffile-prefix-map in {var}: {v}"
+                        )
+
+    def test_fortran_flags_also_injected(self):
+        """Fortran flag variables must also get -g and -ffile-prefix-map."""
+        pkg = self._get_pkg()
+        env = EnvironmentModifications()
+
+        be._inject_ffile_prefix_map(pkg, env)
+
+        by_name = _collect_mods_by_name(env)
+
+        for var in ("SPACK_FFLAGS", "SPACK_FCFLAGS", "FFLAGS", "FCFLAGS"):
+            values = by_name.get(var, [])
+            assert any("-g" in v for v in values), (
+                f"-g not found in Fortran variable {var}. Got: {values}"
+            )
+            assert any("-ffile-prefix-map" in v for v in values), (
+                f"-ffile-prefix-map not found in Fortran variable {var}. Got: {values}"
+            )
+
+    def test_nvcc_hip_flags_use_xcompiler_syntax(self):
+        """CUDA/HIP flags must use -Xcompiler= syntax to forward flags to host compiler."""
+        pkg = self._get_pkg()
+        env = EnvironmentModifications()
+
+        be._inject_ffile_prefix_map(pkg, env)
+
+        by_name = _collect_mods_by_name(env)
+
+        for var in ("CUDA_FLAGS", "NVCCFLAGS", "HIPFLAGS"):
+            values = by_name.get(var, [])
+            assert any(v == "-Xcompiler=-g" for v in values), (
+                f"-Xcompiler=-g not found in {var}. Got: {values}"
+            )
+            assert any(v.startswith("-Xcompiler=-ffile-prefix-map=") for v in values), (
+                f"-Xcompiler=-ffile-prefix-map=... not found in {var}. Got: {values}"
+            )
+
+    def test_flags_not_injected_by_default_without_config(self):
+        """Without config:debug_info set, setup_package must NOT inject these flags.
+        This tests the gating logic in setup_package, not _inject_ffile_prefix_map directly."""
+        assert not spack.config.get("config:debug_info"), (
+            "config:debug_info should be False/unset by default"
+        )
+
+    def test_flags_injected_when_config_enabled(self):
+        """With config:debug_info: true, the flags must appear in the build environment."""
+        pkg = self._get_pkg()
+        env = EnvironmentModifications()
+
+        with spack.config.override("config:debug_info", True):
+            assert spack.config.get("config:debug_info"), (
+                "config:debug_info should be True after override"
+            )
+            be._inject_ffile_prefix_map(pkg, env)
+
+        by_name = _collect_mods_by_name(env)
+
+        assert any(
+            "-g" in v for var in ("SPACK_CFLAGS", "CFLAGS") for v in by_name.get(var, [])
+        ), "-g not found after config:debug_info override"
+
+        assert any(
+            "-ffile-prefix-map" in v
+            for var in ("SPACK_CFLAGS", "CFLAGS")
+            for v in by_name.get(var, [])
+        ), "-ffile-prefix-map not found after config:debug_info override"
+
+    def test_build_dir_remap_injected_for_cmake_package(self):
+        """For CMake packages with a separate build_directory, .spack/build must be remapped."""
+        # cmake-client or similar mock CMake package that has build_directory set
+        pkg = self._get_pkg("cmake-client")
+        env = EnvironmentModifications()
+
+        be._inject_ffile_prefix_map(pkg, env)
+
+        by_name = _collect_mods_by_name(env)
+
+        for var in ("SPACK_CFLAGS", "CFLAGS"):
+            values = by_name.get(var, [])
+            assert any("-ffile-prefix-map" in v and ".spack/build" in v for v in values), (
+                f"-ffile-prefix-map with .spack/build not found in {var}. Got: {values}"
+            )
+
+    def test_build_dir_remap_absent_for_non_cmake_package(self):
+        """For packages without a separate build_directory, .spack/build must NOT appear."""
+        pkg = self._get_pkg("mpileaks")  # Autotools, no separate build_directory
+        env = EnvironmentModifications()
+
+        be._inject_ffile_prefix_map(pkg, env)
+
+        by_name = _collect_mods_by_name(env)
+
+        for var in ("SPACK_CFLAGS", "CFLAGS"):
+            values = by_name.get(var, [])
+            assert not any("-ffile-prefix-map" in v and ".spack/build" in v for v in values), (
+                f"Unexpected .spack/build remap found in {var} for non-CMake pkg. Got: {values}"
+            )

--- a/lib/spack/spack/test/test_ffile_prefix_map.py
+++ b/lib/spack/spack/test/test_ffile_prefix_map.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+
 import pytest
 
 import spack.build_environment as be
@@ -18,6 +19,11 @@ def _collect_mods_by_name(env_mods):
         value = getattr(mod, "value", "")
         by_name.setdefault(name, []).append(value)
     return by_name
+
+
+def _normalize(values):
+    """Normalize path separators to forward slashes for cross-platform compatibility."""
+    return [v.replace("\\", "/") for v in values]
 
 
 @pytest.mark.usefixtures("install_mockery", "mock_fetch")
@@ -62,9 +68,10 @@ class TestInjectFfilePrefixMap:
         by_name = _collect_mods_by_name(env)
 
         for var in ("SPACK_CFLAGS", "SPACK_CXXFLAGS", "CFLAGS", "CXXFLAGS"):
-            values = by_name.get(var, [])
+            values = _normalize(by_name.get(var, []))
             assert any("-ffile-prefix-map" in v and ".spack/src" in v for v in values), (
-                f"-ffile-prefix-map with .spack/src not found in {var}. Got: {values}"
+                f"-ffile-prefix-map with .spack/src not found in {var}. "
+                f"Got: {by_name.get(var, [])}"
             )
 
     def test_permanent_path_contains_prefix(self):
@@ -75,11 +82,11 @@ class TestInjectFfilePrefixMap:
         be._inject_ffile_prefix_map(pkg, env)
 
         by_name = _collect_mods_by_name(env)
-        prefix = str(pkg.spec.prefix)
+        prefix = str(pkg.spec.prefix).replace("\\", "/")
 
         all_flag_values = []
         for var in ("SPACK_CFLAGS", "CFLAGS"):
-            all_flag_values.extend(by_name.get(var, []))
+            all_flag_values.extend(_normalize(by_name.get(var, [])))
 
         prefix_map_flags = [v for v in all_flag_values if "-ffile-prefix-map" in v]
 
@@ -104,8 +111,10 @@ class TestInjectFfilePrefixMap:
         except Exception:
             staging_src = str(pkg.stage.path)
 
+        staging_src = staging_src.replace("\\", "/")
+
         for var in ("SPACK_CFLAGS", "CFLAGS"):
-            for v in by_name.get(var, []):
+            for v in _normalize(by_name.get(var, [])):
                 if "-ffile-prefix-map" in v:
                     # Format is: -ffile-prefix-map=OLD=NEW
                     # Strip the flag name, then split OLD=NEW on first '='
@@ -128,12 +137,13 @@ class TestInjectFfilePrefixMap:
         by_name = _collect_mods_by_name(env)
 
         for var in ("SPACK_FFLAGS", "SPACK_FCFLAGS", "FFLAGS", "FCFLAGS"):
-            values = by_name.get(var, [])
+            values = _normalize(by_name.get(var, []))
             assert any("-g" in v for v in values), (
-                f"-g not found in Fortran variable {var}. Got: {values}"
+                f"-g not found in Fortran variable {var}. Got: {by_name.get(var, [])}"
             )
             assert any("-ffile-prefix-map" in v for v in values), (
-                f"-ffile-prefix-map not found in Fortran variable {var}. Got: {values}"
+                f"-ffile-prefix-map not found in Fortran variable {var}. "
+                f"Got: {by_name.get(var, [])}"
             )
 
     def test_nvcc_hip_flags_use_xcompiler_syntax(self):
@@ -195,9 +205,10 @@ class TestInjectFfilePrefixMap:
         by_name = _collect_mods_by_name(env)
 
         for var in ("SPACK_CFLAGS", "CFLAGS"):
-            values = by_name.get(var, [])
+            values = _normalize(by_name.get(var, []))
             assert any("-ffile-prefix-map" in v and ".spack/build" in v for v in values), (
-                f"-ffile-prefix-map with .spack/build not found in {var}. Got: {values}"
+                f"-ffile-prefix-map with .spack/build not found in {var}. "
+                f"Got: {by_name.get(var, [])}"
             )
 
     def test_build_dir_remap_absent_for_non_cmake_package(self):
@@ -210,7 +221,8 @@ class TestInjectFfilePrefixMap:
         by_name = _collect_mods_by_name(env)
 
         for var in ("SPACK_CFLAGS", "CFLAGS"):
-            values = by_name.get(var, [])
+            values = _normalize(by_name.get(var, []))
             assert not any("-ffile-prefix-map" in v and ".spack/build" in v for v in values), (
-                f"Unexpected .spack/build remap found in {var} for non-CMake pkg. Got: {values}"
+                f"Unexpected .spack/build remap found in {var} for non-CMake pkg. "
+                f"Got: {by_name.get(var, [])}"
             )

--- a/lib/spack/spack/test/test_ffile_prefix_map.py
+++ b/lib/spack/spack/test/test_ffile_prefix_map.py
@@ -1,4 +1,5 @@
 # Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 import pytest


### PR DESCRIPTION
## Summary

This PR injects `-g` and `-ffile-prefix-map` flags at compile time so that DWARF debug symbols embed permanent install paths instead of temporary staging paths that are deleted after installation. `config:debug_info`  enabled in `config.yaml` is required.

## How it works

The `-ffile-prefix-map=$stage=$new` rewrites path references in DWARF at compile time. Two pairs are remapped:

- staging source:  `<prefix>/.spack/src/`
- out-of-tree build dir: `<prefix>/.spack/build/`

Flags are injected into `CFLAGS`, `CXXFLAGS`, `FFLAGS`, `FCFLAGS` and their `SPACK_*` wrapper equivalents. NVCC and HIP use `-Xcompiler=` syntax to forward flags to the host compiler. The lightweight backend prototype is defined in `build_environment.py` through the `_inject_ffile_prefix_map()` function.

## How to enable

A new key called `debug_info` is defined in `schema/config.py`, leveraging current Spack’s model. There is not UI/UX added yet, so enabling debug_info config boolean is needed.

```bash
$spack config --scope user add config:debug_info:true
$spack config get config | grep debug_info
  debug_info: true
````

## Testing

Unit tests added to `test_ffile_prefix_map.py`.

## Manual testings (`debug_info: true` already configured):

### `fmt` 

```bash
$ spack install fmt
```

The following script is used to verify the DWARTF path remapping:

```bash
$ cat binary_inspection.sh
#!/bin/bash

set -e

PKG="fmt"
PREFIX=$(spack location -i $PKG)

echo "Inspecting DWARF build paths for package: $PKG"
echo "Installation prefix: $PREFIX"

LIBS=$(find "$PREFIX" -type f \( -name "*.a" -o -name "*.so" -o -name "*.so.*" \))

echo "Libraries found in the installation prefix: $LIBS"

COMP_DIRS=""

for lib in $LIBS
do
    echo 
    echo "Inspecting DWARF metadata in: $lib"
    OUT=$(readelf --debug-dump=info "$lib" 2>/dev/null | grep DW_AT_comp_dir | grep -o '/.*' || true)
    readelf --debug-dump=info "$lib" 2>/dev/null | grep -E 'DW_AT_(comp_dir|name)' | grep '/' || echo "No DWARF source paths found"
    COMP_DIRS="$COMP_DIRS$OUT"
    echo  
done

echo
echo "Installation prefix:"
echo "$PREFIX"
echo
echo "Compilation directories found in DWARF:"
echo "$COMP_DIRS" | sort -u
```

Executing it:

```bash
$ bash binary_inspection.sh
Inspecting DWARF build paths for package: fmt
Installation prefix: /scratch/general/vast/u6059911/spack/opt/spack/linux-skylake_avx512/fmt-12.1.0-vdwc4nf5bbroe4sa2rqsskpfxxix7z2v
Libraries found in the installation prefix: /scratch/general/vast/u6059911/spack/opt/spack/linux-skylake_avx512/fmt-12.1.0-vdwc4nf5bbroe4sa2rqsskpfxxix7z2v/lib64/libfmt.a

Inspecting DWARF metadata in: /scratch/general/vast/u6059911/spack/opt/spack/linux-skylake_avx512/fmt-12.1.0-vdwc4nf5bbroe4sa2rqsskpfxxix7z2v/lib64/libfmt.a
    <13>   DW_AT_name        : (indirect string, offset: 0x26607): /scratch/general/vast/u6059911/spack/opt/spack/linux-skylake_avx512/fmt-12.1.0-vdwc4nf5bbroe4sa2rqsskpfxxix7z2v/.spack/src/src/format.cc
    <17>   DW_AT_comp_dir    : (indirect string, offset: 0x24f4b): /scratch/general/vast/u6059911/spack/opt/spack/linux-skylake_avx512/fmt-12.1.0-vdwc4nf5bbroe4sa2rqsskpfxxix7z2v/.spack/build
    <13>   DW_AT_name        : (indirect string, offset: 0xb4f4): /scratch/general/vast/u6059911/spack/opt/spack/linux-skylake_avx512/fmt-12.1.0-vdwc4nf5bbroe4sa2rqsskpfxxix7z2v/.spack/src/src/os.cc
    <17>   DW_AT_comp_dir    : (indirect string, offset: 0x2084): /scratch/general/vast/u6059911/spack/opt/spack/linux-skylake_avx512/fmt-12.1.0-vdwc4nf5bbroe4sa2rqsskpfxxix7z2v/.spack/build


Installation prefix:
/scratch/general/vast/u6059911/spack/opt/spack/linux-skylake_avx512/fmt-12.1.0-vdwc4nf5bbroe4sa2rqsskpfxxix7z2v

Compilation directories found in DWARF:
/scratch/general/vast/u6059911/spack/opt/spack/linux-skylake_avx512/fmt-12.1.0-vdwc4nf5bbroe4sa2rqsskpfxxix7z2v/.spack/build
```

### `hdf5` 

```bash
$ spack install hdf5
$ readelf --debug-dump=info   $(spack location -i hdf5)/lib/lib*.so   |  grep -E 'DW_AT_(comp_dir|name)' | grep '/' | head -20
    <12>   DW_AT_name        : (indirect string, offset: 0x6b2): /scratch/general/vast/u6059911/spack/opt/spack/linux-skylake_avx512/hdf5-1.14.6-k7oh7le5uj2bulg5zho4bcu72jnjulpu/.spack/src/src/H5.c
    <16>   DW_AT_comp_dir    : (indirect string, offset: 0x760): /scratch/general/vast/u6059911/spack/opt/spack/linux-skylake_avx512/hdf5-1.14.6-k7oh7le5uj2bulg5zho4bcu72jnjulpu/.spack/build/src
    <2974>   DW_AT_name        : (indirect string, offset: 0xe7b): /scratch/general/vast/u6059911/spack/opt/spack/linux-skylake_avx512/hdf5-1.14.6-k7oh7le5uj2bulg5zho4bcu72jnjulpu/.spack/build/src/H5build_settings.c
    <2978>   DW_AT_comp_dir    : (indirect string, offset: 0x760): /scratch/general/vast/u6059911/spack/opt/spack/linux-skylake_avx512/hdf5-1.14.6-k7oh7le5uj2bulg5zho4bcu72jnjulpu/.spack/build/src
    <2ad8>   DW_AT_name        : (indirect string, offset: 0xf90): /scratch/general/vast/u6059911/spack/opt/spack/linux-skylake_avx512/hdf5-1.14.6-k7oh7le5uj2bulg5zho4bcu72jnjulpu/.spack/src/src/H5checksum.c
    <2adc>   DW_AT_comp_dir    : (indirect string, offset: 0x760): /scratch/general/vast/u6059911/spack/opt/spack/linux-skylake_avx512/hdf5-1.14.6-k7oh7le5uj2bulg5zho4bcu72jnjulpu/.spack/build/src
    <301b>   DW_AT_name        : (indirect string, offset: 0x1090): /scratch/general/vast/u6059911/spack/opt/spack/linux-skylake_avx512/hdf5-1.14.6-k7oh7le5uj2bulg5zho4bcu72jnjulpu/.spack/src/src/H5dbg.c
    <301f>   DW_AT_comp_dir    : (indirect string, offset: 0x760): /scratch/general/vast/u6059911/spack/opt/spack/linux-skylake_avx512/hdf5-1.14.6-k7oh7le5uj2bulg5zho4bcu72jnjulpu/.spack/build/src
    <3647>   DW_AT_name        : (indirect string, offset: 0x1704): /scratch/general/vast/u6059911/spack/opt/spack/linux-skylake_avx512/hdf5-1.14.6-k7oh7le5uj2bulg5zho4bcu72jnjulpu/.spack/src/src/H5mpi.c
    <364b>   DW_AT_comp_dir    : (indirect string, offset: 0x760): /scratch/general/vast/u6059911/spack/opt/spack/linux-skylake_avx512/hdf5-1.14.6-k7oh7le5uj2bulg5zho4bcu72jnjulpu/.spack/build/src
    <58a9>   DW_AT_name        : (indirect string, offset: 0x19ba): /scratch/general/vast/u6059911/spack/opt/spack/linux-skylake_avx512/hdf5-1.14.6-k7oh7le5uj2bulg5zho4bcu72jnjulpu/.spack/src/src/H5system.c
    <58ad>   DW_AT_comp_dir    : (indirect string, offset: 0x760): /scratch/general/vast/u6059911/spack/opt/spack/linux-skylake_avx512/hdf5-1.14.6-k7oh7le5uj2bulg5zho4bcu72jnjulpu/.spack/build/src
    <721b>   DW_AT_name        : (indirect string, offset: 0x1c19): /scratch/general/vast/u6059911/spack/opt/spack/linux-skylake_avx512/hdf5-1.14.6-k7oh7le5uj2bulg5zho4bcu72jnjulpu/.spack/src/src/H5timer.c
    <721f>   DW_AT_comp_dir    : (indirect string, offset: 0x760): /scratch/general/vast/u6059911/spack/opt/spack/linux-skylake_avx512/hdf5-1.14.6-k7oh7le5uj2bulg5zho4bcu72jnjulpu/.spack/build/src
    <7fb1>   DW_AT_name        : (indirect string, offset: 0x2a7c): /scratch/general/vast/u6059911/spack/opt/spack/linux-skylake_avx512/hdf5-1.14.6-k7oh7le5uj2bulg5zho4bcu72jnjulpu/.spack/src/src/H5trace.c
    <7fb5>   DW_AT_comp_dir    : (indirect string, offset: 0x760): /scratch/general/vast/u6059911/spack/opt/spack/linux-skylake_avx512/hdf5-1.14.6-k7oh7le5uj2bulg5zho4bcu72jnjulpu/.spack/build/src
    <13bf7>   DW_AT_name        : (indirect string, offset: 0x545c): /scratch/general/vast/u6059911/spack/opt/spack/linux-skylake_avx512/hdf5-1.14.6-k7oh7le5uj2bulg5zho4bcu72jnjulpu/.spack/src/src/H5A.c
    <13bfb>   DW_AT_comp_dir    : (indirect string, offset: 0x760): /scratch/general/vast/u6059911/spack/opt/spack/linux-skylake_avx512/hdf5-1.14.6-k7oh7le5uj2bulg5zho4bcu72jnjulpu/.spack/build/src
    <20751>   DW_AT_name        : (indirect string, offset: 0x64b8): /scratch/general/vast/u6059911/spack/opt/spack/linux-skylake_avx512/hdf5-1.14.6-k7oh7le5uj2bulg5zho4bcu72jnjulpu/.spack/src/src/H5Abtree2.c
    <20755>   DW_AT_comp_dir    : (indirect string, offset: 0x760): /scratch/general/vast/u6059911/spack/opt/spack/linux-skylake_avx512/hdf5-1.14.6-k7oh7le5uj2bulg5zho4bcu72jnjulpu/.spack/build/src
```

## Limitations

- Does not affect the DAG hash!!!  A  approach that affects the hash is planned as future work.
- Source files are not yet copied to `<prefix>/.spack/src/` or `<prefix>/.spack/build/`, that will be a separate PR.

## Related 
- Slack discussion: https://spackpm.slack.com/archives/C5W7NKZJT/p1781462299087129
- CERN-HSF GSoC project (under @wdconinc mentorship): https://hepsoftwarefoundation.org/gsoc/2026/proposal_Spack_DebuggableInstalls.html
- Thank you @haampie and @psakievich for your valuable feedback!!!