### PR TITLE
style: static join -> f-string

### DIFF
--- a/lib/spack/spack/ci/__init__.py
+++ b/lib/spack/spack/ci/__init__.py
@@ -1099,7 +1099,7 @@ def reproduce_ci_job(url, work_dir, autostart, gpg_url, runtime, use_local_head)
             "--name",
             f"spack_reproducer{container_suffix}",
             "-v",
-            ":".join([work_dir, mounted_workdir, "Z"]),
+            f"{work_dir}:{mounted_workdir}:Z",
             "-v",
             ":".join(
                 [

--- a/lib/spack/spack/cmd/arch.py
+++ b/lib/spack/spack/cmd/arch.py
@@ -84,7 +84,7 @@ def display_targets(targets):
         for family, group in by_family.items():
             vendor = color.colorize(r"@*B{" + vendor + r"}")
             family = color.colorize(r"@*B{" + family + r"}")
-            header = " - ".join([vendor, family])
+            header = f"{vendor} - {family}"
             group = sorted(group, key=lambda x: len(x.ancestors))
             display_target_group(header, group)
 

--- a/lib/spack/spack/container/writers.py
+++ b/lib/spack/spack/container/writers.py
@@ -99,7 +99,7 @@ def _stage_base_images(images_config):
         image_name, tag = build_info(operating_system, spack_version)
         build_stage = "bootstrap"
         if image_name:
-            build_stage = ":".join([image_name, tag])
+            build_stage = f"{image_name}:{tag}"
 
     # Retrieve the bootstrap stage
     bootstrap_stage = None

--- a/lib/spack/spack/filesystem_view.py
+++ b/lib/spack/spack/filesystem_view.py
@@ -843,7 +843,7 @@ def get_spec_from_file(filename) -> Optional[spack.spec.Spec]:
 def colorize_root(root):
     colorize = ft.partial(tty.color.colorize, color=sys.stdout.isatty())
     pre, post = map(colorize, "@M[@. @M]@.".split())
-    return "".join([pre, root, post])
+    return f"{pre}{root}{post}"
 
 
 def colorize_spec(spec):

--- a/lib/spack/spack/llnl/util/filesystem.py
+++ b/lib/spack/spack/llnl/util/filesystem.py
@@ -266,8 +266,7 @@ def possible_library_filenames(library_names):
     """
     lib_extensions = library_extensions
     return set(
-        ".".join((lib, extension))
-        for lib, extension in itertools.product(library_names, lib_extensions)
+        f"{lib}.{extension}" for lib, extension in itertools.product(library_names, lib_extensions)
     )
 
 

--- a/lib/spack/spack/subprocess_context.py
+++ b/lib/spack/spack/subprocess_context.py
@@ -173,7 +173,7 @@ class TestPatches:
                 module_patches.append((module_name, name, new_val))
             elif isinstance(target, type):
                 new_val = getattr(target, name)
-                class_fqn = ".".join([target.__module__, target.__name__])
+                class_fqn = f"{target.__module__}.{target.__name__}"
                 class_patches.append((class_fqn, name, new_val))
 
         return TestPatches(module_patches, class_patches)

--- a/lib/spack/spack/test/util/url.py
+++ b/lib/spack/spack/test/util/url.py
@@ -12,7 +12,7 @@ import spack.util.url
 
 @pytest.fixture(params=spack.util.url.ALLOWED_ARCHIVE_TYPES)
 def archive_and_expected(request):
-    archive_name = ".".join(["Foo", request.param])
+    archive_name = f"Foo.{request.param}"
     return archive_name, request.param
 
 

--- a/lib/spack/spack/util/environment.py
+++ b/lib/spack/spack/util/environment.py
@@ -1189,8 +1189,8 @@ def environment_after_sourcing_files(
         dump_environment_cmd = sys.executable + f' -E -c "{dump_cmd}"'
 
         # Try to source the file
-        source_file_arguments = " ".join(
-            [source_file, suppress_output, concatenate_on_success, dump_environment_cmd]
+        source_file_arguments = (
+            f"{source_file} {suppress_output} {concatenate_on_success} {dump_environment_cmd}"
         )
 
         # Popens argument processing can break command invocations

--- a/lib/spack/spack/util/s3.py
+++ b/lib/spack/spack/util/s3.py
@@ -78,7 +78,7 @@ def get_s3_session(url, method="fetch"):
 
 def _parse_s3_endpoint_url(endpoint_url):
     if not urllib.parse.urlparse(endpoint_url, scheme="").scheme:
-        endpoint_url = "://".join(("https", endpoint_url))
+        endpoint_url = f"https://{endpoint_url}"
 
     return endpoint_url
 


### PR DESCRIPTION
Apply ruff FLY002 where a str.join() over a short, fixed set of values is
clearer as an f-string. Left as-is the few multi-line joins (a large
alternation regex in solver/asp.py and multi-path test fixtures) that read
better as lists.

