### PR TITLE
style: explicit from-import instead of import-as

### DIFF
--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -56,14 +56,12 @@ import spack.oci.oci
 import spack.oci.opener
 import spack.paths
 import spack.platforms
-import spack.relocate as relocate
 import spack.spec
 import spack.stage
 import spack.store
 import spack.user_environment
 import spack.util.archive
 import spack.util.crypto
-import spack.util.file_cache as file_cache
 import spack.util.filesystem as fsys
 import spack.util.gpg
 import spack.util.lang
@@ -71,11 +69,9 @@ import spack.util.parallel
 import spack.util.path
 import spack.util.spack_json as sjson
 import spack.util.spack_yaml as syaml
-import spack.util.timer as timer
-import spack.util.tty as tty
 import spack.util.url as url_util
 import spack.util.web as web_util
-from spack import traverse
+from spack import relocate, traverse
 from spack.oci.image import (
     Digest,
     ImageReference,
@@ -93,6 +89,7 @@ from spack.oci.oci import (
 from spack.package_prefs import get_package_dir_permissions, get_package_group
 from spack.relocate_text import utf8_paths_to_single_binary_regex
 from spack.stage import Stage
+from spack.util import file_cache, timer, tty
 from spack.util.executable import which
 from spack.util.filesystem import mkdirp
 

--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -79,11 +79,11 @@ import spack.store
 import spack.subprocess_context
 import spack.util.executable
 import spack.util.module_cmd
-import spack.util.tty as tty
 from spack import traverse
 from spack.enums import Context
 from spack.error import InstallError, NoHeadersError, NoLibrariesError
 from spack.install_test import spack_install_test_log
+from spack.util import tty
 from spack.util.environment import (
     SYSTEM_DIR_CASE_ENTRY,
     EnvironmentModifications,

--- a/lib/spack/spack/buildcache_migrate.py
+++ b/lib/spack/spack/buildcache_migrate.py
@@ -17,9 +17,9 @@ import spack.stage
 import spack.util.crypto
 import spack.util.gpg
 import spack.util.parallel
-import spack.util.tty as tty
 import spack.util.url as url_util
 import spack.util.web as web_util
+from spack.util import tty
 
 from .enums import InstallRecordStatus
 from .url_buildcache import (

--- a/lib/spack/spack/buildcache_prune.py
+++ b/lib/spack/spack/buildcache_prune.py
@@ -14,9 +14,9 @@ import spack.binary_distribution
 import spack.error
 import spack.stage
 import spack.util.parallel
-import spack.util.tty as tty
 import spack.util.url as url_util
 import spack.util.web as web_util
+from spack.util import tty
 
 from .mirrors.mirror import Mirror
 from .url_buildcache import BuildcacheComponent, URLBuildcacheEntry, get_entries_from_cache

--- a/lib/spack/spack/ci/__init__.py
+++ b/lib/spack/spack/ci/__init__.py
@@ -33,12 +33,12 @@ import spack.util.git
 import spack.util.gpg as gpg_util
 import spack.util.path
 import spack.util.spack_yaml as syaml
-import spack.util.tty as tty
 import spack.util.url as url_util
 import spack.util.web as web_util
 from spack import traverse
 from spack.error import SpackError
 from spack.reporters.cdash import SPACK_CDASH_TIMEOUT
+from spack.util import tty
 from spack.util.tty.color import cescape, colorize
 
 from .common import (

--- a/lib/spack/spack/ci/common.py
+++ b/lib/spack/spack/ci/common.py
@@ -25,15 +25,14 @@ import spack.error
 import spack.mirrors.mirror
 import spack.schema
 import spack.spec
-import spack.util.compression as compression
 import spack.util.filesystem as fs
-import spack.util.tty as tty
 import spack.util.web as web_util
 from spack import traverse
 from spack.reporters import CDash, CDashConfiguration
 from spack.reporters.cdash import SPACK_CDASH_TIMEOUT
 from spack.reporters.cdash import build_stamp as cdash_build_stamp
 from spack.url_buildcache import get_url_buildcache_class
+from spack.util import compression, tty
 from spack.util.lang import memoized
 
 IS_WINDOWS = sys.platform == "win32"

--- a/lib/spack/spack/ci/gitlab.py
+++ b/lib/spack/spack/ci/gitlab.py
@@ -18,7 +18,7 @@ import spack.mirrors.mirror
 import spack.schema
 import spack.spec
 import spack.util.spack_yaml as syaml
-import spack.util.tty as tty
+from spack.util import tty
 
 from .common import (
     SPACK_RESERVED_TAGS,

--- a/lib/spack/spack/cmd/__init__.py
+++ b/lib/spack/spack/cmd/__init__.py
@@ -24,12 +24,12 @@ import spack.repo
 import spack.spec
 import spack.spec_parser
 import spack.store
-import spack.traverse as traverse
 import spack.user_environment as uenv
 import spack.util.spack_json as sjson
 import spack.util.spack_yaml as syaml
 import spack.util.string
-import spack.util.tty as tty
+from spack import traverse
+from spack.util import tty
 from spack.util.filesystem import join_path
 from spack.util.lang import attr_setdefault, index_by
 from spack.util.tty.colify import colify

--- a/lib/spack/spack/cmd/add.py
+++ b/lib/spack/spack/cmd/add.py
@@ -5,8 +5,8 @@
 import argparse
 
 import spack.cmd
-import spack.util.tty as tty
 from spack.cmd.common import arguments
+from spack.util import tty
 
 description = "add a spec to an environment"
 section = "environments"

--- a/lib/spack/spack/cmd/arch.py
+++ b/lib/spack/spack/cmd/arch.py
@@ -10,8 +10,7 @@ import spack.vendor.archspec.cpu
 
 import spack.platforms
 import spack.spec
-import spack.util.tty.colify as colify
-import spack.util.tty.color as color
+from spack.util.tty import colify, color
 
 description = "print architecture information about this machine"
 section = "config"

--- a/lib/spack/spack/cmd/audit.py
+++ b/lib/spack/spack/cmd/audit.py
@@ -6,9 +6,9 @@ import warnings
 
 import spack.audit
 import spack.repo
-import spack.util.tty as tty
 import spack.util.tty.colify
 import spack.util.tty.color as cl
+from spack.util import tty
 
 description = "audit configuration files, packages, etc."
 section = "packaging"

--- a/lib/spack/spack/cmd/blame.py
+++ b/lib/spack/spack/cmd/blame.py
@@ -13,8 +13,8 @@ import spack.config
 import spack.repo
 import spack.util.git
 import spack.util.spack_json as sjson
-import spack.util.tty as tty
 from spack.cmd import spack_is_git_repo
+from spack.util import tty
 from spack.util.executable import ProcessError
 from spack.util.filesystem import working_dir
 from spack.util.lang import pretty_date

--- a/lib/spack/spack/cmd/build_env.py
+++ b/lib/spack/spack/cmd/build_env.py
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-import spack.cmd.common.env_utility as env_utility
+from spack.cmd.common import env_utility
 from spack.enums import Context
 
 description = "dump the install environment for a spec,\nor run a command in that environment"

--- a/lib/spack/spack/cmd/ci.py
+++ b/lib/spack/spack/cmd/ci.py
@@ -13,7 +13,6 @@ from urllib.parse import urlparse, urlunparse
 import spack.binary_distribution
 import spack.ci as spack_ci
 import spack.cmd
-import spack.cmd.buildcache as buildcache
 import spack.cmd.common.arguments
 import spack.config as cfg
 import spack.environment as ev
@@ -28,11 +27,11 @@ import spack.stage
 import spack.util.filesystem as fs
 import spack.util.git
 import spack.util.gpg as gpg_util
-import spack.util.timer as timer
 import spack.util.tty.color as clr
 import spack.util.url as url_util
 import spack.util.web as web_util
-from spack.util import tty
+from spack.cmd import buildcache
+from spack.util import timer, tty
 from spack.version import StandardVersion
 
 from . import doc_dedented, doc_first_line

--- a/lib/spack/spack/cmd/clean.py
+++ b/lib/spack/spack/cmd/clean.py
@@ -12,9 +12,9 @@ import spack.config
 import spack.stage
 import spack.store
 import spack.util.filesystem
-import spack.util.tty as tty
 from spack.cmd.common import arguments
 from spack.paths import lib_path, var_path
+from spack.util import tty
 
 description = "remove temporary build files and/or downloaded archives"
 section = "build"

--- a/lib/spack/spack/cmd/commands.py
+++ b/lib/spack/spack/cmd/commands.py
@@ -16,8 +16,8 @@ import spack.config
 import spack.main
 import spack.paths
 import spack.platforms
-import spack.util.tty as tty
 from spack.main import SpackArgumentParser, section_descriptions
+from spack.util import tty
 from spack.util.argparsewriter import ArgparseRstWriter, ArgparseWriter, Command
 from spack.util.tty.colify import colify
 

--- a/lib/spack/spack/cmd/common/__init__.py
+++ b/lib/spack/spack/cmd/common/__init__.py
@@ -3,8 +3,8 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 import spack.paths
-import spack.util.tty as tty
-import spack.util.tty.color as color
+from spack.util import tty
+from spack.util.tty import color
 
 
 def shell_init_instructions(cmd, equivalent):

--- a/lib/spack/spack/cmd/common/arguments.py
+++ b/lib/spack/spack/cmd/common/arguments.py
@@ -16,7 +16,7 @@ import spack.mirrors.utils
 import spack.reporters
 import spack.spec
 import spack.store
-import spack.util.tty as tty
+from spack.util import tty
 from spack.util.lang import stable_partition
 from spack.util.pattern import Args
 

--- a/lib/spack/spack/cmd/common/confirmation.py
+++ b/lib/spack/spack/cmd/common/confirmation.py
@@ -7,7 +7,7 @@ from typing import List
 
 import spack.cmd
 import spack.spec
-import spack.util.tty as tty
+from spack.util import tty
 
 display_args = {"long": True, "show_flags": False, "variants": False, "indent": 4}
 

--- a/lib/spack/spack/cmd/common/env_utility.py
+++ b/lib/spack/spack/cmd/common/env_utility.py
@@ -9,10 +9,10 @@ import spack.deptypes as dt
 import spack.error
 import spack.spec
 import spack.store
-import spack.util.tty as tty
 from spack import build_environment, traverse
 from spack.cmd.common import arguments
 from spack.enums import Context
+from spack.util import tty
 from spack.util.environment import dump_environment, pickle_environment
 
 

--- a/lib/spack/spack/cmd/common/spec_strings.py
+++ b/lib/spack/spack/cmd/common/spec_strings.py
@@ -9,9 +9,9 @@ import warnings
 from typing import Callable, List, Optional
 
 import spack.util.spack_yaml
-import spack.util.tty as tty
 from spack.spec_parser import NAME, VERSION_LIST, SpecTokens
 from spack.tokenize import Token, TokenBase, Tokenizer
+from spack.util import tty
 
 IS_PROBABLY_COMPILER = re.compile(r"%[a-zA-Z_][a-zA-Z0-9\-]")
 

--- a/lib/spack/spack/cmd/compiler.py
+++ b/lib/spack/spack/cmd/compiler.py
@@ -12,9 +12,9 @@ import spack.compilers.config
 import spack.config
 import spack.spec
 import spack.store
-import spack.util.tty as tty
 from spack.cmd.common import arguments
 from spack.spec import Spec
+from spack.util import tty
 from spack.util.lang import index_by
 from spack.util.tty.colify import colify
 from spack.util.tty.color import colorize

--- a/lib/spack/spack/cmd/concretize.py
+++ b/lib/spack/spack/cmd/concretize.py
@@ -8,7 +8,7 @@ import spack.binary_distribution
 import spack.cmd
 import spack.cmd.common.arguments
 import spack.environment as ev
-import spack.util.tty as tty
+from spack.util import tty
 from spack.util.string import plural
 
 description = "concretize an environment and write a lockfile"

--- a/lib/spack/spack/cmd/config.py
+++ b/lib/spack/spack/cmd/config.py
@@ -18,10 +18,10 @@ import spack.store
 import spack.util.filesystem as fs
 import spack.util.spack_json as sjson
 import spack.util.spack_yaml as syaml
-import spack.util.tty as tty
-import spack.util.tty.color as color
 from spack.cmd.common import arguments
+from spack.util import tty
 from spack.util.editor import editor
+from spack.util.tty import color
 from spack.util.tty.colify import colify_table
 
 description = "get and set configuration options"

--- a/lib/spack/spack/cmd/create.py
+++ b/lib/spack/spack/cmd/create.py
@@ -10,7 +10,6 @@ from typing import List, Optional, Tuple
 
 import spack.repo
 import spack.stage
-import spack.util.tty as tty
 from spack.spec import Spec
 from spack.url import (
     UndetectableNameError,
@@ -19,6 +18,7 @@ from spack.url import (
     parse_name,
     parse_version,
 )
+from spack.util import tty
 from spack.util.editor import editor
 from spack.util.executable import which
 from spack.util.filesystem import mkdirp

--- a/lib/spack/spack/cmd/deconcretize.py
+++ b/lib/spack/spack/cmd/deconcretize.py
@@ -7,11 +7,10 @@ import sys
 from typing import List
 
 import spack.cmd
-import spack.cmd.common.confirmation as confirmation
 import spack.environment as ev
 import spack.spec
-import spack.util.tty as tty
-from spack.cmd.common import arguments
+from spack.cmd.common import arguments, confirmation
+from spack.util import tty
 
 description = "remove specs from the lockfile of an environment"
 section = "environments"

--- a/lib/spack/spack/cmd/dependencies.py
+++ b/lib/spack/spack/cmd/dependencies.py
@@ -8,9 +8,9 @@ import sys
 import spack.cmd
 import spack.environment as ev
 import spack.store
-import spack.util.tty as tty
 from spack.cmd.common import arguments
 from spack.solver.input_analysis import create_graph_analyzer
+from spack.util import tty
 from spack.util.tty.colify import colify
 
 description = "show dependencies of a package"

--- a/lib/spack/spack/cmd/dependents.py
+++ b/lib/spack/spack/cmd/dependents.py
@@ -10,8 +10,8 @@ import spack.cmd
 import spack.environment as ev
 import spack.repo
 import spack.store
-import spack.util.tty as tty
 from spack.cmd.common import arguments
+from spack.util import tty
 from spack.util.tty.colify import colify
 
 description = "show packages that depend on another"

--- a/lib/spack/spack/cmd/deprecate.py
+++ b/lib/spack/spack/cmd/deprecate.py
@@ -20,8 +20,8 @@ import spack.concretize
 import spack.environment as ev
 import spack.installer
 import spack.store
-import spack.util.tty as tty
 from spack.cmd.common import arguments
+from spack.util import tty
 from spack.util.filesystem import symlink
 
 from ..enums import InstallRecordStatus

--- a/lib/spack/spack/cmd/dev_build.py
+++ b/lib/spack/spack/cmd/dev_build.py
@@ -13,8 +13,8 @@ import spack.concretize
 import spack.config
 import spack.installer_dispatch
 import spack.repo
-import spack.util.tty as tty
 from spack.cmd.common import arguments
+from spack.util import tty
 
 description = "build package from code in current working directory"
 section = "build"

--- a/lib/spack/spack/cmd/develop.py
+++ b/lib/spack/spack/cmd/develop.py
@@ -13,10 +13,10 @@ import spack.fetch_strategy
 import spack.repo
 import spack.spec
 import spack.stage
-import spack.util.tty as tty
 import spack.version
 from spack.cmd.common import arguments
 from spack.error import SpackError
+from spack.util import tty
 
 description = "add a spec to an environment's develop: section"
 section = "environments"

--- a/lib/spack/spack/cmd/diff.py
+++ b/lib/spack/spack/cmd/diff.py
@@ -9,10 +9,10 @@ import sys
 import spack.cmd
 import spack.environment as ev
 import spack.hash_lookup
-import spack.solver.asp as asp
 import spack.util.spack_json as sjson
-import spack.util.tty as tty
 from spack.cmd.common import arguments
+from spack.solver import asp
+from spack.util import tty
 from spack.util.tty.color import cprint, get_color_when
 
 description = "compare two specs"

--- a/lib/spack/spack/cmd/edit.py
+++ b/lib/spack/spack/cmd/edit.py
@@ -12,7 +12,7 @@ import spack.cmd
 import spack.paths
 import spack.repo
 import spack.util.editor
-import spack.util.tty as tty
+from spack.util import tty
 
 description = "open package files in ``$EDITOR``"
 section = "packaging"

--- a/lib/spack/spack/cmd/env.py
+++ b/lib/spack/spack/cmd/env.py
@@ -17,15 +17,14 @@ import spack.cmd.common.arguments
 import spack.cmd.modules
 import spack.config
 import spack.environment as ev
-import spack.environment.depfile as depfile
 import spack.environment.environment
 import spack.environment.shell
 import spack.tengine
 import spack.util.filesystem as fs
-import spack.util.string as string
-import spack.util.tty as tty
 from spack.cmd.common import arguments
+from spack.environment import depfile
 from spack.traverse import traverse_nodes
+from spack.util import string, tty
 from spack.util.environment import EnvironmentModifications
 from spack.util.filesystem import islink, symlink
 from spack.util.tty.colify import colify

--- a/lib/spack/spack/cmd/extensions.py
+++ b/lib/spack/spack/cmd/extensions.py
@@ -5,12 +5,12 @@
 import argparse
 import sys
 
-import spack.cmd as cmd
 import spack.environment as ev
 import spack.repo
 import spack.store
-import spack.util.tty as tty
+from spack import cmd
 from spack.cmd.common import arguments
+from spack.util import tty
 from spack.util.tty.colify import colify
 
 description = "list extensions for package"

--- a/lib/spack/spack/cmd/external.py
+++ b/lib/spack/spack/cmd/external.py
@@ -11,15 +11,15 @@ from typing import List, Optional, Set
 import spack
 import spack.cmd
 import spack.config
-import spack.cray_manifest as cray_manifest
 import spack.detection
 import spack.error
 import spack.package_base
 import spack.repo
 import spack.spec
-import spack.util.tty as tty
-import spack.util.tty.colify as colify
+from spack import cray_manifest
 from spack.cmd.common import arguments
+from spack.util import tty
+from spack.util.tty import colify
 
 description = "manage external packages in Spack configuration"
 section = "config"

--- a/lib/spack/spack/cmd/find.py
+++ b/lib/spack/spack/cmd/find.py
@@ -8,7 +8,6 @@ import sys
 from typing import List, Optional, Tuple
 
 import spack.binary_distribution
-import spack.cmd as cmd
 import spack.config
 import spack.environment as ev
 import spack.repo
@@ -16,10 +15,11 @@ import spack.solver.reuse
 import spack.spec
 import spack.store
 import spack.util.lang
-import spack.util.tty as tty
-import spack.util.tty.color as color
+from spack import cmd
 from spack.cmd.common import arguments
 from spack.externals_config import create_external_parser, external_config_with_implicit_externals
+from spack.util import tty
+from spack.util.tty import color
 from spack.util.tty.color import colorize
 
 from ..enums import InstallRecordStatus

--- a/lib/spack/spack/cmd/gc.py
+++ b/lib/spack/spack/cmd/gc.py
@@ -10,7 +10,7 @@ import spack.cmd.uninstall
 import spack.deptypes as dt
 import spack.environment as ev
 import spack.store
-import spack.util.tty as tty
+from spack.util import tty
 
 description = "remove specs that are now no longer needed"
 section = "build"

--- a/lib/spack/spack/cmd/info.py
+++ b/lib/spack/spack/cmd/info.py
@@ -20,12 +20,12 @@ import spack.install_test
 import spack.package_base
 import spack.repo
 import spack.spec
-import spack.util.tty as tty
-import spack.util.tty.color as color
 import spack.variant
 import spack.version
 from spack.cmd.common import arguments
 from spack.package_base import PackageBase
+from spack.util import tty
+from spack.util.tty import color
 from spack.util.tty.colify import colify
 from spack.util.typing import SupportsRichComparison
 

--- a/lib/spack/spack/cmd/isolate.py
+++ b/lib/spack/spack/cmd/isolate.py
@@ -13,7 +13,7 @@ import spack.config
 import spack.paths
 import spack.schema.include
 import spack.util.spack_yaml as syaml
-import spack.util.tty as tty
+from spack.util import tty
 
 description = "isolate the current spack instance from the home directory"
 section = "config"

--- a/lib/spack/spack/cmd/license.py
+++ b/lib/spack/spack/cmd/license.py
@@ -10,7 +10,7 @@ from collections import defaultdict
 from typing import Dict, Generator
 
 import spack.paths
-import spack.util.tty as tty
+from spack.util import tty
 
 description = "list and check license headers on files in spack"
 section = "query"

--- a/lib/spack/spack/cmd/list.py
+++ b/lib/spack/spack/cmd/list.py
@@ -16,8 +16,8 @@ import spack.deptypes as dt
 import spack.package_base
 import spack.repo
 import spack.util.git
-import spack.util.tty as tty
 from spack.cmd.common import arguments
+from spack.util import tty
 from spack.util.filesystem import working_dir
 from spack.util.tty.colify import colify
 from spack.util.url import path_to_file_url

--- a/lib/spack/spack/cmd/location.py
+++ b/lib/spack/spack/cmd/location.py
@@ -11,8 +11,8 @@ import spack.environment as ev
 import spack.paths
 import spack.repo
 import spack.stage
-import spack.util.tty as tty
 from spack.cmd.common import arguments
+from spack.util import tty
 
 description = "print out locations of packages and spack directories"
 section = "query"

--- a/lib/spack/spack/cmd/logs.py
+++ b/lib/spack/spack/cmd/logs.py
@@ -12,9 +12,9 @@ import sys
 
 import spack.cmd
 import spack.spec
-import spack.util.compression as compression
 from spack.cmd.common import arguments
 from spack.error import SpackError
+from spack.util import compression
 
 description = "print out logs for packages"
 section = "query"

--- a/lib/spack/spack/cmd/maintainers.py
+++ b/lib/spack/spack/cmd/maintainers.py
@@ -6,7 +6,7 @@ import argparse
 from collections import defaultdict
 
 import spack.repo
-import spack.util.tty.color as color
+from spack.util.tty import color
 from spack.util.tty.colify import colify
 
 description = "get information about package maintainers"

--- a/lib/spack/spack/cmd/mirror.py
+++ b/lib/spack/spack/cmd/mirror.py
@@ -15,14 +15,13 @@ import spack.mirrors.mirror
 import spack.mirrors.utils
 import spack.repo
 import spack.spec
-import spack.util.lang as lang
 import spack.util.parallel
-import spack.util.tty as tty
-import spack.util.tty.colify as colify
 import spack.util.web as web_util
 from spack.cmd.common import arguments
 from spack.error import SpackError
+from spack.util import lang, tty
 from spack.util.string import comma_or
+from spack.util.tty import colify
 
 description = "manage mirrors (source and binary)"
 section = "config"

--- a/lib/spack/spack/cmd/patch.py
+++ b/lib/spack/spack/cmd/patch.py
@@ -9,8 +9,8 @@ import spack.config
 import spack.environment as ev
 import spack.package_base
 import spack.traverse
-import spack.util.tty as tty
 from spack.cmd.common import arguments
+from spack.util import tty
 
 description = "patch expanded sources in preparation for install"
 section = "build"

--- a/lib/spack/spack/cmd/pkg.py
+++ b/lib/spack/spack/cmd/pkg.py
@@ -10,8 +10,8 @@ import spack.cmd
 import spack.repo
 import spack.util.executable as exe
 import spack.util.package_hash as ph
-import spack.util.tty as tty
 from spack.cmd.common import arguments
+from spack.util import tty
 from spack.util.tty.colify import colify
 
 description = "query packages associated with particular git revisions"

--- a/lib/spack/spack/cmd/providers.py
+++ b/lib/spack/spack/cmd/providers.py
@@ -8,7 +8,7 @@ import sys
 
 import spack.cmd
 import spack.repo
-import spack.util.tty.colify as colify
+from spack.util.tty import colify
 
 description = "list packages that provide a particular virtual package"
 section = "query"

--- a/lib/spack/spack/cmd/python.py
+++ b/lib/spack/spack/cmd/python.py
@@ -11,7 +11,7 @@ import sys
 
 import spack
 import spack.repo
-import spack.util.tty as tty
+from spack.util import tty
 
 description = "launch an interpreter as spack would launch a command"
 section = "developer"

--- a/lib/spack/spack/cmd/remove.py
+++ b/lib/spack/spack/cmd/remove.py
@@ -5,8 +5,8 @@
 import argparse
 
 import spack.cmd
-import spack.util.tty as tty
 from spack.cmd.common import arguments
+from spack.util import tty
 
 description = "remove specs from an environment"
 section = "environments"

--- a/lib/spack/spack/cmd/repo.py
+++ b/lib/spack/spack/cmd/repo.py
@@ -20,9 +20,9 @@ import spack.util.filesystem as fs
 import spack.util.git
 import spack.util.spack_json as sjson
 import spack.util.spack_yaml
-import spack.util.tty as tty
 from spack.cmd.common import arguments
 from spack.error import SpackError
+from spack.util import tty
 from spack.util.tty import color
 from spack.version import StandardVersion
 

--- a/lib/spack/spack/cmd/resource.py
+++ b/lib/spack/spack/cmd/resource.py
@@ -6,8 +6,8 @@ import argparse
 import os
 
 import spack.repo
-import spack.util.tty as tty
-import spack.util.tty.color as color
+from spack.util import tty
+from spack.util.tty import color
 
 description = "list downloadable resources (tarballs, repos, patches)"
 section = "query"

--- a/lib/spack/spack/cmd/spec.py
+++ b/lib/spack/spack/cmd/spec.py
@@ -13,11 +13,11 @@ import spack.config
 import spack.environment
 import spack.hash_types as ht
 import spack.package_base
-import spack.solver.asp as asp
 import spack.spec
-import spack.util.tty as tty
-import spack.util.tty.color as color
 from spack.cmd.common import arguments
+from spack.solver import asp
+from spack.util import tty
+from spack.util.tty import color
 
 description = "show what would be installed, given a spec"
 section = "build"

--- a/lib/spack/spack/cmd/stage.py
+++ b/lib/spack/spack/cmd/stage.py
@@ -10,8 +10,8 @@ import spack.config
 import spack.environment as ev
 import spack.package_base
 import spack.traverse
-import spack.util.tty as tty
 from spack.cmd.common import arguments
+from spack.util import tty
 
 description = "expand downloaded archive in preparation for install"
 section = "build"

--- a/lib/spack/spack/cmd/style.py
+++ b/lib/spack/spack/cmd/style.py
@@ -12,15 +12,15 @@ from typing import Dict, List, Optional, Set, Union
 import spack.paths
 import spack.repo
 import spack.util.git
-import spack.util.tty as tty
-import spack.util.tty.color as color
 from spack.cmd.common.spec_strings import (
     _check_spec_strings,
     _spec_str_default_handler,
     _spec_str_fix_handler,
 )
+from spack.util import tty
 from spack.util.executable import Executable, which
 from spack.util.filesystem import working_dir
+from spack.util.tty import color
 
 description = "runs source code style checks on spack"
 section = "developer"

--- a/lib/spack/spack/cmd/tags.py
+++ b/lib/spack/spack/cmd/tags.py
@@ -9,8 +9,8 @@ from typing import Dict, Iterable, List
 import spack.environment
 import spack.repo
 import spack.util.string
-import spack.util.tty as tty
-import spack.util.tty.colify as colify
+from spack.util import tty
+from spack.util.tty import colify
 
 description = "show package tags and associated packages"
 section = "query"

--- a/lib/spack/spack/cmd/test_env.py
+++ b/lib/spack/spack/cmd/test_env.py
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-import spack.cmd.common.env_utility as env_utility
+from spack.cmd.common import env_utility
 from spack.enums import Context
 
 description = (

--- a/lib/spack/spack/cmd/tutorial.py
+++ b/lib/spack/spack/cmd/tutorial.py
@@ -12,8 +12,8 @@ import spack.config
 import spack.paths
 import spack.util.git
 import spack.util.gpg
-import spack.util.tty as tty
 from spack.cmd.common import arguments
+from spack.util import tty
 from spack.util.filesystem import working_dir
 from spack.util.spack_yaml import syaml_dict
 

--- a/lib/spack/spack/cmd/undevelop.py
+++ b/lib/spack/spack/cmd/undevelop.py
@@ -7,8 +7,8 @@ import argparse
 import spack.cmd
 import spack.config
 import spack.spec
-import spack.util.tty as tty
 from spack.cmd.common import arguments
+from spack.util import tty
 
 description = "remove specs from an environment's develop: section"
 section = "environments"

--- a/lib/spack/spack/cmd/uninstall.py
+++ b/lib/spack/spack/cmd/uninstall.py
@@ -7,13 +7,12 @@ import sys
 from typing import Dict, List, Optional
 
 import spack.cmd
-import spack.cmd.common.confirmation as confirmation
 import spack.environment as ev
 import spack.package_base
 import spack.spec
 import spack.store
-import spack.traverse as traverse
-from spack.cmd.common import arguments
+from spack import traverse
+from spack.cmd.common import arguments, confirmation
 from spack.util import tty
 from spack.util.tty.colify import colify
 

--- a/lib/spack/spack/cmd/unit_test.py
+++ b/lib/spack/spack/cmd/unit_test.py
@@ -18,8 +18,8 @@ except ImportError:
 
 import spack.paths
 import spack.util.filesystem
-import spack.util.tty as tty
-import spack.util.tty.color as color
+from spack.util import tty
+from spack.util.tty import color
 from spack.util.tty.colify import colify
 
 description = "run spack's unit tests (wrapper around pytest)"

--- a/lib/spack/spack/cmd/url.py
+++ b/lib/spack/spack/cmd/url.py
@@ -10,8 +10,6 @@ import spack.fetch_strategy as fs
 import spack.repo
 import spack.spec
 import spack.url
-import spack.util.crypto as crypto
-import spack.util.tty.color as color
 from spack.url import (
     UndetectableNameError,
     UndetectableVersionError,
@@ -24,8 +22,9 @@ from spack.url import (
     substitute_version,
     substitution_offsets,
 )
-from spack.util import tty
+from spack.util import crypto, tty
 from spack.util.naming import simplify_name
+from spack.util.tty import color
 
 description = "debugging tool for url parsing"
 section = "developer"

--- a/lib/spack/spack/cmd/verify.py
+++ b/lib/spack/spack/cmd/verify.py
@@ -9,10 +9,10 @@ import spack.cmd
 import spack.environment as ev
 import spack.spec
 import spack.store
-import spack.util.tty as tty
 import spack.verify
 import spack.verify_libraries
 from spack.cmd.common import arguments
+from spack.util import tty
 from spack.util.filesystem import visit_directory_tree
 from spack.util.string import plural
 

--- a/lib/spack/spack/cmd/versions.py
+++ b/lib/spack/spack/cmd/versions.py
@@ -7,8 +7,8 @@ import sys
 
 import spack.repo
 import spack.spec
-import spack.util.tty as tty
 from spack.cmd.common import arguments
+from spack.util import tty
 from spack.util.tty.colify import colify
 from spack.version import infinity_versions, ver
 

--- a/lib/spack/spack/cmd/view.py
+++ b/lib/spack/spack/cmd/view.py
@@ -41,9 +41,9 @@ import spack.environment as ev
 import spack.filesystem_view as fsv
 import spack.schema.projections
 import spack.store
-import spack.util.tty as tty
 from spack.config import validate
 from spack.util import spack_yaml as s_yaml
+from spack.util import tty
 from spack.util.link_tree import MergeConflictError
 
 description = "manipulate view directories in the filesystem"

--- a/lib/spack/spack/compilers/config.py
+++ b/lib/spack/spack/compilers/config.py
@@ -20,9 +20,9 @@ import spack.repo
 import spack.spec
 import spack.util.filesystem as fs
 import spack.util.lang
-import spack.util.tty as tty
 from spack.externals import ExternalSpecsParser, external_spec, extract_dicts_from_configuration
 from spack.operating_systems import windows_os
+from spack.util import tty
 from spack.util.environment import get_path
 
 #: Tag used to identify packages providing a compiler

--- a/lib/spack/spack/concretize.py
+++ b/lib/spack/spack/concretize.py
@@ -15,8 +15,8 @@ import spack.error
 import spack.hash_lookup
 import spack.repo
 import spack.util.parallel
-import spack.util.tty as tty
 from spack.spec import ArchSpec, CompilerSpec, Spec
+from spack.util import tty
 
 SpecPairInput = Tuple[Spec, Optional[Spec]]
 SpecPair = Tuple[Spec, Spec]

--- a/lib/spack/spack/config.py
+++ b/lib/spack/spack/config.py
@@ -2407,7 +2407,7 @@ def canonicalize_path(path: str, default_wd: Optional[str] = None) -> str:
 
     # Prepend the default, if provided, or current working directory.
     base = default_wd or os.getcwd()
-    import spack.util.tty as tty
+    from spack.util import tty
 
     tty.debug(f"Using working directory {base} as base for abspath")
     return os.path.normpath(os.path.join(base, path))

--- a/lib/spack/spack/container/__init__.py
+++ b/lib/spack/spack/container/__init__.py
@@ -10,8 +10,8 @@ import warnings
 import spack.vendor.jsonschema
 
 import spack.environment as ev
-import spack.schema.env as env
 import spack.util.spack_yaml as syaml
+from spack.schema import env
 
 from .writers import recipe
 

--- a/lib/spack/spack/container/images.py
+++ b/lib/spack/spack/container/images.py
@@ -10,7 +10,7 @@ import sys
 
 import spack.util.filesystem as fs
 import spack.util.git
-import spack.util.tty as tty
+from spack.util import tty
 
 #: Global variable used to cache in memory the content of images.json
 _data = None

--- a/lib/spack/spack/container/writers.py
+++ b/lib/spack/spack/container/writers.py
@@ -15,8 +15,8 @@ import spack.vendor.jsonschema
 import spack.environment as ev
 import spack.error
 import spack.schema.env
-import spack.tengine as tengine
 import spack.util.spack_yaml as syaml
+from spack import tengine
 
 from .images import (
     bootstrap_template_for,

--- a/lib/spack/spack/cray_manifest.py
+++ b/lib/spack/spack/cray_manifest.py
@@ -15,14 +15,14 @@ import spack.cmd
 import spack.compilers.config
 import spack.deptypes as dt
 import spack.error
-import spack.hash_types as hash_types
 import spack.platforms
 import spack.repo
 import spack.spec
 import spack.store
-import spack.util.tty as tty
+from spack import hash_types
 from spack.detection.path import ExecutablesFinder
 from spack.schema.cray_manifest import schema as manifest_schema
+from spack.util import tty
 
 #: Cray systems can store a Spack-compatible description of system
 #: packages here.

--- a/lib/spack/spack/database.py
+++ b/lib/spack/spack/database.py
@@ -59,7 +59,6 @@ import spack.traverse as tr
 import spack.util.filesystem as fs
 import spack.util.lock as lk
 import spack.util.spack_json as sjson
-import spack.util.tty as tty
 import spack.version as vn
 from spack.directory_layout import (
     DirectoryLayout,
@@ -67,6 +66,7 @@ from spack.directory_layout import (
     InconsistentInstallDirectoryError,
 )
 from spack.error import SpackError
+from spack.util import tty
 from spack.util.crypto import bit_length
 from spack.util.socket import _gethostname
 

--- a/lib/spack/spack/detection/path.py
+++ b/lib/spack/spack/detection/path.py
@@ -19,12 +19,12 @@ import spack.error
 import spack.spec
 import spack.util.elf as elf_utils
 import spack.util.environment
-import spack.util.environment as environment
 import spack.util.filesystem
 import spack.util.lang
 import spack.util.ld_so_conf
 import spack.util.parallel
 import spack.util.tty
+from spack.util import environment
 
 from .common import (
     WindowsCompilerExternalPaths,

--- a/lib/spack/spack/environment/depfile.py
+++ b/lib/spack/spack/environment/depfile.py
@@ -16,7 +16,7 @@ import spack.deptypes as dt
 import spack.environment.environment as ev
 import spack.paths
 import spack.spec
-import spack.traverse as traverse
+from spack import traverse
 
 
 class UseBuildCache(Enum):

--- a/lib/spack/spack/environment/environment.py
+++ b/lib/spack/spack/environment/environment.py
@@ -50,7 +50,6 @@ import spack.util.hash
 import spack.util.lock as lk
 import spack.util.spack_json as sjson
 import spack.util.spack_yaml as syaml
-import spack.util.tty as tty
 import spack.util.tty.color as clr
 import spack.variant as vt
 from spack import traverse
@@ -59,6 +58,7 @@ from spack.enums import ConfigScopePriority
 from spack.schema.env import TOP_LEVEL_KEY
 from spack.spec import Spec
 from spack.spec_filter import SpecFilter
+from spack.util import tty
 from spack.util.filesystem import copy_tree, islink, readlink
 from spack.util.lang import stable_partition
 from spack.util.link_tree import ConflictingSpecsError

--- a/lib/spack/spack/environment/shell.py
+++ b/lib/spack/spack/environment/shell.py
@@ -10,7 +10,7 @@ import spack.environment as ev
 import spack.repo
 import spack.schema.environment
 import spack.store
-import spack.util.tty as tty
+from spack.util import tty
 from spack.util.environment import EnvironmentModifications
 from spack.util.tty.color import colorize
 

--- a/lib/spack/spack/error.py
+++ b/lib/spack/spack/error.py
@@ -5,7 +5,7 @@
 import sys
 from typing import Optional
 
-import spack.util.tty as tty
+from spack.util import tty
 
 #: at what level we should write stack traces or short error messages
 #: this is module-scoped because it needs to be set very early

--- a/lib/spack/spack/fetch_strategy.py
+++ b/lib/spack/spack/fetch_strategy.py
@@ -45,15 +45,14 @@ import spack.config
 import spack.error
 import spack.oci.opener
 import spack.util.archive
-import spack.util.crypto as crypto
 import spack.util.executable
 import spack.util.filesystem as fs
 import spack.util.git
-import spack.util.tty as tty
 import spack.util.url
 import spack.util.url as url_util
 import spack.util.web as web_util
 import spack.version
+from spack.util import crypto, tty
 from spack.util.compression import decompressor_for
 from spack.util.executable import CommandNotFoundError, Executable, which
 from spack.util.filesystem import get_single_file, mkdirp, symlink, temp_cwd, working_dir

--- a/lib/spack/spack/hooks/absolutify_elf_sonames.py
+++ b/lib/spack/spack/hooks/absolutify_elf_sonames.py
@@ -7,7 +7,7 @@ import os
 import spack.bootstrap
 import spack.config
 import spack.relocate
-import spack.util.tty as tty
+from spack.util import tty
 from spack.util.elf import ElfParsingError, parse_elf
 from spack.util.filesystem import BaseDirectoryVisitor, visit_directory_tree
 from spack.util.lang import elide_list

--- a/lib/spack/spack/hooks/autopush.py
+++ b/lib/spack/spack/hooks/autopush.py
@@ -4,7 +4,7 @@
 
 import spack.binary_distribution
 import spack.mirrors.mirror
-import spack.util.tty as tty
+from spack.util import tty
 
 
 def post_install(spec, explicit):

--- a/lib/spack/spack/hooks/drop_redundant_rpaths.py
+++ b/lib/spack/spack/hooks/drop_redundant_rpaths.py
@@ -5,7 +5,7 @@
 import os
 from typing import BinaryIO, Optional, Tuple
 
-import spack.util.tty as tty
+from spack.util import tty
 from spack.util.elf import ElfParsingError, parse_elf
 from spack.util.filesystem import BaseDirectoryVisitor, visit_directory_tree
 

--- a/lib/spack/spack/hooks/licensing.py
+++ b/lib/spack/spack/hooks/licensing.py
@@ -5,7 +5,7 @@
 import os
 
 import spack.util.editor as ed
-import spack.util.tty as tty
+from spack.util import tty
 from spack.util.filesystem import mkdirp, symlink
 
 

--- a/lib/spack/spack/hooks/resolve_shared_libraries.py
+++ b/lib/spack/spack/hooks/resolve_shared_libraries.py
@@ -6,8 +6,8 @@ import io
 
 import spack.config
 import spack.error
-import spack.util.tty as tty
 import spack.verify_libraries
+from spack.util import tty
 from spack.util.filesystem import visit_directory_tree
 
 

--- a/lib/spack/spack/hooks/sbang.py
+++ b/lib/spack/spack/hooks/sbang.py
@@ -11,7 +11,7 @@ import tempfile
 
 import spack.error
 import spack.store
-import spack.util.tty as tty
+from spack.util import tty
 
 #: OS-imposed character limit for shebang line: 127 for Linux; 511 for Mac.
 #: Different Linux distributions have different limits, but 127 is the

--- a/lib/spack/spack/install_test.py
+++ b/lib/spack/spack/install_test.py
@@ -23,10 +23,10 @@ import spack.spec
 import spack.util.executable
 import spack.util.filesystem as fs
 import spack.util.spack_json as sjson
-import spack.util.tty as tty
 import spack.util.tty.log
 from spack.error import InstallError
 from spack.spec import Spec
+from spack.util import tty
 from spack.util.lang import nullcontext
 from spack.util.prefix import Prefix
 from spack.util.string import plural

--- a/lib/spack/spack/installer.py
+++ b/lib/spack/spack/installer.py
@@ -42,7 +42,6 @@ from typing import TYPE_CHECKING, Dict, Iterator, List, Optional, Set, Tuple, Un
 
 from spack.vendor.typing_extensions import Literal
 
-import spack.binary_distribution as binary_distribution
 import spack.build_environment
 import spack.builder
 import spack.config
@@ -60,9 +59,9 @@ import spack.store
 import spack.util.filesystem as fs
 import spack.util.lock as lk
 import spack.util.path
-import spack.util.timer as timer
-import spack.util.tty as tty
+from spack import binary_distribution
 from spack.url_buildcache import BuildcacheEntryError
+from spack.util import timer, tty
 from spack.util.environment import EnvironmentModifications, dump_environment
 from spack.util.lang import pretty_seconds
 from spack.util.string import ordinal

--- a/lib/spack/spack/main.py
+++ b/lib/spack/spack/main.py
@@ -42,9 +42,9 @@ import spack.spec
 import spack.util.environment
 import spack.util.lang
 import spack.util.lock
-import spack.util.tty as tty
 import spack.util.tty.colify
-import spack.util.tty.color as color
+from spack.util import tty
+from spack.util.tty import color
 
 from .enums import ConfigScopePriority
 
@@ -1039,7 +1039,7 @@ def _main(argv=None):
     # like `ConstraintAction` and `ConfigSetAction` happen at parse time.
     bootstrap_context = spack.util.lang.nullcontext()
     if args.bootstrap:
-        import spack.bootstrap as bootstrap  # avoid circular imports
+        from spack import bootstrap  # avoid circular imports
 
         bootstrap_context = bootstrap.ensure_bootstrap_configuration()
 

--- a/lib/spack/spack/mirrors/mirror.py
+++ b/lib/spack/spack/mirrors/mirror.py
@@ -20,10 +20,10 @@ from typing import (
 
 import spack.config
 import spack.util.spack_yaml as syaml
-import spack.util.tty as tty
 import spack.util.url as url_util
 from spack.error import MirrorError
 from spack.oci.image import is_oci_url
+from spack.util import tty
 
 if TYPE_CHECKING:
     import spack.spec

--- a/lib/spack/spack/mirrors/utils.py
+++ b/lib/spack/spack/mirrors/utils.py
@@ -10,11 +10,11 @@ import spack.config
 import spack.repo
 import spack.spec
 import spack.util.spack_yaml as syaml
-import spack.util.tty as tty
 import spack.version
 from spack.error import MirrorError
 from spack.mirrors.mirror import Mirror, MirrorCollection
 from spack.package import InstallError
+from spack.util import tty
 from spack.util.filesystem import mkdirp
 
 

--- a/lib/spack/spack/modules/__init__.py
+++ b/lib/spack/spack/modules/__init__.py
@@ -12,7 +12,7 @@ from typing import Dict, Optional, Type
 import spack.repo
 import spack.spec
 import spack.store
-import spack.util.tty as tty
+from spack.util import tty
 
 from . import common
 from .common import BaseModuleFileWriter, disable_modules

--- a/lib/spack/spack/modules/common.py
+++ b/lib/spack/spack/modules/common.py
@@ -52,16 +52,16 @@ import spack.schema
 import spack.schema.environment
 import spack.spec
 import spack.store
-import spack.tengine as tengine
 import spack.user_environment
 import spack.util.environment
 import spack.util.file_permissions as fp
 import spack.util.filesystem
 import spack.util.path
 import spack.util.spack_yaml as syaml
-import spack.util.tty as tty
+from spack import tengine
 from spack.aliases import BUILTIN_TO_LEGACY_COMPILER
 from spack.enums import Context
+from spack.util import tty
 from spack.util.lang import Singleton, dedupe
 
 from .error import (

--- a/lib/spack/spack/oci/oci.py
+++ b/lib/spack/spack/oci/oci.py
@@ -15,8 +15,8 @@ import spack.mirrors.layout
 import spack.mirrors.mirror
 import spack.oci.opener
 import spack.stage
-import spack.util.tty as tty
 import spack.util.url
+from spack.util import tty
 
 from .image import Digest, ImageReference
 

--- a/lib/spack/spack/package_base.py
+++ b/lib/spack/spack/package_base.py
@@ -47,13 +47,13 @@ import spack.util.filesystem as fsys
 import spack.util.git
 import spack.util.naming
 import spack.util.path
-import spack.util.tty as tty
 import spack.util.web
 import spack.variant
 from spack.compilers.adaptor import DeprecatedCompiler
 from spack.error import InstallError, NoURLError, PackageError
 from spack.filesystem_view import YamlFilesystemView
 from spack.resource import Resource
+from spack.util import tty
 from spack.util.filesystem import AlreadyExistsError, find_all_shared_libraries, islink, symlink
 from spack.util.lang import ClassProperty, classproperty, dedupe, memoized
 from spack.util.package_hash import package_hash

--- a/lib/spack/spack/paths.py
+++ b/lib/spack/spack/paths.py
@@ -13,7 +13,7 @@ import os
 from pathlib import PurePath
 
 import spack.util.filesystem
-import spack.util.hash as hash
+from spack.util import hash
 
 #: This file lives in $prefix/lib/spack/spack/__file__
 prefix = str(PurePath(spack.util.filesystem.ancestor(__file__, 4)))

--- a/lib/spack/spack/phase_callbacks.py
+++ b/lib/spack/spack/phase_callbacks.py
@@ -5,7 +5,7 @@
 import collections
 from typing import Optional
 
-import spack.util.lang as lang
+from spack.util import lang
 
 #: An object of this kind is a shared global state used to collect callbacks during
 #: class definition time, and is flushed when the class object is created at the end

--- a/lib/spack/spack/relocate.py
+++ b/lib/spack/spack/relocate.py
@@ -12,11 +12,9 @@ import spack.vendor.macholib.mach_o
 import spack.vendor.macholib.MachO
 
 import spack.store
-import spack.util.elf as elf
-import spack.util.executable as executable
 import spack.util.filesystem as fs
 import spack.util.lang
-import spack.util.tty as tty
+from spack.util import elf, executable, tty
 from spack.util.filesystem import readlink, symlink
 from spack.util.lang import memoized
 

--- a/lib/spack/spack/repo.py
+++ b/lib/spack/spack/repo.py
@@ -55,7 +55,7 @@ import spack.util.lock
 import spack.util.naming as nm
 import spack.util.path
 import spack.util.spack_yaml as syaml
-import spack.util.tty as tty
+from spack.util import tty
 from spack.util.filesystem import working_dir
 from spack.util.lang import Singleton, ensure_unwrapped, memoized
 

--- a/lib/spack/spack/reporters/cdash.py
+++ b/lib/spack/spack/reporters/cdash.py
@@ -22,9 +22,9 @@ import spack.platforms
 import spack.spec
 import spack.tengine
 import spack.util.git
-import spack.util.tty as tty
 import spack.util.web as web_util
 from spack.error import SpackError
+from spack.util import tty
 from spack.util.crypto import checksum
 from spack.util.filesystem import working_dir
 from spack.util.log_parse import parse_log_events

--- a/lib/spack/spack/reporters/extract.py
+++ b/lib/spack/spack/reporters/extract.py
@@ -5,8 +5,8 @@ import re
 import xml.sax.saxutils
 from datetime import datetime
 
-import spack.util.tty as tty
 from spack.install_test import TestStatus
+from spack.util import tty
 
 # The keys here represent the only recognized (ctest/cdash) status values
 completed = {

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -62,13 +62,13 @@ import spack.util.hash
 import spack.util.lang
 import spack.util.module_cmd as md
 import spack.util.timer
-import spack.util.tty as tty
 import spack.variant as vt
 import spack.version as vn
 import spack.version.git_ref_lookup
 from spack import traverse
 from spack.compilers.libraries import CompilerPropertyDetector
 from spack.spec import EMPTY_SPEC
+from spack.util import tty
 from spack.util.lang import elide_list
 
 from .compat import default_clingo_control, make_error_control

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -96,18 +96,17 @@ import spack.traverse
 import spack.util.filesystem as fs
 import spack.util.gpg
 import spack.util.hash
-import spack.util.lang as lang
 import spack.util.path
 import spack.util.prefix
 import spack.util.spack_json as sjson
 import spack.util.spack_yaml as syaml
 import spack.util.string
-import spack.util.tty as tty
 import spack.util.tty.color as clr
 import spack.variant as vt
 import spack.version
 import spack.version as vn
 import spack.version.git_ref_lookup
+from spack.util import lang, tty
 
 from .enums import PropagationPolicy
 

--- a/lib/spack/spack/stage.py
+++ b/lib/spack/spack/stage.py
@@ -26,9 +26,9 @@ import spack.util.lock
 import spack.util.parallel
 import spack.util.path as sup
 import spack.util.string
-import spack.util.tty as tty
 import spack.util.url as url_util
 from spack import fetch_strategy as fs  # breaks a cycle
+from spack.util import tty
 from spack.util.crypto import bit_length, prefix_bits
 from spack.util.editor import editor, executable
 from spack.util.filesystem import (

--- a/lib/spack/spack/test/binary_distribution.py
+++ b/lib/spack/spack/test/binary_distribution.py
@@ -23,7 +23,6 @@ import spack.binary_distribution
 import spack.concretize
 import spack.config
 import spack.environment as ev
-import spack.hooks.sbang as sbang
 import spack.main
 import spack.mirrors.mirror
 import spack.oci.image
@@ -37,6 +36,7 @@ import spack.util.url as url_util
 import spack.util.web as web_util
 from spack.binary_distribution import CannotListKeys, GenerateIndexError
 from spack.database import INDEX_JSON_FILE
+from spack.hooks import sbang
 from spack.installer import PackageInstaller
 from spack.spec import Spec
 from spack.url_buildcache import (

--- a/lib/spack/spack/test/ci.py
+++ b/lib/spack/spack/test/ci.py
@@ -9,14 +9,13 @@ from urllib.error import HTTPError
 
 import pytest
 
-import spack.ci as ci
 import spack.concretize
 import spack.environment as ev
 import spack.error
 import spack.paths
-import spack.repo as repo
 import spack.util.filesystem as fs
 import spack.util.git
+from spack import ci, repo
 from spack.spec import Spec
 from spack.test.conftest import MockHTTPResponse, RepoBuilder
 from spack.version import Version

--- a/lib/spack/spack/test/cmd/ci.py
+++ b/lib/spack/spack/test/cmd/ci.py
@@ -12,7 +12,6 @@ import pytest
 import spack.vendor.jsonschema
 
 import spack.binary_distribution
-import spack.ci as ci
 import spack.cmd
 import spack.cmd.ci
 import spack.concretize
@@ -26,6 +25,7 @@ import spack.stage
 import spack.util.spack_yaml as syaml
 import spack.util.web
 import spack.version
+from spack import ci
 from spack.ci import gitlab as gitlab_generator
 from spack.ci.common import PipelineDag, PipelineOptions, SpackCIConfig
 from spack.ci.generator_registry import generator

--- a/lib/spack/spack/test/cmd/common/arguments.py
+++ b/lib/spack/spack/test/cmd/common/arguments.py
@@ -7,10 +7,10 @@ import argparse
 import pytest
 
 import spack.cmd
-import spack.cmd.common.arguments as arguments
 import spack.config
 import spack.environment as ev
 import spack.main
+from spack.cmd.common import arguments
 
 
 @pytest.fixture()

--- a/lib/spack/spack/test/cmd/env.py
+++ b/lib/spack/spack/test/cmd/env.py
@@ -18,7 +18,6 @@ import spack.cmd.env
 import spack.concretize
 import spack.config
 import spack.environment as ev
-import spack.environment.depfile as depfile
 import spack.error
 import spack.main
 import spack.modules
@@ -35,15 +34,16 @@ import spack.util.filesystem as fs
 import spack.util.link_tree
 import spack.util.spack_json as sjson
 import spack.util.spack_yaml
-import spack.util.tty as tty
 from spack.cmd.env import _env_create
 from spack.config import substitute_path_variables
+from spack.environment import depfile
 from spack.installer import PackageInstaller
 from spack.main import SpackCommand, SpackCommandError
 from spack.spec import Spec
 from spack.stage import stage_prefix
 from spack.test.conftest import RepoBuilder
 from spack.traverse import traverse_nodes
+from spack.util import tty
 from spack.util.executable import Executable
 from spack.util.filesystem import readlink
 from spack.util.lang import dedupe

--- a/lib/spack/spack/test/cmd/init_py_functions.py
+++ b/lib/spack/spack/test/cmd/init_py_functions.py
@@ -8,7 +8,6 @@ import pytest
 import spack.config
 import spack.environment as ev
 import spack.error
-import spack.solver.asp as asp
 import spack.store
 from spack.cmd import (
     CommandNameError,
@@ -20,6 +19,7 @@ from spack.cmd import (
     require_cmd_name,
     require_python_name,
 )
+from spack.solver import asp
 
 
 def test_require_python_name():

--- a/lib/spack/spack/test/cmd/install.py
+++ b/lib/spack/spack/test/cmd/install.py
@@ -27,11 +27,11 @@ import spack.installer
 import spack.package_base
 import spack.store
 import spack.util.filesystem as fs
-import spack.util.tty as tty
 from spack.error import SpackError, SpecSyntaxError
 from spack.installer import PackageInstaller
 from spack.main import SpackCommand
 from spack.spec import Spec
+from spack.util import tty
 
 install = SpackCommand("install")
 env = SpackCommand("env")

--- a/lib/spack/spack/test/cmd/uninstall.py
+++ b/lib/spack/spack/test/cmd/uninstall.py
@@ -8,9 +8,9 @@ import pytest
 import spack.cmd.uninstall
 import spack.environment
 import spack.store
-import spack.util.tty as tty
 from spack.enums import InstallRecordStatus
 from spack.main import SpackCommand, SpackCommandError
+from spack.util import tty
 
 uninstall = SpackCommand("uninstall")
 install = SpackCommand("install")

--- a/lib/spack/spack/test/conftest.py
+++ b/lib/spack/spack/test/conftest.py
@@ -64,7 +64,6 @@ import spack.util.lock
 import spack.util.naming
 import spack.util.parallel
 import spack.util.spack_yaml as syaml
-import spack.util.tty as tty
 import spack.util.tty.color
 import spack.util.url as url_util
 import spack.util.web
@@ -73,6 +72,7 @@ from spack.enums import ConfigScopePriority
 from spack.fetch_strategy import URLFetchStrategy
 from spack.installer import PackageInstaller
 from spack.main import SpackCommand
+from spack.util import tty
 from spack.util.filesystem import (
     copy,
     copy_tree,

--- a/lib/spack/spack/test/container/docker.py
+++ b/lib/spack/spack/test/container/docker.py
@@ -5,7 +5,7 @@ import re
 
 import pytest
 
-import spack.container.writers as writers
+from spack.container import writers
 
 
 def test_manifest(minimal_configuration):

--- a/lib/spack/spack/test/container/singularity.py
+++ b/lib/spack/spack/test/container/singularity.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 import pytest
 
-import spack.container.writers as writers
+from spack.container import writers
 
 
 @pytest.fixture

--- a/lib/spack/spack/test/environment_modifications.py
+++ b/lib/spack/spack/test/environment_modifications.py
@@ -8,8 +8,8 @@ import sys
 
 import pytest
 
-import spack.util.environment as environment
 from spack.paths import spack_root
+from spack.util import environment
 from spack.util.environment import (
     AppendPath,
     EnvironmentModifications,

--- a/lib/spack/spack/test/installer.py
+++ b/lib/spack/spack/test/installer.py
@@ -28,9 +28,9 @@ import spack.spec
 import spack.store
 import spack.util.filesystem as fs
 import spack.util.lock as lk
-import spack.util.tty as tty
 from spack.main import SpackCommand
 from spack.test.conftest import RepoBuilder
+from spack.util import tty
 
 
 def _mock_repo(root, namespace):

--- a/lib/spack/spack/test/packaging.py
+++ b/lib/spack/spack/test/packaging.py
@@ -17,7 +17,6 @@ from collections import OrderedDict
 import pytest
 
 import spack.binary_distribution
-import spack.cmd.buildcache as buildcache
 import spack.cmd.mirror
 import spack.concretize
 import spack.config
@@ -27,6 +26,7 @@ import spack.package_base
 import spack.stage
 import spack.util.gpg
 import spack.util.url as url_util
+from spack.cmd import buildcache
 from spack.fetch_strategy import URLFetchStrategy
 from spack.installer import PackageInstaller
 from spack.paths import mock_gpg_keys_path

--- a/lib/spack/spack/test/relocate.py
+++ b/lib/spack/spack/test/relocate.py
@@ -11,8 +11,8 @@ import pytest
 
 import spack.platforms
 import spack.relocate
-import spack.relocate_text as relocate_text
 import spack.util.executable
+from spack import relocate_text
 
 pytestmark = pytest.mark.not_on_windows("Tests fail on Windows")
 

--- a/lib/spack/spack/test/relocate_text.py
+++ b/lib/spack/spack/test/relocate_text.py
@@ -6,7 +6,7 @@ from collections import OrderedDict
 
 import pytest
 
-import spack.relocate_text as relocate_text
+from spack import relocate_text
 
 
 def test_text_relocation_regex_is_safe():

--- a/lib/spack/spack/test/reporters.py
+++ b/lib/spack/spack/test/reporters.py
@@ -8,9 +8,9 @@ import pytest
 
 import spack.reporters.extract
 import spack.util.filesystem as fs
-import spack.util.tty as tty
 from spack.install_test import TestStatus
 from spack.reporters import CDash, CDashConfiguration
+from spack.util import tty
 
 # Use a path variable to appease Spack style line length checks
 fake_install_prefix = fs.join_path(

--- a/lib/spack/spack/test/sbang.py
+++ b/lib/spack/spack/test/sbang.py
@@ -17,10 +17,10 @@ import tempfile
 import pytest
 
 import spack.config
-import spack.hooks.sbang as sbang
 import spack.store
 import spack.util.filesystem as fs
 import spack.util.spack_yaml as syaml
+from spack.hooks import sbang
 from spack.util.executable import which
 
 if sys.platform != "win32":

--- a/lib/spack/spack/test/tengine.py
+++ b/lib/spack/spack/test/tengine.py
@@ -6,7 +6,7 @@
 import pytest
 
 import spack.config
-import spack.tengine as tengine
+from spack import tengine
 from spack.config import canonicalize_path
 
 

--- a/lib/spack/spack/test/traverse.py
+++ b/lib/spack/spack/test/traverse.py
@@ -5,7 +5,7 @@
 import pytest
 
 import spack.deptypes as dt
-import spack.traverse as traverse
+from spack import traverse
 from spack.spec import Spec
 
 

--- a/lib/spack/spack/test/url_fetch.py
+++ b/lib/spack/spack/test/url_fetch.py
@@ -16,11 +16,10 @@ import spack.config
 import spack.error
 import spack.fetch_strategy as fs
 import spack.url
-import spack.util.crypto as crypto
-import spack.util.tty as tty
 import spack.util.web as web_util
 import spack.version
 from spack.stage import Stage
+from spack.util import crypto, tty
 from spack.util.executable import which
 from spack.util.filesystem import is_exe, working_dir
 

--- a/lib/spack/spack/test/util/elf.py
+++ b/lib/spack/spack/test/util/elf.py
@@ -9,10 +9,10 @@ import pathlib
 import pytest
 
 import spack.platforms
-import spack.util.elf as elf
 import spack.util.executable
 import spack.util.filesystem as fs
 from spack.hooks.drop_redundant_rpaths import drop_redundant_rpaths
+from spack.util import elf
 
 
 # note that our elf parser is platform independent... but I guess creating an elf file

--- a/lib/spack/spack/test/util/ld_so_conf.py
+++ b/lib/spack/spack/test/util/ld_so_conf.py
@@ -8,7 +8,7 @@ import sys
 
 import pytest
 
-import spack.util.ld_so_conf as ld_so_conf
+from spack.util import ld_so_conf
 
 
 @pytest.mark.skipif(sys.platform == "win32", reason="Unix path")

--- a/lib/spack/spack/test/util/path.py
+++ b/lib/spack/spack/test/util/path.py
@@ -9,7 +9,7 @@ import pytest
 
 import spack.config
 import spack.util.path as sup
-import spack.util.tty as tty
+from spack.util import tty
 
 #: Some lines with lots of placeholders
 padded_lines = [

--- a/lib/spack/spack/test/util/remote_file_cache.py
+++ b/lib/spack/spack/test/util/remote_file_cache.py
@@ -9,7 +9,7 @@ import pytest
 
 import spack.config
 import spack.util.remote_file_cache as rfc_util
-import spack.util.tty as tty
+from spack.util import tty
 from spack.util.filesystem import join_path
 
 github_url = "https://github.com/fake/fake/{0}/develop"

--- a/lib/spack/spack/test/util/timer.py
+++ b/lib/spack/spack/test/util/timer.py
@@ -5,7 +5,7 @@
 import json
 from io import StringIO
 
-import spack.util.timer as timer
+from spack.util import timer
 
 
 class Tick:

--- a/lib/spack/spack/test/util/tty/color.py
+++ b/lib/spack/spack/test/util/tty/color.py
@@ -7,7 +7,7 @@ import textwrap
 
 import pytest
 
-import spack.util.tty.color as color
+from spack.util.tty import color
 from spack.util.tty.color import cescape, colorize, csub
 
 test_text = [

--- a/lib/spack/spack/test/util/tty/log.py
+++ b/lib/spack/spack/test/util/tty/log.py
@@ -10,9 +10,9 @@ from typing import List, Optional, Type
 
 import pytest
 
-import spack.util.tty.log as log
 from spack.util.executable import Executable
 from spack.util.filesystem import working_dir
+from spack.util.tty import log
 
 termios: Optional[ModuleType] = None
 try:

--- a/lib/spack/spack/test/util/tty/tty.py
+++ b/lib/spack/spack/test/util/tty/tty.py
@@ -6,7 +6,7 @@ import os
 
 import pytest
 
-import spack.util.tty as tty
+from spack.util import tty
 
 
 def test_get_timestamp(monkeypatch):

--- a/lib/spack/spack/test/web.py
+++ b/lib/spack/spack/test/web.py
@@ -18,9 +18,9 @@ import spack.mirrors.mirror
 import spack.paths
 import spack.url
 import spack.util.s3
-import spack.util.tty as tty
 import spack.util.url as url_util
 import spack.util.web
+from spack.util import tty
 from spack.util.filesystem import working_dir
 from spack.version import Version
 

--- a/lib/spack/spack/url_buildcache.py
+++ b/lib/spack/spack/url_buildcache.py
@@ -19,7 +19,6 @@ from typing import Any, Callable, Dict, List, Optional, Tuple, Type
 
 import spack.vendor.jsonschema
 
-import spack.config as config
 import spack.database
 import spack.error
 import spack.hash_types as ht
@@ -29,11 +28,12 @@ import spack.stage
 import spack.util.crypto
 import spack.util.filesystem as fsys
 import spack.util.gpg
-import spack.util.tty as tty
 import spack.util.url as url_util
 import spack.util.web as web_util
+from spack import config
 from spack.mirrors.mirror import BINARY_MEDIA_TYPE_VERSION
 from spack.schema.url_buildcache_manifest import schema as buildcache_manifest_schema
+from spack.util import tty
 from spack.util.archive import ChecksumWriter
 from spack.util.crypto import hash_fun_for_algo
 from spack.util.executable import which

--- a/lib/spack/spack/user_environment.py
+++ b/lib/spack/spack/user_environment.py
@@ -8,9 +8,9 @@ import sys
 import spack.build_environment
 import spack.config
 import spack.spec
-import spack.util.environment as environment
 from spack import traverse
 from spack.enums import Context
+from spack.util import environment
 
 #: Environment variable name Spack uses to track individually loaded packages
 spack_loaded_hashes_var = "SPACK_LOADED_HASHES"

--- a/lib/spack/spack/util/crypto.py
+++ b/lib/spack/spack/util/crypto.py
@@ -5,7 +5,7 @@
 import hashlib
 from typing import BinaryIO, Callable, Dict, Optional
 
-import spack.util.tty as tty
+from spack.util import tty
 
 HashFactory = Callable[[], "hashlib._Hash"]
 

--- a/lib/spack/spack/util/editor.py
+++ b/lib/spack/spack/util/editor.py
@@ -17,7 +17,7 @@ import shlex
 from typing import Callable, List
 
 import spack.util.executable
-import spack.util.tty as tty
+from spack.util import tty
 
 #: editors to try if VISUAL and EDITOR are not set
 _default_editors = ["vim", "vi", "emacs", "nano", "notepad"]

--- a/lib/spack/spack/util/executable.py
+++ b/lib/spack/spack/util/executable.py
@@ -14,7 +14,7 @@ from typing import BinaryIO, Callable, Dict, List, Optional, Sequence, Tuple, Ty
 from spack.vendor.typing_extensions import Literal
 
 import spack.error
-import spack.util.tty as tty
+from spack.util import tty
 from spack.util.environment import EnvironmentModifications
 
 __all__ = ["Executable", "which", "which_string", "ProcessError"]

--- a/lib/spack/spack/util/gcs.py
+++ b/lib/spack/spack/util/gcs.py
@@ -15,7 +15,7 @@ from typing import List
 from urllib.error import URLError
 from urllib.request import BaseHandler
 
-import spack.util.tty as tty
+from spack.util import tty
 
 
 def gcs_client():

--- a/lib/spack/spack/util/gpg.py
+++ b/lib/spack/spack/util/gpg.py
@@ -18,8 +18,8 @@ import spack.paths
 import spack.util.executable
 import spack.util.filesystem
 import spack.util.spack_json as sjson
-import spack.util.tty as tty
 import spack.version
+from spack.util import tty
 from spack.util.executable import Executable
 
 GPG_NAMES = ("gpg", "gpg2")

--- a/lib/spack/spack/util/link_tree.py
+++ b/lib/spack/spack/util/link_tree.py
@@ -11,7 +11,7 @@ from pathlib import Path
 from typing import Callable, Dict, List, Optional, Sequence, Tuple, Union
 
 import spack.util.filesystem as fs
-import spack.util.tty as tty
+from spack.util import tty
 
 __all__ = ["LinkTree"]
 

--- a/lib/spack/spack/util/module_cmd.py
+++ b/lib/spack/spack/util/module_cmd.py
@@ -12,8 +12,8 @@ import re
 import subprocess
 from typing import MutableMapping, Optional
 
-import spack.util.tty as tty
 from spack.error import SpackError
+from spack.util import tty
 
 # This list is not exhaustive. Currently we only use load and unload
 # If we need another option that changes the environment, add it here.

--- a/lib/spack/spack/util/path.py
+++ b/lib/spack/spack/util/path.py
@@ -16,7 +16,7 @@ import sys
 from typing import List, Optional, Union
 from urllib.parse import urlparse
 
-import spack.util.tty as tty
+from spack.util import tty
 from spack.util.lang import memoized
 
 __all__ = []

--- a/lib/spack/spack/util/remote_file_cache.py
+++ b/lib/spack/spack/util/remote_file_cache.py
@@ -12,7 +12,7 @@ import urllib.request
 from typing import Optional
 
 import spack.util.crypto
-import spack.util.tty as tty
+from spack.util import tty
 from spack.util.filesystem import copy, join_path, mkdirp
 from spack.util.url import validate_scheme
 

--- a/lib/spack/spack/util/tty/log.py
+++ b/lib/spack/spack/util/tty/log.py
@@ -20,11 +20,11 @@ from multiprocessing.connection import Connection
 from threading import Thread
 from typing import IO, Callable, Dict, List, Optional, TextIO, Tuple
 
-import spack.util.tty as tty
+from spack.util import tty
 
 if sys.platform == "win32":
-    import ctypes.wintypes as wintypes
     import msvcrt
+    from ctypes import wintypes
 
     kernel32 = ctypes.windll.kernel32
     kernel32.GetStdHandle.argtypes = [wintypes.DWORD]

--- a/lib/spack/spack/variant.py
+++ b/lib/spack/spack/variant.py
@@ -27,8 +27,8 @@ from typing import (
 
 import spack.error
 import spack.spec_parser
-import spack.util.lang as lang
 import spack.util.tty.color
+from spack.util import lang
 
 if TYPE_CHECKING:
     import spack.package_base

--- a/lib/spack/spack/verify.py
+++ b/lib/spack/spack/verify.py
@@ -10,8 +10,8 @@ from typing import Any, Dict
 import spack.store
 import spack.util.file_permissions as fp
 import spack.util.spack_json as sjson
-import spack.util.tty as tty
 from spack.package_base import spack_times_log
+from spack.util import tty
 from spack.util.filesystem import readlink
 
 

--- a/lib/spack/spack/verify_libraries.py
+++ b/lib/spack/spack/verify_libraries.py
@@ -7,7 +7,7 @@ import os
 import re
 from typing import IO, Dict, List
 
-import spack.util.elf as elf
+from spack.util import elf
 from spack.util.filesystem import BaseDirectoryVisitor
 from spack.util.lang import stable_partition
 

--- a/var/spack/test_repos/spack_repo/builtin_mock/build_systems/compiler.py
+++ b/var/spack/test_repos/spack_repo/builtin_mock/build_systems/compiler.py
@@ -11,8 +11,8 @@ from typing import Dict, List, Optional, Sequence, Tuple, Union
 import spack
 import spack.package_base
 import spack.util.executable
-import spack.util.tty as tty
 from spack.package import CompilerError
+from spack.util import tty
 from spack.util.lang import classproperty, memoized
 
 # Local "type" for type hints

--- a/var/spack/test_repos/spack_repo/tutorial/packages/hdf5/package.py
+++ b/var/spack/test_repos/spack_repo/tutorial/packages/hdf5/package.py
@@ -8,8 +8,8 @@ import sys
 
 from spack_repo.builtin_mock.build_systems.cmake import CMakePackage
 
-import spack.util.tty as tty
 from spack.package import *
+from spack.util import tty
 
 
 class Hdf5(CMakePackage):


### PR DESCRIPTION
Apply ruff PLR0402 across non-vendored files: rewrite `import a.b as b` as
`from a import b`.

