### PR TITLE
cmd/uninstall: option to uninstall implicit dependents

### DIFF
--- a/lib/spack/spack/cmd/uninstall.py
+++ b/lib/spack/spack/cmd/uninstall.py
@@ -4,7 +4,7 @@
 
 import argparse
 import sys
-from typing import Dict, List, Optional
+from typing import Dict, List, Optional, Tuple
 
 import spack.cmd
 import spack.cmd.common.confirmation as confirmation
@@ -62,9 +62,23 @@ def setup_parser(subparser: argparse.ArgumentParser) -> None:
         help="if in an environment, then the spec should also be removed from "
         "the environment description",
     )
-    arguments.add_common_arguments(
-        subparser, ["recurse_dependents", "yes_to_all", "installed_specs"]
+    dependents_group = subparser.add_mutually_exclusive_group()
+    dependents_group.add_argument(
+        "-R",
+        "--dependents",
+        action="store_true",
+        dest="dependents",
+        help="also uninstall any packages that depend on the ones given via command line",
     )
+    dependents_group.add_argument(
+        "-r",
+        "--implicit-dependents",
+        action="store_true",
+        dest="implicit_dependents",
+        help="recursively uninstall any implicitly installed dependents of the ones given via "
+        "command line, but still error if any explicitly installed package depends on them",
+    )
+    arguments.add_common_arguments(subparser, ["yes_to_all", "installed_specs"])
     subparser.add_argument(
         "-a",
         "--all",
@@ -130,16 +144,14 @@ def find_matching_specs(
     return specs_from_cli
 
 
-def installed_dependents(specs: List[spack.spec.Spec]) -> List[spack.spec.Spec]:
+def installed_dependents(
+    specs: List[spack.spec.Spec],
+) -> Tuple[List[spack.spec.Spec], List[spack.spec.Spec]]:
+    """Return the installed dependents of ``specs``, partitioned into explicit and implicit."""
     # Note: the combination of arguments (in particular order=breadth
     # and root=False) ensures dependents and matching_specs are non-overlapping;
     # In the extreme case of "spack uninstall --all" we get the entire database as
-    # input; in that case we return an empty list.
-
-    def is_installed(spec):
-        record = spack.store.STORE.db.query_local_by_spec_hash(spec.dag_hash())
-        return record and record.installed
-
+    # input; in that case we return two empty list.
     all_specs = traverse.traverse_nodes(
         specs,
         root=False,
@@ -150,8 +162,15 @@ def installed_dependents(specs: List[spack.spec.Spec]) -> List[spack.spec.Spec]:
         key=lambda s: s.dag_hash(),
     )
 
+    explicit: List[spack.spec.Spec] = []
+    implicit: List[spack.spec.Spec] = []
     with spack.store.STORE.db.read_transaction():
-        return [spec for spec in all_specs if is_installed(spec)]
+        for spec in all_specs:
+            record = spack.store.STORE.db.query_local_by_spec_hash(spec.dag_hash())
+            if not record or not record.installed:
+                continue
+            (explicit if record.explicit else implicit).append(spec)
+    return explicit, implicit
 
 
 def dependent_environments(
@@ -213,12 +232,21 @@ def get_uninstall_list(args, specs: List[spack.spec.Spec], env: Optional[ev.Envi
     # Gets the list of installed specs that match the ones given via cli
     # args.all takes care of the case where '-a' is given in the cli
     matching_specs = find_matching_specs(env, specs, args.all, origin=args.origin)
-    dependent_specs = installed_dependents(matching_specs)
-    all_uninstall_specs = matching_specs + dependent_specs if args.dependents else matching_specs
-    other_dependent_envs = dependent_environments(all_uninstall_specs, current_env=env)
+    explicit_dependents, implicit_dependents = installed_dependents(matching_specs)
 
-    # There are dependents and we didn't ask to remove dependents
-    dangling_dependents = dependent_specs and not args.dependents
+    # determine which dependents get pulled into or block the uninstall
+    if args.dependents:
+        pulled_in_dependents = explicit_dependents + implicit_dependents
+        dangling_dependents: List[spack.spec.Spec] = []
+    elif args.implicit_dependents:
+        pulled_in_dependents = implicit_dependents
+        dangling_dependents = explicit_dependents
+    else:
+        pulled_in_dependents = []
+        dangling_dependents = explicit_dependents + implicit_dependents
+
+    all_uninstall_specs = matching_specs + pulled_in_dependents
+    other_dependent_envs = dependent_environments(all_uninstall_specs, current_env=env)
 
     # An environment different than the current env depends on
     # one or more of the list of all specs to be uninstalled.
@@ -232,8 +260,11 @@ def get_uninstall_list(args, specs: List[spack.spec.Spec], env: Optional[ev.Envi
         spack.cmd.display_specs(matching_specs, **display_args)
         if dangling_dependents:
             print()
-            tty.info("The following dependents are still installed:")
-            spack.cmd.display_specs(dependent_specs, **display_args)
+            if args.implicit_dependents:
+                tty.info("The following explicitly installed dependents are still installed:")
+            else:
+                tty.info("The following dependents are still installed:")
+            spack.cmd.display_specs(dangling_dependents, **display_args)
             msgs.append("use `spack uninstall --dependents` to remove dependents too")
         if dangling_environments:
             print()

--- a/lib/spack/spack/test/cmd/uninstall.py
+++ b/lib/spack/spack/test/cmd/uninstall.py
@@ -116,7 +116,7 @@ def test_uninstall_implicit_dependents_removes_implicit_chain(mutable_database):
     should remove the whole chain."""
     with spack.store.STORE.db.write_transaction():
         for spec in spack.store.STORE.db.query("mpileaks"):
-            spack.store.STORE.db.query_local_by_spec_hash(spec.dag_hash()).explicit = False
+            spack.store.STORE.db.mark(spec, "explicit", False)
 
     uninstall("-y", "-r", "libelf")
 

--- a/lib/spack/spack/test/cmd/uninstall.py
+++ b/lib/spack/spack/test/cmd/uninstall.py
@@ -57,8 +57,11 @@ def test_correct_installed_dependents(mutable_database):
     # Uninstall it, so it's missing.
     callpath.package.do_uninstall(force=True)
 
-    # Retrieve all dependent hashes
-    dependents = spack.cmd.uninstall.installed_dependents(dependencies)
+    # Retrieve all dependent hashes (explicit and implicit, combined)
+    explicit_dependents, implicit_dependents = spack.cmd.uninstall.installed_dependents(
+        dependencies
+    )
+    dependents = explicit_dependents + implicit_dependents
     assert dependents
 
     dependent_hashes = [s.dag_hash() for s in dependents]
@@ -88,6 +91,44 @@ def test_recursive_uninstall(mutable_database):
     assert len(mpileaks_specs) == 0
     assert len(callpath_specs) == 0
     assert len(mpi_specs) == 3
+
+
+@pytest.mark.db
+def test_uninstall_implicit_dependents_blocks_on_explicit(mutable_database):
+    """`-r/--implicit-dependents` must refuse when an explicitly installed dependent exists.
+
+    In the mock DB, ``mpileaks`` (explicit) transitively depends on ``libelf``, so uninstalling
+    ``libelf`` with ``-r`` must error rather than remove anything.
+    """
+    with pytest.raises(SpackCommandError):
+        uninstall("-y", "-r", "libelf")
+
+    # Nothing was removed.
+    assert len(spack.store.STORE.db.query("libelf", installed=True)) == 1
+    assert len(spack.store.STORE.db.query("mpileaks", installed=True)) == 3
+
+
+@pytest.mark.db
+def test_uninstall_implicit_dependents_removes_implicit_chain(mutable_database):
+    """`-r/--implicit-dependents` recursively uninstalls implicitly installed dependents.
+
+    After marking ``mpileaks`` implicit, every dependent of ``libelf`` is implicit, so ``-r``
+    should remove the whole chain."""
+    with spack.store.STORE.db.write_transaction():
+        for spec in spack.store.STORE.db.query("mpileaks"):
+            spack.store.STORE.db.query_local_by_spec_hash(spec.dag_hash()).explicit = False
+
+    uninstall("-y", "-r", "libelf")
+
+    for name in ("libelf", "callpath", "dyninst", "mpileaks", "libdwarf"):
+        assert len(spack.store.STORE.db.query(name, installed=True)) == 0
+
+
+@pytest.mark.db
+def test_uninstall_dependents_and_implicit_dependents_mutually_exclusive(mutable_database):
+    """`-R` and `-r` cannot be used together."""
+    with pytest.raises(SpackCommandError):
+        uninstall("-y", "-R", "-r", "libelf")
 
 
 @pytest.mark.db

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -2059,7 +2059,7 @@ _spack_undevelop() {
 _spack_uninstall() {
     if $list_options
     then
-        SPACK_COMPREPLY="-h --help -f --force --remove -R --dependents -y --yes-to-all -a --all --origin"
+        SPACK_COMPREPLY="-h --help -f --force --remove -R --dependents -r --implicit-dependents -y --yes-to-all -a --all --origin"
     else
         _installed_packages
     fi

--- a/share/spack/spack-completion.fish
+++ b/share/spack/spack-completion.fish
@@ -3290,7 +3290,7 @@ complete -c spack -n '__fish_spack_using_command undevelop' -s a -l all -f -a al
 complete -c spack -n '__fish_spack_using_command undevelop' -s a -l all -d 'remove all specs from (clear) the environment'
 
 # spack uninstall
-set -g __fish_spack_optspecs_spack_uninstall h/help f/force remove R/dependents y/yes-to-all a/all origin=
+set -g __fish_spack_optspecs_spack_uninstall h/help f/force remove R/dependents r/implicit-dependents y/yes-to-all a/all origin=
 complete -c spack -n '__fish_spack_using_command_pos_remainder 0 uninstall' -f -a '(__fish_spack_installed_specs)'
 complete -c spack -n '__fish_spack_using_command uninstall' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command uninstall' -s h -l help -d 'show this help message and exit'
@@ -3300,6 +3300,8 @@ complete -c spack -n '__fish_spack_using_command uninstall' -l remove -f -a remo
 complete -c spack -n '__fish_spack_using_command uninstall' -l remove -d 'if in an environment, then the spec should also be removed from the environment description'
 complete -c spack -n '__fish_spack_using_command uninstall' -s R -l dependents -f -a dependents
 complete -c spack -n '__fish_spack_using_command uninstall' -s R -l dependents -d 'also uninstall any packages that depend on the ones given via command line'
+complete -c spack -n '__fish_spack_using_command uninstall' -s r -l implicit-dependents -f -a implicit_dependents
+complete -c spack -n '__fish_spack_using_command uninstall' -s r -l implicit-dependents -d 'recursively uninstall any implicitly installed dependents of the ones given via command line, but still error if any explicitly installed package depends on them'
 complete -c spack -n '__fish_spack_using_command uninstall' -s y -l yes-to-all -f -a yes_to_all
 complete -c spack -n '__fish_spack_using_command uninstall' -s y -l yes-to-all -d 'assume "yes" is the answer to every confirmation request'
 complete -c spack -n '__fish_spack_using_command uninstall' -s a -l all -f -a all


### PR DESCRIPTION
`spack uninstall` currently allows `-R/--dependents` to uninstall all dependents, this PR adds an option to uninstall only implicitly installed dependents. Used `-r/--implicit-dependents` as the signature to match the (IMO poorly) named existing option.

Includes tests.

As part of this refactor, removed `-R/--dependents` from the common arguments module, since it's only used for uninstall and I don't want to pollute other commands with it.