### PR TITLE
Bump `develop` version to 1.3.0dev0

### DIFF
--- a/lib/spack/spack/__init__.py
+++ b/lib/spack/spack/__init__.py
@@ -11,7 +11,7 @@ import spack.paths
 import spack.util.git
 
 #: PEP440 canonical <major>.<minor>.<micro>.<devN> string
-__version__ = "1.2.0.dev0"
+__version__ = "1.3.0.dev0"
 spack_version = __version__
 
 #: The current Package API version implemented by this version of Spack. The Package API defines


### PR DESCRIPTION
`v1.2.0` is released, time to bump `develop`