### PR TITLE
environment.py: skip definition references when removing specs

### DIFF
--- a/lib/spack/spack/environment/environment.py
+++ b/lib/spack/spack/environment/environment.py
@@ -3280,6 +3280,10 @@ class EnvironmentManifestFile(collections.abc.Mapping):
         """
         result = []
         for yaml_spec_str in self.configuration["specs"]:
+            # Skip definition references (e.g. "$profilers") and matrices, which
+            # are not parseable as a single spec.
+            if not isinstance(yaml_spec_str, str) or yaml_spec_str.startswith("$"):
+                continue
             if Spec(yaml_spec_str) == Spec(user_spec):
                 result.append(yaml_spec_str)
 

--- a/lib/spack/spack/test/cmd/env.py
+++ b/lib/spack/spack/test/cmd/env.py
@@ -801,6 +801,30 @@ def test_remove_command_all():
             assert name not in find()
 
 
+def test_remove_with_definitions_reference(environment_from_manifest):
+    """Removing a spec must not fail when the specs list references a definition
+    (e.g. ``$profilers``). See https://github.com/spack/spack/issues/52361."""
+    e = environment_from_manifest(
+        """\
+spack:
+  definitions:
+  - profilers: [callpath, mpileaks]
+  specs:
+  - $profilers
+  - libelf
+  concretizer:
+    unify: true
+"""
+    )
+    with e:
+        e.remove("libelf")
+
+    assert Spec("libelf") not in e.user_specs
+    # The reference to the definition must be left untouched
+    assert "$profilers" in e.manifest.configuration["specs"]
+    assert any(s.name == "callpath" for s in e.user_specs)
+
+
 def test_bad_remove_included_env():
     env("create", "test")
     test = ev.read("test")


### PR DESCRIPTION
`Environment._all_matches()` parses every entry in the env's `specs` list as a `Spec`, but those entries can be definition references like `$profilers` (or matrix dicts), which aren't parseable as a single spec, so `spack remove` blows up with a `SpecTokenizationError` before it ever gets to matching. `SpecList.remove()` already guards against this; this just mirrors that, skipping non-string and `$`-prefixed entries.

Added a regression test in `test/cmd/env.py` that removes a spec from a manifest whose `specs` list references a definition. Without the guard it fails with the `SpecTokenizationError` from the issue; with it the removal succeeds and the `$profilers` reference is left untouched. The related env-command tests still pass.

Fixes #52361
