### PR TITLE
Add an option to hide install prefixes from the new installer

### DIFF
--- a/etc/spack/defaults/base/config.yaml
+++ b/etc/spack/defaults/base/config.yaml
@@ -170,6 +170,9 @@ config:
   # Which installer to use: "old" or "new".
   installer: new
 
+  # Print the installation prefix for completed builds.
+  installer_show_prefix: true
+
   # Restrict filesystem and network access during builds. The stage directory,
   # install prefix, and system temp directory are always writable.
   # Spack-installed dependency prefixes are always readable. Use the allow_read

--- a/lib/spack/spack/new_installer.py
+++ b/lib/spack/spack/new_installer.py
@@ -973,6 +973,7 @@ class BuildStatus:
         #: Verbose mode only applies to non-TTY where we want to track a single build log.
         self.verbose = verbose and not self.is_tty
         self.filter_padding = filter_padding
+        self.show_install_path = spack.config.get("config:installer_show_prefix", True)
         #: When True, suppress all terminal output (process is in background).
         #: Controlling code is responsible for modifying this variable based on process state
         self.headless = False
@@ -1429,8 +1430,9 @@ class BuildStatus:
             yield " fetching"
             yield f": {build_info.progress_percent}%"
         elif build_info.state == "finished":
-            prefix = build_info.prefix
-            yield f" {padding_filter(prefix) if self.filter_padding else prefix}"
+            if self.show_install_path:
+                prefix = build_info.prefix
+                yield f" {padding_filter(prefix) if self.filter_padding else prefix}"
         elif build_info.state == "failed":
             yield " failed"
             if build_info.log_path:

--- a/lib/spack/spack/new_installer.py
+++ b/lib/spack/spack/new_installer.py
@@ -936,6 +936,7 @@ class BuildStatus:
         color: Optional[bool] = None,
         verbose: bool = False,
         filter_padding: bool = False,
+        show_install_path: bool = True,
     ) -> None:
         if stdout is None:
             stdout = cast(io.TextIOWrapper, sys.stdout)
@@ -973,7 +974,7 @@ class BuildStatus:
         #: Verbose mode only applies to non-TTY where we want to track a single build log.
         self.verbose = verbose and not self.is_tty
         self.filter_padding = filter_padding
-        self.show_install_path = spack.config.get("config:installer_show_prefix", True)
+        self.show_install_path = show_install_path
         #: When True, suppress all terminal output (process is in background).
         #: Controlling code is responsible for modifying this variable based on process state
         self.headless = False
@@ -2103,6 +2104,7 @@ class PackageInstaller:
             verbose=verbose,
             filter_padding=spack.store.STORE.has_padding(),
             is_tty=TerminalState.stdout_is_interactive(),
+            show_install_path=spack.config.get("config:installer_show_prefix", True),
         )
         self.jobs = spack.config.determine_number_of_jobs(parallel=True)
         self.build_status.actual_jobs = self.jobs

--- a/lib/spack/spack/new_installer.py
+++ b/lib/spack/spack/new_installer.py
@@ -936,7 +936,7 @@ class BuildStatus:
         color: Optional[bool] = None,
         verbose: bool = False,
         filter_padding: bool = False,
-        show_install_path: bool = True,
+        show_install_prefix: bool = True,
     ) -> None:
         if stdout is None:
             stdout = cast(io.TextIOWrapper, sys.stdout)
@@ -974,7 +974,7 @@ class BuildStatus:
         #: Verbose mode only applies to non-TTY where we want to track a single build log.
         self.verbose = verbose and not self.is_tty
         self.filter_padding = filter_padding
-        self.show_install_path = show_install_path
+        self.show_install_prefix = show_install_prefix
         #: When True, suppress all terminal output (process is in background).
         #: Controlling code is responsible for modifying this variable based on process state
         self.headless = False
@@ -1431,7 +1431,7 @@ class BuildStatus:
             yield " fetching"
             yield f": {build_info.progress_percent}%"
         elif build_info.state == "finished":
-            if self.show_install_path:
+            if self.show_install_prefix:
                 prefix = build_info.prefix
                 yield f" {padding_filter(prefix) if self.filter_padding else prefix}"
         elif build_info.state == "failed":
@@ -2104,7 +2104,7 @@ class PackageInstaller:
             verbose=verbose,
             filter_padding=spack.store.STORE.has_padding(),
             is_tty=TerminalState.stdout_is_interactive(),
-            show_install_path=spack.config.get("config:installer_show_prefix", True),
+            show_install_prefix=spack.config.get("config:installer_show_prefix", True),
         )
         self.jobs = spack.config.determine_number_of_jobs(parallel=True)
         self.build_status.actual_jobs = self.jobs

--- a/lib/spack/spack/schema/config.py
+++ b/lib/spack/spack/schema/config.py
@@ -233,6 +233,10 @@ properties: Dict[str, Any] = {
                 "enum": ["old", "new"],
                 "description": "Which installer to use. The new installer is experimental.",
             },
+            "installer_show_prefix": {
+                "type": "boolean",
+                "description": "Whether the new installer prints the installation prefix for completed builds.",
+            },
             "sandbox": {
                 "type": "object",
                 "description": "Restrict filesystem and network access during builds.",

--- a/lib/spack/spack/schema/config.py
+++ b/lib/spack/spack/schema/config.py
@@ -235,7 +235,7 @@ properties: Dict[str, Any] = {
             },
             "installer_show_prefix": {
                 "type": "boolean",
-                "description": "Whether the new installer prints the installation prefix for completed builds.",
+                "description": "Whether the new installer prints the installation prefix.",
             },
             "sandbox": {
                 "type": "object",

--- a/lib/spack/spack/test/installer_tui.py
+++ b/lib/spack/spack/test/installer_tui.py
@@ -303,6 +303,26 @@ class TestOutputRendering:
         # Non-TTY output should not contain ANSI escape codes
         assert "\033[" not in output
 
+    @pytest.mark.parametrize("show_install_prefix", [True, False])
+    def test_show_install_prefix_from_config(self, mutable_config, show_install_prefix):
+        """Test that BuildStatus output includes the prefix only when configured to do so."""
+        mutable_config.set("config:installer_show_prefix", show_install_prefix)
+        spec = MockSpec("mypackage", "1.0", prefix="/custom/prefix/mypackage")
+        status = BuildStatus(
+            total=1, is_tty=False, color=False, show_install_prefix=show_install_prefix
+        )
+
+        status.add_build(spec, explicit=True)
+        build_info = status.builds[spec.dag_hash()]
+        build_info.state = "finished"
+        build_info.duration = 1.0
+
+        output = "".join(
+            status._generate_line_components(build_info, static=True, now=status.get_time())
+        )
+
+        assert (spec.prefix in output) is show_install_prefix
+
     def test_tty_output_contains_ansi(self):
         """Test that TTY mode produces ANSI codes"""
         status, _, fake_stdout = create_build_status()

--- a/lib/spack/spack/test/installer_tui.py
+++ b/lib/spack/spack/test/installer_tui.py
@@ -304,9 +304,8 @@ class TestOutputRendering:
         assert "\033[" not in output
 
     @pytest.mark.parametrize("show_install_prefix", [True, False])
-    def test_show_install_prefix_from_config(self, mutable_config, show_install_prefix):
+    def test_show_install_prefix_from_config(self, show_install_prefix):
         """Test that BuildStatus output includes the prefix only when configured to do so."""
-        mutable_config.set("config:installer_show_prefix", show_install_prefix)
         spec = MockSpec("mypackage", "1.0", prefix="/custom/prefix/mypackage")
         status = BuildStatus(
             total=1, is_tty=False, color=False, show_install_prefix=show_install_prefix

--- a/lib/spack/spack/test/new_installer.py
+++ b/lib/spack/spack/test/new_installer.py
@@ -271,18 +271,18 @@ class TestPackageInstallerConstructor:
         spec._mark_concrete()
         assert PackageInstaller([spec.package]).capacity == 1
 
-    @pytest.mark.parametrize("show_install_path", [True, False])
-    def test_show_install_path_from_config(
-        self, temporary_store, mock_packages, mutable_config, show_install_path
+    @pytest.mark.parametrize("show_install_prefix", [True, False])
+    def test_show_install_prefix_from_config(
+        self, temporary_store, mock_packages, mutable_config, show_install_prefix
     ):
-        """Test that BuildStatus show_install_path is initialized from config."""
-        mutable_config.set("config:installer_show_prefix", show_install_path)
+        """Test that BuildStatus show_install_prefix is initialized from config."""
+        mutable_config.set("config:installer_show_prefix", show_install_prefix)
         spec = spack.spec.Spec("trivial-install-test-package")
         spec._mark_concrete()
 
         installer = PackageInstaller([spec.package])
 
-        assert installer.build_status.show_install_path is show_install_path
+        assert installer.build_status.show_install_prefix is show_install_prefix
 
     def test_no_binary_mirrors_forces_source_only(
         self, temporary_store, mock_packages, mutable_config

--- a/lib/spack/spack/test/new_installer.py
+++ b/lib/spack/spack/test/new_installer.py
@@ -271,19 +271,6 @@ class TestPackageInstallerConstructor:
         spec._mark_concrete()
         assert PackageInstaller([spec.package]).capacity == 1
 
-    @pytest.mark.parametrize("show_install_prefix", [True, False])
-    def test_show_install_prefix_from_config(
-        self, temporary_store, mock_packages, mutable_config, show_install_prefix
-    ):
-        """Test that BuildStatus show_install_prefix is initialized from config."""
-        mutable_config.set("config:installer_show_prefix", show_install_prefix)
-        spec = spack.spec.Spec("trivial-install-test-package")
-        spec._mark_concrete()
-
-        installer = PackageInstaller([spec.package])
-
-        assert installer.build_status.show_install_prefix is show_install_prefix
-
     def test_no_binary_mirrors_forces_source_only(
         self, temporary_store, mock_packages, mutable_config
     ):

--- a/lib/spack/spack/test/new_installer.py
+++ b/lib/spack/spack/test/new_installer.py
@@ -271,6 +271,19 @@ class TestPackageInstallerConstructor:
         spec._mark_concrete()
         assert PackageInstaller([spec.package]).capacity == 1
 
+    @pytest.mark.parametrize("show_install_path", [True, False])
+    def test_show_install_path_from_config(
+        self, temporary_store, mock_packages, mutable_config, show_install_path
+    ):
+        """Test that BuildStatus show_install_path is initialized from config."""
+        mutable_config.set("config:installer_show_prefix", show_install_path)
+        spec = spack.spec.Spec("trivial-install-test-package")
+        spec._mark_concrete()
+
+        installer = PackageInstaller([spec.package])
+
+        assert installer.build_status.show_install_path is show_install_path
+
     def test_no_binary_mirrors_forces_source_only(
         self, temporary_store, mock_packages, mutable_config
     ):


### PR DESCRIPTION
Compared to other tools like Homebrew, npm, pip, or uv, Spack's installer is natively much more verbose by displaying the install path of each and every installation. While this makes sense when deploying HPC stacks across multiple network files systems, it's not as helpful simple use cases like when using Spack to install local development tools on a laptop. 

Additionally when giving the Spack tutorial the verbose installation prefixes often wrap to a newline creating outputs that are harder to follow for the audience. (We could disable line wrapping in our terminals for the tutorial, but I think that has the potential to create additional confusion.)

This PR adds a new `installer_show_prefix: true` config option that retains the existing functionality by default, but allows users to opt into a more minimal UI if they do not need the paths for every install.

**Before:**
```
$ spack bootstrap now --dev
[e] gjtqvhf apple-libuuid@1353.100.2 /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk (0s)
[+] gwm3xgs zlib-ng@2.3.3 /Users/alec/.spack/bootstrap/store/darwin-aarch64/zlib-ng-2.3.3-gwm3xgsciica4wf6426xvzx7czdklppc (0s)
[+] dflpaze libffi@3.5.2 /Users/alec/.spack/bootstrap/store/darwin-aarch64/libffi-3.5.2-dflpazezsrd73wvxdhuipruc32qf6ard (0s)
[+] bnc6nqr bzip2@1.0.8 /Users/alec/.spack/bootstrap/store/darwin-aarch64/bzip2-1.0.8-bnc6nqrwmrimcof6aap6tbzcyjgtf4qu (1s)
[+] 4emb6a6 zstd@1.5.7 /Users/alec/.spack/bootstrap/store/darwin-aarch64/zstd-1.5.7-4emb6a6hzjfcrwn3pixvyxq7dgnpycsv (1s)
Progress: 17/30  +/-: 14 jobs  /: filter  v: logs  n/p: next/prev
```

**After setting `installer_show_prefix: false`:**
```
$ spack bootstrap now --dev
[e] gjtqvhf apple-libuuid@1353.100.2 (0s)
[+] dflpaze libffi@3.5.2 (1s)
[+] gwm3xgs zlib-ng@2.3.3 (2s)
[+] bnc6nqr bzip2@1.0.8 (2s)
[+] qzrtqcr expat@2.7.4 (2s)
Progress: 17/30  +/-: 14 jobs  /: filter  v: logs  n/p: next/prev
```