### PR TITLE
config: remove circular dependency with env

### DIFF
--- a/lib/spack/spack/config.py
+++ b/lib/spack/spack/config.py
@@ -44,6 +44,7 @@ from typing import Any, Callable, Dict, Generator, List, Optional, Set, Tuple, U
 
 from spack.vendor import jsonschema
 
+import spack
 import spack.error
 import spack.paths
 import spack.schema
@@ -526,6 +527,11 @@ class Configuration:
     def __init__(self) -> None:
         self.scopes = lang.PriorityOrderedMapping()
         self.updated_scopes_by_section: Dict[str, List[ConfigScope]] = defaultdict(list)
+        # Path of the active environment, used for the "$env" substitution. It is set
+        # when an environment is activated and unset when it is deactivated, so that
+        # substitutions do not need to import spack.environment (avoiding a circular
+        # import).
+        self.env_path: Optional[str] = None
 
     def highest(self) -> ConfigScope:
         """Scope with the highest precedence"""
@@ -2292,10 +2298,6 @@ NOMATCH = object()
 
 # Substitutions to perform
 def replacements():
-    # break circular imports
-    import spack
-    import spack.environment as ev
-
     arch = architecture()
 
     return {
@@ -2312,7 +2314,7 @@ def replacements():
         "target": lambda: arch.target,
         "target_family": lambda: arch.target.family,
         "date": lambda: __import__("datetime").date.today().strftime("%Y-%m-%d"),
-        "env": lambda: ev.active_environment().path if ev.active_environment() else NOMATCH,
+        "env": lambda: CONFIG.env_path if CONFIG.env_path else NOMATCH,
         "spack_short_version": lambda: spack.get_short_version(),
     }
 

--- a/lib/spack/spack/config.py
+++ b/lib/spack/spack/config.py
@@ -2314,7 +2314,7 @@ def replacements():
         "target": lambda: arch.target,
         "target_family": lambda: arch.target.family,
         "date": lambda: __import__("datetime").date.today().strftime("%Y-%m-%d"),
-        "env": lambda: CONFIG.env_path if CONFIG.env_path else NOMATCH,
+        "env": lambda: CONFIG.env_path or NOMATCH,
         "spack_short_version": lambda: spack.get_short_version(),
     }
 

--- a/lib/spack/spack/environment/environment.py
+++ b/lib/spack/spack/environment/environment.py
@@ -236,6 +236,10 @@ def activate(env, use_env_repo=False):
         if not isinstance(env, Environment):
             raise TypeError("`env` should be of type {0}".format(Environment.__name__))
 
+        # Record the env path so config "$env" substitutions work while the manifest's
+        # config scope is being prepared below (and for the lifetime of the activation).
+        spack.config.CONFIG.env_path = env.path
+
         # Check if we need to reinitialize spack.store.STORE and spack.repo.REPO due to
         # config changes.
         install_tree_before = spack.config.get("config:install_tree")
@@ -260,6 +264,7 @@ def activate(env, use_env_repo=False):
         tty.debug(f"Using environment '{env.name}'")
     except Exception:
         _active_environment = None
+        spack.config.CONFIG.env_path = None
         raise
 
 
@@ -287,6 +292,7 @@ def deactivate():
     tty.debug(f"Deactivated environment '{_active_environment.name}'")
 
     _active_environment = None
+    spack.config.CONFIG.env_path = None
 
 
 def active_environment() -> Optional["Environment"]:

--- a/lib/spack/spack/test/config.py
+++ b/lib/spack/spack/test/config.py
@@ -327,11 +327,6 @@ def test_write_list_in_memory(mock_low_high_config):
     assert config == {**repos_high["repos"], **repos_low["repos"]}
 
 
-class MockEnv:
-    def __init__(self, path):
-        self.path = path
-
-
 def test_substitute_config_variables(mock_low_high_config, monkeypatch, tmp_path: pathlib.Path):
     # Test $spack substitution at the start (valid on all platforms)
     assert os.path.join(spack.paths.prefix, "foo", "bar", "baz") == spack.config.canonicalize_path(
@@ -380,7 +375,7 @@ def test_substitute_config_variables(mock_low_high_config, monkeypatch, tmp_path
 
     # Fake an active environment and $env is replaced properly
     fake_env_path = str(tmp_path / "quux" / "quuux")
-    monkeypatch.setattr(ev, "active_environment", lambda: MockEnv(fake_env_path))
+    monkeypatch.setattr(spack.config.CONFIG, "env_path", fake_env_path)
     assert spack.config.canonicalize_path("$env/foo/bar/baz") == os.path.join(
         fake_env_path, os.path.join("foo", "bar", "baz")
     )
@@ -2177,3 +2172,22 @@ def test_canonicalize_file_relative():
     assert spack.config.canonicalize_path("path/to.txt") == os.path.join(
         os.getcwd(), "path", "to.txt"
     )
+
+
+def test_env_substitution_follows_activation(mutable_mock_env_path):
+    """Tests that the "$env" substitution resolves to the active environment's path only while an
+    environment is active, and is a no-op before and after activation.
+    """
+    # Before activation "$env" is a no-op
+    assert spack.config.CONFIG.env_path is None
+    assert spack.config.substitute_path_variables("$env/foo/bar") == "$env/foo/bar"
+
+    env = ev.create("test")
+    with env:
+        # During activation "$env" resolves to the environment's path
+        assert spack.config.CONFIG.env_path == env.path
+        assert spack.config.substitute_path_variables("$env/foo/bar") == f"{env.path}/foo/bar"
+
+    # After deactivation "$env" is a no-op again
+    assert spack.config.CONFIG.env_path is None
+    assert spack.config.substitute_path_variables("$env/foo/bar") == "$env/foo/bar"


### PR DESCRIPTION
Currently, config.py depends on the `active_environment()` for path substitutions, creating a circular dependency between `spack.config` and `spack.environment`.

Here we add an attribute to record the active environment's path on the Configuration object during activation in order to remove the circular dependency.