### PR TITLE
new_installer.py: enable/add unit tests

### DIFF
--- a/lib/spack/spack/test/installer_build_graph.py
+++ b/lib/spack/spack/test/installer_build_graph.py
@@ -3,13 +3,9 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 """Tests for BuildGraph class in new_installer"""
 
-import sys
 from typing import Dict, List, Tuple, Union
 
 import pytest
-
-if sys.platform == "win32":
-    pytest.skip("Skipping new installer tests on Windows", allow_module_level=True)
 
 import spack.deptypes as dt
 import spack.error

--- a/lib/spack/spack/test/installer_tui.py
+++ b/lib/spack/spack/test/installer_tui.py
@@ -3,18 +3,12 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 """Tests for the TerminalUI terminal UI in new_installer.py"""
 
-import sys
-
-import pytest
-
-if sys.platform == "win32":
-    pytest.skip("No Windows support", allow_module_level=True)
-
-
 import functools
 import io
 import os
 from typing import List, Optional, Tuple
+
+import pytest
 
 import spack.new_installer as inst
 from spack.new_installer import TerminalUI

--- a/lib/spack/spack/test/installer_tui.py
+++ b/lib/spack/spack/test/installer_tui.py
@@ -1070,6 +1070,7 @@ class TestToggle:
         assert "checking for bar... yes\n" in written
         assert "checking for baz...\n" in written
 
+    @pytest.mark.not_on_windows("Padding functionality unsupported on Windows")
     @pytest.mark.parametrize("filter_padding", [True, False])
     def test_print_logs_filters_padding(self, filter_padding):
         """on_log_output strips path-padding placeholders before writing to stdout."""
@@ -1088,6 +1089,7 @@ class TestToggle:
         else:
             assert written == log_output
 
+    @pytest.mark.not_on_windows("Padding functionality unsupported on Windows")
     @pytest.mark.parametrize("filter_padding", [True, False])
     def test_prefix_padding_filter_in_status(self, filter_padding):
         """Test that prefix in status indicator applies padding filter."""

--- a/lib/spack/spack/test/installer_tui.py
+++ b/lib/spack/spack/test/installer_tui.py
@@ -113,7 +113,7 @@ class TestBasicStateManagement:
     """Test basic state management operations"""
 
     def test_on_resize(self):
-        """Test that on_resize sets terminal_size_changed and update() fetches lazily"""
+        """Test that on_resize sets terminal_size_changed and render() fetches lazily"""
         sizes = [os.terminal_size((80, 24))]
         fake_stdout = SimpleTextIOWrapper(tty=True)
         tui = TerminalUI(
@@ -128,12 +128,12 @@ class TestBasicStateManagement:
         assert tui.terminal_size_changed is True
         assert tui.dirty is True
 
-        # The actual size is fetched lazily on the first update()
+        # The actual size is fetched lazily on the first render()
         tui.render()
         assert tui.terminal_size == os.terminal_size((120, 40))
         assert tui.terminal_size_changed is False
 
-    def test_add_build(self):
+    def test_on_build_added(self):
         """Test that on_build_added adds builds correctly"""
         tui, _, _ = create_tui(total=2)
 
@@ -149,7 +149,7 @@ class TestBasicStateManagement:
         assert "pkg2" in tui.builds
         assert tui.builds["pkg2"].explicit is False
 
-    def test_update_state_transitions(self):
+    def test_on_state_changed_transitions(self):
         """Test that on_state_changed transitions states properly"""
         tui, fake_time, _ = create_tui()
         [build_id] = add_mock_builds(tui, 1)
@@ -166,7 +166,7 @@ class TestBasicStateManagement:
         assert tui.completed == 1
         assert tui.builds[build_id].finished_time == fake_time[0] + inst.CLEANUP_TIMEOUT
 
-    def test_update_state_failed(self):
+    def test_on_state_changed_failed(self):
         """Test that failed state increments completed counter"""
         tui, fake_time, _ = create_tui()
         [build_id] = add_mock_builds(tui, 1)
@@ -176,7 +176,7 @@ class TestBasicStateManagement:
         assert tui.completed == 1
         assert tui.builds[build_id].finished_time == fake_time[0] + inst.CLEANUP_TIMEOUT
 
-    def test_remove_build(self):
+    def test_on_build_removed(self):
         """Test that on_build_removed removes the build from the display."""
         tui, _, _ = create_tui(total=2)
         build_ids = add_mock_builds(tui, 2)
@@ -187,7 +187,7 @@ class TestBasicStateManagement:
         assert len(tui.builds) == 1
         assert tui.dirty is True
 
-    def test_remove_build_resets_tracked(self):
+    def test_on_build_removed_resets_tracked(self):
         """Test that removing the tracked build resets tracking to overview mode."""
         tui, _, _ = create_tui(total=1)
         [build_id] = add_mock_builds(tui, 1)
@@ -239,7 +239,7 @@ class TestBasicStateManagement:
         tui.on_finished([*build_ids, "unknown"])
         assert capsys.readouterr().err == "error: nope\n"
 
-    def test_update_progress(self):
+    def test_on_progress(self):
         """Test that on_progress updates percentages"""
         tui, _, _ = create_tui()
         [build_id] = add_mock_builds(tui, 1)
@@ -309,7 +309,7 @@ class TestOutputRendering:
         assert "Progress:" in output
 
     def test_no_output_when_not_dirty(self):
-        """Test that update() skips rendering when not dirty"""
+        """Test that render() skips rendering when not dirty"""
         tui, _, fake_stdout = create_tui()
         add_mock_builds(tui, 1)
         tui.render()
@@ -322,8 +322,8 @@ class TestOutputRendering:
         tui.render()
         assert fake_stdout.getvalue() == ""
 
-    def test_update_throttling(self):
-        """Test that update() throttles redraws"""
+    def test_render_throttling(self):
+        """Test that render() throttles redraws"""
         tui, fake_time, fake_stdout = create_tui()
         add_mock_builds(tui, 1)
 
@@ -410,7 +410,7 @@ class TestTimeBasedBehavior:
         assert tui.spinner_index == (initial_index + 1) % len(tui.spinner_chars)
 
     def test_no_redraw_when_nothing_changed(self):
-        """update() renders nothing when the display is clean and the spinner is not due"""
+        """render() renders nothing when the display is clean and the spinner is not due"""
         tui, fake_time, fake_stdout = create_tui()
         add_mock_builds(tui, 1)
         tui.render()
@@ -1027,7 +1027,7 @@ class TestToggle:
         # Echoing was stopped for the previously tracked build
         assert tui.commands[-1] == inst.SetEcho(tracked_id, False)
 
-    def test_update_state_finished_triggers_toggle_when_tracking(self):
+    def test_on_state_changed_finished_triggers_toggle_when_tracking(self):
         """Test that finishing a tracked build triggers toggle back to overview"""
         tui, _, _ = create_tui(total=2)
         build_ids = add_mock_builds(tui, 2)
@@ -1313,7 +1313,7 @@ class TestEdgeCases:
         assert len(tui.builds) == 0
         assert tui.completed == 2
 
-    def test_update_progress_rounds_correctly(self):
+    def test_on_progress_rounds_correctly(self):
         """Test that progress percentage rounding works"""
         tui, _, _ = create_tui()
         [build_id] = add_mock_builds(tui, 1)
@@ -1427,7 +1427,7 @@ class TestTerminalUIColor:
 class TestTargetJobs:
     """Test on_jobs_changed and its effect on the header."""
 
-    def test_set_jobs_marks_dirty(self):
+    def test_on_jobs_changed_marks_dirty(self):
         """on_jobs_changed with a new value should update target_jobs and mark dirty."""
         tui, _, _ = create_tui()
         tui.dirty = False
@@ -1439,7 +1439,7 @@ class TestTargetJobs:
         assert tui.actual_jobs == 2
         assert tui.target_jobs == 2
 
-    def test_set_jobs_same_value_no_dirty(self):
+    def test_on_jobs_changed_same_value_no_dirty(self):
         """on_jobs_changed with the same value should not mark dirty."""
         tui, _, _ = create_tui()
         tui.on_jobs_changed(5, 5)
@@ -1484,8 +1484,8 @@ class TestHeadlessMode:
         assert tui.headless is False
         assert tui.dirty is True
 
-    def test_update_suppressed_when_headless(self):
-        """update() should not write anything when headless is True."""
+    def test_render_suppressed_when_headless(self):
+        """render() should not write anything when headless is True."""
         tui, time_values, stdout = create_tui(is_tty=True, total=1)
         add_mock_builds(tui, 1)
         tui.headless = True
@@ -1502,7 +1502,7 @@ class TestHeadlessMode:
         tui.on_log_output(build_ids[0], b"hello world\n")
         assert stdout.getvalue() == ""
 
-    def test_update_state_non_tty_suppressed_when_headless(self):
+    def test_on_state_changed_non_tty_suppressed_when_headless(self):
         """on_state_changed() non-TTY output should be suppressed when headless."""
         tui, _, stdout = create_tui(is_tty=False, total=1)
         on_build_added(tui, "pkg")
@@ -1511,8 +1511,8 @@ class TestHeadlessMode:
         tui.on_state_changed("pkg", "finished")
         assert stdout.getvalue() == ""
 
-    def test_update_works_after_headless_cleared(self):
-        """update() should work normally once headless is cleared."""
+    def test_render_works_after_headless_cleared(self):
+        """render() should work normally once headless is cleared."""
         tui, time_values, stdout = create_tui(is_tty=True, total=1, color=False)
         add_mock_builds(tui, 1)
         tui.headless = True
@@ -1538,7 +1538,7 @@ class TestHeadlessMode:
 class TestBlockedIndicator:
     """Test set_blocked and the blocked message in the overview."""
 
-    def test_set_blocked_marks_dirty_once(self):
+    def test_on_blocked_changed_marks_dirty_once(self):
         """set_blocked marks dirty on a change, but not when the value is unchanged."""
         tui, _, _ = create_tui()
         tui.dirty = False

--- a/lib/spack/spack/test/installer_tui.py
+++ b/lib/spack/spack/test/installer_tui.py
@@ -26,7 +26,7 @@ class SimpleTextIOWrapper(io.TextIOWrapper):
     def __init__(self, tty: bool) -> None:
         self._buffer = io.BytesIO()
         self._tty = tty
-        super().__init__(self._buffer, encoding="utf-8", line_buffering=True)
+        super().__init__(self._buffer, encoding="utf-8", newline="", line_buffering=True)
 
     def isatty(self) -> bool:
         return self._tty

--- a/lib/spack/spack/test/installer_tui.py
+++ b/lib/spack/spack/test/installer_tui.py
@@ -235,6 +235,16 @@ class TestBasicStateManagement:
         tui.on_state_changed(build_id, "failed")
         assert tui.builds[build_id].log_summary is None
 
+    def test_print_failure_summaries(self, capsys):
+        """print_failure_summaries writes stored summaries to stderr, skipping builds without a
+        summary and unknown build ids."""
+        tui, _, _ = create_tui()
+        build_ids = add_mock_builds(tui, 2)
+
+        tui.builds[build_ids[0]].log_summary = "error: nope\n"
+        tui.on_finished([*build_ids, "unknown"])
+        assert capsys.readouterr().err == "error: nope\n"
+
     def test_update_progress(self):
         """Test that on_progress updates percentages"""
         tui, _, _ = create_tui()
@@ -404,6 +414,18 @@ class TestTimeBasedBehavior:
 
         # Spinner should have advanced
         assert tui.spinner_index == (initial_index + 1) % len(tui.spinner_chars)
+
+    def test_no_redraw_when_nothing_changed(self):
+        """update() renders nothing when the display is clean and the spinner is not due"""
+        tui, fake_time, fake_stdout = create_tui()
+        add_mock_builds(tui, 1)
+        tui.render()
+        fake_stdout.clear()
+
+        # Past the redraw throttle but before the next spinner advance, with no state changes
+        fake_time[0] = inst.SPINNER_INTERVAL * 0.6
+        tui.render()
+        assert fake_stdout.getvalue() == ""
 
     def test_finished_package_cleanup(self):
         """Test that finished packages are cleaned up after timeout"""
@@ -818,6 +840,22 @@ class TestLogFollowing:
         assert "Error: something went wrong" in output
         assert "/tmp/spack/pkg1.log" in output
 
+    def test_navigate_to_failed_build_without_summary(self):
+        """Navigating to a failed build with no parsed errors points at the full log."""
+        tui, _, fake_stdout = create_tui(total=2)
+        build_ids = add_mock_builds(tui, 2)
+
+        tui.on_state_changed(build_ids[1], "failed")
+        build_info = tui.builds[build_ids[1]]
+        assert build_info.log_summary is None  # no log file, so nothing was parsed
+        build_info.log_path = "/tmp/spack/pkg1.log"
+
+        tui.tracked_build_id = build_ids[0]
+        tui.next(1)
+        assert "No errors parsed from log, see full log: /tmp/spack/pkg1.log" in (
+            fake_stdout.getvalue()
+        )
+
     def test_navigation_skips_finished_build(self):
         """Test that navigation skips successfully finished builds"""
         tui, _, _ = create_tui(total=3)
@@ -1179,6 +1217,48 @@ class TestSearchFilteringIntegration:
         assert "package-c" in output
 
 
+class TestHandleInput:
+    """Test the on_input keyboard dispatch."""
+
+    def test_toggle_and_navigation_keys(self):
+        """'v' toggles log following, 'n'/'p' navigate, 'q' returns to overview."""
+        tui, _, _ = create_tui(total=3)
+        build_ids = add_mock_builds(tui, 3)
+
+        tui.on_input("v")
+        assert tui.overview_mode is False
+        assert tui.tracked_build_id == build_ids[0]
+
+        tui.on_input("n")
+        assert tui.tracked_build_id == build_ids[1]
+
+        tui.on_input("p")
+        assert tui.tracked_build_id == build_ids[0]
+
+        tui.on_input("q")
+        assert tui.overview_mode is True
+
+    def test_search_keys(self):
+        """'/' enters search mode; subsequent characters build the search term."""
+        tui, _, _ = create_tui(total=2)
+        add_mock_builds(tui, 2)
+
+        tui.on_input("/abc")
+        assert tui.search_mode is True
+        assert tui.search_term == "abc"
+
+        tui.on_input("\x1b")  # Escape exits search mode
+        assert tui.search_mode is False
+
+    def test_parallelism_keys(self):
+        """'+' and '-' produce ChangeJobs commands for the event loop."""
+        tui, _, _ = create_tui(total=1)
+        add_mock_builds(tui, 1)
+
+        tui.on_input("++-")
+        assert tui.commands == [inst.ChangeJobs(1), inst.ChangeJobs(1), inst.ChangeJobs(-1)]
+
+
 class TestEdgeCases:
     """Test edge cases and error conditions"""
 
@@ -1209,6 +1289,16 @@ class TestEdgeCases:
         # Should contain final status lines for both builds
         assert f"[+] {build_a[:7]} pkg0@0.0" in output
         assert f"[x] {build_b[:7]} pkg1@1.0" in output
+
+    def test_finalize_forces_overview_mode(self):
+        """update(finalize=True) leaves log-following mode for the final render."""
+        tui, _, _ = create_tui(total=2)
+        add_mock_builds(tui, 2)
+        tui.next()
+        assert tui.overview_mode is False
+
+        tui.render(finalize=True)
+        assert tui.overview_mode is True
 
     def test_all_builds_finished(self):
         """Test when all builds are finished"""
@@ -1384,6 +1474,20 @@ class TestTargetJobs:
 class TestHeadlessMode:
     """Test that headless mode suppresses terminal output."""
 
+    def test_on_headless_changed_transitions(self):
+        """on_headless_changed(True) invalidates the display area; on_headless_changed(False)
+        marks dirty."""
+        tui, _, _ = create_tui(is_tty=True)
+        tui.active_area_rows = 5
+        tui.on_headless_changed(True)
+        assert tui.headless is True
+        assert tui.active_area_rows == 0
+
+        tui.dirty = False
+        tui.on_headless_changed(False)
+        assert tui.headless is False
+        assert tui.dirty is True
+
     def test_update_suppressed_when_headless(self):
         """update() should not write anything when headless is True."""
         tui, time_values, stdout = create_tui(is_tty=True, total=1)
@@ -1424,6 +1528,85 @@ class TestHeadlessMode:
         tui.dirty = True
         tui.render()
         assert "[/] pkg0 pkg0@0.0 starting" in stdout.getvalue()
+
+    def test_refresh_interval_modes(self):
+        """Only an interactive, foreground terminal needs a periodic redraw tick."""
+        tui, _, _ = create_tui(is_tty=True)
+        assert tui.refresh_interval() == inst.SPINNER_INTERVAL
+        tui.headless = True
+        assert tui.refresh_interval() is None
+        non_tty, _, _ = create_tui(is_tty=False)
+        assert non_tty.refresh_interval() is None
+
+
+class TestBlockedIndicator:
+    """Test set_blocked and the blocked message in the overview."""
+
+    def test_set_blocked_marks_dirty_once(self):
+        """set_blocked marks dirty on a change, but not when the value is unchanged."""
+        tui, _, _ = create_tui()
+        tui.dirty = False
+        tui.on_blocked_changed(True)
+        assert tui.blocked is True
+        assert tui.dirty is True
+
+        tui.dirty = False
+        tui.on_blocked_changed(True)
+        assert tui.dirty is False
+
+    def test_blocked_message_rendered(self):
+        """When blocked and nothing is running, the overview shows a waiting message."""
+        tui, _, fake_stdout = create_tui()
+        tui.on_blocked_changed(True)
+        tui.render()
+        assert "Waiting for other Spack install process" in fake_stdout.getvalue()
+
+
+class TestLineRendering:
+    """Test individual build-line components in the rendered output."""
+
+    def test_fetch_progress_rendered(self):
+        """A build with fetch progress shows a percentage instead of its state."""
+        tui, _, fake_stdout = create_tui(total=1)
+        [build_id] = add_mock_builds(tui, 1)
+        tui.on_progress(build_id, 50, 100)
+        tui.render()
+        assert "fetching: 50%" in fake_stdout.getvalue()
+
+    def test_failed_line_shows_log_path(self):
+        """A failed build's line includes the path to its log file."""
+        tui, _, fake_stdout = create_tui(is_tty=False, total=1)
+        on_build_added(tui, "pkg", log_path="/tmp/pkg.log")
+        tui.on_state_changed("pkg", "failed")
+        assert "failed: /tmp/pkg.log" in fake_stdout.getvalue()
+
+    def test_external_indicator(self):
+        """External packages are rendered with the [e] indicator."""
+        tui, _, fake_stdout = create_tui(is_tty=False, total=1)
+        on_build_added(tui, "pkg", external=True)
+        tui.on_state_changed("pkg", "finished")
+        assert "[e]" in fake_stdout.getvalue()
+
+    def test_non_tty_running_build_static_indicator(self):
+        """Non-TTY state lines use the static [ ] indicator for builds still in progress, and
+        render implicit builds with a plain (non-bold) name."""
+        tui, _, fake_stdout = create_tui(is_tty=False, total=1, color=False)
+        on_build_added(tui, "pkg", explicit=False)
+        tui.on_state_changed("pkg", "installing")
+        line = fake_stdout.getvalue()
+        assert line.startswith("[ ] ")
+        assert "pkg@1.0" in line
+
+    def test_line_truncated_to_terminal_width(self):
+        """Build lines are cut off at the terminal width in the interactive overview."""
+        tui, _, fake_stdout = create_tui(total=1, terminal_cols=30, color=False)
+        on_build_added(tui, "pkg", prefix="/quite/long/prefix/path")
+        tui.on_state_changed("pkg", "finished")
+        tui.render()
+        output = fake_stdout.getvalue()
+        assert "pkg@1.0" in output
+        # The prefix would exceed the terminal width, so it is not rendered.
+        assert "/quite/long/prefix/path" not in output
 
 
 class TestStdinReader:

--- a/lib/spack/spack/test/jobserver.py
+++ b/lib/spack/spack/test/jobserver.py
@@ -12,6 +12,7 @@ if sys.platform == "win32":
 import fcntl
 import os
 import pathlib
+import selectors
 import stat
 
 from spack.new_installer_posix import (
@@ -166,6 +167,60 @@ class TestJobServer:
 
         finally:
             js1.close()
+
+    def test_setup_attaches_to_fifo_from_makeflags(self):
+        """A FIFO jobserver advertised in MAKEFLAGS is attached to instead of creating one."""
+        js1 = PosixJobServer(4, makeflags="")
+        assert js1.fifo_path
+        js2 = PosixJobServer(4, makeflags=f" -j4 --jobserver-auth=fifo:{js1.fifo_path}")
+        try:
+            assert js2.created is False
+            assert js2.fifo_path == js1.fifo_path
+            # The creator's tokens are visible through the attached file descriptors.
+            assert js2.acquire(1) == 1
+            js2.release()
+        finally:
+            js2.close()
+            js1.close()
+
+    def test_setup_attaches_to_pipe_from_makeflags(self):
+        """An old-style pipe jobserver advertised in MAKEFLAGS is validated and adopted."""
+        r, w = os.pipe()
+        js = PosixJobServer(4, makeflags=f" -j4 --jobserver-auth={r},{w}")
+        try:
+            assert js.created is False
+            assert js.fifo_path is None
+            assert (js.r, js.w) == (r, w)
+        finally:
+            js.close()  # closes r and w through the Connection objects
+
+    def test_setup_invalid_pipe_fds_creates_fifo(self):
+        """Invalid jobserver file descriptors in MAKEFLAGS fall back to a new FIFO."""
+        r, w = os.pipe()
+        os.close(r)
+        os.close(w)
+        js = PosixJobServer(2, makeflags=f" -j2 --jobserver-auth={r},{w}")
+        try:
+            assert js.created is True
+            assert js.fifo_path is not None
+        finally:
+            js.close()
+
+    def test_update_selector_registers_and_unregisters(self):
+        """update_selector idempotently (un)registers the token fd based on the wake flag."""
+        js = PosixJobServer(2, makeflags="")
+        selector = selectors.DefaultSelector()
+        try:
+            js.update_selector(selector, wake=True)
+            assert js.r in selector.get_map()
+            js.update_selector(selector, wake=True)  # already registered: no-op
+            assert len(selector.get_map()) == 1
+            js.update_selector(selector, wake=False)
+            assert js.r not in selector.get_map()
+            js.update_selector(selector, wake=False)  # already unregistered: no-op
+        finally:
+            selector.close()
+            js.close()
 
     def test_acquire_tokens(self):
         """Should acquire tokens from jobserver."""

--- a/lib/spack/spack/test/new_installer.py
+++ b/lib/spack/spack/test/new_installer.py
@@ -7,14 +7,12 @@ import json
 import os
 import pathlib
 import signal
+import socket
 import sys
 import time
 from typing import Callable, Dict, List, NamedTuple, Optional, Sequence, Set, Tuple, Union
 
 import pytest
-
-if sys.platform == "win32":
-    pytest.skip("No Windows support", allow_module_level=True)
 
 import spack.config
 import spack.deptypes as dt
@@ -47,9 +45,11 @@ from spack.new_installer_base import (
     NoopJobServer,
     ProcessExitNotifier,
 )
-from spack.new_installer_posix import PosixJobServer
 from spack.test.conftest import writable
 from spack.test.traverse import create_dag
+
+if sys.platform != "win32":
+    from spack.new_installer_posix import PosixJobServer
 
 
 @pytest.fixture
@@ -402,6 +402,7 @@ class TestScheduleBuilds:
         for _, _, lock in result.newly_installed:
             lock.release_read()
 
+    @pytest.mark.not_on_windows("Windows has no POSIX jobserver, only NoopJobServer")
     def test_no_jobserver_token_returns_empty(self, temporary_store, mock_packages):
         """When has_running_builds=True and no token is available, nothing is started."""
         spec = self._make_spec("trivial-install-test-package")
@@ -672,27 +673,27 @@ class Script(NamedTuple):
 class FakeBuild(ProcessExitNotifier):
     """A ``ProcessLike`` for builds that run in-process, without forking. It stays alive until
     finish() or terminate() is called (immediately at launch for non-hanging scripts). Doubles as
-    its own exit notifier: a pipe whose write end is closed when the build finishes."""
+    its own exit notifier: a socketpair (selectable on Windows too, like the production
+    WindowsSentinelBridge) whose write end is closed when the build finishes."""
 
     #: There is no real process (group) to signal.
     pid: Optional[int] = None
 
     def __init__(self, exitcode: int, channels: BuildChannels) -> None:
-        self._read, self._write = os.pipe()
+        self._read, self._write = socket.socketpair()
         self._exitcode = exitcode
         self.exitcode: Optional[int] = None
         self.terminated = False
         self.channels = channels
 
     @property
-    def fileobj(self) -> int:
+    def fileobj(self) -> socket.socket:
         return self._read
 
     def close(self) -> None:
-        # Idempotent: the event loop closes this object as notifier and as process.
-        if self._read >= 0:
-            os.close(self._read)
-            self._read = -1
+        # The event loop closes this object as notifier and as process; socket.close() is
+        # idempotent, so that is fine.
+        self._read.close()
 
     def finish(self) -> None:
         if self.exitcode is None:
@@ -700,7 +701,7 @@ class FakeBuild(ProcessExitNotifier):
             # EOF the state/output channels and make the exit notifier fire.
             self.channels.state_w.close()
             self.channels.output_w.close()
-            os.close(self._write)
+            self._write.close()
 
     def terminate(self) -> None:
         self.terminated, self._exitcode = True, -signal.SIGTERM

--- a/lib/spack/spack/test/new_installer.py
+++ b/lib/spack/spack/test/new_installer.py
@@ -3,18 +3,22 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 """Tests for the new_installer.py module"""
 
+import json
+import os
 import pathlib
+import signal
 import sys
 import time
+from typing import Callable, Dict, List, NamedTuple, Optional, Sequence, Set, Tuple, Union
 
 import pytest
 
 if sys.platform == "win32":
     pytest.skip("No Windows support", allow_module_level=True)
 
-from typing import Tuple
-
+import spack.config
 import spack.deptypes as dt
+import spack.error
 import spack.spec
 import spack.store
 from spack.database import Database
@@ -22,12 +26,27 @@ from spack.new_installer import (
     OVERWRITE_GARBAGE_SUFFIX,
     BinaryCacheMiss,
     BuildGraph,
+    BuildRequest,
+    ChangeJobs,
+    ChildInfo,
+    ExitCode,
+    InstallerUI,
     PackageInstaller,
     PrefixPivoter,
+    ScheduleResult,
+    SetEcho,
     _node_to_roots,
+    create_build_channels,
+    read_connection,
     schedule_builds,
+    write_connection,
 )
-from spack.new_installer_base import NoopJobServer
+from spack.new_installer_base import (
+    BuildChannels,
+    JobServerBase,
+    NoopJobServer,
+    ProcessExitNotifier,
+)
 from spack.new_installer_posix import PosixJobServer
 from spack.test.conftest import writable
 from spack.test.traverse import create_dag
@@ -317,6 +336,31 @@ class _FakeBuildGraph:
         self.nodes.pop(dag_hash, None)
 
 
+def _schedule(
+    pending: List[str],
+    build_graph,
+    store,
+    jobserver: Optional[JobServerBase] = None,
+    overwrite: Optional[Set[str]] = None,
+    overwrite_time: float = 0.0,
+    capacity: int = 2,
+    needs_jobserver_token: bool = False,
+    explicit: Optional[Set[str]] = None,
+) -> ScheduleResult:
+    """Call schedule_builds() with inert defaults, so tests spell out only what they are about."""
+    return schedule_builds(
+        pending,
+        build_graph,
+        store,
+        overwrite=overwrite or set(),
+        overwrite_time=overwrite_time,
+        capacity=capacity,
+        needs_jobserver_token=needs_jobserver_token,
+        jobserver=jobserver or NoopJobServer(num_jobs=2),
+        explicit=explicit or set(),
+    )
+
+
 class TestScheduleBuilds:
     """Unit tests for the module-level schedule_builds() function."""
 
@@ -335,77 +379,42 @@ class TestScheduleBuilds:
         """A fresh spec with no running builds is added to to_start."""
         spec = self._make_spec("trivial-install-test-package")
         pending = [spec.dag_hash()]
-        bg = _FakeBuildGraph([spec])
-        jobserver = PosixJobServer(num_jobs=2, makeflags="")
-        try:
-            result = schedule_builds(
-                pending,
-                bg,
-                temporary_store,
-                overwrite=set(),
-                overwrite_time=0.0,
-                capacity=1,
-                needs_jobserver_token=False,
-                jobserver=jobserver,
-                explicit=set(),
-            )
-            assert not result.blocked
-            assert len(result.to_start) == 1
-            assert result.to_start[0][0] == spec.dag_hash()
-            assert not result.newly_installed
-            assert not pending  # removed from the pending list
-        finally:
-            for _, lock in result.to_start:
-                lock.release_write()
-            jobserver.close()
+        result = _schedule(pending, _FakeBuildGraph([spec]), temporary_store)
+        assert not result.blocked
+        assert len(result.to_start) == 1
+        assert result.to_start[0][0] == spec.dag_hash()
+        assert not result.newly_installed
+        assert not pending  # removed from the pending list
+        for _, lock in result.to_start:
+            lock.release_write()
 
     def test_already_installed_yields_newly_installed(self, temporary_store, mock_packages):
         """A spec already in the DB is returned in newly_installed, not in to_start."""
         spec = self._make_spec("trivial-install-test-package")
         self._mark_installed(spec, temporary_store)
         pending = [spec.dag_hash()]
-        bg = _FakeBuildGraph([spec])
-        jobserver = PosixJobServer(num_jobs=2, makeflags="")
-        try:
-            result = schedule_builds(
-                pending,
-                bg,
-                temporary_store,
-                overwrite=set(),
-                overwrite_time=0.0,
-                capacity=1,
-                needs_jobserver_token=False,
-                jobserver=jobserver,
-                explicit=set(),
-            )
-            assert not result.blocked
-            assert not result.to_start
-            assert len(result.newly_installed) == 1
-            assert result.newly_installed[0][0] == spec.dag_hash()
-            assert not pending  # removed from the pending list
-        finally:
-            for _, _, lock in result.newly_installed:
-                lock.release_read()
-            jobserver.close()
+        result = _schedule(pending, _FakeBuildGraph([spec]), temporary_store)
+        assert not result.blocked
+        assert not result.to_start
+        assert len(result.newly_installed) == 1
+        assert result.newly_installed[0][0] == spec.dag_hash()
+        assert not pending  # removed from the pending list
+        for _, _, lock in result.newly_installed:
+            lock.release_read()
 
     def test_no_jobserver_token_returns_empty(self, temporary_store, mock_packages):
         """When has_running_builds=True and no token is available, nothing is started."""
         spec = self._make_spec("trivial-install-test-package")
         pending = [spec.dag_hash()]
-        bg = _FakeBuildGraph([spec])
         # num_jobs=1 writes 0 tokens to the FIFO. Only the implicit token exists.
         jobserver = PosixJobServer(num_jobs=1, makeflags="")
         try:
-            result = schedule_builds(
+            result = _schedule(
                 pending,
-                bg,
+                _FakeBuildGraph([spec]),
                 temporary_store,
-                overwrite=set(),
-                overwrite_time=0.0,
-                capacity=2,
-                needs_jobserver_token=True,
                 jobserver=jobserver,
-                explicit=set(),
+                needs_jobserver_token=True,
             )
             assert not result.blocked
             assert not result.to_start
@@ -418,91 +427,52 @@ class TestScheduleBuilds:
         """When all pending specs are locked externally, blocked_on_locks is True."""
         spec = self._make_spec("trivial-install-test-package")
         pending = [spec.dag_hash()]
-        bg = _FakeBuildGraph([spec])
-        jobserver = PosixJobServer(num_jobs=2, makeflags="")
         # Pre-register the lock in the prefix_locker cache, then patch try_acquire to fail.
         lock = temporary_store.prefix_locker.lock(spec)
         monkeypatch.setattr(lock, "try_acquire_write", lambda: False)
         monkeypatch.setattr(lock, "try_acquire_read", lambda: False)
-        try:
-            result = schedule_builds(
-                pending,
-                bg,
-                temporary_store,
-                overwrite=set(),
-                overwrite_time=0.0,
-                capacity=2,
-                needs_jobserver_token=False,
-                jobserver=jobserver,
-                explicit=set(),
-            )
-            assert result.blocked
-            assert not result.to_start
-            assert not result.newly_installed
-            assert len(pending) == 1
-        finally:
-            jobserver.close()
+        result = _schedule(pending, _FakeBuildGraph([spec]), temporary_store)
+        assert result.blocked
+        assert not result.to_start
+        assert not result.newly_installed
+        assert len(pending) == 1
 
     def test_overwrite_installed_spec_is_started(self, temporary_store, mock_packages):
         """A spec in the overwrite set is scheduled even when already installed."""
         spec = self._make_spec("trivial-install-test-package")
         self._mark_installed(spec, temporary_store)
         pending = [spec.dag_hash()]
-        bg = _FakeBuildGraph([spec])
-        jobserver = PosixJobServer(num_jobs=2, makeflags="")
-        try:
-            result = schedule_builds(
-                pending,
-                bg,
-                temporary_store,
-                overwrite={spec.dag_hash()},
-                overwrite_time=time.time() + 100,
-                capacity=1,
-                needs_jobserver_token=False,
-                jobserver=jobserver,
-                explicit=set(),
-            )
-            assert not result.blocked
-            assert len(result.to_start) == 1
-            assert result.to_start[0][0] == spec.dag_hash()
-            assert not result.newly_installed
-        finally:
-            for _, lock in result.to_start:
-                lock.release_write()
-            jobserver.close()
+        result = _schedule(
+            pending,
+            _FakeBuildGraph([spec]),
+            temporary_store,
+            overwrite={spec.dag_hash()},
+            overwrite_time=time.time() + 100,
+        )
+        assert not result.blocked
+        assert len(result.to_start) == 1
+        assert result.to_start[0][0] == spec.dag_hash()
+        assert not result.newly_installed
+        for _, lock in result.to_start:
+            lock.release_write()
 
     def test_mixed_locked_unlocked(self, temporary_store, mock_packages, monkeypatch):
         """Only the unlocked spec enters to_start when one spec is externally locked."""
         spec_a = self._make_spec("trivial-install-test-package")
         spec_b = self._make_spec("trivial-smoke-test")
         pending = [spec_a.dag_hash(), spec_b.dag_hash()]
-        bg = _FakeBuildGraph([spec_a, spec_b])
-        jobserver = PosixJobServer(num_jobs=4, makeflags="")
         # Patch spec_a's lock to always fail, simulating an external write lock.
         lock_a = temporary_store.prefix_locker.lock(spec_a)
         monkeypatch.setattr(lock_a, "try_acquire_write", lambda: False)
         monkeypatch.setattr(lock_a, "try_acquire_read", lambda: False)
-        try:
-            result = schedule_builds(
-                pending,
-                bg,
-                temporary_store,
-                overwrite=set(),
-                overwrite_time=0.0,
-                capacity=2,
-                needs_jobserver_token=False,
-                jobserver=jobserver,
-                explicit=set(),
-            )
-            assert not result.blocked  # spec_b was schedulable
-            started_hashes = {h for h, _ in result.to_start}
-            assert spec_b.dag_hash() in started_hashes
-            assert spec_a.dag_hash() not in started_hashes
-            assert not result.newly_installed
-        finally:
-            for _, lock in result.to_start:
-                lock.release_write()
-            jobserver.close()
+        result = _schedule(pending, _FakeBuildGraph([spec_a, spec_b]), temporary_store)
+        assert not result.blocked  # spec_b was schedulable
+        started_hashes = {h for h, _ in result.to_start}
+        assert spec_b.dag_hash() in started_hashes
+        assert spec_a.dag_hash() not in started_hashes
+        assert not result.newly_installed
+        for _, lock in result.to_start:
+            lock.release_write()
 
     def test_write_locked_read_locked_installed_yields_newly_installed(
         self, temporary_store, mock_packages, monkeypatch
@@ -516,33 +486,17 @@ class TestScheduleBuilds:
         spec = self._make_spec("trivial-install-test-package")
         self._mark_installed(spec, temporary_store)
         pending = [spec.dag_hash()]
-        bg = _FakeBuildGraph([spec])
-        jobserver = PosixJobServer(num_jobs=2, makeflags="")
         lock = temporary_store.prefix_locker.lock(spec)
         monkeypatch.setattr(lock, "try_acquire_write", lambda: False)
-        try:
-            result = schedule_builds(
-                pending,
-                bg,
-                temporary_store,
-                overwrite=set(),
-                overwrite_time=0.0,
-                capacity=2,
-                needs_jobserver_token=False,
-                jobserver=jobserver,
-                explicit=set(),
-            )
-            assert result.blocked  # no write lock was obtained; jobserver should not fire
-            assert not result.to_start
-            assert len(result.newly_installed) == 1
-            dag_hash, installed_spec, lock = result.newly_installed[0]
-            assert dag_hash == spec.dag_hash()
-            assert installed_spec == spec
-            assert not pending  # spec was removed from pending
-        finally:
-            for _, _, lock in result.newly_installed:
-                lock.release_read()
-            jobserver.close()
+        result = _schedule(pending, _FakeBuildGraph([spec]), temporary_store)
+        assert result.blocked  # no write lock was obtained; jobserver should not fire
+        assert not result.to_start
+        assert len(result.newly_installed) == 1
+        dag_hash, installed_spec, lock = result.newly_installed[0]
+        assert dag_hash == spec.dag_hash()
+        assert installed_spec == spec
+        assert not pending  # spec was removed from pending
+        lock.release_read()
 
     def test_write_locked_read_locked_not_installed_still_blocked(
         self, temporary_store, mock_packages, monkeypatch
@@ -554,56 +508,29 @@ class TestScheduleBuilds:
         """
         spec = self._make_spec("trivial-install-test-package")
         pending = [spec.dag_hash()]
-        bg = _FakeBuildGraph([spec])
-        jobserver = PosixJobServer(num_jobs=2, makeflags="")
         lock = temporary_store.prefix_locker.lock(spec)
         monkeypatch.setattr(lock, "try_acquire_write", lambda: False)
-        try:
-            result = schedule_builds(
-                pending,
-                bg,
-                temporary_store,
-                overwrite=set(),
-                overwrite_time=0.0,
-                capacity=2,
-                needs_jobserver_token=False,
-                jobserver=jobserver,
-                explicit=set(),
-            )
-            assert result.blocked
-            assert not result.to_start
-            assert not result.newly_installed
-            assert pending == [spec.dag_hash()]  # spec stays in pending for retry
-        finally:
-            jobserver.close()
+        result = _schedule(pending, _FakeBuildGraph([spec]), temporary_store)
+        assert result.blocked
+        assert not result.to_start
+        assert not result.newly_installed
+        assert pending == [spec.dag_hash()]  # spec stays in pending for retry
 
     def test_overwrite_handled_by_concurrent_process(self, temporary_store, mock_packages):
         """When a spec in overwrite was installed AFTER overwrite_time, another process did it."""
         spec = self._make_spec("trivial-install-test-package")
         self._mark_installed(spec, temporary_store)  # installation_time = now()
         pending = [spec.dag_hash()]
-        bg = _FakeBuildGraph([spec])
-        jobserver = PosixJobServer(num_jobs=2, makeflags="")
-        try:
-            result = schedule_builds(
-                pending,
-                bg,
-                temporary_store,
-                overwrite={spec.dag_hash()},
-                overwrite_time=0.0,  # earlier than now()
-                capacity=1,
-                needs_jobserver_token=False,
-                jobserver=jobserver,
-                explicit=set(),
-            )
-            assert not result.blocked
-            assert not result.to_start
-            assert len(result.newly_installed) == 1
-            assert result.newly_installed[0][0] == spec.dag_hash()
-        finally:
-            for _, _, lock in result.newly_installed:
-                lock.release_read()
-            jobserver.close()
+        # the default overwrite_time=0.0 is earlier than now()
+        result = _schedule(
+            pending, _FakeBuildGraph([spec]), temporary_store, overwrite={spec.dag_hash()}
+        )
+        assert not result.blocked
+        assert not result.to_start
+        assert len(result.newly_installed) == 1
+        assert result.newly_installed[0][0] == spec.dag_hash()
+        for _, _, lock in result.newly_installed:
+            lock.release_read()
 
     def test_installed_implicit_explicit_set_produces_db_update(
         self, temporary_store, mock_packages
@@ -613,27 +540,14 @@ class TestScheduleBuilds:
         temporary_store.layout.create_install_directory(spec)
         temporary_store.db.add(spec, explicit=False)
         pending = [spec.dag_hash()]
-        bg = _FakeBuildGraph([spec])
-        jobserver = PosixJobServer(num_jobs=2, makeflags="")
-        try:
-            result = schedule_builds(
-                pending,
-                bg,
-                temporary_store,
-                overwrite=set(),
-                overwrite_time=0.0,
-                capacity=1,
-                needs_jobserver_token=False,
-                jobserver=jobserver,
-                explicit={spec.dag_hash()},
-            )
-            assert len(result.to_mark_explicit) == 1
-            assert result.to_mark_explicit[0].spec is spec
-            assert len(result.newly_installed) == 1
-        finally:
-            for _, _, lock in result.newly_installed:
-                lock.release_read()
-            jobserver.close()
+        result = _schedule(
+            pending, _FakeBuildGraph([spec]), temporary_store, explicit={spec.dag_hash()}
+        )
+        assert len(result.to_mark_explicit) == 1
+        assert result.to_mark_explicit[0].spec is spec
+        assert len(result.newly_installed) == 1
+        for _, _, lock in result.newly_installed:
+            lock.release_read()
 
     def test_missing_in_upstream_is_installed_locally(
         self, upstream_and_downstream_db: Tuple[Database, Database], mock_packages
@@ -661,18 +575,7 @@ class TestScheduleBuilds:
         assert upstream_db.layout
         dep.set_prefix(upstream_db.layout.path_for_spec(dep))
 
-        jobserver = NoopJobServer(num_jobs=2)
-        result = schedule_builds(
-            pending=[dep.dag_hash()],
-            build_graph=_FakeBuildGraph([dep]),  # type: ignore[arg-type]
-            store=local_store,
-            overwrite=set(),
-            overwrite_time=0.0,
-            capacity=1,
-            needs_jobserver_token=False,
-            jobserver=jobserver,
-            explicit=set(),
-        )
+        result = _schedule([dep.dag_hash()], _FakeBuildGraph([dep]), local_store)
         assert not result.blocked
         assert [dag_hash for dag_hash, _ in result.to_start] == [dep.dag_hash()]
         # The prefix was repointed from the upstream to the local store.
@@ -681,6 +584,394 @@ class TestScheduleBuilds:
         # Cleanup
         for _, lock in result.to_start:
             lock.release_write()
+
+    def test_overwrite_prefix_mismatch_raises(self, temporary_store, mock_packages):
+        """An overwrite install cannot proceed when the spec prefix differs from the DB path."""
+        spec = self._make_spec("trivial-install-test-package")
+        self._mark_installed(spec, temporary_store)
+        spec.set_prefix("/some/other/prefix")
+        with pytest.raises(spack.error.InstallError, match="Prefix mismatch in overwrite"):
+            _schedule(
+                [spec.dag_hash()],
+                _FakeBuildGraph([spec]),
+                temporary_store,
+                overwrite={spec.dag_hash()},
+                overwrite_time=time.time() + 100,
+            )
+
+    def test_prefix_collision_raises(self, temporary_store, mock_packages):
+        """A spec cannot be scheduled into a prefix already occupied by another spec."""
+        installed = self._make_spec("trivial-install-test-package")
+        self._mark_installed(installed, temporary_store)
+        colliding = self._make_spec("trivial-smoke-test")
+        colliding.set_prefix(temporary_store.layout.path_for_spec(installed))
+        with pytest.raises(spack.error.InstallError, match="already exists"):
+            _schedule([colliding.dag_hash()], _FakeBuildGraph([colliding]), temporary_store)
+
+
+class RecordingUI(InstallerUI):
+    """Frontend that records the events it receives, for testing the event loop."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.events: List[tuple] = []
+
+    def on_build_added(self, info):
+        self.events.append(("build_added", info.id, info.name))
+
+    def on_build_removed(self, build_id):
+        self.events.append(("build_removed", build_id))
+
+    def on_state_changed(self, build_id, state):
+        self.events.append(("state_changed", build_id, state))
+
+    def on_log_output(self, build_id, data):
+        self.events.append(("log_output", build_id, data))
+
+    def on_total_increased(self, count):
+        self.events.append(("total_increased", count))
+
+    def on_progress(self, build_id, current, total):
+        self.events.append(("progress", build_id, current, total))
+
+    def on_jobs_changed(self, actual, target):
+        self.events.append(("jobs_changed", actual, target))
+
+    def on_finished(self, failures):
+        self.events.append(("finished", tuple(failures)))
+
+
+class DrivingUI(RecordingUI):
+    """Records events and runs a callback on every event-loop tick, so tests can finish hanging
+    builds from inside install()."""
+
+    def __init__(self, on_tick: Callable[[], None]) -> None:
+        super().__init__()
+        self.on_tick = on_tick
+
+    def refresh_interval(self) -> float:
+        return 0.01
+
+    def render(self, finalize: bool = False) -> None:
+        if not finalize:
+            self.on_tick()
+
+
+class Script(NamedTuple):
+    """The scripted result of a single launched build."""
+
+    exitcode: int = ExitCode.SUCCESS
+    states: Tuple[str, ...] = ()
+    output: bytes = b""
+    #: Raw bytes written to the state channel verbatim, for protocol edge cases.
+    raw_state: bytes = b""
+    #: Keep the build running until the test calls finish() or the event loop terminates it.
+    hang: bool = False
+
+
+class FakeBuild(ProcessExitNotifier):
+    """A ``ProcessLike`` for builds that run in-process, without forking. It stays alive until
+    finish() or terminate() is called (immediately at launch for non-hanging scripts). Doubles as
+    its own exit notifier: a pipe whose write end is closed when the build finishes."""
+
+    #: There is no real process (group) to signal.
+    pid: Optional[int] = None
+
+    def __init__(self, exitcode: int, channels: BuildChannels) -> None:
+        self._read, self._write = os.pipe()
+        self._exitcode = exitcode
+        self.exitcode: Optional[int] = None
+        self.terminated = False
+        self.channels = channels
+
+    @property
+    def fileobj(self) -> int:
+        return self._read
+
+    def close(self) -> None:
+        # Idempotent: the event loop closes this object as notifier and as process.
+        if self._read >= 0:
+            os.close(self._read)
+            self._read = -1
+
+    def finish(self) -> None:
+        if self.exitcode is None:
+            self.exitcode = self._exitcode
+            # EOF the state/output channels and make the exit notifier fire.
+            self.channels.state_w.close()
+            self.channels.output_w.close()
+            os.close(self._write)
+
+    def terminate(self) -> None:
+        self.terminated, self._exitcode = True, -signal.SIGTERM
+        self.finish()
+
+    kill = terminate
+
+    def is_alive(self) -> bool:
+        return self.exitcode is None
+
+    def join(self, timeout: Optional[float] = None) -> None:
+        pass
+
+
+class ScriptedLauncher:
+    """Build launcher that runs builds in-process with scripted state messages, output and exit
+    code. A list of scripts is consumed one per launch, so retries (e.g. after a binary cache
+    miss) can behave differently per attempt."""
+
+    def __init__(self, scripts: Dict[str, Union[Script, List[Script]]]) -> None:
+        self.scripts = {
+            name: [s] if isinstance(s, Script) else list(s) for name, s in scripts.items()
+        }
+        self.requests: List[BuildRequest] = []
+        #: All launched builds, in launch order, for tests to inspect.
+        self.builds: List[FakeBuild] = []
+        #: The subset of launched builds that hang, for tests to finish() or inspect.
+        self.hanging: List[FakeBuild] = []
+
+    def __call__(self, request: BuildRequest, jobserver: JobServerBase) -> ChildInfo:
+        self.requests.append(request)
+        script = self.scripts[request.spec.name].pop(0)
+        channels = create_build_channels()
+        for state in script.states:
+            write_connection(channels.state_w, json.dumps({"state": state}).encode() + b"\n")
+        if script.raw_state:
+            write_connection(channels.state_w, script.raw_state)
+        if script.output:
+            write_connection(channels.output_w, script.output)
+        build = FakeBuild(script.exitcode, channels)
+        self.builds.append(build)
+        if script.hang:
+            # The channels stay open until the test finishes the build.
+            self.hanging.append(build)
+        else:
+            # Finishing EOFs the channels and the exit notifier, like a child that exited.
+            build.finish()
+        return ChildInfo(
+            build,
+            request.spec,
+            channels.output_r,
+            channels.state_r,
+            channels.control_w,
+            build,
+            request.log_path,
+        )
+
+
+def _make_concrete(
+    name: str, deps: Sequence[spack.spec.Spec] = (), depflag: dt.DepFlag = dt.BUILD | dt.LINK
+) -> spack.spec.Spec:
+    spec = spack.spec.Spec(f"{name}@=1.0")
+    for dep in deps:
+        spec._add_dependency(dep, depflag=depflag, virtuals=())
+    spec._mark_concrete()
+    return spec
+
+
+def _record(store, spec: spack.spec.Spec):
+    """The spec's InstallRecord, or None if it is not in the database."""
+    return store.db.query_by_spec_hash(spec.dag_hash())[1]
+
+
+def _install(launcher, *specs: spack.spec.Spec, ui=None, **kwargs) -> RecordingUI:
+    """Install specs through the event loop with a scripted launcher; explicit by default."""
+    ui = ui or RecordingUI()
+    PackageInstaller(
+        [s.package for s in specs], explicit=True, ui=ui, launcher=launcher, **kwargs
+    ).install()
+    return ui
+
+
+@pytest.mark.disable_clean_stage_check  # failed builds keep their log file in the stage root
+def test_build_failure_reported_through_event_loop(temporary_store, mock_packages):
+    """A build exiting with an error yields exactly one failed event, an InstallError naming the
+    log file, and no database record -- without forking any build process."""
+    spec = _make_concrete("trivial-install-test-package")
+    launcher = ScriptedLauncher({spec.name: Script(exitcode=ExitCode.BUILD_ERROR)})
+    ui = RecordingUI()
+    installer = PackageInstaller([spec.package], explicit=True, ui=ui, launcher=launcher)
+
+    with pytest.raises(spack.error.InstallError) as exc_info:
+        installer.install()
+
+    dag_hash = spec.dag_hash()
+    assert installer.log_paths[dag_hash] in str(exc_info.value)
+    failed = [e for e in ui.events if e[0] == "state_changed" and e[2] == "failed"]
+    assert failed == [("state_changed", dag_hash, "failed")]
+    assert _record(temporary_store, spec) is None
+
+
+def test_cache_miss_falls_back_to_source_build(
+    temporary_store, mock_packages, mutable_config, tmp_path
+):
+    """With a binary mirror configured, the first attempt is cache_only; a cache miss removes the
+    build from the UI, reschedules it as source_only, and the second attempt succeeds."""
+    spack.config.set("mirrors", {"local": {"url": (tmp_path / "mirror").as_uri(), "binary": True}})
+    spec = _make_concrete("trivial-install-test-package")
+    launcher = ScriptedLauncher(
+        {spec.name: [Script(exitcode=ExitCode.BUILD_CACHE_MISS), Script(exitcode=0)]}
+    )
+    ui = _install(launcher, spec)
+
+    assert [r.install_policy for r in launcher.requests] == ["cache_only", "source_only"]
+
+    dag_hash = spec.dag_hash()
+    lifecycle = [e[0] for e in ui.events if e[1] == dag_hash and e[0] != "state_changed"]
+    assert lifecycle == ["build_added", "build_removed", "build_added"]
+    assert ("state_changed", dag_hash, "finished") in ui.events
+    record = _record(temporary_store, spec)
+    assert record is not None and record.explicit
+
+
+def test_build_output_streams_to_frontend(temporary_store, mock_packages):
+    """Output and state messages written by a build arrive at the frontend as log_output and
+    state_changed events, byte for byte and in order."""
+    payload = b"checking for compiler...\nbuilding...\n"
+    spec = _make_concrete("trivial-install-test-package")
+    launcher = ScriptedLauncher({spec.name: Script(states=("staging",), output=payload)})
+    ui = _install(launcher, spec)
+
+    dag_hash = spec.dag_hash()
+    received = b"".join(e[2] for e in ui.events if e[0] == "log_output" and e[1] == dag_hash)
+    assert received == payload
+    assert ("state_changed", dag_hash, "staging") in ui.events
+    assert ("state_changed", dag_hash, "finished") in ui.events
+
+
+def test_package_installer_with_injected_ui(temporary_store, mock_packages):
+    """The event loop runs against a custom InstallerUI frontend without any terminal code.
+
+    Uses the mark-explicit path (spec installed implicitly, requested explicitly) so the loop
+    schedules, reports, and persists to the database without spawning build processes."""
+    spec = _make_concrete("trivial-install-test-package")
+    temporary_store.layout.create_install_directory(spec)
+    temporary_store.db.add(spec, explicit=False)
+
+    ui = _install(None, spec)
+
+    dag_hash = spec.dag_hash()
+    assert ("build_added", dag_hash, spec.name) in ui.events
+    assert ("state_changed", dag_hash, "finished") in ui.events
+
+    # The spec was marked explicit in the database.
+    record = _record(temporary_store, spec)
+    assert record is not None and record.explicit
+
+
+def test_dependency_built_before_dependent(temporary_store, mock_packages):
+    """Builds are launched in dependency order and both land in the database."""
+    dep = _make_concrete("dependency-install")
+    root = _make_concrete("dependent-install", deps=[dep])
+    launcher = ScriptedLauncher({dep.name: Script(), root.name: Script()})
+    _install(launcher, root)
+
+    assert [r.spec.name for r in launcher.requests] == [dep.name, root.name]
+    assert _record(temporary_store, dep) and _record(temporary_store, root)
+
+
+def test_capacity_serializes_launches(temporary_store, mock_packages):
+    """With concurrent_packages=1 the second build is only requested after the first finished."""
+    a, b = _make_concrete("pkg-a"), _make_concrete("pkg-b")
+    launcher = ScriptedLauncher({a.name: Script(hang=True), b.name: Script(hang=True)})
+    requests_at_finish = []
+
+    def tick():
+        if launcher.hanging:
+            requests_at_finish.append(len(launcher.requests))
+            launcher.hanging.pop(0).finish()
+
+    _install(launcher, a, b, ui=DrivingUI(tick), concurrent_packages=1)
+
+    assert requests_at_finish == [1, 2]
+
+
+def test_stopped_at_phase_is_not_a_failure(temporary_store, mock_packages):
+    """A build exiting with STOPPED_AT_PHASE raises nothing, reports no failure, and leaves no
+    database record."""
+    spec = _make_concrete("trivial-install-test-package")
+    launcher = ScriptedLauncher({spec.name: Script(exitcode=ExitCode.STOPPED_AT_PHASE)})
+    ui = _install(launcher, spec)
+
+    assert not [e for e in ui.events if e[0] == "state_changed" and e[2] == "failed"]
+    assert _record(temporary_store, spec) is None
+
+
+@pytest.mark.disable_clean_stage_check  # failed builds keep their log file in the stage root
+def test_fail_fast_terminates_running_builds(temporary_store, mock_packages):
+    """In fail_fast mode a failure terminates the still-running build, which is not itself
+    reported as a failure."""
+    bad, hanging = _make_concrete("pkg-a"), _make_concrete("pkg-b")
+    launcher = ScriptedLauncher(
+        {bad.name: Script(exitcode=ExitCode.BUILD_ERROR), hanging.name: Script(hang=True)}
+    )
+    ui = RecordingUI()
+    with pytest.raises(spack.error.InstallError) as exc_info:
+        _install(launcher, bad, hanging, ui=ui, fail_fast=True, concurrent_packages=2)
+
+    assert launcher.hanging[0].terminated
+    failed = [e for e in ui.events if e[0] == "state_changed" and e[2] == "failed"]
+    assert failed == [("state_changed", bad.dag_hash(), "failed")]
+    assert bad.name in str(exc_info.value) and hanging.name not in str(exc_info.value)
+
+
+def test_set_echo_commands_reach_control_channel(temporary_store, mock_packages):
+    """SetEcho commands queued by the UI are written as b"1"/b"0" to the control channel of the
+    build, which is still registered as running when the command queue is drained."""
+    spec = _make_concrete("trivial-install-test-package")
+    launcher = ScriptedLauncher({spec.name: Script()})
+    ui = RecordingUI()
+    ui.commands += [SetEcho(spec.dag_hash(), True), SetEcho(spec.dag_hash(), False)]
+    _install(launcher, spec, ui=ui)
+
+    assert read_connection(launcher.builds[0].channels.control_r, 16) == b"10"
+
+
+def test_cache_miss_expands_build_deps(temporary_store, mock_packages, mutable_config, tmp_path):
+    """A cache miss on a root with unexpanded build deps schedules those deps (growing the UI
+    total) and retries the root as source_only."""
+    spack.config.set("mirrors", {"local": {"url": (tmp_path / "mirror").as_uri(), "binary": True}})
+    dep = _make_concrete("dependency-install")
+    root = _make_concrete("dependent-install", deps=[dep], depflag=dt.BUILD)
+    launcher = ScriptedLauncher(
+        {root.name: [Script(exitcode=ExitCode.BUILD_CACHE_MISS), Script()], dep.name: Script()}
+    )
+    ui = _install(launcher, root)
+
+    assert [(r.spec.name, r.install_policy) for r in launcher.requests] == [
+        (root.name, "cache_only"),
+        (dep.name, "cache_only"),
+        (root.name, "source_only"),
+    ]
+    assert ("total_increased", 1) in ui.events
+    assert _record(temporary_store, dep) and _record(temporary_store, root)
+
+
+def test_external_spec_uses_devnull_log(temporary_store, mock_packages):
+    """External specs get os.devnull as log path and are recorded in the database."""
+    spec = _make_concrete("trivial-install-test-package")
+    spec.external_path = "/usr"
+    launcher = ScriptedLauncher({spec.name: Script()})
+    _install(launcher, spec)
+
+    assert launcher.requests[0].log_path == os.devnull
+    record = _record(temporary_store, spec)
+    assert record is not None and record.installed
+
+
+def test_overwrite_reinstalls_through_event_loop(temporary_store, mock_packages):
+    """An overwrite install of an already-installed spec launches a build and refreshes the
+    database record."""
+    spec = _make_concrete("trivial-install-test-package")
+    temporary_store.layout.create_install_directory(spec)
+    temporary_store.db.add(spec, explicit=True)
+    old_time = _record(temporary_store, spec).installation_time
+
+    launcher = ScriptedLauncher({spec.name: Script()})
+    _install(launcher, spec, overwrite=[spec.dag_hash()])
+
+    assert len(launcher.requests) == 1
+    assert _record(temporary_store, spec).installation_time > old_time
 
 
 def test_nodes_to_roots():
@@ -724,7 +1015,7 @@ def test_expand_build_deps_source_only_includes_nested_build_deps(temporary_stor
         s._mark_concrete()
 
     # Construct a BuildGraph with root_policy="auto" so root's build deps are deferred.
-    bg = BuildGraph(
+    build_graph = BuildGraph(
         specs=[root],
         root_policy="auto",
         dependencies_policy="source_only",
@@ -735,13 +1026,13 @@ def test_expand_build_deps_source_only_includes_nested_build_deps(temporary_stor
     )
 
     # The initial graph should contain only root (build deps deferred for "auto" policy).
-    assert root.dag_hash() in bg.nodes
-    assert specs["build_tool"].dag_hash() not in bg.nodes
+    assert root.dag_hash() in build_graph.nodes
+    assert specs["build_tool"].dag_hash() not in build_graph.nodes
 
     # Simulate a cache miss: expand build deps for root.
     pending = []
     with temporary_store.db.read_transaction():
-        newly_added = bg.expand_build_deps(
+        newly_added = build_graph.expand_build_deps(
             [root.dag_hash()], pending, temporary_store.db, dependencies_policy="source_only"
         )
 
@@ -756,3 +1047,149 @@ def test_expand_build_deps_source_only_includes_nested_build_deps(temporary_stor
     # nested_build_tool must also be added (BUILD dep of build_tool). This is the bug: without the
     # fix, expand_build_deps only traverses LINK|RUN, so nested_build_tool is missing.
     assert specs["nested_build_tool"].dag_hash() in added_hashes
+
+
+def test_installed_from_binary_cache_message_sets_package_attr(temporary_store, mock_packages):
+    """The installed_from_binary_cache state message sets the corresponding package attribute in
+    the parent process."""
+    spec = _make_concrete("trivial-install-test-package")
+    launcher = ScriptedLauncher(
+        {spec.name: Script(raw_state=b'{"installed_from_binary_cache":true}\n')}
+    )
+    _install(launcher, spec)
+
+    assert spec.package.installed_from_binary_cache is True
+
+
+def test_state_messages_tolerate_garbage_and_partial_lines(temporary_store, mock_packages):
+    """Empty and non-JSON state lines are skipped, and a message split across two writes is
+    reassembled from the per-build state buffer."""
+    spec = _make_concrete("trivial-install-test-package")
+    launcher = ScriptedLauncher({spec.name: Script(raw_state=b'garbage\n\n{"sta', hang=True)})
+
+    def tick():
+        if launcher.hanging:
+            # The first chunk was consumed before the first tick; complete the partial line.
+            proc = launcher.hanging.pop(0)
+            write_connection(proc.channels.state_w, b'te":"staging"}\n')
+            proc.finish()
+
+    ui = _install(launcher, spec, ui=DrivingUI(tick))
+
+    dag_hash = spec.dag_hash()
+    assert ("state_changed", dag_hash, "staging") in ui.events
+    assert ("state_changed", dag_hash, "finished") in ui.events
+
+
+@pytest.mark.disable_clean_stage_check  # failed builds keep their log file in the stage root
+def test_reports_collect_success_failure_and_skips(temporary_store, mock_packages):
+    """With create_reports=True, each root gets a RequestRecord: a failed dep is recorded as
+    failure, its dependent as skipped, and an independent successful root as success."""
+    dep = _make_concrete("dependency-install")
+    root = _make_concrete("dependent-install", deps=[dep])
+    other = _make_concrete("trivial-install-test-package")
+    launcher = ScriptedLauncher(
+        {dep.name: Script(exitcode=ExitCode.BUILD_ERROR), other.name: Script()}
+    )
+    installer = PackageInstaller(
+        [root.package, other.package],
+        explicit=True,
+        ui=RecordingUI(),
+        launcher=launcher,
+        create_reports=True,
+    )
+    with pytest.raises(spack.error.InstallError):
+        installer.install()
+
+    root_results = {r.name: r.result for r in installer.reports[root.dag_hash()].packages}
+    assert root_results == {dep.name: "failure", root.name: "skipped"}
+    root_record = next(
+        r for r in installer.reports[root.dag_hash()].packages if r.name == root.name
+    )
+    assert root_record.message == "Dependencies failed to install"
+    assert [r.result for r in installer.reports[other.dag_hash()].packages] == ["success"]
+
+
+@pytest.mark.disable_clean_stage_check  # interrupted installs keep their log files
+def test_keyboard_interrupt_terminates_builds_and_flushes_db(temporary_store, mock_packages):
+    """A KeyboardInterrupt from the UI propagates, terminates the running build, and still
+    flushes already-finished builds to the database."""
+    dep = _make_concrete("dependency-install")
+    root = _make_concrete("dependent-install", deps=[dep])
+    launcher = ScriptedLauncher({dep.name: Script(), root.name: Script(hang=True)})
+
+    def tick():
+        if launcher.hanging:  # the dep finished and the root build is now running
+            raise KeyboardInterrupt
+
+    with pytest.raises(KeyboardInterrupt):
+        _install(launcher, root, ui=DrivingUI(tick))
+
+    assert launcher.hanging[0].terminated
+    assert _record(temporary_store, dep) is not None
+    assert _record(temporary_store, root) is None
+
+
+@pytest.mark.disable_clean_stage_check  # failed builds keep their log file in the stage root
+def test_failed_builds_reach_on_finished(temporary_store, mock_packages):
+    """The loop notifies the frontend of the failed build ids before raising InstallError."""
+    spec = _make_concrete("trivial-install-test-package")
+    launcher = ScriptedLauncher({spec.name: Script(exitcode=ExitCode.BUILD_ERROR)})
+    ui = RecordingUI()
+
+    with pytest.raises(spack.error.InstallError):
+        _install(launcher, spec, ui=ui)
+
+    assert ("finished", (spec.dag_hash(),)) in ui.events
+
+
+def test_set_echo_unknown_build_is_noop(temporary_store, mock_packages):
+    """A SetEcho command for a build id that is not running does nothing."""
+    spec = _make_concrete("trivial-install-test-package")
+    launcher = ScriptedLauncher({spec.name: Script()})
+    ui = RecordingUI()
+    ui.commands.append(SetEcho("0" * 32, True))
+    _install(launcher, spec, ui=ui)
+
+    assert _record(temporary_store, spec) is not None
+
+
+def test_explicit_policies_reach_build_requests(temporary_store, mock_packages):
+    """Explicit root/dependencies policies are passed through to the build requests instead of
+    being resolved dynamically like "auto"."""
+    dep = _make_concrete("dependency-install")
+    root = _make_concrete("dependent-install", deps=[dep])
+    launcher = ScriptedLauncher({dep.name: Script(), root.name: Script()})
+    _install(launcher, root, root_policy="source_only", dependencies_policy="cache_only")
+
+    assert [(r.spec.name, r.install_policy) for r in launcher.requests] == [
+        (dep.name, "cache_only"),
+        (root.name, "source_only"),
+    ]
+
+
+def test_explicit_as_set_marks_only_those_specs(temporary_store, mock_packages):
+    """When explicit is a set of dag hashes, only those specs are marked explicit in the DB."""
+    a, b = _make_concrete("pkg-a"), _make_concrete("pkg-b")
+    launcher = ScriptedLauncher({a.name: Script(), b.name: Script()})
+    PackageInstaller(
+        [a.package, b.package], explicit={a.dag_hash()}, ui=RecordingUI(), launcher=launcher
+    ).install()
+
+    assert _record(temporary_store, a).explicit
+    assert not _record(temporary_store, b).explicit
+
+
+def test_change_jobs_commands_adjust_parallelism(temporary_store, mock_packages):
+    """ChangeJobs commands queued by the UI adjust the jobserver, and the new job counts are
+    reported back through jobs_changed events."""
+    spec = _make_concrete("trivial-install-test-package")
+    launcher = ScriptedLauncher({spec.name: Script()})
+    ui = RecordingUI()
+    ui.commands += [ChangeJobs(1), ChangeJobs(-1)]
+    _install(launcher, spec, ui=ui)
+
+    jobs_events = [e for e in ui.events if e[0] == "jobs_changed"]
+    initial = jobs_events[0][2]
+    assert ("jobs_changed", initial + 1, initial + 1) in jobs_events
+    assert jobs_events[-1][2] == initial  # target restored after the decrease

--- a/lib/spack/spack/test/new_installer.py
+++ b/lib/spack/spack/test/new_installer.py
@@ -1181,6 +1181,7 @@ def test_explicit_as_set_marks_only_those_specs(temporary_store, mock_packages):
     assert not _record(temporary_store, b).explicit
 
 
+@pytest.mark.not_on_windows("Windows has no POSIX jobserver, only NoopJobServer")
 def test_change_jobs_commands_adjust_parallelism(temporary_store, mock_packages):
     """ChangeJobs commands queued by the UI adjust the jobserver, and the new job counts are
     reported back through jobs_changed events."""


### PR DESCRIPTION
Tests enabled by the preceding refactors: the event loop is tested
with an injected UI instance and build launcher.

Also cover the schedule_builds prefix invariant errors, PosixJobServer
attaching to an existing jobserver from MAKEFLAGS, and a few small
TerminalUI rendering branches.

It enables almost all unit tests on Windows, cause it's mostly platform
independent.

Coverage of `new_installer*.py` goes from 51% -> 73% using just the
unit tests from `new_installer.py`, `installer_build_graph.py`,
`installer_tui.py` and `jobserver.py` and the max runtime per test is
40ms.

The remainder is `start_build` etc, which isn't well suited for unit testing,
and is already covered by integration tests.