### PR TITLE
environment: fix a stale error message

### DIFF
--- a/lib/spack/spack/environment/environment.py
+++ b/lib/spack/spack/environment/environment.py
@@ -970,7 +970,7 @@ class ViewDescriptor:
                     f"    {spec_a}, and\n"
                     f"    {spec_b}.\n"
                     "    To resolve this issue:\n"
-                    "        a. use `concretization:unify:true` to ensure there is only one "
+                    "        a. use `concretizer:unify:true` to ensure there is only one "
                     "package per spec in the environment, or\n"
                     "        b. disable views with `view:false`, or\n"
                     "        c. create custom view projections."


### PR DESCRIPTION
refers #52620

In 2023 we had `concretization:unify:true`. Now this option is under the `concretizer` section, so fix the stale message.