### PR TITLE
Revert "macos: allow installing binaries from older os (#52390)"

### DIFF
--- a/lib/spack/spack/operating_systems/mac_os.py
+++ b/lib/spack/spack/operating_systems/mac_os.py
@@ -106,34 +106,6 @@ def macos_sdk_version():
     return Version(xcrun("--show-sdk-version", output=str).rstrip())
 
 
-mac_releases = {
-    "10.0": "cheetah",
-    "10.1": "puma",
-    "10.2": "jaguar",
-    "10.3": "panther",
-    "10.4": "tiger",
-    "10.5": "leopard",
-    "10.6": "snowleopard",
-    "10.7": "lion",
-    "10.8": "mountainlion",
-    "10.9": "mavericks",
-    "10.10": "yosemite",
-    "10.11": "elcapitan",
-    "10.12": "sierra",
-    "10.13": "highsierra",
-    "10.14": "mojave",
-    "10.15": "catalina",
-    "10.16": "bigsur",
-    "11": "bigsur",
-    "12": "monterey",
-    "13": "ventura",
-    "14": "sonoma",
-    "15": "sequoia",
-    "26": "tahoe",
-    "27": "goldengate",
-}
-
-
 class MacOs(OperatingSystem):
     """This class represents the macOS operating system. This will be
     auto detected using the python platform.mac_ver. The macOS
@@ -141,15 +113,40 @@ class MacOs(OperatingSystem):
     system name, i.e el capitan, yosemite...etc.
     """
 
-    def __init__(self, version=None):
+    def __init__(self):
         """Autodetects the mac version from a dictionary.
 
         If the mac version is too old or too new for Spack to recognize,
         will use a generic "macos" version string until Spack is updated.
         """
-        if isinstance(version, str):
-            version = Version(version)
-        version = version or macos_version()
+        mac_releases = {
+            "10.0": "cheetah",
+            "10.1": "puma",
+            "10.2": "jaguar",
+            "10.3": "panther",
+            "10.4": "tiger",
+            "10.5": "leopard",
+            "10.6": "snowleopard",
+            "10.7": "lion",
+            "10.8": "mountainlion",
+            "10.9": "mavericks",
+            "10.10": "yosemite",
+            "10.11": "elcapitan",
+            "10.12": "sierra",
+            "10.13": "highsierra",
+            "10.14": "mojave",
+            "10.15": "catalina",
+            "10.16": "bigsur",
+            "11": "bigsur",
+            "12": "monterey",
+            "13": "ventura",
+            "14": "sonoma",
+            "15": "sequoia",
+            "26": "tahoe",
+            "27": "goldengate",
+        }
+
+        version = macos_version()
 
         # Big Sur versions go 11.0, 11.0.1, 11.1 (vs. prior versions that
         # only used the minor component)

--- a/lib/spack/spack/platforms/darwin.py
+++ b/lib/spack/spack/platforms/darwin.py
@@ -4,7 +4,7 @@
 
 import platform as py_platform
 
-from spack.operating_systems.mac_os import MacOs, mac_releases
+from spack.operating_systems.mac_os import MacOs
 from spack.version import Version
 
 from ._platform import Platform
@@ -20,11 +20,6 @@ class Darwin(Platform):
         mac_os = MacOs()
         self.default_os = str(mac_os)
         self.add_operating_system(str(mac_os), mac_os)
-
-        for version in mac_releases.keys():
-            mac_os_version = MacOs(version)
-            # This is idempotent, so it doesn't matter if it's already there
-            self.add_operating_system(str(mac_os_version), mac_os_version)
 
     @classmethod
     def detect(cls):


### PR DESCRIPTION
Reverts #52390

I think the os compatibility 2318e9cf6a2cdb536bb0c42b4eb9a1b18dd0ef39 introduced is the right move for correctness, but wanted to bring up the possibility of reverting this while we investigate additional methods of improving OS compatibility modeling while perhaps making a smaller performance degradation to solves on MacOS.

**v1.2.0**
```
$ git checkout v1.2.0
$ spack -c concretizer:concretization_cache:enable:false solve --timers --fresh gmake
    setup          0.966s
    ordering       0.067s
    cache-check     0.004s
    load           0.253s
    ground        11.599s
    solve          7.957s
    construct_specs     0.019s
    total         20.892s

[+]  gmake@4.4.1~guile build_system=generic platform=darwin os=tahoe target=m3 %c=apple-clang@21.0.0
[e]      ^apple-clang@21.0.0 build_system=bundle platform=darwin os=tahoe target=aarch64
[+]      ^compiler-wrapper@1.1.0 build_system=generic platform=darwin os=tahoe target=m3
```

**Post Revert:**
```
$ spack -c concretizer:concretization_cache:enable:false solve --timers --fresh gmake
    setup          0.928s
    ordering       0.066s
    cache-check     0.004s
    load           0.248s
    ground         1.209s
    solve          0.736s
    construct_specs     0.019s
    total          3.237s

[+]  gmake@4.4.1~guile build_system=generic platform=darwin os=tahoe target=m3 %c=apple-clang@21.0.0
[e]      ^apple-clang@21.0.0 build_system=bundle platform=darwin os=tahoe target=aarch64
[+]      ^compiler-wrapper@1.1.0 build_system=generic platform=darwin os=tahoe target=m3
```