### PR TITLE
solver: improve input checking for virtuals

### DIFF
--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -2870,20 +2870,23 @@ class SpackSolverSetup:
                 if s.concrete:
                     continue
 
-                deps = {
-                    edge.spec.name
-                    for edge in s.edges_to_dependencies()
-                    if edge.direct and edge.when == EMPTY_SPEC
-                }
-                if deps:
+                direct_edges = [
+                    e for e in s.edges_to_dependencies() if e.direct and e.when == EMPTY_SPEC
+                ]
+                deps = {edge.spec.name for edge in direct_edges}
+                # Virtuals on a direct edge, must be virtuals the node can actually depend on
+                required_virtuals = {virtual for edge in direct_edges for virtual in edge.virtuals}
+                if deps or required_virtuals:
                     graph = analyzer.possible_dependencies(
                         s, allowed_deps=dt.ALL, transitive=False
                     )
                     deps.difference_update(graph.real_pkgs, graph.virtuals)
-                    if deps:
+                    required_virtuals.difference_update(graph.virtuals)
+                    invalid = deps | required_virtuals
+                    if invalid:
                         start_str = f"'{root}'" if s == root else f"'{s}' in '{root}'"
                         raise UnsatisfiableSpecError(
-                            f"{start_str} cannot depend on {', '.join(deps)}"
+                            f"{start_str} cannot depend on {', '.join(sorted(invalid))}"
                         )
 
                 spack.spec.Spec.ensure_valid_variants(s)

--- a/lib/spack/spack/test/concretization/core.py
+++ b/lib/spack/spack/test/concretization/core.py
@@ -2460,6 +2460,7 @@ packages:
             solver.driver.solve(setup, specs, reuse=[])
 
     @pytest.mark.regression("43141")
+    @pytest.mark.regression("52567")
     @pytest.mark.parametrize(
         "spec_str,expected_match",
         [
@@ -2467,6 +2468,10 @@ packages:
             ("pkg-a ^foo", "since 'foo' does not exist"),
             # Request a compiler for a package that doesn't need it
             ("pkg-c %gcc", "cannot depend on gcc"),
+            # Request a compiler for a language the package doesn't use, while another
+            # compiler is requested for a language it does use. Only the unusable language
+            # must be reported.
+            ("pkg-b %c=gcc %fortran=llvm", "cannot depend on fortran"),
         ],
     )
     def test_errors_on_statically_checked_preconditions(self, spec_str, expected_match):


### PR DESCRIPTION
fixes #52567

Check when validating input if any virtual assignment corresponds to virtuals the package cannot depend on.