### PR TITLE
docs: build from Spack-installed packages without external inkscape

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -4,7 +4,7 @@ build:
   os: "ubuntu-24.04"
   apt_packages:
     - graphviz
-    - inkscape
+    - librsvg2-bin  # provides rsvg-convert for sphinxcontrib.rsvgconverter
     - xindy
   tools:
     python: "3.14"

--- a/lib/spack/docs/conf.py
+++ b/lib/spack/docs/conf.py
@@ -275,7 +275,7 @@ extensions = [
     "sphinx_copybutton",
     "sphinx_last_updated_by_git",
     "sphinx_sitemap",
-    "sphinxcontrib.inkscapeconverter",
+    "sphinxcontrib.rsvgconverter",
     "sphinxcontrib.programoutput",
 ]
 

--- a/lib/spack/docs/spack.yaml
+++ b/lib/spack/docs/spack.yaml
@@ -13,19 +13,29 @@
 #
 spack:
   specs:
-  # Sphinx
-  - "py-sphinx@3.4:4.1.1,4.1.3:"
-  - py-sphinxcontrib-programoutput
-  - py-docutils@:0.16
-  - py-sphinx-design
-  - py-sphinx-rtd-theme
-  - py-pygments@:2.12
+  # Sphinx and the HTML theme
+  - py-sphinx
+  - py-furo
 
-  # VCS
+  # Sphinx extensions enabled in conf.py
+  - py-sphinx-copybutton
+  - py-sphinx-last-updated-by-git
+  - py-sphinx-sitemap
+  - py-sphinxcontrib-programoutput
+  - py-sphinxcontrib-svg2pdfconverter
+
+  # Supporting libraries
+  - py-docutils
+  - py-pygments
+
+  # git is required by sphinx-last-updated-by-git
   - git
-  - mercurial
-  - subversion
-  # Plotting
+  # graphviz provides `dot` for sphinx.ext.graphviz
   - graphviz
+  # librsvg provides the rsvg-convert binary used by
+  # sphinxcontrib.rsvgconverter to convert SVG -> PDF for the PDF build.
+  # rsvg renders the docs' SVGs faithfully; cairosvg mis-renders fonts
+  # (e.g. it drops the monospace/bold styling in the spec-syntax figure).
+  - librsvg
   concretizer:
     unify: true


### PR DESCRIPTION
Update the docs build so it can be produced entirely from Spack-installed packages, and drop the external inkscape dependency.

Needs https://github.com/spack/spack-packages/pull/5341 before this can be used locally, but CI currently uses pip so this can be merged in any order.

* `spack.yaml` refreshes the environment to match `conf.py`
* `conf.py` uses `sphinxcontrib.rsvgconverter` instead of `sphinxcontrib.inkscapeconverter`
* `requirements.txt` installs `sphinxcontrib-svg2pdfconverter`
* `.readthedocs.yml`: replace `inkscape` apt package with `librsvg2-bin`, which provides `rsvg-convert`, which a pip-installed `sphinxcontrib-svg2pdfconverter` can use.

I generated all the PDFs with `rsvg`, and it renders the docs' SVGs accurately.  Tried and compared `cairosvg`, but it still did not render properly -- still has the fonts problem identified in #51358. 