### PR TITLE
solver: improve decisions on `build_set_id`

### DIFF
--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -213,6 +213,10 @@ related(NodeA, NodeB) :- attr("closure", NodeA, NodeB, "linkrun").
 % In the "root" unification set only ID = 0 are allowed
 :- unification_set("root", node(ID, _)), ID != 0.
 
+% Build-set IDs are interchangeable labels, so forbid gaps to avoid churn when searching.
+build_set_used(ID) :- build_set_id(_, ID).
+:- build_set_used(ID), ID > 0, not build_set_used(ID-1).
+
 % In the "root" unification set we allow only packages from the link-run possible subDAG
 :- unification_set("root", node(_, Package)), not possible_in_link_run(Package), not virtual(Package).
 

--- a/lib/spack/spack/solver/heuristic.lp
+++ b/lib/spack/spack/solver/heuristic.lp
@@ -13,7 +13,7 @@
 #heuristic attr("version", node(PackageID, Package), Version). [80, level]
 #heuristic attr("variant_value", PackageNode, Variant, Value). [80, level]
 #heuristic attr("node_target", node(PackageID, Package), Target). [80, level]
-#heuristic virtual_on_edge(PackageNode, ProviderNode, Virtual, Type). [80, level]
+#heuristic build_set_id(PackageNode, ID). [80, level]
 
 #heuristic attr("virtual_node", node(X, Virtual)). [600, init]
 #heuristic attr("virtual_node", node(X, Virtual)). [-1, sign]

--- a/lib/spack/spack/solver/heuristic.lp
+++ b/lib/spack/spack/solver/heuristic.lp
@@ -13,6 +13,7 @@
 #heuristic attr("version", node(PackageID, Package), Version). [80, level]
 #heuristic attr("variant_value", PackageNode, Variant, Value). [80, level]
 #heuristic attr("node_target", node(PackageID, Package), Target). [80, level]
+#heuristic virtual_on_edge(PackageNode, ProviderNode, Virtual, Type). [80, level]
 #heuristic build_set_id(PackageNode, ID). [80, level]
 
 #heuristic attr("virtual_node", node(X, Virtual)). [600, init]


### PR DESCRIPTION
The input file [py-hatchet.lp.zip](https://github.com/user-attachments/files/29584567/py-hatchet.lp.zip) is solving very slow ly on 741ddafc339a0b2fde871d29be07d884a4d779a3, and `clingo` stalls trying to prove optimality of the "build unification sets" criterion. 

In this PR we:
- Adapt heuristics so that we decide on `build_set_id` early
- Trim the search space by imposing a no-gap rule on build set ids