### PR TITLE
Option to skip pushing keys to build cache

### DIFF
--- a/lib/spack/docs/pipelines.rst
+++ b/lib/spack/docs/pipelines.rst
@@ -717,3 +717,11 @@ The default option is ``append`` because that is what is used by the Spack build
 
    Using the ``append`` option with build cache index views is a non-atomic operation.
    It is up to the CI maintainer to ensure that concurrent writes to the build cache are handled appropriately.
+
+``SPACK_CI_BUILDCACHE_UPLOAD_KEY``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Optional.
+Configure the key push behavior for pipelines that sign binaries.
+If set to ``NO``/``N``/``FALSE``/``0`` (case insensitive) the signing key used by the build job will not be uploaded to the build cache.
+Any other values, including unset, will push the key used for signing to the build cache along with the built binary for the build job.

--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -1092,10 +1092,12 @@ class URLUploader(Uploader):
         force: bool,
         update_index: bool,
         signing_key: Optional[str],
+        upload_key: bool = True,
     ) -> None:
         super().__init__(mirror, force, update_index)
         self.url = mirror.push_url
         self.signing_key = signing_key
+        self.upload_key = upload_key
 
     def push(
         self, specs: List[spack.spec.Spec]
@@ -1106,6 +1108,7 @@ class URLUploader(Uploader):
             force=self.force,
             update_index=self.update_index,
             signing_key=self.signing_key,
+            upload_key=self.upload_key,
             tmpdir=self.tmpdir,
             executor=self.executor,
         )
@@ -1116,6 +1119,7 @@ def make_uploader(
     force: bool = False,
     update_index: bool = False,
     signing_key: Optional[str] = None,
+    upload_key: bool = True,
     base_image: Optional[str] = None,
 ) -> Uploader:
     """Builder for the appropriate uploader based on the mirror type"""
@@ -1125,7 +1129,7 @@ def make_uploader(
         )
     else:
         return URLUploader(
-            mirror=mirror, force=force, update_index=update_index, signing_key=signing_key
+            mirror=mirror, force=force, update_index=update_index, signing_key=signing_key, upload_key=upload_key
         )
 
 
@@ -1174,6 +1178,7 @@ def _url_push(
     specs: List[spack.spec.Spec],
     out_url: str,
     signing_key: Optional[str],
+    upload_key: bool,
     force: bool,
     update_index: bool,
     tmpdir: str,
@@ -1249,7 +1254,7 @@ def _url_push(
     cache_class = get_url_buildcache_class(layout_version=CURRENT_BUILD_CACHE_LAYOUT_VERSION)
     cache_class.maybe_push_layout_json(out_url)
 
-    if signing_key:
+    if upload_key and signing_key:
         keys_tmpdir = os.path.join(tmpdir, "keys")
         os.mkdir(keys_tmpdir)
         _url_push_keys(out_url, keys=[signing_key], update_index=update_index, tmpdir=keys_tmpdir)

--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -1129,7 +1129,11 @@ def make_uploader(
         )
     else:
         return URLUploader(
-            mirror=mirror, force=force, update_index=update_index, signing_key=signing_key, upload_key=upload_key
+            mirror=mirror,
+            force=force,
+            update_index=update_index,
+            signing_key=signing_key,
+            upload_key=upload_key,
         )
 
 

--- a/lib/spack/spack/ci/__init__.py
+++ b/lib/spack/spack/ci/__init__.py
@@ -618,7 +618,7 @@ def push_to_build_cache(spec: spack.spec.Spec, mirror_url: str, sign_binaries: b
         sign_binaries: If True, spack will attempt to sign binary package before pushing.
     """
     upload_key = os.environ.get("SPACK_CI_BUILDCACHE_UPLOAD_KEY", True)
-    upload_key= str(upload_key).lower() in ("false", "no", "n", "0")
+    upload_key = str(upload_key).lower() not in ("false", "no", "n", "0")
 
     tty.debug(f"Pushing to build cache ({'signed' if sign_binaries else 'unsigned'})")
     signing_key = spack.binary_distribution.select_signing_key() if sign_binaries else None

--- a/lib/spack/spack/ci/__init__.py
+++ b/lib/spack/spack/ci/__init__.py
@@ -617,11 +617,16 @@ def push_to_build_cache(spec: spack.spec.Spec, mirror_url: str, sign_binaries: b
         mirror_url: URL of target mirror
         sign_binaries: If True, spack will attempt to sign binary package before pushing.
     """
+    upload_key = os.environ.get("SPACK_CI_BUILDCACHE_UPLOAD_KEY", True)
+    upload_key= str(upload_key).lower() in ("false", "no", "n", "0")
+
     tty.debug(f"Pushing to build cache ({'signed' if sign_binaries else 'unsigned'})")
     signing_key = spack.binary_distribution.select_signing_key() if sign_binaries else None
     mirror = spack.mirrors.mirror.Mirror.from_url(mirror_url)
     try:
-        with spack.binary_distribution.make_uploader(mirror, signing_key=signing_key) as uploader:
+        with spack.binary_distribution.make_uploader(
+            mirror, signing_key=signing_key, upload_key=upload_key
+        ) as uploader:
             uploader.push_or_raise([spec])
         return True
     except spack.binary_distribution.PushToBuildCacheError as e:

--- a/lib/spack/spack/cmd/buildcache.py
+++ b/lib/spack/spack/cmd/buildcache.py
@@ -85,6 +85,13 @@ def setup_parser(subparser: argparse.ArgumentParser):
         "--key", "-k", metavar="key", type=str, default=None, help="key for signing"
     )
     push.add_argument(
+        "--no-upload-key",
+        action="store_false",
+        default=True,
+        dest="upload_key",
+        help="Don't upload the public part of the signing to to the build cache",
+    )
+    push.add_argument(
         "mirror", type=arguments.mirror_name_or_url, help="mirror name, path, or URL"
     )
     push.add_argument(
@@ -574,6 +581,7 @@ def push_fn(args):
         force=args.force,
         update_index=args.update_index,
         signing_key=signing_key,
+        upload_key=args.upload_key,
         base_image=args.base_image,
     ) as uploader:
         skipped, upload_errors = uploader.push(specs=specs)

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -566,7 +566,7 @@ _spack_buildcache() {
 _spack_buildcache_push() {
     if $list_options
     then
-        SPACK_COMPREPLY="-h --help -f --force --unsigned -u --signed --key -k --update-index --rebuild-index --only --with-build-dependencies --without-build-dependencies --fail-fast --allow-missing --base-image --tag -t --private --group -j --jobs"
+        SPACK_COMPREPLY="-h --help -f --force --unsigned -u --signed --key -k --no-upload-key --update-index --rebuild-index --only --with-build-dependencies --without-build-dependencies --fail-fast --allow-missing --base-image --tag -t --private --group -j --jobs"
     else
         _mirrors
     fi
@@ -575,7 +575,7 @@ _spack_buildcache_push() {
 _spack_buildcache_create() {
     if $list_options
     then
-        SPACK_COMPREPLY="-h --help -f --force --unsigned -u --signed --key -k --update-index --rebuild-index --only --with-build-dependencies --without-build-dependencies --fail-fast --allow-missing --base-image --tag -t --private --group -j --jobs"
+        SPACK_COMPREPLY="-h --help -f --force --unsigned -u --signed --key -k --no-upload-key --update-index --rebuild-index --only --with-build-dependencies --without-build-dependencies --fail-fast --allow-missing --base-image --tag -t --private --group -j --jobs"
     else
         _mirrors
     fi

--- a/share/spack/spack-completion.fish
+++ b/share/spack/spack-completion.fish
@@ -703,7 +703,7 @@ complete -c spack -n '__fish_spack_using_command buildcache' -s h -l help -f -a 
 complete -c spack -n '__fish_spack_using_command buildcache' -s h -l help -d 'show this help message and exit'
 
 # spack buildcache push
-set -g __fish_spack_optspecs_spack_buildcache_push h/help f/force u/unsigned signed k/key= update-index only= with-build-dependencies without-build-dependencies fail-fast allow-missing base-image= t/tag= private group= j/jobs=
+set -g __fish_spack_optspecs_spack_buildcache_push h/help f/force u/unsigned signed k/key= no-upload-key update-index only= with-build-dependencies without-build-dependencies fail-fast allow-missing base-image= t/tag= private group= j/jobs=
 complete -c spack -n '__fish_spack_using_command_pos_remainder 1 buildcache push' -f -k -a '(__fish_spack_specs)'
 complete -c spack -n '__fish_spack_using_command buildcache push' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command buildcache push' -s h -l help -d 'show this help message and exit'
@@ -715,6 +715,8 @@ complete -c spack -n '__fish_spack_using_command buildcache push' -l signed -f -
 complete -c spack -n '__fish_spack_using_command buildcache push' -l signed -d 'push signed buildcache tarballs'
 complete -c spack -n '__fish_spack_using_command buildcache push' -l key -s k -r -f -a key
 complete -c spack -n '__fish_spack_using_command buildcache push' -l key -s k -r -d 'key for signing'
+complete -c spack -n '__fish_spack_using_command buildcache push' -l no-upload-key -f -a upload_key
+complete -c spack -n '__fish_spack_using_command buildcache push' -l no-upload-key -d 'Don'"'"'t upload the public part of the signing to to the build cache'
 complete -c spack -n '__fish_spack_using_command buildcache push' -l update-index -l rebuild-index -f -a update_index
 complete -c spack -n '__fish_spack_using_command buildcache push' -l update-index -l rebuild-index -d 'regenerate buildcache index after building package(s)'
 complete -c spack -n '__fish_spack_using_command buildcache push' -l only -r -f -a 'package dependencies'
@@ -739,7 +741,7 @@ complete -c spack -n '__fish_spack_using_command buildcache push' -s j -l jobs -
 complete -c spack -n '__fish_spack_using_command buildcache push' -s j -l jobs -r -d 'explicitly set number of parallel jobs'
 
 # spack buildcache create
-set -g __fish_spack_optspecs_spack_buildcache_create h/help f/force u/unsigned signed k/key= update-index only= with-build-dependencies without-build-dependencies fail-fast allow-missing base-image= t/tag= private group= j/jobs=
+set -g __fish_spack_optspecs_spack_buildcache_create h/help f/force u/unsigned signed k/key= no-upload-key update-index only= with-build-dependencies without-build-dependencies fail-fast allow-missing base-image= t/tag= private group= j/jobs=
 complete -c spack -n '__fish_spack_using_command_pos_remainder 1 buildcache create' -f -k -a '(__fish_spack_specs)'
 complete -c spack -n '__fish_spack_using_command buildcache create' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command buildcache create' -s h -l help -d 'show this help message and exit'
@@ -751,6 +753,8 @@ complete -c spack -n '__fish_spack_using_command buildcache create' -l signed -f
 complete -c spack -n '__fish_spack_using_command buildcache create' -l signed -d 'push signed buildcache tarballs'
 complete -c spack -n '__fish_spack_using_command buildcache create' -l key -s k -r -f -a key
 complete -c spack -n '__fish_spack_using_command buildcache create' -l key -s k -r -d 'key for signing'
+complete -c spack -n '__fish_spack_using_command buildcache create' -l no-upload-key -f -a upload_key
+complete -c spack -n '__fish_spack_using_command buildcache create' -l no-upload-key -d 'Don'"'"'t upload the public part of the signing to to the build cache'
 complete -c spack -n '__fish_spack_using_command buildcache create' -l update-index -l rebuild-index -f -a update_index
 complete -c spack -n '__fish_spack_using_command buildcache create' -l update-index -l rebuild-index -d 'regenerate buildcache index after building package(s)'
 complete -c spack -n '__fish_spack_using_command buildcache create' -l only -r -f -a 'package dependencies'


### PR DESCRIPTION
By default `spack buildcache push --signed` will also upload the signing
key used to sign the binaries. This behavior makes sense for most use
cases. However, this can lead to polluted key rings where the key used on
the build node is meant to be an intermediate key for passing binaries
between builder nodes, not for use by build cache consumers.

The intermediate key workflow used by the `spack ci` commands/infrastructure
is one of these cases. As a result intermediate keys are pushed to the protected mirrors
requiring manual removal of intermediate keys for releases. This PR adds
the ability to only push signed binaries, and excluded signing keys, to avoid spilling internal
details into the public cache.