### PR TITLE
solver: add missing fact in display.lp

### DIFF
--- a/lib/spack/spack/solver/display.lp
+++ b/lib/spack/spack/solver/display.lp
@@ -48,5 +48,6 @@
 #show trigger_node/3.
 #show imposed_nodes/2.
 #show variant_single_value/2.
+#show has_provider/1.
 
 % debug


### PR DESCRIPTION
#52411 introduced a regression in the error message reporting mechanism, because it's not passing `has_provider/1` to `error_message.lp`