### PR TITLE
Remove all usage and docs references to deprecated `spack solve` command

### DIFF
--- a/.github/workflows/bootstrap.yml
+++ b/.github/workflows/bootstrap.yml
@@ -180,7 +180,7 @@ jobs:
           ./share/spack/setup-env.ps1
           spack bootstrap disable github-actions-v2
           spack bootstrap disable github-actions-v0.6
-          spack -d solve zlib
+          spack -d spec --show opt,solutions zlib
           ./share/spack/qa/validate_last_exit.ps1
           tree $env:userprofile/.spack/bootstrap/store/
       - name: Bootstrap GnuPG

--- a/.github/workflows/bootstrap.yml
+++ b/.github/workflows/bootstrap.yml
@@ -47,7 +47,7 @@ jobs:
           spack config add config:installer:new
           spack bootstrap disable github-actions-v2
           spack bootstrap disable github-actions-v0.6
-          spack solve zlib
+          spack spec --show opt,solutions zlib
           tree ~/.spack/bootstrap/store/
 
   clingo-sources:
@@ -74,7 +74,7 @@ jobs:
           spack bootstrap disable github-actions-v2
           spack bootstrap disable github-actions-v0.6
           export PATH="$(brew --prefix bison)/bin:$(brew --prefix cmake)/bin:$PATH"
-          spack solve zlib
+          spack spec --show opt,solutions zlib
           tree ~/.spack/bootstrap/store/
 
   gnupg-sources:
@@ -100,7 +100,7 @@ jobs:
         run: |
           . share/spack/setup-env.sh
           spack config add config:installer:new
-          spack solve zlib
+          spack spec --show opt,solutions zlib
           spack bootstrap disable github-actions-v2
           spack bootstrap disable github-actions-v0.6
           spack gpg list
@@ -150,7 +150,7 @@ jobs:
               echo "Python $ver not found"
               exit 1
             fi
-            spack solve zlib
+            spack spec --show opt,solutions zlib
           done
           tree ~/.spack/bootstrap/store
       - name: Bootstrap GnuPG

--- a/.github/workflows/bootstrap.yml
+++ b/.github/workflows/bootstrap.yml
@@ -180,7 +180,7 @@ jobs:
           ./share/spack/setup-env.ps1
           spack bootstrap disable github-actions-v2
           spack bootstrap disable github-actions-v0.6
-          spack -d spec --show opt,solutions zlib
+          spack -d spec --show "opt,solutions" zlib
           ./share/spack/qa/validate_last_exit.ps1
           tree $env:userprofile/.spack/bootstrap/store/
       - name: Bootstrap GnuPG

--- a/.github/workflows/unit_tests.yaml
+++ b/.github/workflows/unit_tests.yaml
@@ -74,7 +74,7 @@ jobs:
           . share/spack/setup-env.sh
           spack bootstrap disable spack-install
           spack bootstrap now
-          spack -v solve zlib
+          spack -v spec --show opt,solutions zlib
     - name: Run unit tests
       env:
           SPACK_PYTHON: python

--- a/.github/workflows/unit_tests.yaml
+++ b/.github/workflows/unit_tests.yaml
@@ -187,7 +187,7 @@ jobs:
         spack bootstrap disable github-actions-v0.6
         spack bootstrap disable github-actions-v2
         spack bootstrap status
-        spack solve zlib
+        spack spec --show opt,solutions zlib
         pytest --verbose --cov --cov-config=pyproject.toml --cov-report=xml:coverage.xml -x -n3 lib/spack/spack/test/concretization/
     - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
       with:
@@ -225,7 +225,7 @@ jobs:
         spack bootstrap disable github-actions-v0.6
         spack bootstrap disable github-actions-v2
         spack bootstrap status
-        spack solve zlib
+        spack spec --show opt,solutions zlib
         pytest --verbose --cov --cov-config=pyproject.toml --cov-report=xml:coverage.xml -x -n3 lib/spack/spack/test/concretization/
     - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
       with:
@@ -262,7 +262,7 @@ jobs:
         . .github/workflows/bin/setup_git.sh
         . share/spack/setup-env.sh
         spack bootstrap disable spack-install
-        spack solve zlib
+        spack spec --show opt,solutions zlib
         python3 -m pytest --verbose --cov --cov-config=pyproject.toml --cov-report=xml:coverage.xml --dist loadfile -x -n4
     - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
       with:

--- a/lib/spack/docs/bootstrapping.rst
+++ b/lib/spack/docs/bootstrapping.rst
@@ -46,7 +46,7 @@ Running a command that concretizes a spec, like:
 
 .. code-block:: console
 
-   % spack solve zlib
+   % spack spec zlib
    ==> Installing "clingo-bootstrap@spack%apple-clang@12.0.0~docs~ipo+python build_type=Release arch=darwin-catalina-x86_64" from a buildcache
    [ ... ]
 

--- a/lib/spack/docs/config_yaml.rst
+++ b/lib/spack/docs/config_yaml.rst
@@ -282,7 +282,7 @@ When set to ``true``, Spack will utilize a cache of solver outputs from successf
 When enabled, Spack will check the concretization cache prior to running the solver.
 If a previous request to solve a given problem is present in the cache, Spack will load the concrete specs and other solver data from the cache rather than running the solver.
 Specs not previously concretized will be added to the cache on a successful solve.
-The cache additionally holds solver statistics, so commands like ``spack solve`` will still return information about the run that produced a given solver result.
+The cache additionally holds solver statistics, so commands like ``spack spec --show opt <spec>`` will still return information about the run that produced a given solver result.
 
 This cache is a subcache of the :ref:`Misc Cache` and as such will be cleaned when the Misc Cache is cleaned.
 

--- a/lib/spack/docs/developer_guide.rst
+++ b/lib/spack/docs/developer_guide.rst
@@ -431,7 +431,7 @@ For example, if you were to add this step to the Linux unit test CI, it would lo
        . share/spack/setup-env.sh
        spack bootstrap disable spack-install
        spack bootstrap now
-       spack -v solve zlib
+       spack -v spec --show opt,solutions zlib
    - name: Setup tmate session
      uses: mxschmitt/action-tmate@c0afd6f790e3a5564914980036ebf83216678101
    - name: Run unit tests

--- a/lib/spack/docs/developer_guide.rst
+++ b/lib/spack/docs/developer_guide.rst
@@ -707,11 +707,11 @@ When working on the ASP-based solver in ``lib/spack/spack/solver/``, it is often
 Generating ASP facts
 ^^^^^^^^^^^^^^^^^^^^
 
-The ``spack solve --show=asp`` flag dumps all ASP facts generated for a given spec to stdout:
+The ``spack spec --show=asp`` flag dumps all ASP facts generated for a given spec to stdout:
 
 .. code-block:: console
 
-   $ spack solve --show=asp zlib-ng > zlib.lp
+   $ spack spec --show=asp zlib-ng > zlib.lp
 
 The resulting file contains both the package facts (versions, variants, dependencies) and the problem-specific facts derived from the user's configuration.
 It can be fed directly to clingo alongside the solver rules.

--- a/lib/spack/docs/frequently_asked_questions.rst
+++ b/lib/spack/docs/frequently_asked_questions.rst
@@ -166,7 +166,7 @@ If it is not obvious *why* the solver made a particular decision -- for example,
 
 .. code-block:: console
 
-   $ spack solve <spec>
+   $ spack spec --show opt,solutions <spec>
 
 The output shows the optimization criteria and the weights assigned to each choice.
 This makes it possible to trace which preference or requirement is driving an unexpected result.

--- a/lib/spack/docs/packages_yaml.rst
+++ b/lib/spack/docs/packages_yaml.rst
@@ -505,7 +505,7 @@ In the example above, that means you could build ``mpich+cuda`` or ``mpich+rocm`
 .. note::
 
    When using a conditional requirement, Spack is allowed to actively avoid the triggering condition (the ``when=...`` spec) if that leads to a concrete spec with better scores in the optimization criteria.
-   To check the current optimization criteria and their priorities you can run ``spack solve zlib``.
+   To check the current optimization criteria and their priorities you can run ``spack spec --show opt,solutions zlib``.
 
 Setting default requirements
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
#52596 deprecated `spack solve` in favor of options on `spack spec`. I forgot to clean up all references and uses in CI.

Thanks @haampie for catching this.