### PR TITLE
tests: install --test

### DIFF
--- a/lib/spack/spack/installer.py
+++ b/lib/spack/spack/installer.py
@@ -1353,12 +1353,6 @@ class BuildTask(Task):
         if self.error_result is not None:
             self.fail(self.error_result)
 
-        # hook that allows tests to inspect the Package before installation
-        # see _unit_test_check() docs.
-        if not pkg._unit_test_check():
-            self.succeed()
-            return ExecuteResult.FAILED
-
         try:
             # Check if the task's child process has completed
             spack.package_base.PackageBase._verbose = self.process_handle.complete()

--- a/lib/spack/spack/package_base.py
+++ b/lib/spack/spack/package_base.py
@@ -2045,23 +2045,6 @@ class PackageBase(WindowsRPath, PackageViewMixin, metaclass=PackageMeta):
 
         self.tester.stand_alone_tests(kwargs, timeout=timeout)
 
-    def _unit_test_check(self) -> bool:
-        """Hook for Spack's own unit tests to assert things about package internals.
-
-        Unit tests can override this function to perform checks after
-        ``Package.install`` and all post-install hooks run, but before
-        the database is updated.
-
-        The overridden function may indicate that the install procedure
-        should terminate early (before updating the database) by
-        returning :data:`False` (or any value such that ``bool(result)`` is
-        :data:`False`).
-
-        Return:
-            :data:`True` to continue, :data:`False` to skip ``install()``
-        """
-        return True
-
     @classmethod
     def inject_flags(cls: Type[Pb], name: str, flags: Iterable[str]) -> FLAG_HANDLER_RETURN_TYPE:
         """See :func:`spack.package.inject_flags`."""

--- a/lib/spack/spack/test/cmd/install.py
+++ b/lib/spack/spack/test/cmd/install.py
@@ -73,36 +73,6 @@ def test_install_package_and_dependency(
     assert 'errors="0"' in content
 
 
-def _check_runtests_none(pkg):
-    assert not pkg.run_tests
-
-
-def _check_runtests_dttop(pkg):
-    assert pkg.run_tests == (pkg.name == "dttop")
-
-
-def _check_runtests_all(pkg):
-    assert pkg.run_tests
-
-
-@pytest.mark.disable_clean_stage_check
-def test_install_runtests_notests(monkeypatch, mock_packages, install_mockery):
-    monkeypatch.setattr(spack.package_base.PackageBase, "_unit_test_check", _check_runtests_none)
-    install("-v", "dttop")
-
-
-@pytest.mark.disable_clean_stage_check
-def test_install_runtests_root(monkeypatch, mock_packages, install_mockery):
-    monkeypatch.setattr(spack.package_base.PackageBase, "_unit_test_check", _check_runtests_dttop)
-    install("--test=root", "dttop")
-
-
-@pytest.mark.disable_clean_stage_check
-def test_install_runtests_all(monkeypatch, mock_packages, install_mockery):
-    monkeypatch.setattr(spack.package_base.PackageBase, "_unit_test_check", _check_runtests_all)
-    install("--test=all", "pkg-a")
-
-
 def test_install_package_already_installed(
     tmp_path: pathlib.Path,
     mock_packages,

--- a/lib/spack/spack/test/cmd/install.py
+++ b/lib/spack/spack/test/cmd/install.py
@@ -23,6 +23,7 @@ import spack.environment as ev
 import spack.error
 import spack.hash_types as ht
 import spack.hooks.sbom_generate
+import spack.install_test
 import spack.installer
 import spack.llnl.util.tty as tty
 import spack.package_base
@@ -989,9 +990,11 @@ def test_install_empty_env(
         ("test-install-callbacks", "undefined-install-test"),
     ],
 )
-def test_installation_fail_tests(install_mockery, mock_fetch, name, method):
+def test_installation_fail_tests(install_mockery, mock_fetch, name, method, installer_variant):
     """Confirm build-time tests with unknown methods fail."""
     output = install("--test=root", "--no-cache", name, fail_on_error=False)
+
+    assert install.error is not None
 
     # Check that there is a single test failure reported
     assert output.count("TestFailure: 1 test failed") == 1
@@ -1000,8 +1003,30 @@ def test_installation_fail_tests(install_mockery, mock_fetch, name, method):
     assert output.count(method) == 2
     assert output.count("method not implemented") == 1
 
-    # Check that the path to the test log file is also output
-    assert "See test log for details" in output
+    if installer_variant == "old":
+        # Check that the path to the test log file is also output
+        assert "See test log for details" in output
+
+    # Check that the test log was written to the stage directory
+    pkg = spack.concretize.concretize_one(name).package
+    test_log = pathlib.Path(pkg.stage.path) / spack.install_test.spack_install_test_log
+    assert f"method not implemented [{method}]" in test_log.read_text()
+
+
+@pytest.mark.not_on_windows("Windows logger I/O operation on closed file when install fails")
+@pytest.mark.disable_clean_stage_check
+def test_install_tests_root_vs_all(install_mockery, mock_fetch, installer_variant):
+    """Confirm --test=all runs tests of dependencies and --test=root does not. The dependency
+    test-build-callbacks fails its build-time tests whenever they are run."""
+    output = install(
+        "--test=all", "--no-cache", "dependent-of-test-callbacks", fail_on_error=False
+    )
+    assert install.error is not None
+    assert output.count("TestFailure: 1 test failed") == 1
+    assert not spack.store.STORE.db.query("test-build-callbacks")
+
+    install("--test=root", "--no-cache", "dependent-of-test-callbacks")
+    assert spack.store.STORE.db.query("dependent-of-test-callbacks")
 
 
 # Unit tests should not be affected by the user's managed environments
@@ -1085,7 +1110,7 @@ def test_install_use_buildcache(
 @pytest.mark.not_on_windows("Windows logger I/O operation on closed file when install fails")
 @pytest.mark.regression("34006")
 @pytest.mark.disable_clean_stage_check
-def test_padded_install_runtests_root(install_mockery, mock_fetch):
+def test_padded_install_runtests_root(install_mockery, mock_fetch, installer_variant):
     spack.config.set("config:install_tree:padded_length", 255)
     output = install(
         "--verbose", "--test=root", "--no-cache", "test-build-callbacks", fail_on_error=False

--- a/var/spack/test_repos/spack_repo/builtin_mock/packages/dependent_of_test_callbacks/package.py
+++ b/var/spack/test_repos/spack_repo/builtin_mock/packages/dependent_of_test_callbacks/package.py
@@ -1,0 +1,22 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack_repo.builtin_mock.build_systems.generic import Package
+
+from spack.package import *
+
+
+class DependentOfTestCallbacks(Package):
+    """Package depending on test-build-callbacks, whose build-time tests fail. Used to check
+    that --test=root does not run tests of dependencies, while --test=all does."""
+
+    homepage = "http://www.example.com"
+    url = "http://www.example.com/dependent-of-test-callbacks-1.0.tar.gz"
+
+    version("1.0", md5="0123456789abcdef0123456789abcdef")
+
+    depends_on("test-build-callbacks")
+
+    def install(self, spec, prefix):
+        mkdirp(prefix.bin)


### PR DESCRIPTION
Currently there are no good tests for `spack install --test` which was the
reason that a forkserver related bug went unnoticed.

This removes the old tests that were bad style, and adds new integration tests
that run the real thing.

Depends on #52637, which fixes a failure-lock double release that the new
integration test exposes.