### PR TITLE
solver: deprioritize target selection

### DIFF
--- a/lib/spack/spack/cmd/spec.py
+++ b/lib/spack/spack/cmd/spec.py
@@ -112,7 +112,20 @@ def _process_result(result, show, required_format, kwargs):
         maxlen = max(len(s.name) for s in result.criteria)
         color.cprint("@*{  Priority  Value  Criterion}")
 
+        # Width of a data row past its 2-space indent, matching the row format below:
+        # 8-wide priority + 2 gap + 5-wide value + 2 gap + maxlen-wide criterion name.
+        divider_width = 8 + 2 + 5 + 2 + maxlen
+        prev_band = None
+
         for i, criterion in enumerate(result.criteria, 1):
+            # Criteria are grouped into priority bands; print a header when the band changes.
+            band = asp.optimization_band(criterion.priority)
+            if band != prev_band:
+                label = f"-- {band.value}"
+                dashes = "-" * max(0, divider_width - len(label) - 1)
+                color.cprint(f"  @*{{{label}}} @K{{{dashes}}}")
+                prev_band = band
+
             value = f"@K{{{criterion.value:>5}}}"
             grey_out = True
             if criterion.value > 0:

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -103,29 +103,61 @@ DEFAULT_OUTPUT_CONFIGURATION = OutputConfiguration(
 )
 
 
-# Below numbers are used to map names of criteria to the order
-# they appear in the solution. See concretize.lp
-
-# The space of possible priorities for optimization targets
-# is partitioned in the following ranges:
+# Below numbers are used to map names of criteria to the order they appear in the solution
 #
-# [0-100) Optimization criteria for software being reused
-# [100-200) Fixed criteria that are higher priority than reuse, but lower than build
-# [200-300) Optimization criteria for software being built
-# [300-1000) High-priority fixed criteria
-# [1000-inf) Error conditions
+# The space of possible priorities for optimization targets is partitioned in the following ranges:
 #
+# [0-100)     Low-priority criteria (target-related criteria plus symmetry tie-breakers)
+# [100-200)   Optimization criteria for software being reused (concrete slot)
+# [200-300)   Fixed criteria higher priority than reuse, lower than build
+# [300-400)   Optimization criteria for software being built (build slot)
+# [400-1000)  High-priority fixed criteria
+# [1000-inf)  Error conditions
+#
+# The "low" band sits strictly below the reused/concrete band, so the solver decides compilers,
+# versions, etc. before targets and tie-breakers.
+#
+# The priority of an opt_criterion() fact is the level of its slot. Priorities in the "concrete"
+# band have an implicit "build" priority shifted by build_priority_offset.
 # Each optimization target is a minimization with optimal value 0.
 
-#: High fixed priority offset for criteria that supersede all build criteria
-high_fixed_priority_offset = 300
+#: Exclusive upper bound of each priority band, in ascending order
+low_band_max = 100
+concrete_band_max = 200
+fixed_band_max = 300
+build_band_max = 400
 
-#: Priority offset for "build" criteria (regular criterio shifted to
-#: higher priority for specs we have to build)
+#: Displacement from a concrete-band criterion's level to its implicit build-band twin
 build_priority_offset = 200
 
-#: Priority offset of "fixed" criteria (those w/o build criteria)
-fixed_priority_offset = 100
+
+class OptimizationBand(enum.Enum):
+    """Grouping for optimization criteria by their priority range."""
+
+    LOW = "Lowest priority"
+    REUSED = "Reused nodes"
+    FIXED = "Fixed (reuse vs build)"
+    BUILD = "Built nodes"
+    HIGHEST = "Highest priority"
+
+
+#: Exclusive upper bound of each band's priority range, in ascending order.
+_BAND_UPPER_BOUNDS = (
+    (low_band_max, OptimizationBand.LOW),  # [0, 100)
+    (concrete_band_max, OptimizationBand.REUSED),  # [100, 200)
+    (fixed_band_max, OptimizationBand.FIXED),  # [200, 300)
+    (build_band_max, OptimizationBand.BUILD),  # [300, 400)
+    # [400, inf) -> OptimizationBand.HIGHEST (requirement weight, unsolved input specs)
+)
+
+
+def optimization_band(priority: int) -> OptimizationBand:
+    """Return the display band a criterion belongs to, given its clingo priority."""
+    for upper_bound, band in _BAND_UPPER_BOUNDS:
+        if priority < upper_bound:
+            return band
+    return OptimizationBand.HIGHEST
+
 
 # type aliases for the data structures we get back from the solver
 SpecDict = Dict[NodeId, spack.spec.Spec]
@@ -161,12 +193,12 @@ def build_criteria_names(costs, arg_tuples):
         priority, name = args[:2]
         priority = int(priority)
 
-        # Add the priority of this opt criterion and its name
-        if priority < fixed_priority_offset:
-            # if the priority is less than fixed_priority_offset, then it
-            # has an associated build priority -- the same criterion but for
-            # nodes that we have to build.
+        if priority < low_band_max:
+            priorities_names.append((priority, name, OptimizationKind.OTHER))
+        elif priority < concrete_band_max:
+            # Reused/concrete criterion in the [100, 200) band.
             priorities_names.append((priority, name, OptimizationKind.CONCRETE))
+            # Same build criterion in the [300, 400) band.
             build_priority = priority + build_priority_offset
             priorities_names.append((build_priority, name, OptimizationKind.BUILD))
         else:

--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -2199,40 +2199,40 @@ build_priority(PackageNode, 0)   :- concrete(PackageNode), attr("node", PackageN
 % A condition group specifies one or more specs that must be satisfied.
 % Specs declared first are preferred, so we assign increasing weights and
 % minimize the weights.
-opt_criterion(310, "requirement weight").
-#minimize{ 0@310: #true }.
+opt_criterion(410, "requirement weight").
+#minimize{ 0@410: #true }.
 #minimize {
-    Weight@310,PackageNode,Group
+    Weight@410,PackageNode,Group
     : requirement_penalty(PackageNode, Group, Weight)
 }.
 #minimize {
-    Weight@310,PackageNode,Language,Group
+    Weight@410,PackageNode,Language,Group
     : requirement_penalty(PackageNode, Language, Group, Weight)
 }.
 
 % Try hard to reuse installed packages (i.e., minimize the number built)
-opt_criterion(120, "number of packages to build (vs. reuse)").
-#minimize { 0@120: #true }.
-#minimize { 1@120,PackageNode : build(PackageNode), not treat_node_as_concrete(PackageNode) }.
+opt_criterion(220, "number of packages to build (vs. reuse)").
+#minimize { 0@220: #true }.
+#minimize { 1@220,PackageNode : build(PackageNode), not treat_node_as_concrete(PackageNode) }.
 
-opt_criterion(110, "number of nodes from the same package").
-#minimize { 0@110: #true }.
-#minimize { ID@110,Package : attr("node", node(ID, Package)), not is_self_build_req(node(ID, Package)) }.
-#minimize { ID@110,Package : attr("virtual_node", node(ID, Package)) }.
+opt_criterion(210, "number of nodes from the same package").
+#minimize { 0@210: #true }.
+#minimize { ID@210,Package : attr("node", node(ID, Package)), not is_self_build_req(node(ID, Package)) }.
+#minimize { ID@210,Package : attr("virtual_node", node(ID, Package)) }.
 #defined optimize_for_reuse/0.
 
 % Minimize the unification set ID used for build dependencies. This reduces the number of optimal
 % solutions that differ only by which node belongs to which unification set.
-opt_criterion(100, "build unification sets").
-#minimize{ 0@100: #true }.
-#minimize{ ID@100,ParentNode : build_set_id(ParentNode, ID) }.
+opt_criterion(200, "build unification sets").
+#minimize{ 0@200: #true }.
+#minimize{ ID@200,ParentNode : build_set_id(ParentNode, ID) }.
 
 % Minimize the number of deprecated versions being used
-opt_criterion(73, "deprecated versions used").
-#minimize{ 0@273: #true }.
-#minimize{ 0@73: #true }.
+opt_criterion(173, "deprecated versions used").
+#minimize{ 0@373: #true }.
+#minimize{ 0@173: #true }.
 #minimize{
-    1@73+Priority,PackageNode
+    1@173+Priority,PackageNode
     : attr("deprecated", PackageNode, _),
       not external(PackageNode),
       build_priority(PackageNode, Priority)
@@ -2242,37 +2242,37 @@ opt_criterion(73, "deprecated versions used").
 % 1. Version weight
 % 2. Number of variants with a non default value, if not set
 % for the root package.
-opt_criterion(70, "version badness (roots)").
-#minimize{ 0@270: #true }.
-#minimize{ 0@70: #true }.
+opt_criterion(170, "version badness (roots)").
+#minimize{ 0@370: #true }.
+#minimize{ 0@170: #true }.
 #minimize {
-    Weight@70+Priority,PackageNode
+    Weight@170+Priority,PackageNode
     : attr("root", PackageNode),
       version_weight(PackageNode, Weight),
       build_priority(PackageNode, Priority)
 }.
 #minimize {
-    Penalty@70+Priority,PackageNode
+    Penalty@170+Priority,PackageNode
     : attr("root", PackageNode),
       version_deprecation_penalty(PackageNode, Penalty),
       build_priority(PackageNode, Priority)
 }.
 
-opt_criterion(65, "variant penalty (roots)").
-#minimize{ 0@265: #true }.
-#minimize{ 0@65: #true }.
+opt_criterion(165, "variant penalty (roots)").
+#minimize{ 0@365: #true }.
+#minimize{ 0@165: #true }.
 #minimize {
-    Penalty@65+Priority,PackageNode,Variant,Value
+    Penalty@165+Priority,PackageNode,Variant,Value
     : variant_penalty(PackageNode, Variant, Value, Penalty),
       attr("root", PackageNode),
       build_priority(PackageNode, Priority)
 }.
 
-opt_criterion(55, "default values of variants not being used (roots)").
-#minimize{ 0@255: #true }.
-#minimize{ 0@55: #true }.
+opt_criterion(155, "default values of variants not being used (roots)").
+#minimize{ 0@355: #true }.
+#minimize{ 0@155: #true }.
 #minimize{
-    1@55+Priority,PackageNode,Variant,Value
+    1@155+Priority,PackageNode,Variant,Value
     : variant_default_not_used(PackageNode, Variant, Value),
       attr("root", PackageNode),
       build_priority(PackageNode, Priority)
@@ -2280,38 +2280,38 @@ opt_criterion(55, "default values of variants not being used (roots)").
 
 % Choose the preferred compiler before penalizing variants, to avoid that a variant penalty
 % on e.g. gcc causes clingo to pick another compiler e.g. llvm
-opt_criterion(48, "preferred compilers").
-#minimize{ 0@248: #true }.
-#minimize{ 0@48: #true }.
+opt_criterion(148, "preferred compilers").
+#minimize{ 0@348: #true }.
+#minimize{ 0@148: #true }.
 #minimize{
-    Weight@48+Priority,ProviderNode,X,Virtual
+    Weight@148+Priority,ProviderNode,X,Virtual
     : provider_weight(ProviderNode, node(X, Virtual), Weight),
       language(Virtual),
       build_priority(ProviderNode, Priority)
 }.
 
-opt_criterion(41, "compiler penalty from reuse").
-#minimize{ 0@241: #true }.
-#minimize{ 0@41: #true }.
-#minimize{1@41,Hash : compiler_penalty_from_reuse(Hash)}.
+opt_criterion(141, "compiler penalty from reuse").
+#minimize{ 0@341: #true }.
+#minimize{ 0@141: #true }.
+#minimize{1@141,Hash : compiler_penalty_from_reuse(Hash)}.
 
 % Try to use default variants or variants that have been set
-opt_criterion(40, "variant penalty (non-roots)").
-#minimize{ 0@240: #true }.
-#minimize{ 0@40: #true }.
+opt_criterion(140, "variant penalty (non-roots)").
+#minimize{ 0@340: #true }.
+#minimize{ 0@140: #true }.
 #minimize {
-    Penalty@40+Priority,PackageNode,Variant,Value
+    Penalty@140+Priority,PackageNode,Variant,Value
     : variant_penalty(PackageNode, Variant, Value, Penalty),
       not attr("root", PackageNode),
       build_priority(PackageNode, Priority)
 }.
 
 % Minimize the weights of all the other providers (mpi, lapack, etc.)
-opt_criterion(38, "preferred providers (excluded compilers and language runtimes)").
-#minimize{ 0@238: #true }.
-#minimize{ 0@38: #true }.
+opt_criterion(138, "preferred providers (excluded compilers and language runtimes)").
+#minimize{ 0@338: #true }.
+#minimize{ 0@138: #true }.
 #minimize{
-    Weight@38+Priority,ProviderNode,X,Virtual
+    Weight@138+Priority,ProviderNode,X,Virtual
     : provider_weight(ProviderNode, node(X, Virtual), Weight),
       not language(Virtual), not language_runtime(Virtual),
       build_priority(ProviderNode, Priority)
@@ -2322,37 +2322,37 @@ compiler_penalty(PackageNode, C-1) :-
    C = #count { CompilerNode : node_compiler(PackageNode, CompilerNode) },
    node_compiler(PackageNode, _), C > 0.
 
-opt_criterion(36, "number of compilers used on the same node").
-#minimize{ 0@236: #true }.
-#minimize{ 0@36: #true }.
+opt_criterion(136, "number of compilers used on the same node").
+#minimize{ 0@336: #true }.
+#minimize{ 0@136: #true }.
 #minimize{
-    Penalty@36+Priority,PackageNode
+    Penalty@136+Priority,PackageNode
     : compiler_penalty(PackageNode, Penalty), build_priority(PackageNode, Priority)
 }.
 
 
-opt_criterion(30, "non-preferred OS's").
-#minimize{ 0@230: #true }.
-#minimize{ 0@30: #true }.
+opt_criterion(130, "non-preferred OS's").
+#minimize{ 0@330: #true }.
+#minimize{ 0@130: #true }.
 #minimize{
-    Weight@30+Priority,PackageNode
+    Weight@130+Priority,PackageNode
     : node_os_weight(PackageNode, Weight),
       build_priority(PackageNode, Priority)
 }.
 
 % Choose more recent versions for nodes
-opt_criterion(25, "version badness (non roots)").
-#minimize{ 0@225: #true }.
-#minimize{ 0@25: #true }.
+opt_criterion(125, "version badness (non roots)").
+#minimize{ 0@325: #true }.
+#minimize{ 0@125: #true }.
 #minimize{
-    Weight@25+Priority,node(X, Package)
+    Weight@125+Priority,node(X, Package)
     : version_weight(node(X, Package), Weight),
       build_priority(node(X, Package), Priority),
       not attr("root", node(X, Package)),
       not runtime(Package)
 }.
 #minimize {
-    Penalty@25+Priority,node(X, Package)
+    Penalty@125+Priority,node(X, Package)
     : version_deprecation_penalty(node(X, Package), Penalty),
       build_priority(node(X, Package), Priority),
       not attr("root", node(X, Package)),
@@ -2361,51 +2361,58 @@ opt_criterion(25, "version badness (non roots)").
 
 
 % Try to use all the default values of variants
-opt_criterion(20, "default values of variants not being used (non-roots)").
-#minimize{ 0@220: #true }.
-#minimize{ 0@20: #true }.
+opt_criterion(120, "default values of variants not being used (non-roots)").
+#minimize{ 0@320: #true }.
+#minimize{ 0@120: #true }.
 #minimize{
-    1@20+Priority,PackageNode,Variant,Value
+    1@120+Priority,PackageNode,Variant,Value
     : variant_default_not_used(PackageNode, Variant, Value),
       not attr("root", PackageNode),
       build_priority(PackageNode, Priority)
 }.
 
-% Minimize the number of mismatches for targets in the DAG, try
-% to select the preferred target.
-opt_criterion(10, "target mismatches").
-#minimize{ 0@210: #true }.
-#minimize{ 0@10: #true }.
+% Prefer more optimal providers for language runtimes.
+opt_criterion(105, "preferred providers (language runtimes)").
+#minimize{ 0@305: #true }.
+#minimize{ 0@105: #true }.
 #minimize{
-    1@10+Priority,PackageNode,node(ID, Dependency)
-    : node_target_mismatch(PackageNode, node(ID, Dependency)),
-      build_priority(node(ID, Dependency), Priority),
-      not runtime(Dependency)
-}.
-
-opt_criterion(7, "non-preferred targets").
-#minimize{ 0@207: #true }.
-#minimize{ 0@7: #true }.
-#minimize{
-    Weight@7+Priority,node(X, Package)
-    : node_target_weight(node(X, Package), Weight),
-      build_priority(node(X, Package), Priority),
-      not runtime(Package)
-}.
-
-opt_criterion(5, "preferred providers (language runtimes)").
-#minimize{ 0@205: #true }.
-#minimize{ 0@5: #true }.
-#minimize{
-    Weight@5+Priority,ProviderNode,X,Virtual
+    Weight@105+Priority,ProviderNode,X,Virtual
     : provider_weight(ProviderNode, node(X, Virtual), Weight),
       language_runtime(Virtual),
       build_priority(ProviderNode, Priority)
 }.
 
+% Build and concrete mismatches are sandwiched between node target penalty so that
+% we can still reuse an old, available target and build a more specific software on
+% top of it by default
+opt_criterion(12, "target mismatches (built nodes)").
+#minimize{ 0@12: #true }.
+#minimize{
+    1@12,PackageNode,node(ID, Dependency)
+    : node_target_mismatch(PackageNode, node(ID, Dependency)),
+      build_priority(node(ID, Dependency), 200),
+      not runtime(Dependency)
+}.
+
+opt_criterion(10, "non-preferred targets").
+#minimize{ 0@10: #true }.
+#minimize{
+    Weight@10,node(X, Package)
+    : node_target_weight(node(X, Package), Weight),
+      not runtime(Package)
+}.
+
+opt_criterion(7, "target mismatches (reused nodes)").
+#minimize{ 0@7: #true }.
+#minimize{
+    1@7,PackageNode,node(ID, Dependency)
+    : node_target_mismatch(PackageNode, node(ID, Dependency)),
+      build_priority(node(ID, Dependency), 0),
+      not runtime(Dependency)
+}.
+
 % Choose more recent versions for runtimes
 opt_criterion(4, "version badness (runtimes)").
-#minimize{ 0@204: #true }.
 #minimize{ 0@4: #true }.
 #minimize{
     Weight@4,node(X, Package)
@@ -2415,7 +2422,6 @@ opt_criterion(4, "version badness (runtimes)").
 
 % Choose best target for runtimes
 opt_criterion(3, "non-preferred targets (runtimes)").
-#minimize{ 0@203: #true }.
 #minimize{ 0@3: #true }.
 #minimize{
     Weight@3,node(X, Package)
@@ -2425,7 +2431,6 @@ opt_criterion(3, "non-preferred targets (runtimes)").
 
 % Try to use the most optimal providers as much as possible
 opt_criterion(2, "providers on edges").
-#minimize{ 0@202: #true }.
 #minimize{ 0@2: #true }.
 #minimize{
     Weight@2,ParentNode,ProviderNode,node(X, Virtual)
@@ -2438,7 +2443,6 @@ opt_criterion(2, "providers on edges").
 
 % Try to use latest versions of nodes as much as possible
 opt_criterion(1, "version badness on edges").
-#minimize{ 0@201: #true }.
 #minimize{ 0@1: #true }.
 #minimize{
     Weight@1,ParentNode,node(X, Package)
@@ -2450,7 +2454,6 @@ opt_criterion(1, "version badness on edges").
 
 % Reduce symmetry on duplicates
 opt_criterion(0, "penalty on symmetric duplicates").
-#minimize{ 0@200: #true }.
 #minimize{ 0@0: #true }.
 #minimize{
     Weight@1,PackageNode,Reason : duplicate_penalty(PackageNode, Weight, Reason)

--- a/lib/spack/spack/solver/when_possible.lp
+++ b/lib/spack/spack/solver/when_possible.lp
@@ -29,9 +29,9 @@ do_not_impose(EffectID, node(X, Package)) :-
   trigger_and_effect(_, TriggerID, EffectID),
   trigger_requestor_node(TriggerID, node(X, Package)).
 
-opt_criterion(320, "number of input specs not concretized").
-#minimize{ 0@320: #true }.
-#minimize { 1@320,ID : literal_not_solved(ID) }.
+opt_criterion(420, "number of input specs not concretized").
+#minimize{ 0@420: #true }.
+#minimize { 1@420,ID : literal_not_solved(ID) }.
 
 #heuristic solve_literal(ID) : literal(ID). [1, sign]
 #heuristic solve_literal(ID) : literal(ID). [1000, init]

--- a/lib/spack/spack/test/concretization/core.py
+++ b/lib/spack/spack/test/concretization/core.py
@@ -1153,6 +1153,41 @@ spack:
         s = spack.concretize.concretize_one(spec)
         assert str(s.architecture.target) == str(expected)
 
+    @pytest.mark.not_on_windows("Not supported on Windows (yet)")
+    @pytest.mark.usefixtures("mock_targets")
+    def test_preferred_compiler_kept_by_downgrading_target(
+        self, compiler_factory, mutable_config, monkeypatch
+    ):
+        """When the preferred compiler cannot reach the host target, but a non-preferred
+        compiler could, Spack keeps the preferred compiler and downgrades the target
+        rather than switching compilers to get a better target.
+        """
+        core2 = spack.vendor.archspec.cpu.TARGETS["core2"]
+        haswell = spack.vendor.archspec.cpu.TARGETS["haswell"]
+
+        # Host is haswell, but the only available gcc (the preferred c/cxx provider) is
+        # gcc@4.4.7, which supports at most core2. llvm@15 (available by default) could
+        # reach haswell.
+        monkeypatch.setattr(spack.platforms.Test, "default", "haswell")
+        monkeypatch.setattr(
+            spack.archspec, "HOST_TARGET_FAMILY", spack.vendor.archspec.cpu.TARGETS["x86_64"]
+        )
+        monkeypatch.setattr(spack.vendor.archspec.cpu, "host", lambda: haswell)
+        mutable_config.set(
+            "packages:gcc",
+            {
+                "require": "@4.4.7",
+                "externals": [compiler_factory(spec="gcc@4.4.7 languages=c,c++,fortran")],
+            },
+        )
+
+        s = spack.concretize.concretize_one("pkg-a")
+
+        # The preferred compiler is kept and the target is downgraded, instead of
+        # switching to llvm to reach a better target.
+        assert s.satisfies("%c=gcc@4.4.7")
+        assert str(s.architecture.target) == str(core2)
+
     @pytest.mark.parametrize(
         "constraint,expected", [("%gcc@10.2", "@=10.2.1"), ("%gcc@10.2:", "@=10.2.1")]
     )


### PR DESCRIPTION
Currently, on systems where the host target is not supported by the default compiler, Spack tries to swap compilers in order to optimize for the target.

This situation is unfrequent, but the behavior is surprising - if GCC is the preferred compiler users would prefer to see a lower target than have Spack swap to LLVM or Intel without a request.

Since this behavior is currently untested, in this PR:
1. We added a regression test for this use case
2. We lowered target related optimizations below compiler selection

As a bonus, we also improved the output for the optimization criteria, which are now shown grouped:

<img width="1641" height="2040" alt="image" src="https://github.com/user-attachments/assets/b6fcbf6d-7958-4692-9678-300975a350f1" />
