### PR TITLE
style: drop unnecessary generators

### DIFF
--- a/lib/spack/spack/audit.py
+++ b/lib/spack/spack/audit.py
@@ -705,11 +705,11 @@ def _ensure_env_methods_are_ported_to_builders(pkgs, error_cls):
         pkg_cls = spack.repo.PATH.get_pkg_class(pkg_name)
 
         # values are either ConditionalValue objects or the values themselves
-        build_system_names = set(
+        build_system_names = {
             v.value if isinstance(v, spack.variant.ConditionalValue) else v
             for _, variant in pkg_cls.variant_definitions("build_system")
             for v in variant.values
-        )
+        }
         builder_cls_names = [spack.builder.BUILDER_CLS[x].__name__ for x in build_system_names]
 
         has_builders_in_package_py = any(

--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -797,7 +797,7 @@ def generate_key_index(mirror_url: str, tmpdir: str) -> None:
 
     target = os.path.join(tmpdir, "index.json")
 
-    index = {"keys": dict((fingerprint, {}) for fingerprint in sorted(set(fingerprints)))}
+    index: dict = {"keys": {fingerprint: {} for fingerprint in sorted(set(fingerprints))}}
     with open(target, "w", encoding="utf-8") as f:
         sjson.dump(index, f)
 
@@ -1929,7 +1929,7 @@ def relocate_package(spec: spack.spec.Spec) -> None:
     # the context of the relevant root spec. This ensures that the analog for a spec s is the spec
     # that s replaced when we spliced.
     relocation_specs = specs_to_relocate(spec)
-    build_spec_ids = set(id(s) for s in spec.build_spec.traverse(deptype=dt.ALL & ~dt.BUILD))
+    build_spec_ids = {id(s) for s in spec.build_spec.traverse(deptype=dt.ALL & ~dt.BUILD)}
     for s in relocation_specs:
         analog = s
         if id(s) not in build_spec_ids:

--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -503,7 +503,7 @@ def set_wrapper_variables(pkg, env):
         env.set("CCACHE_DISABLE", "1")
 
     # Gather information about various types of dependencies
-    rpath_hashes = set(s.dag_hash() for s in get_rpath_deps(pkg))
+    rpath_hashes = {s.dag_hash() for s in get_rpath_deps(pkg)}
     link_deps = pkg.spec.traverse(root=False, order="topo", deptype=dt.LINK)
     external_link_deps, nonexternal_link_deps = stable_partition(link_deps, lambda d: d.external)
 
@@ -846,7 +846,7 @@ class EnvironmentVisitor:
     def __init__(self, *roots: spack.spec.Spec, context: Context):
         # For the roots (well, marked specs) we follow different edges
         # than for their deps, depending on the context.
-        self.root_hashes = set(s.dag_hash() for s in roots)
+        self.root_hashes = {s.dag_hash() for s in roots}
 
         if context == Context.BUILD:
             # Drop direct run deps in build context
@@ -991,7 +991,7 @@ class SetupContext:
         self.external: List[Tuple[spack.spec.Spec, UseMode]]
         self.nonexternal: List[Tuple[spack.spec.Spec, UseMode]]
         # Reverse so we go from leaf to root
-        self.nodes_in_subdag = set(id(s) for s, _ in specs_with_type)
+        self.nodes_in_subdag = {id(s) for s, _ in specs_with_type}
 
         # Split into non-external and external, maintaining topo order per group.
         self.external, self.nonexternal = stable_partition(

--- a/lib/spack/spack/cmd/compiler.py
+++ b/lib/spack/spack/cmd/compiler.py
@@ -212,7 +212,7 @@ def compiler_list(args):
     # Python 3
     convert_str = lambda tuple_container: tuple(str(x) if x else "" for x in tuple_container)
 
-    index_str_keys = list((convert_str(x), y) for x, y in index.items())
+    index_str_keys = [(convert_str(x), y) for x, y in index.items()]
     ordered_sections = sorted(index_str_keys, key=lambda item: item[0])
     for i, (key, compilers) in enumerate(ordered_sections):
         if i >= 1:

--- a/lib/spack/spack/cmd/config.py
+++ b/lib/spack/spack/cmd/config.py
@@ -358,7 +358,7 @@ def _config_basic_scope_types(scope, included):
 
 def config_scopes(args):
     """List configured scopes in descending order of precedence."""
-    included = list(i.name for s in spack.config.scopes().values() for i in s.included_scopes)
+    included = [i.name for s in spack.config.scopes().values() for i in s.included_scopes]
     active = [s.name for s in spack.config.CONFIG.active_scopes]
     scopes = [
         s

--- a/lib/spack/spack/cmd/diff.py
+++ b/lib/spack/spack/cmd/diff.py
@@ -88,20 +88,20 @@ def compare_specs(a, b, to_string=False, color=None, ignore_packages=None):
 
     # get facts for specs, making sure to include build dependencies of concrete
     # specs and to descend into dependency hashes so we include all facts.
-    a_facts = set(
+    a_facts = {
         shift(func)
         for func in setup.spec_clauses(
             a, body=True, expand_hashes=True, concrete_build_deps=True, include_runtimes=True
         )
         if func.name == "attr"
-    )
-    b_facts = set(
+    }
+    b_facts = {
         shift(func)
         for func in setup.spec_clauses(
             b, body=True, expand_hashes=True, concrete_build_deps=True, include_runtimes=True
         )
         if func.name == "attr"
-    )
+    }
 
     # We want to present them to the user as simple key: values
     intersect = sorted(a_facts.intersection(b_facts))

--- a/lib/spack/spack/cmd/gc.py
+++ b/lib/spack/spack/cmd/gc.py
@@ -101,7 +101,7 @@ def gc(parser, args):
 
         # limit search to constraint specs if provided
         if args.constraint:
-            hashes = set(spec.dag_hash() for spec in args.specs())
+            hashes = {spec.dag_hash() for spec in args.specs()}
             specs = [spec for spec in specs if spec.dag_hash() in hashes]
 
         if not specs:

--- a/lib/spack/spack/cmd/modules/__init__.py
+++ b/lib/spack/spack/cmd/modules/__init__.py
@@ -158,7 +158,7 @@ def loads(module_type, specs, args, out=None):
                 ]
             )
 
-    modules = list(
+    modules = [
         (
             spec,
             spack.modules.get_module(
@@ -170,7 +170,7 @@ def loads(module_type, specs, args, out=None):
             ),
         )
         for spec in specs
-    )
+    ]
 
     module_commands = {"tcl": "module load ", "lmod": "module load "}
 
@@ -234,7 +234,7 @@ def find(module_type, specs, args):
 
     if not all(modules):
         tty.warn(_missing_modules_warning)
-    modules = list(x for x in modules if x)
+    modules = [x for x in modules if x]
     print(" ".join(modules))
 
 
@@ -283,7 +283,7 @@ def refresh(module_type, specs, args):
         return
 
     if not args.upstream_modules:
-        specs = list(s for s in specs if not s.installed_upstream)
+        specs = [s for s in specs if not s.installed_upstream]
 
     if not args.yes_to_all:
         msg = "You are about to regenerate {types} module files for:\n"

--- a/lib/spack/spack/cmd/test.py
+++ b/lib/spack/spack/cmd/test.py
@@ -328,9 +328,9 @@ def _report_suite_results(test_suite, args, constraints):
             for s in spack.store.STORE.db.query(spec, installed=True):
                 specs[s.dag_hash()] = s
         specs = sorted(specs.values())
-        test_specs = dict((test_suite.test_pkg_id(s), s) for s in test_suite.specs if s in specs)
+        test_specs = {test_suite.test_pkg_id(s): s for s in test_suite.specs if s in specs}
     else:
-        test_specs = dict((test_suite.test_pkg_id(s), s) for s in test_suite.specs)
+        test_specs = {test_suite.test_pkg_id(s): s for s in test_suite.specs}
 
     if not test_specs:
         return

--- a/lib/spack/spack/cmd/undevelop.py
+++ b/lib/spack/spack/cmd/undevelop.py
@@ -63,7 +63,7 @@ def undevelop(parser, args):
 
     updated_all_dev_specs = set(spack.config.get("develop"))
 
-    remove_spec_names = set(x.name for x in remove_specs)
+    remove_spec_names = {x.name for x in remove_specs}
     not_fully_removed = updated_all_dev_specs & remove_spec_names
 
     if not_fully_removed:

--- a/lib/spack/spack/cmd/uninstall.py
+++ b/lib/spack/spack/cmd/uninstall.py
@@ -192,7 +192,7 @@ def _remove_from_env(spec, env):
 def do_uninstall(specs: List[spack.spec.Spec], force: bool = False):
     # TODO: get rid of the call-sites that use this function,
     # so that we don't have to do a dance of list -> set -> list -> set
-    hashes_to_remove = set(s.dag_hash() for s in specs)
+    hashes_to_remove = {s.dag_hash() for s in specs}
 
     for s in traverse.traverse_nodes(
         specs, order="topo", direction="children", root=True, cover="nodes", deptype="all"

--- a/lib/spack/spack/compilers/config.py
+++ b/lib/spack/spack/compilers/config.py
@@ -264,11 +264,11 @@ class CompilerFactory:
         packages_yaml = configuration.deepcopy_as_builtin("packages", scope=scope)
 
         init_external_dicts = extract_dicts_from_configuration(packages_yaml)
-        init_external_dicts = list(
+        init_external_dicts = [
             x
             for x in init_external_dicts
             if spack.spec.Spec(x["spec"]).name in compiler_package_names
-        )
+        ]
 
         externals_dicts = []
         for current in init_external_dicts:

--- a/lib/spack/spack/compilers/libraries.py
+++ b/lib/spack/spack/compilers/libraries.py
@@ -59,7 +59,7 @@ def parse_non_system_link_dirs(compiler_debug_output: str) -> List[str]:
     # exact match, while 'in_system_subdirectory' checks if a path contains
     # a system directory as a subdirectory
     link_dirs = filter_system_paths(link_dirs)
-    return list(p for p in link_dirs if not in_system_subdirectory(p))
+    return [p for p in link_dirs if not in_system_subdirectory(p)]
 
 
 def filter_non_existing_dirs(dirs):

--- a/lib/spack/spack/config.py
+++ b/lib/spack/spack/config.py
@@ -1702,11 +1702,11 @@ def existing_scopes() -> List[ConfigScope]:
 
 
 def writable_scope_names() -> List[str]:
-    return list(x.name for x in writable_scopes())
+    return [x.name for x in writable_scopes()]
 
 
 def existing_scope_names() -> List[str]:
-    return list(x.name for x in existing_scopes())
+    return [x.name for x in existing_scopes()]
 
 
 def matched_config(cfg_path: str) -> List[Tuple[str, Any]]:

--- a/lib/spack/spack/database.py
+++ b/lib/spack/spack/database.py
@@ -683,9 +683,7 @@ class Database:
         self._ensure_parent_directories()
 
         # map from per-spec hash code to installation record.
-        installs = dict(
-            (k, v.to_dict(include_fields=self.record_fields)) for k, v in self._data.items()
-        )
+        installs = {k: v.to_dict(include_fields=self.record_fields) for k, v in self._data.items()}
 
         # database includes installation list and version.
 
@@ -1817,7 +1815,7 @@ class Database:
                 )
             )
 
-        results = list(local_results) + list(x for x in upstream_results if x not in local_results)
+        results = list(local_results) + [x for x in upstream_results if x not in local_results]
         results.sort()  # type: ignore[call-arg,call-overload]
         return results
 
@@ -1874,7 +1872,7 @@ class Database:
 
         with self.read_transaction():
             roots = [rec.spec for key, rec in self._data.items() if root(key, rec)]
-            needed = set(id(spec) for spec in tr.traverse_nodes(roots, deptype=deptype))
+            needed = {id(spec) for spec in tr.traverse_nodes(roots, deptype=deptype)}
             return [
                 rec.spec
                 for rec in self._data.values()

--- a/lib/spack/spack/environment/depfile.py
+++ b/lib/spack/spack/environment/depfile.py
@@ -51,7 +51,7 @@ class DepfileNode:
         self, target: spack.spec.Spec, prereqs: List[spack.spec.Spec], buildcache: UseBuildCache
     ):
         self.target = MakefileSpec(target)
-        self.prereqs = list(MakefileSpec(x) for x in prereqs)
+        self.prereqs = [MakefileSpec(x) for x in prereqs]
         if buildcache == UseBuildCache.ONLY:
             self.buildcache_flag = "--use-buildcache=only"
         elif buildcache == UseBuildCache.NEVER:
@@ -145,7 +145,7 @@ class MakefileModel:
         self.env_path = env.path
 
         # These specs are built in the default target.
-        self.roots = list(MakefileSpec(x) for x in roots)
+        self.roots = [MakefileSpec(x) for x in roots]
 
         # The SPACK_PACKAGE_IDS variable is "exported", which can be used when including
         # generated makefiles to add post-install hooks, like pushing to a buildcache,

--- a/lib/spack/spack/environment/environment.py
+++ b/lib/spack/spack/environment/environment.py
@@ -1517,7 +1517,7 @@ class Environment:
                 " specify a named list that is not a matrix"
             )
 
-        matches = list((idx, x) for idx, x in enumerate(list_to_change) if x.satisfies(match_spec))
+        matches = [(idx, x) for idx, x in enumerate(list_to_change) if x.satisfies(match_spec)]
         if len(matches) == 0:
             raise ValueError(
                 "There are no specs named {0} in {1}".format(match_spec.name, list_name)
@@ -3514,7 +3514,7 @@ class EnvironmentManifestFile(collections.abc.Mapping):
         """Iterates on definitions, returning the active ones matching a given name."""
 
         def extract_name(_item):
-            names = list(x for x in _item if x != "when")
+            names = [x for x in _item if x != "when"]
             assert len(names) == 1, f"more than one name in {_item}"
             return names[0]
 

--- a/lib/spack/spack/fetch_strategy.py
+++ b/lib/spack/spack/fetch_strategy.py
@@ -1526,7 +1526,7 @@ def _check_version_attributes(fetcher, pkg, version):
     This assumes that we have already determined the fetcher for the
     specific version using ``for_package_version()``
     """
-    all_optionals = set(a for s in all_strategies for a in s.optional_attrs)
+    all_optionals = {a for s in all_strategies for a in s.optional_attrs}
 
     args = pkg.versions[version]
     extra = set(args) - set(fetcher.optional_attrs) - set([fetcher.url_attr, "no_cache"])

--- a/lib/spack/spack/filesystem_view.py
+++ b/lib/spack/spack/filesystem_view.py
@@ -500,7 +500,7 @@ class YamlFilesystemView(FilesystemView):
         to_deactivate_sorted = list()
         depmap = dict()
         for spec in to_deactivate:
-            depmap[spec] = set(d for d in spec.traverse(root=False) if d in to_deactivate)
+            depmap[spec] = {d for d in spec.traverse(root=False) if d in to_deactivate}
 
         while depmap:
             for spec in [s for s, d in depmap.items() if not d]:

--- a/lib/spack/spack/installer.py
+++ b/lib/spack/spack/installer.py
@@ -763,11 +763,11 @@ class BuildRequest:
         # Save off dependency package ids for quick checks since traversals
         # are not able to return full dependents for all packages across
         # environment specs.
-        self.dependencies = set(
+        self.dependencies = {
             package_id(d)
             for d in self.pkg.spec.dependencies(deptype=self.get_depflags(self.pkg))
             if package_id(d) != self.pkg_id
-        )
+        }
 
     def __repr__(self) -> str:
         """Return a formal representation of the build request."""
@@ -969,17 +969,15 @@ class Task:
         # Be consistent wrt use of dependents and dependencies.  That is,
         # if use traverse for transitive dependencies, then must remove
         # transitive dependents on failure.
-        self.dependencies = set(
+        self.dependencies = {
             package_id(d)
             for d in self.pkg.spec.dependencies(deptype=self.request.get_depflags(self.pkg))
             if package_id(d) != self.pkg_id
-        )
+        }
 
         # List of uninstalled dependencies, which is used to establish
         # the priority of the task.
-        self.uninstalled_deps = set(
-            pkg_id for pkg_id in self.dependencies if pkg_id not in installed
-        )
+        self.uninstalled_deps = {pkg_id for pkg_id in self.dependencies if pkg_id not in installed}
 
         # Ensure key sequence-related properties are updated accordingly.
         self.attempts = attempts

--- a/lib/spack/spack/main.py
+++ b/lib/spack/spack/main.py
@@ -225,10 +225,10 @@ class SpackArgumentParser(argparse.ArgumentParser):
 
         def add_subcommand_group(title, commands):
             """Add informational help group for a specific subcommand set."""
-            cmd_set = set(c for c in commands)
+            cmd_set = set(commands)
 
             # make a dict of commands of interest
-            cmds = dict((a.dest, a) for a in self.actions if a.dest in cmd_set)
+            cmds = {a.dest: a for a in self.actions if a.dest in cmd_set}
 
             # add commands to a group in order, and add the group
             group = argparse._ArgumentGroup(self, title=title)
@@ -818,9 +818,9 @@ def print_setup_info(*info):
     other_spack_instances = spack.config.get("upstreams") or {}
     for install_properties in other_spack_instances.values():
         upstream_module_roots = install_properties.get("modules", {})
-        upstream_module_roots = dict(
-            (k, v) for k, v in upstream_module_roots.items() if k in module_to_roots
-        )
+        upstream_module_roots = {
+            k: v for k, v in upstream_module_roots.items() if k in module_to_roots
+        }
         for module_type, root in upstream_module_roots.items():
             module_to_roots[module_type].append(root)
 

--- a/lib/spack/spack/package_base.py
+++ b/lib/spack/spack/package_base.py
@@ -352,7 +352,7 @@ class PackageViewMixin:
         Alternative implementations may allow some of the files to exist in
         the view (in this case they would be omitted from the results).
         """
-        return set(dst for dst in merge_map.values() if os.path.lexists(dst))
+        return {dst for dst in merge_map.values() if os.path.lexists(dst)}
 
     def add_files_to_view(self, view, merge_map, skip_if_exists=True):
         """Given a map of package files to destination paths in the view, add
@@ -1541,7 +1541,7 @@ class PackageBase(WindowsRPath, PackageViewMixin, metaclass=PackageMeta):
     def provided_virtual_names(cls):
         """Return sorted list of names of virtuals that can be provided by this package."""
         return sorted(
-            set(vpkg.name for virtuals in cls.provided.values() for vpkg in sorted(virtuals))
+            {vpkg.name for virtuals in cls.provided.values() for vpkg in sorted(virtuals)}
         )
 
     @property

--- a/lib/spack/spack/provider_index.py
+++ b/lib/spack/spack/provider_index.py
@@ -220,7 +220,7 @@ class ProviderIndex:
     def copy(self):
         """Return a deep copy of this index."""
         clone = ProviderIndex(repository=self.repository)
-        clone.providers = self._transform(lambda vpkg, pset: (vpkg, set((p.copy() for p in pset))))
+        clone.providers = self._transform(lambda vpkg, pset: (vpkg, {p.copy() for p in pset}))
         return clone
 
     @staticmethod
@@ -246,7 +246,7 @@ class ProviderIndex:
             providers,
             lambda vpkg, plist: (
                 SpecfileLatest.from_node_dict(vpkg),
-                set(SpecfileLatest.from_node_dict(p) for p in plist),
+                {SpecfileLatest.from_node_dict(p) for p in plist},
             ),
         )
         return index
@@ -272,10 +272,10 @@ def _transform(providers, transform_fun, out_mapping_type=dict):
         else:
             return iter(mappings)
 
-    return dict(
-        (name, out_mapping_type([transform_fun(vpkg, pset) for vpkg, pset in mapiter(mappings)]))
+    return {
+        name: out_mapping_type([transform_fun(vpkg, pset) for vpkg, pset in mapiter(mappings)])
         for name, mappings in providers.items()
-    )
+    }
 
 
 class ProviderIndexError(spack.error.SpackError):

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -427,7 +427,7 @@ class Result:
     def _compute_specs_from_answer_set(self):
         if not self.satisfiable:
             self._concrete_specs = []
-            self._unsolved_specs = list((x, None) for x in self.abstract_specs)
+            self._unsolved_specs = [(x, None) for x in self.abstract_specs]
             self._concrete_specs_by_input = {}
             return
 
@@ -773,10 +773,10 @@ class ErrorHandler:
             A list of strings describing the causes, formatted to display tree structure.
         """
         conditions: Dict[str, str] = dict(extract_args(self.full_model, "condition_reason"))
-        condition_causes: List[Tuple[Tuple[str, str], Tuple[str, str]]] = list(
+        condition_causes: List[Tuple[Tuple[str, str], Tuple[str, str]]] = [
             ((Effect, EID), (Cause, CID))
             for Effect, EID, Cause, CID in extract_args(self.full_model, "condition_cause")
-        )
+        ]
         return self._get_cause_tree(cause, conditions, condition_causes, set())
 
     def handle_error(self, msg, *args):
@@ -3673,7 +3673,7 @@ def reorder_flags(specs: SpecDict) -> None:
         # For flags that are applied by dependents, put flags from parents
         # before children; we depend on the stability of traverse() to
         # achieve a stable flag order for flags introduced in this manner.
-        topo_order = list(s.name for s in spec.traverse(order="post", direction="parents"))
+        topo_order = [s.name for s in spec.traverse(order="post", direction="parents")]
 
         for flag_type in spec.compiler_flags.valid_compiler_flags():
             ordered_flags: List[str] = []
@@ -3721,12 +3721,12 @@ def reorder_flags(specs: SpecDict) -> None:
                 )
                 if grp_flags == from_compiler:
                     continue
-                as_compiler_flags = list(
+                as_compiler_flags = [
                     spack.spec.CompilerFlag(
                         x, propagate=grp.propagate, flag_group=grp.flag_group, source=grp.source
                     )
                     for x in grp_flags
-                )
+                ]
                 extend_flag_list(ordered_flags, as_compiler_flags)
 
             # 3. Now put cmd-line flags last
@@ -3786,7 +3786,7 @@ def post_process_concretization_result(specs: SpecDict) -> None:
     # roots here, because the specs aren't complete, and the hash
     # function will loop forever.
     roots = [spec.root for spec in specs.values()]
-    roots = dict((id(r), r) for r in roots)
+    roots = {id(r): r for r in roots}
     for root in roots.values():
         spack.spec._inject_patches_variant(root)
 
@@ -4062,7 +4062,7 @@ class Solver:
                 # loop if we tried again
                 raise OutputDoesNotSatisfyInputError(result.unsolved_specs)
 
-            input_specs = list(x for (x, y) in result.unsolved_specs)
+            input_specs = [x for (x, y) in result.unsolved_specs]
             for spec in result.specs:
                 reusable_specs.extend(spec.traverse())
 

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -943,9 +943,9 @@ class FlagMap(lang.HashableMap[str, List[CompilerFlag]]):
             else:
                 extra_other = set(other[flag_type]) - set(self[flag_type])
                 if extra_other:
-                    self[flag_type] = list(self[flag_type]) + list(
+                    self[flag_type] = list(self[flag_type]) + [
                         x for x in other[flag_type] if x in extra_other
-                    )
+                    ]
                     changed = True
 
                 # Next, if any flags in other propagate, we force them to propagate in our case
@@ -4652,7 +4652,7 @@ class Spec:
         """Return set of virtuals provided by self in the context of root"""
         if root is self:
             # Could be using any virtual the package can provide
-            return set(v.name for v in self.package.virtuals_provided)
+            return {v.name for v in self.package.virtuals_provided}
 
         hashes = [s.dag_hash() for s in root.traverse()]
         in_edges = set(
@@ -4732,7 +4732,7 @@ class Spec:
                 for evaluating whether ``replacement`` is a match for each node of ``self``. See
                 ``Spec._splice_match`` and ``Spec._virtuals_provided`` for details.
         """
-        ids = set(id(s) for s in replacement.traverse())
+        ids = {id(s) for s in replacement.traverse()}
 
         # Sort all possible replacements by name and virtual for easy access later
         replacements_by_name = collections.defaultdict(list)

--- a/lib/spack/spack/test/build_environment.py
+++ b/lib/spack/spack/test/build_environment.py
@@ -421,7 +421,7 @@ def test_wrapper_variables(
         env_mods.apply_modifications()
 
         def normpaths(paths):
-            return list(os.path.normpath(p) for p in paths)
+            return [os.path.normpath(p) for p in paths]
 
         link_dir_var = os.environ["SPACK_LINK_DIRS"]
         assert normpaths(link_dir_var.split(":")) == normpaths(dep_lib_dirs)
@@ -482,8 +482,8 @@ dt-diamond-left:
     )
     # The external lib paths should be the last two entries of the list and
     # should not appear anywhere before the last two entries
-    assert set(os.path.normpath(x) for x in link_dirs[-2:]) == external_lib_paths
-    assert not (set(os.path.normpath(x) for x in link_dirs[:-2]) & external_lib_paths)
+    assert {os.path.normpath(x) for x in link_dirs[-2:]} == external_lib_paths
+    assert not ({os.path.normpath(x) for x in link_dirs[:-2]} & external_lib_paths)
 
 
 def test_parallel_false_is_not_propagating(default_mock_concretization):

--- a/lib/spack/spack/test/cmd/env.py
+++ b/lib/spack/spack/test/cmd/env.py
@@ -1864,7 +1864,7 @@ def test_uninstall_keeps_in_env(mock_stage, mock_fetch, install_mockery):
 
     test = ev.read("test")
     # Save this spec to check later if it is still in the env
-    (mpileaks_hash,) = list(x for x, y in test.specs_by_hash.items() if y.name == "mpileaks")
+    (mpileaks_hash,) = [x for x, y in test.specs_by_hash.items() if y.name == "mpileaks"]
     user_specs_before = test.user_specs
     user_spec_hashes_before = {x.hash for x in test.concretized_roots}
 
@@ -2123,12 +2123,12 @@ def test_env_include_concrete_envs_lockfile():
     with open(combined.lock_path, encoding="utf-8") as f:
         lockfile_as_dict = combined._read_lockfile(f)
 
-    assert set(
+    assert {
         entry["hash"] for entry in lockfile_as_dict[ev.lockfile_include_key][test1.path]["roots"]
-    ) == set(test1.specs_by_hash)
-    assert set(
+    } == set(test1.specs_by_hash)
+    assert {
         entry["hash"] for entry in lockfile_as_dict[ev.lockfile_include_key][test2.path]["roots"]
-    ) == set(test2.specs_by_hash)
+    } == set(test2.specs_by_hash)
 
 
 def test_env_include_concrete_add_env():
@@ -4133,7 +4133,7 @@ def test_read_legacy_lockfile_and_reconcretize(
     assert len(test.specs_by_hash) == 2
 
     expected_versions = set([Version("0.5"), Version("1.0")])
-    current_versions = set(s["dtbuild1"].version for s in test.specs_by_hash.values())
+    current_versions = {s["dtbuild1"].version for s in test.specs_by_hash.values()}
     assert current_versions == expected_versions
 
 

--- a/lib/spack/spack/test/cmd/find.py
+++ b/lib/spack/spack/test/cmd/find.py
@@ -245,11 +245,7 @@ def test_find_format(database, config):
 
     output = find("--format", "{name}-{^mpi.name}-{hash:7}", "mpileaks")
     elements = output.strip().split("\n")
-    assert set(e[:-7] for e in elements) == {
-        "mpileaks-zmpi-",
-        "mpileaks-mpich-",
-        "mpileaks-mpich2-",
-    }
+    assert {e[:-7] for e in elements} == {"mpileaks-zmpi-", "mpileaks-mpich-", "mpileaks-mpich2-"}
 
     # hashes are in base32
     for e in elements:

--- a/lib/spack/spack/test/cmd/load.py
+++ b/lib/spack/spack/test/cmd/load.py
@@ -75,9 +75,9 @@ def test_load_recursive(install_mockery, mock_fetch, mock_archive, mock_packages
         pkgs = [prefix_to_pkg(p) for p in paths_shell[:-2]]
 
         # Do we have all the runtime packages?
-        assert set(pkgs) == set(
+        assert set(pkgs) == {
             s.name for s in mpileaks_spec.traverse(deptype=("link", "run"), root=True)
-        )
+        }
 
         # Finally, do we list them in topo order?
         for i, pkg in enumerate(pkgs):

--- a/lib/spack/spack/test/cmd/mirror.py
+++ b/lib/spack/spack/test/cmd/mirror.py
@@ -241,10 +241,10 @@ def test_exclude_specs(mock_packages, config):
     )
 
     mirror_specs = spack.cmd.mirror._specs_to_mirror(args)
-    expected_include = set(
+    expected_include = {
         spack.concretize.concretize_one(x) for x in ["mpich@3.0.3", "mpich@3.0.4", "mpich@3.0"]
-    )
-    expected_exclude = set(spack.spec.Spec(x) for x in ["mpich@3.0.1", "mpich@3.0.2", "mpich@1.0"])
+    }
+    expected_exclude = {spack.spec.Spec(x) for x in ["mpich@3.0.1", "mpich@3.0.2", "mpich@1.0"]}
     assert expected_include <= set(mirror_specs)
     assert not any(spec.satisfies(y) for spec in mirror_specs for y in expected_exclude)
 
@@ -275,10 +275,10 @@ mpich@1.0
     args = MockMirrorArgs(specs=["mpich"], versions_per_spec="all", exclude_file=str(exclude_path))
 
     mirror_specs = spack.cmd.mirror._specs_to_mirror(args)
-    expected_include = set(
+    expected_include = {
         spack.concretize.concretize_one(x) for x in ["mpich@3.0.3", "mpich@3.0.4", "mpich@3.0"]
-    )
-    expected_exclude = set(spack.spec.Spec(x) for x in ["mpich@3.0.1", "mpich@3.0.2", "mpich@1.0"])
+    }
+    expected_exclude = {spack.spec.Spec(x) for x in ["mpich@3.0.1", "mpich@3.0.2", "mpich@1.0"]}
     assert expected_include <= set(mirror_specs)
     assert not any(spec.satisfies(y) for spec in mirror_specs for y in expected_exclude)
 

--- a/lib/spack/spack/test/cmd/uninstall.py
+++ b/lib/spack/spack/test/cmd/uninstall.py
@@ -257,7 +257,7 @@ class TestUninstallFromEnv:
 
             # The specs should still be in the environment, since
             # --remove was not specified
-            assert set(root.name for (root, _) in e1.concretized_specs()) == set(
+            assert {root.name for (root, _) in e1.concretized_specs()} == set(
                 ["diamond-link-left", "diamond-link-bottom"]
             )
 
@@ -268,7 +268,7 @@ class TestUninstallFromEnv:
         # have been uninstalled. The roots should be unchanged though.
         e2 = spack.environment.read("e2")
         with e2:
-            assert set(root.name for (root, _) in e2.concretized_specs()) == set(
+            assert {root.name for (root, _) in e2.concretized_specs()} == set(
                 ["diamond-link-right", "diamond-link-bottom"]
             )
             for _, concretized_spec in e2.concretized_specs():
@@ -296,7 +296,7 @@ class TestUninstallFromEnv:
         # (and e2 should be unchanged)
         e2 = spack.environment.read("e2")
         with e2:
-            assert set(root.name for (root, _) in e2.concretized_specs()) == set(
+            assert {root.name for (root, _) in e2.concretized_specs()} == set(
                 ["diamond-link-right", "diamond-link-bottom"]
             )
             for _, concretized_spec in e2.concretized_specs():
@@ -315,7 +315,7 @@ class TestUninstallFromEnv:
 
         # The environment should be unchanged and nothing should have been
         # uninstalled
-        assert set(root.name for (root, _) in e1.concretized_specs()) == set(
+        assert {root.name for (root, _) in e1.concretized_specs()} == set(
             ["diamond-link-left", "diamond-link-bottom"]
         )
         for _, concretized_spec in e1.concretized_specs():
@@ -340,7 +340,7 @@ class TestUninstallFromEnv:
 
         e2 = spack.environment.read("e2")
         with e2:
-            assert set(root.name for (root, _) in e2.concretized_specs()) == set(
+            assert {root.name for (root, _) in e2.concretized_specs()} == set(
                 ["diamond-link-right", "diamond-link-bottom"]
             )
             for _, concretized_spec in e2.concretized_specs():
@@ -362,12 +362,12 @@ class TestUninstallFromEnv:
             uninstall("-f", "-y", "--remove", "diamond-link-bottom")
             # diamond-link-bottom was removed from the list of roots (note that
             # it would still be installed since diamond-link-left depends on it)
-            assert set(x.name for x in e1.roots()) == set(["diamond-link-left"])
+            assert {x.name for x in e1.roots()} == set(["diamond-link-left"])
             assert dtdiamondleft.installed
 
         e2 = spack.environment.read("e2")
         with e2:
-            assert set(root.name for (root, _) in e2.concretized_specs()) == set(
+            assert {root.name for (root, _) in e2.concretized_specs()} == set(
                 ["diamond-link-right", "diamond-link-bottom"]
             )
             dtdiamondright = next(

--- a/lib/spack/spack/test/concretization/core.py
+++ b/lib/spack/spack/test/concretization/core.py
@@ -1101,11 +1101,11 @@ spack:
         concrete_specs = spack.concretize._concretize_specs_together(abstract_specs)
 
         # Check there's only one configuration of each package in the DAG
-        names = set(
+        names = {
             dep.name for spec in concrete_specs for dep in spec.traverse(deptype=("link", "run"))
-        )
+        }
         for name in names:
-            name_specs = set(spec[name] for spec in concrete_specs if name in spec)
+            name_specs = {spec[name] for spec in concrete_specs if name in spec}
             assert len(name_specs) == 1
 
         # Check that there's at least one Spec that satisfies the
@@ -1993,7 +1993,7 @@ spack:
         solver = spack.solver.asp.Solver()
         solver.reuse = False
 
-        simulate_unsolved_property = list((x, None) for x in specs)
+        simulate_unsolved_property = [(x, None) for x in specs]
         monkeypatch.setattr(spack.solver.asp.Result, "unsolved_specs", simulate_unsolved_property)
         monkeypatch.setattr(spack.solver.asp.Result, "specs", list())
 
@@ -2449,7 +2449,7 @@ packages:
         solver = spack.solver.asp.Solver()
         setup = spack.solver.asp.SpackSolverSetup()
 
-        simulate_unsolved_property = list((x, None) for x in specs)
+        simulate_unsolved_property = [(x, None) for x in specs]
 
         monkeypatch.setattr(spack.solver.asp.Result, "unsolved_specs", simulate_unsolved_property)
 
@@ -4456,8 +4456,8 @@ def test_result_roundtrip(mock_packages, config, specs):
     # to come back as exactly the same graph they were before.
     assert len(result.answers) == len(roundtrip.answers)
     for (_, _, lspecs), (_, _, rspecs) in zip(result.answers, roundtrip.answers):
-        lids = set(id(lspec) for lspec in spack.traverse.traverse_nodes(lspecs.values()))
-        rids = set(id(rspec) for rspec in spack.traverse.traverse_nodes(rspecs.values()))
+        lids = {id(lspec) for lspec in spack.traverse.traverse_nodes(lspecs.values())}
+        rids = {id(rspec) for rspec in spack.traverse.traverse_nodes(rspecs.values())}
         assert len(lids) == len(rids)
 
     assert roundtrip == result
@@ -4631,11 +4631,11 @@ def test_concretization_cache_count_cleanup(use_concretization_cache, mutable_co
     spack.config.set("concretizer:concretization_cache:entry_limit", 1000)
 
     def names():
-        return set(
+        return {
             x.name
             for x in conc_cache_dir.iterdir()
             if (not x.is_dir() and not x.name.startswith("."))
-        )
+        }
 
     assert len(names()) == 0
 

--- a/lib/spack/spack/test/concretization/flag_mixing.py
+++ b/lib/spack/spack/test/concretization/flag_mixing.py
@@ -253,7 +253,7 @@ spack:
         e.concretize()
     e.write()
 
-    (result,) = list(j for i, j in e.concretized_specs() if j.name == "y")
+    (result,) = [j for i, j in e.concretized_specs() if j.name == "y"]
 
     assert result["y"].satisfies("cflags='-fsanitize=address -f1'")
 

--- a/lib/spack/spack/test/cray_manifest.py
+++ b/lib/spack/spack/test/cray_manifest.py
@@ -238,7 +238,7 @@ def generate_openmpi_entries(_common_arch, _common_compiler):
         parameters={"internal-hwloc": False, "fabrics": ["psm"], "missing_variant": True},
     )
 
-    return list(x.to_dict() for x in [openmpi, hwloc])
+    return [x.to_dict() for x in [openmpi, hwloc]]
 
 
 def test_generate_specs_from_manifest(generate_openmpi_entries):
@@ -246,7 +246,7 @@ def test_generate_specs_from_manifest(generate_openmpi_entries):
     including dependency references.
     """
     specs = entries_to_specs(generate_openmpi_entries)
-    (openmpi_spec,) = list(x for x in specs.values() if x.name == "openmpi")
+    (openmpi_spec,) = [x for x in specs.values() if x.name == "openmpi"]
     assert openmpi_spec["hwloc"]
 
 

--- a/lib/spack/spack/test/database.py
+++ b/lib/spack/spack/test/database.py
@@ -900,7 +900,7 @@ def test_query_unused_specs(mutable_database):
 
     def check_unused(roots, deptype, expected):
         unused = spack.store.STORE.db.unused_specs(root_hashes=roots, deptype=deptype)
-        assert set(u.name for u in unused) == set(expected)
+        assert {u.name for u in unused} == set(expected)
 
     default_dt = dt.LINK | dt.RUN
     check_unused(None, default_dt, ["cmake", "gcc", "compiler-wrapper"])
@@ -1169,7 +1169,7 @@ def test_db_all_hashes(database):
 
     # and make sure the hashes match
     with database.read_transaction():
-        assert set(s.dag_hash() for s in database.query()) == set(hashes)
+        assert {s.dag_hash() for s in database.query()} == set(hashes)
 
 
 def test_consistency_of_dependents_upon_remove(mutable_database):

--- a/lib/spack/spack/test/directory_layout.py
+++ b/lib/spack/spack/test/directory_layout.py
@@ -209,7 +209,7 @@ def test_find(temporary_store, config, mock_packages):
 
     # Make sure all the installed specs appear in
     # DirectoryLayout.all_specs()
-    found_specs = dict((s.name, s) for s in layout.all_specs())
+    found_specs = {s.name: s for s in layout.all_specs()}
     for name, spec in found_specs.items():
         assert name in found_specs
         assert found_specs[name].eq_dag(spec)

--- a/lib/spack/spack/test/env.py
+++ b/lib/spack/spack/test/env.py
@@ -1026,7 +1026,7 @@ spack:
     with e.manifest.use_config():
         assert not spack.config.get("config:verify_ssl")
         python_reqs = spack.config.get("packages")["python"]["require"]
-        req_specs = set(x["spec"] for x in python_reqs)
+        req_specs = {x["spec"] for x in python_reqs}
         assert req_specs == set(["@3.11:"])
 
 

--- a/lib/spack/spack/test/error_messages.py
+++ b/lib/spack/spack/test/error_messages.py
@@ -328,7 +328,7 @@ from spack.package import Package
     )
 
 
-all_pkgs = list((x, _add_import(y)) for (x, y) in all_pkgs)
+all_pkgs = [(x, _add_import(y)) for (x, y) in all_pkgs]
 
 
 _repo_name_id = 0

--- a/lib/spack/spack/test/link_paths.py
+++ b/lib/spack/spack/test/link_paths.py
@@ -37,10 +37,10 @@ def check_link_paths(filename, paths):
     actual = detected_paths
     expected = paths
 
-    missing_paths = list(x for x in expected if x not in actual)
+    missing_paths = [x for x in expected if x not in actual]
     assert not missing_paths
 
-    extra_paths = list(x for x in actual if x not in expected)
+    extra_paths = [x for x in actual if x not in expected]
     assert not extra_paths
 
     assert actual == expected

--- a/lib/spack/spack/test/main.py
+++ b/lib/spack/spack/test/main.py
@@ -246,7 +246,7 @@ packages:
 
     assert spack.config.get("config:dirty")
     python_reqs = spack.config.get("packages")["python"]["require"]
-    req_specs = set(x["spec"] for x in python_reqs)
+    req_specs = {x["spec"] for x in python_reqs}
     assert req_specs == set(["@3.11:", "+ssl", "+tk"])
 
 

--- a/lib/spack/spack/test/spec_dag.py
+++ b/lib/spack/spack/test/spec_dag.py
@@ -534,8 +534,8 @@ class TestSpecDag:
         assert orig._concrete == copy._concrete
 
         # ensure no shared nodes bt/w orig and copy.
-        orig_ids = set(id(s) for s in orig.traverse())
-        copy_ids = set(id(s) for s in copy.traverse())
+        orig_ids = {id(s) for s in orig.traverse()}
+        copy_ids = {id(s) for s in copy.traverse()}
         assert not orig_ids.intersection(copy_ids)
 
     def test_copy_concretized(self):
@@ -549,8 +549,8 @@ class TestSpecDag:
         assert orig._concrete == copy._concrete
 
         # ensure no shared nodes bt/w orig and copy.
-        orig_ids = set(id(s) for s in orig.traverse())
-        copy_ids = set(id(s) for s in copy.traverse())
+        orig_ids = {id(s) for s in orig.traverse()}
+        copy_ids = {id(s) for s in copy.traverse()}
         assert not orig_ids.intersection(copy_ids)
 
     def test_copy_through_spec_build_interface(self):
@@ -646,8 +646,8 @@ class TestSpecDag:
         """Ensure getting first n bits of a base32-encoded DAG hash works."""
 
         # RFC 4648 base32 decode table
-        b32 = dict((j, i) for i, j in enumerate("abcdefghijklmnopqrstuvwxyz"))
-        b32.update(dict((j, i) for i, j in enumerate("234567", 26)))
+        b32 = {j: i for i, j in enumerate("abcdefghijklmnopqrstuvwxyz")}
+        b32.update({j: i for i, j in enumerate("234567", 26)})
 
         # some package hashes
         tests = [

--- a/lib/spack/spack/test/util/lock_unix.py
+++ b/lib/spack/spack/test/util/lock_unix.py
@@ -209,7 +209,7 @@ def lock_path(lock_dir):
 
 def test_poll_interval_generator():
     interval_iter = iter(lk.Lock._poll_interval_generator(_wait_times=[1, 2, 3]))
-    intervals = list(next(interval_iter) for i in range(100))
+    intervals = [next(interval_iter) for i in range(100)]
     assert intervals == [1] * 20 + [2] * 40 + [3] * 40
 
 

--- a/lib/spack/spack/util/crypto.py
+++ b/lib/spack/spack/util/crypto.py
@@ -15,7 +15,7 @@ hashes = {"sha256": 32, "md5": 16, "sha1": 20, "sha224": 28, "sha384": 48, "sha5
 
 
 #: size of hash digests in bytes, mapped to algorithm names
-_size_to_hash = dict((v, k) for k, v in hashes.items())
+_size_to_hash = {v: k for k, v in hashes.items()}
 
 
 #: List of deprecated hash functions. On some systems, these cannot be

--- a/lib/spack/spack/util/elf.py
+++ b/lib/spack/spack/util/elf.py
@@ -382,9 +382,9 @@ def parse_pt_dynamic(f: BinaryIO, elf: ElfFile) -> None:
     string_table = retrieve_strtab(f, elf, elf.pt_dynamic_strtab_offset)
 
     if elf.has_needed:
-        elf.dt_needed_strs = list(
+        elf.dt_needed_strs = [
             parse_c_string(string_table, offset) for offset in elf.dt_needed_strtab_offsets
-        )
+        ]
 
     if elf.has_soname:
         elf.dt_soname_str = parse_c_string(string_table, elf.dt_soname_strtab_offset)

--- a/lib/spack/spack/util/filesystem.py
+++ b/lib/spack/spack/util/filesystem.py
@@ -275,10 +275,10 @@ def possible_library_filenames(library_names):
     library filenames that may be found on the system (e.g. libfoo.so).
     """
     lib_extensions = library_extensions
-    return set(
+    return {
         ".".join((lib, extension))
         for lib, extension in itertools.product(library_names, lib_extensions)
-    )
+    }
 
 
 def paths_containing_libs(paths, library_names):

--- a/lib/spack/spack/util/web.py
+++ b/lib/spack/spack/util/web.py
@@ -761,7 +761,7 @@ def list_url(url, recursive=False):
         if recursive:
             return list(_iter_s3_prefix(s3, url))
 
-        return list(set(key.split("/", 1)[0] for key in _iter_s3_prefix(s3, url)))
+        return list({key.split("/", 1)[0] for key in _iter_s3_prefix(s3, url)})
 
     elif url.scheme == "gs":
         gcs = GCSBucket(url)

--- a/share/spack/qa/flake8_formatter.py
+++ b/share/spack/qa/flake8_formatter.py
@@ -35,13 +35,12 @@ pattern_exemptions = {
 
 
 # compile all regular expressions.
-pattern_exemptions = dict(
-    (
-        re.compile(file_pattern),
-        dict((code, [re.compile(p) for p in patterns]) for code, patterns in error_dict.items()),
-    )
+pattern_exemptions = {
+    re.compile(file_pattern): {
+        code: [re.compile(p) for p in patterns] for code, patterns in error_dict.items()
+    }
     for file_pattern, error_dict in pattern_exemptions.items()
-)
+}
 
 
 class SpackFormatter(Pylint):

--- a/var/spack/test_repos/spack_repo/builtin_mock/packages/find_externals1/package.py
+++ b/var/spack/test_repos/spack_repo/builtin_mock/packages/find_externals1/package.py
@@ -22,7 +22,7 @@ class FindExternals1(AutotoolsPackage):
 
     @classmethod
     def determine_spec_details(cls, prefix, exes_in_prefix):
-        exe_to_path = dict((os.path.basename(p), p) for p in exes_in_prefix)
+        exe_to_path = {os.path.basename(p): p for p in exes_in_prefix}
         exes = [x for x in exe_to_path.keys() if "find-externals1-exe" in x]
         if not exes:
             return


### PR DESCRIPTION
In recent python `[x for x in xs]` is lowered to an append-loop, which is faster
than the generator (two frames, fewer allocs).

Apply ruff C400/C401/C402 across non-vendored files: turn list/set/dict around
a generator expression into the corresponding comprehension.
