### PR TITLE
Add audit for testing missing builders

### DIFF
--- a/lib/spack/spack/audit.py
+++ b/lib/spack/spack/audit.py
@@ -616,16 +616,15 @@ def _ensure_package_builders(pkgs, error_cls):
     errors = []
     for pkg_name in pkgs:
         pkg_cls = spack.repo.PATH.get_pkg_class(pkg_name)
-        print(f"Checking {pkg_name}")
         pkg = pkg_cls(spack.spec.Spec(pkg_name))
         try:
             b = spack.builder.buildsystem_name(pkg)
             if not isinstance(b, str):
                 raise TypeError("invalid builder type {!s}".format(type(b)))
         except Exception as e:
-            error_msg = "The package '{}' does not have a build system"
-            details = [str(e)]
-            errors.append(error_cls(error_msg.format(pkg_name), details))
+            errors.append(
+                error_cls("The package '{pkg_name}' does not have a build system", [str(e)])
+            )
     return errors
 
 

--- a/lib/spack/spack/audit.py
+++ b/lib/spack/spack/audit.py
@@ -611,6 +611,23 @@ def _ensure_all_versions_can_produce_a_fetcher(pkgs, error_cls):
 
 
 @package_properties
+def _ensure_package_builders(pkgs, error_cls):
+    """Ensure all packages can produce a builder"""
+    errors = []
+    for pkg_name in pkgs:
+        pkg_cls = spack.repo.PATH.get_pkg_class(pkg_name)
+        print(f"Checking {pkg_name}")
+        pkg = pkg_cls(spack.spec.Spec(pkg_name))
+        try:
+            b = spack.builder.buildsystem_name(pkg)
+        except Exception as e:
+            error_msg = "The package '{}' does not have a build system"
+            details = [str(e)]
+            errors.append(error_cls(error_msg.format(pkg_name), details))
+    return errors
+
+
+@package_properties
 def _ensure_docstring_and_no_fixme(pkgs, error_cls):
     """Ensure the package has a docstring and no fixmes"""
     errors = []

--- a/lib/spack/spack/audit.py
+++ b/lib/spack/spack/audit.py
@@ -620,6 +620,8 @@ def _ensure_package_builders(pkgs, error_cls):
         pkg = pkg_cls(spack.spec.Spec(pkg_name))
         try:
             b = spack.builder.buildsystem_name(pkg)
+            if not isinstance(b, str):
+                raise TypeError("invalid builder type {!s}".format(type(b)))
         except Exception as e:
             error_msg = "The package '{}' does not have a build system"
             details = [str(e)]

--- a/lib/spack/spack/test/audit.py
+++ b/lib/spack/spack/test/audit.py
@@ -32,6 +32,8 @@ import spack.config
         (["fail-test-audit-docstring"], ["PKG-PROPERTIES"]),
         # This package has a stand-alone test method without an implementation
         (["fail-test-audit-impl"], ["PKG-PROPERTIES"]),
+        # This package doesn't inherit from a package that creates a builder
+        (["fail-test-audit-builder"], ["PKG-PROPERTIES"]),
         # This package has maintainers with placeholders
         (["invalid-maintainer"], ["PKG-DIRECTIVES"]),
         # This package has no issues

--- a/var/spack/test_repos/spack_repo/builtin_mock/packages/fail_test_audit_builder/package.py
+++ b/var/spack/test_repos/spack_repo/builtin_mock/packages/fail_test_audit_builder/package.py
@@ -1,0 +1,14 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+from spack.package import PackageBase, version
+
+
+class FailTestAuditBuilder(PackageBase):
+    """This package inherits from PackageBase but not a GenericPackage or
+    Package."""
+
+    homepage = "http://github.com/dummy/fail-test-audit-builder"
+    url = "https://github.com/dummy/fail-test-audit-builder/archive/v1.0.tar.gz"
+
+    version("1.0", sha256="abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234")


### PR DESCRIPTION
This should prevent issues like spack/spack-packages#5223 where a package definition accidentally inherits only from `BasePackage` (or a mixin).