### PR TITLE
performance bugfix: only expose buildable oses to solver

### DIFF
--- a/lib/spack/spack/platforms/_platform.py
+++ b/lib/spack/spack/platforms/_platform.py
@@ -80,6 +80,9 @@ class Platform:
 
         return self.operating_sys.get(name, None)
 
+    def buildable_oses(self):
+        return set(self.operating_sys.keys())
+
     def setup_platform_environment(self, pkg, env):
         """Platform-specific build environment modifications.
 

--- a/lib/spack/spack/platforms/darwin.py
+++ b/lib/spack/spack/platforms/darwin.py
@@ -26,6 +26,9 @@ class Darwin(Platform):
             # This is idempotent, so it doesn't matter if it's already there
             self.add_operating_system(str(mac_os_version), mac_os_version)
 
+    def buildable_oses(self):
+        return set(self.default_os)
+
     @classmethod
     def detect(cls):
         return "darwin" in py_platform.system().lower()

--- a/lib/spack/spack/platforms/darwin.py
+++ b/lib/spack/spack/platforms/darwin.py
@@ -27,7 +27,7 @@ class Darwin(Platform):
             self.add_operating_system(str(mac_os_version), mac_os_version)
 
     def buildable_oses(self):
-        return set(self.default_os)
+        return {self.default_os}
 
     @classmethod
     def detect(cls):

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -2517,7 +2517,7 @@ class SpackSolverSetup:
         platform = spack.platforms.host()
 
         # create set of OS's to consider
-        buildable = set(platform.operating_sys.keys())
+        buildable = platform.buildable_oses()
 
         # Consider any OS's mentioned on the command line. We need this to
         # cross-concretize in CI, and for some tests.

--- a/lib/spack/spack/test/architecture.py
+++ b/lib/spack/spack/test/architecture.py
@@ -133,3 +133,28 @@ def test_concretize_target_ranges(root_target_range, dep_target_range, result, m
         f"pkg-a foobar=bar target={root_target_range} %gcc@10 ^pkg-b target={dep_target_range}"
     )
     assert spec.target == spec["pkg-b"].target == result
+
+
+def test_instantiate_non_default_macos(mock_packages):
+    darwin = spack.platforms.Darwin()
+    default_macos = darwin.operating_system("default_os")
+
+    for name, macos in darwin.operating_sys.items():
+        if name != darwin.default_os:
+            non_default_macos_name = name
+            non_default_macos = macos
+            break
+    else:
+        assert False, "Failed to find non-default macos version in test"
+
+    with spack.platforms.use_platform(darwin):
+        # zlib isn't important but we need a spec with no compiler because our test environment
+        # has no macos compilers
+        spec = spack.concretize.concretize_one(f"zlib platform=darwin os={non_default_macos_name} target=aarch64")
+
+    # Primarily testing that these lines doesn't throw
+    os = spec.os
+    os_object = spack.platforms.by_name(spec.platform).operating_system(os)
+
+    assert os == non_default_macos_name
+    assert os_object == non_default_macos

--- a/lib/spack/spack/test/architecture.py
+++ b/lib/spack/spack/test/architecture.py
@@ -149,8 +149,9 @@ def test_instantiate_non_default_macos(mock_packages):
     with spack.platforms.use_platform(darwin):
         # zlib isn't important but we need a spec with no compiler because our test environment
         # has no macos compilers
+        target = str(spack.vendor.archspec.cpu.host().family)
         spec = spack.concretize.concretize_one(
-            f"zlib platform=darwin os={non_default_macos_name} target=aarch64"
+            f"zlib platform=darwin os={non_default_macos_name} target={target}"
         )
 
     # Primarily testing that these lines doesn't throw

--- a/lib/spack/spack/test/architecture.py
+++ b/lib/spack/spack/test/architecture.py
@@ -137,7 +137,6 @@ def test_concretize_target_ranges(root_target_range, dep_target_range, result, m
 
 def test_instantiate_non_default_macos(mock_packages):
     darwin = spack.platforms.Darwin()
-    default_macos = darwin.operating_system("default_os")
 
     for name, macos in darwin.operating_sys.items():
         if name != darwin.default_os:

--- a/lib/spack/spack/test/architecture.py
+++ b/lib/spack/spack/test/architecture.py
@@ -150,7 +150,9 @@ def test_instantiate_non_default_macos(mock_packages):
     with spack.platforms.use_platform(darwin):
         # zlib isn't important but we need a spec with no compiler because our test environment
         # has no macos compilers
-        spec = spack.concretize.concretize_one(f"zlib platform=darwin os={non_default_macos_name} target=aarch64")
+        spec = spack.concretize.concretize_one(
+            f"zlib platform=darwin os={non_default_macos_name} target=aarch64"
+        )
 
     # Primarily testing that these lines doesn't throw
     os = spec.os


### PR DESCRIPTION
Fixes #52602 

Macos needs to know about older operating systems, to reconstruct specs from them, but it doesn't need to expose them to the solver unless they are coming in from a reused spec.

Generalized to a `buildable_oses` method on the `Platform` class.

@alecbcs 