### PR TITLE
Fix warning message construction

### DIFF
--- a/lib/spack/spack/solver/requirements.py
+++ b/lib/spack/spack/solver/requirements.py
@@ -23,7 +23,11 @@ from spack.util.spack_yaml import get_mark_from_yaml_data
 def _mark_str(raw) -> str:
     """Return a 'file:line: ' prefix from the YAML mark on *raw*, or empty string."""
     mark = get_mark_from_yaml_data(raw)
-    return f"{mark.name}:{mark.line + 1}: " if mark else ""
+    if not mark:
+        return ""
+    if mark.line is None:
+        return f"{mark.name}: "
+    return f"{mark.name}:{mark.line + 1}: "
 
 
 def _check_unknown_virtuals_on_edges(raw_strs: List[str], specs: List["spack.spec.Spec"]) -> None:
@@ -428,8 +432,7 @@ class RequirementParser:
             suggestion = spack.util.spack_yaml.dump(data).rstrip()
             suggestions.append(f"{comment}{suggestion}")
         if suggestions:
-            mark = get_mark_from_yaml_data(spec_str)
-            location = f"{mark.name}:{mark.line + 1}: " if mark else ""
+            location = _mark_str(spec_str)
             prefix = (
                 f"{location}'packages: all: {section}: [\"{spec_str}\"]' applies a dependency "
                 f"constraint to all packages"

--- a/lib/spack/spack/test/concretization/requirements.py
+++ b/lib/spack/spack/test/concretization/requirements.py
@@ -21,6 +21,7 @@ import spack.version
 from spack.externals_config import create_external_parser, external_config_with_implicit_externals
 from spack.installer import PackageInstaller
 from spack.solver.asp import InternalConcretizerError, UnsatisfiableSpecError
+from spack.solver.requirements import RequirementParser
 from spack.solver.reuse import spec_filter_from_packages_yaml
 from spack.spec import Spec
 from spack.util.url import path_to_file_url
@@ -1663,3 +1664,24 @@ packages:
     # With clang as compiler, condition does not fire -> default highest version @2.3
     s_clang = spack.concretize.concretize_one("multivalue-variant %clang")
     assert s_clang.satisfies("@2.3 %c=clang"), f"expected @2.3 with clang, got {s_clang.version}"
+
+
+@pytest.mark.regression("52636")
+def test_compiler_in_all_from_internal_scope_warns(mock_packages):
+    """Tests that building a warning on an InternalConfigScope doesn't raise because
+    there's no "line" attribute.
+    """
+    scope = spack.config.InternalConfigScope(
+        "env:groups:libs", {"packages": {"all": {"require": ["%gcc"]}}}
+    )
+    config = spack.config.Configuration()
+    config.push_scope(scope)
+    parser = RequirementParser(config)
+
+    require = config.get("packages:all:require")
+    # The mark on the requirement string has a name but no line number.
+    mark = syaml.get_mark_from_yaml_data(require[0])
+    assert mark is not None and mark.line is None
+
+    with pytest.warns(UserWarning, match="applies a dependency constraint to all packages"):
+        parser._maybe_warn_compiler_in_all(require, "require")


### PR DESCRIPTION
fixes #52636

When the scope is an `InternalConfigScope` there is no `.line`, so use just the scope name.