### PR TITLE
filesystem.py: improve `write_tmp_and_move` and use throughout

### DIFF
--- a/lib/spack/spack/config.py
+++ b/lib/spack/spack/config.py
@@ -274,14 +274,8 @@ class DirectoryConfigScope(ConfigScope):
 
         try:
             filesystem.mkdirp(self.path)
-            fd, tmp = tempfile.mkstemp(dir=self.path, suffix=".tmp")
-            try:
-                with os.fdopen(fd, "w", encoding="utf-8") as f:
-                    syaml.dump_config(data, stream=f, default_flow_style=False)
-                filesystem.rename(tmp, filename)
-            except Exception:
-                os.unlink(tmp)
-                raise
+            with filesystem.write_tmp_and_move(filename, encoding="utf-8") as f:
+                syaml.dump_config(data, stream=f, default_flow_style=False)
         except (syaml.SpackYAMLError, OSError) as e:
             raise ConfigFileError(f"cannot write to '{filename}'") from e
 
@@ -417,16 +411,9 @@ class SingleFileScope(ConfigScope):
 
         validate(data_to_write, self.schema)
         try:
-            parent = os.path.dirname(self.path)
-            filesystem.mkdirp(parent)
-            fd, tmp = tempfile.mkstemp(dir=parent, suffix=".tmp")
-            try:
-                with os.fdopen(fd, "w", encoding="utf-8") as f:
-                    syaml.dump_config(data_to_write, stream=f, default_flow_style=False)
-                filesystem.rename(tmp, self.path)
-            except Exception:
-                os.unlink(tmp)
-                raise
+            filesystem.mkdirp(os.path.dirname(self.path))
+            with filesystem.write_tmp_and_move(self.path, encoding="utf-8") as f:
+                syaml.dump_config(data_to_write, stream=f, default_flow_style=False)
         except (syaml.SpackYAMLError, OSError) as e:
             raise ConfigFileError(f"cannot write to config file {str(e)}") from e
 

--- a/lib/spack/spack/store.py
+++ b/lib/spack/spack/store.py
@@ -21,7 +21,6 @@ import filecmp
 import os
 import pathlib
 import re
-import secrets
 import shutil
 import sys
 import uuid
@@ -234,23 +233,13 @@ class Store:
         else:
             fs.set_install_permissions(bin_dir)
 
-        sbang_tmp_path = os.path.join(bin_dir, f".sbang.{secrets.token_hex(8)}.tmp")
-        # Open a randomized temporary file with O_EXCL to error on races. Outside the try-except
-        # to ensure we don't delete a file created by another process in the except block.
-        sbang_tmp_file = open(sbang_tmp_path, "xb")
-        try:
-            with open(spack.paths.sbang_script, "rb") as src, sbang_tmp_file as dst:
-                shutil.copyfileobj(src, dst)
-                os.fchmod(dst.fileno(), config_mode | 0o111)  # ensure executable
-                if group_name:
-                    os.fchown(dst.fileno(), -1, gid)
-            os.rename(sbang_tmp_path, sbang_path)
-        except BaseException:
-            try:
-                os.unlink(sbang_tmp_path)
-            except OSError:
-                pass
-            raise
+        with fs.write_tmp_and_move(sbang_path, mode="wb") as dst, open(
+            spack.paths.sbang_script, "rb"
+        ) as src:
+            shutil.copyfileobj(src, dst)
+            os.fchmod(dst.fileno(), config_mode | 0o111)  # ensure executable
+            if group_name:
+                os.fchown(dst.fileno(), -1, gid)
 
     def __reduce__(self):
         return Store, (

--- a/lib/spack/spack/test/util/filesystem.py
+++ b/lib/spack/spack/test/util/filesystem.py
@@ -1360,3 +1360,51 @@ def test_edit_in_place_through_temporary_file(tmp_path: pathlib.Path):
             f.write("World")
     assert (tmp_path / "example.txt").read_text() == "World"
     assert os.stat(tmp_path / "example.txt").st_ino == current_ino
+
+
+def test_write_tmp_and_move_replaces_and_cleans_up(tmp_path: pathlib.Path):
+    dst = tmp_path / "file.txt"
+    dst.write_text("old")
+    with fs.write_tmp_and_move(str(dst), encoding="utf-8") as f:
+        f.write("new")
+    assert dst.read_text() == "new"
+    assert os.listdir(tmp_path) == ["file.txt"]
+
+
+def test_write_tmp_and_move_failure_keeps_destination(tmp_path: pathlib.Path):
+    dst = tmp_path / "file.txt"
+    dst.write_text("old")
+    with pytest.raises(ValueError, match="expected"):
+        with fs.write_tmp_and_move(str(dst), encoding="utf-8") as f:
+            f.write("partial")
+            raise ValueError("expected")
+    assert dst.read_text() == "old"
+    assert os.listdir(tmp_path) == ["file.txt"]
+
+
+def test_write_tmp_and_move_binary_mode(tmp_path: pathlib.Path):
+    dst = tmp_path / "file.bin"
+    with fs.write_tmp_and_move(str(dst), mode="wb") as f:
+        f.write(b"\x00\x01\x02")
+    assert dst.read_bytes() == b"\x00\x01\x02"
+    assert os.listdir(tmp_path) == ["file.bin"]
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="umask is not supported on Windows")
+def test_write_tmp_and_move_permissions(tmp_path: pathlib.Path):
+    old_umask = os.umask(0o022)
+    try:
+        # new files are created with mode 0o666 & ~umask
+        dst = tmp_path / "file.txt"
+        with fs.write_tmp_and_move(str(dst), encoding="utf-8") as f:
+            f.write("content")
+        assert stat.S_IMODE(os.stat(dst).st_mode) == 0o644
+
+        # permissions of an existing destination are preserved
+        os.chmod(dst, 0o600)
+        with fs.write_tmp_and_move(str(dst), encoding="utf-8") as f:
+            f.write("updated")
+        assert stat.S_IMODE(os.stat(dst).st_mode) == 0o600
+        assert dst.read_text() == "updated"
+    finally:
+        os.umask(old_umask)

--- a/lib/spack/spack/util/filesystem.py
+++ b/lib/spack/spack/util/filesystem.py
@@ -15,6 +15,7 @@ import os
 import pathlib
 import posixpath
 import re
+import secrets
 import shutil
 import stat
 import subprocess
@@ -24,7 +25,10 @@ from contextlib import contextmanager
 from itertools import accumulate
 from typing import (
     IO,
+    Any,
+    BinaryIO,
     Callable,
+    ContextManager,
     Deque,
     Dict,
     Generator,
@@ -34,9 +38,13 @@ from typing import (
     Optional,
     Sequence,
     Set,
+    TextIO,
     Tuple,
     Union,
+    overload,
 )
+
+from spack.vendor.typing_extensions import Literal
 
 from spack.llnl.util import tty
 from spack.util import lang
@@ -1235,16 +1243,45 @@ def hash_directory(directory, ignore=[]):
     return md5_hash.hexdigest()
 
 
+@overload
+def write_tmp_and_move(
+    filename: str, *, mode: Literal["w"] = ..., encoding: Optional[str] = ...
+) -> ContextManager[TextIO]: ...
+
+
+@overload
+def write_tmp_and_move(
+    filename: str, *, mode: Literal["wb"], encoding: None = ...
+) -> ContextManager[BinaryIO]: ...
+
+
 @contextmanager
 @system_path_filter
-def write_tmp_and_move(filename: str, *, encoding: Optional[str] = None):
-    """Write to a temporary file, then move into place."""
-    dirname = os.path.dirname(filename)
-    basename = os.path.basename(filename)
-    tmp = os.path.join(dirname, ".%s.tmp" % basename)
-    with open(tmp, "w", encoding=encoding) as f:
-        yield f
-    shutil.move(tmp, filename)
+def write_tmp_and_move(
+    filename: str, *, mode: Literal["w", "wb"] = "w", encoding: Optional[str] = None
+) -> Generator[IO[Any], None, None]:
+    """Write to a new temporary file, then atomically move into place. The temporary file is
+    removed on failure. If ``filename`` does not exist, the new file respects umask; if it does
+    exist, permissions of the existing file are preserved."""
+    dirname, basename = os.path.split(filename)
+    tmp = os.path.join(dirname, f".{basename}.{secrets.token_hex(8)}.tmp")
+    # "x" errors on collision instead of clobbering; opened outside the try block so we never
+    # unlink a file created by another process
+    f = open(tmp, mode.replace("w", "x"), encoding=encoding)
+    try:
+        with f:
+            try:
+                os.chmod(tmp, stat.S_IMODE(os.stat(filename).st_mode))
+            except FileNotFoundError:
+                pass
+            yield f
+        rename(tmp, filename)
+    except BaseException:
+        try:
+            os.unlink(tmp)
+        except OSError:
+            pass
+        raise
 
 
 @system_path_filter


### PR DESCRIPTION
Closes #52651

The `mkstemp` + `rename` pattern is used in various places in Spack, which is
a reasonable way to get a new file in a given directory to atomically
replace a target file. The downside is that it doesn't respect umask, cause
it's supposed to be "safe" too (mode 0600).

That was realized in #52369 but not in #52041.

Instead, improve `write_tmp_and_move` to create a randomized temporary
file name opened with "x", which both keeps the atomicity guarantees and
respects umask. Permissions of an existing destination file are preserved, and
the temporary file is removed on failure.

Call sites can still do an `fchmod` on the yielded file.

(Not part of `spack.package` fortunately)
