### PR TITLE
(mock compiler_wrapper) sync `SPACK_DEBUG_PREFIX_MAP` with production recipe

### DIFF
--- a/var/spack/test_repos/spack_repo/builtin_mock/packages/compiler_wrapper/package.py
+++ b/var/spack/test_repos/spack_repo/builtin_mock/packages/compiler_wrapper/package.py
@@ -234,6 +234,16 @@ class CompilerWrapper(Package):
             extra_rpaths = lang.dedupe(extra_rpaths)
             env.set("SPACK_COMPILER_EXTRA_RPATHS", ":".join(extra_rpaths))
 
+        # Set SPACK_DEBUG_PREFIX_MAP to the staging path
+        # Develop packages are excluded
+        if not dependent_spec.variants.get("dev_path"):
+            try:
+                staging_src = dependent_spec.package.stage.source_path
+                env.set("SPACK_DEBUG_PREFIX_MAP", staging_src)
+            except Exception:
+                # Stage not yet set up
+                pass
+
         env.set("SPACK_ENABLE_NEW_DTAGS", self.enable_new_dtags)
         env.set("SPACK_DISABLE_NEW_DTAGS", self.disable_new_dtags)
 


### PR DESCRIPTION
This PR keeps the mock `compiler_wrapper` package used in unit tests in sync with the production recipe updated in the companion PR https://github.com/spack/spack-packages/pull/5353 in  `spack-packages`. In summary, it sets `SPACK_DEBUG_PREFIX_MAP` in `setup_dependent_build_environment` to match the behavior added in the following companion PRs:

- (`compiler-wrapper`) https://github.com/spack/compiler-wrapper/pull/19
- (`spack-packages`) https://github.com/spack/spack-packages/pull/5353

That said, and based on the issue:

- https://github.com/spack/spack/issues/52580

This full `compiler-wrapper`-`spack-packages`-`spack` workflow matches the `-ffile-prefix-map=<staging>=.` injection at compiler-wrapper level suggested by @haampie, @psakievich and @vbrunini, and it is part of the first step (the DWARF remapping) before moving things forward to the source copying at debug time, in accordance with our GSoC project in progress under @wdconinc guidance. 

Note: `spack style` warnings encountered on the script are pre-existing (present before this change) and unrelated to this PR.