### PR TITLE
spack location: fix crash with -v / --view

### DIFF
--- a/lib/spack/spack/cmd/location.py
+++ b/lib/spack/spack/cmd/location.py
@@ -126,7 +126,7 @@ def location(parser, args):
 
     # no -v corresponds to False, -v without arg to None, -v name to the string name.
     if args.location_view is not False:
-        env = spack.cmd.require_active_env("location -v")
+        env = spack.cmd.require_active_env(args.subparser)
         view_name = args.location_view
         if view_name is None:
             # get active view name


### PR DESCRIPTION
`spack location -v` (or `--view`) crashed when there was no active environment:

    ==> Error: 'str' object has no attribute 'error'

`require_active_env()` expects the command's subparser (it calls `parser.error(...)` and reads `parser.prog`), but it was being passed the string "location -v". Pass `args.subparser` instead, consistent with the other calls in this command, so the user gets the proper "requires an active environment" message.
