### PR TITLE
new_installer.py: dependency injection of Store

### DIFF
--- a/lib/spack/spack/new_installer.py
+++ b/lib/spack/spack/new_installer.py
@@ -1470,7 +1470,7 @@ class BuildGraph:
         include_build_deps: bool,
         install_package: bool,
         install_deps: bool,
-        database: spack.database.Database,
+        store: spack.store.Store,
         overwrite_set: Optional[Set[str]] = None,
         tests: Union[bool, List[str], Set[str]] = False,
         explicit_set: Optional[Set[str]] = None,
@@ -1479,6 +1479,7 @@ class BuildGraph:
         """Construct a build graph from the given specs. This includes only packages that need to
         be installed. Installed packages are pruned from the graph, and build dependencies are only
         included when necessary."""
+        database = store.db
         self.roots = {s.dag_hash() for s in specs}
         self.nodes = {s.dag_hash(): s for s in specs}
         self.parent_to_child: Dict[str, Set[str]] = {}
@@ -1501,7 +1502,7 @@ class BuildGraph:
                 if record and record.path:
                     s.set_prefix(record.path)
                 else:
-                    s.set_prefix(spack.store.STORE.layout.path_for_spec(s))
+                    s.set_prefix(store.layout.path_for_spec(s))
 
             # Build the graph and determine which specs to prune
             while stack:
@@ -2021,6 +2022,7 @@ class PackageInstaller:
         root_policy: InstallPolicy = "auto",
         dependencies_policy: InstallPolicy = "auto",
         create_reports: bool = False,
+        store: Optional[spack.store.Store] = None,
     ) -> None:
         assert install_package or install_deps, "Must install package, dependencies or both"
 
@@ -2029,7 +2031,7 @@ class PackageInstaller:
         self.stop_before = stop_before
         self.tests: Union[bool, List[str], Set[str]] = tests
 
-        self.db = spack.store.STORE.db
+        self.store = store or spack.store.STORE
 
         specs = [pkg.spec for pkg in packages]
 
@@ -2065,7 +2067,7 @@ class PackageInstaller:
             include_build_deps,
             install_package,
             install_deps,
-            self.db,
+            self.store,
             self.overwrite,
             tests,
             self.explicit,
@@ -2105,7 +2107,7 @@ class PackageInstaller:
         self.build_status = BuildStatus(
             len(self.build_graph.nodes),
             verbose=verbose,
-            filter_padding=spack.store.STORE.has_padding(),
+            filter_padding=self.store.has_padding(),
             is_tty=TerminalState.stdout_is_interactive(),
         )
         self.jobs = spack.config.determine_number_of_jobs(parallel=True)
@@ -2135,7 +2137,7 @@ class PackageInstaller:
         self._installer()
 
     def _installer(self) -> None:
-        spack.store.STORE.install_sbang()
+        self.store.install_sbang()
         jobserver = JobServer(self.jobs)
         selector = selectors.DefaultSelector()
 
@@ -2294,9 +2296,10 @@ class PackageInstaller:
             db_exc = None
             if database_actions:
                 try:
-                    with self.db.write_transaction():
+                    db = self.store.db
+                    with db.write_transaction():
                         for action in database_actions:
-                            action.save_to_db(self.db)
+                            action.save_to_db(db)
                 except Exception as e:
                     db_exc = e
 
@@ -2432,7 +2435,8 @@ class PackageInstaller:
     def _try_expand_build_deps(self) -> None:
         """Try to expand build deps for specs with cache misses. Non-blocking: returns immediately
         if the DB read lock is unavailable."""
-        with self.db.try_read_transaction() as acquired:
+        db = self.store.db
+        with db.try_read_transaction() as acquired:
             if not acquired:
                 return
             dep_policy = (
@@ -2441,7 +2445,7 @@ class PackageInstaller:
                 else self.dependencies_policy
             )
             newly_added = self.build_graph.expand_build_deps(
-                self.pending_expansions, self.pending_builds, self.db, dep_policy
+                self.pending_expansions, self.pending_builds, db, dep_policy
             )
             for h in newly_added:
                 self.binary_cache_for_spec[h] = (
@@ -2474,11 +2478,12 @@ class PackageInstaller:
         database_actions: List[DatabaseAction],
         retained_read_locks: List[spack.util.lock.Lock],
     ) -> bool:
-        with self.db.try_write_transaction() as acquired:
+        db = self.store.db
+        with db.try_write_transaction() as acquired:
             if not acquired:
                 return False
             for action in database_actions:
-                action.save_to_db(self.db)
+                action.save_to_db(db)
 
         # DB has been written and flushed; downgrade per-spec prefix write locks to read locks so
         # other processes can see the specs are installed, while preventing concurrent uninstalls.
@@ -2517,7 +2522,7 @@ class PackageInstaller:
         result = schedule_builds(
             pending=self.pending_builds,
             build_graph=self.build_graph,
-            store=spack.store.STORE,  # todo: dependency injection
+            store=self.store,
             overwrite=self.overwrite,
             overwrite_time=self.overwrite_time,
             capacity=self.capacity,

--- a/lib/spack/spack/test/installer_build_graph.py
+++ b/lib/spack/spack/test/installer_build_graph.py
@@ -140,7 +140,7 @@ class TestBuildGraph:
             include_build_deps=False,
             install_package=True,
             install_deps=True,
-            database=temporary_store.db,
+            store=temporary_store,
         )
 
         # Root should be in roots set
@@ -159,7 +159,7 @@ class TestBuildGraph:
             include_build_deps=False,
             install_package=False,  # Only install dependencies
             install_deps=True,
-            database=temporary_store.db,
+            store=temporary_store,
         )
 
         # Root should NOT be in nodes when install_package=False
@@ -182,7 +182,7 @@ class TestBuildGraph:
                 include_build_deps=False,
                 install_package=True,
                 install_deps=False,  # Don't install dependencies
-                database=temporary_store.db,
+                store=temporary_store,
             )
 
     def test_multiple_roots(self, mock_specs: Dict[str, Spec], temporary_store: Store):
@@ -194,7 +194,7 @@ class TestBuildGraph:
             include_build_deps=False,
             install_package=True,
             install_deps=True,
-            database=temporary_store.db,
+            store=temporary_store,
         )
 
         # Both should be in roots
@@ -211,7 +211,7 @@ class TestBuildGraph:
             include_build_deps=False,
             install_package=True,
             install_deps=True,
-            database=temporary_store.db,
+            store=temporary_store,
         )
 
         # Verify parent_to_child and child_to_parent are inverse mappings
@@ -231,7 +231,7 @@ class TestBuildGraph:
             include_build_deps=False,
             install_package=True,
             install_deps=True,
-            database=temporary_store.db,
+            store=temporary_store,
         )
 
         # Shared dependency should have two parents
@@ -254,7 +254,7 @@ class TestBuildGraph:
             include_build_deps=False,
             install_package=True,
             install_deps=True,
-            database=temporary_store.db,
+            store=temporary_store,
         )
 
         # dep2 should be pruned since it's installed
@@ -278,7 +278,7 @@ class TestBuildGraph:
             include_build_deps=False,
             install_package=True,
             install_deps=True,
-            database=temporary_store.db,
+            store=temporary_store,
         )
 
         # Shared should be pruned
@@ -303,7 +303,7 @@ class TestBuildGraph:
             include_build_deps=False,
             install_package=True,
             install_deps=True,
-            database=temporary_store.db,
+            store=temporary_store,
             overwrite_set={dep2.dag_hash()},
         )
 
@@ -329,7 +329,7 @@ class TestBuildGraph:
             include_build_deps=True,  # Should be ignored for installed root
             install_package=True,
             install_deps=True,
-            database=temporary_store.db,
+            store=temporary_store,
         )
 
         # build_dep should NOT be in the graph (installed root never needs build deps)
@@ -350,7 +350,7 @@ class TestBuildGraph:
             include_build_deps=False,  # exclude build deps when possible
             install_package=True,
             install_deps=True,
-            database=temporary_store.db,
+            store=temporary_store,
         )
 
         assert specs_with_build_deps["build_dep"].dag_hash() not in graph.nodes
@@ -373,7 +373,7 @@ class TestBuildGraph:
             include_build_deps=True,
             install_package=True,
             install_deps=True,
-            database=temporary_store.db,
+            store=temporary_store,
         )
 
         # All dependencies should be in the graph, including build_dep
@@ -397,7 +397,7 @@ class TestBuildGraph:
             include_build_deps=False,
             install_package=True,
             install_deps=False,
-            database=temporary_store.db,
+            store=temporary_store,
         )
 
         # Only the root should be in the graph
@@ -436,7 +436,7 @@ class TestBuildGraph:
             include_build_deps=False,
             install_package=True,
             install_deps=True,
-            database=temporary_store.db,
+            store=temporary_store,
         )
 
         parent1_hash = complex_pruning_dag["parent1"].dag_hash()
@@ -491,7 +491,7 @@ class TestBuildGraph:
             include_build_deps=False,
             install_package=True,
             install_deps=True,
-            database=temporary_store.db,
+            store=temporary_store,
         )
 
         # All nodes should be pruned, resulting in an empty graph
@@ -514,7 +514,7 @@ class TestBuildGraph:
             include_build_deps=False,
             install_package=False,  # Don't install the root
             install_deps=True,
-            database=temporary_store.db,
+            store=temporary_store,
         )
 
         # Root is pruned because install_package=False
@@ -541,7 +541,7 @@ class TestBuildGraph:
             include_build_deps=False,
             install_package=True,
             install_deps=True,
-            database=temporary_store.db,
+            store=temporary_store,
         )
 
         dep2_hash = dep2.dag_hash()
@@ -570,7 +570,7 @@ class TestBuildGraph:
             include_build_deps=False,
             install_package=False,  # Prune the root
             install_deps=True,
-            database=temporary_store.db,
+            store=temporary_store,
         )
 
         dep1_hash = mock_specs["dep1"].dag_hash()
@@ -619,7 +619,7 @@ class TestBuildGraphTestDeps:
             include_build_deps=True,
             install_package=True,
             install_deps=True,
-            database=temporary_store.db,
+            store=temporary_store,
             tests=False,
         )
 
@@ -638,7 +638,7 @@ class TestBuildGraphTestDeps:
             include_build_deps=True,
             install_package=True,
             install_deps=True,
-            database=temporary_store.db,
+            store=temporary_store,
             tests=["root"],
         )
 
@@ -658,7 +658,7 @@ class TestBuildGraphTestDeps:
             include_build_deps=True,
             install_package=True,
             install_deps=True,
-            database=temporary_store.db,
+            store=temporary_store,
             tests=True,
         )
 
@@ -681,7 +681,7 @@ class TestBuildGraphTestDeps:
             include_build_deps=True,
             install_package=True,
             install_deps=True,
-            database=temporary_store.db,
+            store=temporary_store,
             explicit_set={root.dag_hash()},
         )
         # root should be in graph (not pruned) because it needs to be marked explicit.
@@ -702,7 +702,7 @@ class TestExpandBuildDeps:
             include_build_deps=False,
             install_package=True,
             install_deps=True,
-            database=temporary_store.db,
+            store=temporary_store,
         )
 
     def _expand(self, graph, dag_hash, pending, db, tests=False):

--- a/lib/spack/spack/test/new_installer.py
+++ b/lib/spack/spack/test/new_installer.py
@@ -731,7 +731,7 @@ def test_expand_build_deps_source_only_includes_nested_build_deps(temporary_stor
         include_build_deps=False,
         install_package=True,
         install_deps=True,
-        database=temporary_store.db,
+        store=temporary_store,
     )
 
     # The initial graph should contain only root (build deps deferred for "auto" policy).


### PR DESCRIPTION
Extracted from #52642 

Consistently use a single Store instance, instead of a mix of DI instance vs
global.

