### PR TITLE
style: f-strings, string concat

### DIFF
--- a/bin/spack
+++ b/bin/spack
@@ -31,8 +31,8 @@ min_python3 = (3, 6)
 
 if sys.version_info[:2] < min_python3:
     v_info = sys.version_info[:3]
-    msg = "Spack requires Python %d.%d or higher " % min_python3
-    msg += "You are running spack with Python %d.%d.%d." % v_info
+    msg = "Spack requires Python {}.{} or higher ".format(*min_python3)
+    msg += "You are running spack with Python {}.{}.{}.".format(*v_info)
     sys.exit(msg)
 
 # Find spack's location and its prefix.

--- a/lib/spack/spack/audit.py
+++ b/lib/spack/spack/audit.py
@@ -248,7 +248,7 @@ def _search_duplicate_specs_in_externals(error_cls):
             continue
 
         # Otherwise wwe need to report an error
-        error_msg = "Multiple externals share the same spec: {0}".format(spec)
+        error_msg = f"Multiple externals share the same spec: {spec}"
         try:
             lines = [str(x._start_mark).strip() for x in entries]
             details = (
@@ -476,8 +476,8 @@ def _check_patch_urls(pkgs, error_cls):
                     errors.append(
                         error_cls(
                             f"patch URL in package {pkg_cls.name} "
-                            + "must not be a pull request commit; "
-                            + f"instead use {url}",
+                            "must not be a pull request commit; "
+                            f"instead use {url}",
                             [patch.url],
                         )
                     )
@@ -487,7 +487,7 @@ def _check_patch_urls(pkgs, error_cls):
                         errors.append(
                             error_cls(
                                 f"patch URL in package {pkg_cls.name} "
-                                + f"must end with {full_index_arg}",
+                                f"must end with {full_index_arg}",
                                 [patch.url],
                             )
                         )
@@ -527,9 +527,7 @@ def _search_for_reserved_attributes_names_in_packages(pkgs, error_cls):
                 "Package '{}' overrides the '{}' attribute or method, "
                 "which is reserved for Spack internal use"
             )
-            definitions = [
-                "defined in '{}'".format(x[0].__module__) for x in name_definitions[name]
-            ]
+            definitions = [f"defined in '{x[0].__module__}'" for x in name_definitions[name]]
             errors.append(error_cls(error_msg.format(pkg_name, name), definitions))
 
     return errors
@@ -561,8 +559,8 @@ def _ensure_packages_are_pickeleable(pkgs, error_cls):
         try:
             pickle.dumps(pkg)
         except Exception as e:
-            error_msg = "Package '{}' failed to pickle".format(pkg_name)
-            details = ["{}".format(str(e))]
+            error_msg = f"Package '{pkg_name}' failed to pickle"
+            details = [f"{str(e)}"]
             errors.append(error_cls(error_msg, details))
     return errors
 
@@ -577,16 +575,16 @@ def _ensure_packages_are_unparseable(pkgs, error_cls):
         try:
             source = ph.canonical_source(spack.spec.Spec(pkg_name), filter_multimethods=False)
         except Exception as e:
-            error_msg = "Package '{}' failed to unparse".format(pkg_name)
-            details = ["{}".format(str(e))]
+            error_msg = f"Package '{pkg_name}' failed to unparse"
+            details = [f"{str(e)}"]
             errors.append(error_cls(error_msg, details))
             continue
 
         try:
             compile(source, "internal", "exec", ast.PyCF_ONLY_AST)
         except Exception as e:
-            error_msg = "The unparsed package '{}' failed to compile".format(pkg_name)
-            details = ["{}".format(str(e))]
+            error_msg = f"The unparsed package '{pkg_name}' failed to compile"
+            details = [f"{str(e)}"]
             errors.append(error_cls(error_msg, details))
 
     return errors
@@ -605,7 +603,7 @@ def _ensure_all_versions_can_produce_a_fetcher(pkgs, error_cls):
                 assert spack.fetch_strategy.for_package_version(pkg, version)
         except Exception as e:
             error_msg = "The package '{}' cannot produce a fetcher for some of its versions"
-            details = ["{}".format(str(e))]
+            details = [f"{str(e)}"]
             errors.append(error_cls(error_msg.format(pkg_name), details))
     return errors
 
@@ -628,7 +626,7 @@ def _ensure_docstring_and_no_fixme(pkgs, error_cls):
                 pattern = next((r for r in fixme_regexes if r.search(line)), None)
                 if pattern:
                     details.append(
-                        "%s:%d: boilerplate needs to be removed: %s" % (filename, i, line.strip())
+                        f"{filename}:{i}: boilerplate needs to be removed: {line.strip()}"
                     )
         if details:
             error_msg = "Package '{}' contains boilerplate that need to be removed"
@@ -703,8 +701,8 @@ def _ensure_env_methods_are_ported_to_builders(pkgs, error_cls):
         for method_name in ("setup_build_environment", "setup_dependent_build_environment"):
             if hasattr(pkg_cls, method_name):
                 msg = (
-                    "Package '{}' need to move the '{}' method from the package class to the"
-                    " appropriate builder class".format(pkg_name, method_name)
+                    f"Package '{pkg_name}' need to move the '{method_name}' method "
+                    "from the package class to the appropriate builder class"
                 )
                 errors.append(error_cls(msg, []))
 
@@ -1174,8 +1172,9 @@ def _version_constraints_are_satisfiable_by_some_version_in_repo(pkgs, error_cls
                 )
             except Exception:
                 summary = (
-                    "{0}: dependency on {1} cannot be satisfied by known versions of {1.name}"
-                ).format(pkg_name, s)
+                    f"{pkg_name}: dependency on {s} cannot be satisfied "
+                    f"by known versions of {s.name}"
+                )
                 details = ["happening in " + filename]
                 if dependency_pkg_cls is not None:
                     details.append(

--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -155,7 +155,7 @@ class FetchCacheError(Exception):
             )
         else:
             err = errors[0]
-            self.message = "{0}: {1}".format(err.__class__.__name__, str(err))
+            self.message = f"{err.__class__.__name__}: {str(err)}"
         super().__init__(self.message)
 
 
@@ -495,7 +495,7 @@ class BinaryIndexCache:
 
         # Persist new index.json
         url_hash = compute_hash(str(mirror_metadata))
-        cache_key = "{}_{}.json".format(url_hash[:10], result.hash[:10])
+        cache_key = f"{url_hash[:10]}_{result.hash[:10]}.json"
         with self._index_file_cache.write_transaction(cache_key) as (old, new):
             new.write(result.data)
 
@@ -1997,7 +1997,7 @@ def relocate_package(spec: spack.spec.Spec) -> None:
     )
     if not os.path.exists(install_manifest):
         spec_id = spec.format("{name}/{hash:7}")
-        tty.warn("No manifest file in tarball for spec %s" % spec_id)
+        tty.warn(f"No manifest file in tarball for spec {spec_id}")
 
     # overwrite old metadata with new
     if spec.spliced:
@@ -2152,10 +2152,10 @@ def install_root_node(
     """
     # Early termination
     if spec.external or not spec.concrete:
-        warnings.warn("Skipping external or abstract spec {0}".format(spec.format()))
+        warnings.warn(f"Skipping external or abstract spec {spec.format()}")
         return
     elif spec.installed and not force:
-        warnings.warn("Package for spec {0} already installed.".format(spec.format()))
+        warnings.warn(f"Package for spec {spec.format()} already installed.")
         return
 
     tarball_stage = download_tarball(spec.build_spec, unsigned)
@@ -2165,7 +2165,7 @@ def install_root_node(
 
     # don't print long padded paths while extracting/relocating binaries
     with spack.util.path.filter_padding():
-        tty.msg('Installing "{0}" from a buildcache'.format(spec.format()))
+        tty.msg(f'Installing "{spec.format()}" from a buildcache')
         extract_tarball(spec, tarball_stage, force)
         spec.package.windows_establish_runtime_linkage()
         spack.hooks.post_install(spec, False)
@@ -2311,7 +2311,7 @@ def _get_keys(
 ) -> Optional[List[str]]:
     cache_class = get_url_buildcache_class(layout_version=layout_version)
 
-    tty.debug("Finding public keys in {0}".format(url_util.format(mirror_url)))
+    tty.debug(f"Finding public keys in {url_util.format(mirror_url)}")
 
     keys_prefix = url_util.join(
         mirror_url, *cache_class.get_relative_path_components(BuildcacheComponent.KEY)
@@ -2343,7 +2343,7 @@ def _get_keys(
             key_entry.destroy()
             continue
 
-        tty.debug("Found key {0}".format(fingerprint))
+        tty.debug(f"Found key {fingerprint}")
         if install:
             if trust:
                 spack.util.gpg.trust(key_blob_path, yes_to_all=yes_to_all)
@@ -2368,7 +2368,7 @@ def _get_keys_v2(
     )
     keys_index = url_util.join(keys_url, "index.json")
 
-    tty.debug("Finding public keys in {0}".format(url_util.format(mirror_url)))
+    tty.debug(f"Finding public keys in {url_util.format(mirror_url)}")
 
     try:
         json_index = web_util.read_json(keys_index)
@@ -2395,7 +2395,7 @@ def _get_keys_v2(
                 except spack.error.FetchError:
                     continue
 
-        tty.debug("Found key {0}".format(fingerprint))
+        tty.debug(f"Found key {fingerprint}")
         if install:
             if trust:
                 spack.util.gpg.trust(stage.save_filename, yes_to_all=yes_to_all)
@@ -2454,7 +2454,7 @@ def needs_rebuild(spec, mirror_url):
     pkg_version = spec.version
     pkg_hash = spec.dag_hash()
 
-    tty.debug("Checking {0}-{1}, dag_hash = {2}".format(pkg_name, pkg_version, pkg_hash))
+    tty.debug(f"Checking {pkg_name}-{pkg_version}, dag_hash = {pkg_hash}")
     tty.debug(spec.tree())
 
     # Try to retrieve the specfile directly, based on the known
@@ -2483,7 +2483,7 @@ def check_specs_against_mirrors(mirrors, specs, output_file=None):
     """
     rebuilds = {}
     for mirror in spack.mirrors.mirror.MirrorCollection(mirrors, binary=True).values():
-        tty.debug("Checking for built specs at {0}".format(mirror.fetch_url))
+        tty.debug(f"Checking for built specs at {mirror.fetch_url}")
 
         rebuild_list = []
 
@@ -2585,7 +2585,7 @@ class FetchIndexError(Exception):
         if len(self.args) == 1:
             return str(self.args[0])
         else:
-            return "{}, due to: {}".format(self.args[0], self.args[1])
+            return f"{self.args[0]}, due to: {self.args[1]}"
 
 
 class BuildcacheIndexError(spack.error.SpackError):
@@ -2973,7 +2973,7 @@ class PickKeyException(spack.error.SpackError):
     """
 
     def __init__(self, keys):
-        err_msg = "Multiple keys available for signing\n%s\n" % keys
+        err_msg = f"Multiple keys available for signing\n{keys}\n"
         err_msg += "Use spack buildcache create -k <key hash> to pick a key."
         super().__init__(err_msg)
 

--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -446,7 +446,7 @@ def set_wrapper_environment_variables_for_flags(pkg, env):
         # Concreteness guarantees key safety here
         if inject_flags[flag]:
             # variables SPACK_<FLAG> inject flags through wrapper
-            var_name = "SPACK_{0}".format(flag.upper())
+            var_name = f"SPACK_{flag.upper()}"
             env.set(var_name, " ".join(f for f in inject_flags[flag]))
         if env_flags[flag]:
             # implicit variables
@@ -645,7 +645,7 @@ def _static_to_shared_library(arch, compiler, static_lib, shared_lib=None, **kwa
     compat_version = kwargs.get("compat_version", version)
 
     if not shared_lib:
-        shared_lib = "{0}.{1}".format(os.path.splitext(static_lib)[0], dso_suffix)
+        shared_lib = f"{os.path.splitext(static_lib)[0]}.{dso_suffix}"
 
     compiler_args = []
 
@@ -655,11 +655,11 @@ def _static_to_shared_library(arch, compiler, static_lib, shared_lib=None, **kwa
         soname = os.path.basename(shared_lib)
 
         if compat_version:
-            soname += ".{0}".format(compat_version)
+            soname += f".{compat_version}"
 
         compiler_args = [
             "-shared",
-            "-Wl,-soname,{0}".format(soname),
+            f"-Wl,-soname,{soname}",
             "-Wl,--whole-archive",
             static_lib,
             "-Wl,--no-whole-archive",
@@ -668,20 +668,20 @@ def _static_to_shared_library(arch, compiler, static_lib, shared_lib=None, **kwa
         install_name = shared_lib
 
         if compat_version:
-            install_name += ".{0}".format(compat_version)
+            install_name += f".{compat_version}"
 
         compiler_args = [
             "-dynamiclib",
             "-install_name",
-            "{0}".format(install_name),
-            "-Wl,-force_load,{0}".format(static_lib),
+            f"{install_name}",
+            f"-Wl,-force_load,{static_lib}",
         ]
 
         if compat_version:
-            compiler_args.extend(["-compatibility_version", "{0}".format(compat_version)])
+            compiler_args.extend(["-compatibility_version", f"{compat_version}"])
 
         if version:
-            compiler_args.extend(["-current_version", "{0}".format(version)])
+            compiler_args.extend(["-current_version", f"{version}"])
 
     if len(arguments) > 0:
         compiler_args.extend(arguments)
@@ -689,9 +689,9 @@ def _static_to_shared_library(arch, compiler, static_lib, shared_lib=None, **kwa
     shared_lib_base = shared_lib
 
     if version:
-        shared_lib += ".{0}".format(version)
+        shared_lib += f".{version}"
     elif compat_version:
-        shared_lib += ".{0}".format(compat_version)
+        shared_lib += f".{compat_version}"
 
     compiler_args.extend(["-o", shared_lib])
 
@@ -702,7 +702,7 @@ def _static_to_shared_library(arch, compiler, static_lib, shared_lib=None, **kwa
         symlink(shared_lib_link, shared_lib_base)
 
     if compat_version and compat_version != version:
-        symlink(shared_lib_link, "{0}.{1}".format(shared_lib_base, compat_version))
+        symlink(shared_lib_link, f"{shared_lib_base}.{compat_version}")
 
     return compiler(*compiler_args, output=compiler_output)
 
@@ -1230,15 +1230,15 @@ def _setup_pkg_and_run(
         if isinstance(e, (spack.multimethod.NoSuchMethodError, AttributeError)):
             process = "test the installation" if context == "test" else "build from sources"
             error_msg = (
-                "The '{}' package cannot find an attribute while trying to {}. You can fix this "
-                "by updating the {} recipe, and you can also report the issue as a build-error or "
-                "a bug at https://github.com/spack/spack/issues"
-            ).format(pkg.name, process, context)
-            error_msg = colorize("@*R{{{}}}".format(error_msg))
-            error_msg = "{}\n\n{}".format(str(e), error_msg)
+                f"The '{pkg.name}' package cannot find an attribute while trying to {process}. "
+                f"You can fix this by updating the {context} recipe, and you can also report the "
+                "issue as a build-error or a bug at https://github.com/spack/spack/issues"
+            )
+            error_msg = colorize(f"@*R{{{error_msg}}}")
+            error_msg = f"{str(e)}\n\n{error_msg}"
 
         # make a pickleable exception to send to parent.
-        msg = "%s: %s" % (exc_type.__name__, error_msg)
+        msg = f"{exc_type.__name__}: {error_msg}"
 
         ce = ChildError(
             msg,
@@ -1538,7 +1538,7 @@ def get_package_context(traceback, context=3):
         # Add start to get lineno relative to start of file, not function.
         marked = f"  {'>> ' if is_error else '   '}{start + start_ctx + i:-6d}{line.rstrip()}"
         if is_error:
-            marked = colorize("@R{%s}" % cescape(marked))
+            marked = colorize(f"@R{{{cescape(marked)}}}")
         lines.append(marked)
 
     return lines
@@ -1616,15 +1616,15 @@ class ChildError(InstallError):
             out.write("\n")
 
         if have_log:
-            out.write("See {0} log for details:\n".format(self.log_type))
-            out.write("  {0}\n".format(self.log_name))
+            out.write(f"See {self.log_type} log for details:\n")
+            out.write(f"  {self.log_name}\n")
 
         # Also output the test log path IF it exists
         if self.context != "test" and have_log:
             test_log = join_path(os.path.dirname(self.log_name), spack_install_test_log)
             if os.path.isfile(test_log):
                 out.write("\nSee test log for details:\n")
-                out.write("  {0}\n".format(test_log))
+                out.write(f"  {test_log}\n")
 
         return out.getvalue()
 
@@ -1664,7 +1664,7 @@ def write_log_summary(out, log_type, log, last=None):
             nerr = last
 
         # If errors are found, only display errors
-        out.write("\n%s found in %s log:\n" % (plural(nerr, "error"), log_type))
+        out.write("\n{} found in {} log:\n".format(plural(nerr, "error"), log_type))
         out.write(make_log_context(errors))
     elif nwar > 0:
         if last and nwar > last:
@@ -1672,7 +1672,7 @@ def write_log_summary(out, log_type, log, last=None):
             nwar = last
 
         # If no errors are found but warnings are, display warnings
-        out.write("\n%s found in %s log:\n" % (plural(nwar, "warning"), log_type))
+        out.write("\n{} found in {} log:\n".format(plural(nwar, "warning"), log_type))
         out.write(make_log_context(warnings))
 
 

--- a/lib/spack/spack/builder.py
+++ b/lib/spack/spack/builder.py
@@ -402,13 +402,13 @@ class InstallationPhase:
         # If a phase has a matching stop_before_phase attribute,
         # stop the installation process raising a StopPhase
         if getattr(instance, "stop_before_phase", None) == self.name:
-            raise spack.error.StopPhase("Stopping before '{0}' phase".format(self.name))
+            raise spack.error.StopPhase(f"Stopping before '{self.name}' phase")
 
     def _on_phase_exit(self, instance):
         # If a phase has a matching last_phase attribute,
         # stop the installation process raising a StopPhase
         if getattr(instance, "last_phase", None) == self.name:
-            raise spack.error.StopPhase("Stopping at '{0}' phase".format(self.name))
+            raise spack.error.StopPhase(f"Stopping at '{self.name}' phase")
 
     def copy(self):
         return copy.deepcopy(self)

--- a/lib/spack/spack/ci/common.py
+++ b/lib/spack/spack/ci/common.py
@@ -53,10 +53,10 @@ def copy_gzipped(glob_or_path: str, dest: str) -> None:
 
     files = glob.glob(glob_or_path)
     if not files:
-        raise OSError("No such file or directory: '{0}'".format(glob_or_path), errno.ENOENT)
+        raise OSError(f"No such file or directory: '{glob_or_path}'", errno.ENOENT)
     if len(files) > 1 and not os.path.isdir(dest):
         raise ValueError(
-            "'{0}' matches multiple files but '{1}' is not a directory".format(glob_or_path, dest)
+            f"'{glob_or_path}' matches multiple files but '{dest}' is not a directory"
         )
 
     def is_gzipped(path):
@@ -618,7 +618,7 @@ class SpackCIConfig:
                     "script:": [
                         "spack env activate --without-view {env_dir}",
                         "spack -v buildcache update-index --keys "
-                        + f"{' '.join(update_index_extra_args)} buildcache-destination",
+                        f"{' '.join(update_index_extra_args)} buildcache-destination",
                     ]
                 }
             },

--- a/lib/spack/spack/cmd/__init__.py
+++ b/lib/spack/spack/cmd/__init__.py
@@ -124,7 +124,7 @@ def get_module(cmd_name):
         # Try to import the command from the built-in directory
         module_name = f"{__name__}.{pname}"
         module = importlib.import_module(module_name)
-        tty.debug("Imported {0} from built-in commands".format(pname))
+        tty.debug(f"Imported {pname} from built-in commands")
     except ImportError:
         module = spack.extensions.get_module(cmd_name)
         if not module:
@@ -135,8 +135,7 @@ def get_module(cmd_name):
 
     if not hasattr(module, pname):
         tty.die(
-            "Command module %s (%s) must define function '%s'."
-            % (module.__name__, module.__file__, pname)
+            f"Command module {module.__name__} ({module.__file__}) must define function '{pname}'."
         )
 
     return module
@@ -339,9 +338,9 @@ def ensure_single_spec_or_die(spec, matching_specs):
         "{ platform=architecture.platform}{ os=architecture.os}{ target=architecture.target}"
         "{compilers}"
     )
-    args = ["%s matches multiple packages." % spec, "Matching packages:"]
+    args = [f"{spec} matches multiple packages.", "Matching packages:"]
     args += [
-        colorize("  @K{%s} " % s.dag_hash(7)) + s.cformat(format_string) for s in matching_specs
+        colorize(f"  @K{{{s.dag_hash(7)}}} ") + s.cformat(format_string) for s in matching_specs
     ]
     args += ["Use a more specific spec (e.g., prepend '/' to the hash)."]
     tty.die(*args)
@@ -352,7 +351,7 @@ def gray_hash(spec, length):
         # default to maximum hash length
         length = 32
     h = spec.dag_hash(length) if spec.concrete else "-" * length
-    return colorize("@K{%s}" % h)
+    return colorize(f"@K{{{h}}}")
 
 
 def buildcache_status_fn(
@@ -417,7 +416,7 @@ def iter_groups(specs, indent, all_headers):
 
         # Drop the leading space from compilers to clean up output and aid checks.
         compilers_info = compilers.strip() or "no compilers"
-        header = "%s{%s} / %s{%s}" % (
+        header = "{}{{{}}} / {}{{{}}}".format(
             spack.spec.ARCHITECTURE_COLOR,
             architecture if architecture else "no arch",
             spack.spec.COMPILER_COLOR,
@@ -551,7 +550,7 @@ def display_specs(specs, args=None, **kwargs):
 
         # otherwise, we'll print specs one by one
         max_width = max(len(f[0]) for f in formatted)
-        path_fmt = "%%-%ds%%s" % (max_width + 2)
+        path_width = max_width + 2
 
         out = ""
         # getting lots of prefixes requires DB lookups. Ensure
@@ -564,7 +563,7 @@ def display_specs(specs, args=None, **kwargs):
                     continue
 
                 if paths:
-                    out += path_fmt % (string, spec.prefix) + "\n"
+                    out += f"{string:<{path_width}}{spec.prefix}\n"
                 else:
                     out += string + "\n"
 
@@ -599,7 +598,7 @@ def print_how_many_pkgs(specs, pkg_type="", suffix=""):
             category, e.g. if pkg_type is "installed" then the message
             would be "3 installed packages"
     """
-    tty.msg("%s" % spack.util.string.plural(len(specs), pkg_type + " package") + suffix)
+    tty.msg("{}".format(spack.util.string.plural(len(specs), pkg_type + " package")) + suffix)
 
 
 def spack_is_git_repo():
@@ -628,7 +627,7 @@ class PythonNameError(spack.error.SpackError):
 
     def __init__(self, name):
         self.name = name
-        super().__init__("{0} is not a permissible Python name.".format(name))
+        super().__init__(f"{name} is not a permissible Python name.")
 
 
 class CommandNameError(spack.error.SpackError):
@@ -636,7 +635,7 @@ class CommandNameError(spack.error.SpackError):
 
     def __init__(self, name):
         self.name = name
-        super().__init__("{0} is not a permissible Spack command name.".format(name))
+        super().__init__(f"{name} is not a permissible Spack command name.")
 
 
 class MultipleSpecsMatch(Exception):
@@ -659,7 +658,7 @@ def extant_file(f):
     Argparse type for files that exist.
     """
     if not os.path.isfile(f):
-        raise argparse.ArgumentTypeError("%s does not exist" % f)
+        raise argparse.ArgumentTypeError(f"{f} does not exist")
     return f
 
 
@@ -682,7 +681,7 @@ def require_active_env(parser):
         "  activate an environment first:\n"
         "      spack env activate ENV\n"
         "  or use:\n"
-        "      spack -e ENV %s ..." % parser.prog.partition(" ")[2]
+        "      spack -e ENV {} ...".format(parser.prog.partition(" ")[2])
     )
 
 
@@ -726,7 +725,7 @@ def find_environment(args: argparse.Namespace) -> Optional[ev.Environment]:
     if ev.is_env_dir(env):
         return ev.Environment(env)
 
-    raise ev.SpackEnvironmentError("no environment in %s" % env)
+    raise ev.SpackEnvironmentError(f"no environment in {env}")
 
 
 def doc_first_line(function: object) -> Optional[str]:

--- a/lib/spack/spack/cmd/add.py
+++ b/lib/spack/spack/cmd/add.py
@@ -30,7 +30,7 @@ def add(parser, args):
     with env.write_transaction():
         for spec in spack.cmd.parse_specs(args.specs):
             if not env.add(spec, args.list_name):
-                tty.msg("Package {0} was already added to {1}".format(spec.name, env.name))
+                tty.msg(f"Package {spec.name} was already added to {env.name}")
             else:
-                tty.msg("Adding %s to environment %s" % (spec, env.name))
+                tty.msg(f"Adding {spec} to environment {env.name}")
         env.write()

--- a/lib/spack/spack/cmd/audit.py
+++ b/lib/spack/spack/cmd/audit.py
@@ -95,7 +95,7 @@ def list(parser, args):
             print("  " + audit_obj.description)
             if args.verbose:
                 for idx, fn in enumerate(audit_obj.callbacks):
-                    print("    {0}. ".format(idx + 1) + fn.__doc__)
+                    print(f"    {idx + 1}. " + fn.__doc__)
                 print()
         print()
 

--- a/lib/spack/spack/cmd/bootstrap.py
+++ b/lib/spack/spack/cmd/bootstrap.py
@@ -147,10 +147,10 @@ def _enable_or_disable(args):
         # Set to True if we called "enable", otherwise set to false
         old_value = spack.config.get("bootstrap:enable", scope=args.scope)
         if old_value == value:
-            spack.llnl.util.tty.msg("Bootstrapping is already {}d".format(args.subcommand))
+            spack.llnl.util.tty.msg(f"Bootstrapping is already {args.subcommand}d")
         else:
             spack.config.set("bootstrap:enable", value, scope=args.scope)
-            spack.llnl.util.tty.msg("Bootstrapping has been {}d".format(args.subcommand))
+            spack.llnl.util.tty.msg(f"Bootstrapping has been {args.subcommand}d")
         return
 
     if value is True:
@@ -232,7 +232,7 @@ def _list(args):
 
             info_lines = ["\n"]
             for key, value in source.get("info", {}).items():
-                info_lines.append(" " * 4 + "@*{{{0}}}: {1}\n".format(key, value))
+                info_lines.append(" " * 4 + f"@*{{{key}}}: {value}\n")
             if len(info_lines) > 1:
                 fmt("  Info", "".join(info_lines))
 
@@ -277,16 +277,16 @@ def _write_bootstrapping_source_status(name, enabled, scope=None):
 
     if len(matches) > 1:
         msg = (
-            'there is more than one bootstrapping method named "{0}". '
+            f'there is more than one bootstrapping method named "{name}". '
             "Please delete all methods but one from bootstrap.yaml "
             "before proceeding"
-        ).format(name)
+        )
         raise RuntimeError(msg)
 
     # Setting the scope explicitly is needed to not copy over to a new scope
     # the entire default configuration for bootstrap.yaml
     scope = scope or spack.config.default_modify_scope("bootstrap")
-    spack.config.add("bootstrap:trusted:{0}:{1}".format(name, str(enabled)), scope=scope)
+    spack.config.add(f"bootstrap:trusted:{name}:{str(enabled)}", scope=scope)
 
 
 def _enable_source(args):
@@ -308,8 +308,8 @@ def _status(args):
     if args.dev:
         sections.append("develop")
 
-    header = "@*b{{Spack v{0} - {1}}}".format(
-        spack.spack_version, spack.bootstrap.config.spec_for_current_python()
+    header = (
+        f"@*b{{Spack v{spack.spack_version} - {spack.bootstrap.config.spec_for_current_python()}}}"
     )
     print(spack.llnl.util.tty.color.colorize(header))
     print()
@@ -346,11 +346,11 @@ def _add(args):
     # Check that the metadata file exists
     metadata_dir = spack.util.path.canonicalize_path(args.metadata_dir)
     if not os.path.exists(metadata_dir) or not os.path.isdir(metadata_dir):
-        raise RuntimeError('the directory "{0}" does not exist'.format(args.metadata_dir))
+        raise RuntimeError(f'the directory "{args.metadata_dir}" does not exist')
 
     file = os.path.join(metadata_dir, "metadata.yaml")
     if not os.path.exists(file):
-        raise RuntimeError('the file "{0}" does not exist'.format(file))
+        raise RuntimeError(f'the file "{file}" does not exist')
 
     # Insert the new source as the highest priority one
     write_scope = args.scope or spack.config.default_modify_scope(section="bootstrap")
@@ -436,9 +436,9 @@ def _mirror(args):
 
     instructions = (
         "\nTo register the mirror on the platform where it's supposed "
-        'to be used, move "{0}" to its final location and run the '
+        f'to be used, move "{args.root_dir}" to its final location and run the '
         "following command(s):\n\n"
-    ).format(args.root_dir)
+    )
     cmd = "  % spack bootstrap add --trust {0} <final-path>/{1}\n"
     _, rel_directory = write_metadata(subdir="sources", metadata=SOURCE_METADATA)
     instructions += cmd.format("local-sources", rel_directory)

--- a/lib/spack/spack/cmd/buildcache.py
+++ b/lib/spack/spack/cmd/buildcache.py
@@ -646,7 +646,7 @@ def list_fn(args):
         specs = [s for s in specs if any(s.intersects(c) for c in constraints)]
     if sys.stdout.isatty():
         builds = len(specs)
-        tty.msg("%s." % plural(builds, "cached build"))
+        tty.msg("{}.".format(plural(builds, "cached build")))
         if not builds and not args.allarch:
             tty.msg(
                 "You can query all available architectures with:",
@@ -846,11 +846,7 @@ def sync_fn(args):
     # Get the active environment
     env = spack.cmd.require_active_env(args.subparser)
 
-    tty.msg(
-        "Syncing environment buildcache files from {0} to {1}".format(
-            src_mirror_url, dest_mirror_url
-        )
-    )
+    tty.msg(f"Syncing environment buildcache files from {src_mirror_url} to {dest_mirror_url}")
 
     tty.debug("Syncing the following specs:")
     specs_to_sync = [s for s in env.all_specs() if not s.external]

--- a/lib/spack/spack/cmd/cd.py
+++ b/lib/spack/spack/cmd/cd.py
@@ -22,5 +22,5 @@ def setup_parser(subparser: argparse.ArgumentParser) -> None:
 def cd(parser, args):
     spec = " ".join(args.spec) if args.spec else "SPEC"
     spack.cmd.common.shell_init_instructions(
-        "spack cd", "cd `spack location --install-dir %s`" % spec
+        "spack cd", f"cd `spack location --install-dir {spec}`"
     )

--- a/lib/spack/spack/cmd/ci.py
+++ b/lib/spack/spack/cmd/ci.py
@@ -330,8 +330,8 @@ def ci_rebuild(args):
     concrete_env_dir = os.path.join(ci_project_dir, concrete_env_dir)
 
     # Debug print some of the key environment variables we should have received
-    tty.debug("pipeline_artifacts_dir = {0}".format(pipeline_artifacts_dir))
-    tty.debug("job_spec_pkg_name = {0}".format(job_spec_pkg_name))
+    tty.debug(f"pipeline_artifacts_dir = {pipeline_artifacts_dir}")
+    tty.debug(f"job_spec_pkg_name = {job_spec_pkg_name}")
 
     # Query the environment manifest to find out whether we're reporting to a
     # CDash instance, and if so, gather some information from the manifest to
@@ -340,24 +340,20 @@ def ci_rebuild(args):
     cdash_handler = None
     if "build-group" in cdash_config:
         cdash_handler = spack_ci.CDashHandler(cdash_config)
-        tty.debug("cdash url = {0}".format(cdash_handler.url))
-        tty.debug("cdash project = {0}".format(cdash_handler.project))
-        tty.debug("cdash project_enc = {0}".format(cdash_handler.project_enc))
-        tty.debug("cdash build_name = {0}".format(cdash_handler.build_name))
-        tty.debug("cdash build_stamp = {0}".format(cdash_handler.build_stamp))
-        tty.debug("cdash site = {0}".format(cdash_handler.site))
-        tty.debug("cdash build_group = {0}".format(cdash_handler.build_group))
+        tty.debug(f"cdash url = {cdash_handler.url}")
+        tty.debug(f"cdash project = {cdash_handler.project}")
+        tty.debug(f"cdash project_enc = {cdash_handler.project_enc}")
+        tty.debug(f"cdash build_name = {cdash_handler.build_name}")
+        tty.debug(f"cdash build_stamp = {cdash_handler.build_stamp}")
+        tty.debug(f"cdash site = {cdash_handler.site}")
+        tty.debug(f"cdash build_group = {cdash_handler.build_group}")
 
     # Is this a pipeline run on a spack PR or a merge to develop?  It might
     # be neither, e.g. a pipeline run on some environment repository.
     spack_is_pr_pipeline = spack_pipeline_type == "spack_pull_request"
     spack_is_develop_pipeline = spack_pipeline_type == "spack_protected_branch"
 
-    tty.debug(
-        "Pipeline type - PR: {0}, develop: {1}".format(
-            spack_is_pr_pipeline, spack_is_develop_pipeline
-        )
-    )
+    tty.debug(f"Pipeline type - PR: {spack_is_pr_pipeline}, develop: {spack_is_develop_pipeline}")
 
     full_rebuild = True if rebuild_everything and rebuild_everything.lower() == "true" else False
 
@@ -372,9 +368,9 @@ def ci_rebuild(args):
     try:
         job_spec = env.get_one_by_hash(job_spec_dag_hash)
     except AssertionError:
-        tty.die("Could not find environment spec with hash {0}".format(job_spec_dag_hash))
+        tty.die(f"Could not find environment spec with hash {job_spec_dag_hash}")
 
-    job_spec_json_file = "{0}.json".format(job_spec_pkg_name)
+    job_spec_json_file = f"{job_spec_pkg_name}.json"
     job_spec_json_path = os.path.join(repro_dir, job_spec_json_file)
 
     # To provide logs, cdash reports, etc for developer download/perusal,
@@ -419,7 +415,7 @@ def ci_rebuild(args):
 
     # Write this job's spec json into the reproduction directory, and it will
     # also be used in the generated "spack install" command to install the spec
-    tty.debug("job concrete spec path: {0}".format(job_spec_json_path))
+    tty.debug(f"job concrete spec path: {job_spec_json_path}")
     with open(job_spec_json_path, "w", encoding="utf-8") as fd:
         fd.write(job_spec.to_json(hash=ht.dag_hash))
 
@@ -454,9 +450,9 @@ def ci_rebuild(args):
         # of the matches and download the buildcache files from there to
         # the artifacts, so they're available to be used by dependent
         # jobs in subsequent stages.
-        tty.msg("No need to rebuild {0}, found hash match at: ".format(job_spec_pkg_name))
+        tty.msg(f"No need to rebuild {job_spec_pkg_name}, found hash match at: ")
         for match in matches:
-            tty.msg("    {0}".format(match.url))
+            tty.msg(f"    {match.url}")
 
         # Now we are done and successful
         return 0
@@ -502,11 +498,11 @@ def ci_rebuild(args):
         spack_cmd + deps_install_args + [slash_hash],
         spack_cmd + root_install_args + [slash_hash],
     ]
-    tty.debug("Installing {0} from source".format(job_spec.name))
+    tty.debug(f"Installing {job_spec.name} from source")
     install_exit_code = spack_ci.process_command("install", commands, repro_dir)
 
     # Now do the post-install tasks
-    tty.debug("spack install exited {0}".format(install_exit_code))
+    tty.debug(f"spack install exited {install_exit_code}")
 
     # If a spec fails to build in a spack develop pipeline, we add it to a
     # list of known broken hashes.  This allows spack PR pipelines to
@@ -517,7 +513,7 @@ def ci_rebuild(args):
             broken_specs_url = ci_config["broken-specs-url"]
             dev_fail_hash = job_spec.dag_hash()
             broken_spec_path = url_util.join(broken_specs_url, dev_fail_hash)
-            tty.msg("Reporting broken develop build as: {0}".format(broken_spec_path))
+            tty.msg(f"Reporting broken develop build as: {broken_spec_path}")
             spack_ci.write_broken_spec(
                 broken_spec_path,
                 job_spec_pkg_name,
@@ -553,8 +549,8 @@ def ci_rebuild(args):
                 # First ensure we will use a reasonable test stage directory
                 stage_root = os.path.dirname(str(job_spec.package.stage.path))
                 test_stage = fs.join_path(stage_root, "spack-standalone-tests")
-                tty.debug("Configuring test_stage to {0}".format(test_stage))
-                config_test_path = "config:test_stage:{0}".format(test_stage)
+                tty.debug(f"Configuring test_stage to {test_stage}")
+                config_test_path = f"config:test_stage:{test_stage}"
                 cfg.add(config_test_path, scope=cfg.default_modify_scope())
 
                 # Run the tests, resorting to junit results if not using cdash
@@ -572,7 +568,7 @@ def ci_rebuild(args):
 
             except Exception as err:
                 # If there is any error, just print a warning.
-                msg = "Error processing stand-alone tests: {0}".format(str(err))
+                msg = f"Error processing stand-alone tests: {str(err)}"
                 tty.warn(msg)
 
             finally:
@@ -615,7 +611,7 @@ def ci_rebuild(args):
             just_built_hash = job_spec.dag_hash()
             broken_spec_path = url_util.join(broken_specs_url, just_built_hash)
             if web_util.url_exists(broken_spec_path):
-                tty.msg("Removing {0} from the list of broken specs".format(broken_spec_path))
+                tty.msg(f"Removing {broken_spec_path} from the list of broken specs")
                 try:
                     web_util.remove_url(broken_spec_path)
                 except Exception as err:

--- a/lib/spack/spack/cmd/clean.py
+++ b/lib/spack/spack/cmd/clean.py
@@ -72,12 +72,12 @@ def remove_python_cache():
             for f in files:
                 if f.endswith(".pyc") or f.endswith(".pyo"):
                     fname = os.path.join(root, f)
-                    tty.debug("Removing {0}".format(fname))
+                    tty.debug(f"Removing {fname}")
                     os.remove(fname)
             for d in dirs:
                 if d == "__pycache__":
                     dname = os.path.join(root, d)
-                    tty.debug("Removing {0}".format(dname))
+                    tty.debug(f"Removing {dname}")
                     shutil.rmtree(dname)
 
 

--- a/lib/spack/spack/cmd/commands.py
+++ b/lib/spack/spack/cmd/commands.py
@@ -221,7 +221,7 @@ class BashCompletionWriter(ArgparseWriter):
             Function definition beginning.
         """
         name = prog.replace("-", "_").replace(" ", "_")
-        return "\n_{0}() {{".format(name)
+        return f"\n_{name}() {{"
 
     def end_function(self, prog: str) -> str:
         """Return the syntax needed to end a function definition.
@@ -715,11 +715,10 @@ def rst_index(out: IO) -> None:
     dmax = max(len(section_descriptions.get(s, s)) for s in sections) + 2
     cmax = max(len(c) for _, c in sections.items()) + 60
 
-    row = "%s  %s\n" % ("=" * dmax, "=" * cmax)
-    line = "%%-%ds  %%s\n" % dmax
+    row = "{}  {}\n".format("=" * dmax, "=" * cmax)
 
     out.write(row)
-    out.write(line % (" Category ", " Commands "))
+    out.write(f"{' Category ':<{dmax}}  {' Commands '}\n")
     out.write(row)
     for section, commands in sorted(sections.items()):
         description = section_descriptions.get(section, section)
@@ -729,7 +728,7 @@ def rst_index(out: IO) -> None:
             ref = f":ref:`{cmd} <spack-{cmd}>`"
             comma = "," if i != len(commands) - 1 else ""
             bar = "| " if i % 8 == 0 else "  "
-            out.write(line % (description, bar + ref + comma))
+            out.write(f"{description:<{dmax}}  {bar + ref + comma}\n")
     out.write(row)
 
 

--- a/lib/spack/spack/cmd/common/__init__.py
+++ b/lib/spack/spack/cmd/common/__init__.py
@@ -20,24 +20,24 @@ def shell_init_instructions(cmd, equivalent):
     shell_specific = "{sh_arg}" in equivalent
 
     msg = [
-        "`%s` requires Spack's shell support." % cmd,
+        f"`{cmd}` requires Spack's shell support.",
         "",
         "To set up shell support, run the command below for your shell.",
         "",
         color.colorize("@*c{For bash/zsh/sh:}"),
-        "  . %s/setup-env.sh" % spack.paths.share_path,
+        f"  . {spack.paths.share_path}/setup-env.sh",
         "",
         color.colorize("@*c{For csh/tcsh:}"),
-        "  source %s/setup-env.csh" % spack.paths.share_path,
+        f"  source {spack.paths.share_path}/setup-env.csh",
         "",
         color.colorize("@*c{For fish:}"),
-        "  source %s/setup-env.fish" % spack.paths.share_path,
+        f"  source {spack.paths.share_path}/setup-env.fish",
         "",
         color.colorize("@*c{For Windows batch:}"),
-        "  %s\\spack_cmd.bat" % spack.paths.bin_path,
+        f"  {spack.paths.bin_path}\\spack_cmd.bat",
         "",
         color.colorize("@*c{For PowerShell:}"),
-        "  %s\\setup-env.ps1" % spack.paths.share_path,
+        f"  {spack.paths.share_path}\\setup-env.ps1",
         "",
         "Or, if you do not want to use shell support, run "
         + ("one of these" if shell_specific else "this")

--- a/lib/spack/spack/cmd/common/arguments.py
+++ b/lib/spack/spack/cmd/common/arguments.py
@@ -368,7 +368,9 @@ def deptype():
         "--deptype",
         action=DeptypeAction,
         default=dt.ALL,
-        help="comma-separated list of deptypes to traverse (default=%s)" % ",".join(dt.ALL_TYPES),
+        help="comma-separated list of deptypes to traverse (default={})".format(
+            ",".join(dt.ALL_TYPES)
+        ),
     )
 
 

--- a/lib/spack/spack/cmd/common/env_utility.py
+++ b/lib/spack/spack/cmd/common/env_utility.py
@@ -75,7 +75,7 @@ class AreDepsInstalledVisitor:
 
 def emulate_env_utility(cmd_name, context: Context, args):
     if not args.spec:
-        tty.die("spack %s requires a spec." % cmd_name)
+        tty.die(f"spack {cmd_name} requires a spec.")
 
     # Specs may have spaces in them, so if they do, require that the
     # caller put a '--' between the spec and the command to be
@@ -91,11 +91,11 @@ def emulate_env_utility(cmd_name, context: Context, args):
         cmd = args.spec[1:]
 
     if not spec:
-        tty.die("spack %s requires a spec." % cmd_name)
+        tty.die(f"spack {cmd_name} requires a spec.")
 
     specs = spack.cmd.parse_specs(spec, concretize=False)
     if len(specs) > 1:
-        tty.die("spack %s only takes one spec." % cmd_name)
+        tty.die(f"spack {cmd_name} only takes one spec.")
     spec = specs[0]
 
     spec = spack.cmd.matching_spec_from_env(spec)
@@ -125,12 +125,12 @@ def emulate_env_utility(cmd_name, context: Context, args):
 
     if args.dump:
         # Dump a source-able environment to a text file.
-        tty.msg("Dumping a source-able environment to {0}".format(args.dump))
+        tty.msg(f"Dumping a source-able environment to {args.dump}")
         dump_environment(args.dump)
 
     if args.pickle:
         # Dump a source-able environment to a pickle file.
-        tty.msg("Pickling a source-able environment to {0}".format(args.pickle))
+        tty.msg(f"Pickling a source-able environment to {args.pickle}")
         pickle_environment(args.pickle)
 
     if cmd:
@@ -141,4 +141,4 @@ def emulate_env_utility(cmd_name, context: Context, args):
         # If no command or dump/pickle option then act like the "env" command
         # and print out env vars.
         for key, val in os.environ.items():
-            print("%s=%s" % (key, val))
+            print(f"{key}={val}")

--- a/lib/spack/spack/cmd/config.py
+++ b/lib/spack/spack/cmd/config.py
@@ -562,7 +562,7 @@ def config_update(args):
     if cannot_overwrite:
         msg = "Detected permission issues with the following scopes:\n\n"
         for scope, cfg_file in cannot_overwrite:
-            msg += "\t[scope={0}, cfg={1}]\n".format(scope.name, cfg_file)
+            msg += f"\t[scope={scope.name}, cfg={cfg_file}]\n"
         msg += (
             "\nEither ensure that you have sufficient permissions to "
             "modify these files or do not include these scopes in the "
@@ -587,7 +587,7 @@ def config_update(args):
         )
         for scope in updates:
             cfg_file = spack.config.CONFIG.get_config_filename(scope.name, args.section)
-            msg += "\t[scope={0}, file={1}]\n".format(scope.name, cfg_file)
+            msg += f"\t[scope={scope.name}, file={cfg_file}]\n"
         msg += (
             "\nIf the configuration files are updated, versions of Spack "
             "that are older than this version may not be able to read "
@@ -653,7 +653,7 @@ def config_revert(args):
     if cannot_overwrite:
         msg = "Detected permission issues with the following scopes:\n\n"
         for e in cannot_overwrite:
-            msg += "\t[scope={0.scope}, cfg={0.cfg}, bkp={0.bkp}]\n".format(e)
+            msg += f"\t[scope={e.scope}, cfg={e.cfg}, bkp={e.bkp}]\n"
         msg += (
             "\nEither ensure to have the right permissions before retrying"
             " or be more specific on the scope to revert."
@@ -664,7 +664,7 @@ def config_revert(args):
     if not args.yes_to_all:
         msg = "The following scopes will be restored from the corresponding backup files:\n"
         for entry in to_be_restored:
-            msg += "\t[scope={0.scope}, bkp={0.bkp}]\n".format(entry)
+            msg += f"\t[scope={entry.scope}, bkp={entry.bkp}]\n"
         msg += "This operation cannot be undone."
         tty.msg(msg)
         proceed = tty.get_yes_or_no("Do you want to proceed?", default=False)
@@ -743,7 +743,7 @@ def config_prefer_upstream(args):
     spack.config.set("packages", new, scope)
     config_file = spack.config.CONFIG.get_config_filename(scope, section)
 
-    tty.msg("Updated config at {0}".format(config_file))
+    tty.msg(f"Updated config at {config_file}")
 
 
 def config(parser, args):

--- a/lib/spack/spack/cmd/create.py
+++ b/lib/spack/spack/cmd/create.py
@@ -248,8 +248,8 @@ class LuaPackageTemplate(PackageTemplate):
         # If the user provided `--name lua-lpeg`, don't rename it lua-lua-lpeg
         if not name.startswith("lua-"):
             # Make it more obvious that we are renaming the package
-            tty.msg("Changing package name from {0} to lua-{0}".format(name))
-            name = "lua-{0}".format(name)
+            tty.msg(f"Changing package name from {name} to lua-{name}")
+            name = f"lua-{name}"
         super().__init__(name, url, versions, languages)
 
 
@@ -363,8 +363,8 @@ class RacketPackageTemplate(PackageTemplate):
         # If the user provided `--name rkt-scribble`, don't rename it rkt-rkt-scribble
         if not name.startswith("rkt-"):
             # Make it more obvious that we are renaming the package
-            tty.msg("Changing package name from {0} to rkt-{0}".format(name))
-            name = "rkt-{0}".format(name)
+            tty.msg(f"Changing package name from {name} to rkt-{name}")
+            name = f"rkt-{name}"
         self.body_def = self.body_def.format(name[4:])
         super().__init__(name, url, versions, languages)
 
@@ -406,8 +406,8 @@ class PythonPackageTemplate(PackageTemplate):
         # If the user provided `--name py-numpy`, don't rename it py-py-numpy
         if not name.startswith("py-"):
             # Make it more obvious that we are renaming the package
-            tty.msg("Changing package name from {0} to py-{0}".format(name))
-            name = "py-{0}".format(name)
+            tty.msg(f"Changing package name from {name} to py-{name}")
+            name = f"py-{name}"
 
         # Simple PyPI URLs:
         # https://<hostname>/packages/<type>/<first character of project>/<project>/<download file>
@@ -481,8 +481,8 @@ class RPackageTemplate(PackageTemplate):
         # If the user provided `--name r-rcpp`, don't rename it r-r-rcpp
         if not name.startswith("r-"):
             # Make it more obvious that we are renaming the package
-            tty.msg("Changing package name from {0} to r-{0}".format(name))
-            name = "r-{0}".format(name)
+            tty.msg(f"Changing package name from {name} to r-{name}")
+            name = f"r-{name}"
 
         r_name = parse_name(url)
 
@@ -495,7 +495,7 @@ class RPackageTemplate(PackageTemplate):
         bioc = re.search(r"(?:bioconductor)[^/]+/packages" + "/([^/]+)" * 5, url)
 
         if bioc:
-            self.url_line = '    url = "{0}"\n    bioc = "{1}"'.format(url, r_name)
+            self.url_line = f'    url = "{url}"\n    bioc = "{r_name}"'
 
         super().__init__(name, url, versions, languages)
 
@@ -523,8 +523,8 @@ class PerlmakePackageTemplate(PackageTemplate):
         # If the user provided `--name perl-cpp`, don't rename it perl-perl-cpp
         if not name.startswith("perl-"):
             # Make it more obvious that we are renaming the package
-            tty.msg("Changing package name from {0} to perl-{0}".format(name))
-            name = "perl-{0}".format(name)
+            tty.msg(f"Changing package name from {name} to perl-{name}")
+            name = f"perl-{name}"
 
         super().__init__(name, url, versions, languages)
 
@@ -559,8 +559,8 @@ class OctavePackageTemplate(PackageTemplate):
         # octave-octave-splines
         if not name.startswith("octave-"):
             # Make it more obvious that we are renaming the package
-            tty.msg("Changing package name from {0} to octave-{0}".format(name))
-            name = "octave-{0}".format(name)
+            tty.msg(f"Changing package name from {name} to octave-{name}")
+            name = f"octave-{name}"
 
         super().__init__(name, url, versions, languages)
 
@@ -589,8 +589,8 @@ class RubyPackageTemplate(PackageTemplate):
         # ruby-ruby-numpy
         if not name.startswith("ruby-"):
             # Make it more obvious that we are renaming the package
-            tty.msg("Changing package name from {0} to ruby-{0}".format(name))
-            name = "ruby-{0}".format(name)
+            tty.msg(f"Changing package name from {name} to ruby-{name}")
+            name = f"ruby-{name}"
 
         super().__init__(name, url, versions, languages)
 
@@ -637,8 +637,8 @@ class SIPPackageTemplate(PackageTemplate):
         # If the user provided `--name py-pyqt4`, don't rename it py-py-pyqt4
         if not name.startswith("py-"):
             # Make it more obvious that we are renaming the package
-            tty.msg("Changing package name from {0} to py-{0}".format(name))
-            name = "py-{0}".format(name)
+            tty.msg(f"Changing package name from {name} to py-{name}")
+            name = f"py-{name}"
 
         super().__init__(name, url, versions, languages)
 
@@ -896,7 +896,7 @@ def get_name(name, url):
         # Use a user-supplied name if one is present
         result = name
         if len(name.strip()) > 0:
-            tty.msg("Using specified package name: '{0}'".format(result))
+            tty.msg(f"Using specified package name: '{result}'")
         else:
             tty.die("A package name must be provided when using the option.")
     elif url is not None:
@@ -907,7 +907,7 @@ def get_name(name, url):
                 desc = "URL"
             else:
                 desc = "package name"
-            tty.msg("This looks like a {0} for {1}".format(desc, result))
+            tty.msg(f"This looks like a {desc} for {result}")
         except UndetectableNameError:
             tty.die(
                 "Couldn't guess a name for this package.",
@@ -984,7 +984,7 @@ def get_versions(args: argparse.Namespace, name: str) -> Tuple[str, BuildSystemA
                 url_dict = url_dict_filtered
         except UndetectableVersionError:
             # Use fake versions
-            tty.warn("Couldn't detect version in: {0}".format(args.url))
+            tty.warn(f"Couldn't detect version in: {args.url}")
             return hashed_versions, guesser
 
         if not url_dict:
@@ -1027,7 +1027,7 @@ def get_build_system(
     if template is not None:
         selected_template = template
         # Use a user-supplied template if one is present
-        tty.msg("Using specified package template: '{0}'".format(selected_template))
+        tty.msg(f"Using specified package template: '{selected_template}'")
     elif url is not None:
         # Use whatever build system the guesser detected
         selected_template = guesser.build_system
@@ -1054,7 +1054,7 @@ def get_repository(args: argparse.Namespace, name: str) -> spack.repo.Repo:
     spec = Spec(name)
     # Figure out namespace for spec
     if spec.namespace and args.namespace and spec.namespace != args.namespace:
-        tty.die("Namespaces '{0}' and '{1}' do not match.".format(spec.namespace, args.namespace))
+        tty.die(f"Namespaces '{spec.namespace}' and '{args.namespace}' do not match.")
 
     if not spec.namespace and args.namespace:
         spec.namespace = args.namespace
@@ -1065,9 +1065,8 @@ def get_repository(args: argparse.Namespace, name: str) -> spack.repo.Repo:
         repo = spack.repo.from_path(repo_path)
         if spec.namespace and spec.namespace != repo.namespace:
             tty.die(
-                "Can't create package with namespace {0} in repo with namespace {1}".format(
-                    spec.namespace, repo.namespace
-                )
+                f"Can't create package with namespace {spec.namespace} "
+                f"in repo with namespace {repo.namespace}"
             )
     else:
         if spec.namespace:
@@ -1097,22 +1096,21 @@ def create(parser, args):
     if package_class != BundlePackageTemplate:
         constr_args["url"] = url
     package = package_class(**constr_args)
-    tty.msg("Created template for {0} package".format(package.name))
+    tty.msg(f"Created template for {package.name} package")
 
     # Create a directory for the new package
     repo = get_repository(args, name)
     pkg_path = repo.filename_for_package_name(package.name)
     if os.path.exists(pkg_path) and not args.force:
         tty.die(
-            "{0} already exists.".format(pkg_path),
-            "  Try running `spack create --force` to overwrite it.",
+            f"{pkg_path} already exists.", "  Try running `spack create --force` to overwrite it."
         )
     else:
         mkdirp(os.path.dirname(pkg_path))
 
     # Write the new package file
     package.write(pkg_path)
-    tty.msg("Created package file: {0}".format(pkg_path))
+    tty.msg(f"Created package file: {pkg_path}")
 
     # Optionally open up the new package file in your $EDITOR
     if not args.skip_editor:

--- a/lib/spack/spack/cmd/dependencies.py
+++ b/lib/spack/spack/cmd/dependencies.py
@@ -57,7 +57,7 @@ def dependencies(parser, args):
 
         format_string = "{name}{@version}{/hash:7}{%compiler}"
         if sys.stdout.isatty():
-            tty.msg("Dependencies of %s" % spec.format(format_string, color=True))
+            tty.msg(f"Dependencies of {spec.format(format_string, color=True)}")
         deps = spack.store.STORE.db.installed_relatives(
             spec, "children", args.transitive, deptype=args.deptype
         )

--- a/lib/spack/spack/cmd/dependents.py
+++ b/lib/spack/spack/cmd/dependents.py
@@ -95,7 +95,7 @@ def dependents(parser, args):
 
         format_string = "{name}{@version}{/hash:7}{%compiler}"
         if sys.stdout.isatty():
-            tty.msg("Dependents of %s" % spec.cformat(format_string))
+            tty.msg(f"Dependents of {spec.cformat(format_string)}")
         deps = spack.store.STORE.db.installed_relatives(spec, "parents", args.transitive)
         if deps:
             spack.cmd.display_specs(deps, long=True)

--- a/lib/spack/spack/cmd/dev_build.py
+++ b/lib/spack/spack/cmd/dev_build.py
@@ -117,7 +117,7 @@ def dev_build(self, args):
     spec = spack.concretize.concretize_one(spec)
 
     if spec.installed:
-        tty.error("Already installed in %s" % spec.prefix)
+        tty.error(f"Already installed in {spec.prefix}")
         tty.msg("Uninstall or try adding a version suffix for this dev build.")
         sys.exit(1)
 

--- a/lib/spack/spack/cmd/diff.py
+++ b/lib/spack/spack/cmd/diff.py
@@ -149,8 +149,8 @@ def print_difference(c, attributes="all", out=None):
     A = c["b_not_a"]
     B = c["a_not_b"]
 
-    cprint("@R{--- %s}" % c["a_name"])  # bright red
-    cprint("@G{+++ %s}" % c["b_name"])  # bright green
+    cprint("@R{{--- {}}}".format(c["a_name"]))  # bright red
+    cprint("@G{{+++ {}}}".format(c["b_name"]))  # bright green
 
     # Cut out early if we don't have any differences!
     if not A and not B:
@@ -193,17 +193,17 @@ def print_difference(c, attributes="all", out=None):
             category = key
 
             # print category in bold, colorized
-            cprint("@*b{@@ %s @@}" % category)  # bold blue
+            cprint(f"@*b{{@@ {category} @@}}")  # bold blue
 
         # Print subtractions first
         while subtraction:
-            cprint("@R{-  %s}" % subtraction.pop(0))  # bright red
+            cprint(f"@R{{-  {subtraction.pop(0)}}}")  # bright red
             if addition:
-                cprint("@G{+  %s}" % addition.pop(0))  # bright green
+                cprint(f"@G{{+  {addition.pop(0)}}}")  # bright green
 
         # Any additions left?
         while addition:
-            cprint("@G{+  %s}" % addition.pop(0))
+            cprint(f"@G{{+  {addition.pop(0)}}}")
 
 
 def diff(parser, args):

--- a/lib/spack/spack/cmd/env.py
+++ b/lib/spack/spack/cmd/env.py
@@ -356,9 +356,9 @@ def env_activate(args):
         return
 
     else:
-        tty.die("No such environment: '%s'" % args.env_name)
+        tty.die(f"No such environment: '{args.env_name}'")
 
-    env_prompt = "[%s]" % short_name
+    env_prompt = f"[{short_name}]"
 
     # We only support one active environment at a time, so deactivate the current one.
     if ev.active_environment() is None:
@@ -758,7 +758,7 @@ def env_list(args):
     color_names = []
     for name in names:
         if ev.active(name):
-            name = colorize("@*g{%s}" % name)
+            name = colorize(f"@*g{{{name}}}")
         color_names.append(name)
 
     # say how many there are if writing to a tty
@@ -766,7 +766,7 @@ def env_list(args):
         if not names:
             tty.msg("No environments")
         else:
-            tty.msg("%d environments" % len(names))
+            tty.msg(f"{len(names)} environments")
 
     colify(color_names, indent=4)
 
@@ -828,9 +828,9 @@ def env_status(args):
     env = ev.active_environment()
     if env:
         if env.path == os.getcwd():
-            tty.msg("Using %s in current directory: %s" % (ev.manifest_name, env.path))
+            tty.msg(f"Using {ev.manifest_name} in current directory: {env.path}")
         else:
-            tty.msg("In environment %s" % env.name)
+            tty.msg(f"In environment {env.name}")
 
         # Check if environment views can be safely activated
         env.check_views()
@@ -879,7 +879,7 @@ def env_loads(args):
         spack.cmd.modules.loads(module_type, specs, args, f)
 
     print("To load this environment, type:")
-    print("   source %s" % loads_file)
+    print(f"   source {loads_file}")
 
 
 def env_update_setup_parser(subparser):
@@ -905,7 +905,7 @@ def env_update(args):
 
     needs_update = not ev.is_latest_format(manifest_file)
     if not needs_update:
-        tty.msg('No update needed for the environment "{0}"'.format(args.update_env))
+        tty.msg(f'No update needed for the environment "{args.update_env}"')
         return
 
     proceed = True

--- a/lib/spack/spack/cmd/extensions.py
+++ b/lib/spack/spack/cmd/extensions.py
@@ -72,19 +72,19 @@ def extensions(parser, args):
     spec = cmd.disambiguate_spec(spec[0], env)
 
     if not spec.package.extendable:
-        tty.die("%s is not an extendable package." % spec.name)
+        tty.die(f"{spec.name} is not an extendable package.")
 
     if not spec.package.extendable:
-        tty.die("%s does not have extensions." % spec.short_spec)
+        tty.die(f"{spec.short_spec} does not have extensions.")
 
     if args.show in ("packages", "all"):
         # List package names of extensions
         extensions = spack.repo.PATH.extensions_for(spec)
         if not extensions:
-            tty.msg("%s has no extensions." % spec.cshort_spec)
+            tty.msg(f"{spec.cshort_spec} has no extensions.")
         else:
             tty.msg(spec.cshort_spec)
-            tty.msg("%d extensions:" % len(extensions))
+            tty.msg(f"{len(extensions)} extensions:")
             colify(ext.name for ext in extensions)
 
     if args.show in ("installed", "all"):
@@ -96,5 +96,5 @@ def extensions(parser, args):
         if not installed:
             tty.msg("None installed.")
         else:
-            tty.msg("%d installed:" % len(installed))
+            tty.msg(f"{len(installed)} installed:")
             cmd.display_specs(installed, args)

--- a/lib/spack/spack/cmd/external.py
+++ b/lib/spack/spack/cmd/external.py
@@ -114,7 +114,7 @@ def external_find(args):
                 # print a warning and keep going
                 tty.warn("Unable to read manifest due to insufficient permissions.", skip_msg)
             else:
-                tty.warn("Unable to read manifest, unexpected error: {0}".format(str(e)), skip_msg)
+                tty.warn(f"Unable to read manifest, unexpected error: {str(e)}", skip_msg)
 
     # Outside the Cray manifest, the search is done by tag for performance reasons,
     # since tags are cached.
@@ -207,30 +207,24 @@ def _collect_and_consume_cray_manifest_files(
 
     if not ignore_default_dir and os.path.isdir(cray_manifest.default_path):
         tty.debug(
-            "Cray manifest path {0} exists: collecting all files to read.".format(
-                cray_manifest.default_path
-            )
+            f"Cray manifest path {cray_manifest.default_path} exists: "
+            "collecting all files to read."
         )
         manifest_dirs.append(cray_manifest.default_path)
     else:
-        tty.debug(
-            "Default Cray manifest directory {0} does not exist.".format(
-                cray_manifest.default_path
-            )
-        )
+        tty.debug(f"Default Cray manifest directory {cray_manifest.default_path} does not exist.")
 
     for directory in manifest_dirs:
         for fname in os.listdir(directory):
             if fname.endswith(".json"):
                 fpath = os.path.join(directory, fname)
-                tty.debug("Adding manifest file: {0}".format(fpath))
+                tty.debug(f"Adding manifest file: {fpath}")
                 manifest_files.append(os.path.join(directory, fpath))
 
     if not manifest_files:
         raise NoManifestFileError(
-            "--file/--directory not specified, and no manifest found at {0}".format(
-                cray_manifest.default_path
-            )
+            f"--file/--directory not specified, "
+            f"and no manifest found at {cray_manifest.default_path}"
         )
 
     for path in manifest_files:
@@ -241,7 +235,7 @@ def _collect_and_consume_cray_manifest_files(
             if fail_on_error:
                 raise
             else:
-                tty.warn("Failure reading manifest file: {0}\n\t{1}".format(path, str(e)))
+                tty.warn(f"Failure reading manifest file: {path}\n\t{str(e)}")
 
 
 def external_list(args):

--- a/lib/spack/spack/cmd/find.py
+++ b/lib/spack/spack/cmd/find.py
@@ -329,7 +329,7 @@ def display_env(env, args, decorator, results, status_fn=None):
         cmd.display_specs(
             env.included_user_specs,
             root_args,
-            decorator=lambda s, f: color.colorize("@*{%s}" % f),
+            decorator=lambda s, f: color.colorize(f"@*{{{f}}}"),
             namespace=True,
             show_flags=True,
             variants=True,

--- a/lib/spack/spack/cmd/info.py
+++ b/lib/spack/spack/cmd/info.py
@@ -270,7 +270,7 @@ def print_phases(pkg: PackageBase, args: Namespace) -> None:
         color.cprint(section_title("Installation Phases:"))
         phase_str = ""
         for phase in builder.phases:
-            phase_str += "    {0}".format(phase)
+            phase_str += f"    {phase}"
         color.cprint(phase_str)
 
 
@@ -301,7 +301,7 @@ def print_tests(pkg: PackageBase, args: Namespace) -> None:
         (getattr(pkg, "install_time_test_callbacks", None), "Install"),
     ]:
         color.cprint("")
-        color.cprint(section_title("Available {0} Phase Test Methods:".format(phase)))
+        color.cprint(section_title(f"Available {phase} Phase Test Methods:"))
         names = []
         if callbacks:
             for name in callbacks:
@@ -595,7 +595,7 @@ def print_versions(pkg: PackageBase, args: Namespace) -> None:
                 return "No URL"
 
         url = get_url(preferred) if pkg.has_code else ""
-        line = version("    {0}".format(pad(preferred))) + color.cescape(str(url))
+        line = version(f"    {pad(preferred)}") + color.cescape(str(url))
         color.cwrite(line)
 
         print()
@@ -612,13 +612,13 @@ def print_versions(pkg: PackageBase, args: Namespace) -> None:
 
         for title, vers in [("Safe", safe), ("Deprecated", deprecated)]:
             color.cprint("")
-            color.cprint(section_title("{0} versions:  ".format(title)))
+            color.cprint(section_title(f"{title} versions:  "))
             if not vers:
                 color.cprint(version("    None"))
                 continue
 
             for v, url in vers:
-                line = version("    {0}".format(pad(v))) + color.cescape(str(url))
+                line = version(f"    {pad(v)}") + color.cescape(str(url))
                 color.cprint(line)
 
 
@@ -629,7 +629,9 @@ def print_virtuals(pkg: PackageBase, args: Namespace) -> None:
     color.cprint(section_title("Virtual Packages: "))
     if pkg.provided:
         for when, specs in reversed(sorted(pkg.provided.items())):
-            line = "    %s provides %s" % (when.cformat(), ", ".join(s.cformat() for s in specs))
+            line = "    {} provides {}".format(
+                when.cformat(), ", ".join(s.cformat() for s in specs)
+            )
             print(line)
 
     else:

--- a/lib/spack/spack/cmd/list.py
+++ b/lib/spack/spack/cmd/list.py
@@ -140,7 +140,7 @@ def name_only(pkgs, out):
     indent = 0
     colify(pkgs, indent=indent, output=out)
     if out.isatty():
-        tty.msg("%d packages" % len(pkgs))
+        tty.msg(f"{len(pkgs)} packages")
 
 
 def github_url(pkg: Type[spack.package_base.PackageBase]) -> Optional[str]:
@@ -229,22 +229,14 @@ def version_json(pkg_names, out):
     # output name and latest version for each package
     pkg_latest = ",\n".join(
         [
-            '  {{"name": "{0}",\n'
-            '   "latest_version": "{1}",\n'
-            '   "versions": {2},\n'
-            '   "homepage": "{3}",\n'
-            '   "file": "{4}",\n'
-            '   "maintainers": {5},\n'
-            '   "dependencies": {6}'
-            "}}".format(
-                pkg_cls.name,
-                VersionList(pkg_cls.versions).preferred(),
-                json.dumps([str(v) for v in reversed(sorted(pkg_cls.versions))]),
-                pkg_cls.homepage,
-                github_url(pkg_cls),
-                json.dumps(pkg_cls.maintainers),
-                json.dumps(get_dependencies(pkg_cls)),
-            )
+            f'  {{"name": "{pkg_cls.name}",\n'
+            f'   "latest_version": "{VersionList(pkg_cls.versions).preferred()}",\n'
+            f'   "versions": {json.dumps([str(v) for v in reversed(sorted(pkg_cls.versions))])},\n'
+            f'   "homepage": "{pkg_cls.homepage}",\n'
+            f'   "file": "{github_url(pkg_cls)}",\n'
+            f'   "maintainers": {json.dumps(pkg_cls.maintainers)},\n'
+            f'   "dependencies": {json.dumps(get_dependencies(pkg_cls))}'
+            "}"
             for pkg_cls in pkg_classes
         ]
     )
@@ -274,19 +266,16 @@ def html(pkg_names, out):
         if anchor is None:
             anchor = title
         out.write(
-            (
-                '<span id="id%d"></span>'
-                '<h1>%s<a class="headerlink" href="#%s" '
-                'title="Permalink to this headline">&para;</a>'
-                "</h1>\n"
-            )
-            % (span_id, title, anchor)
+            f'<span id="id{span_id}"></span>'
+            f'<h1>{title}<a class="headerlink" href="#{anchor}" '
+            'title="Permalink to this headline">&para;</a>'
+            "</h1>\n"
         )
 
     # Start with the number of packages, skipping the title and intro
     # blurb, which we maintain in the RST file.
     out.write("<p>\n")
-    out.write("Spack currently has %d mainline packages:\n" % len(pkg_classes))
+    out.write(f"Spack currently has {len(pkg_classes)} mainline packages:\n")
     out.write("</p>\n")
 
     # Table of links to all packages
@@ -296,7 +285,7 @@ def html(pkg_names, out):
         out.write('<tr class="row-odd">\n' if i % 2 == 0 else '<tr class="row-even">\n')
         for name in row:
             out.write("<td>\n")
-            out.write('<a class="reference internal" href="#%s">%s</a></td>\n' % (name, name))
+            out.write(f'<a class="reference internal" href="#{name}">{name}</a></td>\n')
             out.write("</td>\n")
         out.write("</tr>\n")
     out.write("</tbody>\n")
@@ -305,7 +294,7 @@ def html(pkg_names, out):
 
     # Output some text for each package.
     for pkg_cls in pkg_classes:
-        out.write('<div class="section" id="%s">\n' % pkg_cls.name)
+        out.write(f'<div class="section" id="{pkg_cls.name}">\n')
         head(2, span_id, pkg_cls.name)
         span_id += 1
 
@@ -316,8 +305,8 @@ def html(pkg_names, out):
 
         if pkg_cls.homepage:
             out.write(
-                ('<li><a class="reference external" href="%s">%s</a></li>\n')
-                % (pkg_cls.homepage, escape(pkg_cls.homepage, True))
+                f'<li><a class="reference external" href="{pkg_cls.homepage}">'
+                f"{escape(pkg_cls.homepage, True)}</a></li>\n"
             )
         else:
             out.write("No homepage\n")
@@ -326,8 +315,8 @@ def html(pkg_names, out):
         out.write("<dt>Spack package:</dt>\n")
         out.write('<dd><ul class="first last simple">\n')
         out.write(
-            ('<li><a class="reference external" href="%s">%s/package.py</a></li>\n')
-            % (github_url(pkg_cls), pkg_cls.name)
+            f'<li><a class="reference external" href="{github_url(pkg_cls)}">'
+            f"{pkg_cls.name}/package.py</a></li>\n"
         )
         out.write("</ul></dd>\n")
 
@@ -341,14 +330,14 @@ def html(pkg_names, out):
         for deptype in dt.ALL_TYPES:
             deps = pkg_cls.dependencies_of_type(dt.flag_from_string(deptype))
             if deps:
-                out.write("<dt>%s Dependencies:</dt>\n" % deptype.capitalize())
+                out.write(f"<dt>{deptype.capitalize()} Dependencies:</dt>\n")
                 out.write("<dd>\n")
                 out.write(
                     ", ".join(
                         (
                             d
                             if d not in pkg_names
-                            else '<a class="reference internal" href="#%s">%s</a>' % (d, d)
+                            else f'<a class="reference internal" href="#{d}">{d}</a>'
                         )
                         for d in deps
                     )
@@ -390,10 +379,10 @@ def list(parser, args):
         # change output stream if user asked for update
         if os.path.exists(args.update):
             if os.path.getmtime(args.update) > spack.repo.PATH.last_mtime():
-                tty.msg("File is up to date: %s" % args.update)
+                tty.msg(f"File is up to date: {args.update}")
                 return
 
-        tty.msg("Updating file: %s" % args.update)
+        tty.msg(f"Updating file: {args.update}")
         with open(args.update, "w", encoding="utf-8") as f:
             formatter(sorted_packages, f)
 

--- a/lib/spack/spack/cmd/location.py
+++ b/lib/spack/spack/cmd/location.py
@@ -119,7 +119,7 @@ def location(parser, args):
         else:
             # Get path of requested environment
             if not ev.exists(args.location_env):
-                tty.die("no such environment: '%s'" % args.location_env)
+                tty.die(f"no such environment: '{args.location_env}'")
             path = ev.root(args.location_env)
         print(path)
         return
@@ -137,7 +137,7 @@ def location(parser, args):
         if env.has_view(view_name):
             print(f"{env.views[view_name].root}\n")
         else:
-            tty.die("no such view in the current environment: '%s'" % view_name)
+            tty.die(f"no such view in the current environment: '{view_name}'")
         return
 
     if args.repo is not False:

--- a/lib/spack/spack/cmd/log_parse.py
+++ b/lib/spack/spack/cmd/log_parse.py
@@ -77,15 +77,15 @@ def log_parse(parser, args):
     types = [s.strip() for s in args.show.split(",")]
     for e in types:
         if e not in event_types:
-            args.subparser.error("invalid event type: %s" % e)
+            args.subparser.error(f"invalid event type: {e}")
 
     events = []
     if "errors" in types:
         events.extend(log_errors)
-        print("%d errors" % len(log_errors))
+        print(f"{len(log_errors)} errors")
     if "warnings" in types:
         events.extend(log_warnings)
-        print("%d warnings" % len(log_warnings))
+        print(f"{len(log_warnings)} warnings")
 
     if tail:
         events.append(tail)

--- a/lib/spack/spack/cmd/maintainers.py
+++ b/lib/spack/spack/cmd/maintainers.py
@@ -111,13 +111,13 @@ def maintainers(parser, args):
         if args.by_user:
             maintainers = maintainers_to_packages(args.package_or_user)
             for user, packages in sorted(maintainers.items()):
-                color.cprint("@c{%s}: %s" % (user, ", ".join(sorted(packages))))
+                color.cprint("@c{{{}}}: {}".format(user, ", ".join(sorted(packages))))
             return 0 if maintainers else 1
 
         else:
             packages = packages_to_maintainers(args.package_or_user)
             for pkg, maintainers in sorted(packages.items()):
-                color.cprint("@c{%s}: %s" % (pkg, ", ".join(sorted(maintainers))))
+                color.cprint("@c{{{}}}: {}".format(pkg, ", ".join(sorted(maintainers))))
             return 0 if packages else 1
 
     if args.by_user:

--- a/lib/spack/spack/cmd/make_installer.py
+++ b/lib/spack/spack/cmd/make_installer.py
@@ -75,7 +75,7 @@ def make_installer(parser, args):
 
         if spack_source:
             if not os.path.exists(spack_source):
-                print("%s does not exist" % spack_source)
+                print(f"{spack_source} does not exist")
                 return
             else:
                 if not os.path.isabs(spack_source):
@@ -103,11 +103,11 @@ def make_installer(parser, args):
                 source_dir,
                 "-B",
                 output_dir,
-                "-DSPACK_VERSION=%s" % spack_version,
-                "-DSPACK_SOURCE=%s" % spack_source,
-                "-DSPACK_LICENSE=%s" % spack_license,
-                "-DSPACK_LOGO=%s" % spack_logo,
-                "-DSPACK_GIT_VERBOSITY=%s" % git_verbosity,
+                f"-DSPACK_VERSION={spack_version}",
+                f"-DSPACK_SOURCE={spack_source}",
+                f"-DSPACK_LICENSE={spack_license}",
+                f"-DSPACK_LOGO={spack_logo}",
+                f"-DSPACK_GIT_VERBOSITY={git_verbosity}",
             )
         except spack.util.executable.ProcessError:
             print("Failed to generate installer")
@@ -115,7 +115,7 @@ def make_installer(parser, args):
 
         try:
             spack.util.executable.Executable(cpack_path)(
-                "--config", "%s/CPackConfig.cmake" % output_dir, "-B", "%s/" % output_dir
+                "--config", f"{output_dir}/CPackConfig.cmake", "-B", f"{output_dir}/"
             )
         except spack.util.executable.ProcessError:
             print("Failed to generate installer")
@@ -124,9 +124,9 @@ def make_installer(parser, args):
             spack.util.executable.Executable(os.environ.get("WIX") + "/bin/candle.exe")(
                 "-ext",
                 "WixBalExtension",
-                "%s/bundle.wxs" % output_dir,
+                f"{output_dir}/bundle.wxs",
                 "-out",
-                "%s/bundle.wixobj" % output_dir,
+                f"{output_dir}/bundle.wixobj",
             )
         except spack.util.executable.ProcessError:
             print("Failed to generate installer chain")
@@ -136,13 +136,13 @@ def make_installer(parser, args):
                 "-sw1134",
                 "-ext",
                 "WixBalExtension",
-                "%s/bundle.wixobj" % output_dir,
+                f"{output_dir}/bundle.wixobj",
                 "-out",
-                "%s/Spack.exe" % output_dir,
+                f"{output_dir}/Spack.exe",
             )
         except spack.util.executable.ProcessError:
             print("Failed to generate installer chain")
             return spack.util.executable.ProcessError.returncode
-        print("Successfully generated Spack.exe in %s" % (output_dir))
+        print(f"Successfully generated Spack.exe in {output_dir}")
     else:
         print("The make-installer command is currently only supported on Windows.")

--- a/lib/spack/spack/cmd/mark.py
+++ b/lib/spack/spack/cmd/mark.py
@@ -71,7 +71,7 @@ def find_matching_specs(
         # For each spec provided, make sure it refers to only one package.
         # Fail and ask user to be unambiguous if it doesn't
         if not allow_multiple_matches and len(matching) > 1:
-            tty.error("{0} matches multiple packages:".format(spec))
+            tty.error(f"{spec} matches multiple packages:")
             sys.stderr.write("\n")
             spack.cmd.display_specs(matching, output=sys.stderr, **display_args)
             sys.stderr.write("\n")

--- a/lib/spack/spack/cmd/mirror.py
+++ b/lib/spack/spack/cmd/mirror.py
@@ -435,7 +435,7 @@ def _configure_mirror(args):
         mirrors[args.name] = entry.to_dict()
         spack.config.set("mirrors", mirrors, scope=args.scope)
     else:
-        tty.msg("No changes made to mirror %s." % args.name)
+        tty.msg(f"No changes made to mirror {args.name}.")
 
 
 def mirror_set(args):
@@ -524,7 +524,7 @@ def concrete_specs_from_cli_or_file(args):
     if args.file:
         specs = specs_from_text_file(args.file, concretize=False)
         if not specs:
-            raise SpackError("unable to parse specs from file '{}'".format(args.file))
+            raise SpackError(f"unable to parse specs from file '{args.file}'")
 
     concrete_specs = spack.cmd.matching_specs_from_env(specs)
     return concrete_specs
@@ -551,9 +551,9 @@ class IncludeFilter:
             return True
         else:
             tty.debug(
-                "Skip adding {0} to mirror: the package.py file"
+                f"Skip adding {x.name} to mirror: the package.py file"
                 " indicates that a public mirror should not contain"
-                " it.".format(x.name)
+                " it."
             )
             return False
 
@@ -588,9 +588,7 @@ def versions_per_spec(args):
             num_versions = int(args.versions_per_spec)
         except ValueError:
             args.subparser.error(
-                "'--versions-per-spec' must be a number or 'all', got '{0}'".format(
-                    args.versions_per_spec
-                )
+                f"'--versions-per-spec' must be a number or 'all', got '{args.versions_per_spec}'"
             )
     return num_versions
 
@@ -599,9 +597,9 @@ def process_mirror_stats(present, mirrored, error):
     p, m, e = len(present), len(mirrored), len(error)
     tty.msg(
         "Archive stats:",
-        "  %-4d already present" % p,
-        "  %-4d added" % m,
-        "  %-4d failed to fetch." % e,
+        f"  {p:<4} already present",
+        f"  {m:<4} added",
+        f"  {e:<4} failed to fetch.",
     )
     if error:
         tty.error("Failed downloads:")

--- a/lib/spack/spack/cmd/modules/__init__.py
+++ b/lib/spack/spack/cmd/modules/__init__.py
@@ -179,12 +179,10 @@ def loads(module_type, specs, args, out=None):
     load_template = "{comment}{exclude}{command}{prefix}{name}"
     for spec, mod in modules:
         if not mod:
-            module_output_for_spec = "## excluded or missing from upstream: {0}".format(
-                spec.format()
-            )
+            module_output_for_spec = f"## excluded or missing from upstream: {spec.format()}"
         else:
             d["exclude"] = "## " if spec.name in exclude_set else ""
-            d["comment"] = "" if not args.shell else "# {0}\n".format(spec.format())
+            d["comment"] = "" if not args.shell else f"# {spec.format()}\n"
             d["name"] = mod
             module_output_for_spec = load_template.format(**d)
         out.write(module_output_for_spec)
@@ -313,9 +311,9 @@ def refresh(module_type, specs, args):
         message = "Name clashes detected in module files:\n"
         for filename, writer_list in file2writer.items():
             if len(writer_list) > 1:
-                message += "\nfile: {0}\n".format(filename)
+                message += f"\nfile: {filename}\n"
                 for x in writer_list:
-                    message += "spec: {0}\n".format(x.spec.format(spec_fmt_str))
+                    message += f"spec: {x.spec.format(spec_fmt_str)}\n"
         tty.error(message)
         tty.error("Operation aborted")
         raise SystemExit(1)
@@ -328,7 +326,7 @@ def refresh(module_type, specs, args):
     module_type_root = writers[0].layout.dirname()
 
     # Proceed regenerating module files
-    tty.msg("Regenerating {name} module files".format(name=module_type))
+    tty.msg(f"Regenerating {module_type} module files")
     if os.path.isdir(module_type_root) and args.delete_tree:
         shutil.rmtree(module_type_root, ignore_errors=False)
     filesystem.mkdirp(module_type_root)

--- a/lib/spack/spack/cmd/pkg.py
+++ b/lib/spack/spack/cmd/pkg.py
@@ -109,13 +109,13 @@ def pkg_diff(args):
     u1, u2 = spack.repo.diff_packages(args.rev1, args.rev2, spack.repo.builtin_repo())
 
     if u1:
-        print("%s:" % args.rev1)
+        print(f"{args.rev1}:")
         colify(sorted(u1), indent=4)
         if u1:
             print()
 
     if u2:
-        print("%s:" % args.rev2)
+        print(f"{args.rev2}:")
         colify(sorted(u2), indent=4)
 
 
@@ -154,10 +154,10 @@ def pkg_source(args):
 
     # regular source dump -- just get the package and print its contents
     if args.canonical:
-        message = "Canonical source for %s:" % filename
+        message = f"Canonical source for {filename}:"
         content = ph.canonical_source(spec)
     else:
-        message = "Source for %s:" % filename
+        message = f"Source for {filename}:"
         with open(filename, encoding="utf-8") as f:
             content = f.read()
 
@@ -261,6 +261,6 @@ def pkg(parser, args, unknown_args):
     if args.pkg_command == "grep":
         return pkg_grep(args, unknown_args)
     elif unknown_args:
-        args.subparser.error("unrecognized arguments: %s" % " ".join(unknown_args))
+        args.subparser.error("unrecognized arguments: {}".format(" ".join(unknown_args)))
     else:
         return action[args.pkg_command](args)

--- a/lib/spack/spack/cmd/providers.py
+++ b/lib/spack/spack/cmd/providers.py
@@ -55,6 +55,6 @@ def providers(parser, args):
     # Display providers
     for spec in specs:
         if sys.stdout.isatty():
-            print("{0}:".format(spec))
+            print(f"{spec}:")
         spack.cmd.display_specs(sorted(spack.repo.PATH.providers_for(spec)))
         print("")

--- a/lib/spack/spack/cmd/python.py
+++ b/lib/spack/spack/cmd/python.py
@@ -71,7 +71,7 @@ def python(parser, args, unknown_args):
         return
 
     if unknown_args:
-        args.subparser.error("unrecognized arguments: %s" % " ".join(unknown_args))
+        args.subparser.error("unrecognized arguments: {}".format(" ".join(unknown_args)))
 
     # Unexpected behavior from supplying both
     if args.python_command and args.python_args:
@@ -107,11 +107,9 @@ def ipython_interpreter(args):
     elif args.python_command:
         IPython.start_ipython(argv=["-c", args.python_command])
     else:
-        header = "Spack version %s\nPython %s, %s %s" % (
-            spack.spack_version,
-            platform.python_version(),
-            platform.system(),
-            platform.machine(),
+        header = (
+            f"Spack version {spack.spack_version}\n"
+            f"Python {platform.python_version()}, {platform.system()} {platform.machine()}"
         )
 
         __name__ = "__main__"  # noqa: F841
@@ -146,13 +144,8 @@ def python_interpreter(args):
                 console.push('readline.parse_and_bind("tab: complete")')
 
             console.interact(
-                "Spack version %s\nPython %s, %s %s"
-                % (
-                    spack.spack_version,
-                    platform.python_version(),
-                    platform.system(),
-                    platform.machine(),
-                )
+                f"Spack version {spack.spack_version}\n"
+                f"Python {platform.python_version()}, {platform.system()} {platform.machine()}"
             )
 
 

--- a/lib/spack/spack/cmd/repo.py
+++ b/lib/spack/spack/cmd/repo.py
@@ -220,8 +220,8 @@ def setup_parser(subparser: argparse.ArgumentParser):
 def repo_create(args):
     """create a new package repository"""
     full_path, namespace = spack.repo.create_repo(args.directory, args.namespace, args.subdir)
-    tty.msg("Created repo with namespace '%s'." % namespace)
-    tty.msg("To register it with spack, run this command:", "spack repo add %s" % full_path)
+    tty.msg(f"Created repo with namespace '{namespace}'.")
+    tty.msg("To register it with spack, run this command:", f"spack repo add {full_path}")
 
 
 def _add_repo(

--- a/lib/spack/spack/cmd/resource.py
+++ b/lib/spack/spack/cmd/resource.py
@@ -34,27 +34,27 @@ def _show_patch(sha256):
     if not data:
         candidates = [k for k in patches if k.startswith(sha256)]
         if not candidates:
-            tty.die("no such resource: %s" % sha256)
+            tty.die(f"no such resource: {sha256}")
         elif len(candidates) > 1:
             tty.die("%s: ambiguous hash prefix. Options are:", *candidates)
 
         sha256 = candidates[0]
         data = patches.get(sha256)
 
-    color.cprint("@c{%s}" % sha256)
+    color.cprint(f"@c{{{sha256}}}")
     for package, rec in data.items():
         owner = rec["owner"]
 
         if "relative_path" in rec:
             pkg_dir = spack.repo.PATH.get_pkg_class(owner).package_dir
             path = os.path.join(pkg_dir, rec["relative_path"])
-            print("    path:       %s" % path)
+            print(f"    path:       {path}")
         else:
-            print("    url:        %s" % rec["url"])
+            print("    url:        {}".format(rec["url"]))
 
-        print("    applies to: %s" % package)
+        print(f"    applies to: {package}")
         if owner != package:
-            print("    patched by: %s" % owner)
+            print(f"    patched by: {owner}")
 
 
 def resource_list(args):

--- a/lib/spack/spack/cmd/solve.py
+++ b/lib/spack/spack/cmd/solve.py
@@ -57,7 +57,7 @@ def setup_parser(subparser: argparse.ArgumentParser) -> None:
 def _process_result(result, show, required_format, kwargs):
     opt, _, _ = min(result.answers)
     if ("opt" in show) and (not required_format):
-        tty.msg("Best of %d considered solutions." % result.nmodels)
+        tty.msg(f"Best of {result.nmodels} considered solutions.")
 
         print()
         maxlen = max(len(s.name) for s in result.criteria)
@@ -142,8 +142,9 @@ def solve(parser, args):
     for d in show:
         if d not in show_options:
             raise ValueError(
-                "Invalid option for '--show': '%s'\nchoose from: (%s)"
-                % (d, ", ".join(show_options + ("all",)))
+                "Invalid option for '--show': '{}'\nchoose from: ({})".format(
+                    d, ", ".join(show_options + ("all",))
+                )
             )
 
     # Format required for the output (JSON, YAML or None)
@@ -174,10 +175,10 @@ def solve(parser, args):
             )
         ):
             if "solutions" in show:
-                tty.msg("ROUND {0}".format(idx))
+                tty.msg(f"ROUND {idx}")
                 tty.msg("")
             else:
-                print("% END ROUND {0}\n".format(idx))
+                print(f"% END ROUND {idx}\n")
             if not setup_only:
                 _process_result(result, show, required_format, kwargs)
     elif unify:

--- a/lib/spack/spack/cmd/style.py
+++ b/lib/spack/spack/cmd/style.py
@@ -90,12 +90,12 @@ def changed_files(base="develop", untracked=True, all_files=False, root=None) ->
     )
     if git.returncode != 0:
         tty.die(
-            "This repository does not have a '%s' revision." % base,
+            f"This repository does not have a '{base}' revision.",
             "spack style needs this branch to determine which files changed.",
-            "Ensure that '%s' exists, or specify files to check explicitly." % base,
+            f"Ensure that '{base}' exists, or specify files to check explicitly.",
         )
 
-    range = "{0}...".format(base_sha.strip())
+    range = f"{base_sha.strip()}..."
 
     git_args = [
         # Add changed files committed since branching off of develop
@@ -179,14 +179,14 @@ def setup_parser(subparser: argparse.ArgumentParser) -> None:
         "-t",
         "--tool",
         action="append",
-        help="specify which tools to run (default: %s)" % ", ".join(tool_names),
+        help="specify which tools to run (default: {})".format(", ".join(tool_names)),
     )
     tool_group.add_argument(
         "-s",
         "--skip",
         metavar="TOOL",
         action="append",
-        help="specify tools to skip (choose from %s)" % ", ".join(tool_names),
+        help="specify tools to skip (choose from {})".format(", ".join(tool_names)),
     )
     subparser.add_argument(
         "--spec-strings",
@@ -236,9 +236,9 @@ def rewrite_and_print_output(
 
 def print_tool_result(tool, returncode):
     if returncode == 0:
-        color.cprint("  @g{%s checks were clean}" % tool)
+        color.cprint(f"  @g{{{tool} checks were clean}}")
     else:
-        color.cprint("  @r{%s found errors}" % tool)
+        color.cprint(f"  @r{{{tool} found errors}}")
 
 
 @tool("ruff-check", cmd="ruff")
@@ -489,7 +489,7 @@ def validate_toolset(arg_value):
     tools = set(",".join(arg_value).split(","))  # allow args like 'isort,flake8'
     for tool in tools:
         if tool not in tool_names:
-            tty.die("Invalid tool: '%s'" % tool, "Choose from: %s" % ", ".join(tool_names))
+            tty.die(f"Invalid tool: '{tool}'", "Choose from: {}".format(", ".join(tool_names)))
     return tools
 
 
@@ -522,7 +522,7 @@ def style(parser, args):
     args.root = Path(args.root).resolve() if args.root else Path(spack.paths.prefix)
     spack_script = args.root / "bin" / "spack"
     if not spack_script.exists():
-        tty.die("This does not look like a valid spack root.", "No such file: '%s'" % spack_script)
+        tty.die("This does not look like a valid spack root.", f"No such file: '{spack_script}'")
 
     def prefix_relative(path: Union[Path, str]) -> Path:
         return Path(os.path.relpath(os.path.abspath(os.path.realpath(path)), args.root))

--- a/lib/spack/spack/cmd/tags.py
+++ b/lib/spack/spack/cmd/tags.py
@@ -23,8 +23,8 @@ def report_tags(category, tags):
 
     if isatty:
         num = len(tags)
-        fmt = "{0} package tag".format(category)
-        buffer.write("{0}:\n".format(spack.util.string.plural(num, fmt)))
+        fmt = f"{category} package tag"
+        buffer.write(f"{spack.util.string.plural(num, fmt)}:\n")
 
     if tags:
         colify.colify(tags, output=buffer, tty=isatty, indent=4)
@@ -97,12 +97,12 @@ def tags(parser, args):
         # TODO: tag cache since it can accumulate duplicates.
         packages = sorted(list(set(tag_pkgs[tag])))
         if isatty:
-            buffer.write("{0}:\n".format(tag))
+            buffer.write(f"{tag}:\n")
 
         if packages:
             colify.colify(packages, output=buffer, tty=isatty, indent=4)
         else:
-            buffer.write("    {0}\n".format(missing))
+            buffer.write(f"    {missing}\n")
         buffer.write("\n")
     print(buffer.getvalue())
 

--- a/lib/spack/spack/cmd/test.py
+++ b/lib/spack/spack/cmd/test.py
@@ -156,7 +156,7 @@ def test_run(args):
     if args.alias:
         suites = spack.install_test.get_named_test_suites(args.alias)
         if suites:
-            tty.die('Test suite "{0}" already exists. Try another alias.'.format(args.alias))
+            tty.die(f'Test suite "{args.alias}" already exists. Try another alias.')
 
     # cdash help option
     if args.help_cdash:
@@ -216,7 +216,7 @@ def test_run(args):
 
 
 def report_filename(args, test_suite):
-    return os.path.abspath(args.log_file or "test-{}".format(test_suite.name))
+    return os.path.abspath(args.log_file or f"test-{test_suite.name}")
 
 
 def test_list(args):
@@ -236,7 +236,7 @@ def test_list(args):
 
         if sys.stdout.isatty():
             filtered = " tagged" if args.tag else ""
-            tty.msg("{0}{1} packages with tests.".format(len(report_packages), filtered))
+            tty.msg(f"{len(report_packages)}{filtered} packages with tests.")
         colify.colify(report_packages)
         return
 
@@ -284,7 +284,7 @@ def test_find(args):  # TODO: merge with status (noargs)
     if names:
         # TODO: Make these specify results vs active
         msg = "Spack test results available for the following tests:\n"
-        msg += "        %s\n" % " ".join(names)
+        msg += "        {}\n".format(" ".join(names))
         msg += "    Run `spack test remove` to remove all tests"
         tty.msg(msg)
     else:
@@ -302,7 +302,7 @@ def test_status(args):
             if test_suite:
                 test_suites.append(test_suite)
             else:
-                tty.msg("No test suite %s found in test stage" % name)
+                tty.msg(f"No test suite {name} found in test stage")
     else:
         test_suites = spack.install_test.get_all_test_suites()
         if not test_suites:
@@ -311,7 +311,7 @@ def test_status(args):
     for test_suite in test_suites:
         # TODO: Make this handle capability tests too
         # TODO: Make this handle tests running in another process
-        tty.msg("Test suite %s completed" % test_suite.name)
+        tty.msg(f"Test suite {test_suite.name} completed")
 
 
 def _report_suite_results(test_suite, args, constraints):
@@ -338,7 +338,7 @@ def _report_suite_results(test_suite, args, constraints):
     if os.path.exists(test_suite.results_file):
         results_desc = "Failing results" if args.failed else "Results"
         matching = ", spec matching '{0}'".format(" ".join(constraints)) if constraints else ""
-        tty.msg("{0} for test suite '{1}'{2}:".format(results_desc, test_suite.name, matching))
+        tty.msg(f"{results_desc} for test suite '{test_suite.name}'{matching}:")
 
         results = {}
         with open(test_suite.results_file, "r", encoding="utf-8") as f:
@@ -361,7 +361,7 @@ def _report_suite_results(test_suite, args, constraints):
                 if args.failed and status != spack.install_test.TestStatus.FAILED:
                     continue
 
-                msg = "  {0} {1}".format(pkg_id, status)
+                msg = f"  {pkg_id} {status}"
                 if args.logs:
                     spec = test_specs[pkg_id]
                     log_file = test_suite.log_file_for_spec(spec)
@@ -372,9 +372,9 @@ def _report_suite_results(test_suite, args, constraints):
 
         spack.install_test.write_test_summary(counts)
     else:
-        msg = "Test %s has no results.\n" % test_suite.name
+        msg = f"Test {test_suite.name} has no results.\n"
         msg += "        Check if it is running with "
-        msg += "`spack test status %s`" % test_suite.name
+        msg += f"`spack test status {test_suite.name}`"
         tty.msg(msg)
 
 
@@ -421,7 +421,7 @@ def test_remove(args):
             if test_suite:
                 test_suites.append(test_suite)
             else:
-                tty.msg("No test suite %s found in test stage" % name)
+                tty.msg(f"No test suite {name} found in test stage")
     else:
         test_suites = spack.install_test.get_all_test_suites()
 
@@ -443,4 +443,4 @@ def test_remove(args):
 
 
 def test(parser, args):
-    globals()["test_%s" % args.test_command](args)
+    globals()[f"test_{args.test_command}"](args)

--- a/lib/spack/spack/cmd/undevelop.py
+++ b/lib/spack/spack/cmd/undevelop.py
@@ -38,7 +38,7 @@ def _update_config(specs_to_remove):
         modified = False
         for spec in specs_to_remove:
             if spec.name in dev_config:
-                tty.msg("Undevelop: removing {0}".format(spec.name))
+                tty.msg(f"Undevelop: removing {spec.name}")
                 del dev_config[spec.name]
                 modified = True
         return modified

--- a/lib/spack/spack/cmd/uninstall.py
+++ b/lib/spack/spack/cmd/uninstall.py
@@ -107,7 +107,7 @@ def find_matching_specs(
         # For each spec provided, make sure it refers to only one package.
         # Fail and ask user to be unambiguous if it doesn't
         if not allow_multiple_matches and len(matching) > 1:
-            tty.error("{0} matches multiple packages:".format(spec))
+            tty.error(f"{spec} matches multiple packages:")
             sys.stderr.write("\n")
             spack.cmd.display_specs(matching, output=sys.stderr, **display_args)
             sys.stderr.write("\n")
@@ -117,10 +117,10 @@ def find_matching_specs(
         # No installed package matches the query
         if len(matching) == 0 and spec is not None:
             if env:
-                pkg_type = "packages in environment '%s'" % env.name
+                pkg_type = f"packages in environment '{env.name}'"
             else:
                 pkg_type = "installed packages"
-            tty.die("{0} does not match any {1}.".format(spec, pkg_type))
+            tty.die(f"{spec} does not match any {pkg_type}.")
 
         specs_from_cli.extend(matching)
 

--- a/lib/spack/spack/cmd/unit_test.py
+++ b/lib/spack/spack/cmd/unit_test.py
@@ -114,8 +114,8 @@ def do_list(args, extra_args):
 
     def colorize(c, prefix):
         if isinstance(prefix, tuple):
-            return "::".join(color.colorize("@%s{%s}" % (c, p)) for p in prefix if p != "()")
-        return color.colorize("@%s{%s}" % (c, prefix))
+            return "::".join(color.colorize(f"@{c}{{{p}}}") for p in prefix if p != "()")
+        return color.colorize(f"@{c}{{{prefix}}}")
 
     # To list the files we just need to inspect the filesystem,
     # which doesn't need to wait for pytest collection and doesn't

--- a/lib/spack/spack/cmd/unload.py
+++ b/lib/spack/spack/cmd/unload.py
@@ -84,7 +84,7 @@ def unload(parser, args):
         specs_str = " ".join(args.specs) or "SPECS"
 
         spack.cmd.common.shell_init_instructions(
-            "spack unload", "    eval `spack unload {sh_arg}` %s" % specs_str
+            "spack unload", f"    eval `spack unload {{sh_arg}}` {specs_str}"
         )
         return 1
 

--- a/lib/spack/spack/cmd/url.py
+++ b/lib/spack/spack/cmd/url.py
@@ -111,14 +111,14 @@ def url(parser, args):
 def url_parse(args):
     url = args.url
 
-    tty.msg("Parsing URL: {0}".format(url))
+    tty.msg(f"Parsing URL: {url}")
     print()
 
     ver, vs, vl, vi, vregex = parse_version_offset(url)
-    tty.msg("Matched version regex {0:>2}: r{1!r}".format(vi, vregex))
+    tty.msg(f"Matched version regex {vi:>2}: r{vregex!r}")
 
     name, ns, nl, ni, nregex = parse_name_offset(url, ver)
-    tty.msg("Matched  name   regex {0:>2}: r{1!r}".format(ni, nregex))
+    tty.msg(f"Matched  name   regex {ni:>2}: r{nregex!r}")
 
     print()
     tty.msg("Detected:")
@@ -127,8 +127,8 @@ def url_parse(args):
     except UrlParseError as e:
         tty.error(str(e))
 
-    print("    name:    {0}".format(name))
-    print("    version: {0}".format(ver))
+    print(f"    name:    {name}")
+    print(f"    version: {ver}")
     print()
 
     tty.msg("Substituting version 9.9.9b:")
@@ -141,7 +141,7 @@ def url_parse(args):
         versions = spack.url.find_versions_of_archive(url)
 
         if not versions:
-            print("  Found no versions for {0}".format(name))
+            print(f"  Found no versions for {name}")
             return
 
         max_len = max(len(str(v)) for v in versions)
@@ -234,16 +234,14 @@ def url_summary(args):
                 pass
 
     print()
-    print("    Total URLs found:          {0}".format(total_urls))
+    print(f"    Total URLs found:          {total_urls}")
     print(
-        "    Names correctly parsed:    {0:>4}/{1:>4} ({2:>6.2%})".format(
-            correct_names, total_urls, correct_names / total_urls
-        )
+        f"    Names correctly parsed:    {correct_names:>4}/{total_urls:>4} "
+        f"({correct_names / total_urls:>6.2%})"
     )
     print(
-        "    Versions correctly parsed: {0:>4}/{1:>4} ({2:>6.2%})".format(
-            correct_versions, total_urls, correct_versions / total_urls
-        )
+        f"    Versions correctly parsed: {correct_versions:>4}/{total_urls:>4} "
+        f"({correct_versions / total_urls:>6.2%})"
     )
     print()
 
@@ -253,13 +251,8 @@ def url_summary(args):
     print("    Index   Right   Wrong   Total   Regular Expression")
     for ni in sorted(name_regex_dict.keys()):
         print(
-            "    {0:>5}   {1:>5}   {2:>5}   {3:>5}   r{4!r}".format(
-                ni,
-                right_name_count[ni],
-                wrong_name_count[ni],
-                right_name_count[ni] + wrong_name_count[ni],
-                name_regex_dict[ni],
-            )
+            f"    {ni:>5}   {right_name_count[ni]:>5}   {wrong_name_count[ni]:>5}   "
+            f"{right_name_count[ni] + wrong_name_count[ni]:>5}   r{name_regex_dict[ni]!r}"
         )
     print()
 
@@ -269,13 +262,8 @@ def url_summary(args):
     print("    Index   Right   Wrong   Total   Regular Expression")
     for vi in sorted(version_regex_dict.keys()):
         print(
-            "    {0:>5}   {1:>5}   {2:>5}   {3:>5}   r{4!r}".format(
-                vi,
-                right_version_count[vi],
-                wrong_version_count[vi],
-                right_version_count[vi] + wrong_version_count[vi],
-                version_regex_dict[vi],
-            )
+            f"    {vi:>5}   {right_version_count[vi]:>5}   {wrong_version_count[vi]:>5}   "
+            f"{right_version_count[vi] + wrong_version_count[vi]:>5}   r{version_regex_dict[vi]!r}"
         )
     print()
 
@@ -351,27 +339,25 @@ def url_stats(args):
                 resource_stats.add(pkg_cls.name, resource.fetcher)
 
     # print a nice summary table
-    tty.msg("URL stats for %d packages:" % npkgs)
+    tty.msg(f"URL stats for {npkgs} packages:")
 
     def print_line():
         print("-" * 62)
 
     def print_stat(indent, name, stat_name=None):
         width = 20 - indent
-        fmt = " " * indent
-        fmt += "%%-%ds" % width
+        prefix = " " * indent
         if stat_name is None:
-            print(fmt % name)
+            print(f"{prefix}{name:<{width}}")
         else:
-            fmt += "%12d%8.1f%%%12d%8.1f%%"
             v = getattr(version_stats, stat_name).get(name, 0)
             r = getattr(resource_stats, stat_name).get(name, 0)
-            print(
-                fmt % (name, v, v / version_stats.total * 100, r, r / resource_stats.total * 100)
-            )
+            vp = v / version_stats.total * 100
+            rp = r / resource_stats.total * 100
+            print(f"{prefix}{name:<{width}}{v:12d}{vp:8.1f}%{r:12d}{rp:8.1f}%")
 
     print_line()
-    print("%-20s%12s%9s%12s%9s" % ("stat", "versions", "%", "resources", "%"))
+    print(f"{'stat':<20}{'versions':>12}{'%':>9}{'resources':>12}{'%':>9}")
     print_line()
     print_stat(0, "url", "url_type")
 
@@ -403,13 +389,13 @@ def url_stats(args):
             len(issues) for _, pkg_issues in issues.items() for _, issues in pkg_issues.items()
         )
         print()
-        tty.msg("Found %d issues." % total_issues)
+        tty.msg(f"Found {total_issues} issues.")
         for issue_type, pkgs in issues.items():
-            tty.msg("Package URLs with %s" % issue_type)
+            tty.msg(f"Package URLs with {issue_type}")
             for pkg_cls, pkg_issues in pkgs.items():
-                color.cprint("    @*C{%s}" % pkg_cls)
+                color.cprint(f"    @*C{{{pkg_cls}}}")
                 for issue in pkg_issues:
-                    print("      %s" % issue)
+                    print(f"      {issue}")
 
 
 def print_name_and_version(url):
@@ -426,7 +412,7 @@ def print_name_and_version(url):
     for i in range(vs, vs + vl):
         underlines[i] = "~"
 
-    print("    {0}".format(url))
+    print(f"    {url}")
     print("    {0}".format("".join(underlines)))
 
 

--- a/lib/spack/spack/cmd/verify.py
+++ b/lib/spack/spack/cmd/verify.py
@@ -226,7 +226,7 @@ def verify_manifest(args):
             if args.json:
                 print(results.json_string())
             else:
-                tty.msg("In package %s" % spec.format("{name}/{hash:7}"))
+                tty.msg("In package {}".format(spec.format("{name}/{hash:7}")))
                 print(results)
             return 1
         else:

--- a/lib/spack/spack/cmd/view.py
+++ b/lib/spack/spack/cmd/view.py
@@ -222,7 +222,7 @@ def view(parser, args):
     if getattr(args, "all", False):
         specs = view.get_all_specs()
         if len(specs) == 0:
-            tty.warn("Found no specs in %s" % path)
+            tty.warn(f"Found no specs in {path}")
 
     elif args.action in actions_link:
         # only link commands need to disambiguate specs
@@ -266,4 +266,4 @@ def view(parser, args):
         view.print_status(*specs, with_dependencies=with_dependencies)
 
     else:
-        tty.error('Unknown action: "%s"' % args.action)
+        tty.error(f'Unknown action: "{args.action}"')

--- a/lib/spack/spack/config.py
+++ b/lib/spack/spack/config.py
@@ -1540,7 +1540,7 @@ def config_paths_from_entry_points() -> List[Tuple[str, str]]:
         if callable(hook):
             config_path = hook()
             if config_path and os.path.exists(config_path):
-                config_paths.append(("plugin-%s" % entry_point.name, str(config_path)))
+                config_paths.append((f"plugin-{entry_point.name}", str(config_path)))
     return config_paths
 
 
@@ -2059,7 +2059,7 @@ class ConfigPath:
             if element.endswith("::") or (element.endswith(":") and i == last_element_idx):
                 if seen_override_in_path:
                     raise syaml.SpackYAMLError(
-                        "Meaningless second override indicator `::' in path `{0}'".format(path), ""
+                        f"Meaningless second override indicator `::' in path `{path}'", ""
                     )
                 override = True
                 seen_override_in_path = True

--- a/lib/spack/spack/container/images.py
+++ b/lib/spack/spack/container/images.py
@@ -92,7 +92,7 @@ def bootstrap_template_for(image):
 
 def _verify_ref(url, ref, enforce_sha):
     # Do a checkout in a temporary directory
-    msg = 'Cloning "{0}" to verify ref "{1}"'.format(url, ref)
+    msg = f'Cloning "{url}" to verify ref "{ref}"'
     tty.info(msg, stream=sys.stderr)
     git = spack.util.git.git(required=True)
     with fs.temporary_dir():

--- a/lib/spack/spack/cray_manifest.py
+++ b/lib/spack/spack/cray_manifest.py
@@ -152,7 +152,7 @@ def spec_from_entry(entry):
 
             # Value could be a list (of strings), boolean, or string
             if isinstance(value, str):
-                variant_strs.append("{0}={1}".format(name, value))
+                variant_strs.append(f"{name}={value}")
             else:
                 try:
                     iter(value)
@@ -164,12 +164,10 @@ def spec_from_entry(entry):
                 # At this point not a string or collection, check for boolean
                 if value in [True, False]:
                     bool_symbol = "+" if value else "~"
-                    variant_strs.append("{0}{1}".format(bool_symbol, name))
+                    variant_strs.append(f"{bool_symbol}{name}")
                 else:
                     raise ValueError(
-                        "Unexpected value for {0} ({1}): {2}".format(
-                            name, str(type(value)), str(value)
-                        )
+                        f"Unexpected value for {name} ({str(type(value))}): {str(value)}"
                     )
         spec_str += " " + " ".join(variant_strs)
 
@@ -231,7 +229,7 @@ def read(path, apply_updates):
         raise ManifestValidationError("error parsing manifest JSON:", str(e)) from e
 
     specs = entries_to_specs(json_data["specs"])
-    tty.debug("{0}: {1} specs read from manifest".format(path, str(len(specs))))
+    tty.debug(f"{path}: {str(len(specs))} specs read from manifest")
     compilers = []
     if "compilers" in json_data:
         for x in json_data["compilers"]:

--- a/lib/spack/spack/database.py
+++ b/lib/spack/spack/database.py
@@ -1128,8 +1128,8 @@ class Database:
             found = rec.ref_count
             if not expected == found:
                 raise AssertionError(
-                    "Invalid ref_count: %s: %d (expected %d), in DB %s"
-                    % (key, found, expected, self._index_path)
+                    f"Invalid ref_count: {key}: {found} (expected {expected}), "
+                    f"in DB {self._index_path}"
                 )
 
     def _write(self, type=None, value=None, traceback=None):
@@ -1153,7 +1153,7 @@ class Database:
             self._state_is_inconsistent = True
             return
 
-        temp_file = str(self._index_path) + (".%s.%s.temp" % (_gethostname(), os.getpid()))
+        temp_file = str(self._index_path) + (f".{_gethostname()}.{os.getpid()}.temp")
 
         # Write a temporary database file them move it into place
         try:
@@ -1468,7 +1468,7 @@ class Database:
     ) -> Set["spack.spec.Spec"]:
         """Return installed specs related to this one."""
         if direction not in ("parents", "children"):
-            raise ValueError("Invalid direction: %s" % direction)
+            raise ValueError(f"Invalid direction: {direction}")
 
         relatives: Set[spack.spec.Spec] = set()
         for spec in self.query(spec):

--- a/lib/spack/spack/detection/common.py
+++ b/lib/spack/spack/detection/common.py
@@ -101,7 +101,7 @@ def _spec_is_valid(spec: spack.spec.Spec) -> bool:
     except spack.error.SpackError:
         tty.warn(
             "Constructed spec has a string representation but the string"
-            " representation does not evaluate to a valid spec: {0}".format(str(spec))
+            f" representation does not evaluate to a valid spec: {str(spec)}"
         )
         return False
 
@@ -402,7 +402,7 @@ def find_win32_additional_install_paths() -> List[str]:
     # to interact with Windows
     # Add search path for default Chocolatey (https://github.com/chocolatey/choco)
     # install directory
-    windows_search_ext.append("%s\\ProgramData\\chocolatey\\bin" % drive_letter)
+    windows_search_ext.append(f"{drive_letter}\\ProgramData\\chocolatey\\bin")
     # Add search path for NuGet package manager default install location
     windows_search_ext.append(os.path.join(user, ".nuget", "packages"))
     windows_search_ext.extend(

--- a/lib/spack/spack/directives.py
+++ b/lib/spack/spack/directives.py
@@ -603,7 +603,7 @@ def _execute_patch(
 
     if hasattr(pkg, "has_code") and not pkg.has_code:
         raise UnsupportedPackageDirective(
-            "Patches are not allowed in {0}: package has no code.".format(pkg.name)
+            f"Patches are not allowed in {pkg.name}: package has no code."
         )
 
     when_spec = _make_when_spec(when)

--- a/lib/spack/spack/directory_layout.py
+++ b/lib/spack/spack/directory_layout.py
@@ -104,7 +104,7 @@ class DirectoryLayout:
                         "install_tree projections"
                     )
                 self.projections[when_spec] = projection.replace(
-                    "{hash}", "{hash:%d}" % self.hash_length
+                    "{hash}", f"{{hash:{self.hash_length}}}"
                 )
 
         # If any of these paths change, downstream databases may not be able to
@@ -120,7 +120,7 @@ class DirectoryLayout:
 
     @property
     def hidden_file_regexes(self) -> Tuple[str]:
-        return ("^{0}$".format(re.escape(self.metadata_dir)),)
+        return (f"^{re.escape(self.metadata_dir)}$",)
 
     def relative_path_for_spec(self, spec: "spack.spec.Spec") -> str:
         _check_concrete(spec)
@@ -252,9 +252,7 @@ class DirectoryLayout:
         spec_file_path = self.spec_file_path(spec)
 
         if not os.path.isdir(path):
-            raise InconsistentInstallDirectoryError(
-                "Install prefix {0} does not exist.".format(path)
-            )
+            raise InconsistentInstallDirectoryError(f"Install prefix {path} does not exist.")
 
         if not os.path.isfile(spec_file_path):
             raise InconsistentInstallDirectoryError(
@@ -264,7 +262,7 @@ class DirectoryLayout:
         installed_spec = self.read_spec(spec_file_path)
         if installed_spec.dag_hash() != spec.dag_hash():
             raise InconsistentInstallDirectoryError(
-                "Spec file in %s does not match hash!" % spec_file_path
+                f"Spec file in {spec_file_path} does not match hash!"
             )
 
     def path_for_spec(self, spec: "spack.spec.Spec") -> str:
@@ -368,7 +366,7 @@ class RemoveFailedError(DirectoryLayoutError):
 
     def __init__(self, installed_spec, prefix, error):
         super().__init__(
-            "Could not remove prefix %s for %s : %s" % (prefix, installed_spec.short_spec, error)
+            f"Could not remove prefix {prefix} for {installed_spec.short_spec} : {error}"
         )
         self.cause = error
 
@@ -399,7 +397,7 @@ class ExtensionAlreadyInstalledError(DirectoryLayoutError):
     """Raised when an extension is added to a package that already has it."""
 
     def __init__(self, spec, ext_spec):
-        super().__init__("%s is already installed in %s" % (ext_spec.short_spec, spec.short_spec))
+        super().__init__(f"{ext_spec.short_spec} is already installed in {spec.short_spec}")
 
 
 class ExtensionConflictError(DirectoryLayoutError):
@@ -407,6 +405,6 @@ class ExtensionConflictError(DirectoryLayoutError):
 
     def __init__(self, spec, ext_spec, conflict):
         super().__init__(
-            "%s cannot be installed in %s because it conflicts with %s"
-            % (ext_spec.short_spec, spec.short_spec, conflict.short_spec)
+            f"{ext_spec.short_spec} cannot be installed in {spec.short_spec} "
+            f"because it conflicts with {conflict.short_spec}"
         )

--- a/lib/spack/spack/environment/environment.py
+++ b/lib/spack/spack/environment/environment.py
@@ -234,7 +234,7 @@ def activate(env, use_env_repo=False):
 
         # Fail early to avoid ending in an invalid state
         if not isinstance(env, Environment):
-            raise TypeError("`env` should be of type {0}".format(Environment.__name__))
+            raise TypeError(f"`env` should be of type {Environment.__name__}")
 
         # Check if we need to reinitialize spack.store.STORE and spack.repo.REPO due to
         # config changes.
@@ -329,7 +329,7 @@ def as_env_dir(name_or_dir):
     else:
         validate_env_name(name_or_dir)
         if not exists(name_or_dir):
-            raise SpackEnvironmentError("no such environment '%s'" % name_or_dir)
+            raise SpackEnvironmentError(f"no such environment '{name_or_dir}'")
         return _root(name_or_dir)
 
 
@@ -342,7 +342,7 @@ def read(name):
     """Get an environment with the supplied name."""
     validate_env_name(name)
     if not exists(name):
-        raise SpackEnvironmentError("no such environment '%s'" % name)
+        raise SpackEnvironmentError(f"no such environment '{name}'")
     return Environment(root(name))
 
 
@@ -474,7 +474,7 @@ def _rewrite_relative_dev_paths_on_relocation(env, init_file_dir, copied_env=Fal
             if copied_env and expanded_path.startswith(init_file_dir):
                 continue
 
-            tty.debug("Expanding develop path for {0} to {1}".format(name, expanded_path))
+            tty.debug(f"Expanding develop path for {name} to {expanded_path}")
 
             dev_specs[name]["path"] = expanded_path
 
@@ -509,7 +509,7 @@ def _rewrite_relative_repos_paths_on_relocation(env, init_file_dir, copied_env=F
             if copied_env and expanded_path.startswith(init_file_dir):
                 continue
 
-            tty.debug("Expanding repo path for {0} to {1}".format(entry, expanded_path))
+            tty.debug(f"Expanding repo path for {entry} to {expanded_path}")
 
             repos_specs[name] = expanded_path
 
@@ -961,7 +961,7 @@ class ViewDescriptor:
         if os.path.islink(old_root):
             # Old format: only remove symlink target if it lives inside ._<name>/
             target = os.path.realpath(old_root)
-            old_view_container = os.path.join(root_parent, "._%s" % root_basename)
+            old_view_container = os.path.join(root_parent, f"._{root_basename}")
             if target.startswith(old_view_container + os.sep):
                 try:
                     shutil.rmtree(target)
@@ -1499,9 +1499,7 @@ class Environment:
 
         matches = list((idx, x) for idx, x in enumerate(list_to_change) if x.satisfies(match_spec))
         if len(matches) == 0:
-            raise ValueError(
-                "There are no specs named {0} in {1}".format(match_spec.name, list_name)
-            )
+            raise ValueError(f"There are no specs named {match_spec.name} in {list_name}")
         elif len(matches) > 1 and not allow_changing_multiple_specs:
             raise ValueError(f"{str(match_spec)} matches multiple specs")
 
@@ -1887,8 +1885,8 @@ class Environment:
         except (spack.repo.UnknownPackageError, spack.repo.UnknownNamespaceError) as e:
             tty.warn(e)
             tty.warn(
-                "Environment %s includes out of date packages or repos. "
-                "Loading the environment view will require reconcretization." % self.name
+                f"Environment {self.name} includes out of date packages or repos. "
+                "Loading the environment view will require reconcretization."
             )
 
     def _env_modifications_for_view(
@@ -2968,7 +2966,7 @@ def manifest_file(env_name_or_dir):
     elif exists(env_name_or_dir):
         env_dir = os.path.abspath(root(env_name_or_dir))
 
-    assert env_dir, "environment not found [env={0}]".format(env_name_or_dir)
+    assert env_dir, f"environment not found [env={env_name_or_dir}]"
     return os.path.join(env_dir, manifest_name)
 
 
@@ -2992,7 +2990,7 @@ def update_yaml(manifest, backup_file):
     top_level_key = _top_level_key(data)
     needs_update = spack.schema.env.update(data[top_level_key])
     if not needs_update:
-        msg = "No update needed [manifest={0}]".format(manifest)
+        msg = f"No update needed [manifest={manifest}]"
         tty.debug(msg)
         return False
 

--- a/lib/spack/spack/environment/shell.py
+++ b/lib/spack/spack/environment/shell.py
@@ -20,21 +20,21 @@ def activate_header(env, shell, prompt=None, view: Optional[str] = None):
     cmds = ""
     if shell == "csh":
         # TODO: figure out how to make color work for csh
-        cmds += "setenv SPACK_ENV %s;\n" % env.path
+        cmds += f"setenv SPACK_ENV {env.path};\n"
         if view:
-            cmds += "setenv SPACK_ENV_VIEW %s;\n" % view
+            cmds += f"setenv SPACK_ENV_VIEW {view};\n"
         cmds += 'alias despacktivate "spack env deactivate";\n'
         if prompt:
             cmds += "if (! $?SPACK_OLD_PROMPT ) "
             cmds += 'setenv SPACK_OLD_PROMPT "${prompt}";\n'
-            cmds += 'set prompt="%s ${prompt}";\n' % prompt
+            cmds += f'set prompt="{prompt} ${{prompt}}";\n'
     elif shell == "fish":
         if "color" in os.getenv("TERM", "") and prompt:
-            prompt = colorize("@G{%s} " % prompt, color=True)
+            prompt = colorize(f"@G{{{prompt}}} ", color=True)
 
-        cmds += "set -gx SPACK_ENV %s;\n" % env.path
+        cmds += f"set -gx SPACK_ENV {env.path};\n"
         if view:
-            cmds += "set -gx SPACK_ENV_VIEW %s;\n" % view
+            cmds += f"set -gx SPACK_ENV_VIEW {view};\n"
         cmds += "function despacktivate;\n"
         cmds += "   spack env deactivate;\n"
         cmds += "end;\n"
@@ -45,9 +45,9 @@ def activate_header(env, shell, prompt=None, view: Optional[str] = None):
         #
     elif shell == "bat":
         # TODO: Color
-        cmds += 'set "SPACK_ENV=%s"\n' % env.path
+        cmds += f'set "SPACK_ENV={env.path}"\n'
         if view:
-            cmds += 'set "SPACK_ENV_VIEW=%s"\n' % view
+            cmds += f'set "SPACK_ENV_VIEW={view}"\n'
         if prompt:
             old_prompt = os.environ.get("SPACK_OLD_PROMPT")
             if not old_prompt:
@@ -55,23 +55,23 @@ def activate_header(env, shell, prompt=None, view: Optional[str] = None):
             cmds += f'set "SPACK_OLD_PROMPT={old_prompt}"\n'
             cmds += f'set "PROMPT={prompt} $P$G"\n'
     elif shell == "pwsh":
-        cmds += "$Env:SPACK_ENV='%s'\n" % env.path
+        cmds += f"$Env:SPACK_ENV='{env.path}'\n"
         if view:
-            cmds += "$Env:SPACK_ENV_VIEW='%s'\n" % view
+            cmds += f"$Env:SPACK_ENV_VIEW='{view}'\n"
         if prompt:
             cmds += (
                 "function global:prompt { $pth = $(Convert-Path $(Get-Location))"
                 ' | Split-Path -leaf; if(!"$Env:SPACK_OLD_PROMPT") '
                 '{$Env:SPACK_OLD_PROMPT="[spack] PS $pth>"}; '
-                '"%s PS $pth>"}\n' % prompt
+                f'"{prompt} PS $pth>"}}\n'
             )
     else:
         bash_color_prompt = colorize(f"@G{{{prompt}}}", color=True, enclose=True)
         zsh_color_prompt = colorize(f"@G{{{prompt}}}", color=True, enclose=False, zsh=True)
 
-        cmds += "export SPACK_ENV=%s;\n" % env.path
+        cmds += f"export SPACK_ENV={env.path};\n"
         if view:
-            cmds += "export SPACK_ENV_VIEW=%s;\n" % view
+            cmds += f"export SPACK_ENV_VIEW={view};\n"
         cmds += "alias despacktivate='spack env deactivate';\n"
         if prompt:
             cmds += textwrap.dedent(
@@ -193,9 +193,9 @@ def activate(
         tty.die(
             "Environment view is broken due to a missing package or repo.\n",
             "  To activate without views enabled, activate with:\n",
-            "    spack env activate -V {0}\n".format(env.name),
+            f"    spack env activate -V {env.name}\n",
             "  To remove it and resolve the issue, force concretize with the command:\n",
-            "    spack -e {0} concretize --force".format(env.name),
+            f"    spack -e {env.name} concretize --force",
         )
 
     return env_mods

--- a/lib/spack/spack/error.py
+++ b/lib/spack/spack/error.py
@@ -104,7 +104,7 @@ class NoLibrariesError(SpackError):
         super().__init__(
             message_or_name
             if prefix is None
-            else "Unable to locate {0} libraries in {1}".format(message_or_name, prefix)
+            else f"Unable to locate {message_or_name} libraries in {prefix}"
         )
 
 
@@ -130,7 +130,7 @@ class UnsatisfiableSpecError(SpecError):
 
     def __init__(self, provided, required, constraint_type):
         # This is only the entrypoint for old concretizer errors
-        super().__init__("%s does not satisfy %s" % (provided, required))
+        super().__init__(f"{provided} does not satisfy {required}")
 
         self.provided = provided
         self.required = required
@@ -168,7 +168,7 @@ class NoURLError(PackageError):
     """Raised when someone tries to build a URL for a package with no URLs."""
 
     def __init__(self, cls):
-        super().__init__("Package %s has no version with a URL." % cls.__name__)
+        super().__init__(f"Package {cls.__name__} has no version with a URL.")
 
 
 class InstallError(SpackError):

--- a/lib/spack/spack/extensions.py
+++ b/lib/spack/spack/extensions.py
@@ -59,9 +59,9 @@ def load_command_extension(command, path):
     extension = _python_name(extension_name(path))
 
     # Compute the name of the module we search, exit early if already imported
-    cmd_package = "{0}.{1}.cmd".format(__name__, extension)
+    cmd_package = f"{__name__}.{extension}.cmd"
     python_name = _python_name(command)
-    module_name = "{0}.{1}".format(cmd_package, python_name)
+    module_name = f"{cmd_package}.{python_name}"
     if module_name in sys.modules:
         return sys.modules[module_name]
 
@@ -83,7 +83,7 @@ def load_command_extension(command, path):
 
 def ensure_extension_loaded(extension, *, path):
     def ensure_package_creation(name):
-        package_name = "{0}.{1}".format(__name__, name)
+        package_name = f"{__name__}.{name}"
         if package_name in sys.modules:
             return
 
@@ -190,7 +190,7 @@ def path_for_extension(target_name: str, *, paths: List[str]) -> str:
         if name == target_name:
             return path
     else:
-        raise OSError('extension "{0}" not found'.format(target_name))
+        raise OSError(f'extension "{target_name}" not found')
 
 
 def get_module(cmd_name):
@@ -226,4 +226,4 @@ class ExtensionNamingError(spack.error.SpackError):
     """
 
     def __init__(self, path):
-        super().__init__("{0} does not match the format for a Spack extension path.".format(path))
+        super().__init__(f"{path} does not match the format for a Spack extension path.")

--- a/lib/spack/spack/fetch_strategy.py
+++ b/lib/spack/spack/fetch_strategy.py
@@ -546,9 +546,7 @@ class URLFetchStrategy(FetchStrategy):
     def expand(self):
         if not self.expand_archive:
             tty.debug(
-                "Staging unexpanded archive {0} in {1}".format(
-                    self.archive_file, self.stage.source_path
-                )
+                f"Staging unexpanded archive {self.archive_file} in {self.stage.source_path}"
             )
             if not self.stage.expanded:
                 mkdirp(self.stage.source_path)
@@ -556,11 +554,11 @@ class URLFetchStrategy(FetchStrategy):
             shutil.move(self.archive_file, dest)
             return
 
-        tty.debug("Staging archive: {0}".format(self.archive_file))
+        tty.debug(f"Staging archive: {self.archive_file}")
 
         if not self.archive_file:
             raise NoArchiveFileError(
-                "Couldn't find archive file", "Failed on expand() for URL %s" % self.url
+                "Couldn't find archive file", f"Failed on expand() for URL {self.url}"
             )
 
         # TODO: replace this by mime check.
@@ -568,7 +566,7 @@ class URLFetchStrategy(FetchStrategy):
             self.extension = spack.util.url.determine_url_file_extension(self.url)
 
         if self.stage.expanded:
-            tty.debug("Source already staged to %s" % self.stage.source_path)
+            tty.debug(f"Source already staged to {self.stage.source_path}")
             return
 
         decompress = decompressor_for(self.archive_file, self.extension)
@@ -777,7 +775,7 @@ class GoFetchStrategy(VCSFetchStrategy):
 
     @_needs_stage
     def fetch(self):
-        tty.debug("Getting go resource: {0}".format(self.url))
+        tty.debug(f"Getting go resource: {self.url}")
 
         with working_dir(self.stage.path):
             try:
@@ -793,7 +791,7 @@ class GoFetchStrategy(VCSFetchStrategy):
 
     @_needs_stage
     def expand(self):
-        tty.debug("Source fetched with %s is already expanded." % self.url_attr)
+        tty.debug(f"Source fetched with {self.url_attr} is already expanded.")
 
         # Move the directory to the well-known stage source path
         repo_root = _ensure_one_stage_entry(self.stage.path)
@@ -805,7 +803,7 @@ class GoFetchStrategy(VCSFetchStrategy):
             self.go("clean")
 
     def __str__(self):
-        return "[go] %s" % self.url
+        return f"[go] {self.url}"
 
 
 @fetcher
@@ -1123,10 +1121,10 @@ class CvsFetchStrategy(VCSFetchStrategy):
     @_needs_stage
     def fetch(self):
         if self.stage.expanded:
-            tty.debug("Already fetched {0}".format(self.stage.source_path))
+            tty.debug(f"Already fetched {self.stage.source_path}")
             return
 
-        tty.debug("Checking out CVS repository: {0}".format(self.url))
+        tty.debug(f"Checking out CVS repository: {self.url}")
 
         with temp_cwd():
             url, module = self.url.split("%module=")
@@ -1163,7 +1161,7 @@ class CvsFetchStrategy(VCSFetchStrategy):
             self.cvs("update", "-C", ".")
 
     def __str__(self):
-        return "[cvs] %s" % self.url
+        return f"[cvs] {self.url}"
 
 
 @fetcher
@@ -1216,10 +1214,10 @@ class SvnFetchStrategy(VCSFetchStrategy):
     @_needs_stage
     def fetch(self):
         if self.stage.expanded:
-            tty.debug("Already fetched {0}".format(self.stage.source_path))
+            tty.debug(f"Already fetched {self.stage.source_path}")
             return
 
-        tty.debug("Checking out subversion repository: {0}".format(self.url))
+        tty.debug(f"Checking out subversion repository: {self.url}")
 
         args = ["checkout", "--force", "--quiet"]
         if self.revision:
@@ -1256,7 +1254,7 @@ class SvnFetchStrategy(VCSFetchStrategy):
             self.svn("revert", ".", "-R")
 
     def __str__(self):
-        return "[svn] %s" % self.url
+        return f"[svn] {self.url}"
 
 
 @fetcher
@@ -1325,13 +1323,13 @@ class HgFetchStrategy(VCSFetchStrategy):
     @_needs_stage
     def fetch(self):
         if self.stage.expanded:
-            tty.debug("Already fetched {0}".format(self.stage.source_path))
+            tty.debug(f"Already fetched {self.stage.source_path}")
             return
 
         args = []
         if self.revision:
-            args.append("at revision %s" % self.revision)
-        tty.debug("Cloning mercurial repository: {0} {1}".format(self.url, args))
+            args.append(f"at revision {self.revision}")
+        tty.debug(f"Cloning mercurial repository: {self.url} {args}")
 
         args = ["clone"]
 
@@ -1515,8 +1513,8 @@ def check_pkg_attributes(pkg):
 
     if len(conflicts) > 1:
         raise FetcherConflict(
-            "Package %s cannot specify %s together. Pick at most one."
-            % (pkg.name, comma_and(quote(conflicts)))
+            f"Package {pkg.name} cannot specify {comma_and(quote(conflicts))} together. "
+            "Pick at most one."
         )
 
 
@@ -1535,10 +1533,9 @@ def _check_version_attributes(fetcher, pkg, version):
     if extra:
         legal_attrs = [fetcher.url_attr] + list(fetcher.optional_attrs)
         raise FetcherConflict(
-            "%s version '%s' has extra arguments: %s"
-            % (pkg.name, version, comma_and(quote(extra))),
-            "Valid arguments for a %s fetcher are: \n    %s"
-            % (fetcher.url_attr, comma_and(quote(legal_attrs))),
+            f"{pkg.name} version '{version}' has extra arguments: {comma_and(quote(extra))}",
+            f"Valid arguments for a {fetcher.url_attr} fetcher are: \n    "
+            f"{comma_and(quote(legal_attrs))}",
         )
 
 
@@ -1753,7 +1750,7 @@ def from_list_url(pkg):
                 )
             except KeyError as e:
                 tty.debug(e)
-                tty.msg("Cannot find version %s in url_list" % pkg.version)
+                tty.msg(f"Cannot find version {pkg.version} in url_list")
 
         except BaseException as e:
             # TODO: Don't catch BaseException here! Be more specific.
@@ -1838,10 +1835,10 @@ class InvalidArgsError(spack.error.FetchError):
     def __init__(self, pkg=None, version=None, **args):
         msg = "Could not guess a fetch strategy"
         if pkg:
-            msg += " for {pkg}".format(pkg=pkg)
+            msg += f" for {pkg}"
             if version:
-                msg += "@{version}".format(version=version)
-        long_msg = "with arguments: {args}".format(args=args)
+                msg += f"@{version}"
+        long_msg = f"with arguments: {args}"
         super().__init__(msg, long_msg)
 
 
@@ -1853,4 +1850,4 @@ class NoStageError(spack.error.FetchError):
     """Raised when fetch operations are called before set_stage()."""
 
     def __init__(self, method):
-        super().__init__("Must call FetchStrategy.set_stage() before calling %s" % method.__name__)
+        super().__init__(f"Must call FetchStrategy.set_stage() before calling {method.__name__}")

--- a/lib/spack/spack/filesystem_view.py
+++ b/lib/spack/spack/filesystem_view.py
@@ -484,15 +484,17 @@ class YamlFilesystemView(FilesystemView):
             if len(dependents) > 0:
                 tty.warn(
                     self._croot
-                    + "The following dependents will be removed: %s"
-                    % ", ".join((s.name for s in dependents))
+                    + "The following dependents will be removed: {}".format(
+                        ", ".join((s.name for s in dependents))
+                    )
                 )
                 to_deactivate.update(dependents)
         elif len(dependents) > 0:
             tty.warn(
                 self._croot
-                + "The following packages will be unusable: %s"
-                % ", ".join((s.name for s in dependents))
+                + "The following packages will be unusable: {}".format(
+                    ", ".join((s.name for s in dependents))
+                )
             )
 
         # Determine the order that packages should be removed from the view;
@@ -653,13 +655,12 @@ class YamlFilesystemView(FilesystemView):
                 # Print one spec per line along with prefix path
                 width = max(len(s) for s in abbreviated)
                 width += 2
-                format = "    %%-%ds%%s" % width
 
                 for abbrv, s in zip(abbreviated, specs):
                     prefix = ""
                     if self.verbose:
-                        prefix = colorize("@K{%s}" % s.dag_hash(7))
-                    print(prefix + (format % (abbrv, self.get_projection_for_spec(s))))
+                        prefix = colorize(f"@K{{{s.dag_hash(7)}}}")
+                    print(prefix + f"    {abbrv:<{width}}{self.get_projection_for_spec(s)}")
         else:
             tty.warn(self._croot + "No packages found.")
 

--- a/lib/spack/spack/hooks/absolutify_elf_sonames.py
+++ b/lib/spack/spack/hooks/absolutify_elf_sonames.py
@@ -113,7 +113,7 @@ def patch_sonames(patchelf, root, rel_paths):
             fixed.append(rel_path)
         else:
             # Note: treat as warning to avoid (long) builds to fail post-install.
-            tty.warn("patchelf: failed to set soname of {}: {}".format(normalized, output.strip()))
+            tty.warn(f"patchelf: failed to set soname of {normalized}: {output.strip()}")
     return fixed
 
 

--- a/lib/spack/spack/hooks/licensing.py
+++ b/lib/spack/spack/hooks/licensing.py
@@ -39,26 +39,25 @@ def set_up_license(pkg):
             ed.editor(license_path, exec_fn=ed.executable)
         else:
             # Use already existing license file
-            tty.msg("Found already existing license %s" % license_path)
+            tty.msg(f"Found already existing license {license_path}")
 
     # If not a file, what about an environment variable?
     elif pkg.license_vars:
         tty.warn(
-            "A license is required to use %s. Please set %s to the "
+            "A license is required to use {}. Please set {} to the "
             "full pathname to the license file, or port@host if you"
-            " store your license keys on a dedicated license server"
-            % (pkg.name, " or ".join(pkg.license_vars))
+            " store your license keys on a dedicated license server".format(
+                pkg.name, " or ".join(pkg.license_vars)
+            )
         )
 
     # If not a file or variable, suggest a website for further info
     elif pkg.license_url:
-        tty.warn(
-            "A license is required to use %s. See %s for details" % (pkg.name, pkg.license_url)
-        )
+        tty.warn(f"A license is required to use {pkg.name}. See {pkg.license_url} for details")
 
     # If all else fails, you're on your own
     else:
-        tty.warn("A license is required to use %s" % pkg.name)
+        tty.warn(f"A license is required to use {pkg.name}")
 
 
 def write_license_file(pkg, license_path):
@@ -70,38 +69,38 @@ def write_license_file(pkg, license_path):
     # License files
     linktargets = ""
     for f in pkg.license_files:
-        linktargets += "\t%s\n" % f
+        linktargets += f"\t{f}\n"
 
     # Environment variables
     envvars = ""
     if pkg.license_vars:
         for varname in pkg.license_vars:
-            envvars += "\t%s\n" % varname
+            envvars += f"\t{varname}\n"
 
     # Documentation
     url = ""
     if pkg.license_url:
-        url += "\t%s\n" % pkg.license_url
+        url += f"\t{pkg.license_url}\n"
 
     # Assemble. NB: pkg.license_comment will be prepended upon output.
-    txt = """
- A license is required to use package '{0}'.
+    txt = f"""
+ A license is required to use package '{pkg.name}'.
 
  * If your system is already properly configured for such a license, save this
    file UNCHANGED. The system may be configured if:
 
     - A license file is installed in a default location.
-""".format(pkg.name)
+"""
 
     if envvars:
-        txt += """\
+        txt += f"""\
     - One of the following environment variable(s) is set for you, possibly via
       a module file:
 
-{0}
-""".format(envvars)
+{envvars}
+"""
 
-    txt += """\
+    txt += f"""\
  * Otherwise, depending on the license you have, enter AT THE BEGINNING of
    this file:
 
@@ -111,15 +110,15 @@ def write_license_file(pkg, license_path):
    After installation, the following symlink(s) will be added to point to
    this Spack-global file (relative to the installation prefix).
 
-{0}
-""".format(linktargets)
+{linktargets}
+"""
 
     if url:
-        txt += """\
+        txt += f"""\
  * For further information on licensing, see:
 
-{0}
-""".format(url)
+{url}
+"""
 
     txt += """\
  Recap:
@@ -133,7 +132,7 @@ def write_license_file(pkg, license_path):
     # Output
     with open(license_path, "w", encoding="utf-8") as f:
         for line in txt.splitlines():
-            f.write("{0}{1}\n".format(pkg.license_comment, line))
+            f.write(f"{pkg.license_comment}{line}\n")
         f.close()
 
 
@@ -162,4 +161,4 @@ def symlink_license(pkg):
 
         if os.path.exists(target):
             symlink(target, link_name)
-            tty.msg("Added local symlink %s to global license file" % link_name)
+            tty.msg(f"Added local symlink {link_name} to global license file")

--- a/lib/spack/spack/hooks/sbang.py
+++ b/lib/spack/spack/hooks/sbang.py
@@ -63,7 +63,7 @@ def sbang_shebang_line():
     This should be the only place in Spack that knows about what
     interpreter we use for ``sbang``.
     """
-    return "#!/bin/sh %s" % sbang_install_path()
+    return f"#!/bin/sh {sbang_install_path()}"
 
 
 def get_interpreter(binary_string):
@@ -175,7 +175,7 @@ def filter_shebangs_in_directory(directory, filenames=None):
 
         # test the file for a long shebang, and filter
         if filter_shebang(path):
-            tty.debug("Patched overlong shebang in %s" % path)
+            tty.debug(f"Patched overlong shebang in {path}")
 
 
 def post_install(spec, explicit=None):

--- a/lib/spack/spack/install_test.py
+++ b/lib/spack/spack/install_test.py
@@ -1042,7 +1042,7 @@ class TestSuite:
         Args:
             spec: instance of the spec under test
         """
-        return "%s-tested.txt" % cls.test_pkg_id(spec)
+        return f"{cls.test_pkg_id(spec)}-tested.txt"
 
     def tested_file_for_spec(self, spec: Spec) -> str:
         """The test status file path for the spec.
@@ -1182,8 +1182,8 @@ class TestFailure(spack.error.SpackError):
         num = len(failures)
         msg = "{} failed.\n".format(plural(num, "test"))
         for failure, message in failures:
-            msg += "\n\n%s\n" % str(failure)
-            msg += "\n%s\n" % message
+            msg += f"\n\n{str(failure)}\n"
+            msg += f"\n{message}\n"
 
         super().__init__(msg)
 
@@ -1196,7 +1196,7 @@ class TestSuiteFailure(spack.error.SpackError):
     """Raised when one or more tests in a suite have failed."""
 
     def __init__(self, num_failures):
-        msg = "%d test(s) in the suite failed.\n" % num_failures
+        msg = f"{num_failures} test(s) in the suite failed.\n"
 
         super().__init__(msg)
 

--- a/lib/spack/spack/installer.py
+++ b/lib/spack/spack/installer.py
@@ -188,7 +188,7 @@ class TermStatusLine:
 
         self.pkg_set.add(pkg_id)
         self.pkg_list.append(pkg_id)
-        tty.msg(colorize("@*{Waiting for} @*g{%s}" % pkg_id))
+        tty.msg(colorize(f"@*{{Waiting for}} @*g{{{pkg_id}}}"))
         sys.stdout.flush()
 
     def clear(self):
@@ -314,9 +314,9 @@ def _hms(seconds: int) -> str:
 
     parts = []
     if h:
-        parts.append("%dh" % h)
+        parts.append(f"{int(h)}h")
     if m:
-        parts.append("%dm" % m)
+        parts.append(f"{int(m)}m")
     if s:
         parts.append(f"{s:.2f}s")
     return " ".join(parts)
@@ -613,11 +613,11 @@ def install_msg(name: str, pid: int, install_status: InstallStatus) -> str:
     """
     pre = f"{pid}: " if tty.show_pid() else ""
     post = (
-        " @*{%s}" % install_status.get_progress()
+        f" @*{{{install_status.get_progress()}}}"
         if install_status and spack.config.get("config:install_status", True)
         else ""
     )
-    return pre + colorize("@*{Installing} @*g{%s}%s" % (name, post))
+    return pre + colorize(f"@*{{Installing}} @*g{{{name}}}{post}")
 
 
 def archive_install_logs(pkg: "spack.package_base.PackageBase", phase_log_dir: str) -> None:
@@ -1028,8 +1028,9 @@ class Task:
     def __str__(self) -> str:
         """Returns a printable version of the task."""
         dependencies = f"#dependencies={len(self.dependencies)}"
-        return "priority={0}, status={1}, start_time={2}, {3}".format(
-            self.priority, self.status, self.start_time, dependencies
+        return (
+            f"priority={self.priority}, status={self.status}, "
+            f"start_time={self.start_time}, {dependencies}"
         )
 
     def _update(self) -> None:
@@ -2739,7 +2740,7 @@ class BuildProcessInstaller:
             for i, phase_fn in enumerate(builder):
                 # Keep a log file for each phase
                 log_dir = os.path.dirname(pkg.log_path)
-                log_file = "spack-build-%02d-%s-out.txt" % (i + 1, phase_fn.name.lower())
+                log_file = f"spack-build-{i + 1:02d}-{phase_fn.name.lower()}-out.txt"
                 log_file = os.path.join(log_dir, log_file)
 
                 try:

--- a/lib/spack/spack/llnl/util/filesystem.py
+++ b/lib/spack/spack/llnl/util/filesystem.py
@@ -467,8 +467,8 @@ def change_sed_delimiter(old_delim: str, new_delim: str, *filenames: str) -> Non
     filenames = path_to_os_path(*filenames)
     for f in filenames:
         filter_file(whole_lines, repl, f)
-        filter_file(single_quoted, "'%s'" % repl, f)
-        filter_file(double_quoted, '"%s"' % repl, f)
+        filter_file(single_quoted, f"'{repl}'", f)
+        filter_file(double_quoted, f'"{repl}"', f)
 
 
 @contextmanager
@@ -669,9 +669,7 @@ def get_owner_uid(path, err_msg=None) -> Union[str, int]:
         p_stat = os.stat(path)
         if p_stat.st_mode & stat.S_IRWXU != stat.S_IRWXU:
             tty.error(
-                "Expected {0} to support mode {1}, but it is {2}".format(
-                    path, stat.S_IRWXU, p_stat.st_mode
-                )
+                f"Expected {path} to support mode {stat.S_IRWXU}, but it is {p_stat.st_mode}"
             )
 
             raise OSError(errno.EACCES, err_msg.format(path, path) if err_msg else "")
@@ -876,9 +874,9 @@ def copy_tree(
         ValueError: if ``src`` is a parent directory of ``dest``
     """
     if _permissions:
-        tty.debug("Installing {0} to {1}".format(src, dest))
+        tty.debug(f"Installing {src} to {dest}")
     else:
-        tty.debug("Copying {0} to {1}".format(src, dest))
+        tty.debug(f"Copying {src} to {dest}")
 
     abs_dest = os.path.abspath(dest)
     if not abs_dest.endswith(os.path.sep):
@@ -886,7 +884,7 @@ def copy_tree(
 
     files = glob.glob(src)
     if not files:
-        raise OSError("No such file or directory: '{0}'".format(src), errno.ENOENT)
+        raise OSError(f"No such file or directory: '{src}'", errno.ENOENT)
 
     # For Windows hard-links and junctions, the source path must exist to make a symlink. Add
     # all symlinks to this list while traversing the tree, then when finished, make all
@@ -901,9 +899,7 @@ def copy_tree(
         # Stop early to avoid unnecessary recursion if being asked to copy
         # from a parent directory.
         if abs_dest.startswith(abs_src):
-            raise ValueError(
-                "Cannot copy ancestor directory {0} into {1}".format(abs_src, abs_dest)
-            )
+            raise ValueError(f"Cannot copy ancestor directory {abs_src} into {abs_dest}")
 
         mkdirp(abs_dest)
 
@@ -926,7 +922,7 @@ def copy_tree(
 
                         new_target = re.sub(escaped_path(abs_src), escaped_path(abs_dest), target)
                         if new_target != target:
-                            tty.debug("Redirecting link {0} to {1}".format(target, new_target))
+                            tty.debug(f"Redirecting link {target} to {new_target}")
                             target = new_target
 
                     links.append((target, d, s))
@@ -1069,7 +1065,7 @@ def mkdirp(
                     intermediate_mode = stat_info.st_mode
                     intermediate_group = stat_info.st_gid
                 else:
-                    msg = "Invalid value: '%s'. " % default_perms
+                    msg = f"Invalid value: '{default_perms}'. "
                     msg += "Choose from 'args' or 'parents'."
                     raise ValueError(msg)
 
@@ -1181,7 +1177,7 @@ def replace_directory_transaction(directory_name):
     # os.rename(directory_name, tmpdir) errors there.
     backup_dir = os.path.join(tmpdir, "backup")
     os.rename(directory_name, backup_dir)
-    tty.debug("Directory moved [src={0}, dest={1}]".format(directory_name, backup_dir))
+    tty.debug(f"Directory moved [src={directory_name}, dest={backup_dir}]")
 
     try:
         yield backup_dir
@@ -1196,12 +1192,12 @@ def replace_directory_transaction(directory_name):
         except Exception as outer_exception:
             raise CouldNotRestoreDirectoryBackup(inner_exception, outer_exception)
 
-        tty.debug("Directory recovered [{0}]".format(directory_name))
+        tty.debug(f"Directory recovered [{directory_name}]")
         raise
     else:
         # Otherwise delete the temporary directory
         shutil.rmtree(tmpdir, ignore_errors=True)
-        tty.debug("Temporary directory deleted [{0}]".format(tmpdir))
+        tty.debug(f"Temporary directory deleted [{tmpdir}]")
 
 
 @system_path_filter
@@ -1238,7 +1234,7 @@ def write_tmp_and_move(filename: str, *, encoding: Optional[str] = None):
     """Write to a temporary file, then move into place."""
     dirname = os.path.dirname(filename)
     basename = os.path.basename(filename)
-    tmp = os.path.join(dirname, ".%s.tmp" % basename)
+    tmp = os.path.join(dirname, f".{basename}.tmp")
     with open(tmp, "w", encoding=encoding) as f:
         yield f
     shutil.move(tmp, filename)
@@ -1299,7 +1295,7 @@ def ancestor(dir, n=1):
 def get_single_file(directory):
     fnames = os.listdir(directory)
     if len(fnames) != 1:
-        raise ValueError("Expected exactly 1 file, got {0}".format(str(len(fnames))))
+        raise ValueError(f"Expected exactly 1 file, got {str(len(fnames))}")
     return fnames[0]
 
 
@@ -1785,7 +1781,7 @@ def safe_remove(*files_or_dirs):
                 continue
             # The monotonic ID is a simple way to make the filename
             # or directory name unique in the temporary folder
-            basename = os.path.basename(file_or_dir) + "-{0}".format(id)
+            basename = os.path.basename(file_or_dir) + f"-{id}"
             temporary_path = os.path.join(dst_root, basename)
             shutil.move(file_or_dir, temporary_path)
             removed[file_or_dir] = temporary_path
@@ -2294,7 +2290,7 @@ def find_headers(headers: Union[str, List[str]], root: str, recursive: bool = Fa
     ]
 
     # List of headers we are searching with suffixes
-    headers = ["{0}.{1}".format(header, suffix) for header in headers for suffix in suffixes]
+    headers = [f"{header}.{suffix}" for header in headers for suffix in suffixes]
 
     return HeaderList(find(root, headers, recursive))
 
@@ -2530,7 +2526,7 @@ def find_libraries(
         suffixes = [static_ext]
 
     # List of libraries we are searching with suffixes
-    libraries = ["{0}.{1}".format(lib, suffix) for lib in libraries for suffix in suffixes]
+    libraries = [f"{lib}.{suffix}" for lib in libraries for suffix in suffixes]
 
     if not recursive:
         if max_depth:

--- a/lib/spack/spack/llnl/util/lang.py
+++ b/lib/spack/spack/llnl/util/lang.py
@@ -655,7 +655,7 @@ def pretty_seconds_formatter(seconds):
         multiplier, unit = 1e6, "us"
     else:
         multiplier, unit = 1e9, "ns"
-    return lambda s: "%.3f%s" % (multiplier * s, unit)
+    return lambda s: f"{multiplier * s:.3f}{unit}"
 
 
 def pretty_seconds(seconds):

--- a/lib/spack/spack/llnl/util/lock.py
+++ b/lib/spack/spack/llnl/util/lock.py
@@ -148,7 +148,7 @@ def _attempts_str(wait_time, nattempts):
         return ""
 
     attempts = plural(nattempts, "attempt")
-    return " after {} and {}".format(lang.pretty_seconds(wait_time), attempts)
+    return f" after {lang.pretty_seconds(wait_time)} and {attempts}"
 
 
 class LockType:
@@ -272,9 +272,8 @@ class PosixBackend:
                 # All locks read the owner PID and host
                 self._read_log_debug_data()
                 tty.debug(
-                    "{0} locked {1} [{2}:{3}] (owner={4})".format(
-                        LockType.to_str(op), self.path, self._start, self._length, self.pid
-                    ),
+                    f"{LockType.to_str(op)} locked {self.path} "
+                    f"[{self._start}:{self._length}] (owner={self.pid})",
                     level=2,
                 )
 
@@ -487,15 +486,14 @@ class Lock:
         assert LockType.is_valid(op)
         op_str = LockType.to_str(op)
 
-        self._log_acquiring("{0} LOCK".format(op_str))
+        self._log_acquiring(f"{op_str} LOCK")
         timeout = timeout or self.default_timeout
 
         self.backend.prepare(op)
 
         self._log_debug(
-            "{} locking [{}:{}]: timeout {}".format(
-                op_str.lower(), self._start, self._length, lang.pretty_seconds(timeout or 0)
-            )
+            f"{op_str.lower()} locking [{self._start}:{self._length}]: "
+            f"timeout {lang.pretty_seconds(timeout or 0)}"
         )
 
         start_time = time.monotonic()
@@ -741,15 +739,13 @@ class Lock:
             raise LockError("Attempting to cleanup active lock.")
 
     def _get_counts_desc(self) -> str:
-        return (
-            "(reads {0}, writes {1})".format(self._reads, self._writes) if tty.is_verbose() else ""
-        )
+        return f"(reads {self._reads}, writes {self._writes})" if tty.is_verbose() else ""
 
     def _log_acquired(self, locktype, wait_time, nattempts) -> None:
         attempts_part = _attempts_str(wait_time, nattempts)
         now = datetime.now()
-        desc = "Acquired at %s" % now.strftime("%H:%M:%S.%f")
-        self._log_debug(self._status_msg(locktype, "{0}{1}".format(desc, attempts_part)))
+        desc = "Acquired at {}".format(now.strftime("%H:%M:%S.%f"))
+        self._log_debug(self._status_msg(locktype, f"{desc}{attempts_part}"))
 
     def _log_acquiring(self, locktype) -> None:
         self._log_debug(self._status_msg(locktype, "Acquiring"), level=3)
@@ -762,15 +758,15 @@ class Lock:
     def _log_downgraded(self, wait_time, nattempts) -> None:
         attempts_part = _attempts_str(wait_time, nattempts)
         now = datetime.now()
-        desc = "Downgraded at %s" % now.strftime("%H:%M:%S.%f")
-        self._log_debug(self._status_msg("READ LOCK", "{0}{1}".format(desc, attempts_part)))
+        desc = "Downgraded at {}".format(now.strftime("%H:%M:%S.%f"))
+        self._log_debug(self._status_msg("READ LOCK", f"{desc}{attempts_part}"))
 
     def _log_downgrading(self) -> None:
         self._log_debug(self._status_msg("WRITE LOCK", "Downgrading"), level=3)
 
     def _log_released(self, locktype) -> None:
         now = datetime.now()
-        desc = "Released at %s" % now.strftime("%H:%M:%S.%f")
+        desc = "Released at {}".format(now.strftime("%H:%M:%S.%f"))
         self._log_debug(self._status_msg(locktype, desc))
 
     def _log_releasing(self, locktype) -> None:
@@ -779,17 +775,15 @@ class Lock:
     def _log_upgraded(self, wait_time, nattempts) -> None:
         attempts_part = _attempts_str(wait_time, nattempts)
         now = datetime.now()
-        desc = "Upgraded at %s" % now.strftime("%H:%M:%S.%f")
-        self._log_debug(self._status_msg("WRITE LOCK", "{0}{1}".format(desc, attempts_part)))
+        desc = "Upgraded at {}".format(now.strftime("%H:%M:%S.%f"))
+        self._log_debug(self._status_msg("WRITE LOCK", f"{desc}{attempts_part}"))
 
     def _log_upgrading(self) -> None:
         self._log_debug(self._status_msg("READ LOCK", "Upgrading"), level=3)
 
     def _status_msg(self, locktype: str, status: str) -> str:
-        status_desc = "[{0}] {1}".format(status, self._get_counts_desc())
-        return "{0}{1.desc}: {1.path}[{1._start}:{1._length}] {2}".format(
-            locktype, self, status_desc
-        )
+        status_desc = f"[{status}] {self._get_counts_desc()}"
+        return f"{locktype}{self.desc}: {self.path}[{self._start}:{self._length}] {status_desc}"
 
 
 class LockTransaction:
@@ -948,7 +942,7 @@ class LockDowngradeError(LockError):
     """Raised when unable to downgrade from a write to a read lock."""
 
     def __init__(self, path: str) -> None:
-        msg = "Cannot downgrade lock from write to read on file: %s" % path
+        msg = f"Cannot downgrade lock from write to read on file: {path}"
         super().__init__(msg)
 
 
@@ -973,7 +967,7 @@ class LockUpgradeError(LockError):
     """Raised when unable to upgrade from a read to a write lock."""
 
     def __init__(self, path: str) -> None:
-        msg = "Cannot upgrade lock from read to write on file: %s" % path
+        msg = f"Cannot upgrade lock from read to write on file: {path}"
         super().__init__(msg)
 
 
@@ -985,7 +979,7 @@ class LockROFileError(LockPermissionError):
     """Tried to take an exclusive lock on a read-only file."""
 
     def __init__(self, path: str) -> None:
-        msg = "Can't take write lock on read-only file: %s" % path
+        msg = f"Can't take write lock on read-only file: {path}"
         super().__init__(msg)
 
 
@@ -993,6 +987,6 @@ class CantCreateLockError(LockPermissionError):
     """Attempt to create a lock in an unwritable location."""
 
     def __init__(self, path: str) -> None:
-        msg = "cannot create lock '%s': " % path
+        msg = f"cannot create lock '{path}': "
         msg += "file does not exist and location is not writable"
         super().__init__(msg)

--- a/lib/spack/spack/llnl/util/tty/__init__.py
+++ b/lib/spack/spack/llnl/util/tty/__init__.py
@@ -199,8 +199,7 @@ def info(
     if _stacktrace:
         st_text = process_stacktrace(countback)
     cprint(
-        "@%s{%s==>} %s%s"
-        % (format, st_text, get_timestamp(), cescape(_output_filter(str(message)))),
+        f"@{format}{{{st_text}==>}} {get_timestamp()}{cescape(_output_filter(str(message)))}",
         stream=stream,
     )
     for arg in args:

--- a/lib/spack/spack/llnl/util/tty/colify.py
+++ b/lib/spack/spack/llnl/util/tty/colify.py
@@ -24,7 +24,7 @@ class ColumnConfig:
 
     def __repr__(self) -> str:
         attrs = [(a, getattr(self, a)) for a in dir(self) if not a.startswith("__")]
-        return f"<Config: {', '.join('%s: %r' % a for a in attrs)}>"
+        return f"<Config: {', '.join('{}: {!r}'.format(*a) for a in attrs)}>"
 
 
 def config_variable_cols(
@@ -192,8 +192,7 @@ def colify(
             elt = col * rows + row
             width = config.widths[col] + cextra(elts[elt])
             if col < cols - 1:
-                fmt = "%%-%ds" % width
-                output.write(fmt % elts[elt])
+                output.write(f"{elts[elt]:<{width}}")
             else:
                 # Don't pad the rightmost column (spaces can wrap on
                 # small teriminals if one line is overlong)

--- a/lib/spack/spack/main.py
+++ b/lib/spack/spack/main.py
@@ -111,7 +111,7 @@ def index_commands():
         for p in required_command_properties:
             prop = getattr(cmd_module, p, None)
             if not prop:
-                tty.die("Command doesn't define a property '%s': %s" % (p, command))
+                tty.die(f"Command doesn't define a property '{p}': {command}")
 
         # add commands to lists for their level and higher levels
         for level in reversed(levels):
@@ -137,7 +137,7 @@ class SpackHelpFormatter(argparse.RawTextHelpFormatter):
         chars = "".join(re.findall(r"\[-(.)\]", usage))
         usage = re.sub(r"\[-.\] ?", "", usage)
         if chars:
-            usage = "[-%s] %s" % (chars, usage)
+            usage = f"[-{chars}] {usage}"
         return usage.strip()
 
     def start_section(self, heading):
@@ -201,7 +201,7 @@ class SpackArgumentParser(argparse.ArgumentParser):
             level (str): ``"short"`` or ``"long"`` (more commands shown for long)
         """
         if level not in levels:
-            raise ValueError("level must be one of: %s" % levels)
+            raise ValueError(f"level must be one of: {levels}")
 
         # lazily add all commands to the parser when needed.
         add_all_commands(self)
@@ -388,7 +388,7 @@ class SpackArgumentParser(argparse.ArgumentParser):
         # converted value must be one of the choices (if specified)
         if action.choices is not None and value not in action.choices:
             cols = spack.llnl.util.tty.colify.colified(sorted(action.choices), indent=4, tty=True)
-            msg = "invalid choice: %r choose from:\n%s" % (value, cols)
+            msg = f"invalid choice: {value!r} choose from:\n{cols}"
             raise argparse.ArgumentError(action, msg)
 
 
@@ -629,7 +629,7 @@ def _invoke_command(command, parser, args, unknown_args):
         return_val = command(parser, args, unknown_args)
     else:
         if unknown_args:
-            args.subparser.error("unrecognized arguments: %s" % " ".join(unknown_args))
+            args.subparser.error("unrecognized arguments: {}".format(" ".join(unknown_args)))
         return_val = command(parser, args)
 
     # Allow commands to return and error code if they want
@@ -738,7 +738,7 @@ def _profile_wrapper(command, main_args, parser, args, unknown_args):
         nlines = int(main_args.lines)
     except ValueError:
         if main_args.lines != "all":
-            tty.die("Invalid number for --lines: %s" % main_args.lines)
+            tty.die(f"Invalid number for --lines: {main_args.lines}")
         nlines = -1
 
     # allow comma-separated list of fields
@@ -747,7 +747,7 @@ def _profile_wrapper(command, main_args, parser, args, unknown_args):
         sortby = main_args.sorted_profile.split(",")
         for stat in sortby:
             if stat not in stat_names:
-                tty.die("Invalid sort field: %s" % stat)
+                tty.die(f"Invalid sort field: {stat}")
 
     try:
         # make a profiler and run the code.
@@ -800,9 +800,9 @@ def print_setup_info(*info):
 
     def shell_set(var, value):
         if shell == "sh":
-            print("%s='%s'" % (var, value))
+            print(f"{var}='{value}'")
         elif shell == "csh":
-            print("set %s = '%s'" % (var, value))
+            print(f"set {var} = '{value}'")
         else:
             tty.die("shell must be sh or csh")
 
@@ -829,7 +829,7 @@ def print_setup_info(*info):
         # preserve the intended priority: the modules of the local Spack
         # instance are the highest-precedence.
         roots_val = ":".join(reversed(paths))
-        shell_set("_sp_%s_roots" % name, roots_val)
+        shell_set(f"_sp_{name}_roots", roots_val)
 
 
 def restore_macos_dyld_vars():

--- a/lib/spack/spack/mirrors/layout.py
+++ b/lib/spack/spack/mirrors/layout.py
@@ -133,12 +133,12 @@ def default_mirror_layout(
     ext = ext or _determine_extension(fetcher)
 
     if ext:
-        per_package_ref += ".%s" % ext
+        per_package_ref += f".{ext}"
 
     global_ref = fetcher.mirror_id()
     if global_ref:
         global_ref = os.path.join("_source-cache", global_ref)
     if global_ref and ext:
-        global_ref += ".%s" % ext
+        global_ref += f".{ext}"
 
     return DefaultLayout(per_package_ref, global_ref)

--- a/lib/spack/spack/mirrors/utils.py
+++ b/lib/spack/spack/mirrors/utils.py
@@ -31,7 +31,7 @@ def get_all_versions(specs):
         pkg_cls = spack.repo.PATH.get_pkg_class(spec.name)
         # Skip any package that has no known versions.
         if not pkg_cls.versions:
-            tty.msg("No safe (checksummed) versions for package %s" % pkg_cls.name)
+            tty.msg(f"No safe (checksummed) versions for package {pkg_cls.name}")
             continue
 
         for version in pkg_cls.versions:
@@ -54,7 +54,7 @@ def get_matching_versions(specs, num_versions=1):
 
         # Skip any package that has no known versions.
         if not pkg.versions:
-            tty.msg("No safe (checksummed) versions for package %s" % pkg.name)
+            tty.msg(f"No safe (checksummed) versions for package {pkg.name}")
             continue
 
         pkg_versions = num_versions
@@ -84,7 +84,7 @@ def get_matching_versions(specs, num_versions=1):
                 pkg_versions -= 1
 
         if not matching_spec:
-            tty.warn("No known version matches spec: %s" % spec)
+            tty.warn(f"No known version matches spec: {spec}")
         matching.extend(matching_spec)
 
     return matching
@@ -107,7 +107,7 @@ def get_mirror_cache(path, skip_unstable_versions=False):
         try:
             mkdirp(path)
         except OSError as e:
-            raise MirrorError("Cannot create directory '%s':" % path, str(e))
+            raise MirrorError(f"Cannot create directory '{path}':", str(e))
     mirror_cache = spack.caches.MirrorCache(path, skip_unstable_versions=skip_unstable_versions)
     return mirror_cache
 
@@ -119,7 +119,7 @@ def add(mirror: Mirror, scope=None):
         mirrors = syaml.syaml_dict()
 
     if mirror.name in mirrors:
-        tty.die("Mirror with name {} already exists.".format(mirror.name))
+        tty.die(f"Mirror with name {mirror.name} already exists.")
 
     items = [(n, u) for n, u in mirrors.items()]
     items.insert(0, (mirror.name, mirror.to_dict()))
@@ -229,7 +229,8 @@ def create_mirror_from_package_object(
                     traceback.print_exc()
                 else:
                     tty.warn(
-                        "Error while fetching %s" % pkg_obj.spec.format("{name}{@version}"), str(e)
+                        "Error while fetching {}".format(pkg_obj.spec.format("{name}{@version}")),
+                        str(e),
                     )
                 mirror_stats.error()
                 return False

--- a/lib/spack/spack/modules/__init__.py
+++ b/lib/spack/spack/modules/__init__.py
@@ -71,15 +71,12 @@ def get_module(
             fmt_str = "{name}{@version}{/hash:7}"
             if not writer.conf.excluded:
                 raise common.ModuleNotFoundError(
-                    "The module for package {} should be at {}, but it does not exist".format(
-                        spec.format(fmt_str), writer.layout.filename
-                    )
+                    f"The module for package {spec.format(fmt_str)} should be at "
+                    f"{writer.layout.filename}, but it does not exist"
                 )
             elif required:
                 tty.debug(
-                    "The module configuration has excluded {}: omitting it".format(
-                        spec.format(fmt_str)
-                    )
+                    f"The module configuration has excluded {spec.format(fmt_str)}: omitting it"
                 )
             else:
                 return None

--- a/lib/spack/spack/modules/common.py
+++ b/lib/spack/spack/modules/common.py
@@ -550,7 +550,7 @@ class BaseFileLayout:
         if self.extension:
             filename = f"{self.use_name}.{self.extension}"
         # Architecture sub-folder
-        arch_folder_conf = spack.config.get("modules:%s:arch_folder" % self.conf.name, True)
+        arch_folder_conf = spack.config.get(f"modules:{self.conf.name}:arch_folder", True)
         if arch_folder_conf:
             # include an arch specific folder between root and filename
             arch_folder = str(self.spec.architecture)

--- a/lib/spack/spack/modules/lmod.py
+++ b/lib/spack/spack/modules/lmod.py
@@ -248,7 +248,7 @@ class LmodFileLayout(BaseFileLayout):
     def arch_dirname(self):
         """Returns the root folder for THIS architecture"""
         # Architecture sub-folder
-        arch_folder_conf = spack.config.get("modules:%s:arch_folder" % self.conf.name, True)
+        arch_folder_conf = spack.config.get(f"modules:{self.conf.name}:arch_folder", True)
         if arch_folder_conf:
             # include an arch specific folder between root and filename
             arch_folder = "-".join(
@@ -458,7 +458,7 @@ class LmodContext(BaseContext):
 
                 def manipulate_path(token):
                     if token in self.conf.hierarchy_tokens:
-                        return "{0}_name, {0}_version".format(token)
+                        return f"{token}_name, {token}_version"
                     return '"' + token + '"'
 
                 path = ", ".join([manipulate_path(x) for x in parts])

--- a/lib/spack/spack/multimethod.py
+++ b/lib/spack/spack/multimethod.py
@@ -317,6 +317,7 @@ class NoSuchMethodError(spack.error.SpackError):
 
     def __init__(self, cls, method_name, spec, possible_specs):
         super().__init__(
-            "Package %s does not support %s called with %s.  Options are: %s"
-            % (cls.__name__, method_name, spec, ", ".join(str(s) for s in possible_specs))
+            "Package {} does not support {} called with {}.  Options are: {}".format(
+                cls.__name__, method_name, spec, ", ".join(str(s) for s in possible_specs)
+            )
         )

--- a/lib/spack/spack/operating_systems/_operating_system.py
+++ b/lib/spack/spack/operating_systems/_operating_system.py
@@ -30,7 +30,7 @@ class OperatingSystem:
         self.version = str(version).replace("-", "_")
 
     def __str__(self):
-        return "%s%s" % (self.name, self.version)
+        return f"{self.name}{self.version}"
 
     def __repr__(self):
         return self.__str__()

--- a/lib/spack/spack/operating_systems/windows_os.py
+++ b/lib/spack/spack/operating_systems/windows_os.py
@@ -37,7 +37,7 @@ class WindowsOs(OperatingSystem):
         plat_ver = windows_version()
         if plat_ver < Version("10"):
             raise SpackError("Spack is not supported on Windows versions older than 10")
-        super().__init__("windows{}".format(plat_ver), plat_ver)
+        super().__init__(f"windows{plat_ver}", plat_ver)
 
     def __str__(self):
         return self.name

--- a/lib/spack/spack/package_base.py
+++ b/lib/spack/spack/package_base.py
@@ -174,7 +174,7 @@ class DetectablePackageMeta(type):
             def platform_executables(cls):
                 def to_windows_exe(exe):
                     if exe.endswith("$"):
-                        exe = exe.replace("$", "%s$" % spack.util.path.win_exe_ext())
+                        exe = exe.replace("$", f"{spack.util.path.win_exe_ext()}$")
                     else:
                         exe += spack.util.path.win_exe_ext()
                     return exe
@@ -820,7 +820,7 @@ class PackageBase(WindowsRPath, PackageViewMixin, metaclass=PackageMeta):
     @classproperty
     def fullname(cls):
         """Name of this package, including the namespace"""
-        return "%s.%s" % (cls.namespace, cls.name)
+        return f"{cls.namespace}.{cls.name}"
 
     @classproperty
     def fullnames(cls):
@@ -1597,7 +1597,7 @@ class PackageBase(WindowsRPath, PackageViewMixin, metaclass=PackageMeta):
         Working directory will be set to the stage directory.
         """
         if not self.has_code or self.spec.external:
-            tty.debug("No fetch required for {0}".format(self.name))
+            tty.debug(f"No fetch required for {self.name}")
             return
 
         checksum = spack.config.get("config:checksum")
@@ -1608,8 +1608,9 @@ class PackageBase(WindowsRPath, PackageViewMixin, metaclass=PackageMeta):
             and ("dev_path" not in self.spec.variants)
         ):
             tty.warn(
-                "There is no checksum on file to fetch %s safely."
-                % self.spec.cformat("{name}{@version}")
+                "There is no checksum on file to fetch {} safely.".format(
+                    self.spec.cformat("{name}{@version}")
+                )
             )
 
             # Ask the user whether to skip the checksum if we're
@@ -1619,11 +1620,11 @@ class PackageBase(WindowsRPath, PackageViewMixin, metaclass=PackageMeta):
             if sys.stdout.isatty():
                 ignore_checksum = tty.get_yes_or_no("  Fetch anyway?", default=False)
                 if ignore_checksum:
-                    tty.debug("Fetching with no checksum. {0}".format(ck_msg))
+                    tty.debug(f"Fetching with no checksum. {ck_msg}")
 
             if not ignore_checksum:
                 raise spack.error.FetchError(
-                    "Will not fetch %s" % self.spec.format("{name}{@version}"), ck_msg
+                    "Will not fetch {}".format(self.spec.format("{name}{@version}")), ck_msg
                 )
 
         deprecated = spack.config.get("config:deprecated")
@@ -1646,7 +1647,7 @@ class PackageBase(WindowsRPath, PackageViewMixin, metaclass=PackageMeta):
                 ignore_deprecation = tty.get_yes_or_no("  Fetch anyway?", default=False)
 
                 if ignore_deprecation:
-                    tty.debug("Fetching deprecated version. {0}".format(dp_msg))
+                    tty.debug(f"Fetching deprecated version. {dp_msg}")
 
             if not ignore_deprecation:
                 raise spack.error.FetchError(
@@ -1698,7 +1699,7 @@ class PackageBase(WindowsRPath, PackageViewMixin, metaclass=PackageMeta):
 
         # If there are no patches, note it.
         if not patches and not has_patch_fun:
-            tty.msg("No patches needed for {0}".format(self.name))
+            tty.msg(f"No patches needed for {self.name}")
             return
 
         # Construct paths to special files in the archive dir used to
@@ -1724,10 +1725,10 @@ class PackageBase(WindowsRPath, PackageViewMixin, metaclass=PackageMeta):
 
         # If this file exists, then we already applied all the patches.
         if os.path.isfile(good_file):
-            tty.msg("Already patched {0}".format(self.name))
+            tty.msg(f"Already patched {self.name}")
             return
         elif os.path.isfile(no_patches_file):
-            tty.msg("No patches needed for {0}".format(self.name))
+            tty.msg(f"No patches needed for {self.name}")
             return
 
         errors = []
@@ -1772,7 +1773,7 @@ class PackageBase(WindowsRPath, PackageViewMixin, metaclass=PackageMeta):
             try:
                 with fsys.working_dir(self.stage.source_path):
                     self.patch()
-                tty.msg("Ran patch() for {0}".format(self.name))
+                tty.msg(f"Ran patch() for {self.name}")
                 patched = True
             except spack.multimethod.NoSuchMethodError:
                 # We are running a multimethod without a default case.
@@ -1782,7 +1783,7 @@ class PackageBase(WindowsRPath, PackageViewMixin, metaclass=PackageMeta):
                     # directive, AND the patch function didn't apply, say
                     # no patches are needed.  Otherwise, we already
                     # printed a message for each patch.
-                    tty.msg("No patches needed for {0}".format(self.name))
+                    tty.msg(f"No patches needed for {self.name}")
             except spack.error.SpackError as e:
                 # Touch bad file if anything goes wrong.
                 fsys.touch(bad_file)
@@ -1951,7 +1952,7 @@ class PackageBase(WindowsRPath, PackageViewMixin, metaclass=PackageMeta):
 
         for missing_target_msg in missing_target_msgs:
             if missing_target_msg.format(target) in stderr:
-                tty.debug("Target '{0}' not found in {1}".format(target, makefile))
+                tty.debug(f"Target '{target}' not found in {makefile}")
                 return False
 
         return True
@@ -1990,7 +1991,7 @@ class PackageBase(WindowsRPath, PackageViewMixin, metaclass=PackageMeta):
         matches = [line for line in all_targets if line.startswith(target + ":")]
 
         if not matches:
-            tty.debug("Target '{0}' not found in build.ninja".format(target))
+            tty.debug(f"Target '{target}' not found in build.ninja")
             return False
 
         return True
@@ -2158,7 +2159,7 @@ class PackageBase(WindowsRPath, PackageViewMixin, metaclass=PackageMeta):
     def flags_to_build_system_args(self, flags: Dict[str, List[str]]) -> None:
         # Takes flags as a dict name: list of values
         if any(v for v in flags.values()):
-            msg = "The {0} build system".format(self.__class__.__name__)
+            msg = f"The {self.__class__.__name__} build system"
             msg += " cannot take command line arguments for compiler flags"
             raise NotImplementedError(msg)
 
@@ -2171,10 +2172,10 @@ class PackageBase(WindowsRPath, PackageViewMixin, metaclass=PackageMeta):
             if specs:
                 if deprecator:
                     spack.store.STORE.db.deprecate(specs[0], deprecator)
-                    tty.debug("Deprecating stale DB entry for {0}".format(spec.short_spec))
+                    tty.debug(f"Deprecating stale DB entry for {spec.short_spec}")
                 else:
                     spack.store.STORE.db.remove(specs[0])
-                    tty.debug("Removed stale DB entry for {0}".format(spec.short_spec))
+                    tty.debug(f"Removed stale DB entry for {spec.short_spec}")
                 return
             else:
                 raise InstallError(str(spec) + " is not installed.")
@@ -2201,11 +2202,11 @@ class PackageBase(WindowsRPath, PackageViewMixin, metaclass=PackageMeta):
                     if force:
                         error_msg = (
                             "One or more pre_uninstall hooks have failed"
-                            " for {0}, but Spack is continuing with the"
-                            " uninstall".format(str(spec))
+                            f" for {str(spec)}, but Spack is continuing with the"
+                            " uninstall"
                         )
                         if isinstance(error, spack.error.SpackError):
-                            error_msg += "\n\nError message: {0}".format(str(error))
+                            error_msg += f"\n\nError message: {str(error)}"
                         tty.warn(error_msg)
                         # Note that if the uninstall succeeds then we won't be
                         # seeing this error again and won't have another chance
@@ -2241,14 +2242,14 @@ class PackageBase(WindowsRPath, PackageViewMixin, metaclass=PackageMeta):
                 # will not have another chance to run.
                 error_msg = (
                     "One or more post-uninstallation hooks failed for"
-                    " {0}, but the prefix has been removed (if it is not"
-                    " external).".format(str(spec))
+                    f" {str(spec)}, but the prefix has been removed (if it is not"
+                    " external)."
                 )
                 tb_msg = traceback.format_exc()
-                error_msg += "\n\nThe error:\n\n{0}".format(tb_msg)
+                error_msg += f"\n\nThe error:\n\n{tb_msg}"
                 tty.warn(error_msg)
 
-        tty.msg("Successfully uninstalled {0}".format(spec.short_spec))
+        tty.msg(f"Successfully uninstalled {spec.short_spec}")
 
     def do_uninstall(self, force=False):
         """Uninstall this package by spec."""
@@ -2356,7 +2357,7 @@ class PackageBase(WindowsRPath, PackageViewMixin, metaclass=PackageMeta):
         """
         Get the rpath args as a string, with -Wl,-rpath, for each element
         """
-        return " ".join("-Wl,-rpath,%s" % p for p in self.rpath)
+        return " ".join(f"-Wl,-rpath,{p}" for p in self.rpath)
 
 
 class WindowsSimulatedRPath:
@@ -2500,11 +2501,12 @@ class WindowsSimulatedRPath:
             # either way, we don't want to overwrite existing libraries
             already_linked = islink(str(dest_file))
             tty.debug(
-                "Linking library %s to %s failed, " % (str(path), str(dest_file))
-                + "already linked."
+                f"Linking library {str(path)} to {str(dest_file)} failed, already linked."
                 if already_linked
-                else "library with name %s already exists at location %s."
-                % (str(file_name), str(dest_dir))
+                else (
+                    f"library with name {str(file_name)} already exists "
+                    f"at location {str(dest_dir)}."
+                )
             )
 
         file_name = path.name
@@ -2691,7 +2693,7 @@ class DependencyConflictError(spack.error.SpackError):
     """Raised when the dependencies cannot be flattened as asked for."""
 
     def __init__(self, conflict):
-        super().__init__("%s conflicts with another file in the flattened directory." % (conflict))
+        super().__init__(f"{conflict} conflicts with another file in the flattened directory.")
 
 
 class ManualDownloadRequiredError(InvalidPackageOpError):

--- a/lib/spack/spack/package_prefs.py
+++ b/lib/spack/spack/package_prefs.py
@@ -111,7 +111,7 @@ class PackagePrefs:
             if order:
                 ret = [str(s).strip() for s in order]
                 if component == "target":
-                    ret = ["target=%s" % tname for tname in ret]
+                    ret = [f"target={tname}" for tname in ret]
                 return ret
 
         return []
@@ -191,9 +191,9 @@ def get_package_dir_permissions(spec):
         perms |= stat.S_ISGID
         if spec.concrete and "/afs/" in spec.prefix:
             warnings.warn(
-                "Directory {0} seems to be located on AFS. If you"
+                f"Directory {spec.prefix} seems to be located on AFS. If you"
                 " encounter errors, try disabling the allow_sgid option"
-                " using: spack config add 'config:allow_sgid:false'".format(spec.prefix)
+                " using: spack config add 'config:allow_sgid:false'"
             )
     return perms
 
@@ -206,7 +206,7 @@ def get_package_permissions(spec):
     # Get read permissions level
     for name in (spec.name, "all"):
         try:
-            readable = spack.config.get("packages:%s:permissions:read" % name, "")
+            readable = spack.config.get(f"packages:{name}:permissions:read", "")
             if readable:
                 break
         except AttributeError:
@@ -215,7 +215,7 @@ def get_package_permissions(spec):
     # Get write permissions level
     for name in (spec.name, "all"):
         try:
-            writable = spack.config.get("packages:%s:permissions:write" % name, "")
+            writable = spack.config.get(f"packages:{name}:permissions:write", "")
             if writable:
                 break
         except AttributeError:
@@ -231,16 +231,16 @@ def get_package_permissions(spec):
         if readable == "user":
             raise ConfigError(
                 "Writable permissions may not be more"
-                + " permissive than readable permissions.\n"
-                + "      Violating package is %s" % spec.name
+                " permissive than readable permissions.\n"
+                f"      Violating package is {spec.name}"
             )
         perms |= stat.S_IWGRP
     if writable == "world":
         if readable != "world":
             raise ConfigError(
                 "Writable permissions may not be more"
-                + " permissive than readable permissions.\n"
-                + "      Violating package is %s" % spec.name
+                " permissive than readable permissions.\n"
+                f"      Violating package is {spec.name}"
             )
         perms |= stat.S_IWOTH
 
@@ -253,7 +253,7 @@ def get_package_group(spec):
     Package-specific settings take precedence over settings for ``all``"""
     for name in (spec.name, "all"):
         try:
-            group = spack.config.get("packages:%s:permissions:group" % name, "")
+            group = spack.config.get(f"packages:{name}:permissions:group", "")
             if group:
                 break
         except AttributeError:

--- a/lib/spack/spack/package_test.py
+++ b/lib/spack/spack/package_test.py
@@ -18,7 +18,7 @@ def compile_c_and_execute(
     flags.extend([source_file])
     cc("-c", *flags)
     name = os.path.splitext(os.path.basename(source_file))[0]
-    cc("-o", "check", "%s.o" % name, *link_flags)
+    cc("-o", "check", f"{name}.o", *link_flags)
 
     check = Executable("./check")
     return check(output=str)

--- a/lib/spack/spack/patch.py
+++ b/lib/spack/spack/patch.py
@@ -198,8 +198,8 @@ class FilePatch(Patch):
                 break
 
         if abs_path is None:
-            msg = "FilePatch: Patch file %s for " % relative_path
-            msg += "package %s.%s does not exist." % (pkg.namespace, pkg.name)
+            msg = f"FilePatch: Patch file {relative_path} for "
+            msg += f"package {pkg.namespace}.{pkg.name} does not exist."
             raise ValueError(msg)
 
         super().__init__(pkg, abs_path, level, working_dir, reverse, ordering_key)
@@ -272,7 +272,7 @@ class UrlPatch(Patch):
         if allowed_archive(self.url) and not archive_sha256:
             raise spack.error.PatchDirectiveError(
                 "Compressed patches require 'archive_sha256' "
-                "and patch 'sha256' attributes: %s" % self.url
+                f"and patch 'sha256' attributes: {self.url}"
             )
         self.archive_sha256 = archive_sha256
 
@@ -353,13 +353,13 @@ def from_dict(dictionary: Dict[str, Any], repository: "spack.repo.RepoPath") -> 
         checker = Checker(sha256)
         if patch.path and not checker.check(patch.path):
             raise spack.fetch_strategy.ChecksumError(
-                "sha256 checksum failed for %s" % patch.path,
-                "Expected %s but got %s " % (sha256, checker.sum)
-                + "Patch may have changed since concretization.",
+                f"sha256 checksum failed for {patch.path}",
+                f"Expected {sha256} but got {checker.sum} "
+                "Patch may have changed since concretization.",
             )
         return patch
     else:
-        raise ValueError("Invalid patch dictionary: %s" % dictionary)
+        raise ValueError(f"Invalid patch dictionary: {dictionary}")
 
 
 class PatchCache:

--- a/lib/spack/spack/paths.py
+++ b/lib/spack/spack/paths.py
@@ -91,7 +91,7 @@ spack_instance_id = hash.b32_hash(spack_root)[:7]
 # setting `SPACK_USER_CACHE_PATH`. Otherwise it defaults to ~/.spack.
 #
 def _get_user_cache_path():
-    return os.path.expanduser(os.getenv("SPACK_USER_CACHE_PATH") or "~%s.spack" % os.sep)
+    return os.path.expanduser(os.getenv("SPACK_USER_CACHE_PATH") or f"~{os.sep}.spack")
 
 
 user_cache_path = str(PurePath(_get_user_cache_path()))
@@ -128,7 +128,7 @@ default_misc_cache_path = os.path.join(user_cache_path, spack_instance_id, "cach
 
 # User configuration and caches in $HOME/.spack
 def _get_user_config_path():
-    return os.path.expanduser(os.getenv("SPACK_USER_CONFIG_PATH") or "~%s.spack" % os.sep)
+    return os.path.expanduser(os.getenv("SPACK_USER_CONFIG_PATH") or f"~{os.sep}.spack")
 
 
 # Configuration in /etc/spack on the system

--- a/lib/spack/spack/relocate.py
+++ b/lib/spack/spack/relocate.py
@@ -135,15 +135,15 @@ def _macholib_get_paths(cur_path):
     except ValueError:
         pass
     if not headers:
-        tty.warn("Failed to read Mach-O headers: {0}".format(cur_path))
+        tty.warn(f"Failed to read Mach-O headers: {cur_path}")
         commands = []
     else:
         if len(headers) > 1:
             # Reproduce original behavior of only returning the last mach-O
             # header section
-            tty.warn("Encountered fat binary: {0}".format(cur_path))
+            tty.warn(f"Encountered fat binary: {cur_path}")
         if headers[-1].filetype == "dylib_stub":
-            tty.warn("File is a stub, not a full library: {0}".format(cur_path))
+            tty.warn(f"File is a stub, not a full library: {cur_path}")
         commands = headers[-1].commands
 
     LC_ID_DYLIB = spack.vendor.macholib.mach_o.LC_ID_DYLIB
@@ -352,7 +352,7 @@ def fixup_macos_rpath(root, filename):
     spack_root = spack.store.STORE.layout.root
     for name in deps:
         if name.startswith(spack_root):
-            tty.debug("Spack-installed dependency for {0}: {1}".format(abspath, name))
+            tty.debug(f"Spack-installed dependency for {abspath}: {name}")
             (dirname, basename) = os.path.split(name)
             if dirname != root or dirname in rpaths:
                 # Only change the rpath if it's a dependency *or* if the root
@@ -369,14 +369,14 @@ def fixup_macos_rpath(root, filename):
             # Allowable relative paths
             pass
         elif not _exists_dir(rpath):
-            tty.debug("Nonexistent rpath in {0}: {1}".format(abspath, rpath))
+            tty.debug(f"Nonexistent rpath in {abspath}: {rpath}")
             del_rpaths.add(rpath)
         elif count > 1:
             # Rpath should only be there once, but it can sometimes be
             # duplicated between Spack's compiler and libtool. If there are
             # more copies of the same one, something is very odd....
             tty_debug = tty.debug if count == 2 else tty.warn
-            tty_debug("Rpath appears {0} times in {1}: {2}".format(count, abspath, rpath))
+            tty_debug(f"Rpath appears {count} times in {abspath}: {rpath}")
             del_rpaths.add(rpath)
 
     # Delete bad rpaths
@@ -406,7 +406,7 @@ def fixup_macos_rpaths(spec):
     -delete_rpath``.
     """
     if spec.external or not spec.concrete:
-        tty.warn("external/abstract spec cannot be fixed up: {0!s}".format(spec))
+        tty.warn(f"external/abstract spec cannot be fixed up: {spec!s}")
         return False
 
     if "platform=darwin" not in spec:
@@ -419,9 +419,8 @@ def fixup_macos_rpaths(spec):
 
     if not os.path.exists(prefix):
         raise RuntimeError(
-            "Could not fix up install prefix spec {0} because it does not exist: {1!s}".format(
-                prefix, spec.name
-            )
+            f"Could not fix up install prefix spec {prefix} "
+            f"because it does not exist: {spec.name!s}"
         )
 
     # Explore the installation prefix of the spec
@@ -431,7 +430,7 @@ def fixup_macos_rpaths(spec):
             try:
                 needed_fix = fixup_macos_rpath(root, name)
             except Exception as e:
-                tty.warn("Failed to apply library fixups to: {0}/{1}: {2!s}".format(root, name, e))
+                tty.warn(f"Failed to apply library fixups to: {root}/{name}: {e!s}")
                 needed_fix = False
             if needed_fix:
                 applied += 1

--- a/lib/spack/spack/repo.py
+++ b/lib/spack/spack/repo.py
@@ -163,7 +163,7 @@ class ReposFinder:
     def find_spec(self, fullname, python_path, target=None):
         # "target" is not None only when calling importlib.reload()
         if target is not None:
-            raise RuntimeError('cannot reload module "{0}"'.format(fullname))
+            raise RuntimeError(f'cannot reload module "{fullname}"')
 
         # Preferred API from https://peps.python.org/pep-0451/
         if not fullname.startswith(PKG_MODULE_PREFIX_V1) and fullname != "spack.pkg":
@@ -635,7 +635,7 @@ class RepoIndex:
         of allow_stale."""
         indexer = self.indexers.get(name)
         if not indexer:
-            raise KeyError("no such index: %s" % name)
+            raise KeyError(f"no such index: {name}")
         if name not in self.indexes or (not allow_stale and not self.is_fresh):
             self._build_all_indexes(allow_stale=allow_stale)
         return self.indexes[name]
@@ -1671,7 +1671,7 @@ def create_repo(
             shutil.rmtree(root, ignore_errors=True)
 
         raise BadRepoError(
-            "Failed to create new repository in %s." % root, "Caused by %s: %s" % (type(e), e)
+            f"Failed to create new repository in {root}.", f"Caused by {type(e)}: {e}"
         ) from e
 
     return repo_yaml_dir, namespace
@@ -2243,9 +2243,8 @@ class FailedConstructorError(RepoError):
 
     def __init__(self, name, exc_type, exc_obj, exc_tb):
         super().__init__(
-            "Class constructor failed for package '%s'." % name,
+            f"Class constructor failed for package '{name}'.",
             "\nCaused by:\n"
-            + ("%s: %s\n" % (exc_type.__name__, exc_obj))
-            + "".join(traceback.format_tb(exc_tb)),
+            f"{exc_type.__name__}: {exc_obj}\n" + "".join(traceback.format_tb(exc_tb)),
         )
         self.name = name

--- a/lib/spack/spack/reporters/cdash.py
+++ b/lib/spack/spack/reporters/cdash.py
@@ -67,7 +67,7 @@ CDashConfiguration = collections.namedtuple(
 
 
 def build_stamp(track, timestamp):
-    buildstamp_format = "%Y%m%d-%H%M-{0}".format(track)
+    buildstamp_format = f"%Y%m%d-%H%M-{track}"
     return time.strftime(buildstamp_format, time.localtime(timestamp))
 
 
@@ -119,12 +119,12 @@ class CDash(Reporter):
         git = spack.util.git.git(required=True)
         with working_dir(spack.paths.spack_root):
             self.revision = git("rev-parse", "HEAD", output=str).strip()
-        self.generator = "spack-{0}".format(spack.get_version())
+        self.generator = f"spack-{spack.get_version()}"
         self.multiple_packages = False
 
     def report_build_name(self, pkg_name):
         buildname = (
-            "{0} - {1}".format(self.base_buildname, pkg_name)
+            f"{self.base_buildname} - {pkg_name}"
             if self.multiple_packages
             else self.base_buildname
         )
@@ -333,7 +333,7 @@ class CDash(Reporter):
                 t = env.get_template(phase_template)
                 f.write(t.render(report_data))
 
-            tty.debug("Preparing to upload {0}".format(phase_report))
+            tty.debug(f"Preparing to upload {phase_report}")
             self.upload(phase_report)
 
     def test_report_for_package(self, report_dir, package, duration):
@@ -384,9 +384,9 @@ class CDash(Reporter):
             spec: spec being tested
             reason: optional reason the test is being skipped
         """
-        output = "Skipped {0} package".format(spec.name)
+        output = f"Skipped {spec.name} package"
         if reason:
-            output += "\n{0}".format(reason)
+            output += f"\n{reason}"
 
         package = {"name": spec.name, "id": spec.dag_hash(), "result": "skipped", "stdout": output}
         self.test_report_for_package(report_dir, package, duration=0.0)
@@ -429,7 +429,7 @@ class CDash(Reporter):
 
     def upload(self, filename):
         if not self.cdash_upload_url:
-            print("Cannot upload {0} due to missing upload url".format(filename))
+            print(f"Cannot upload {filename} due to missing upload url")
             return
 
         # Compute md5 checksum for the contents of this file.
@@ -443,12 +443,12 @@ class CDash(Reporter):
                 "MD5": md5sum,
             }
             encoded_params = urlencode(params_dict)
-            url = "{0}&{1}".format(self.cdash_upload_url, encoded_params)
+            url = f"{self.cdash_upload_url}&{encoded_params}"
             request = Request(url, data=f, method="PUT")
             request.add_header("Content-Type", "text/xml")
             request.add_header("Content-Length", os.path.getsize(filename))
             if self.authtoken:
-                request.add_header("Authorization", "Bearer {0}".format(self.authtoken))
+                request.add_header("Authorization", f"Bearer {self.authtoken}")
             try:
                 with web_util.urlopen(request, timeout=SPACK_CDASH_TIMEOUT) as response:
                     if self.current_package_name not in self.buildIds:
@@ -468,7 +468,7 @@ class CDash(Reporter):
                 # a buildId.
                 build_url = self.cdash_upload_url
                 build_url = build_url[0 : build_url.find("submit.php")]
-                build_url += "buildSummary.php?buildid={0}".format(buildid)
-                tty.msg("{0}: {1}".format(package_name, build_url))
+                build_url += f"buildSummary.php?buildid={buildid}"
+                tty.msg(f"{package_name}: {build_url}")
         if not self.success:
             raise SpackError("Errors encountered, see above for more details")

--- a/lib/spack/spack/reporters/extract.py
+++ b/lib/spack/spack/reporters/extract.py
@@ -20,9 +20,9 @@ log_regexp = re.compile(r"^==> \[([0-9:.\-]*)(?:, [0-9]*)?\] (.*)")
 returns_regexp = re.compile(r"\[([0-9 ,]*)\]")
 
 skip_msgs = ["Testing package", "Results for", "Detected the following", "Warning:"]
-skip_regexps = [re.compile(r"{0}".format(msg)) for msg in skip_msgs]
+skip_regexps = [re.compile(rf"{msg}") for msg in skip_msgs]
 
-status_regexps = [re.compile(r"^({0})".format(str(stat))) for stat in TestStatus]
+status_regexps = [re.compile(rf"^({str(stat)})") for stat in TestStatus]
 
 
 def add_part_output(part, line):
@@ -35,7 +35,7 @@ def elapsed(current, previous):
         return 0
 
     diff = current - previous
-    tty.debug("elapsed = %s - %s = %s" % (current, previous, diff))
+    tty.debug(f"elapsed = {current} - {previous} = {diff}")
     return diff.total_seconds()
 
 
@@ -167,7 +167,7 @@ def extract_test_parts(default_name, outputs):
                     process_part_end(part, curr_time, last_time)
 
             else:
-                tty.debug("Did not recognize test output '{0}'".format(line))
+                tty.debug(f"Did not recognize test output '{line}'")
 
             # Each log message potentially represents a new test part so
             # save off the last timestamp
@@ -181,7 +181,7 @@ def extract_test_parts(default_name, outputs):
                 part["status"] = stat
                 add_part_output(part, line)
             else:
-                tty.warn("No part to add status from '{0}'".format(line))
+                tty.warn(f"No part to add status from '{line}'")
             continue
 
         add_part_output(part, line)

--- a/lib/spack/spack/rewiring.py
+++ b/lib/spack/spack/rewiring.py
@@ -57,7 +57,7 @@ class PackageNotInstalledError(RewireError):
 
     def __init__(self, spliced_spec, build_spec, dep):
         super().__init__(
-            """Rewire of {0}
-            failed due to missing install of build spec {1}
-            for spec {2}""".format(spliced_spec, build_spec, dep)
+            f"""Rewire of {spliced_spec}
+            failed due to missing install of build spec {build_spec}
+            for spec {dep}"""
         )

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -2101,8 +2101,7 @@ class SpackSolverSetup:
 
         if not self.target_specs_cache:
             self.target_specs_cache = [
-                spack.spec.Spec("target={0}".format(target_name))
-                for _, target_name in self.default_targets
+                spack.spec.Spec(f"target={target_name}") for _, target_name in self.default_targets
             ]
 
         package_targets = self.target_specs_cache[:]
@@ -2982,8 +2981,9 @@ class SpackSolverSetup:
         if env:
             dev_specs = tuple(
                 spack.spec.Spec(info["spec"]).constrained(
-                    'dev_path="%s"'
-                    % spack.util.path.canonicalize_path(info["path"], default_wd=env.path)
+                    'dev_path="{}"'.format(
+                        spack.util.path.canonicalize_path(info["path"], default_wd=env.path)
+                    )
                 )
                 for name, info in env.dev_specs.items()
             )

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -343,9 +343,8 @@ class ArchSpec:
 
             if self.platform != curr_platform:
                 raise ValueError(
-                    "Can't set arch spec OS to reserved value '%s' when the "
-                    "arch platform (%s) isn't the current platform (%s)"
-                    % (value, self.platform, curr_platform)
+                    f"Can't set arch spec OS to reserved value '{value}' when the "
+                    f"arch platform ({self.platform}) isn't the current platform ({curr_platform})"
                 )
 
             spec_platform = spack.platforms.by_name(self.platform)
@@ -381,9 +380,9 @@ class ArchSpec:
 
             if self.platform != curr_platform:
                 raise ValueError(
-                    "Can't set arch spec target to reserved value '%s' when "
-                    "the arch platform (%s) isn't the current platform (%s)"
-                    % (value, self.platform, curr_platform)
+                    f"Can't set arch spec target to reserved value '{value}' when "
+                    f"the arch platform ({self.platform}) isn't the current "
+                    f"platform ({curr_platform})"
                 )
 
             spec_platform = spack.platforms.by_name(self.platform)
@@ -624,7 +623,7 @@ class ArchSpec:
         return ArchSpec((arch["platform"], arch["platform_os"], target))
 
     def __str__(self):
-        return "%s-%s-%s" % (self.platform, self.os, self.target)
+        return f"{self.platform}-{self.os}-{self.target}"
 
     def __repr__(self):
         fmt = "ArchSpec(({0.platform!r}, {0.os!r}, {1!r}))"
@@ -1241,7 +1240,7 @@ class ForwardQueryToPackage:
         callbacks_chain = []
         # First in the chain : specialized attribute for virtual packages
         if query.isvirtual:
-            specialized_name = "{0}_{1}".format(query.name, self.attribute_name)
+            specialized_name = f"{query.name}_{self.attribute_name}"
             callbacks_chain.append(lambda: getattr(pkg, specialized_name))
         # Try to get the generic method from Package
         callbacks_chain.append(lambda: getattr(pkg, self.attribute_name))
@@ -1376,7 +1375,7 @@ def tree(
         out += " " * indent
 
         if depth:
-            out += "%-4d" % d
+            out += f"{d:<4d}"
 
         if status_fn:
             status = status_fn(node)
@@ -1399,7 +1398,7 @@ def tree(
                 depflag = dep_spec.depflag
 
             type_chars = dt.flag_to_chars(depflag)
-            out += "[%s]  " % type_chars
+            out += f"[{type_chars}]  "
 
         out += "    " * d
         if d > 0:
@@ -2041,9 +2040,7 @@ class Spec:
 
     @property
     def package(self):
-        assert self.concrete, "{0}: Spec.package can only be called on concrete specs".format(
-            self.name
-        )
+        assert self.concrete, f"{self.name}: Spec.package can only be called on concrete specs"
         if not self._package:
             self._package = spack.repo.PATH.get(self)
         return self._package
@@ -2590,7 +2587,7 @@ class Spec:
                 else:
                     new_spec.variants[vname] = value
             else:
-                raise ValueError("{0} is not a variant of {1}".format(vname, new_spec.name))
+                raise ValueError(f"{vname} is not a variant of {new_spec.name}")
 
         if change_spec.compiler_flags:
             for flagname, flagvals in change_spec.compiler_flags.items():
@@ -2860,7 +2857,7 @@ class Spec:
             msg = "\n    The following specs have been deprecated"
             msg += " in favor of specs with the hashes shown:\n"
             for rec in deprecated:
-                msg += "        %s  --> %s\n" % (rec.spec, rec.deprecated_for)
+                msg += f"        {rec.spec}  --> {rec.deprecated_for}\n"
             msg += "\n"
             msg += "    For each package listed, choose another spec\n"
             raise SpecDeprecatedError(msg)
@@ -5093,7 +5090,7 @@ class VariantMap(lang.HashableMap[str, vt.VariantValue]):
 
         # Raise an error if the variant was already in this map
         if name in self.dict:
-            msg = 'Cannot specify variant "{0}" twice'.format(name)
+            msg = f'Cannot specify variant "{name}" twice'
             raise vt.DuplicateVariantError(msg)
 
         # Raise an error if name and vspec.name don't match
@@ -5879,9 +5876,7 @@ class InvalidDependencyError(spack.error.SpecError):
 
     def __init__(self, pkg, deps):
         self.invalid_deps = deps
-        super().__init__(
-            "Package {0} does not depend on {1}".format(pkg, spack.util.string.comma_or(deps))
-        )
+        super().__init__(f"Package {pkg} does not depend on {spack.util.string.comma_or(deps)}")
 
 
 class UnsatisfiableSpecNameError(spack.error.UnsatisfiableSpecError):
@@ -5918,7 +5913,7 @@ class UnconstrainableDependencySpecError(spack.error.SpecError):
     """Raised when attempting to constrain by an anonymous dependency spec"""
 
     def __init__(self, spec):
-        msg = "Cannot constrain by spec '%s'. Cannot constrain by a" % spec
+        msg = f"Cannot constrain by spec '{spec}'. Cannot constrain by a"
         msg += " spec containing anonymous dependencies"
         super().__init__(msg)
 
@@ -5953,14 +5948,14 @@ class SpecFormatSigilError(SpecFormatStringError):
     """Called for mismatched sigils and attributes in format strings"""
 
     def __init__(self, sigil, requirement, used):
-        msg = "The sigil %s may only be used for %s." % (sigil, requirement)
-        msg += " It was used with the attribute %s." % used
+        msg = f"The sigil {sigil} may only be used for {requirement}."
+        msg += f" It was used with the attribute {used}."
         super().__init__(msg)
 
 
 class ConflictsInSpecError(spack.error.SpecError, RuntimeError):
     def __init__(self, spec, matches):
-        message = 'Conflicts in concretized spec "{0}"\n'.format(spec.short_spec)
+        message = f'Conflicts in concretized spec "{spec.short_spec}"\n'
 
         visited = set()
 

--- a/lib/spack/spack/stage.py
+++ b/lib/spack/spack/stage.py
@@ -95,16 +95,12 @@ def create_stage_root(path: str) -> None:
             p_stat = os.stat(p)
             if par_stat.st_gid != p_stat.st_gid:
                 tty.warn(
-                    "Expected {0} to have group {1}, but it is {2}".format(
-                        p, par_stat.st_gid, p_stat.st_gid
-                    )
+                    f"Expected {p} to have group {par_stat.st_gid}, but it is {p_stat.st_gid}"
                 )
 
             if par_stat.st_mode & p_stat.st_mode != par_stat.st_mode:
                 tty.warn(
-                    "Expected {0} to support mode {1}, but it is {2}".format(
-                        p, par_stat.st_mode, p_stat.st_mode
-                    )
+                    f"Expected {p} to support mode {par_stat.st_mode}, but it is {p_stat.st_mode}"
                 )
 
             if not can_access(p):
@@ -120,11 +116,7 @@ def create_stage_root(path: str) -> None:
         # restricted to the user.
         owner_uid = get_owner_uid(p)
         if user_uid != owner_uid:
-            tty.warn(
-                "Expected user {0} to own {1}, but it is owned by {2}".format(
-                    user_uid, p, owner_uid
-                )
-            )
+            tty.warn(f"Expected user {user_uid} to own {p}, but it is owned by {owner_uid}")
 
     spack_src_subdir = os.path.join(path, _source_path_subdir)
     # When staging into a user-specified directory with `spack stage -p <PATH>`, we need
@@ -150,7 +142,7 @@ def _first_accessible_path(paths):
                 return path
 
         except OSError as e:
-            tty.debug("OSError while checking stage path %s: %s" % (path, str(e)))
+            tty.debug(f"OSError while checking stage path {path}: {str(e)}")
 
     return None
 
@@ -832,9 +824,7 @@ class ResourceStage(Stage):
             if not os.path.exists(destination_path):
                 tty.info(
                     "Moving resource stage\n\tsource: "
-                    "{stage}\n\tdestination: {destination}".format(
-                        stage=source_path, destination=destination_path
-                    )
+                    f"{source_path}\n\tdestination: {destination_path}"
                 )
 
                 src = os.path.realpath(source_path)
@@ -1052,7 +1042,7 @@ class DevelopStage(AbstractStage):
 def ensure_access(file):
     """Ensure we can access a directory and die with an error if we can't."""
     if not can_access(file):
-        tty.die("Insufficient permissions for %s" % file)
+        tty.die(f"Insufficient permissions for {file}")
 
 
 def purge():

--- a/lib/spack/spack/store.py
+++ b/lib/spack/spack/store.py
@@ -123,8 +123,8 @@ def parse_install_tree(config_dict: dict) -> Tuple[str, str, Dict[str, str]]:
     if padded_length:
         root = spack.util.path.add_padding(unpadded_root, padded_length)
         if len(root) != padded_length:
-            msg = "Cannot pad %s to %s characters." % (root, padded_length)
-            msg += " It is already %s characters long" % len(root)
+            msg = f"Cannot pad {root} to {padded_length} characters."
+            msg += f" It is already {len(root)} characters long"
             tty.warn(msg)
     else:
         root = unpadded_root
@@ -183,7 +183,7 @@ class Store:
         timeout_format_str = (
             f"{str(lock_cfg.package_timeout)}s" if lock_cfg.package_timeout else "No timeout"
         )
-        tty.debug("PACKAGE LOCK TIMEOUT: {0}".format(str(timeout_format_str)))
+        tty.debug(f"PACKAGE LOCK TIMEOUT: {str(timeout_format_str)}")
 
         self.prefix_locker = spack.database.SpecLocker(
             spack.database.prefix_lock_path(root), default_timeout=lock_cfg.package_timeout
@@ -421,7 +421,7 @@ def use_store(
     global STORE
 
     assert not isinstance(path, Store), "cannot pass a store anymore"
-    scope_name = "use-store-{}".format(uuid.uuid4())
+    scope_name = f"use-store-{uuid.uuid4()}"
     data = {"root": str(path)}
     if extra_data:
         data.update(extra_data)

--- a/lib/spack/spack/tengine.py
+++ b/lib/spack/spack/tengine.py
@@ -104,12 +104,12 @@ def prepend_to_line(text, token):
 
 def quote(text):
     """Quotes each line in text"""
-    return ['"{0}"'.format(line) for line in text]
+    return [f'"{line}"' for line in text]
 
 
 def curly_quote(text):
     """Encloses each line of text in curly braces"""
-    return ["{{{0}}}".format(line) for line in text]
+    return [f"{{{line}}}" for line in text]
 
 
 def _set_filters(env):

--- a/lib/spack/spack/test/binary_distribution.py
+++ b/lib/spack/spack/test/binary_distribution.py
@@ -581,7 +581,7 @@ def test_v2_etag_fetching_304():
                 hdrs={},  # type: ignore[arg-type]
                 fp=None,  # type: ignore[arg-type]
             )
-        assert False, "Should not fetch {}".format(url)
+        assert False, f"Should not fetch {url}"
 
     fetcher = spack.binary_distribution.EtagIndexHandlerV2(
         spack.binary_distribution.MirrorMetadata("https://www.example.com", 2),
@@ -606,7 +606,7 @@ def test_v2_etag_fetching_200():
                 url=url,
                 code=200,
             )
-        assert False, "Should not fetch {}".format(url)
+        assert False, f"Should not fetch {url}"
 
     fetcher = spack.binary_distribution.EtagIndexHandlerV2(
         spack.binary_distribution.MirrorMetadata("https://www.example.com", 2),
@@ -665,7 +665,7 @@ def test_v2_default_index_fetch_200():
                 code=200,
             )
 
-        assert False, "Unexpected request {}".format(url)
+        assert False, f"Unexpected request {url}"
 
     fetcher = spack.binary_distribution.DefaultIndexHandlerV2(
         spack.binary_distribution.MirrorMetadata("https://www.example.com", 2),
@@ -698,7 +698,7 @@ def test_v2_default_index_dont_fetch_index_json_hash_if_no_local_hash():
                 code=200,
             )
 
-        assert False, "Unexpected request {}".format(url)
+        assert False, f"Unexpected request {url}"
 
     fetcher = spack.binary_distribution.DefaultIndexHandlerV2(
         spack.binary_distribution.MirrorMetadata("https://www.example.com", 2),
@@ -730,7 +730,7 @@ def test_v2_default_index_not_modified():
             )
 
         # No request to index.json should be made.
-        assert False, "Unexpected request {}".format(url)
+        assert False, f"Unexpected request {url}"
 
     fetcher = spack.binary_distribution.DefaultIndexHandlerV2(
         spack.binary_distribution.MirrorMetadata("https://www.example.com", 2),
@@ -787,7 +787,7 @@ def test_v2_default_index_json_404():
                 fp=None,
             )
 
-        assert False, "Unexpected fetch {}".format(url)
+        assert False, f"Unexpected fetch {url}"
 
     fetcher = spack.binary_distribution.DefaultIndexHandlerV2(
         spack.binary_distribution.MirrorMetadata("https://www.example.com", 2),
@@ -1278,7 +1278,7 @@ def test_etag_fetching_304():
                 hdrs={},  # type: ignore[arg-type]
                 fp=None,  # type: ignore[arg-type]
             )
-        assert False, "Unexpected request {}".format(url)
+        assert False, f"Unexpected request {url}"
 
     fetcher = spack.binary_distribution.EtagIndexHandler(
         spack.binary_distribution.MirrorMetadata(
@@ -1305,7 +1305,7 @@ def test_etag_fetching_200(mock_index):
                 url=url,
                 code=200,
             )
-        assert False, "Unexpected request {}".format(url)
+        assert False, f"Unexpected request {url}"
 
     fetcher = spack.binary_distribution.EtagIndexHandler(
         spack.binary_distribution.MirrorMetadata(
@@ -1359,7 +1359,7 @@ def test_default_index_fetch_200(mock_index):
                 code=200,
             )
 
-        assert False, "Unexpected request {}".format(url)
+        assert False, f"Unexpected request {url}"
 
     fetcher = spack.binary_distribution.DefaultIndexHandler(
         spack.binary_distribution.MirrorMetadata(
@@ -1415,7 +1415,7 @@ def test_default_index_not_modified(mock_index):
             )
 
         # No other request should be made.
-        assert False, "Unexpected request {}".format(url)
+        assert False, f"Unexpected request {url}"
 
     fetcher = spack.binary_distribution.DefaultIndexHandler(
         spack.binary_distribution.MirrorMetadata(

--- a/lib/spack/spack/test/bootstrap.py
+++ b/lib/spack/spack/test/bootstrap.py
@@ -174,14 +174,14 @@ def test_bootstrap_custom_store_in_environment(mutable_config, tmp_path: pathlib
     spack_yaml = tmp_path / "spack.yaml"
     install_root = tmp_path / "store"
     spack_yaml.write_text(
-        """
+        f"""
 spack:
   specs:
   - libelf
   config:
     install_tree:
-      root: {0}
-""".format(install_root)
+      root: {install_root}
+"""
     )
     with spack.environment.Environment(str(tmp_path)):
         assert spack.environment.active_environment()

--- a/lib/spack/spack/test/build_environment.py
+++ b/lib/spack/spack/test/build_environment.py
@@ -138,7 +138,7 @@ def test_static_to_shared_library(build_environment):
             ).strip()
 
             if not shared_lib:
-                shared_lib = "{0}.{1}".format(os.path.splitext(static_lib)[0], dso_suffix)
+                shared_lib = f"{os.path.splitext(static_lib)[0]}.{dso_suffix}"
 
             assert set(output.split()) == set(
                 expected[arch].format(static_lib, shared_lib, os.path.basename(shared_lib)).split()

--- a/lib/spack/spack/test/ci.py
+++ b/lib/spack/spack/test/ci.py
@@ -307,14 +307,14 @@ def test_setup_spack_repro_version(
     _, err = capfd.readouterr()
 
     assert not ret
-    assert "Missing commit: {0}".format(c2) in err
+    assert f"Missing commit: {c2}" in err
 
     git_cmd.check = lambda *a, **k: 1 if len(a) > 2 and a[2] == c1 else 0
     ret = ci.setup_spack_repro_version(str(repro_dir), c2, c1)
     _, err = capfd.readouterr()
 
     assert not ret
-    assert "Missing commit: {0}".format(c1) in err
+    assert f"Missing commit: {c1}" in err
 
     git_cmd.check = lambda *a, **k: 1 if a[0] == "clone" else 0
     ret = ci.setup_spack_repro_version(str(repro_dir), c2, c1)
@@ -335,7 +335,7 @@ def test_setup_spack_repro_version(
     _, err = capfd.readouterr()
 
     assert not ret
-    assert "Unable to merge {0}".format(c1) in err
+    assert f"Unable to merge {c1}" in err
 
 
 def test_get_spec_filter_list(mutable_mock_env_path, mutable_mock_repo):

--- a/lib/spack/spack/test/cmd/bootstrap.py
+++ b/lib/spack/spack/test/cmd/bootstrap.py
@@ -22,7 +22,7 @@ _bootstrap = spack.main.SpackCommand("bootstrap")
 def test_enable_and_disable(mutable_config, scope):
     scope_args = []
     if scope:
-        scope_args = ["--scope={0}".format(scope)]
+        scope_args = [f"--scope={scope}"]
 
     _bootstrap("enable", *scope_args)
     assert spack.config.get("bootstrap:enable", scope=scope) is True
@@ -35,7 +35,7 @@ def test_enable_and_disable(mutable_config, scope):
 def test_root_get_and_set(mutable_config, tmp_path, scope):
     scope_args, path = [], str(tmp_path)
     if scope:
-        scope_args = ["--scope={0}".format(scope)]
+        scope_args = [f"--scope={scope}"]
 
     _bootstrap("root", path, *scope_args)
     out = _bootstrap("root", *scope_args)
@@ -47,7 +47,7 @@ def test_reset_in_file_scopes(mutable_config, scopes):
     # Assert files are created in the right scopes
     bootstrap_yaml_files = []
     for s in scopes:
-        _bootstrap("disable", "--scope={0}".format(s))
+        _bootstrap("disable", f"--scope={s}")
         scope_path = spack.config.CONFIG.scopes[s].path
         bootstrap_yaml = os.path.join(scope_path, "bootstrap.yaml")
         assert os.path.exists(bootstrap_yaml)
@@ -187,7 +187,7 @@ def test_bootstrap_mirror_metadata(mutable_config, linux_os, monkeypatch, tmp_pa
         {
             "compiler": {
                 "spec": "gcc@12.0.1",
-                "operating_system": "{0.name}{0.version}".format(linux_os),
+                "operating_system": f"{linux_os.name}{linux_os.version}",
                 "modules": [],
                 "paths": {
                     "cc": "/usr/bin",

--- a/lib/spack/spack/test/cmd/ci.py
+++ b/lib/spack/spack/test/cmd/ci.py
@@ -1277,7 +1277,7 @@ def test_ci_generate_read_broken_specs_url(
     broken_specs_url = tmp_path.as_uri()
 
     # Mark 'a' as broken (but not 'dependent-install')
-    broken_spec_a_url = "{0}/{1}".format(broken_specs_url, a_dag_hash)
+    broken_spec_a_url = f"{broken_specs_url}/{a_dag_hash}"
     job_stack = "job_stack"
     a_job_url = "a_job_url"
     ci.write_broken_spec(

--- a/lib/spack/spack/test/cmd/commands.py
+++ b/lib/spack/spack/test/cmd/commands.py
@@ -127,10 +127,10 @@ _cmd-spack-install:
 
     out = commands("--format=rst", str(filename))
     for name in ["fetch", "stage", "patch"]:
-        assert (":ref:`More documentation <cmd-spack-%s>`" % name) in out
+        assert (f":ref:`More documentation <cmd-spack-{name}>`") in out
 
     for name in ["list", "install"]:
-        assert (":ref:`More documentation <cmd-spack-%s>`" % name) not in out
+        assert (f":ref:`More documentation <cmd-spack-{name}>`") not in out
 
 
 def test_rst_with_header(tmp_path: pathlib.Path):

--- a/lib/spack/spack/test/cmd/common/arguments.py
+++ b/lib/spack/spack/test/cmd/common/arguments.py
@@ -68,7 +68,7 @@ def test_parse_spec_flags_with_spaces(specs, cflags, propagation, negated_varian
     assert flag_propagation == propagation
     assert list(s.variants.keys()) == negated_variants
     for v in negated_variants:
-        assert "~{0}".format(v) in s
+        assert f"~{v}" in s
 
 
 def test_match_spec_env(mock_packages, mutable_mock_env_path):

--- a/lib/spack/spack/test/cmd/dev_build.py
+++ b/lib/spack/spack/test/cmd/dev_build.py
@@ -125,7 +125,7 @@ def test_dev_build_drop_in(
 
 def test_dev_build_fails_already_installed(tmp_path: pathlib.Path, install_mockery):
     spec = spack.concretize.concretize_one(
-        spack.spec.Spec("dev-build-test-install@0.0.0 dev_path=%s" % str(tmp_path))
+        spack.spec.Spec(f"dev-build-test-install@0.0.0 dev_path={str(tmp_path)}")
     )
 
     with fs.working_dir(str(tmp_path)):
@@ -134,7 +134,7 @@ def test_dev_build_fails_already_installed(tmp_path: pathlib.Path, install_mocke
 
         dev_build("dev-build-test-install@0.0.0")
         output = dev_build("dev-build-test-install@0.0.0", fail_on_error=False)
-        assert "Already installed in %s" % spec.prefix in output
+        assert f"Already installed in {spec.prefix}" in output
 
 
 def test_dev_build_fails_no_spec():
@@ -187,7 +187,7 @@ def test_dev_build_env(
     build_dir = tmp_path / "build"
     build_dir.mkdir()
     spec = spack.concretize.concretize_one(
-        spack.spec.Spec("dev-build-test-install@0.0.0 dev_path=%s" % str(build_dir))
+        spack.spec.Spec(f"dev-build-test-install@0.0.0 dev_path={str(build_dir)}")
     )
 
     with fs.working_dir(str(build_dir)):
@@ -271,7 +271,7 @@ def test_dev_build_env_version_mismatch(
     build_dir = tmp_path / "build"
     build_dir.mkdir()
     spec = spack.concretize.concretize_one(
-        spack.spec.Spec("dev-build-test-install@0.0.0 dev_path=%s" % str(tmp_path))
+        spack.spec.Spec(f"dev-build-test-install@0.0.0 dev_path={str(tmp_path)}")
     )
 
     with fs.working_dir(str(build_dir)):
@@ -420,7 +420,7 @@ spack:
 
     # Ensure variants set properly; ensure build_dir is absolute and normalized
     for dep in (dep_spec, spec["dev-build-test-install"]):
-        assert dep.satisfies("dev_path=%s" % str(build_dir))
+        assert dep.satisfies(f"dev_path={str(build_dir)}")
     assert spec.satisfies("^dev_path=*")
 
 
@@ -437,7 +437,7 @@ def test_dev_build_rebuild_on_source_changes(
     build_dir = tmp_path / "build"
     build_dir.mkdir()
     spec = spack.concretize.concretize_one(
-        spack.spec.Spec("dev-build-test-install@0.0.0 dev_path=%s" % str(build_dir))
+        spack.spec.Spec(f"dev-build-test-install@0.0.0 dev_path={str(build_dir)}")
     )
 
     def reset_string():

--- a/lib/spack/spack/test/cmd/develop.py
+++ b/lib/spack/spack/test/cmd/develop.py
@@ -50,7 +50,7 @@ class TestDevelop:
         if build_dir is not None:
             scope = env.scope_name
             assert build_dir == spack.config.get(
-                "packages:{}:package_attributes:build_directory".format(spec.name), scope
+                f"packages:{spec.name}:package_attributes:build_directory", scope
             )
 
     def test_develop_no_path_no_clone(self):
@@ -223,7 +223,7 @@ class TestDevelop:
 
             # Check modifications actually worked
             spec = next(e.roots())
-            assert spec.satisfies("dev_path=%s" % abspath)
+            assert spec.satisfies(f"dev_path={abspath}")
 
     def test_develop_canonicalize_path_no_args(self, monkeypatch):
         env("create", "test")
@@ -256,7 +256,7 @@ class TestDevelop:
 
             # Check modifications actually worked
             spec = next(e.roots())
-            assert spec.satisfies("dev_path=%s" % abspath)
+            assert spec.satisfies(f"dev_path={abspath}")
 
 
 def _git_commit_list(git_repo_dir):
@@ -277,7 +277,7 @@ def test_develop_full_git_repo(
 ):
     repo_path, filename, commits = mock_git_version_info
     monkeypatch.setattr(
-        spack.package_base.PackageBase, "git", "file://%s" % repo_path, raising=False
+        spack.package_base.PackageBase, "git", f"file://{repo_path}", raising=False
     )
 
     spec = spack.concretize.concretize_one("git-test-commit@1.2")

--- a/lib/spack/spack/test/cmd/diff.py
+++ b/lib/spack/spack/test/cmd/diff.py
@@ -94,8 +94,8 @@ def test_diff_cmd(install_mockery, mock_fetch, mock_archive, mock_packages):
     assert ["variant_value", "mpileaks debug True"] in c["b_not_a"]
 
     # ensure that hash diffs are in here the result
-    assert ["hash", "mpileaks %s" % specA.dag_hash()] in c["a_not_b"]
-    assert ["hash", "mpileaks %s" % specB.dag_hash()] in c["b_not_a"]
+    assert ["hash", f"mpileaks {specA.dag_hash()}"] in c["a_not_b"]
+    assert ["hash", f"mpileaks {specB.dag_hash()}"] in c["b_not_a"]
 
 
 def test_diff_runtimes(install_mockery, mock_fetch, mock_archive, mock_packages):
@@ -168,13 +168,11 @@ def test_load_first(install_mockery, mock_fetch, mock_archive, mock_packages):
     debug_hash = find_cmd("--format", "{hash}", "mpileaks+debug").strip()
     no_debug_hashes = find_cmd("--format", "{hash}", "mpileaks~debug")
     no_debug_hash = no_debug_hashes.split()[0]
-    output = diff_cmd(
-        "--json", "mpileaks/{0}".format(debug_hash), "mpileaks/{0}".format(no_debug_hash)
-    )
+    output = diff_cmd("--json", f"mpileaks/{debug_hash}", f"mpileaks/{no_debug_hash}")
     result = sjson.load(output)
 
-    assert ["hash", "mpileaks %s" % debug_hash] in result["a_not_b"]
+    assert ["hash", f"mpileaks {debug_hash}"] in result["a_not_b"]
     assert ["variant_value", "mpileaks debug True"] in result["a_not_b"]
 
-    assert ["hash", "mpileaks %s" % no_debug_hash] in result["b_not_a"]
+    assert ["hash", f"mpileaks {no_debug_hash}"] in result["b_not_a"]
     assert ["variant_value", "mpileaks debug False"] in result["b_not_a"]

--- a/lib/spack/spack/test/cmd/env.py
+++ b/lib/spack/spack/test/cmd/env.py
@@ -1159,14 +1159,14 @@ spack:
     )
 
     external_config = io.StringIO(
-        """\
+        f"""\
 packages:
   pkg-a:
     externals:
     - spec: pkg-a@2.0
-      prefix: {a_prefix}
+      prefix: {str(fake_prefix)}
     buildable: false
-""".format(a_prefix=str(fake_prefix))
+"""
     )
     external_config_dict = spack.util.spack_yaml.load_config(external_config)
 
@@ -1344,13 +1344,13 @@ packages:
 def mpileaks_env_config(include_path):
     """Return the contents of an environment that includes the provided
     path and lists mpileaks as the sole spec."""
-    return """\
+    return f"""\
 spack:
   include:
-  - {0}
+  - {include_path}
   specs:
   - mpileaks
-""".format(include_path)
+"""
 
 
 def test_env_with_included_config_file(mutable_mock_env_path, packages_file):
@@ -1509,7 +1509,7 @@ def test_env_with_included_config_file_url(
 
     spack_yaml = tmp_path / "spack.yaml"
     with spack_yaml.open("w") as f:
-        f.write("spack:\n  include:\n    - {0}\n".format(packages_file.as_uri()))
+        f.write(f"spack:\n  include:\n    - {packages_file.as_uri()}\n")
 
     env = ev.Environment(str(tmp_path))
     ev.activate(env)
@@ -1973,7 +1973,7 @@ def test_store_different_build_deps(repo_builder: RepoBuilder):
 
 def test_env_updates_view_install(tmp_path: pathlib.Path, mock_stage, mock_fetch, install_mockery):
     view_dir = tmp_path / "view"
-    env("create", "--with-view=%s" % view_dir, "test")
+    env("create", f"--with-view={view_dir}", "test")
     with ev.read("test"):
         add("mpileaks")
         install("--fake")
@@ -1990,7 +1990,7 @@ def test_env_view_fails(
     # It also throws on file-file conflicts. That's what we're checking here
     # by adding the same package twice to a view.
     view_dir = tmp_path / "view"
-    env("create", "--with-view=%s" % view_dir, "test")
+    env("create", f"--with-view={view_dir}", "test")
     with ev.read("test"):
         add("libelf")
         add("libelf cflags=-g")
@@ -2006,7 +2006,7 @@ def test_env_view_fails_dir_file(
     # This environment view fails to be created because a file
     # and a dir are in the same path. Test that it mentions the problematic path.
     view_dir = tmp_path / "view"
-    env("create", "--with-view=%s" % view_dir, "test")
+    env("create", f"--with-view={view_dir}", "test")
     with ev.read("test"):
         add("view-file")
         add("view-dir")
@@ -2021,7 +2021,7 @@ def test_env_view_succeeds_symlinked_dir_file(
 ):
     # A symlinked dir and an ordinary dir merge happily
     view_dir = tmp_path / "view"
-    env("create", "--with-view=%s" % view_dir, "test")
+    env("create", f"--with-view={view_dir}", "test")
     with ev.read("test"):
         add("view-symlinked-dir")
         add("view-dir")
@@ -2470,7 +2470,7 @@ def test_env_updates_view_install_package(
     tmp_path: pathlib.Path, mock_stage, mock_fetch, install_mockery
 ):
     view_dir = tmp_path / "view"
-    env("create", "--with-view=%s" % view_dir, "test")
+    env("create", f"--with-view={view_dir}", "test")
     with ev.read("test"):
         install("--fake", "--add", "mpileaks")
 
@@ -2481,7 +2481,7 @@ def test_env_updates_view_add_concretize(
     tmp_path: pathlib.Path, mock_stage, mock_fetch, install_mockery
 ):
     view_dir = tmp_path / "view"
-    env("create", "--with-view=%s" % view_dir, "test")
+    env("create", f"--with-view={view_dir}", "test")
     install("--fake", "mpileaks")
     with ev.read("test"):
         add("mpileaks")
@@ -2494,7 +2494,7 @@ def test_env_updates_view_uninstall(
     tmp_path: pathlib.Path, mock_stage, mock_fetch, install_mockery
 ):
     view_dir = tmp_path / "view"
-    env("create", "--with-view=%s" % view_dir, "test")
+    env("create", f"--with-view={view_dir}", "test")
     with ev.read("test"):
         install("--fake", "--add", "mpileaks")
 
@@ -2510,7 +2510,7 @@ def test_env_updates_view_uninstall_referenced_elsewhere(
     tmp_path: pathlib.Path, mock_stage, mock_fetch, install_mockery
 ):
     view_dir = tmp_path / "view"
-    env("create", "--with-view=%s" % view_dir, "test")
+    env("create", f"--with-view={view_dir}", "test")
     install("--fake", "mpileaks")
     with ev.read("test"):
         add("mpileaks")
@@ -2528,7 +2528,7 @@ def test_env_updates_view_remove_concretize(
     tmp_path: pathlib.Path, mock_stage, mock_fetch, install_mockery
 ):
     view_dir = tmp_path / "view"
-    env("create", "--with-view=%s" % view_dir, "test")
+    env("create", f"--with-view={view_dir}", "test")
     install("--fake", "mpileaks")
     with ev.read("test"):
         add("mpileaks")
@@ -2547,7 +2547,7 @@ def test_env_updates_view_force_remove(
     tmp_path: pathlib.Path, mock_stage, mock_fetch, install_mockery
 ):
     view_dir = tmp_path / "view"
-    env("create", "--with-view=%s" % view_dir, "test")
+    env("create", f"--with-view={view_dir}", "test")
     with ev.read("test"):
         install("--add", "--fake", "mpileaks")
 
@@ -3080,18 +3080,17 @@ def test_view_link_run(
     envdir = str(tmp_path)
     with open(yaml, "w", encoding="utf-8") as f:
         f.write(
-            """
+            f"""
 spack:
   specs:
   - dttop
 
   view:
     combinatorial:
-      root: %s
+      root: {viewdir}
       link: run
       projections:
-        all: '{name}'"""
-            % viewdir
+        all: '{{name}}'"""
         )
 
     with ev.Environment(envdir):
@@ -3337,9 +3336,9 @@ def test_env_activate_default_view_root_unconditional(mutable_mock_env_path):
     viewdir_bin = os.path.join(viewdir, "bin")
 
     assert (
-        "export PATH={0}".format(viewdir_bin) in out
-        or "export PATH='{0}".format(viewdir_bin) in out
-        or 'export PATH="{0}'.format(viewdir_bin) in out
+        f"export PATH={viewdir_bin}" in out
+        or f"export PATH='{viewdir_bin}" in out
+        or f'export PATH="{viewdir_bin}' in out
     )
 
 
@@ -3639,7 +3638,7 @@ spack:
         user_spec_hash = e.concretized_roots[0].hash
         spec = e.specs_by_hash[user_spec_hash]
         view_prefix = e.default_view.get_projection_for_spec(spec)
-        modules_glob = "%s/modules/**/*/*" % e.path
+        modules_glob = f"{e.path}/modules/**/*/*"
         modules = glob.glob(modules_glob)
         assert len(modules) == 1
         module = modules[0]
@@ -3821,14 +3820,14 @@ def test_custom_store_in_environment(mutable_config, tmp_path: pathlib.Path):
     spack_yaml = tmp_path / "spack.yaml"
     install_root = tmp_path / "store"
     spack_yaml.write_text(
-        """
+        f"""
 spack:
   specs:
   - libelf
   config:
     install_tree:
-      root: {0}
-""".format(install_root)
+      root: {install_root}
+"""
     )
     current_store_root = str(spack.store.STORE.root)
     assert str(current_store_root) != str(install_root)
@@ -3914,7 +3913,7 @@ def test_env_view_backward_compat_old_symlink_format(
 ):
     """An old-style symlink view pointing to ._view/<hash>/ is recognized as up-to-date."""
     view = str(tmp_path / "view")
-    env("create", "--with-view={0}".format(view), "test")
+    env("create", f"--with-view={view}", "test")
     with ev.read("test") as e:
         add("libelf")
         install("--fake")
@@ -3925,7 +3924,7 @@ def test_env_view_backward_compat_old_symlink_format(
     # Simulate old format: remove the real view dir and replace with a symlink
     root_name = os.path.basename(view)
     root_dir = os.path.dirname(view)
-    old_hash_dir = os.path.join(root_dir, "._%s" % root_name, content_hash)
+    old_hash_dir = os.path.join(root_dir, f"._{root_name}", content_hash)
     shutil.rmtree(view)
     os.makedirs(old_hash_dir, exist_ok=True)
     os.symlink(old_hash_dir, view)
@@ -3967,7 +3966,7 @@ def test_environment_view_target_already_exists(
     symlink format does not prevent regeneration."""
 
     view = str(tmp_path / "view")
-    env("create", "--with-view={0}".format(view), "test")
+    env("create", f"--with-view={view}", "test")
     with ev.read("test"):
         add("libelf")
         install("--fake")
@@ -4022,7 +4021,7 @@ def test_read_old_lock_and_write_new(tmp_path: pathlib.Path, lockfile):
     # the environment, anyway.
     #
     # This test ensures the behavior described above.
-    lockfile_path = os.path.join(spack.paths.test_path, "data", "legacy_env", "%s.lock" % lockfile)
+    lockfile_path = os.path.join(spack.paths.test_path, "data", "legacy_env", f"{lockfile}.lock")
 
     # read in the JSON from a legacy lockfile
     with open(lockfile_path, encoding="utf-8") as f:
@@ -4412,7 +4411,7 @@ post-install: $(addprefix example/post-install/,$(example/SPACK_PACKAGE_IDS))
     # post-install: <hash> should've been executed
     with ev.read("test") as test:
         for s in test.all_specs():
-            assert "post-install: {}".format(s.dag_hash()) in out
+            assert f"post-install: {s.dag_hash()}" in out
 
 
 def test_depfile_empty_does_not_error(tmp_path: pathlib.Path):

--- a/lib/spack/spack/test/cmd/find.py
+++ b/lib/spack/spack/test/cmd/find.py
@@ -310,7 +310,7 @@ def test_find_very_long(database, config):
     ]
 
     assert set(output.strip().split("\n")) == set(
-        [("%s mpileaks@2.3" % s.dag_hash()) for s in specs]
+        [(f"{s.dag_hash()} mpileaks@2.3") for s in specs]
     )
 
 

--- a/lib/spack/spack/test/cmd/install.py
+++ b/lib/spack/spack/test/cmd/install.py
@@ -392,8 +392,8 @@ def test_junit_output_with_failures(tmp_path: pathlib.Path, exc_typename, msg, i
             "--log-format=junit",
             "--log-file=test.xml",
             "raiser",
-            "exc_type={0}".format(exc_typename),
-            'msg="{0}"'.format(msg),
+            f"exc_type={exc_typename}",
+            f'msg="{msg}"',
             fail_on_error=False,
         )
 
@@ -1054,13 +1054,13 @@ def test_install_use_buildcache(
 
     def validate(mode, out, pkg):
         def assert_auto(pkg, out):
-            assert "==> Extracting {0}".format(pkg) in out
+            assert f"==> Extracting {pkg}" in out
 
         def assert_only(pkg, out):
-            assert "==> Extracting {0}".format(pkg) in out
+            assert f"==> Extracting {pkg}" in out
 
         def assert_never(pkg, out):
-            assert "==> {0}: Executing phase: 'install'".format(pkg) in out
+            assert f"==> {pkg}: Executing phase: 'install'" in out
 
         if mode == "auto":
             assert_auto(pkg, out)
@@ -1098,13 +1098,9 @@ def test_install_use_buildcache(
 
     # Install using the matrix of possible combinations with --use-buildcache
     for pkg, deps in itertools.product(["auto", "only", "never"], repeat=2):
-        tty.debug(
-            "Testing `spack install --use-buildcache package:{0},dependencies:{1}`".format(
-                pkg, deps
-            )
-        )
-        install_use_buildcache("package:{0},dependencies:{1}".format(pkg, deps))
-        install_use_buildcache("dependencies:{0},package:{1}".format(deps, pkg))
+        tty.debug(f"Testing `spack install --use-buildcache package:{pkg},dependencies:{deps}`")
+        install_use_buildcache(f"package:{pkg},dependencies:{deps}")
+        install_use_buildcache(f"dependencies:{deps},package:{pkg}")
 
     # Install using a default override option
     # Alternative to --cache-only (always) or --no-cache (never)

--- a/lib/spack/spack/test/cmd/location.py
+++ b/lib/spack/spack/test/cmd/location.py
@@ -63,8 +63,9 @@ def test_location_source_dir_missing():
     spec = "mpileaks"
     prefix = "==> Error: "
     expected = (
-        "%sSource directory does not exist yet. Run this to create it:"
-        "%s  spack stage %s" % (prefix, "\n", spec)
+        "{}Source directory does not exist yet. Run this to create it:{}  spack stage {}".format(
+            prefix, "\n", spec
+        )
     )
     out = location("--source-dir", spec, fail_on_error=False).strip()
     assert out == expected
@@ -104,7 +105,7 @@ def test_location_with_active_env(mutable_mock_env_path):
 def test_location_env_missing():
     """Tests spack location --env."""
     missing_env_name = "missing-env"
-    error = "==> Error: no such environment: '%s'" % missing_env_name
+    error = f"==> Error: no such environment: '{missing_env_name}'"
     out = location("--env", missing_env_name, fail_on_error=False).strip()
     assert out == error
 
@@ -177,7 +178,7 @@ def test_location_view_missing(mutable_mock_env_path):
     e = ev.create("example", with_view=True)
     e.write()
     missing_view_name = "missing-view"
-    error = "==> Error: no such view in the current environment: '%s'" % missing_view_name
+    error = f"==> Error: no such view in the current environment: '{missing_view_name}'"
     with e:
         out = location("--view", missing_view_name, fail_on_error=False).strip()
         assert out == error

--- a/lib/spack/spack/test/cmd/mirror.py
+++ b/lib/spack/spack/test/cmd/mirror.py
@@ -59,7 +59,7 @@ def test_mirror_from_env(mutable_mock_env_path, tmp_path: pathlib.Path, mock_pac
     assert set(os.listdir(mirror_dir)) == set([s.name for s in e.user_specs])
     for spec in e.specs_by_hash.values():
         mirror_res = os.listdir(os.path.join(mirror_dir, spec.name))
-        expected = ["%s.tar.gz" % spec.format("{name}-{version}")]
+        expected = ["{}.tar.gz".format(spec.format("{name}-{version}"))]
         assert mirror_res == expected
 
 
@@ -110,7 +110,7 @@ def test_mirror_from_env_parallel(tmp_path, mock_packages, mock_fetch, mutable_m
     assert set(os.listdir(mirror_dir)) == set([s.name for s in e.user_specs])
     for spec in e.specs_by_hash.values():
         mirror_res = os.listdir(os.path.join(mirror_dir, spec.name))
-        expected = ["%s.tar.gz" % spec.format("{name}-{version}")]
+        expected = ["{}.tar.gz".format(spec.format("{name}-{version}"))]
         assert mirror_res == expected
 
 
@@ -182,7 +182,7 @@ def test_mirror_spec_from_env(
     assert set(os.listdir(mirror_dir)) == set([s.name for s in e.user_specs])
     spec = e.concrete_roots()[0]
     mirror_res = os.listdir(os.path.join(mirror_dir, spec.name))
-    expected = ["%s.tar.gz" % spec.format("{name}-{version}")]
+    expected = ["{}.tar.gz".format(spec.format("{name}-{version}"))]
     assert mirror_res == expected
 
 

--- a/lib/spack/spack/test/cmd/stage.py
+++ b/lib/spack/spack/test/cmd/stage.py
@@ -51,7 +51,7 @@ def check_stage_path(monkeypatch, tmp_path: pathlib.Path):
 
 def test_stage_path(check_stage_path):
     """Verify that --path only works with single specs."""
-    stage("--path={0}".format(check_stage_path), "trivial-install-test-package")
+    stage(f"--path={check_stage_path}", "trivial-install-test-package")
 
 
 def test_stage_path_errors_multiple_specs(check_stage_path):

--- a/lib/spack/spack/test/cmd/test.py
+++ b/lib/spack/spack/test/cmd/test.py
@@ -274,7 +274,7 @@ def test_test_results_status(mock_packages, mock_test_stage, status):
             assert str(status) not in results
         else:
             assert str(status) in results
-        assert "1 {0}".format(status.lower()) in results
+        assert f"1 {status.lower()}" in results
 
 
 @pytest.mark.regression("35337")

--- a/lib/spack/spack/test/cmd/uninstall.py
+++ b/lib/spack/spack/test/cmd/uninstall.py
@@ -178,7 +178,7 @@ def test_force_uninstall_and_reinstall_by_hash(mutable_database):
     assert len(mpi_specs) == 3
 
     # Now, REINSTALL the spec and make sure everything still holds
-    install("--fake", "/%s" % dag_hash[:7])
+    install("--fake", f"/{dag_hash[:7]}")
 
     validate_callpath_spec(True)
 

--- a/lib/spack/spack/test/cmd/url.py
+++ b/lib/spack/spack/test/cmd/url.py
@@ -117,7 +117,7 @@ def test_url_summary(mock_packages):
 
 def test_url_stats(mock_packages):
     output = url("stats")
-    npkgs = "%d packages" % len(spack.repo.all_package_names())
+    npkgs = f"{len(spack.repo.all_package_names())} packages"
     assert npkgs in output
     assert "url" in output
     assert "git" in output
@@ -126,7 +126,7 @@ def test_url_stats(mock_packages):
     assert "resources" in output
 
     output = url("stats", "--show-issues")
-    npkgs = "%d packages" % len(spack.repo.all_package_names())
+    npkgs = f"{len(spack.repo.all_package_names())} packages"
     assert npkgs in output
     assert "url" in output
     assert "git" in output

--- a/lib/spack/spack/test/cmd/verify.py
+++ b/lib/spack/spack/test/cmd/verify.py
@@ -82,18 +82,18 @@ def test_single_spec_verify_cmd(mock_packages, mock_archive, mock_fetch, install
     prefix = s.prefix
     hash = s.dag_hash()
 
-    results = verify("manifest", "/%s" % hash, fail_on_error=False)
+    results = verify("manifest", f"/{hash}", fail_on_error=False)
     assert not results
 
     new_file = os.path.join(prefix, "new_file_for_verify_test")
     with open(new_file, "w", encoding="utf-8") as f:
         f.write("New file")
 
-    results = verify("manifest", "/%s" % hash, fail_on_error=False)
+    results = verify("manifest", f"/{hash}", fail_on_error=False)
     assert new_file in results
     assert "added" in results
 
-    results = verify("manifest", "-j", "/%s" % hash, fail_on_error=False)
+    results = verify("manifest", "-j", f"/{hash}", fail_on_error=False)
     res = sjson.load(results)
     assert len(res) == 1
     assert res[new_file] == ["added"]

--- a/lib/spack/spack/test/cmd/view.py
+++ b/lib/spack/spack/test/cmd/view.py
@@ -60,8 +60,8 @@ def test_view_link_type_remove(
     tmp_path: pathlib.Path, mock_packages, mock_archive, mock_fetch, install_mockery, add_cmd
 ):
     install("needs-relocation")
-    viewpath = str(tmp_path / "view_{0}".format(add_cmd))
-    (tmp_path / "view_{0}".format(add_cmd)).mkdir()
+    viewpath = str(tmp_path / f"view_{add_cmd}")
+    (tmp_path / f"view_{add_cmd}").mkdir()
     view(add_cmd, viewpath, "needs-relocation")
     bindir = os.path.join(viewpath, "bin")
     assert os.path.exists(bindir)
@@ -223,8 +223,8 @@ def test_view_files_not_ignored(
 
     install("view-file")  # Arbitrary package to add noise
 
-    viewpath = str(tmp_path / "view_{0}".format(cmd))
-    (tmp_path / "view_{0}".format(cmd)).mkdir()
+    viewpath = str(tmp_path / f"view_{cmd}")
+    (tmp_path / f"view_{cmd}").mkdir()
 
     if with_projection:
         proj = str(tmp_path / "proj.yaml")

--- a/lib/spack/spack/test/cmd_extensions.py
+++ b/lib/spack/spack/test/cmd_extensions.py
@@ -113,9 +113,9 @@ def hello_world_with_module_in_root(extension_creator):
             # fixture.
             extension.add_command(
                 "hello",
-                """
+                f"""
 # Test an absolute import
-from spack.extensions.{ext_pname}.implementation import hello_world
+from spack.extensions.{extension.pname}.implementation import hello_world
 
 # Test a relative import
 from ..implementation import hello_folks
@@ -143,7 +143,7 @@ def hello(parser, args):
         hello_folks()
     elif args.subcommand == 'global':
         print(global_message)
-""".format(ext_pname=extension.pname),
+""",
             )
 
             init_file = extension.main / "__init__.py"

--- a/lib/spack/spack/test/concretization/core.py
+++ b/lib/spack/spack/test/concretization/core.py
@@ -1019,7 +1019,7 @@ spack:
         # registered as an external
         ext = Spec(spec_str)
         data = {"externals": [{"spec": spec_str, "prefix": "/fake/path"}]}
-        spack.config.set("packages::{0}".format(ext.name), data)
+        spack.config.set(f"packages::{ext.name}", data)
         ext = spack.concretize.concretize_one(ext)  # failure raises exception
 
     def test_regression_issue_4492(self):
@@ -1218,9 +1218,9 @@ spack:
         s = spack.concretize.concretize_one(spec_str)
 
         for var in expected:
-            assert s.satisfies("%s=*" % var)
+            assert s.satisfies(f"{var}=*")
         for var in unexpected:
-            assert not s.satisfies("%s=*" % var)
+            assert not s.satisfies(f"{var}=*")
 
     @pytest.mark.parametrize(
         "bad_spec",
@@ -1338,7 +1338,7 @@ spack:
     def test_dependency_conditional_on_another_dependency_state(self):
         root_str = "variant-on-dependency-condition-root"
         dep_str = "variant-on-dependency-condition-a"
-        spec_str = "{0} ^{1}".format(root_str, dep_str)
+        spec_str = f"{root_str} ^{dep_str}"
 
         s = spack.concretize.concretize_one(spec_str)
         assert s.concrete
@@ -1535,7 +1535,7 @@ spack:
 
         # Try to concretize with the spec installed previously
         new_root_with_reuse = spack.concretize.concretize_one(
-            Spec("root ^/{0}".format(dependency.dag_hash()))
+            Spec(f"root ^/{dependency.dag_hash()}")
         )
 
         new_root_without_reuse = spack.concretize.concretize_one("root")
@@ -1816,9 +1816,9 @@ spack:
         default_target = spack.platforms.test.Test.default
         generic_target = spack.vendor.archspec.cpu.TARGETS[default_target].generic.name
         s = Spec("python")
-        assert spack.concretize.concretize_one(s).satisfies("target=%s" % default_target)
+        assert spack.concretize.concretize_one(s).satisfies(f"target={default_target}")
         with spack.config.override("concretizer:targets", {"granularity": "generic"}):
-            assert spack.concretize.concretize_one(s).satisfies("target=%s" % generic_target)
+            assert spack.concretize.concretize_one(s).satisfies(f"target={generic_target}")
 
     def test_host_compatible_concretization(self):
         # Check that after setting "host_compatible" to false we cannot concretize.
@@ -2255,9 +2255,7 @@ spack:
         s = spack.concretize.concretize_one(root_spec)
         other_os = s.copy()
         mock_os = "ubuntu2204"
-        other_os.architecture = spack.spec.ArchSpec(
-            "test-{os}-{target}".format(os=mock_os, target=str(s.architecture.target))
-        )
+        other_os.architecture = spack.spec.ArchSpec(f"test-{mock_os}-{str(s.architecture.target)}")
         reusable_specs = [other_os]
         overrides = {"concretizer": {"reuse": True, "os_compatible": {s.os: [mock_os]}}}
         custom_scope = spack.config.InternalConfigScope("concretize_override", overrides)
@@ -2266,17 +2264,17 @@ spack:
             setup = spack.solver.asp.SpackSolverSetup()
             result, _, _ = solver.driver.solve(setup, [root_spec], reuse=reusable_specs)
         concrete_spec = result.specs[0]
-        assert concrete_spec.satisfies("os={}".format(other_os.architecture.os))
+        assert concrete_spec.satisfies(f"os={other_os.architecture.os}")
 
     def test_git_hash_assigned_version_is_preferred(self):
         hash = "a" * 40
-        s = Spec("develop-branch-version@%s=develop" % hash)
+        s = Spec(f"develop-branch-version@{hash}=develop")
         c = spack.concretize.concretize_one(s)
         assert hash in str(c)
 
     @pytest.mark.parametrize("git_ref", ("a" * 40, "0.2.15", "main"))
     def test_git_ref_version_is_equivalent_to_specified_version(self, git_ref):
-        s = Spec("develop-branch-version@git.%s=develop" % git_ref)
+        s = Spec(f"develop-branch-version@git.{git_ref}=develop")
         c = spack.concretize.concretize_one(s)
         assert git_ref in str(c)
         assert s.satisfies("@develop")
@@ -2285,7 +2283,7 @@ spack:
     @pytest.mark.parametrize("git_ref", ("a" * 40, "0.2.15", "fbranch"))
     def test_git_ref_version_succeeds_with_unknown_version(self, git_ref):
         # main is not defined in the package.py for this file
-        s = Spec("develop-branch-version@git.%s=main" % git_ref)
+        s = Spec(f"develop-branch-version@git.{git_ref}=main")
         s = spack.concretize.concretize_one(s)
         assert s.satisfies("develop-branch-version@main")
 

--- a/lib/spack/spack/test/concretization/requirements.py
+++ b/lib/spack/spack/test/concretization/requirements.py
@@ -155,11 +155,11 @@ def test_requirement_adds_new_version(
     )
 
     a_commit_hash = commits[0]
-    conf_str = """\
+    conf_str = f"""\
 packages:
   v:
-    require: "@{0}=2.2"
-""".format(a_commit_hash)
+    require: "@{a_commit_hash}=2.2"
+"""
     update_packages_config(conf_str)
 
     s1 = spack.concretize.concretize_one("v")
@@ -186,11 +186,11 @@ def test_requirement_adds_version_satisfies(
     s0 = spack.concretize.concretize_one("t@2.0")
     assert "u" not in s0
 
-    conf_str = """\
+    conf_str = f"""\
 packages:
   t:
-    require: "@{0}=2.2"
-""".format(commits[0])
+    require: "@{commits[0]}=2.2"
+"""
     update_packages_config(conf_str)
 
     s1 = spack.concretize.concretize_one("t")

--- a/lib/spack/spack/test/config.py
+++ b/lib/spack/spack/test/config.py
@@ -863,7 +863,7 @@ def test_nested_override():
         ]
 
         for i in range(num_expected):
-            name = "{0}{1}".format(base_name, i)
+            name = f"{base_name}{i}"
             assert name in scope_names
 
             data = spack.config.CONFIG.get_config("config", name)
@@ -882,13 +882,13 @@ def test_alternate_override(monkeypatch):
     base_name = spack.config._OVERRIDES_BASE_NAME
 
     def _matching_scopes(regexpr):
-        return [spack.config.InternalConfigScope("{0}1".format(base_name))]
+        return [spack.config.InternalConfigScope(f"{base_name}1")]
 
     # Check that the alternate naming works
     monkeypatch.setattr(spack.config.CONFIG, "matching_scopes", _matching_scopes)
 
     with spack.config.override("config:debug", False):
-        name = "{0}2".format(base_name)
+        name = f"{base_name}2"
 
         scope_names = [
             s.name for s in spack.config.CONFIG.scopes.values() if s.name.startswith(base_name)
@@ -1241,7 +1241,7 @@ def test_user_config_path_is_overridable(working_env):
 
 def test_user_config_path_is_default_when_env_var_is_empty(working_env):
     os.environ["SPACK_USER_CONFIG_PATH"] = ""
-    assert os.path.expanduser("~%s.spack" % os.sep) == spack.paths._get_user_config_path()
+    assert os.path.expanduser(f"~{os.sep}.spack") == spack.paths._get_user_config_path()
 
 
 def test_default_install_tree(monkeypatch, default_config):
@@ -1522,7 +1522,7 @@ def test_user_cache_path_is_overridable(working_env):
 
 def test_user_cache_path_is_default_when_env_var_is_empty(working_env):
     os.environ["SPACK_USER_CACHE_PATH"] = ""
-    assert os.path.expanduser("~%s.spack" % os.sep) == spack.paths._get_user_cache_path()
+    assert os.path.expanduser(f"~{os.sep}.spack") == spack.paths._get_user_cache_path()
 
 
 def test_config_file_dir_failure(tmp_path: pathlib.Path, mutable_empty_config):

--- a/lib/spack/spack/test/conftest.py
+++ b/lib/spack/spack/test/conftest.py
@@ -197,7 +197,7 @@ def mock_git_version_info(git, tmp_path: Path, override_git_repos_cache_path):
             "commit",
             "--no-gpg-sign",
             "--date",
-            "2020-01-%02d 12:0:00 +0300" % commit_counter,
+            f"2020-01-{commit_counter:02d} 12:0:00 +0300",
             "-am",
             message,
         )
@@ -300,7 +300,7 @@ def mock_git_package_changes(git, tmp_path: Path, override_git_repos_cache_path,
             "commit",
             "--no-gpg-sign",
             "--date",
-            "2020-01-%02d 12:0:00 +0300" % commit_counter,
+            f"2020-01-{commit_counter:02d} 12:0:00 +0300",
             "-am",
             message,
         )
@@ -1472,8 +1472,8 @@ def mock_archive(request, tmp_path_factory: pytest.TempPathFactory):
 
     # Archive it
     with working_dir(str(tmpdir)):
-        archive_name = "{0}{1}".format(spack.stage._source_path_subdir, ext)
-        tar("-c{0}f".format(tar_flag), archive_name, spack.stage._source_path_subdir)
+        archive_name = f"{spack.stage._source_path_subdir}{ext}"
+        tar(f"-c{tar_flag}f", archive_name, spack.stage._source_path_subdir)
 
     Archive = collections.namedtuple(
         "Archive", ["url", "path", "archive_file", "expanded_archive_basedir"]
@@ -1666,7 +1666,7 @@ def mock_git_repository(git, tmp_path_factory: pytest.TempPathFactory):
     # Create two git repositories which will be used as submodules in the
     # main repository
     for submodule_count in range(2):
-        tmpdir = tmp_path_factory.mktemp("mock-git-repo-submodule-dir-{0}".format(submodule_count))
+        tmpdir = tmp_path_factory.mktemp(f"mock-git-repo-submodule-dir-{submodule_count}")
         source_dir = tmpdir / spack.stage._source_path_subdir
         source_dir.mkdir()
         repodir = source_dir
@@ -1678,15 +1678,11 @@ def mock_git_repository(git, tmp_path_factory: pytest.TempPathFactory):
             git("config", "user.email", "spack@spack.io")
 
             # r0 is just the first commit
-            submodule_file = "r0_file_{0}".format(submodule_count)
+            submodule_file = f"r0_file_{submodule_count}"
             (repodir / submodule_file).touch()
             git("add", submodule_file)
             git(
-                "-c",
-                "commit.gpgsign=false",
-                "commit",
-                "-m",
-                "mock-git-repo r0 {0}".format(submodule_count),
+                "-c", "commit.gpgsign=false", "commit", "-m", f"mock-git-repo r0 {submodule_count}"
             )
 
     tmpdir = tmp_path_factory.mktemp("mock-git-repo-dir")
@@ -1702,7 +1698,7 @@ def mock_git_repository(git, tmp_path_factory: pytest.TempPathFactory):
         git("checkout", "-b", "main")
         url = url_util.path_to_file_url(str(repodir))
         for number, suburl in suburls:
-            git("submodule", "add", suburl, "third_party/submodule{0}".format(number))
+            git("submodule", "add", suburl, f"third_party/submodule{number}")
 
         # r0 is the first commit: it consists of one file and two submodules
         r0_file = "r0_file"
@@ -2256,12 +2252,12 @@ def binary_with_rpaths(prefix_tmpdir: Path):
     def _factory(rpaths, message="Hello world!", dynamic_linker="/lib64/ld-linux.so.2"):
         source = prefix_tmpdir / "main.c"
         source.write_text(
-            """
+            f"""
         #include <stdio.h>
         int main(){{
-            printf("{0}");
+            printf("{message}");
         }}
-        """.format(message)
+        """
         )
         gcc = spack.util.executable.which("gcc", required=True)
         executable = source.parent / "main.x"

--- a/lib/spack/spack/test/database.py
+++ b/lib/spack/spack/test/database.py
@@ -397,11 +397,11 @@ def _print_ref_counts():
         cspecs = spack.store.STORE.db.query(spec, installed=InstallRecordStatus.ANY)
 
         if not cspecs:
-            recs.append("[ %-7s ] %-20s-" % ("", spec))
+            recs.append(f"[ {'':<7} ] {spec:<20}-")
         else:
             key = cspecs[0].dag_hash()
             rec = spack.store.STORE.db.get_record(cspecs[0])
-            recs.append("[ %-7s ] %-20s%d" % (key[:7], spec, rec.ref_count))
+            recs.append(f"[ {key[:7]:<7} ] {spec:<20}{rec.ref_count}")
 
     with spack.store.STORE.db.read_transaction():
         add_rec("mpileaks ^mpich")

--- a/lib/spack/spack/test/entry_points.py
+++ b/lib/spack/spack/test/entry_points.py
@@ -76,7 +76,7 @@ def test_spack_entry_point_config(tmp_path: pathlib.Path, mock_get_entry_points)
     config_path = config_paths.get("plugin-mypackage_config")
     my_config_path = tmp_path / "spack/etc"
     if config_path is None:
-        raise ValueError("Did not find entry point config in %s" % str(config_paths))
+        raise ValueError(f"Did not find entry point config in {str(config_paths)}")
     else:
         assert os.path.samefile(config_path, my_config_path)
     config = spack.config.create()
@@ -89,11 +89,11 @@ def test_spack_entry_point_extension(tmp_path: pathlib.Path, mock_get_entry_poin
     extensions = spack.extensions.get_extension_paths()
     found = bool([ext for ext in extensions if os.path.samefile(ext, my_ext)])
     if not found:
-        raise ValueError("Did not find extension in %s" % ", ".join(extensions))
+        raise ValueError("Did not find extension in {}".format(", ".join(extensions)))
     extensions = spack.extensions.extension_paths_from_entry_points()
     found = bool([ext for ext in extensions if os.path.samefile(ext, my_ext)])
     if not found:
-        raise ValueError("Did not find extension in %s" % ", ".join(extensions))
+        raise ValueError("Did not find extension in {}".format(", ".join(extensions)))
     root = spack.extensions.load_extension("myext")
     assert os.path.samefile(root, my_ext)
     module = spack.extensions.get_module("spam")

--- a/lib/spack/spack/test/git_fetch.py
+++ b/lib/spack/spack/test/git_fetch.py
@@ -195,7 +195,7 @@ def test_adhoc_version_submodules(
     monkeypatch.setattr(pkg_class, "git", mock_git_repository.url, raising=False)
 
     spec = spack.concretize.concretize_one(
-        Spec("git-test@{0}".format(mock_git_repository.unversioned_commit))
+        Spec(f"git-test@{mock_git_repository.unversioned_commit}")
     )
     spec.package.do_stage()
     collected_fnames = set()
@@ -258,7 +258,7 @@ def test_get_full_repo(
     """Ensure that we can clone a full repository."""
 
     if git_version < Version(min_opt_string):
-        pytest.skip("Not testing get_full_repo for older git {0}".format(git_version))
+        pytest.skip(f"Not testing get_full_repo for older git {git_version}")
 
     # newer git allows for direct commit fetching
     can_use_direct_commit = git_version >= Version(min_direct_commit)
@@ -350,7 +350,7 @@ def test_gitsubmodule(
         for submodule_count in range(2):
             file_path = os.path.join(
                 s.package.stage.source_path,
-                "third_party/submodule{0}/r0_file_{0}".format(submodule_count),
+                f"third_party/submodule{submodule_count}/r0_file_{submodule_count}",
             )
             if submodules:
                 assert os.path.isfile(file_path)

--- a/lib/spack/spack/test/graph.py
+++ b/lib/spack/spack/test/graph.py
@@ -33,7 +33,7 @@ def test_dynamic_dot_graph_mpileaks(default_mock_concretization):
         ("dyninst", "libelf"),
     ]
     for parent, child in dependencies_to_check:
-        assert '  "{0}" -> "{1}"\n'.format(hashes[parent], hashes[child]) in dot
+        assert f'  "{hashes[parent]}" -> "{hashes[child]}"\n' in dot
 
 
 def test_ascii_graph_mpileaks(config, mock_packages, monkeypatch):

--- a/lib/spack/spack/test/installer.py
+++ b/lib/spack/spack/test/installer.py
@@ -63,7 +63,7 @@ def _none(*args, **kwargs):
 
 def _not_locked(installer, lock_type, pkg):
     """Generic monkeypatch function for _ensure_locked to return no lock"""
-    tty.msg("{0} locked {1}".format(lock_type, pkg.spec.name))
+    tty.msg(f"{lock_type} locked {pkg.spec.name}")
     return lock_type, None
 
 
@@ -115,13 +115,13 @@ def test_install_msg(monkeypatch):
     """Test results of call to install_msg based on debug level."""
     name = "some-package"
     pid = 123456
-    install_msg = "Installing {0}".format(name)
+    install_msg = f"Installing {name}"
 
     monkeypatch.setattr(tty, "_debug", 0)
     assert inst.install_msg(name, pid, None) == install_msg
 
     install_status = inst.InstallStatus(1)
-    expected = "{0} [0/1]".format(install_msg)
+    expected = f"{install_msg} [0/1]"
     assert inst.install_msg(name, pid, install_status) == expected
 
     monkeypatch.setattr(tty, "_debug", 1)
@@ -129,7 +129,7 @@ def test_install_msg(monkeypatch):
 
     # Expect the PID to be added at debug level 2
     monkeypatch.setattr(tty, "_debug", 2)
-    expected = "{0}: {1}".format(pid, install_msg)
+    expected = f"{pid}: {install_msg}"
     assert inst.install_msg(name, pid, None) == expected
 
 
@@ -174,7 +174,7 @@ def test_process_external_package_module(install_mockery, monkeypatch, capfd):
     inst._process_external_package(spec.package, False)
 
     out = capfd.readouterr()[0]
-    assert "has external module in {0}".format(spec.external_modules) in out
+    assert f"has external module in {spec.external_modules}" in out
 
 
 def test_process_binary_cache_tarball_tar(install_mockery, monkeypatch, capfd):
@@ -543,7 +543,7 @@ def test_combine_phase_logs(tmp_path: pathlib.Path):
     for log_file in log_files:
         phase_log_file = tmp_path / log_file
         with open(phase_log_file, "w", encoding="utf-8") as plf:
-            plf.write("Output from %s\n" % log_file)
+            plf.write(f"Output from {log_file}\n")
         phase_log_files.append(str(phase_log_file))
 
     # This is the output log we will combine them into
@@ -554,7 +554,7 @@ def test_combine_phase_logs(tmp_path: pathlib.Path):
 
     # Ensure each phase log file is represented
     for log_file in log_files:
-        assert "Output from %s\n" % log_file in out
+        assert f"Output from {log_file}\n" in out
 
 
 def test_combine_phase_logs_does_not_care_about_encoding(tmp_path: pathlib.Path):
@@ -815,7 +815,7 @@ def test_release_lock_write_n_exception(install_mockery, tmp_path: pathlib.Path,
 
         installer._release_lock(pkg_id)
         out = str(capfd.readouterr()[1])
-        msg = "exception when releasing write lock for {0}".format(pkg_id)
+        msg = f"exception when releasing write lock for {pkg_id}"
         assert msg in out
 
 
@@ -1011,7 +1011,7 @@ def _interrupt(installer, task, install_status, **kwargs):
 def test_install_fail_on_interrupt(install_mockery, mock_fetch, monkeypatch):
     """Test ctrl-c interrupted install."""
     spec_name = "pkg-a"
-    err_msg = "mock keyboard interrupt for {0}".format(spec_name)
+    err_msg = f"mock keyboard interrupt for {spec_name}"
     installer = create_installer([spec_name], {"fake": True})
     setattr(inst.PackageInstaller, "_real_install_task", inst.PackageInstaller._complete_task)
     # Raise a KeyboardInterrupt error to trigger early termination
@@ -1135,7 +1135,7 @@ def test_install_lock_failures(install_mockery, monkeypatch, capfd):
 
     # Note: this test relies on installing a package with no dependencies
     def _requeued(installer, task, install_status):
-        tty.msg("requeued {0}".format(task.pkg.spec.name))
+        tty.msg(f"requeued {task.pkg.spec.name}")
 
     installer = create_installer(["pkg-c"], {})
 
@@ -1193,15 +1193,15 @@ def test_install_read_locked_requeue(install_mockery, monkeypatch, capfd):
     orig_fn = inst.PackageInstaller._ensure_locked
 
     def _read(installer, lock_type, pkg):
-        tty.msg("{0}->read locked {1}".format(lock_type, pkg.spec.name))
+        tty.msg(f"{lock_type}->read locked {pkg.spec.name}")
         return orig_fn(installer, "read", pkg)
 
     def _prep(installer, task):
-        tty.msg("preparing {0}".format(task.pkg.spec.name))
+        tty.msg(f"preparing {task.pkg.spec.name}")
         assert task.pkg.spec.name not in installer.installed
 
     def _requeued(installer, task, install_status):
-        tty.msg("requeued {0}".format(task.pkg.spec.name))
+        tty.msg(f"requeued {task.pkg.spec.name}")
 
     # Force a read lock
     monkeypatch.setattr(inst.PackageInstaller, "_ensure_locked", _read)

--- a/lib/spack/spack/test/llnl/util/file_list.py
+++ b/lib/spack/spack/test/llnl/util/file_list.py
@@ -73,12 +73,12 @@ class TestLibraryList:
         s1 = library_list.joined()
         expected = " ".join(
             [
-                "/dir1/liblapack.%s" % plat_static_ext,
+                f"/dir1/liblapack.{plat_static_ext}",
                 "/dir2/libpython3.6.%s"
                 % (plat_apple_shared_ext if sys.platform != "win32" else "dll"),
-                "/dir1/libblas.%s" % plat_static_ext,
-                "/dir3/libz.%s" % plat_shared_ext,
-                "libmpi.%s.20.10.1" % plat_shared_ext,
+                f"/dir1/libblas.{plat_static_ext}",
+                f"/dir3/libz.{plat_shared_ext}",
+                f"libmpi.{plat_shared_ext}.20.10.1",
             ]
         )
         assert s1 == expected
@@ -89,12 +89,12 @@ class TestLibraryList:
         s3 = library_list.joined(";")
         expected = ";".join(
             [
-                "/dir1/liblapack.%s" % plat_static_ext,
+                f"/dir1/liblapack.{plat_static_ext}",
                 "/dir2/libpython3.6.%s"
                 % (plat_apple_shared_ext if sys.platform != "win32" else "dll"),
-                "/dir1/libblas.%s" % plat_static_ext,
-                "/dir3/libz.%s" % plat_shared_ext,
-                "libmpi.%s.20.10.1" % plat_shared_ext,
+                f"/dir1/libblas.{plat_static_ext}",
+                f"/dir3/libz.{plat_shared_ext}",
+                f"libmpi.{plat_shared_ext}.20.10.1",
             ]
         )
         assert s3 == expected
@@ -129,7 +129,7 @@ class TestLibraryList:
 
     def test_get_item(self, library_list):
         a = library_list[0]
-        assert a == "/dir1/liblapack.%s" % plat_static_ext
+        assert a == f"/dir1/liblapack.{plat_static_ext}"
 
         b = library_list[:]
         assert type(b) is type(library_list)
@@ -138,9 +138,9 @@ class TestLibraryList:
 
     def test_add(self, library_list):
         pylist = [
-            "/dir1/liblapack.%s" % plat_static_ext,  # removed from the final list
-            "/dir2/libmpi.%s" % plat_shared_ext,
-            "/dir4/libnew.%s" % plat_static_ext,
+            f"/dir1/liblapack.{plat_static_ext}",  # removed from the final list
+            f"/dir2/libmpi.{plat_shared_ext}",
+            f"/dir4/libnew.{plat_static_ext}",
         ]
         another = LibraryList(pylist)
         both = library_list + another

--- a/lib/spack/spack/test/llnl/util/lock.py
+++ b/lib/spack/spack/test/llnl/util/lock.py
@@ -153,7 +153,7 @@ def lock_dir(lock_test_directory):
     )
     if not parent:
         # Skip filesystems that don't exist or aren't writable
-        pytest.skip("requires filesystem: '%s'" % lock_test_directory)
+        pytest.skip(f"requires filesystem: '{lock_test_directory}'")
     elif mpi and parent == tempfile.gettempdir():
         # Skip local tmp test for MPI runs
         pytest.skip("skipping local tmp directory for MPI test.")
@@ -186,7 +186,7 @@ def private_lock_path(lock_dir):
     """
     lock_file = os.path.join(lock_dir, "lockfile")
     if mpi:
-        lock_file += ".%s" % comm.rank
+        lock_file += f".{comm.rank}"
 
     yield lock_file
 
@@ -242,7 +242,7 @@ def mpi_multiproc_test(*functions):
     """
     procs = len(functions)
     if procs > comm.size:
-        pytest.skip("requires at least %d MPI processes" % procs)
+        pytest.skip(f"requires at least {procs} MPI processes")
 
     comm.Barrier()  # barrier before each MPI test
 
@@ -897,12 +897,12 @@ def test_transaction(lock_path, transaction, type):
 
     def enter_fn():
         # assert enter_fn is called while lock is held
-        assert vals["acquired_%s" % type]
+        assert vals[f"acquired_{type}"]
         vals["entered_fn"] = True
 
     def exit_fn(t, v, tb):
         # assert exit_fn is called while lock is held
-        assert not vals["released_%s" % type]
+        assert not vals[f"released_{type}"]
         vals["exited_fn"] = True
         vals["exception"] = t or v or tb
 
@@ -910,13 +910,13 @@ def test_transaction(lock_path, transaction, type):
     lock = MockLock(lock_path, vals)
 
     with transaction(lock, acquire=enter_fn, release=exit_fn):
-        assert vals["acquired_%s" % type]
-        assert not vals["released_%s" % type]
+        assert vals[f"acquired_{type}"]
+        assert not vals[f"released_{type}"]
 
     assert vals["entered_fn"]
     assert vals["exited_fn"]
-    assert vals["acquired_%s" % type]
-    assert vals["released_%s" % type]
+    assert vals[f"acquired_{type}"]
+    assert vals[f"released_{type}"]
     assert not vals["exception"]
 
 
@@ -942,11 +942,11 @@ def test_transaction_with_exception(lock_path, transaction, type):
             assert not vals["exited_fn"]
 
     def enter_fn():
-        assert vals["acquired_%s" % type]
+        assert vals[f"acquired_{type}"]
         vals["entered_fn"] = True
 
     def exit_fn(t, v, tb):
-        assert not vals["released_%s" % type]
+        assert not vals[f"released_{type}"]
         vals["exited_fn"] = True
         vals["exception"] = t or v or tb
         return exit_result
@@ -1102,10 +1102,10 @@ def test_try_transaction(lock_path, transaction, type):
     with transaction(lock, acquire=enter_fn, release=exit_fn) as acquired:
         assert acquired
         assert vals["entered_fn"]
-        assert not vals["released_%s" % type]
+        assert not vals[f"released_{type}"]
 
     assert vals["exited_fn"]
-    assert vals["released_%s" % type]
+    assert vals[f"released_{type}"]
     assert not vals["exception"]
 
 

--- a/lib/spack/spack/test/llnl/util/tty/color.py
+++ b/lib/spack/spack/test/llnl/util/tty/color.py
@@ -55,14 +55,14 @@ def test_color_wrap(cols, text, indent):
 def test_cescape_at_sign_roundtrip():
     """cescape followed by colorize should not double-escape '@' inside color blocks."""
     raw = 'if spec.satisfies("@:25.1"):'
-    colorized = colorize("@R{%s}" % cescape(raw), color=True)
+    colorized = colorize(f"@R{{{cescape(raw)}}}", color=True)
     assert csub(colorized) == raw
 
 
 def test_cescape_multiple_at_signs_roundtrip():
     """Multiple consecutive '@' characters should survive a cescape/colorize roundtrip."""
     raw = "foo @@@@@bar"
-    colorized = colorize("@R{%s}" % cescape(raw), color=True)
+    colorized = colorize(f"@R{{{cescape(raw)}}}", color=True)
     assert csub(colorized) == raw
 
 

--- a/lib/spack/spack/test/llnl/util/tty/tty.py
+++ b/lib/spack/spack/test/llnl/util/tty/tty.py
@@ -19,7 +19,7 @@ def test_get_timestamp(monkeypatch):
     # Debug disabled but force the timestamp should return a string
     assert tty.get_timestamp(True), "Expected a timestamp/non-empty string"
 
-    pid_str = " {0}".format(os.getpid())
+    pid_str = f" {os.getpid()}"
 
     # Level 1 debugging should return a timestamp WITHOUT the pid
     monkeypatch.setattr(tty, "_debug", 1)
@@ -51,7 +51,7 @@ def test_msg(capfd, monkeypatch, enabled, msg, trace, newline):
 
     expected = [msg if isinstance(msg, str) else "Exception: "]
     if newline:
-        expected[0] = "{0}\n".format(expected[0])
+        expected[0] = f"{expected[0]}\n"
     if trace:
         expected.insert(0, ".py")
 

--- a/lib/spack/spack/test/main.py
+++ b/lib/spack/spack/test/main.py
@@ -65,14 +65,14 @@ def test_git_sha_output(tmp_path: pathlib.Path, working_env, monkeypatch):
     sha = "26552533be04e83e66be2c28e0eb5011cb54e8fa"
     with open(git, "w", encoding="utf-8") as f:
         f.write(
-            """#!/bin/sh
-echo {0}
-""".format(sha)
+            f"""#!/bin/sh
+echo {sha}
+"""
         )
     fs.set_executable(str(git))
 
     monkeypatch.setattr(spack.util.git, "git", lambda: exe.which(str(git)))
-    expected = "{0} ({1})".format(spack.spack_version, sha)
+    expected = f"{spack.spack_version} ({sha})"
     assert expected == spack.get_version()
 
 

--- a/lib/spack/spack/test/module_parsing.py
+++ b/lib/spack/spack/test/module_parsing.py
@@ -88,7 +88,7 @@ def test_module_function_no_change(tmp_path: pathlib.Path):
         f.write("echo TEST_MODULE_FUNCTION_PRINT")
 
     old_env = os.environ.copy()
-    text = module("show", src_file, module_template=". {0} 2>&1".format(src_file))
+    text = module("show", src_file, module_template=f". {src_file} 2>&1")
 
     assert text == "TEST_MODULE_FUNCTION_PRINT\n"
     assert os.environ == old_env

--- a/lib/spack/spack/test/modules/common.py
+++ b/lib/spack/spack/test/modules/common.py
@@ -111,12 +111,12 @@ def test_upstream_module_index():
     s3 = MockSpec("spec-3")
     s4 = MockSpec("spec-4")
 
-    tcl_module_index = """\
+    tcl_module_index = f"""\
 module_index:
-  {0}:
+  {s1.dag_hash()}:
     path: /path/to/a
     use_name: a
-""".format(s1.dag_hash())
+"""
 
     module_indices = [{"tcl": spack.modules.common._read_module_index(tcl_module_index)}, {}]
 
@@ -147,12 +147,12 @@ module_index:
 def test_get_module_upstream():
     s1 = MockSpec("spec-1")
 
-    tcl_module_index = """\
+    tcl_module_index = f"""\
 module_index:
-  {0}:
+  {s1.dag_hash()}:
     path: /path/to/a
     use_name: a
-""".format(s1.dag_hash())
+"""
 
     module_indices = [{}, {"tcl": spack.modules.common._read_module_index(tcl_module_index)}]
 

--- a/lib/spack/spack/test/modules/lmod.py
+++ b/lib/spack/spack/test/modules/lmod.py
@@ -302,14 +302,12 @@ class TestLmod:
         path = module.layout.filename
         mpi_spec = spec["mpi"]
 
-        mpi_element = "{0}/{1}-{2}/".format(
-            mpi_spec.name, mpi_spec.version, mpi_spec.dag_hash(length=7)
-        )
+        mpi_element = f"{mpi_spec.name}/{mpi_spec.version}-{mpi_spec.dag_hash(length=7)}/"
 
         assert mpi_element in path
 
         mpileaks_spec = spec
-        mpileaks_element = "{0}/{1}.lua".format(mpileaks_spec.name, mpileaks_spec.version)
+        mpileaks_element = f"{mpileaks_spec.name}/{mpileaks_spec.version}.lua"
 
         assert path.endswith(mpileaks_element)
 

--- a/lib/spack/spack/test/package_class.py
+++ b/lib/spack/spack/test/package_class.py
@@ -206,7 +206,7 @@ def test_cache_extra_sources(install_mockery, spec, sources, extras, expect):
     emsg_dir = "Expected {0} to be a directory"
     emsg_file = "Expected {0} to be a file"
     for src in srcs:
-        assert os.path.exists(src), "Expected {0} to exist".format(src)
+        assert os.path.exists(src), f"Expected {src} to exist"
         if os.path.splitext(src)[1]:
             assert os.path.isfile(src), emsg_file.format(src)
         else:

--- a/lib/spack/spack/test/projections.py
+++ b/lib/spack/spack/test/projections.py
@@ -15,4 +15,7 @@ def test_projection_expansion(mock_packages, monkeypatch):
     projections = {"all": "{name}-{version}/$FOO_ENV_VAR/$date"}
     spec = spack.spec.Spec("fake@1.0")
     projection = spack.projections.get_projection(projections, spec)
-    assert "{name}-{version}/test-string/%s" % date.today().strftime("%Y-%m-%d") == projection
+    assert (
+        "{{name}}-{{version}}/test-string/{}".format(date.today().strftime("%Y-%m-%d"))
+        == projection
+    )

--- a/lib/spack/spack/test/relocate.py
+++ b/lib/spack/spack/test/relocate.py
@@ -133,7 +133,7 @@ def test_relocate_text_bin(binary_with_rpaths, prefix_like):
     spack.relocate.relocate_text_bin([str(executable)], {prefix_bytes: new_prefix_bytes})
 
     # Some compilers add rpaths so ensure changes included in final result
-    assert "%s/lib:%s/lib64" % (new_prefix, new_prefix) in rpaths_for(executable)
+    assert f"{new_prefix}/lib:{new_prefix}/lib64" in rpaths_for(executable)
 
 
 @pytest.mark.requires_executables("patchelf", "gcc")

--- a/lib/spack/spack/test/reporters.py
+++ b/lib/spack/spack/test/reporters.py
@@ -36,18 +36,18 @@ def test_reporters_extract_basics():
     name = "test_no_status"
     desc = "basic description"
     status = TestStatus.PASSED
-    outputs = """
+    outputs = f"""
 ==> Testing package fake-1.0-abcdefg
-==> [2022-02-15-18:44:21.250165] test: {0}: {1}
-==> [2022-02-15-18:44:21.250200] '{2}'
-{3}: {0}
-""".format(name, desc, fake_bin, status).splitlines()
+==> [2022-02-15-18:44:21.250165] test: {name}: {desc}
+==> [2022-02-15-18:44:21.250200] '{fake_bin}'
+{status}: {name}
+""".splitlines()
 
     parts = spack.reporters.extract.extract_test_parts("fake", outputs)
     assert len(parts) == 1
-    assert parts[0]["command"] == "{0}".format(fake_bin)
+    assert parts[0]["command"] == f"{fake_bin}"
     assert parts[0]["desc"] == desc
-    assert parts[0]["loglines"] == ["{0}: {1}".format(status, name)]
+    assert parts[0]["loglines"] == [f"{status}: {name}"]
     assert parts[0]["status"] == status.lower()
 
 
@@ -57,11 +57,11 @@ def test_reporters_extract_no_parts(capfd):
     #  2) does not define any test parts;
     #  3) has a status value without a part so generates a warning
     status = TestStatus.NO_TESTS
-    outputs = """
+    outputs = f"""
 ==> Testing package fake-1.0-abcdefg
-==> [2022-02-11-17:14:38.875259] Installing {0} to {1}
-{2}
-""".format(fake_install_test_root, fake_test_cache, status).splitlines()
+==> [2022-02-11-17:14:38.875259] Installing {fake_install_test_root} to {fake_test_cache}
+{status}
+""".splitlines()
 
     parts = spack.reporters.extract.extract_test_parts("fake", outputs)
     err = capfd.readouterr()[1]
@@ -80,30 +80,19 @@ def test_reporters_extract_missing_desc():
     failed = TestStatus.FAILED
     passed = TestStatus.PASSED
     results = [passed, failed, passed]
-    outputs = """
+    outputs = f"""
 ==> Testing package fake-1.0-abcdefg
-==> [2022-02-15-18:44:21.250165] test: {0}: {1}
-==> [2022-02-15-18:44:21.250170] '{5}' '-c' 'import fake.bin'
-{2}: {0}
-==> [2022-02-15-18:44:21.250185] test: {3}: {4}
-==> [2022-02-15-18:44:21.250200] '{5}' '-c' 'import fake.util'
-{6}: {3}
-==> [2022-02-15-18:44:21.250205] test: {7}: {8}
+==> [2022-02-15-18:44:21.250165] test: {names[0]}: {descs[0]}
+==> [2022-02-15-18:44:21.250170] '{fake_bin}' '-c' 'import fake.bin'
+{results[0]}: {names[0]}
+==> [2022-02-15-18:44:21.250185] test: {names[1]}: {descs[1]}
+==> [2022-02-15-18:44:21.250200] '{fake_bin}' '-c' 'import fake.util'
+{results[1]}: {names[1]}
+==> [2022-02-15-18:44:21.250205] test: {names[2]}: {descs[2]}
 ==> [2022-02-15-18:44:21.250210] 'exe1 1'
 ==> [2022-02-15-18:44:21.250250] 'exe2 2'
-{9}: {7}
-""".format(
-        names[0],
-        descs[0],
-        results[0],
-        names[1],
-        descs[1],
-        fake_bin,
-        results[1],
-        names[2],
-        descs[2],
-        results[2],
-    ).splitlines()
+{results[2]}: {names[2]}
+""".splitlines()
 
     parts = spack.reporters.extract.extract_test_parts("fake", outputs)
 
@@ -117,11 +106,11 @@ def test_reporters_extract_missing_desc():
 
 @pytest.mark.parametrize("state", [("not installed"), ("external")])
 def test_reporters_extract_skipped(state):
-    expected = "Skipped {0} package".format(state)
-    outputs = """
+    expected = f"Skipped {state} package"
+    outputs = f"""
 ==> Testing package fake-1.0-abcdefg
-{0}
-""".format(expected).splitlines()
+{expected}
+""".splitlines()
 
     parts = spack.reporters.extract.extract_test_parts("fake", outputs)
 

--- a/lib/spack/spack/test/sbang.py
+++ b/lib/spack/spack/test/sbang.py
@@ -58,7 +58,7 @@ last_line = "last!\n"
 
 @pytest.fixture  # type: ignore[no-redef]
 def sbang_line():
-    yield "#!/bin/sh %s/bin/sbang\n" % spack.store.STORE.layout.root
+    yield f"#!/bin/sh {spack.store.STORE.layout.root}/bin/sbang\n"
 
 
 class ScriptDirectory:
@@ -275,13 +275,13 @@ def configure_group_perms():
     group_name = grp.getgrgid(gid).gr_name
 
     conf = syaml.load_config(
-        """\
+        f"""\
 all:
   permissions:
     read: world
     write: group
-    group: {0}
-""".format(group_name)
+    group: {group_name}
+"""
     )
     spack.config.set("packages", conf, scope="user")
 
@@ -314,16 +314,16 @@ def check_sbang_installation(group=False):
     status = os.stat(sbang_bin_dir)
     mode = status.st_mode & 0o777
     if group:
-        assert mode == 0o775, "Unexpected {0}".format(oct(mode))
+        assert mode == 0o775, f"Unexpected {oct(mode)}"
     else:
-        assert mode == 0o755, "Unexpected {0}".format(oct(mode))
+        assert mode == 0o755, f"Unexpected {oct(mode)}"
 
     status = os.stat(sbang_path)
     mode = status.st_mode & 0o777
     if group:
-        assert mode == 0o775, "Unexpected {0}".format(oct(mode))
+        assert mode == 0o775, f"Unexpected {oct(mode)}"
     else:
-        assert mode == 0o755, "Unexpected {0}".format(oct(mode))
+        assert mode == 0o755, f"Unexpected {oct(mode)}"
 
 
 def run_test_install_sbang(group):

--- a/lib/spack/spack/test/spec_dag.py
+++ b/lib/spack/spack/test/spec_dag.py
@@ -164,7 +164,7 @@ def test_conditional_dep_with_user_constraints(
     with spack.repo.use_repositories(repo_builder.root):
         spec = spack.concretize.concretize_one(spec_str)
         result = expr_str in spec
-        assert result is expected, "{0} in {1}".format(expr_str, spec)
+        assert result is expected, f"{expr_str} in {spec}"
 
 
 @pytest.mark.usefixtures("mutable_mock_repo", "config")

--- a/lib/spack/spack/test/stage.py
+++ b/lib/spack/spack/test/stage.py
@@ -29,7 +29,7 @@ from spack.util.path import canonicalize_path
 
 # The following values are used for common fetch and stage mocking fixtures:
 _archive_base = "test-files"
-_archive_fn = "%s.tar.gz" % _archive_base
+_archive_fn = f"{_archive_base}.tar.gz"
 _extra_fn = "extra.sh"
 _hidden_fn = ".hidden"
 _readme_fn = "README.txt"

--- a/lib/spack/spack/test/test_suite.py
+++ b/lib/spack/spack/test/test_suite.py
@@ -104,7 +104,7 @@ def test_test_external(
 ):
     name = "trivial-smoke-test"
     spec = spack.concretize.concretize_one(name)
-    spec.external_path = "/path/to/external/{0}".format(name)
+    spec.external_path = f"/path/to/external/{name}"
 
     monkeypatch.setattr(spack.spec.Spec, "installed", _true)
 
@@ -238,7 +238,7 @@ def test_test_virtuals():
     # This check assumes the method will not provide a unique set of compilers
     v_names = spack.install_test.virtuals(pkg)
     for name, number in [("c", 2), ("cxx", 2), ("fortran", 1), ("llvm", 1)]:
-        assert v_names.count(name) == number, "Expected {0} of '{1}'".format(number, name)
+        assert v_names.count(name) == number, f"Expected {number} of '{name}'"
 
 
 def test_package_copy_test_files_fails(mock_packages):

--- a/lib/spack/spack/test/url_parse.py
+++ b/lib/spack/spack/test/url_parse.py
@@ -297,7 +297,7 @@ def test_url_parse_offset(name, noffset, ver, voffset, path):
         # 3rd Pass: No separator characters are used
         # Assume name contains no digits
         # namever
-        ("turbolinux", "702", "file://{0}/turbolinux702.tar.gz".format(os.getcwd())),
+        ("turbolinux", "702", f"file://{os.getcwd()}/turbolinux702.tar.gz"),
         ("nauty", "26r7", "http://pallini.di.uniroma1.it/nauty26r7.tar.gz"),
         # 4th Pass: A single separator character is used
         # Assume name contains no digits
@@ -420,7 +420,7 @@ def test_url_parse_offset(name, noffset, ver, voffset, path):
         (
             "STAR-CCM+",
             "11.06.010_02",
-            "file://{0}/STAR-CCM+11.06.010_02_linux-x86_64.tar.gz".format(os.getcwd()),
+            f"file://{os.getcwd()}/STAR-CCM+11.06.010_02_linux-x86_64.tar.gz",
         ),
         # name-name_name-ver.ver
         (

--- a/lib/spack/spack/test/url_substitution.py
+++ b/lib/spack/spack/test/url_substitution.py
@@ -48,9 +48,9 @@ import spack.url
         ),
         # No separator between the name and version of the package
         (
-            "file://{0}/turbolinux702.tar.gz".format(os.getcwd()),
+            f"file://{os.getcwd()}/turbolinux702.tar.gz",
             "703",
-            "file://{0}/turbolinux703.tar.gz".format(os.getcwd()),
+            f"file://{os.getcwd()}/turbolinux703.tar.gz",
         ),
         (
             "https://github.com/losalamos/CLAMR/blob/packages/PowerParser_v2.0.7.tgz?raw=true",

--- a/lib/spack/spack/test/util/editor.py
+++ b/lib/spack/spack/test/util/editor.py
@@ -187,7 +187,7 @@ def test_editor_both_bad(nosuch_exe, vim_exe):
     os.environ["VISUAL"] = nosuch_exe
     os.environ["EDITOR"] = nosuch_exe
 
-    os.environ["PATH"] = "%s%s%s" % (os.path.dirname(vim_exe), os.pathsep, os.environ["PATH"])
+    os.environ["PATH"] = "{}{}{}".format(os.path.dirname(vim_exe), os.pathsep, os.environ["PATH"])
 
     def assert_exec(exe, args):
         assert exe == vim_exe

--- a/lib/spack/spack/test/util/environment.py
+++ b/lib/spack/spack/test/util/environment.py
@@ -122,11 +122,11 @@ def test_dump_environment(prepare_environment_for_tests, shell_as, shell, tmp_pa
     envutil.dump_environment(dumpfile_path)
     with open(dumpfile_path, "r", encoding="utf-8") as dumpfile:
         if shell == "pwsh":
-            assert "$Env:TEST_ENV_VAR={}\n".format(test_paths) in list(dumpfile)
+            assert f"$Env:TEST_ENV_VAR={test_paths}\n" in list(dumpfile)
         elif shell == "bat":
-            assert 'set "TEST_ENV_VAR={}"\n'.format(test_paths) in list(dumpfile)
+            assert f'set "TEST_ENV_VAR={test_paths}"\n' in list(dumpfile)
         else:
-            assert "TEST_ENV_VAR={0}; export TEST_ENV_VAR\n".format(test_paths) in list(dumpfile)
+            assert f"TEST_ENV_VAR={test_paths}; export TEST_ENV_VAR\n" in list(dumpfile)
 
 
 def test_reverse_environment_modifications(working_env):

--- a/lib/spack/spack/test/util/executable.py
+++ b/lib/spack/spack/test/util/executable.py
@@ -21,18 +21,18 @@ def test_read_unicode(tmp_path: pathlib.Path, working_env):
         script_args: List[str] = []
         # read the unicode back in and see whether things work
         if sys.platform == "win32":
-            script = ex.Executable("%s" % (sys.executable))
+            script = ex.Executable(f"{sys.executable}")
             script_args.append(script_name)
         else:
-            script = ex.Executable("./%s" % script_name)
+            script = ex.Executable(f"./{script_name}")
 
         os.environ["LD_LIBRARY_PATH"] = spack.main.spack_ld_library_path
         # make a script that prints some unicode
         with open(script_name, "w", encoding="utf-8") as f:
             f.write(
-                """#!{0}
+                f"""#!{sys.executable}
 print(u'\\xc3')
-""".format(sys.executable)
+"""
             )
 
         # make it executable
@@ -49,7 +49,7 @@ def test_which_relative_path_with_slash(tmp_path: pathlib.Path, working_env):
     os.environ["PATH"] = ""
 
     with fs.working_dir(str(tmp_path)):
-        no_exe = ex.which(".{0}exe".format(os.path.sep))
+        no_exe = ex.which(f".{os.path.sep}exe")
         assert no_exe is None
         if sys.platform == "win32":
             # These checks are for 'executable' files, Windows
@@ -59,7 +59,7 @@ def test_which_relative_path_with_slash(tmp_path: pathlib.Path, working_env):
         else:
             fs.set_executable(path)
 
-        exe = ex.which(".{0}exe".format(os.path.sep), required=True)
+        exe = ex.which(f".{os.path.sep}exe", required=True)
         assert exe.path == path
 
 
@@ -83,7 +83,7 @@ def test_which_with_slash_ignores_path(tmp_path: pathlib.Path, working_env):
             fs.set_executable(path)
             fs.set_executable(wrong_path)
 
-        exe = ex.which(".{0}exe".format(os.path.sep), required=True)
+        exe = ex.which(f".{os.path.sep}exe", required=True)
         assert exe.path == path
 
 

--- a/lib/spack/spack/test/util/package_hash.py
+++ b/lib/spack/spack/test/util/package_hash.py
@@ -216,9 +216,7 @@ class HasManyDirectives:
         pass
 
 {directives}
-""".format(
-    directives="\n".join("    %s()" % name for name in spack.directives_meta.directive_names)
-)
+""".format(directives="\n".join(f"    {name}()" for name in spack.directives_meta.directive_names))
 
 
 def test_remove_all_directives():
@@ -369,7 +367,7 @@ def test_package_hash_consistency(package_spec, expected_hash):
 
     """
     spec = Spec(package_spec)
-    filename = os.path.join(datadir, "%s.txt" % spec.name)
+    filename = os.path.join(datadir, f"{spec.name}.txt")
     with open(filename, "rb") as f:
         source = f.read()
     h = ph.package_hash(spec, source=source)

--- a/lib/spack/spack/test/util/path.py
+++ b/lib/spack/spack/test/util/path.py
@@ -85,36 +85,36 @@ class TestPathPadding:
 def test_output_filtering(capfd, install_mockery, mutable_config):
     """Test filtering padding out of tty messages."""
     long_path = "/" + "/".join([sup.SPACK_PATH_PADDING_CHARS] * 200)
-    padding_string = "[padded-to-%d-chars]" % len(long_path)
+    padding_string = f"[padded-to-{len(long_path)}-chars]"
 
     # test filtering when padding is enabled
     with spack.config.override("config:install_tree", {"padded_length": 256}):
         # tty.msg with filtering on the first argument
         with sup.filter_padding():
-            tty.msg("here is a long path: %s/with/a/suffix" % long_path)
+            tty.msg(f"here is a long path: {long_path}/with/a/suffix")
         out, err = capfd.readouterr()
         assert padding_string in out
 
         # tty.msg with filtering on a laterargument
         with sup.filter_padding():
-            tty.msg("here is a long path:", "%s/with/a/suffix" % long_path)
+            tty.msg("here is a long path:", f"{long_path}/with/a/suffix")
         out, err = capfd.readouterr()
         assert padding_string in out
 
         # tty.error with filtering on the first argument
         with sup.filter_padding():
-            tty.error("here is a long path: %s/with/a/suffix" % long_path)
+            tty.error(f"here is a long path: {long_path}/with/a/suffix")
         out, err = capfd.readouterr()
         assert padding_string in err
 
         # tty.error with filtering on a later argument
         with sup.filter_padding():
-            tty.error("here is a long path:", "%s/with/a/suffix" % long_path)
+            tty.error("here is a long path:", f"{long_path}/with/a/suffix")
         out, err = capfd.readouterr()
         assert padding_string in err
 
     # test no filtering
-    tty.msg("here is a long path: %s/with/a/suffix" % long_path)
+    tty.msg(f"here is a long path: {long_path}/with/a/suffix")
     out, err = capfd.readouterr()
     assert padding_string not in out
 
@@ -134,11 +134,11 @@ def test_pad_on_path_sep_boundary():
 def test_path_debug_padded_filter(debug, monkeypatch):
     """Ensure padded filter works as expected with different debug levels."""
     fmt = "{0}{1}{2}{1}{3}"
-    prefix = "[+] {0}home{0}user{0}install".format(os.sep)
+    prefix = f"[+] {os.sep}home{os.sep}user{os.sep}install"
     suffix = "mypackage"
     string = fmt.format(prefix, os.sep, os.sep.join([sup.SPACK_PATH_PADDING_CHARS] * 2), suffix)
     expected = (
-        fmt.format(prefix, os.sep, "[padded-to-{0}-chars]".format(72), suffix)
+        fmt.format(prefix, os.sep, f"[padded-to-{72}-chars]", suffix)
         if debug <= 1 and sys.platform != "win32"
         else string
     )

--- a/lib/spack/spack/test/util/prefix.py
+++ b/lib/spack/spack/test/util/prefix.py
@@ -22,9 +22,9 @@ def test_prefix_join():
     """Test prefix join  ``prefix.join(...)``"""
     prefix = Prefix(os.sep + "usr")
 
-    a1 = prefix.join("a_{0}".format(1)).lib64
-    a2 = prefix.join("a-{0}".format(1)).lib64
-    a3 = prefix.join("a.{0}".format(1)).lib64
+    a1 = prefix.join(f"a_{1}").lib64
+    a2 = prefix.join(f"a-{1}").lib64
+    a3 = prefix.join(f"a.{1}").lib64
 
     assert a1 == os.sep + os.path.join("usr", "a_1", "lib64")
     assert a2 == os.sep + os.path.join("usr", "a-1", "lib64")
@@ -69,8 +69,8 @@ def test_string_like_behavior():
     assert isinstance(prefix, str)
 
     assert prefix + "/bin" == "/usr/bin"
-    assert "--prefix=%s" % prefix == "--prefix=/usr"
-    assert "--prefix={0}".format(prefix) == "--prefix=/usr"
+    assert f"--prefix={prefix}" == "--prefix=/usr"
+    assert f"--prefix={prefix}" == "--prefix=/usr"
 
     assert prefix.find("u", 1)
     assert prefix.upper() == "/USR"

--- a/lib/spack/spack/test/util/spack_yaml.py
+++ b/lib/spack/spack/test/util/spack_yaml.py
@@ -35,7 +35,7 @@ def check_blame(element, file_name, line=None):
 
     annotation = file_name
     if line is not None:
-        annotation += ":%d" % line
+        annotation += f":{line}"
 
     assert file_name in element_line
 

--- a/lib/spack/spack/test/util/unparse/unparse.py
+++ b/lib/spack/spack/test/util/unparse/unparse.py
@@ -237,7 +237,7 @@ def check_ast_roundtrip(code1, filename="internal", mode="exec"):
 
     ast2 = compile(code2, filename, mode, ast.PyCF_ONLY_AST)
 
-    error_msg = "Failed to roundtrip {} [mode={}]".format(filename, mode)
+    error_msg = f"Failed to roundtrip {filename} [mode={mode}]"
     assert ast.dump(ast1) == ast.dump(ast2), error_msg
 
 
@@ -245,7 +245,9 @@ def test_core_lib_files():
     """Roundtrip source files from the Python core libs."""
     test_directories = [
         os.path.join(
-            getattr(sys, "real_prefix", sys.prefix), "lib", "python%s.%s" % sys.version_info[:2]
+            getattr(sys, "real_prefix", sys.prefix),
+            "lib",
+            "python{}.{}".format(*sys.version_info[:2]),
         )
     ]
 

--- a/lib/spack/spack/test/versions.py
+++ b/lib/spack/spack/test/versions.py
@@ -686,7 +686,7 @@ def test_versions_from_git(git, mock_git_version_info, monkeypatch, mock_package
     )
 
     for commit in commits:
-        spec = spack.spec.Spec("git-test-commit@%s" % commit)
+        spec = spack.spec.Spec(f"git-test-commit@{commit}")
         version: GitVersion = spec.version
         comparator = [str(v) if not isinstance(v, int) else v for v in version.ref_version]
 
@@ -1073,7 +1073,7 @@ def test_git_version_repo_attached_after_serialization(
     """
     repo_path, _, commits = mock_git_version_info
     monkeypatch.setattr(
-        spack.package_base.PackageBase, "git", "file://%s" % repo_path, raising=False
+        spack.package_base.PackageBase, "git", f"file://{repo_path}", raising=False
     )
     spec = spack.concretize.concretize_one(f"git-test-commit@{commits[-2]}")
 
@@ -1092,7 +1092,7 @@ def test_resolved_git_version_is_shown_in_str(
     as <hash>=<version>, and not just <hash>."""
     repo_path, _, commits = mock_git_version_info
     monkeypatch.setattr(
-        spack.package_base.PackageBase, "git", "file://%s" % repo_path, raising=False
+        spack.package_base.PackageBase, "git", f"file://{repo_path}", raising=False
     )
     commit = commits[-3]
     spec = spack.concretize.concretize_one(f"git-test-commit@{commit}")

--- a/lib/spack/spack/url_buildcache.py
+++ b/lib/spack/spack/url_buildcache.py
@@ -1228,7 +1228,7 @@ def get_entries_from_cache(url: str, tmpspecsdir: str, component_type: Buildcach
         if file_to_mtime_mapping:
             return file_to_mtime_mapping, read_fn
 
-    raise ListMirrorSpecsError("Failed to get list of entries from {0}".format(url))
+    raise ListMirrorSpecsError(f"Failed to get list of entries from {url}")
 
 
 def validate_checksum(file_path, checksum_algorithm, expected_checksum) -> None:

--- a/lib/spack/spack/util/argparsewriter.py
+++ b/lib/spack/spack/util/argparsewriter.py
@@ -285,12 +285,12 @@ class ArgparseRstWriter(ArgparseWriter):
         Returns:
             Usage of a command.
         """
-        return """\
+        return f"""\
 .. code-block:: console
 
-    {0}
+    {usage}
 
-""".format(usage)
+"""
 
     def begin_positionals(self) -> str:
         """Text to print before positional arguments.
@@ -310,11 +310,11 @@ class ArgparseRstWriter(ArgparseWriter):
         Returns:
             Positional argument description.
         """
-        return """\
-``{0}``
-  {1}
+        return f"""\
+``{name}``
+  {help}
 
-""".format(name, help)
+"""
 
     def end_positionals(self) -> str:
         """Text to print after positional arguments.
@@ -342,11 +342,11 @@ class ArgparseRstWriter(ArgparseWriter):
         Returns:
             Optional argument description.
         """
-        return """\
-``{0}``
-  {1}
+        return f"""\
+``{opts}``
+  {help}
 
-""".format(opts, help)
+"""
 
     def end_optionals(self) -> str:
         """Text to print after optional arguments.

--- a/lib/spack/spack/util/compression.py
+++ b/lib/spack/spack/util/compression.py
@@ -276,8 +276,9 @@ def _system_7zip(archive_file):
     _7z = which("7z")
     if not _7z:
         raise CommandNotFoundError(
-            "7z unavailable, unable to extract %s files. 7z can be installed via Spack"
-            % spack.util.url.extension_from_path(archive_file)
+            f"7z unavailable, unable to extract "
+            f"{spack.util.url.extension_from_path(archive_file)} files. "
+            "7z can be installed via Spack"
         )
     _7z.add_default_arg("e")
     _7z(archive_file)

--- a/lib/spack/spack/util/crypto.py
+++ b/lib/spack/spack/util/crypto.py
@@ -36,8 +36,8 @@ class DeprecatedHash:
     def __call__(self, disable_alert=False):
         if not disable_alert:
             self.alert_fn(
-                "Deprecation warning: {0} checksums will not be"
-                " supported in future Spack releases.".format(self.hash_alg)
+                f"Deprecation warning: {self.hash_alg} checksums will not be"
+                " supported in future Spack releases."
             )
         if self.disable_security_check:
             return hashlib.new(self.hash_alg, usedforsecurity=False)  # novermin

--- a/lib/spack/spack/util/ctest_log_parser.py
+++ b/lib/spack/spack/util/ctest_log_parser.py
@@ -257,9 +257,9 @@ class LogEvent:
         out = io.StringIO()
         for i in range(self.start, self.end):
             if i == self.line_no:
-                out.write("  >> %-6d%s" % (i, self[i]))
+                out.write(f"  >> {i:<6d}{self[i]}")
             else:
-                out.write("     %-6d%s" % (i, self[i]))
+                out.write(f"     {i:<6d}{self[i]}")
         return out.getvalue()
 
 
@@ -342,11 +342,11 @@ class _ProfileMatcher(_Matcher):
         print()
         print(f"{kind}_matches")
         for pattern, t in zip(self.matches, self.match_times):
-            print("%16.2f        %s" % (t * 1e6, pattern.pattern))
+            print(f"{t * 1e6:16.2f}        {pattern.pattern}")
         print()
         print(f"{kind}_exceptions")
         for pattern, t in zip(self.exceptions, self.exc_times):
-            print("%16.2f        %s" % (t * 1e6, pattern.pattern))
+            print(f"{t * 1e6:16.2f}        {pattern.pattern}")
 
 
 def _parse(

--- a/lib/spack/spack/util/editor.py
+++ b/lib/spack/spack/util/editor.py
@@ -103,8 +103,8 @@ def editor(*args: str, exec_fn: Callable[[str, List[str]], int] = os.execv) -> b
 
             # Show variable we were trying to use, if it's from one
             if var:
-                exe = "$%s (%s)" % (var, exe)
-            tty.warn("Could not execute %s due to error:" % exe, str(e))
+                exe = f"${var} ({exe})"
+            tty.warn(f"Could not execute {exe} due to error:", str(e))
             return False
 
     def try_env_var(var):
@@ -118,7 +118,7 @@ def editor(*args: str, exec_fn: Callable[[str, List[str]], int] = os.execv) -> b
 
         exe, editor_args = _find_exe_from_env_var(var)
         if not exe:
-            tty.warn("$%s is not an executable:" % var, os.environ[var])
+            tty.warn(f"${var} is not an executable:", os.environ[var])
             return False
 
         full_args = editor_args + list(args)

--- a/lib/spack/spack/util/file_cache.py
+++ b/lib/spack/spack/util/file_cache.py
@@ -19,9 +19,9 @@ def _maybe_open(path: Union[str, pathlib.Path]) -> Optional[IO[str]]:
     try:
         return open(path, "r", encoding="utf-8")
     except IsADirectoryError:
-        raise CacheError("Cache file is not a file: %s" % path)
+        raise CacheError(f"Cache file is not a file: {path}")
     except PermissionError:
-        raise CacheError("Cannot access cache file: %s" % path)
+        raise CacheError(f"Cannot access cache file: {path}")
     except FileNotFoundError:
         return None
 

--- a/lib/spack/spack/util/gcs.py
+++ b/lib/spack/spack/util/gcs.py
@@ -28,8 +28,8 @@ def gcs_client():
         from google.cloud import storage
     except ImportError as ex:
         tty.error(
-            "{0}, google-cloud-storage python module is missing.".format(ex)
-            + " Please install to use the gs:// backend."
+            f"{ex}, google-cloud-storage python module is missing."
+            " Please install to use the gs:// backend."
         )
         sys.exit(1)
 
@@ -53,11 +53,7 @@ class GCSBucket:
                  client that will be used to access the GCS bucket.
         """
         if url.scheme != "gs":
-            raise ValueError(
-                "Can not create GCS bucket connection with scheme {SCHEME}".format(
-                    SCHEME=url.scheme
-                )
-            )
+            raise ValueError(f"Can not create GCS bucket connection with scheme {url.scheme}")
         self.url = url
         self.name = self.url.netloc
         if self.url.path[0] == "/":
@@ -69,8 +65,8 @@ class GCSBucket:
 
         self.bucket = None
         tty.debug("New GCS bucket:")
-        tty.debug("    name: {0}".format(self.name))
-        tty.debug("    prefix: {0}".format(self.prefix))
+        tty.debug(f"    name: {self.name}")
+        tty.debug(f"    prefix: {self.prefix}")
 
     def exists(self):
         from google.cloud.exceptions import NotFound
@@ -79,7 +75,7 @@ class GCSBucket:
             try:
                 self.bucket = self.client.bucket(self.name)
             except NotFound as ex:
-                tty.error("{0}, Failed check for bucket existence".format(ex))
+                tty.error(f"{ex}, Failed check for bucket existence")
                 sys.exit(1)
         return self.bucket is not None
 
@@ -106,7 +102,7 @@ class GCSBucket:
             relative: If true (default), print blob paths relative to 'build_cache' directory.
                 If false, print absolute blob paths (useful for destruction of bucket)
         """
-        tty.debug("Getting GCS blobs... Recurse {0} -- Rel: {1}".format(recursive, relative))
+        tty.debug(f"Getting GCS blobs... Recurse {recursive} -- Rel: {relative}")
 
         converter = self._relative_blob_name if relative else str
 
@@ -139,7 +135,7 @@ class GCSBucket:
         """
         from google.cloud.exceptions import NotFound
 
-        tty.debug("Bucket.destroy(recursive={0})".format(recursive))
+        tty.debug(f"Bucket.destroy(recursive={recursive})")
         try:
             bucket_blobs = self.get_all_blobs(recursive=recursive, relative=False)
             batch_size = 1000
@@ -151,7 +147,7 @@ class GCSBucket:
                         blob = self.blob(bucket_blobs[j])
                         blob.delete()
         except NotFound as ex:
-            tty.error("{0}, Could not delete a blob in bucket {1}.".format(ex, self.name))
+            tty.error(f"{ex}, Could not delete a blob in bucket {self.name}.")
             sys.exit(1)
 
 
@@ -164,11 +160,7 @@ class GCSBlob:
     def __init__(self, url, client=None):
         self.url = url
         if url.scheme != "gs":
-            raise ValueError(
-                "Can not create GCS blob connection with scheme: {SCHEME}".format(
-                    SCHEME=url.scheme
-                )
-            )
+            raise ValueError(f"Can not create GCS blob connection with scheme: {url.scheme}")
 
         self.client = client or gcs_client()
 
@@ -177,10 +169,10 @@ class GCSBlob:
         self.blob_path = self.url.path.lstrip("/")
 
         tty.debug("New GCSBlob")
-        tty.debug("  blob_path = {0}".format(self.blob_path))
+        tty.debug(f"  blob_path = {self.blob_path}")
 
         if not self.bucket.exists():
-            tty.warn("The bucket {0} does not exist, it will be created".format(self.bucket.name))
+            tty.warn(f"The bucket {self.bucket.name} does not exist, it will be created")
             self.bucket.create()
 
     def get(self):
@@ -204,7 +196,7 @@ class GCSBlob:
             blob = self.bucket.blob(self.blob_path)
             blob.delete()
         except NotFound as ex:
-            tty.error("{0}, Could not delete gcs blob {1}".format(ex, self.blob_path))
+            tty.error(f"{ex}, Could not delete gcs blob {self.blob_path}")
 
     def upload_to_blob(self, local_file_path):
         blob = self.bucket.blob(self.blob_path)
@@ -232,7 +224,7 @@ def gcs_open(req, *args, **kwargs):
     gcsblob = GCSBlob(url)
 
     if not gcsblob.exists():
-        raise URLError("GCS blob {0} does not exist".format(gcsblob.blob_path))
+        raise URLError(f"GCS blob {gcsblob.blob_path} does not exist")
     stream = gcsblob.get_blob_byte_stream()
     headers = gcsblob.get_blob_headers()
 

--- a/lib/spack/spack/util/gpg.py
+++ b/lib/spack/spack/util/gpg.py
@@ -501,11 +501,11 @@ class Gpg:
             os.chmod(gnupghome, 0o700)
 
         if not os.path.isdir(gnupghome):
-            msg = 'gnupghome "{0}" exists and is not a directory'.format(gnupghome)
+            msg = f'gnupghome "{gnupghome}" exists and is not a directory'
             raise SpackGPGError(msg)
 
         if not os.access(gnupghome, os.R_OK | os.W_OK | os.X_OK):
-            msg = 'gnupghome "{0}" exists but is not accessible'.format(gnupghome)
+            msg = f'gnupghome "{gnupghome}" exists but is not accessible'
             raise SpackGPGError(msg)
 
         return pathlib.Path(gnupghome)
@@ -930,14 +930,13 @@ def create(**kwargs):
 Key-Type: rsa
 Key-Length: 4096
 Key-Usage: sign
-Name-Real: %(name)s
-Name-Email: %(email)s
-Name-Comment: %(comment)s
-Expire-Date: %(expires)s
-%%no-protection
-%%commit
-"""
-                % kwargs
+Name-Real: {name}
+Name-Email: {email}
+Name-Comment: {comment}
+Expire-Date: {expires}
+%no-protection
+%commit
+""".format(**kwargs)
             )
         GPG("--gen-key", "--batch", input=r)
 
@@ -1080,7 +1079,7 @@ def _verify_exe_or_raise(exe) -> spack.version.VersionType:
     output = exe("--version", output=str)
     match = re.search(r"^gpg(conf)? \(GnuPG(?:/MacGPG2)?\) (.*)$", output, re.M)
     if not match:
-        raise SpackGPGError('Could not determine "{0}" version'.format(exe.name))
+        raise SpackGPGError(f'Could not determine "{exe.name}" version')
 
     gpg_version = spack.version.Version(match.group(2))
     if gpg_version < spack.version.Version("2"):

--- a/lib/spack/spack/util/hash.py
+++ b/lib/spack/spack/util/hash.py
@@ -19,7 +19,7 @@ def b32_hash(content):
 def base32_prefix_bits(hash_string, bits):
     """Return the first <bits> bits of a base32 string as an integer."""
     if bits > len(hash_string) * 5:
-        raise ValueError("Too many bits! Requested %d bit prefix of '%s'." % (bits, hash_string))
+        raise ValueError(f"Too many bits! Requested {bits} bit prefix of '{hash_string}'.")
 
     hash_bytes = base64.b32decode(hash_string, casefold=True)
     return spack.util.crypto.prefix_bits(hash_bytes, bits)

--- a/lib/spack/spack/util/link_tree.py
+++ b/lib/spack/spack/util/link_tree.py
@@ -20,7 +20,7 @@ empty_file_name = ".spack-empty"
 
 def remove_link(src, dest):
     if not fs.islink(dest):
-        raise ValueError("%s is not a link tree!" % dest)
+        raise ValueError(f"{dest} is not a link tree!")
     # remove if dest is a hardlink/symlink to src; this will only
     # be false if two packages are merged into a prefix and have a
     # conflicting file
@@ -477,9 +477,9 @@ class LinkTree:
         for src, dest in fs.traverse_tree(self._root, dest_root, **kwargs):
             if os.path.isdir(src):
                 if os.path.exists(dest) and not os.path.isdir(dest):
-                    conflicts.append("File blocks directory: %s" % dest)
+                    conflicts.append(f"File blocks directory: {dest}")
             elif os.path.exists(dest) and os.path.isdir(dest):
-                conflicts.append("Directory blocks directory: %s" % dest)
+                conflicts.append(f"Directory blocks directory: {dest}")
         return conflicts
 
     def get_file_map(self, dest_root, ignore):
@@ -498,7 +498,7 @@ class LinkTree:
                     continue
 
                 if not os.path.isdir(dest):
-                    raise ValueError("File blocks directory: %s" % dest)
+                    raise ValueError(f"File blocks directory: {dest}")
 
                 # mark empty directories so they aren't removed on unmerge.
                 if not os.listdir(dest):
@@ -511,7 +511,7 @@ class LinkTree:
                 if not os.path.exists(dest):
                     continue
                 elif not os.path.isdir(dest):
-                    raise ValueError("File blocks directory: %s" % dest)
+                    raise ValueError(f"File blocks directory: {dest}")
 
                 # remove directory if it is empty.
                 if not os.listdir(dest):
@@ -568,7 +568,7 @@ class LinkTree:
                 link(src, dst)
 
         for c in existing:
-            tty.warn("Could not merge: %s" % c)
+            tty.warn(f"Could not merge: {c}")
 
     def unmerge(self, dest_root, ignore=None, remove_file=remove_link):
         """Unlink all files in dest that exist in src.
@@ -594,7 +594,7 @@ class ConflictingSpecsError(MergeConflictError):
 
 class SingleMergeConflictError(MergeConflictError):
     def __init__(self, path):
-        super().__init__("Package merge blocked by file: %s" % path)
+        super().__init__(f"Package merge blocked by file: {path}")
 
 
 class MergeConflictSummary(MergeConflictError):
@@ -603,10 +603,10 @@ class MergeConflictSummary(MergeConflictError):
         A human-readable summary of file system view merge conflicts (showing only the
         first 3 issues.)
         """
-        msg = "{0} fatal error(s) when merging prefixes:".format(len(conflicts))
+        msg = f"{len(conflicts)} fatal error(s) when merging prefixes:"
         # show the first 3 merge conflicts.
         for conflict in conflicts[:3]:
-            msg += "\n    `{0}` and `{1}` both project to `{2}`".format(
-                conflict.src_a, conflict.src_b, conflict.dst
+            msg += (
+                f"\n    `{conflict.src_a}` and `{conflict.src_b}` both project to `{conflict.dst}`"
             )
         super().__init__(msg)

--- a/lib/spack/spack/util/log_parse.py
+++ b/lib/spack/spack/util/log_parse.py
@@ -65,7 +65,7 @@ def make_log_context(log_events: List[LogEvent]) -> str:
 
     def flush_block():
         block_end = block_start + len(block_lines) - 1
-        out.write(colorize("@c{-- lines %d to %d --}\n" % (block_start, block_end)))
+        out.write(colorize(f"@c{{-- lines {block_start} to {block_end} --}}\n"))
         out.writelines(block_lines)
         block_lines.clear()
 
@@ -83,9 +83,9 @@ def make_log_context(log_events: List[LogEvent]) -> str:
         for i in range(start, event.end):
             if i in event_colors:
                 color = event_colors[i]
-                block_lines.append(colorize("@%s{> %s}\n" % (color, cescape(event[i]))))
+                block_lines.append(colorize(f"@{color}{{> {cescape(event[i])}}}\n"))
             else:
-                block_lines.append("  %s\n" % event[i])
+                block_lines.append(f"  {event[i]}\n")
 
         next_line = event.end
 

--- a/lib/spack/spack/util/module_cmd.py
+++ b/lib/spack/spack/util/module_cmd.py
@@ -93,7 +93,7 @@ def load_module(mod):
     Raises:
         ModuleLoadError: if the module could not be loaded
     """
-    tty.debug("module_cmd.load_module: {0}".format(mod))
+    tty.debug(f"module_cmd.load_module: {mod}")
     # Read the module and remove any conflicting modules
     # We do this without checking that they are already installed
     # for ease of programming because unloading a module that is not
@@ -225,11 +225,11 @@ def get_path_from_module_contents(text, module_name):
         match_pattern_and_strip(line, pattern, lib_endings)
 
         # Check {name}_DIR entries
-        pattern = r"\W{0}_DIR".format(pkg_var_prefix)
+        pattern = rf"\W{pkg_var_prefix}_DIR"
         match_pattern_and_strip(line, pattern)
 
         # Check {name}_ROOT entries
-        pattern = r"\W{0}_ROOT".format(pkg_var_prefix)
+        pattern = rf"\W{pkg_var_prefix}_ROOT"
         match_pattern_and_strip(line, pattern)
 
         # Check entries that update the PATH variable

--- a/lib/spack/spack/util/naming.py
+++ b/lib/spack/spack/util/naming.py
@@ -210,10 +210,10 @@ class NamespaceTrie:
         first, sep, rest = namespace.partition(self._sep)
         if not first:
             if not self._value:
-                raise KeyError("Can't find namespace '%s' in trie" % full_name)
+                raise KeyError(f"Can't find namespace '{full_name}' in trie")
             return self._value.value
         elif first not in self._subspaces:
-            raise KeyError("Can't find namespace '%s' in trie" % full_name)
+            raise KeyError(f"Can't find namespace '{full_name}' in trie")
         else:
             return self._subspaces[first]._get_helper(rest, full_name)
 

--- a/lib/spack/spack/util/path.py
+++ b/lib/spack/spack/util/path.py
@@ -149,9 +149,7 @@ def get_system_path_max():
             proc_output = str(path_max_proc.communicate()[0].decode())
             sys_max_path_length = int(proc_output)
         except (ValueError, subprocess.CalledProcessError, OSError):
-            tty.msg(
-                "Unable to find system max path length, using: {0}".format(sys_max_path_length)
-            )
+            tty.msg(f"Unable to find system max path length, using: {sys_max_path_length}")
 
     return sys_max_path_length
 
@@ -315,10 +313,8 @@ def longest_prefix_re(string, capture=True):
     if len(string) < 2:
         return string
 
-    return "(%s%s%s?)" % (
-        "" if capture else "?:",
-        string[0],
-        longest_prefix_re(string[1:], capture=False),
+    return "({}{}{}?)".format(
+        "" if capture else "?:", string[0], longest_prefix_re(string[1:], capture=False)
     )
 
 

--- a/lib/spack/spack/util/spack_yaml.py
+++ b/lib/spack/spack/util/spack_yaml.py
@@ -353,7 +353,7 @@ class LineAnnotationEmitter(emitter.Emitter):
                 color = self.colors[len(self.filename_colors) % ncolors]
                 self.filename_colors[mark.name] = color
 
-            fmt = "@%s{%%s}" % color
+            fmt = f"@{color}{{%s}}"
             ann = fmt % mark.name
             if mark.line is not None:
                 ann += ":@c{%s}" % (mark.line + 1)
@@ -488,10 +488,10 @@ def _dump_annotated(handler, data, stream=None):
 
     # write out annotations and lines, accounting for color
     width = max(clen(a) for a in _ANNOTATIONS)
-    formats = ["%%-%ds  %%s\n" % (width + cextra(a)) for a in _ANNOTATIONS]
 
-    for fmt, annotation, line in zip(formats, _ANNOTATIONS, lines):
-        stream.write(fmt % (annotation, line))
+    for annotation, line in zip(_ANNOTATIONS, lines):
+        annotation_width = width + cextra(annotation)
+        stream.write(f"{annotation:<{annotation_width}}  {line}\n")
 
     if getvalue:
         return getvalue()

--- a/lib/spack/spack/util/web.py
+++ b/lib/spack/spack/util/web.py
@@ -268,7 +268,7 @@ def _urlopen():
 urlopen = lang.Singleton(_urlopen)
 
 #: User-Agent used in Request objects
-SPACK_USER_AGENT = "Spackbot/{0}".format(spack.spack_version)
+SPACK_USER_AGENT = f"Spackbot/{spack.spack_version}"
 
 
 # Also, HTMLParseError is deprecated and never raised.
@@ -346,9 +346,9 @@ def read_from_url(url, accept_content_type=None):
             reject_content_type = True
 
         if reject_content_type:
-            msg = "ignoring page {}".format(url.geturl())
+            msg = f"ignoring page {url.geturl()}"
             if content_type:
-                msg += " with content type {}".format(content_type)
+                msg += f" with content type {content_type}"
             tty.debug(msg)
             return None, None, None
 
@@ -539,13 +539,13 @@ def fetch_url_text(url, curl: Optional[Executable] = None, dest_dir="."):
     if not url:
         raise spack.error.FetchError("A URL is required to fetch its text")
 
-    tty.debug("Fetching text at {0}".format(url))
+    tty.debug(f"Fetching text at {url}")
 
     filename = os.path.basename(url)
     path = os.path.join(dest_dir, filename)
 
     fetch_method = spack.config.get("config:url_fetch_method")
-    tty.debug("Using '{0}' to fetch {1} into {2}".format(fetch_method, url, path))
+    tty.debug(f"Using '{fetch_method}' to fetch {url} into {path}")
     if fetch_method and fetch_method.startswith("curl"):
         curl_exe = curl or require_curl()
         curl_args = fetch_method.split()[1:] + ["-O"]
@@ -599,7 +599,7 @@ def url_exists(url, curl=None):
 
     Returns (bool): True if it exists; False otherwise.
     """
-    tty.debug("Checking existence of {0}".format(url))
+    tty.debug(f"Checking existence of {url}")
     url_result = urllib.parse.urlparse(url)
 
     # Use curl if configured to do so

--- a/lib/spack/spack/util/windows_registry.py
+++ b/lib/spack/spack/util/windows_registry.py
@@ -237,7 +237,7 @@ class WindowsRegistryView:
             yield
         except FileNotFoundError as e:
             if sys.platform == "win32" and e.winerror == 2:
-                tty.debug("Key %s at position %s does not exist" % (self.key, str(self.root)))
+                tty.debug(f"Key {self.key} at position {str(self.root)} does not exist")
             else:
                 raise e
 
@@ -250,7 +250,7 @@ class WindowsRegistryView:
         except FileNotFoundError as e:
             if sys.platform == "win32" and e.winerror == 2:
                 self._reg = -1
-                tty.debug("Key %s at position %s does not exist" % (self.key, str(self.root)))
+                tty.debug(f"Key {self.key} at position {str(self.root)} does not exist")
             else:
                 raise e
 

--- a/lib/spack/spack/verify.py
+++ b/lib/spack/spack/verify.py
@@ -198,9 +198,9 @@ class VerificationResults:
     def __str__(self):
         res = ""
         for path, fields in self.errors.items():
-            res += "%s verification failed with error(s):\n" % path
+            res += f"{path} verification failed with error(s):\n"
             for error in fields:
-                res += "    %s\n" % error
+                res += f"    {error}\n"
 
         if not res:
             res += "No Errors"

--- a/lib/spack/spack/version/git_ref_lookup.py
+++ b/lib/spack/spack/version/git_ref_lookup.py
@@ -146,10 +146,10 @@ class GitRefLookup(AbstractRefLookup):
             # Note the brackets are literals, the ref replaces the format string
             try:
                 self.fetcher.git(
-                    "cat-file", "-e", "%s^{commit}" % ref, output=os.devnull, error=os.devnull
+                    "cat-file", "-e", f"{ref}^{{commit}}", output=os.devnull, error=os.devnull
                 )
             except spack.util.executable.ProcessError:
-                raise VersionLookupError("%s is not a valid git ref for %s" % (ref, self.pkg_name))
+                raise VersionLookupError(f"{ref} is not a valid git ref for {self.pkg_name}")
 
             # List tags (refs) by date, so last reference of a tag is newest
             tag_info = self.fetcher.git(
@@ -186,7 +186,7 @@ class GitRefLookup(AbstractRefLookup):
                 self.fetcher.git("merge-base", "--is-ancestor", tag_commit, ref, ignore_errors=[1])
                 if self.fetcher.git.returncode == 0:
                     distance = self.fetcher.git(
-                        "rev-list", "%s..%s" % (tag_commit, ref), "--count", output=str, error=str
+                        "rev-list", f"{tag_commit}..{ref}", "--count", output=str, error=str
                     ).strip()
                     ancestor_commits.append((tag_commit, int(distance)))
 
@@ -204,7 +204,7 @@ class GitRefLookup(AbstractRefLookup):
                 prev_version = None
                 distance = int(
                     self.fetcher.git(
-                        "rev-list", "%s..%s" % (commits[-1], ref), "--count", output=str, error=str
+                        "rev-list", f"{commits[-1]}..{ref}", "--count", output=str, error=str
                     ).strip()
                 )
 

--- a/lib/spack/spack/version/version_types.py
+++ b/lib/spack/spack/version/version_types.py
@@ -128,7 +128,7 @@ def parse_string_components(string: str) -> Tuple[VersionTuple, SeparatorTuple]:
     string = string.strip()
 
     if string and not VALID_VERSION.match(string):
-        raise ValueError("Bad characters in version string: %s" % string)
+        raise ValueError(f"Bad characters in version string: {string}")
 
     segments = SEGMENT_REGEX.findall(string)
     separators: Tuple[str] = tuple([m[2] for m in segments])
@@ -1004,7 +1004,7 @@ class VersionList(VersionType):
                 self.versions.insert(i, item)
 
         else:
-            raise TypeError("Can't add %s to VersionList" % type(item))
+            raise TypeError(f"Can't add {type(item)} to VersionList")
 
     @property
     def concrete(self) -> Optional[ConcreteVersion]:
@@ -1354,7 +1354,7 @@ def ver(obj: Union[VersionType, str, list, tuple, int, float]) -> VersionType:
     elif isinstance(obj, (int, float)):
         return from_string(str(obj))
     else:
-        raise TypeError("ver() can't convert %s to version!" % type(obj))
+        raise TypeError(f"ver() can't convert {type(obj)} to version!")
 
 
 _STANDARD_VERSION_TYPEMIN = StandardVersion("", ((), (ALPHA,)), ("",))

--- a/var/spack/test_repos/spack_repo/builtin_mock/packages/boost/package.py
+++ b/var/spack/test_repos/spack_repo/builtin_mock/packages/boost/package.py
@@ -50,7 +50,7 @@ class Boost(Package):
         variant(
             lib,
             default=(lib not in default_noinstall_libs),
-            description="Compile with {0} library".format(lib),
+            description=f"Compile with {lib} library",
         )
 
     variant("debug", default=False, description="Switch to the debug version of Boost")

--- a/var/spack/test_repos/spack_repo/builtin_mock/packages/build_error/package.py
+++ b/var/spack/test_repos/spack_repo/builtin_mock/packages/build_error/package.py
@@ -35,7 +35,7 @@ class BuildError(Package):
                   """
                 )
 
-            Executable("configure.bat")("--prefix=%s" % self.prefix)
+            Executable("configure.bat")(f"--prefix={self.prefix}")
             configure()
         else:
             with open("configure", "w", encoding="utf-8") as f:

--- a/var/spack/test_repos/spack_repo/builtin_mock/packages/build_warnings/package.py
+++ b/var/spack/test_repos/spack_repo/builtin_mock/packages/build_warnings/package.py
@@ -33,7 +33,7 @@ class BuildWarnings(Package):
                   """
                 )
 
-            Executable("configure.bat")("--prefix=%s" % self.prefix)
+            Executable("configure.bat")(f"--prefix={self.prefix}")
         else:
             with open("configure", "w", encoding="utf-8") as f:
                 f.write(

--- a/var/spack/test_repos/spack_repo/builtin_mock/packages/cmake/package.py
+++ b/var/spack/test_repos/spack_repo/builtin_mock/packages/cmake/package.py
@@ -70,6 +70,6 @@ class Cmake(Package):
             "Couldn't read env var set in compile envieonmnt",
         )
         cmake_exe_ext = ".exe" if sys.platform == "win32" else ""
-        cmake_exe = join_path(prefix.bin, "cmake{}".format(cmake_exe_ext))
+        cmake_exe = join_path(prefix.bin, f"cmake{cmake_exe_ext}")
         touch(cmake_exe)
         set_executable(cmake_exe)

--- a/var/spack/test_repos/spack_repo/builtin_mock/packages/cmake_client/package.py
+++ b/var/spack/test_repos/spack_repo/builtin_mock/packages/cmake_client/package.py
@@ -113,7 +113,7 @@ class CmakeClient(CMakePackage):
         print(cmake.exe)
         check(
             cmake.path.startswith(spec["cmake"].prefix.bin),
-            "Wrong cmake was in environment: %s" % cmake,
+            f"Wrong cmake was in environment: {cmake}",
         )
 
         check(from_cmake == "from_cmake", "Couldn't read global set by cmake.")

--- a/var/spack/test_repos/spack_repo/builtin_mock/packages/conflict/package.py
+++ b/var/spack/test_repos/spack_repo/builtin_mock/packages/conflict/package.py
@@ -22,7 +22,7 @@ class Conflict(Package):
     depends_on("c", type="build")
 
     def install(self, spec, prefix):
-        configure("--prefix=%s" % prefix)
+        configure(f"--prefix={prefix}")
         make()
         make("install")
 

--- a/var/spack/test_repos/spack_repo/builtin_mock/packages/conflict_parent/package.py
+++ b/var/spack/test_repos/spack_repo/builtin_mock/packages/conflict_parent/package.py
@@ -21,7 +21,7 @@ class ConflictParent(Package):
     conflicts("^conflict~foo", when="@0.9")
 
     def install(self, spec, prefix):
-        configure("--prefix=%s" % prefix)
+        configure(f"--prefix={prefix}")
         make()
         make("install")
 

--- a/var/spack/test_repos/spack_repo/builtin_mock/packages/corge/package.py
+++ b/var/spack/test_repos/spack_repo/builtin_mock/packages/corge/package.py
@@ -102,24 +102,24 @@ main(int argc, char* argv[])
     return 0;
 }
 """
-        mkdirp("%s/corge" % prefix.include)
-        mkdirp("%s/corge" % self.stage.source_path)
-        with open("%s/corge_version.h" % self.stage.source_path, "w", encoding="utf-8") as f:
+        mkdirp(f"{prefix.include}/corge")
+        mkdirp(f"{self.stage.source_path}/corge")
+        with open(f"{self.stage.source_path}/corge_version.h", "w", encoding="utf-8") as f:
             f.write(corge_version_h % (self.version[0], self.version[1:]))
-        with open("%s/corge/corge.cc" % self.stage.source_path, "w", encoding="utf-8") as f:
+        with open(f"{self.stage.source_path}/corge/corge.cc", "w", encoding="utf-8") as f:
             f.write(corge_cc % prefix.config)
-        with open("%s/corge/corge.h" % self.stage.source_path, "w", encoding="utf-8") as f:
+        with open(f"{self.stage.source_path}/corge/corge.h", "w", encoding="utf-8") as f:
             f.write(corge_h)
-        with open("%s/corge/corgegator.cc" % self.stage.source_path, "w", encoding="utf-8") as f:
+        with open(f"{self.stage.source_path}/corge/corgegator.cc", "w", encoding="utf-8") as f:
             f.write(corgegator_cc)
         gpp = which("g++")
         if sys.platform == "darwin":
             gpp = which("clang++")
         gpp(
             "-Dcorge_EXPORTS",
-            "-I%s" % self.stage.source_path,
-            "-I%s" % spec["quux"].prefix.include,
-            "-I%s" % spec["garply"].prefix.include,
+            f"-I{self.stage.source_path}",
+            "-I{}".format(spec["quux"].prefix.include),
+            "-I{}".format(spec["garply"].prefix.include),
             "-O2",
             "-g",
             "-DNDEBUG",
@@ -131,9 +131,9 @@ main(int argc, char* argv[])
         )
         gpp(
             "-Dcorge_EXPORTS",
-            "-I%s" % self.stage.source_path,
-            "-I%s" % spec["quux"].prefix.include,
-            "-I%s" % spec["garply"].prefix.include,
+            f"-I{self.stage.source_path}",
+            "-I{}".format(spec["quux"].prefix.include),
+            "-I{}".format(spec["garply"].prefix.include),
             "-O2",
             "-g",
             "-DNDEBUG",
@@ -155,10 +155,10 @@ main(int argc, char* argv[])
                 "-o",
                 "libcorge.dylib",
                 "corge.cc.o",
-                "-Wl,-rpath,%s" % spec["quux"].prefix.lib64,
-                "-Wl,-rpath,%s" % spec["garply"].prefix.lib64,
-                "%s/libquux.dylib" % spec["quux"].prefix.lib64,
-                "%s/libgarply.dylib" % spec["garply"].prefix.lib64,
+                "-Wl,-rpath,{}".format(spec["quux"].prefix.lib64),
+                "-Wl,-rpath,{}".format(spec["garply"].prefix.lib64),
+                "{}/libquux.dylib".format(spec["quux"].prefix.lib64),
+                "{}/libgarply.dylib".format(spec["garply"].prefix.lib64),
             )
             gpp(
                 "-O2",
@@ -168,16 +168,16 @@ main(int argc, char* argv[])
                 "corgegator.cc.o",
                 "-o",
                 "corgegator",
-                "-Wl,-rpath,%s" % prefix.lib64,
-                "-Wl,-rpath,%s" % spec["quux"].prefix.lib64,
-                "-Wl,-rpath,%s" % spec["garply"].prefix.lib64,
+                f"-Wl,-rpath,{prefix.lib64}",
+                "-Wl,-rpath,{}".format(spec["quux"].prefix.lib64),
+                "-Wl,-rpath,{}".format(spec["garply"].prefix.lib64),
                 "libcorge.dylib",
-                "%s/libquux.dylib.3.0" % spec["quux"].prefix.lib64,
-                "%s/libgarply.dylib.3.0" % spec["garply"].prefix.lib64,
+                "{}/libquux.dylib.3.0".format(spec["quux"].prefix.lib64),
+                "{}/libgarply.dylib.3.0".format(spec["garply"].prefix.lib64),
             )
             mkdirp(prefix.lib64)
-            copy("libcorge.dylib", "%s/libcorge.dylib" % prefix.lib64)
-            os.link("%s/libcorge.dylib" % prefix.lib64, "%s/libcorge.dylib.3.0" % prefix.lib64)
+            copy("libcorge.dylib", f"{prefix.lib64}/libcorge.dylib")
+            os.link(f"{prefix.lib64}/libcorge.dylib", f"{prefix.lib64}/libcorge.dylib.3.0")
         else:
             gpp(
                 "-fPIC",
@@ -189,9 +189,11 @@ main(int argc, char* argv[])
                 "-o",
                 "libcorge.so",
                 "corge.cc.o",
-                "-Wl,-rpath,%s:%s::::" % (spec["quux"].prefix.lib64, spec["garply"].prefix.lib64),
-                "%s/libquux.so" % spec["quux"].prefix.lib64,
-                "%s/libgarply.so" % spec["garply"].prefix.lib64,
+                "-Wl,-rpath,{}:{}::::".format(
+                    spec["quux"].prefix.lib64, spec["garply"].prefix.lib64
+                ),
+                "{}/libquux.so".format(spec["quux"].prefix.lib64),
+                "{}/libgarply.so".format(spec["garply"].prefix.lib64),
             )
             gpp(
                 "-O2",
@@ -201,20 +203,22 @@ main(int argc, char* argv[])
                 "corgegator.cc.o",
                 "-o",
                 "corgegator",
-                "-Wl,-rpath,%s" % prefix.lib64,
-                "-Wl,-rpath,%s" % spec["quux"].prefix.lib64,
-                "-Wl,-rpath,%s" % spec["garply"].prefix.lib64,
+                f"-Wl,-rpath,{prefix.lib64}",
+                "-Wl,-rpath,{}".format(spec["quux"].prefix.lib64),
+                "-Wl,-rpath,{}".format(spec["garply"].prefix.lib64),
                 "libcorge.so",
-                "%s/libquux.so.3.0" % spec["quux"].prefix.lib64,
-                "%s/libgarply.so.3.0" % spec["garply"].prefix.lib64,
+                "{}/libquux.so.3.0".format(spec["quux"].prefix.lib64),
+                "{}/libgarply.so.3.0".format(spec["garply"].prefix.lib64),
             )
             mkdirp(prefix.lib64)
-            copy("libcorge.so", "%s/libcorge.so" % prefix.lib64)
-            os.link("%s/libcorge.so" % prefix.lib64, "%s/libcorge.so.3.0" % prefix.lib64)
-        copy("corgegator", "%s/corgegator" % prefix.lib64)
-        copy("%s/corge/corge.h" % self.stage.source_path, "%s/corge/corge.h" % prefix.include)
+            copy("libcorge.so", f"{prefix.lib64}/libcorge.so")
+            os.link(f"{prefix.lib64}/libcorge.so", f"{prefix.lib64}/libcorge.so.3.0")
+        copy("corgegator", f"{prefix.lib64}/corgegator")
+        copy(f"{self.stage.source_path}/corge/corge.h", f"{prefix.include}/corge/corge.h")
         mkdirp(prefix.bin)
-        copy("corge_version.h", "%s/corge_version.h" % prefix.bin)
-        os.symlink("%s/corgegator" % prefix.lib64, "%s/corgegator" % prefix.bin)
-        os.symlink("%s/quuxifier" % spec["quux"].prefix.lib64, "%s/quuxifier" % prefix.bin)
-        os.symlink("%s/garplinator" % spec["garply"].prefix.lib64, "%s/garplinator" % prefix.bin)
+        copy("corge_version.h", f"{prefix.bin}/corge_version.h")
+        os.symlink(f"{prefix.lib64}/corgegator", f"{prefix.bin}/corgegator")
+        os.symlink("{}/quuxifier".format(spec["quux"].prefix.lib64), f"{prefix.bin}/quuxifier")
+        os.symlink(
+            "{}/garplinator".format(spec["garply"].prefix.lib64), f"{prefix.bin}/garplinator"
+        )

--- a/var/spack/test_repos/spack_repo/builtin_mock/packages/garply/package.py
+++ b/var/spack/test_repos/spack_repo/builtin_mock/packages/garply/package.py
@@ -74,15 +74,15 @@ main()
         garply_version_h = """const int garply_version_major = %s;
 const int garply_version_minor = %s;
 """
-        mkdirp("%s/garply" % prefix.include)
-        mkdirp("%s/garply" % self.stage.source_path)
-        with open("%s/garply_version.h" % self.stage.source_path, "w", encoding="utf-8") as f:
+        mkdirp(f"{prefix.include}/garply")
+        mkdirp(f"{self.stage.source_path}/garply")
+        with open(f"{self.stage.source_path}/garply_version.h", "w", encoding="utf-8") as f:
             f.write(garply_version_h % (self.version[0], self.version[1:]))
-        with open("%s/garply/garply.h" % self.stage.source_path, "w", encoding="utf-8") as f:
+        with open(f"{self.stage.source_path}/garply/garply.h", "w", encoding="utf-8") as f:
             f.write(garply_h)
-        with open("%s/garply/garply.cc" % self.stage.source_path, "w", encoding="utf-8") as f:
+        with open(f"{self.stage.source_path}/garply/garply.cc", "w", encoding="utf-8") as f:
             f.write(garply_cc % prefix.config)
-        with open("%s/garply/garplinator.cc" % self.stage.source_path, "w", encoding="utf-8") as f:
+        with open(f"{self.stage.source_path}/garply/garplinator.cc", "w", encoding="utf-8") as f:
             f.write(garplinator_cc)
         gpp = which(
             "g++",
@@ -94,7 +94,7 @@ const int garply_version_minor = %s;
             gpp = which("/usr/bin/clang++")
         gpp(
             "-Dgarply_EXPORTS",
-            "-I%s" % self.stage.source_path,
+            f"-I{self.stage.source_path}",
             "-O2",
             "-g",
             "-DNDEBUG",
@@ -102,11 +102,11 @@ const int garply_version_minor = %s;
             "-o",
             "garply.cc.o",
             "-c",
-            "%s/garply/garply.cc" % self.stage.source_path,
+            f"{self.stage.source_path}/garply/garply.cc",
         )
         gpp(
             "-Dgarply_EXPORTS",
-            "-I%s" % self.stage.source_path,
+            f"-I{self.stage.source_path}",
             "-O2",
             "-g",
             "-DNDEBUG",
@@ -114,7 +114,7 @@ const int garply_version_minor = %s;
             "-o",
             "garplinator.cc.o",
             "-c",
-            "%s/garply/garplinator.cc" % self.stage.source_path,
+            f"{self.stage.source_path}/garply/garplinator.cc",
         )
         if sys.platform == "darwin":
             gpp(
@@ -139,12 +139,12 @@ const int garply_version_minor = %s;
                 "garplinator.cc.o",
                 "-o",
                 "garplinator",
-                "-Wl,-rpath,%s" % prefix.lib64,
+                f"-Wl,-rpath,{prefix.lib64}",
                 "libgarply.dylib",
             )
             mkdirp(prefix.lib64)
-            copy("libgarply.dylib", "%s/libgarply.dylib" % prefix.lib64)
-            os.link("%s/libgarply.dylib" % prefix.lib64, "%s/libgarply.dylib.3.0" % prefix.lib64)
+            copy("libgarply.dylib", f"{prefix.lib64}/libgarply.dylib")
+            os.link(f"{prefix.lib64}/libgarply.dylib", f"{prefix.lib64}/libgarply.dylib.3.0")
         else:
             gpp(
                 "-fPIC",
@@ -165,14 +165,14 @@ const int garply_version_minor = %s;
                 "garplinator.cc.o",
                 "-o",
                 "garplinator",
-                "-Wl,-rpath,%s" % prefix.lib64,
+                f"-Wl,-rpath,{prefix.lib64}",
                 "libgarply.so",
             )
             mkdirp(prefix.lib64)
-            copy("libgarply.so", "%s/libgarply.so" % prefix.lib64)
-            os.link("%s/libgarply.so" % prefix.lib64, "%s/libgarply.so.3.0" % prefix.lib64)
-        copy("garplinator", "%s/garplinator" % prefix.lib64)
-        copy("%s/garply/garply.h" % self.stage.source_path, "%s/garply/garply.h" % prefix.include)
+            copy("libgarply.so", f"{prefix.lib64}/libgarply.so")
+            os.link(f"{prefix.lib64}/libgarply.so", f"{prefix.lib64}/libgarply.so.3.0")
+        copy("garplinator", f"{prefix.lib64}/garplinator")
+        copy(f"{self.stage.source_path}/garply/garply.h", f"{prefix.include}/garply/garply.h")
         mkdirp(prefix.bin)
-        copy("garply_version.h", "%s/garply_version.h" % prefix.bin)
-        os.symlink("%s/garplinator" % prefix.lib64, "%s/garplinator" % prefix.bin)
+        copy("garply_version.h", f"{prefix.bin}/garply_version.h")
+        os.symlink(f"{prefix.lib64}/garplinator", f"{prefix.bin}/garplinator")

--- a/var/spack/test_repos/spack_repo/builtin_mock/packages/gcc/package.py
+++ b/var/spack/test_repos/spack_repo/builtin_mock/packages/gcc/package.py
@@ -80,7 +80,7 @@ class Gcc(CompilerPackage, Package):
         # Create the minimal compiler that will fool `spack compiler find`
         mkdirp(prefix.bin)
         with open(prefix.bin.gcc, "w", encoding="utf-8") as f:
-            f.write('#!/bin/bash\necho "%s"' % str(spec.version))
+            f.write(f'#!/bin/bash\necho "{str(spec.version)}"')
         set_executable(prefix.bin.gcc)
 
     def _cc_path(self):

--- a/var/spack/test_repos/spack_repo/builtin_mock/packages/llvm/package.py
+++ b/var/spack/test_repos/spack_repo/builtin_mock/packages/llvm/package.py
@@ -91,7 +91,7 @@ class Llvm(Package, CompilerPackage):
         # Create the minimal compiler that will fool `spack compiler find`
         mkdirp(prefix.bin)
         with open(prefix.bin.gcc, "w", encoding="utf-8") as f:
-            f.write('#!/bin/bash\necho "%s"' % str(spec.version))
+            f.write(f'#!/bin/bash\necho "{str(spec.version)}"')
         set_executable(prefix.bin.gcc)
 
     def _cc_path(self):

--- a/var/spack/test_repos/spack_repo/builtin_mock/packages/mpich2/package.py
+++ b/var/spack/test_repos/spack_repo/builtin_mock/packages/mpich2/package.py
@@ -29,6 +29,6 @@ class Mpich2(Package):
     depends_on("c", type="build")
 
     def install(self, spec, prefix):
-        configure("--prefix=%s" % prefix)
+        configure(f"--prefix={prefix}")
         make()
         make("install")

--- a/var/spack/test_repos/spack_repo/builtin_mock/packages/quux/package.py
+++ b/var/spack/test_repos/spack_repo/builtin_mock/packages/quux/package.py
@@ -88,15 +88,15 @@ main()
         quux_version_h = """const int quux_version_major = %s;
 const int quux_version_minor = %s;
 """
-        mkdirp("%s/quux" % prefix.include)
-        mkdirp("%s/quux" % self.stage.source_path)
-        with open("%s/quux_version.h" % self.stage.source_path, "w", encoding="utf-8") as f:
+        mkdirp(f"{prefix.include}/quux")
+        mkdirp(f"{self.stage.source_path}/quux")
+        with open(f"{self.stage.source_path}/quux_version.h", "w", encoding="utf-8") as f:
             f.write(quux_version_h % (self.version[0], self.version[1:]))
-        with open("%s/quux/quux.cc" % self.stage.source_path, "w", encoding="utf-8") as f:
+        with open(f"{self.stage.source_path}/quux/quux.cc", "w", encoding="utf-8") as f:
             f.write(quux_cc % (prefix.config))
-        with open("%s/quux/quux.h" % self.stage.source_path, "w", encoding="utf-8") as f:
+        with open(f"{self.stage.source_path}/quux/quux.h", "w", encoding="utf-8") as f:
             f.write(quux_h)
-        with open("%s/quux/quuxifier.cc" % self.stage.source_path, "w", encoding="utf-8") as f:
+        with open(f"{self.stage.source_path}/quux/quuxifier.cc", "w", encoding="utf-8") as f:
             f.write(quuxifier_cc)
         gpp = which(
             "g++",
@@ -108,8 +108,8 @@ const int quux_version_minor = %s;
             gpp = which("/usr/bin/clang++")
         gpp(
             "-Dquux_EXPORTS",
-            "-I%s" % self.stage.source_path,
-            "-I%s" % spec["garply"].prefix.include,
+            f"-I{self.stage.source_path}",
+            "-I{}".format(spec["garply"].prefix.include),
             "-O2",
             "-g",
             "-DNDEBUG",
@@ -121,8 +121,8 @@ const int quux_version_minor = %s;
         )
         gpp(
             "-Dquux_EXPORTS",
-            "-I%s" % self.stage.source_path,
-            "-I%s" % spec["garply"].prefix.include,
+            f"-I{self.stage.source_path}",
+            "-I{}".format(spec["garply"].prefix.include),
             "-O2",
             "-g",
             "-DNDEBUG",
@@ -145,9 +145,9 @@ const int quux_version_minor = %s;
                 "-install_name",
                 "@rpath/libquux.dylib",
                 "quux.cc.o",
-                "-Wl,-rpath,%s" % prefix.lib64,
-                "-Wl,-rpath,%s" % spec["garply"].prefix.lib64,
-                "%s/libgarply.dylib" % spec["garply"].prefix.lib64,
+                f"-Wl,-rpath,{prefix.lib64}",
+                "-Wl,-rpath,{}".format(spec["garply"].prefix.lib64),
+                "{}/libgarply.dylib".format(spec["garply"].prefix.lib64),
             )
             gpp(
                 "-O2",
@@ -156,14 +156,14 @@ const int quux_version_minor = %s;
                 "quuxifier.cc.o",
                 "-o",
                 "quuxifier",
-                "-Wl,-rpath,%s" % prefix.lib64,
-                "-Wl,-rpath,%s" % spec["garply"].prefix.lib64,
+                f"-Wl,-rpath,{prefix.lib64}",
+                "-Wl,-rpath,{}".format(spec["garply"].prefix.lib64),
                 "libquux.dylib",
-                "%s/libgarply.dylib" % spec["garply"].prefix.lib64,
+                "{}/libgarply.dylib".format(spec["garply"].prefix.lib64),
             )
             mkdirp(prefix.lib64)
-            copy("libquux.dylib", "%s/libquux.dylib" % prefix.lib64)
-            os.link("%s/libquux.dylib" % prefix.lib64, "%s/libquux.dylib.3.0" % prefix.lib64)
+            copy("libquux.dylib", f"{prefix.lib64}/libquux.dylib")
+            os.link(f"{prefix.lib64}/libquux.dylib", f"{prefix.lib64}/libquux.dylib.3.0")
         else:
             gpp(
                 "-fPIC",
@@ -175,8 +175,8 @@ const int quux_version_minor = %s;
                 "-o",
                 "libquux.so",
                 "quux.cc.o",
-                "-Wl,-rpath,%s:%s::::" % (prefix.lib64, spec["garply"].prefix.lib64),
-                "%s/libgarply.so" % spec["garply"].prefix.lib64,
+                "-Wl,-rpath,{}:{}::::".format(prefix.lib64, spec["garply"].prefix.lib64),
+                "{}/libgarply.so".format(spec["garply"].prefix.lib64),
             )
             gpp(
                 "-O2",
@@ -186,16 +186,18 @@ const int quux_version_minor = %s;
                 "quuxifier.cc.o",
                 "-o",
                 "quuxifier",
-                "-Wl,-rpath,%s:%s::::" % (prefix.lib64, spec["garply"].prefix.lib64),
+                "-Wl,-rpath,{}:{}::::".format(prefix.lib64, spec["garply"].prefix.lib64),
                 "libquux.so",
-                "%s/libgarply.so" % spec["garply"].prefix.lib64,
+                "{}/libgarply.so".format(spec["garply"].prefix.lib64),
             )
             mkdirp(prefix.lib64)
-            copy("libquux.so", "%s/libquux.so" % prefix.lib64)
-            os.link("%s/libquux.so" % prefix.lib64, "%s/libquux.so.3.0" % prefix.lib64)
-        copy("quuxifier", "%s/quuxifier" % prefix.lib64)
-        copy("%s/quux/quux.h" % self.stage.source_path, "%s/quux/quux.h" % prefix.include)
+            copy("libquux.so", f"{prefix.lib64}/libquux.so")
+            os.link(f"{prefix.lib64}/libquux.so", f"{prefix.lib64}/libquux.so.3.0")
+        copy("quuxifier", f"{prefix.lib64}/quuxifier")
+        copy(f"{self.stage.source_path}/quux/quux.h", f"{prefix.include}/quux/quux.h")
         mkdirp(prefix.bin)
-        copy("quux_version.h", "%s/quux_version.h" % prefix.bin)
-        os.symlink("%s/quuxifier" % prefix.lib64, "%s/quuxifier" % prefix.bin)
-        os.symlink("%s/garplinator" % spec["garply"].prefix.lib64, "%s/garplinator" % prefix.bin)
+        copy("quux_version.h", f"{prefix.bin}/quux_version.h")
+        os.symlink(f"{prefix.lib64}/quuxifier", f"{prefix.bin}/quuxifier")
+        os.symlink(
+            "{}/garplinator".format(spec["garply"].prefix.lib64), f"{prefix.bin}/garplinator"
+        )

--- a/var/spack/test_repos/spack_repo/builtin_mock/packages/splice_a/package.py
+++ b/var/spack/test_repos/spack_repo/builtin_mock/packages/splice_a/package.py
@@ -27,5 +27,5 @@ class SpliceA(Package):
 
     def install(self, spec, prefix):
         with open(prefix.join("splice-a"), "w", encoding="utf-8") as f:
-            f.write("splice-a: {0}".format(prefix))
+            f.write(f"splice-a: {prefix}")
             f.write("splice-z: {0}".format(spec["splice-z"].prefix))

--- a/var/spack/test_repos/spack_repo/builtin_mock/packages/splice_depends_on_t/package.py
+++ b/var/spack/test_repos/spack_repo/builtin_mock/packages/splice_depends_on_t/package.py
@@ -19,5 +19,5 @@ class SpliceDependsOnT(Package):
 
     def install(self, spec, prefix):
         with open(prefix.join("splice-depends-on-t"), "w", encoding="utf-8") as f:
-            f.write("splice-depends-on-t: {0}".format(prefix))
+            f.write(f"splice-depends-on-t: {prefix}")
             f.write("splice-t: {0}".format(spec["splice-t"].prefix))

--- a/var/spack/test_repos/spack_repo/builtin_mock/packages/splice_h/package.py
+++ b/var/spack/test_repos/spack_repo/builtin_mock/packages/splice_h/package.py
@@ -34,5 +34,5 @@ class SpliceH(Package):
 
     def install(self, spec, prefix):
         with open(prefix.join("splice-h"), "w", encoding="utf-8") as f:
-            f.write("splice-h: {0}".format(prefix))
+            f.write(f"splice-h: {prefix}")
             f.write("splice-z: {0}".format(spec["splice-z"].prefix))

--- a/var/spack/test_repos/spack_repo/builtin_mock/packages/splice_t/package.py
+++ b/var/spack/test_repos/spack_repo/builtin_mock/packages/splice_t/package.py
@@ -20,6 +20,6 @@ class SpliceT(Package):
 
     def install(self, spec, prefix):
         with open(prefix.join("splice-t"), "w", encoding="utf-8") as f:
-            f.write("splice-t: {0}".format(prefix))
+            f.write(f"splice-t: {prefix}")
             f.write("splice-h: {0}".format(spec["splice-h"].prefix))
             f.write("splice-z: {0}".format(spec["splice-z"].prefix))

--- a/var/spack/test_repos/spack_repo/builtin_mock/packages/splice_vh/package.py
+++ b/var/spack/test_repos/spack_repo/builtin_mock/packages/splice_vh/package.py
@@ -26,5 +26,5 @@ class SpliceVh(Package):
 
     def install(self, spec, prefix):
         with open(prefix.join("splice-vh"), "w", encoding="utf-8") as f:
-            f.write("splice-vh: {0}".format(prefix))
+            f.write(f"splice-vh: {prefix}")
             f.write("splice-z: {0}".format(spec["splice-z"].prefix))

--- a/var/spack/test_repos/spack_repo/builtin_mock/packages/splice_vt/package.py
+++ b/var/spack/test_repos/spack_repo/builtin_mock/packages/splice_vt/package.py
@@ -20,6 +20,6 @@ class SpliceVt(Package):
 
     def install(self, spec, prefix):
         with open(prefix.join("splice-vt"), "w", encoding="utf-8") as f:
-            f.write("splice-vt: {0}".format(prefix))
+            f.write(f"splice-vt: {prefix}")
             f.write("splice-h: {0}".format(spec["somethingelse"].prefix))
             f.write("splice-z: {0}".format(spec["splice-z"].prefix))

--- a/var/spack/test_repos/spack_repo/builtin_mock/packages/splice_z/package.py
+++ b/var/spack/test_repos/spack_repo/builtin_mock/packages/splice_z/package.py
@@ -26,4 +26,4 @@ class SpliceZ(Package):
 
     def install(self, spec, prefix):
         with open(prefix.join("splice-z"), "w", encoding="utf-8") as f:
-            f.write("splice-z: {0}".format(prefix))
+            f.write(f"splice-z: {prefix}")

--- a/var/spack/test_repos/spack_repo/builtin_mock/packages/symly/package.py
+++ b/var/spack/test_repos/spack_repo/builtin_mock/packages/symly/package.py
@@ -27,8 +27,8 @@ int main() {
     return 0;
 }
 """
-        mkdirp("%s/symly" % self.stage.source_path)
-        with open("%s/symly/symly.c" % self.stage.source_path, "w", encoding="utf-8") as f:
+        mkdirp(f"{self.stage.source_path}/symly")
+        with open(f"{self.stage.source_path}/symly/symly.c", "w", encoding="utf-8") as f:
             f.write(symly_c)
         gcc = which("/usr/bin/gcc")
         if sys.platform == "darwin":
@@ -37,8 +37,8 @@ int main() {
         mkdirp(prefix.lib64)
         gcc("-o", "symly.bin", "symly/symly.c")
         print("prefix.bin", prefix.bin)
-        copy("symly.bin", "%s/symly" % prefix.bin)
+        copy("symly.bin", f"{prefix.bin}/symly")
         # create a symlinked file.
-        os.symlink("%s/symly" % prefix.bin, "%s/symly" % prefix.lib64)
+        os.symlink(f"{prefix.bin}/symly", f"{prefix.lib64}/symly")
         # Create a symlinked directory.
         os.symlink(prefix.bin, prefix.include)

--- a/var/spack/test_repos/spack_repo/builtin_mock/packages/view_not_ignored/package.py
+++ b/var/spack/test_repos/spack_repo/builtin_mock/packages/view_not_ignored/package.py
@@ -38,10 +38,10 @@ class ViewNotIgnored(Package):
     def assert_installed(cls, prefix):
         for test_file in cls.install_test_files:
             path = os.path.join(prefix, test_file)
-            assert os.path.exists(path), "Missing installed file: {}".format(path)
+            assert os.path.exists(path), f"Missing installed file: {path}"
 
     @classmethod
     def assert_not_installed(cls, prefix):
         for test_file in cls.install_test_files:
             path = os.path.join(prefix, test_file)
-            assert not os.path.exists(path), "File was not uninstalled: {}".format(path)
+            assert not os.path.exists(path), f"File was not uninstalled: {path}"

--- a/var/spack/test_repos/spack_repo/builtin_mock/packages/zlib/package.py
+++ b/var/spack/test_repos/spack_repo/builtin_mock/packages/zlib/package.py
@@ -47,7 +47,7 @@ class Zlib(Package):
         config_args = []
         if "~shared" in spec:
             config_args.append("--static")
-        configure("--prefix={0}".format(prefix), *config_args)
+        configure(f"--prefix={prefix}", *config_args)
 
         make()
         if self.run_tests:

--- a/var/spack/test_repos/spack_repo/tutorial/packages/hdf5/package.py
+++ b/var/spack/test_repos/spack_repo/tutorial/packages/hdf5/package.py
@@ -487,7 +487,7 @@ HDF5 version {version} {version}
 
     def _test_check_versions(self):
         """Perform version checks on selected installed package binaries."""
-        spec_vers_str = "Version {0}".format(self.spec.version)
+        spec_vers_str = f"Version {self.spec.version}"
 
         exes = [
             "h5copy",
@@ -502,7 +502,7 @@ HDF5 version {version} {version}
         ]
         use_short_opt = ["h52gif", "h5repart", "h5unjam"]
         for exe in exes:
-            reason = "test: ensuring version of {0} is {1}".format(exe, spec_vers_str)
+            reason = f"test: ensuring version of {exe} is {spec_vers_str}"
             option = "-V" if exe in use_short_opt else "--version"
             self.run_test(
                 exe, option, spec_vers_str, installed=True, purpose=reason, skip_missing=True


### PR DESCRIPTION
Convert printf-style %-formatting to str.format() (ruff UP031) and then
to f-strings (ruff UP032) across all non-vendored source files. Also
collapse redundant explicit concatenation of adjacent string literals
(ruff ISC003) introduced by the f-string conversion.

bin/spack keeps str.format() instead of f-strings, since it runs the
Python version check before f-strings are guaranteed to be available.

