### PR TITLE
solver: better error message when multiple provider compete for a single virtual spot

### DIFF
--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -1136,7 +1136,7 @@ error(100, "Cannot find valid provider for virtual {0}", Virtual)
   :- attr("virtual_node", node(X, Virtual)),
      not has_provider(node(X, Virtual)).
 
-error(100, "Cannot select a single provider for virtual '{0}'", Virtual)
+error(100, "Multiple providers are required for the same '{0}' virtual", Virtual)
   :- attr("virtual_node", node(X, Virtual)),
      2 { provider(P, node(X, Virtual)) }.
 
@@ -1149,7 +1149,7 @@ attr("root", PackageNode) :- attr("virtual_root", VirtualNode), provider(Package
 
 % The provider is selected among the nodes for which the virtual condition holds
 1 { provider(PackageNode, node(X, Virtual)) :
-    attr("node", PackageNode), virtual_condition_holds(PackageNode, Virtual) } 1
+    attr("node", PackageNode), virtual_condition_holds(PackageNode, Virtual) }
   :- attr("virtual_node", node(X, Virtual)).
 
 % The provider provides the virtual if some provider condition holds.

--- a/lib/spack/spack/solver/display.lp
+++ b/lib/spack/spack/solver/display.lp
@@ -48,5 +48,6 @@
 #show trigger_node/3.
 #show imposed_nodes/2.
 #show variant_single_value/2.
+#show has_provider/1.
 
 % debug


### PR DESCRIPTION
fixes #52610

**Before**
```console
$ spack spec caliper +papi %c,cxx,fortran=llvm ^papi %c,cxx,fortran=gcc
==> Error: Spack concretizer internal error. Please submit a bug report at https://github.com/spack/spack and include the command and environment if applicable.
    caliper+papi %c,cxx,fortran=clang ^papi %c,cxx,fortran=gcc is unsatisfiable
```

**After**
```console
$ spack spec caliper +papi %c,cxx,fortran=llvm ^papi %c,cxx,fortran=gcc
==> Error: failed to concretize `caliper+papi %c,cxx,fortran=clang ^papi %c,cxx,fortran=gcc` for the following reasons:
     1. Multiple providers are required for the same 'fortran' virtual
     2. papi cannot have a dependency on fortran
     3. caliper cannot have a dependency on fortran
     4. Only external, or concrete, compilers are allowed for the fortran language
     5. Only external, or concrete, compilers are allowed for the cxx language
     6. Only external, or concrete, compilers are allowed for the c language
```

Not great, but definitely better than before.