### PR TITLE
Pin v1.2 to packages release v2026.06

### DIFF
--- a/etc/spack/defaults/base/repos.yaml
+++ b/etc/spack/defaults/base/repos.yaml
@@ -13,3 +13,4 @@
 repos:
   builtin:
     git: https://github.com/spack/spack-packages.git
+    branch: releases/v2026.06


### PR DESCRIPTION
Pin Spack v1.2 to the newly released packages release branch v2026.06