### PR TITLE
database.py: do not expose locks in FailureTracker

### DIFF
--- a/lib/spack/spack/database.py
+++ b/lib/spack/spack/database.py
@@ -460,8 +460,8 @@ class FailureTracker:
         if locked:
             tty.warn(f"Removing failure marking despite lock for {spec.name}")
 
-        succeeded, lock = self.locker.clear(spec)
-        if succeeded and lock is not None:
+        _, lock = self.locker.clear(spec)
+        if lock is not None:
             lock.release_write()
 
         if self.persistent_mark(spec):
@@ -496,7 +496,7 @@ class FailureTracker:
             except OSError as exc:
                 tty.warn(f"Unable to remove failure marking file {fail_mark}: {str(exc)}")
 
-    def mark(self, spec: "spack.spec.Spec") -> lk.Lock:
+    def mark(self, spec: "spack.spec.Spec") -> None:
         """Marks a spec as failing to install.
 
         Args:
@@ -517,10 +517,16 @@ class FailureTracker:
             except lk.LockTimeoutError:
                 # Unlikely that another process failed to install at the same
                 # time but log it anyway.
+                self.locker.clear(spec)
                 tty.debug(f"PID {os.getpid()} failed to mark install failure for {spec.name}")
                 tty.warn(f"Unable to mark {spec.name} as failed.")
 
-        return self.locker.lock(spec)
+    def release(self, spec: "spack.spec.Spec") -> None:
+        """Releases and forgets the write lock taken by :meth:`mark`, keeping the persistent
+        failure mark, so that other processes can clear the failure once this one exits."""
+        _, lock = self.locker.clear(spec)
+        if lock is not None:
+            lock.release_write()
 
     def has_failed(self, spec: "spack.spec.Spec") -> bool:
         """Return True if the spec is marked as failed."""

--- a/lib/spack/spack/installer.py
+++ b/lib/spack/spack/installer.py
@@ -1571,8 +1571,9 @@ class PackageInstaller:
         # Mapping of unique package ids to task
         self.build_tasks: Dict[str, Task] = {}
 
-        # Cache of package locks for failed packages, keyed on package's ids
-        self.failed: Dict[str, Optional[lk.Lock]] = {}
+        # Specs of failed packages, keyed on package's ids; the spec is set only if the
+        # failure was marked in the failure tracker
+        self.failed: Dict[str, Optional[spack.spec.Spec]] = {}
 
         # Cache the PID for distributed build messaging
         self.pid: int = os.getpid()
@@ -1777,12 +1778,12 @@ class PackageInstaller:
         Args:
             pkg_id (str): identifier for the failed package
         """
-        lock = self.failed.get(pkg_id, None)
-        if lock is not None:
+        spec = self.failed.get(pkg_id, None)
+        if spec is not None:
             err = "{0} exception when removing failure tracking for {1}: {2}"
             try:
                 tty.verbose(f"Removing failure mark on {pkg_id}")
-                lock.release_write()
+                spack.store.STORE.failure_tracker.release(spec)
             except Exception as exc:
                 tty.warn(err.format(exc.__class__.__name__, pkg_id, str(exc)))
 
@@ -2177,7 +2178,8 @@ class PackageInstaller:
         err = "" if exc is None else f": {str(exc)}"
         tty.debug(f"Flagging {pkg_id} as failed{err}")
         if mark:
-            self.failed[pkg_id] = spack.store.STORE.failure_tracker.mark(task.pkg.spec)
+            spack.store.STORE.failure_tracker.mark(task.pkg.spec)
+            self.failed[pkg_id] = task.pkg.spec
         else:
             self.failed[pkg_id] = None
         task.status = BuildStatus.FAILED

--- a/lib/spack/spack/test/cmd/install.py
+++ b/lib/spack/spack/test/cmd/install.py
@@ -709,11 +709,9 @@ def test_cache_only_fails(mock_fetch, install_mockery, installer_variant):
         assert "Skipping build of libdwarf" in out
         assert "was not installed" in out
 
-        # Check that failure prefix locks are still cached
-        failed_packages = [
-            pkg_name
-            for dag_hash, pkg_name in spack.store.STORE.failure_tracker.locker.locks.keys()
-        ]
+        # Check that persistent failure markers exist
+        failure_marker_dir = spack.store.STORE.failure_tracker.dir
+        failed_packages = [item.name.split("-")[0] for item in failure_marker_dir.iterdir()]
         assert "libelf" in failed_packages
         assert "libdwarf" in failed_packages
 

--- a/lib/spack/spack/test/database.py
+++ b/lib/spack/spack/test/database.py
@@ -1070,6 +1070,9 @@ def test_mark_failed(mutable_database, monkeypatch, tmp_path: pathlib.Path, capf
         out = str(capfd.readouterr()[1])
         assert "Unable to mark pkg-a as failed" in out
 
+        # the un-acquired lock must not linger in the locker cache
+        assert not spack.store.STORE.failure_tracker.locker.has_lock(s)
+
     spack.store.STORE.failure_tracker.clear_all()
 
 

--- a/lib/spack/spack/test/installer.py
+++ b/lib/spack/spack/test/installer.py
@@ -918,7 +918,7 @@ def test_setup_install_dir_grp(install_mockery, monkeypatch, capfd):
     assert expected_msg in out
 
 
-def test_cleanup_failed_err(install_mockery, tmp_path: pathlib.Path, monkeypatch, capfd):
+def test_cleanup_failed_err(install_mockery, monkeypatch, capfd):
     """Test _cleanup_failed exception path."""
     msg = "Fake release_write exception"
 
@@ -926,17 +926,17 @@ def test_cleanup_failed_err(install_mockery, tmp_path: pathlib.Path, monkeypatch
         raise RuntimeError(msg)
 
     installer = create_installer(["trivial-install-test-package"], {})
+    spec = installer.build_requests[0].pkg.spec
+    spack.store.STORE.failure_tracker.mark(spec)
 
     monkeypatch.setattr(lk.Lock, "release_write", _raise_except)
     pkg_id = "test"
-    with fs.working_dir(str(tmp_path)):
-        lock = lk.Lock("./test", default_timeout=1e-9, desc="test")
-        installer.failed[pkg_id] = lock
+    installer.failed[pkg_id] = spec
 
-        installer._cleanup_failed(pkg_id)
-        out = str(capfd.readouterr()[1])
-        assert "exception when removing failure tracking" in out
-        assert msg in out
+    installer._cleanup_failed(pkg_id)
+    out = str(capfd.readouterr()[1])
+    assert "exception when removing failure tracking" in out
+    assert msg in out
 
 
 def test_update_failed_no_dependent_task(install_mockery):


### PR DESCRIPTION
FailureTracker.mark returned the write lock to PackageInstaller, which
released it in cleanup while the lock object stayed cached in the
tracker's SpecLocker.

A later cleanup of FailureTracker for the same spec in the same process
released the stale lock a second time, which raises an assertion error.

Fix this by keeping the lock private to FailureTracker. This
unfortunately does require minimal changes to the old installer. The
new interface is that the installer communicates with FailureTracker
using Spec instances, instead of directly working with Lock objects.

Also fix a minor issue where FailureTracker would cache a lock even if
it is never acquired in the `mark` code path. This ensures the invariant
is that an instance is only cached if we hold a lock.
