### PR TITLE
print a better error message when signature check fails when using `spack install --cache-only`

### DIFF
--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -106,6 +106,7 @@ from .url_buildcache import (
     InvalidMetadataFile,
     ListMirrorSpecsError,
     MirrorMetadata,
+    NoVerifyException,
     URLBuildcacheEntry,
     get_entries_from_cache,
     get_url_buildcache_class,
@@ -1833,6 +1834,14 @@ def download_tarball(
 
             try:
                 cache_entry.fetch_archive()
+            except NoVerifyException as e:
+                tty.error(
+                    f"Failed to verify signature for binary package "
+                    f"{spec.name}/{spec.dag_hash()[:7]} from {fetch_url} "
+                    f"(v{layout_version}): {e}"
+                )
+                cache_entry.destroy()
+                continue
             except Exception as e:
                 tty.debug(
                     f"Encountered error attempting to fetch archive for "

--- a/lib/spack/spack/test/binary_distribution.py
+++ b/lib/spack/spack/test/binary_distribution.py
@@ -192,6 +192,45 @@ def test_built_spec_cache(install_mockery, tmp_path: pathlib.Path):
         assert results[0].url == url_util.path_to_file_url(str(tmp_path))
 
 
+def test_download_tarball_reports_signature_verification_failure(
+    monkeypatch, mock_packages, capfd
+):
+    spec = spack.concretize.concretize_one("corge")
+    mirror_url = "file:///test-mirror"
+
+    class MockMirror:
+        fetch_url = mirror_url
+        fetch_view = None
+        signed = True
+        supported_layout_versions = [3]
+
+    class MockCacheEntry:
+        def __init__(self, url, spec, allow_unsigned=False):
+            self.url = url
+            assert allow_unsigned is False
+
+        def fetch_archive(self):
+            raise spack.url_buildcache.NoVerifyException("Signature could not be verified")
+
+        def destroy(self):
+            pass
+
+    monkeypatch.setattr(
+        spack.mirrors.mirror, "MirrorCollection", lambda binary=True: {"test": MockMirror()}
+    )
+    monkeypatch.setattr(
+        spack.binary_distribution,
+        "get_url_buildcache_class",
+        lambda layout_version: MockCacheEntry,
+    )
+
+    assert spack.binary_distribution.download_tarball(spec, unsigned=None) is None
+
+    output = capfd.readouterr().err
+    assert "Failed to verify signature for binary package corge/" in output
+    assert "Signature could not be verified" in output
+
+
 def fake_dag_hash(spec, length=None):
     # Generate an arbitrary hash that is intended to be different than
     # whatever a Spec reported before (to test actions that trigger when

--- a/lib/spack/spack/test/binary_distribution.py
+++ b/lib/spack/spack/test/binary_distribution.py
@@ -204,6 +204,10 @@ def test_download_tarball_reports_signature_verification_failure(
         signed = True
         supported_layout_versions = [3]
 
+        def matches_binary(self, spec, direction):
+            assert direction == "fetch"
+            return True
+
     class MockCacheEntry:
         def __init__(self, url, spec, allow_unsigned=False):
             self.url = url


### PR DESCRIPTION
Currently, if you do `spack install --cache-only <spec>` and the spec is in the binary cache but the signature check fails, you will only receive the generic error `spack.error.InstallError: No binary available for <spec>`. This PR catches the signature check exception and logs a clear error message. 

CC @tdrwenski 