### PR TITLE
Provide environment variable for command line argument -y

### DIFF
--- a/lib/spack/spack/cmd/common/arguments.py
+++ b/lib/spack/spack/cmd/common/arguments.py
@@ -320,11 +320,14 @@ def installed_specs():
 
 @arg
 def yes_to_all():
+    no_prompt = os.environ.get("SPACK_YES_TO_ALL")
+    no_prompt = bool(no_prompt and no_prompt.lower() not in ("false", "no", "0"))
     return Args(
         "-y",
         "--yes-to-all",
         action="store_true",
         dest="yes_to_all",
+        default=no_prompt,
         help='assume "yes" is the answer to every confirmation request',
     )
 

--- a/lib/spack/spack/test/cmd/common/arguments.py
+++ b/lib/spack/spack/test/cmd/common/arguments.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 import argparse
+import os
 
 import pytest
 
@@ -182,3 +183,20 @@ def test_missing_config_scopes_not_valid_read_scope(mock_missing_dir_include_sco
     )
     with pytest.raises(SystemExit):
         a.parse_args(["--scope", "sub_base"])
+
+
+@pytest.mark.parametrize(
+    "no_prompt,yes_to_all",
+    (("yes", True), ("no", False), ("FAlSe", False), ("asdf", True), ("", False), (None, False)),
+)
+def test_yes_to_all(no_prompt, yes_to_all):
+    if no_prompt is None:
+        os.environ.pop("SPACK_YES_TO_ALL")
+    else:
+        os.environ["SPACK_YES_TO_ALL"] = no_prompt
+
+    p = argparse.ArgumentParser()
+    arguments.add_common_arguments(p, ["yes_to_all"])
+    args = p.parse_args([])
+
+    assert args.yes_to_all == yes_to_all


### PR DESCRIPTION
By default some commands may require a -y option. This can be repetitive or disruptive in scripts that users want to just run commands without user input. The environment variable `SPACK_YES_TO_ALL=1` can be used to answer yes to all prompts.