### PR TITLE
new_installer.py: allow local install if missing upstream

### DIFF
--- a/lib/spack/spack/new_installer.py
+++ b/lib/spack/spack/new_installer.py
@@ -1725,8 +1725,7 @@ class ScheduleResult(NamedTuple):
 def schedule_builds(
     pending: List[str],
     build_graph: BuildGraph,
-    db: spack.database.Database,
-    prefix_locker: spack.database.SpecLocker,
+    store: spack.store.Store,
     overwrite: Set[str],
     overwrite_time: float,
     capacity: int,
@@ -1749,8 +1748,7 @@ def schedule_builds(
     Args:
         pending: List of dag hashes pending installation; modified in-place.
         build_graph: The build dependency graph; used for node lookup and parent enqueueing.
-        db: Package database; used for read lock and installed-status queries.
-        prefix_locker: Per-spec write locker.
+        store: The local store for installs.
         overwrite: Set of dag hashes to overwrite even if already installed.
         overwrite_time: Timestamp (from time.time()) at which the overwrite install was requested.
             A spec in ``overwrite`` whose DB installation_time >= overwrite_time was installed by
@@ -1768,6 +1766,7 @@ def schedule_builds(
     newly_installed: List[Tuple[str, spack.spec.Spec, spack.util.lock.Lock]] = []
     to_mark_explicit: List[MarkExplicitAction] = []
     blocked = True
+    db = store.db
 
     # Acquire the DB read lock non-blocking; hold it throughout the loop so the in-memory snapshot
     # stays consistent while we acquire per-spec prefix locks.
@@ -1779,7 +1778,7 @@ def schedule_builds(
         while capacity and idx < len(pending):
             dag_hash = pending[idx]
             spec = build_graph.nodes[dag_hash]
-            lock = prefix_locker.lock(spec)
+            lock = store.prefix_locker.lock(spec)
 
             if lock.try_acquire_write():
                 blocked = False
@@ -2503,8 +2502,7 @@ class PackageInstaller:
         result = schedule_builds(
             pending=self.pending_builds,
             build_graph=self.build_graph,
-            db=self.db,
-            prefix_locker=spack.store.STORE.prefix_locker,
+            store=spack.store.STORE,  # todo: dependency injection
             overwrite=self.overwrite,
             overwrite_time=self.overwrite_time,
             capacity=self.capacity,

--- a/lib/spack/spack/new_installer.py
+++ b/lib/spack/spack/new_installer.py
@@ -1819,12 +1819,16 @@ def schedule_builds(
                 continue
 
             # Write lock acquired: proceed with scheduling.
-            # Don't schedule builds for specs from upstream databases.
-            if upstream and record and not record.installed:
-                lock.release_write()
-                raise spack.error.InstallError(
-                    f"Cannot install {spec}: it is uninstalled in an upstream database."
-                )
+
+            # Allow local installs of specs that are referenced but uninstalled in an upstream db.
+            # In edge cases where an upstream has forcibly uninstalled just a link dep, we cannot
+            # fix the situation by installing it locally, because dependents in the upstream
+            # reference the missing upstream path. However, we document that users should not
+            # remove installed specs from upstreams, so it's a relatively safe assumption that
+            # missing upstream specs were never installed or garbage collected build deps, and are
+            # not referenced by absolute path in installed dependents.
+            if upstream and record and not record.installed and not spec.external:
+                spec.set_prefix(store.layout.path_for_spec(spec))
 
             # Defensively assert prefix invariants
             if not spec.external:

--- a/lib/spack/spack/test/conftest.py
+++ b/lib/spack/spack/test/conftest.py
@@ -4,6 +4,7 @@
 
 import base64
 import collections
+import contextlib
 import datetime
 import email.message
 import errno
@@ -36,6 +37,7 @@ import spack.compilers.config
 import spack.compilers.libraries
 import spack.concretize
 import spack.config
+import spack.database
 import spack.directives_meta
 import spack.environment as ev
 import spack.error
@@ -1351,6 +1353,55 @@ def gen_mock_layout(tmp_path: Path):
         return MockLayout(str(subroot))
 
     yield create_layout
+
+
+@contextlib.contextmanager
+def writable(database):
+    """Allow a database to be written inside this context manager."""
+    old_lock, old_is_upstream = database.lock, database.is_upstream
+    db_root = Path(database.root)
+
+    try:
+        # this is safe on all platforms during tests (tests get their own tmpdirs)
+        database.lock = spack.util.lock.Lock(str(database._lock_path), enable=False)
+        database.is_upstream = False
+        db_root.chmod(mode=0o755)
+        with database.write_transaction():
+            yield
+    finally:
+        db_root.chmod(mode=0o555)
+        database.lock = old_lock
+        database.is_upstream = old_is_upstream
+
+
+@pytest.fixture()
+def upstream_and_downstream_db(tmp_path: Path, gen_mock_layout):
+    """Fixture for a pair of stores: upstream and downstream.
+
+    Upstream API prohibits writing to an upstream, so we also return a writable version
+    of the upstream DB for tests to use.
+
+    """
+    mock_db_root = tmp_path / "mock_db_root"
+    mock_db_root.mkdir()
+    mock_db_root.chmod(0o555)
+
+    upstream_db = spack.database.Database(
+        str(mock_db_root), is_upstream=True, layout=gen_mock_layout("a")
+    )
+    with writable(upstream_db):
+        upstream_db._write()
+
+    downstream_db_root = tmp_path / "mock_downstream_db_root"
+    downstream_db_root.mkdir()
+    downstream_db_root.chmod(0o755)
+
+    downstream_db = spack.database.Database(
+        str(downstream_db_root), upstream_dbs=[upstream_db], layout=gen_mock_layout("b")
+    )
+    downstream_db._write()
+
+    yield upstream_db, downstream_db
 
 
 class ConfigUpdate:

--- a/lib/spack/spack/test/database.py
+++ b/lib/spack/spack/test/database.py
@@ -3,7 +3,6 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 """Check the database is functioning properly, both in memory and in its file."""
 
-import contextlib
 import datetime
 import functools
 import gzip
@@ -44,59 +43,10 @@ from spack.enums import InstallRecordStatus
 from spack.installer import PackageInstaller
 from spack.llnl.util.tty.colify import colify
 from spack.schema.database_index import schema
-from spack.test.conftest import RepoBuilder
+from spack.test.conftest import RepoBuilder, writable
 from spack.util.executable import Executable
 
 pytestmark = pytest.mark.db
-
-
-@contextlib.contextmanager
-def writable(database):
-    """Allow a database to be written inside this context manager."""
-    old_lock, old_is_upstream = database.lock, database.is_upstream
-    db_root = pathlib.Path(database.root)
-
-    try:
-        # this is safe on all platforms during tests (tests get their own tmpdirs)
-        database.lock = lk.Lock(str(database._lock_path), enable=False)
-        database.is_upstream = False
-        db_root.chmod(mode=0o755)
-        with database.write_transaction():
-            yield
-    finally:
-        db_root.chmod(mode=0o555)
-        database.lock = old_lock
-        database.is_upstream = old_is_upstream
-
-
-@pytest.fixture()
-def upstream_and_downstream_db(tmp_path: pathlib.Path, gen_mock_layout):
-    """Fixture for a pair of stores: upstream and downstream.
-
-    Upstream API prohibits writing to an upstream, so we also return a writable version
-    of the upstream DB for tests to use.
-
-    """
-    mock_db_root = tmp_path / "mock_db_root"
-    mock_db_root.mkdir()
-    mock_db_root.chmod(0o555)
-
-    upstream_db = spack.database.Database(
-        str(mock_db_root), is_upstream=True, layout=gen_mock_layout("a")
-    )
-    with writable(upstream_db):
-        upstream_db._write()
-
-    downstream_db_root = tmp_path / "mock_downstream_db_root"
-    downstream_db_root.mkdir()
-    downstream_db_root.chmod(0o755)
-
-    downstream_db = spack.database.Database(
-        str(downstream_db_root), upstream_dbs=[upstream_db], layout=gen_mock_layout("b")
-    )
-    downstream_db._write()
-
-    yield upstream_db, downstream_db
 
 
 @pytest.mark.parametrize(

--- a/lib/spack/spack/test/new_installer.py
+++ b/lib/spack/spack/test/new_installer.py
@@ -12,7 +12,12 @@ import pytest
 if sys.platform == "win32":
     pytest.skip("No Windows support", allow_module_level=True)
 
+from typing import Tuple
+
+import spack.deptypes as dt
 import spack.spec
+import spack.store
+from spack.database import Database
 from spack.new_installer import (
     OVERWRITE_GARBAGE_SUFFIX,
     BinaryCacheMiss,
@@ -22,7 +27,9 @@ from spack.new_installer import (
     _node_to_roots,
     schedule_builds,
 )
+from spack.new_installer_base import NoopJobServer
 from spack.new_installer_posix import PosixJobServer
+from spack.test.conftest import writable
 from spack.test.traverse import create_dag
 
 
@@ -627,6 +634,53 @@ class TestScheduleBuilds:
             for _, _, lock in result.newly_installed:
                 lock.release_read()
             jobserver.close()
+
+    def test_missing_in_upstream_is_installed_locally(
+        self, upstream_and_downstream_db: Tuple[Database, Database], mock_packages
+    ):
+        """A spec that is referenced but not installed in an upstream database is scheduled for
+        a local build, with its prefix repointed to the local store."""
+        upstream_db, downstream_db = upstream_and_downstream_db
+        dep = self._make_spec("dependency-install")
+        parent = spack.spec.Spec("dependent-install")
+        parent._add_dependency(dep, depflag=dt.BUILD, virtuals=())
+        parent._mark_concrete()
+
+        # Register both specs in the upstream, then uninstall the dep: its record is kept as
+        # uninstalled because the parent still references it.
+        with writable(upstream_db):
+            upstream_db.add(parent, explicit=True)
+            upstream_db.remove(dep)
+
+        # Create a Store for schedule_builds based on the downstream database.
+        local_store = spack.store.Store(downstream_db.root, upstreams=[upstream_db])
+        upstream, record = local_store.db.query_by_spec_hash(dep.dag_hash())
+        assert upstream and record is not None and not record.installed
+
+        # Like BuildGraph, start out with the prefix from the upstream record.
+        assert upstream_db.layout
+        dep.set_prefix(upstream_db.layout.path_for_spec(dep))
+
+        jobserver = NoopJobServer(num_jobs=2)
+        result = schedule_builds(
+            pending=[dep.dag_hash()],
+            build_graph=_FakeBuildGraph([dep]),  # type: ignore[arg-type]
+            store=local_store,
+            overwrite=set(),
+            overwrite_time=0.0,
+            capacity=1,
+            needs_jobserver_token=False,
+            jobserver=jobserver,
+            explicit=set(),
+        )
+        assert not result.blocked
+        assert [dag_hash for dag_hash, _ in result.to_start] == [dep.dag_hash()]
+        # The prefix was repointed from the upstream to the local store.
+        assert dep.prefix == local_store.layout.path_for_spec(dep)
+
+        # Cleanup
+        for _, lock in result.to_start:
+            lock.release_write()
 
 
 def test_nodes_to_roots():

--- a/lib/spack/spack/test/new_installer.py
+++ b/lib/spack/spack/test/new_installer.py
@@ -334,8 +334,7 @@ class TestScheduleBuilds:
             result = schedule_builds(
                 pending,
                 bg,
-                temporary_store.db,
-                temporary_store.prefix_locker,
+                temporary_store,
                 overwrite=set(),
                 overwrite_time=0.0,
                 capacity=1,
@@ -364,8 +363,7 @@ class TestScheduleBuilds:
             result = schedule_builds(
                 pending,
                 bg,
-                temporary_store.db,
-                temporary_store.prefix_locker,
+                temporary_store,
                 overwrite=set(),
                 overwrite_time=0.0,
                 capacity=1,
@@ -394,8 +392,7 @@ class TestScheduleBuilds:
             result = schedule_builds(
                 pending,
                 bg,
-                temporary_store.db,
-                temporary_store.prefix_locker,
+                temporary_store,
                 overwrite=set(),
                 overwrite_time=0.0,
                 capacity=2,
@@ -424,8 +421,7 @@ class TestScheduleBuilds:
             result = schedule_builds(
                 pending,
                 bg,
-                temporary_store.db,
-                temporary_store.prefix_locker,
+                temporary_store,
                 overwrite=set(),
                 overwrite_time=0.0,
                 capacity=2,
@@ -451,8 +447,7 @@ class TestScheduleBuilds:
             result = schedule_builds(
                 pending,
                 bg,
-                temporary_store.db,
-                temporary_store.prefix_locker,
+                temporary_store,
                 overwrite={spec.dag_hash()},
                 overwrite_time=time.time() + 100,
                 capacity=1,
@@ -484,8 +479,7 @@ class TestScheduleBuilds:
             result = schedule_builds(
                 pending,
                 bg,
-                temporary_store.db,
-                temporary_store.prefix_locker,
+                temporary_store,
                 overwrite=set(),
                 overwrite_time=0.0,
                 capacity=2,
@@ -523,8 +517,7 @@ class TestScheduleBuilds:
             result = schedule_builds(
                 pending,
                 bg,
-                temporary_store.db,
-                temporary_store.prefix_locker,
+                temporary_store,
                 overwrite=set(),
                 overwrite_time=0.0,
                 capacity=2,
@@ -562,8 +555,7 @@ class TestScheduleBuilds:
             result = schedule_builds(
                 pending,
                 bg,
-                temporary_store.db,
-                temporary_store.prefix_locker,
+                temporary_store,
                 overwrite=set(),
                 overwrite_time=0.0,
                 capacity=2,
@@ -589,8 +581,7 @@ class TestScheduleBuilds:
             result = schedule_builds(
                 pending,
                 bg,
-                temporary_store.db,
-                temporary_store.prefix_locker,
+                temporary_store,
                 overwrite={spec.dag_hash()},
                 overwrite_time=0.0,  # earlier than now()
                 capacity=1,
@@ -621,8 +612,7 @@ class TestScheduleBuilds:
             result = schedule_builds(
                 pending,
                 bg,
-                temporary_store.db,
-                temporary_store.prefix_locker,
+                temporary_store,
                 overwrite=set(),
                 overwrite_time=0.0,
                 capacity=1,


### PR DESCRIPTION
Closes #52606
Closes #51969
Closes #51513

The new installer has a strict check that ensures uninstalled specs upstream
cannot be built locally.

In practice, also thanks to the new installer, build dependencies can be
missing in the upstream. Some people use `spack gc`, others prepare the
upstream using `spack install` from a buildcache, which omits build deps by
default.

After some back and forth regarding desired behavior, I think it's partly the
user's responsibility to prevent issues with upstreams, instead of trying to
pedantically prevent them in the installer. So: the installer simply installs
the missing specs locally, and when users manage their upstream correctly this
is unlikely to be problematic.
