### PR TITLE
new_installer.py: exit tee thread w/ control byte

### DIFF
--- a/lib/spack/spack/new_installer.py
+++ b/lib/spack/spack/new_installer.py
@@ -390,7 +390,8 @@ def worker_function(
     run_tests: bool,
     state: IpcChannel,
     parent: IpcChannel,
-    echo_control: IpcChannel,
+    tee_control_r: IpcChannel,
+    tee_control_w: Optional[IpcChannel],
     jobserver_info: Tuple[Optional[str], Any],
     log_path: str,
     global_state: GlobalStateMarshaler,
@@ -415,7 +416,8 @@ def worker_function(
         run_tests: Whether to run install-time tests for this package
         state: Connection to send state updates to
         parent: Connection to send build output to
-        echo_control: Connection to receive echo control messages from
+        tee_control_r: Read end of the control pipe; the parent sends echo on/off here
+        tee_control_w: Write end of the control pipe; used to stop the tee thread on POSIX
         jobserver_info: MAKEFLAGS to set, so that the build process uses the POSIX jobserver, and
             opaque data only to be serialized (e.g. old style jobserver r/w pipes, only to be
             inherited in the build process)
@@ -473,7 +475,7 @@ def worker_function(
     sys.stdin = open(os.devnull, "r", encoding=sys.stdin.encoding)
 
     # Start the tee thread to forward output to the log file and parent process.
-    tee = Tee(echo_control, parent, log_path)
+    tee = Tee(tee_control_r, tee_control_w, parent, log_path)
 
     # Use closedfd=false because of the connection objects. Use line buffering.
     # Replace sys.stdout/stderr AFTER Tee.dup2() so Python creates FileIO (WriteFile) rather
@@ -853,6 +855,7 @@ def start_build(
             state_w_conn,
             output_w_conn,
             control_r_conn,
+            control_w_conn if sys.platform != "win32" else None,
             jobserver_details,
             log_path,
             GlobalStateMarshaler(serialize_env=False),

--- a/lib/spack/spack/new_installer_base.py
+++ b/lib/spack/spack/new_installer_base.py
@@ -31,6 +31,9 @@ else:
 #: Size of the output buffer for child processes
 OUTPUT_BUFFER_SIZE = 32768
 
+#: Control byte that stops the tee thread
+TEE_STOP = b"2"
+
 
 class StdinReader:
     """Non-blocking stdin reading with UTF-8 decoding, on top of a platform-specific function
@@ -219,11 +222,20 @@ class NoopJobServer(JobServerBase):
 
 class Tee(abc.ABC):
     """Emulates ./build 2>&1 | tee build.log. Output is sent to a log file and the parent
-    process (if echoing is enabled). The control socket is used to enable/disable echoing."""
+    process (if echoing is enabled). The control channel is used to enable/disable echoing."""
 
-    def __init__(self, control: IpcChannel, parent: IpcChannel, log_path: str) -> None:
-        self.control = control
+    def __init__(
+        self,
+        control_r: IpcChannel,
+        control_w: Optional[IpcChannel],
+        parent: IpcChannel,
+        log_path: str,
+    ) -> None:
+        # Read end: the parent sends echo on/off here.
+        self.control_r = control_r
         self.parent = parent
+        # Write end, used by tee itself to stop the thread (and by parent to toggle echoing).
+        self.control_w = control_w
         # sys.stdout and sys.stderr may have been replaced with file objects under pytest, so
         # redirect their file descriptors in addition to the original fds 1 and 2.
         fds = {sys.stdout.fileno(), sys.stderr.fileno(), 1, 2}
@@ -251,17 +263,24 @@ class Tee(abc.ABC):
         pass
 
     def close(self) -> None:
-        # Closing stdout and stderr should close the last reference to the write end of the pipe,
-        # causing the tee thread to wake up, flush the last data, and exit. We restore stdout and
-        # stderr, because between sys.exit and the actual process exit buffers may be flushed, and
-        # can cause exit code 120 (witnessed under pytest+coverage on macOS).
+        # We restore stdout and stderr, because between sys.exit and the actual process exit
+        # buffers may be flushed, and can cause exit code 120 (witnessed under pytest+coverage on
+        # macOS).
         sys.stdout.flush()
         sys.stderr.flush()
         for fd, saved_fd in self.saved_fds.items():
             os.dup2(saved_fd, fd)
             os.close(saved_fd)
+        if self.control_w is not None:
+            # Send a control byte to stop the tee thread.
+            try:
+                os.write(self.control_w.fileno(), TEE_STOP)
+            except OSError:
+                pass
         self.tee_thread.join()
         # Only then close the other fds.
-        self.control.close()
+        if self.control_w is not None:
+            self.control_w.close()
+        self.control_r.close()
         self.parent.close()
         self._restore_handles()

--- a/lib/spack/spack/new_installer_posix.py
+++ b/lib/spack/spack/new_installer_posix.py
@@ -25,6 +25,7 @@ import spack.spec
 from spack.llnl.util.tty.log import _is_background_tty, ignore_signal
 from spack.new_installer_base import (
     OUTPUT_BUFFER_SIZE,
+    TEE_STOP,
     BaseTerminalState,
     JobServerBase,
     ProcessExitNotifier,
@@ -193,10 +194,12 @@ class PosixExitNotifier(ProcessExitNotifier):
 class PosixTee(Tee):
     def run(self, log_r: int, log_file: io.BufferedWriter) -> None:
         """Forward log_r to log_file and parent (if echoing is enabled).
-        Echoing is enabled and disabled by reading from control."""
-        control_r = self.control.fileno()
+        Echoing is enabled and disabled by reading 1 and 0 resp. from control.
+        Thread exit is triggered by EOF or by reading TEE_STOP from control."""
+        control_r = self.control_r.fileno()
         parent_w = self.parent.fileno()
         echo_on = False
+        exit = False
         selector = selectors.DefaultSelector()
         selector.register(log_r, selectors.EVENT_READ)
         selector.register(control_r, selectors.EVENT_READ)
@@ -204,7 +207,12 @@ class PosixTee(Tee):
         try:
             with log_file, open(parent_w, "wb", closefd=False) as parent:
                 while True:
-                    for key, _ in selector.select():
+                    # If not done, block until log/control has data. If done, do one more iteration
+                    # to drain the log.
+                    events = selector.select(0 if exit else None)
+                    if exit and not events:
+                        return
+                    for key, _ in events:
                         if key.fd == log_r:
                             data = os.read(log_r, OUTPUT_BUFFER_SIZE)
                             if not data:  # EOF: exit the thread
@@ -217,8 +225,10 @@ class PosixTee(Tee):
 
                         elif key.fd == control_r:
                             control_data = os.read(control_r, 1)
-                            if not control_data:
-                                return
+                            if not control_data or control_data == TEE_STOP:
+                                # EOF or TEE_STOP: exit the thread after draining the log.
+                                selector.unregister(control_r)
+                                exit = True
                             else:
                                 echo_on = control_data == b"1"
         except OSError:  # do not raise

--- a/lib/spack/spack/new_installer_windows.py
+++ b/lib/spack/spack/new_installer_windows.py
@@ -199,7 +199,7 @@ class WindowsTee(Tee):
 
     def run(self, log_r: int, log_file: io.BufferedWriter) -> None:
         _echo = False
-        control_r = cast(socket.socket, self.control)
+        control_r = cast(socket.socket, self.control_r)
         parent_w = cast(socket.socket, self.parent)
 
         def _control_reader() -> None:


### PR DESCRIPTION
Closes #52573.

Fixes a hang of the new installer under forkserver (Python 3.14+ on Linux and
macOS in general)

The Tee thread exits when log pipe's read end hits EOF, which happens
when all fds referring to the write end have been closed. When using
forkserver based multiprocessing, the forkserver daemon process stays
alive and keeps the write end open, resulting in a deadlock.

Instead of relying on EOF, send a `b"2"` byte over the control pipe to
signal it's time to exit.

Independently of this I'd like to get rid of multiprocessing in install_test.py,
which triggered the issue.

