### PR TITLE
graph.py: drop compiler, use flags for hashes

### DIFF
--- a/lib/spack/spack/cmd/graph.py
+++ b/lib/spack/spack/cmd/graph.py
@@ -51,7 +51,7 @@ in the lockfile.
         "-i", "--installed", action="store_true", help="graph specs from the DB"
     )
 
-    arguments.add_common_arguments(subparser, ["deptype", "specs"])
+    arguments.add_common_arguments(subparser, ["deptype", "long", "very_long", "specs"])
 
 
 def graph(parser, args):
@@ -86,9 +86,16 @@ def graph(parser, args):
         return
 
     if args.dot:
-        builder = SimpleDAG()
+        if args.very_long:
+            node_label_fmt = "{name}{@version}{/hash}"
+        elif args.long:
+            node_label_fmt = "{name}{@version}{/hash:7}"
+        else:
+            node_label_fmt = "{name}{@version}"
         if args.color:
-            builder = DAGWithDependencyTypes()
+            builder = DAGWithDependencyTypes(node_label_fmt)
+        else:
+            builder = SimpleDAG(node_label_fmt)
         graph_dot(specs, builder=builder, depflag=args.deptype)
         return
 

--- a/lib/spack/spack/graph.py
+++ b/lib/spack/spack/graph.py
@@ -480,7 +480,7 @@ class SimpleDAG(DotGraphBuilder):
     """Simple DOT graph, with nodes colored uniformly and edges without properties"""
 
     def node_entry(self, node):
-        format_option = "{name}{@version}{/hash:7}{%compiler}"
+        format_option = "{name}{@version}{/hash:7}"
         return node.dag_hash(), f'[label="{node.format(format_option)}"]'
 
     def edge_entry(self, edge):
@@ -513,7 +513,7 @@ class DAGWithDependencyTypes(DotGraphBuilder):
         super().visit(edge)
 
     def node_entry(self, node):
-        node_str = node.format("{name}{@version}{/hash:7}{%compiler}")
+        node_str = node.format("{name}{@version}{/hash:7}")
         options = f'[label="{node_str}", group="build_dependencies", fillcolor="coral"]'
         if node.dag_hash() in self.main_unified_space:
             options = f'[label="{node_str}", group="main_psid"]'

--- a/lib/spack/spack/graph.py
+++ b/lib/spack/spack/graph.py
@@ -439,10 +439,15 @@ def graph_ascii(
     graph.write(spec, color=color, out=out)
 
 
+#: default spec format for DOT node labels
+DEFAULT_NODE_LABEL_FMT = "{name}{@version}"
+
+
 class DotGraphBuilder:
     """Visit edges of a graph a build DOT options for nodes and edges"""
 
-    def __init__(self):
+    def __init__(self, node_label_fmt: str = DEFAULT_NODE_LABEL_FMT):
+        self.node_label_fmt = node_label_fmt
         self.nodes: Set[Tuple[str, str]] = set()
         self.edges: Set[Tuple[str, str, str]] = set()
 
@@ -480,8 +485,7 @@ class SimpleDAG(DotGraphBuilder):
     """Simple DOT graph, with nodes colored uniformly and edges without properties"""
 
     def node_entry(self, node):
-        format_option = "{name}{@version}{/hash:7}"
-        return node.dag_hash(), f'[label="{node.format(format_option)}"]'
+        return node.dag_hash(), f'[label="{node.format(self.node_label_fmt)}"]'
 
     def edge_entry(self, edge):
         return edge.parent.dag_hash(), edge.spec.dag_hash(), None
@@ -502,8 +506,8 @@ class DAGWithDependencyTypes(DotGraphBuilder):
     the dependency types.
     """
 
-    def __init__(self):
-        super().__init__()
+    def __init__(self, node_label_fmt: str = DEFAULT_NODE_LABEL_FMT):
+        super().__init__(node_label_fmt)
         self.main_unified_space: Set[str] = set()
 
     def visit(self, edge):
@@ -513,7 +517,7 @@ class DAGWithDependencyTypes(DotGraphBuilder):
         super().visit(edge)
 
     def node_entry(self, node):
-        node_str = node.format("{name}{@version}{/hash:7}")
+        node_str = node.format(self.node_label_fmt)
         options = f'[label="{node_str}", group="build_dependencies", fillcolor="coral"]'
         if node.dag_hash() in self.main_unified_space:
             options = f'[label="{node_str}", group="main_psid"]'

--- a/lib/spack/spack/test/cmd/graph.py
+++ b/lib/spack/spack/test/cmd/graph.py
@@ -4,6 +4,7 @@
 
 import pytest
 
+import spack.concretize
 from spack.main import SpackCommand, SpackCommandError
 
 graph = SpackCommand("graph")
@@ -21,6 +22,25 @@ def test_graph_ascii():
 def test_graph_dot():
     """Tests spack graph --dot"""
     graph("--dot", "dt-diamond")
+
+
+@pytest.mark.db
+@pytest.mark.usefixtures("mock_packages", "database")
+def test_graph_dot_hashes():
+    """Tests that --long/--very-long control the hash in --dot node labels"""
+    spec = spack.concretize.concretize_one("dt-diamond")
+    no_hash = f'label="{spec.format("{name}{@version}")}"'
+    short_hash = f'label="{spec.format("{name}{@version}{/hash:7}")}"'
+    full_hash = f'label="{spec.format("{name}{@version}{/hash}")}"'
+
+    none = graph("--dot", "dt-diamond")
+    assert no_hash in none and short_hash not in none
+
+    short = graph("--dot", "--long", "dt-diamond")
+    assert short_hash in short and full_hash not in short
+
+    full = graph("--dot", "--very-long", "dt-diamond")
+    assert full_hash in full
 
 
 @pytest.mark.db

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -1340,7 +1340,7 @@ _spack_gpg_sign() {
 _spack_graph() {
     if $list_options
     then
-        SPACK_COMPREPLY="-h --help -a --ascii -d --dot -s --static -c --color -i --installed --deptype"
+        SPACK_COMPREPLY="-h --help -a --ascii -d --dot -s --static -c --color -i --installed --deptype -l --long -L --very-long"
     else
         _all_packages
     fi

--- a/share/spack/spack-completion.fish
+++ b/share/spack/spack-completion.fish
@@ -2071,7 +2071,7 @@ complete -c spack -n '__fish_spack_using_command gpg sign' -l clearsign -f -a cl
 complete -c spack -n '__fish_spack_using_command gpg sign' -l clearsign -d 'if specified, create a clearsign signature'
 
 # spack graph
-set -g __fish_spack_optspecs_spack_graph h/help a/ascii d/dot s/static c/color i/installed deptype=
+set -g __fish_spack_optspecs_spack_graph h/help a/ascii d/dot s/static c/color i/installed deptype= l/long L/very-long
 complete -c spack -n '__fish_spack_using_command_pos_remainder 0 graph' -f -k -a '(__fish_spack_specs_or_id)'
 complete -c spack -n '__fish_spack_using_command graph' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command graph' -s h -l help -d 'show this help message and exit'
@@ -2087,6 +2087,10 @@ complete -c spack -n '__fish_spack_using_command graph' -s i -l installed -f -a 
 complete -c spack -n '__fish_spack_using_command graph' -s i -l installed -d 'graph specs from the DB'
 complete -c spack -n '__fish_spack_using_command graph' -l deptype -r -f -a deptype
 complete -c spack -n '__fish_spack_using_command graph' -l deptype -r -d 'comma-separated list of deptypes to traverse (default=build,link,run,test)'
+complete -c spack -n '__fish_spack_using_command graph' -s l -l long -f -a long
+complete -c spack -n '__fish_spack_using_command graph' -s l -l long -d 'show dependency hashes as well as versions'
+complete -c spack -n '__fish_spack_using_command graph' -s L -l very-long -f -a very_long
+complete -c spack -n '__fish_spack_using_command graph' -s L -l very-long -d 'show full dependency hashes as well as versions'
 
 # spack help
 set -g __fish_spack_optspecs_spack_help h/help a/all spec


### PR DESCRIPTION
This reduces the verbosity of the nodes produced by `spack graph --dot`.

* `{%compiler}` is redundant because the compiler has its own node
* add `-l/--long`, `-L/--very-long` flags for hash, default to no hash

That way `spack graph --dot pkg | tred` looks readable (even better with `rankdir = "LR"`)

