### PR TITLE
Allow multiple py-setuptools-scm specs in a dependency graph

### DIFF
--- a/etc/spack/defaults/base/concretizer.yaml
+++ b/etc/spack/defaults/base/concretizer.yaml
@@ -60,6 +60,7 @@ concretizer:
       py-flit-core: 2
       py-pip: 2
       py-setuptools: 2
+      py-setuptools-scm: 2
       py-versioneer: 2
       py-wheel: 2
       xcb-proto: 2


### PR DESCRIPTION
Allow multiple `py-setuptools-scm` specs in a dependency graph to help with constrained build dep packages.