### PR TITLE
binary_distribution: Handle relocating static libraries that may have the install prefix embedded as text.

### DIFF
--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -1975,7 +1975,9 @@ def relocate_package(spec: spack.spec.Spec) -> None:
     # Text files containing the prefix text
     textfiles = [os.path.join(spec_prefix, f) for f in buildinfo["relocate_textfiles"]]
     binaries = [os.path.join(spec_prefix, f) for f in buildinfo.get("relocate_binaries")]
-    static_libraries = [os.path.join(spec_prefix, f) for f in buildinfo.get("relocate_static_libraries", [])]
+    static_libraries = [
+        os.path.join(spec_prefix, f) for f in buildinfo.get("relocate_static_libraries", [])
+    ]
     links = [os.path.join(spec_prefix, f) for f in buildinfo.get("relocate_links", [])]
 
     platform = spack.platforms.by_name(spec.platform)

--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -822,6 +822,7 @@ class FileTypes:
     BINARY = 0
     TEXT = 1
     UNKNOWN = 2
+    STATIC_LIBRARY = 3
 
 
 NOT_ISO8859_1_TEXT = re.compile(b"[\x00\x7f-\x9f]")
@@ -835,6 +836,8 @@ def file_type(f: IO[bytes]) -> int:
             return FileTypes.UNKNOWN
         elif relocate.is_elf_magic(magic) or relocate.is_macho_magic(magic):
             return FileTypes.BINARY
+        elif relocate.is_static_library_magic(magic):
+            return FileTypes.STATIC_LIBRARY
 
         f.seek(0)
 
@@ -887,6 +890,7 @@ def tarfile_of_spec_prefix(
     relocate_binaries = []
     relocate_links = []
     relocate_textfiles = []
+    relocate_static_libraries = []
 
     # use callbacks to add files and symlinks, so we can register which files need relocation upon
     # extraction.
@@ -902,6 +906,8 @@ def tarfile_of_spec_prefix(
                 relocate_binaries.append(os.path.relpath(path, prefix))
             elif f_type == FileTypes.TEXT and file_matches(f, binary_regex):
                 relocate_textfiles.append(os.path.relpath(path, prefix))
+            elif f_type == FileTypes.STATIC_LIBRARY and file_matches(f, binary_regex):
+                relocate_static_libraries.append(os.path.relpath(path, prefix))
             tar.addfile(info, f)
 
     def add_symlink(tar: tarfile.TarFile, info: tarfile.TarInfo, path: str):
@@ -924,6 +930,7 @@ def tarfile_of_spec_prefix(
         "relocate_binaries": relocate_binaries,
         "relocate_links": relocate_links,
         "relocate_textfiles": relocate_textfiles,
+        "relocate_static_libraries": relocate_static_libraries,
     }
 
 
@@ -1968,6 +1975,7 @@ def relocate_package(spec: spack.spec.Spec) -> None:
     # Text files containing the prefix text
     textfiles = [os.path.join(spec_prefix, f) for f in buildinfo["relocate_textfiles"]]
     binaries = [os.path.join(spec_prefix, f) for f in buildinfo.get("relocate_binaries")]
+    static_libraries = [os.path.join(spec_prefix, f) for f in buildinfo.get("relocate_static_libraries", [])]
     links = [os.path.join(spec_prefix, f) for f in buildinfo.get("relocate_links", [])]
 
     platform = spack.platforms.by_name(spec.platform)
@@ -1978,6 +1986,7 @@ def relocate_package(spec: spack.spec.Spec) -> None:
 
     relocate.relocate_links(links, prefix_to_prefix)
     relocate.relocate_text(textfiles, prefix_to_prefix)
+    relocate.relocate_text_bin(static_libraries, prefix_to_prefix)
     changed_files = relocate.relocate_text_bin(binaries, prefix_to_prefix)
 
     # Add ad-hoc signatures to patched macho files when on macOS.

--- a/lib/spack/spack/relocate.py
+++ b/lib/spack/spack/relocate.py
@@ -295,6 +295,10 @@ def is_macho_magic(magic: bytes) -> bool:
     )
 
 
+def is_static_library_magic(magic: bytes) -> bool:
+    return magic.startswith(b"!<arch>\n")
+
+
 def is_elf_magic(magic: bytes) -> bool:
     return magic.startswith(b"\x7fELF")
 

--- a/lib/spack/spack/test/binary_distribution.py
+++ b/lib/spack/spack/test/binary_distribution.py
@@ -535,10 +535,10 @@ def test_static_lib_relocate_if_needed(
     )
 
     relocated_prefix_path = tmp_path / "relocated-install"
-    spec.set_prefix(f"{relocated_prefix_path}")
+    spec.set_prefix(str(relocated_prefix_path))
 
     relocated_prefix_path.mkdir(parents=True)
-    spack.binary_distribution.extract_buildcache_tarball(tgz_path, relocated_prefix_path)
+    spack.binary_distribution.extract_buildcache_tarball(str(tgz_path), str(relocated_prefix_path))
     spack.binary_distribution.relocate_package(spec)
 
     relocated_static_lib_path = spec.prefix.lib.join("static_lib_with_prefix.a")

--- a/lib/spack/spack/test/binary_distribution.py
+++ b/lib/spack/spack/test/binary_distribution.py
@@ -513,6 +513,43 @@ def test_text_relocate_if_needed(
     assert join_path("bin", "secretexe") not in manifest["relocate_textfiles"]
 
 
+def test_static_lib_relocate_if_needed(
+    install_mockery, temporary_store, mock_fetch, tmp_path: pathlib.Path
+):
+    install_cmd("needs-relocation")
+    spec = temporary_store.db.query_one("needs-relocation")
+    orig_prefix = spec.prefix
+    tgz_path = tmp_path / "relocatable.tar.gz"
+    spack.binary_distribution.create_tarball(spec, str(tgz_path))
+
+    # extract the .spack/binary_distribution file
+    with tarfile.open(tgz_path) as tar:
+        entry_name = next(x for x in tar.getnames() if x.endswith(".spack/binary_distribution"))
+        bd_file = tar.extractfile(entry_name)
+        manifest = syaml.load(bd_file)
+
+    assert join_path("lib", "static_lib_with_prefix.a") in manifest["relocate_static_libraries"]
+    assert (
+        join_path("lib", "static_lib_without_prefix.a")
+        not in manifest["relocate_static_libraries"]
+    )
+
+    relocated_prefix_path = tmp_path / "relocated-install"
+    spec.set_prefix(f"{relocated_prefix_path}")
+
+    relocated_prefix_path.mkdir(parents=True)
+    spack.binary_distribution.extract_buildcache_tarball(tgz_path, relocated_prefix_path)
+    spack.binary_distribution.relocate_package(spec)
+
+    relocated_static_lib_path = spec.prefix.lib.join("static_lib_with_prefix.a")
+    with open(str(relocated_static_lib_path), "rb") as f:
+        binary_content = f.read()
+
+    assert binary_content.startswith(b"!<arch>\n")
+    assert spec.prefix.encode("utf-8") in binary_content
+    assert orig_prefix.encode("utf-8") not in binary_content
+
+
 def test_compression_writer(tmp_path: pathlib.Path):
     text = "This is some text. We might or might not like to compress it as we write."
     checksum_algo = "sha256"
@@ -831,6 +868,7 @@ def test_tarball_doesnt_include_buildinfo_twice(tmp_path: Path):
             "relocate_binaries": [],
             "relocate_textfiles": [],
             "relocate_links": [],
+            "relocate_static_libraries": [],
         }
         assert tar.getnames() == [
             *_all_parents(expected_prefix),

--- a/var/spack/test_repos/spack_repo/builtin_mock/packages/needs_relocation/package.py
+++ b/var/spack/test_repos/spack_repo/builtin_mock/packages/needs_relocation/package.py
@@ -28,3 +28,13 @@ class NeedsRelocation(Package):
         with open(exe, "w", encoding="utf-8") as f:
             f.write(prefix)
         set_executable(exe)
+
+        mkdirp(prefix.lib)
+
+        static_lib_with_prefix = join_path(prefix.lib, "static_lib_with_prefix.a")
+        with open(static_lib_with_prefix, "wb") as f:
+            f.write(f"!<arch>\n{prefix}".encode("utf-8"))
+
+        static_lib_without_prefix = join_path(prefix.lib, "static_lib_without_prefix.a")
+        with open(static_lib_without_prefix, "wb") as f:
+            f.write(b"!<arch>\nnothing_to_relocate")


### PR DESCRIPTION
Shared libraries were already recognized as ELF binaries, but static would be detected as an unknown file type before.