### PR TITLE
Spec: remove the `.installed` and `.installed upstream` properties

### DIFF
--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -2151,7 +2151,7 @@ def install_root_node(
     if spec.external or not spec.concrete:
         warnings.warn("Skipping external or abstract spec {0}".format(spec.format()))
         return
-    elif spec.installed and not force:
+    elif spack.store.STORE.db.installed(spec) and not force:
         warnings.warn("Package for spec {0} already installed.".format(spec.format()))
         return
 

--- a/lib/spack/spack/bootstrap/_common.py
+++ b/lib/spack/spack/bootstrap/_common.py
@@ -67,7 +67,7 @@ def _try_import_from_store(
             python, *_ = candidate_spec.dependencies("python")
 
         # if python is installed, ask it for the layout
-        if python.installed:
+        if spack.store.STORE.db.installed(python):
             module_paths = [
                 os.path.join(candidate_spec.prefix, python.package.purelib),
                 os.path.join(candidate_spec.prefix, python.package.platlib),

--- a/lib/spack/spack/cmd/__init__.py
+++ b/lib/spack/spack/cmd/__init__.py
@@ -366,7 +366,7 @@ def buildcache_status_fn(
     """
 
     def _status_fn(spec: "spack.spec.Spec") -> "spack.spec.InstallStatus":
-        status = spec.install_status()
+        status = spack.store.STORE.db.install_status(spec)
         if (
             status in (spack.spec.InstallStatus.absent, spack.spec.InstallStatus.missing)
             and spec.dag_hash() in available_hashes

--- a/lib/spack/spack/cmd/buildcache.py
+++ b/lib/spack/spack/cmd/buildcache.py
@@ -550,8 +550,10 @@ def push_fn(args):
     # push installed package in best effort mode.
     failed: List[Tuple[Spec, BaseException]] = []
     with spack.store.STORE.db.read_transaction():
-        if any(not s.installed for s in specs):
-            specs, not_installed = stable_partition(specs, lambda s: s.installed)
+        if any(not spack.store.STORE.db.installed(s) for s in specs):
+            specs, not_installed = stable_partition(
+                specs, lambda s: spack.store.STORE.db.installed(s)
+            )
             if args.fail_fast and not args.allow_missing:
                 raise PackagesAreNotInstalledError(not_installed)
             elif args.allow_missing:

--- a/lib/spack/spack/cmd/common/env_utility.py
+++ b/lib/spack/spack/cmd/common/env_utility.py
@@ -60,7 +60,7 @@ class AreDepsInstalledVisitor:
             return False
 
         spec = item.edge.spec
-        if not spec.external and not spec.installed:
+        if not spec.external and not spack.store.STORE.db.installed(spec):
             self.has_uninstalled_deps = True
             return False
 

--- a/lib/spack/spack/cmd/common/env_utility.py
+++ b/lib/spack/spack/cmd/common/env_utility.py
@@ -7,7 +7,6 @@ import os
 import spack.cmd
 import spack.deptypes as dt
 import spack.error
-import spack.spec
 import spack.store
 from spack import build_environment, traverse
 from spack.cmd.common import arguments
@@ -112,7 +111,7 @@ def emulate_env_utility(cmd_name, context: Context, args):
             f"Not all dependencies of {spec.name} are installed. "
             f"Cannot setup {context} environment:",
             spec.tree(
-                status_fn=spack.spec.Spec.install_status,
+                status_fn=spack.store.STORE.db.install_status,
                 hashlen=7,
                 hashes=True,
                 # This shows more than necessary, but we cannot dynamically change deptypes

--- a/lib/spack/spack/cmd/compiler.py
+++ b/lib/spack/spack/cmd/compiler.py
@@ -149,7 +149,9 @@ def compiler_info(args):
             )
             continue
 
-        print(f"{c.tree(recurse_dependencies=False, status_fn=spack.spec.Spec.install_status)}")
+        print(
+            f"{c.tree(recurse_dependencies=False, status_fn=spack.store.STORE.db.install_status)}"
+        )
         print(f"  prefix: {c.prefix}")
         print("  compilers:")
         for language, exe in exes.items():
@@ -189,7 +191,7 @@ def compiler_list(args):
     status_fn = (
         spack.cmd.buildcache_status_fn(spack.binary_distribution.BINARY_INDEX)
         if args.remote
-        else spack.spec.Spec.install_status
+        else spack.store.STORE.db.install_status
     )
 
     # If there are no compilers in any scope, and we're outputting to a tty, give a

--- a/lib/spack/spack/cmd/dev_build.py
+++ b/lib/spack/spack/cmd/dev_build.py
@@ -13,6 +13,7 @@ import spack.concretize
 import spack.config
 import spack.installer_dispatch
 import spack.repo
+import spack.store
 from spack.cmd.common import arguments
 from spack.util import tty
 
@@ -116,7 +117,7 @@ def dev_build(self, args):
     spec.constrain(f'dev_path="{source_path}"')
     spec = spack.concretize.concretize_one(spec)
 
-    if spec.installed:
+    if spack.store.STORE.db.installed(spec):
         tty.error("Already installed in %s" % spec.prefix)
         tty.msg("Uninstall or try adding a version suffix for this dev build.")
         sys.exit(1)

--- a/lib/spack/spack/cmd/fetch.py
+++ b/lib/spack/spack/cmd/fetch.py
@@ -7,6 +7,7 @@ import argparse
 import spack.cmd
 import spack.config
 import spack.environment as ev
+import spack.store
 import spack.traverse
 from spack.cmd.common import arguments
 
@@ -65,7 +66,7 @@ def fetch(parser, args):
         to_be_fetched = specs
 
     for spec in to_be_fetched:
-        if args.missing and spec.installed:
+        if args.missing and spack.store.STORE.db.installed(spec):
             continue
 
         pkg = spec.package

--- a/lib/spack/spack/cmd/find.py
+++ b/lib/spack/spack/cmd/find.py
@@ -264,7 +264,7 @@ def display_env(env, args, decorator, results, status_fn=None):
     tty.msg(f"In environment {env.name} ({root_spec_str})")
 
     concrete_specs = {x.root: env.specs_by_hash[x.hash] for x in env.concretized_roots}
-    _status_fn = status_fn if status_fn is not None else spack.spec.Spec.install_status
+    _status_fn = status_fn if status_fn is not None else spack.store.STORE.db.install_status
 
     def root_decorator(spec, string):
         """Decorate root specs with their install status if needed"""

--- a/lib/spack/spack/cmd/find.py
+++ b/lib/spack/spack/cmd/find.py
@@ -366,7 +366,7 @@ def _find_query(
         results = list()
         with spack.store.STORE.db.read_transaction():
             for spec in env_specs:
-                if not spec.installed:
+                if not spack.store.STORE.db.installed(spec):
                     concretized_but_not_installed.append(spec)
                 if spec in specs_meeting_q_args:
                     results.append(spec)

--- a/lib/spack/spack/cmd/logs.py
+++ b/lib/spack/spack/cmd/logs.py
@@ -12,6 +12,7 @@ import sys
 
 import spack.cmd
 import spack.spec
+import spack.store
 from spack.cmd.common import arguments
 from spack.error import SpackError
 from spack.util import compression
@@ -32,7 +33,7 @@ def _dump_byte_stream_to_stdout(instream: io.BufferedIOBase) -> None:
 
 
 def _logs(cmdline_spec: spack.spec.Spec, concrete_spec: spack.spec.Spec):
-    if concrete_spec.installed:
+    if spack.store.STORE.db.installed(concrete_spec):
         log_path = concrete_spec.package.install_log_path
     elif os.path.exists(concrete_spec.package.stage.path):
         # TODO: `spack logs` can currently not show the logs while a package is being built, as the

--- a/lib/spack/spack/cmd/modules/__init__.py
+++ b/lib/spack/spack/cmd/modules/__init__.py
@@ -16,6 +16,7 @@ import spack.modules
 import spack.modules.common
 import spack.modules.error
 import spack.repo
+import spack.store
 from spack.cmd import MultipleSpecsMatch, NoSpecMatches
 from spack.cmd.common import arguments
 from spack.util import filesystem, tty
@@ -292,7 +293,7 @@ def refresh(module_type, specs, args):
         return
 
     if not args.upstream_modules:
-        specs = [s for s in specs if not s.installed_upstream]
+        specs = [s for s in specs if not spack.store.STORE.db.installed_upstream(s)]
 
     if not args.yes_to_all:
         msg = "You are about to regenerate {types} module files for:\n"

--- a/lib/spack/spack/cmd/stage.py
+++ b/lib/spack/spack/cmd/stage.py
@@ -9,6 +9,7 @@ import spack.cmd
 import spack.config
 import spack.environment as ev
 import spack.package_base
+import spack.store
 import spack.traverse
 from spack.cmd.common import arguments
 from spack.util import tty
@@ -36,7 +37,7 @@ class StageFilter:
         if spec.external:
             return True
 
-        if self.skip_installed and spec.installed:
+        if self.skip_installed and spack.store.STORE.db.installed(spec):
             return True
 
         if any(spec.satisfies(exclude) for exclude in self.exclusions):

--- a/lib/spack/spack/database.py
+++ b/lib/spack/spack/database.py
@@ -1349,6 +1349,24 @@ class Database:
         upstream, record = self.query_by_spec_hash(spec.dag_hash())
         return bool(upstream and record and record.installed)
 
+    def install_status(self, spec: "spack.spec.Spec") -> "spack.spec.InstallStatus":
+        """Return the installation status of a spec (helper for tree display)."""
+        if not spec.concrete:
+            return spack.spec.InstallStatus.absent
+
+        if spec.external:
+            return spack.spec.InstallStatus.external
+
+        upstream, record = self.query_by_spec_hash(spec.dag_hash())
+        if not record:
+            return spack.spec.InstallStatus.absent
+        elif upstream and record.installed:
+            return spack.spec.InstallStatus.upstream
+        elif record.installed:
+            return spack.spec.InstallStatus.installed
+        else:
+            return spack.spec.InstallStatus.missing
+
     def _decrement_ref_count(self, spec: "spack.spec.Spec") -> None:
         key = spec.dag_hash()
 

--- a/lib/spack/spack/database.py
+++ b/lib/spack/spack/database.py
@@ -1333,6 +1333,22 @@ class Database:
         _, record = self.query_by_spec_hash(key)
         return record
 
+    def installed(self, spec: "spack.spec.Spec") -> bool:
+        """Return whether the spec is installed, locally or in an upstream."""
+        if not spec.concrete:
+            return False
+        try:
+            return self.get_record(spec).installed
+        except KeyError:
+            return False
+
+    def installed_upstream(self, spec: "spack.spec.Spec") -> bool:
+        """Return whether the spec is installed in an upstream database."""
+        if not spec.concrete:
+            return False
+        upstream, record = self.query_by_spec_hash(spec.dag_hash())
+        return bool(upstream and record and record.installed)
+
     def _decrement_ref_count(self, spec: "spack.spec.Spec") -> None:
         key = spec.dag_hash()
 

--- a/lib/spack/spack/environment/environment.py
+++ b/lib/spack/spack/environment/environment.py
@@ -672,7 +672,7 @@ def _is_dev_spec_and_has_changed(spec):
         return False
 
     # Now we can check whether the code changed since the last installation
-    if not spec.installed:
+    if not spack.store.STORE.db.installed(spec):
         # Not installed -> nothing to compare against
         return False
 
@@ -911,7 +911,7 @@ class ViewDescriptor:
 
         # Filter selected, installed specs
         with spack.store.STORE.db.read_transaction():
-            result = [s for s in specs if s in self and s.installed]
+            result = [s for s in specs if s in self and spack.store.STORE.db.installed(s)]
 
         return self._exclude_duplicate_runtimes(result)
 
@@ -1898,11 +1898,12 @@ class Environment:
         try:
             # This is effectively a no-op, but it touches all packages in the
             # default view if they are installed.
-            for view_name, view in self.views.items():
-                for spec in self.concrete_roots():
-                    if spec in view and spec.package and spec.installed:
-                        msg = '{0} in view "{1}"'
-                        tty.debug(msg.format(spec.name, view_name))
+            with spack.store.STORE.db.read_transaction():
+                for view_name, view in self.views.items():
+                    for spec in self.concrete_roots():
+                        if spec in view and spec.package and spack.store.STORE.db.installed(spec):
+                            msg = '{0} in view "{1}"'
+                            tty.debug(msg.format(spec.name, view_name))
 
         except (spack.repo.UnknownPackageError, spack.repo.UnknownNamespaceError) as e:
             tty.warn(e)
@@ -1916,7 +1917,9 @@ class Environment:
     ) -> spack.util.environment.EnvironmentModifications:
         try:
             with spack.store.STORE.db.read_transaction():
-                installed_roots = [s for s in self.concrete_roots() if s.installed]
+                installed_roots = [
+                    s for s in self.concrete_roots() if spack.store.STORE.db.installed(s)
+                ]
             mods = uenv.environment_modifications_for_specs(*installed_roots, view=view)
         except Exception as e:
             # Failing to setup spec-specific changes shouldn't be a hard error.
@@ -1994,29 +1997,32 @@ class Environment:
 
     def _dev_specs_that_need_overwrite(self):
         """Return the hashes of all specs that need to be reinstalled due to source code change."""
-        changed_dev_specs = [
-            s
-            for s in traverse.traverse_nodes(
-                self.concrete_roots(), order="breadth", key=traverse.by_dag_hash
-            )
-            if _is_dev_spec_and_has_changed(s)
-        ]
+        # Single read transaction to avoid repeated `Database.installed` overhead, both here and
+        # in the `_is_dev_spec_and_has_changed` calls below.
+        with spack.store.STORE.db.read_transaction():
+            changed_dev_specs = [
+                s
+                for s in traverse.traverse_nodes(
+                    self.concrete_roots(), order="breadth", key=traverse.by_dag_hash
+                )
+                if _is_dev_spec_and_has_changed(s)
+            ]
 
-        # Collect their hashes, and the hashes of their installed parents.
-        # Notice: with order=breadth all changed dev specs are at depth 0,
-        # even if they occur as parents of one another.
-        return [
-            spec.dag_hash()
-            for depth, spec in traverse.traverse_nodes(
-                changed_dev_specs,
-                root=True,
-                order="breadth",
-                depth=True,
-                direction="parents",
-                key=traverse.by_dag_hash,
-            )
-            if depth == 0 or spec.installed
-        ]
+            # Collect their hashes, and the hashes of their installed parents.
+            # Notice: with order=breadth all changed dev specs are at depth 0,
+            # even if they occur as parents of one another.
+            return [
+                spec.dag_hash()
+                for depth, spec in traverse.traverse_nodes(
+                    changed_dev_specs,
+                    root=True,
+                    order="breadth",
+                    depth=True,
+                    direction="parents",
+                    key=traverse.by_dag_hash,
+                )
+                if depth == 0 or spack.store.STORE.db.installed(spec)
+            ]
 
     def _partition_roots_by_install_status(self):
         """Partition root specs into those that do not have to be passed to the
@@ -2108,14 +2114,14 @@ class Environment:
         spec for already concretized but not yet installed specs.
         """
         # use a transaction to avoid overhead of repeated calls
-        # to `package.spec.installed`
+        # to `Database.installed`
         with spack.store.STORE.db.read_transaction():
             concretized = dict(self.concretized_specs())
             for spec in self.user_specs:
                 concrete = concretized.get(spec)
                 if not concrete:
                     yield spec
-                elif not concrete.installed:
+                elif not spack.store.STORE.db.installed(concrete):
                     yield concrete
 
     def concretized_specs(self):
@@ -2593,7 +2599,9 @@ class Environment:
 
 
 def _is_uninstalled(spec):
-    return not spec.installed or (spec.satisfies("dev_path=*") or spec.satisfies("^dev_path=*"))
+    return not spack.store.STORE.db.installed(spec) or (
+        spec.satisfies("dev_path=*") or spec.satisfies("^dev_path=*")
+    )
 
 
 class ReusableSpecsFactory:

--- a/lib/spack/spack/environment/environment.py
+++ b/lib/spack/spack/environment/environment.py
@@ -2951,14 +2951,14 @@ def display_specs(
         highlight_non_defaults: if True, highlights non-default versions and variants in the specs
             being displayed
         status_fn: callable mapping a spec to its InstallStatus; defaults to
-            ``spack.spec.Spec.install_status``
+            ``spack.store.STORE.db.install_status``
     """
     tree_string = spack.spec.tree(
         specs,
         format=spack.spec.DISPLAY_FORMAT,
         hashes=True,
         hashlen=7,
-        status_fn=status_fn if status_fn is not None else spack.spec.Spec.install_status,
+        status_fn=status_fn if status_fn is not None else spack.store.STORE.db.install_status,
         highlight_version_fn=(
             spack.package_base.non_preferred_version if highlight_non_defaults else None
         ),

--- a/lib/spack/spack/install_test.py
+++ b/lib/spack/spack/install_test.py
@@ -20,6 +20,7 @@ import spack.paths
 import spack.repo
 import spack.report
 import spack.spec
+import spack.store
 import spack.util.executable
 import spack.util.filesystem as fs
 import spack.util.spack_json as sjson
@@ -714,7 +715,7 @@ def test_process(pkg: "spack.package_base.PackageBase", kwargs):
             pkg.tester.status(pkg.spec.name, TestStatus.SKIPPED)
             return
 
-        if not pkg.spec.installed:
+        if not spack.store.STORE.db.installed(pkg.spec):
             print_message(logger, "Skipped not installed package", verbose)
             pkg.tester.status(pkg.spec.name, TestStatus.SKIPPED)
             return
@@ -970,7 +971,7 @@ class TestSuite:
             self.ensure_stage()
             if spec.external and not externals:
                 status = TestStatus.SKIPPED
-            elif not spec.installed:
+            elif not spack.store.STORE.db.installed(spec):
                 status = TestStatus.SKIPPED
             else:
                 status = TestStatus.NO_TESTS

--- a/lib/spack/spack/modules/__init__.py
+++ b/lib/spack/spack/modules/__init__.py
@@ -62,7 +62,7 @@ def get_module(
         available.
     """
     try:
-        upstream = spec.installed_upstream
+        upstream = spack.store.STORE.db.installed_upstream(spec)
     except spack.repo.UnknownPackageError:
         upstream, record = spack.store.STORE.db.query_by_spec_hash(spec.dag_hash())
     if upstream:

--- a/lib/spack/spack/modules/common.py
+++ b/lib/spack/spack/modules/common.py
@@ -354,7 +354,13 @@ class BaseConfiguration:
         """
         if cache is None:
             cache = {}
-        explicit = bool(spec._installed_explicitly()) if explicit is None else explicit
+
+        if explicit is None:
+            try:
+                explicit = bool(spack.store.STORE.db.get_record(spec).explicit)
+            except KeyError:
+                explicit = False
+
         key = (spec.dag_hash(), module_set_name, explicit)
         configuration = cache.get(key)
         if configuration is None:

--- a/lib/spack/spack/old_installer.py
+++ b/lib/spack/spack/old_installer.py
@@ -249,7 +249,7 @@ def _handle_external_and_upstream(pkg: "spack.package_base.PackageBase", explici
         _print_installed_pkg(f"{pkg.prefix} (external {package_id(pkg.spec)})")
         return True
 
-    if pkg.spec.installed_upstream:
+    if spack.store.STORE.db.installed_upstream(pkg.spec):
         tty.verbose(
             f"{package_id(pkg.spec)} is installed in an upstream Spack instance at "
             f"{pkg.spec.prefix}"
@@ -822,7 +822,7 @@ class BuildRequest:
         # if build deps are explicitly requested.
         if include_build_deps or not (
             policy == "cache_only"
-            or pkg.spec.installed
+            or spack.store.STORE.db.installed(pkg.spec)
             and pkg.spec.dag_hash() not in self.overwrite
         ):
             depflag |= dt.BUILD
@@ -1421,7 +1421,7 @@ class RewireTask(Task):
         """
         oldstatus = self.status
         self.status = BuildStatus.INSTALLING
-        if not self.pkg.spec.build_spec.installed:
+        if not spack.store.STORE.db.installed(self.pkg.spec.build_spec):
             try:
                 install_args = self.request.install_args
                 unsigned = install_args.get("unsigned")
@@ -1673,7 +1673,7 @@ class PackageInstaller:
                 raise spack.error.InstallError(err.format(request.pkg_id, msg), pkg=request.pkg)
 
             # Flag external and upstream packages as being installed
-            if dep_pkg.spec.external or dep_pkg.spec.installed_upstream:
+            if dep_pkg.spec.external or spack.store.STORE.db.installed_upstream(dep_pkg.spec):
                 self._flag_installed(dep_pkg)
                 continue
 
@@ -1812,7 +1812,7 @@ class PackageInstaller:
             raise ExternalPackageError(f"{pre} is external")
 
         # Upstream packages cannot be installed locally.
-        if pkg.spec.installed_upstream:
+        if spack.store.STORE.db.installed_upstream(pkg.spec):
             raise UpstreamPackageError(f"{pre} is upstream")
 
         # The package must have a prefix lock at this stage.
@@ -2440,7 +2440,7 @@ class PackageInstaller:
 
         # Perform basic task cleanup for the installed spec to
         # include downgrading the write to a read lock
-        if pkg.spec.installed:
+        if spack.store.STORE.db.installed(pkg.spec):
             self._cleanup_task(pkg)
             # mark installed if we haven't yet - may be discovering installed for the first time
             self._update_installed(task)

--- a/lib/spack/spack/report.py
+++ b/lib/spack/spack/report.py
@@ -11,6 +11,7 @@ import traceback
 from typing import Optional
 
 import spack.error
+import spack.store
 
 reporter = None
 report_file = None
@@ -64,10 +65,13 @@ class RequestRecord(Record):
 
     def skip_installed(self):
         """Insert records for all nodes in the DAG that are no-ops for this request"""
-        for dep in filter(lambda x: x.installed or x.external, self._spec.traverse()):
-            record = InstallRecord(dep)
-            record.skip(msg="Spec external or already installed")
-            self.packages.append(record)
+        with spack.store.STORE.db.read_transaction():
+            for dep in filter(
+                lambda x: spack.store.STORE.db.installed(x) or x.external, self._spec.traverse()
+            ):
+                record = InstallRecord(dep)
+                record.skip(msg="Spec external or already installed")
+                self.packages.append(record)
 
     def append_record(self, record):
         self.packages.append(record)

--- a/lib/spack/spack/rewiring.py
+++ b/lib/spack/spack/rewiring.py
@@ -16,12 +16,12 @@ def rewire(spliced_spec):
     nodes in the DAG of that spec."""
     assert spliced_spec.spliced
     for spec in spliced_spec.traverse(order="post", root=True):
-        if not spec.build_spec.installed:
+        if not spack.store.STORE.db.installed(spec.build_spec):
             # TODO: May want to change this at least for the root spec...
             # TODO: Also remember to import PackageInstaller
             # PackageInstaller([spec.build_spec.package]).install()
             raise PackageNotInstalledError(spliced_spec, spec.build_spec, spec)
-        if spec.build_spec is not spec and not spec.installed:
+        if spec.build_spec is not spec and not spack.store.STORE.db.installed(spec):
             explicit = spec is spliced_spec
             rewire_node(spec, explicit)
 

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -3127,7 +3127,7 @@ class SpackSolverSetup:
                 continue
 
             current_libc = None
-            if compiler.external or compiler.installed:
+            if compiler.external or spack.store.STORE.db.installed(compiler):
                 current_libc = CompilerPropertyDetector(compiler).default_libc()
             else:
                 try:

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -3812,7 +3812,7 @@ def post_process_concretization_result(specs: SpecDict) -> None:
 
     # needs to happen after finalize_concretization, as it looks up hashes
     for s in specs.values():
-        spack.spec.Spec.ensure_no_deprecated(s)
+        _ensure_no_deprecated(s, spack.store.STORE)
 
     # Add git version lookup info to concrete Specs (this is generated for
     # abstract specs as well but the Versions may be replaced during the
@@ -3902,6 +3902,29 @@ def _ensure_external_path_if_external(spec: spack.spec.Spec) -> None:
     spec.external_path = getattr(package, "external_prefix", None) or md.path_from_modules(
         spec.external_modules
     )
+
+
+def _ensure_no_deprecated(root: spack.spec.Spec, store: spack.store.Store) -> None:
+    """Raise if a deprecated spec is in the dag of the given root spec.
+
+    Raises:
+        spack.spec.SpecDeprecatedError: if any deprecated spec is found
+    """
+    deprecated = []
+    db = store.db
+    with db.read_transaction():
+        for x in root.traverse():
+            _, rec = db.query_by_spec_hash(x.dag_hash())
+            if rec and rec.deprecated_for:
+                deprecated.append(rec)
+    if deprecated:
+        msg = "\n    The following specs have been deprecated"
+        msg += " in favor of specs with the hashes shown:\n"
+        for rec in deprecated:
+            msg += "        %s  --> %s\n" % (rec.spec, rec.deprecated_for)
+        msg += "\n"
+        msg += "    For each package listed, choose another spec\n"
+        raise spack.spec.SpecDeprecatedError(msg)
 
 
 def _develop_specs_from_env(spec, env):

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -2073,42 +2073,6 @@ class Spec:
         """
         return any(s.build_spec is not s for s in self.traverse(root=True))
 
-    @property
-    def installed(self):
-        """Installation status of a package.
-
-        Returns:
-            True if the package has been installed, False otherwise.
-        """
-        if not self.concrete:
-            return False
-
-        try:
-            # If the spec is in the DB, check the installed
-            # attribute of the record
-            from spack.store import STORE
-
-            return STORE.db.get_record(self).installed
-        except KeyError:
-            # If the spec is not in the DB, the method
-            #  above raises a Key error
-            return False
-
-    @property
-    def installed_upstream(self):
-        """Whether the spec is installed in an upstream repository.
-
-        Returns:
-            True if the package is installed in an upstream, False otherwise.
-        """
-        if not self.concrete:
-            return False
-
-        from spack.store import STORE
-
-        upstream, record = STORE.db.query_by_spec_hash(self.dag_hash())
-        return upstream and record and record.installed
-
     @overload
     def traverse(
         self,

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -2073,6 +2073,20 @@ class Spec:
         """
         return any(s.build_spec is not s for s in self.traverse(root=True))
 
+    @property
+    def installed(self):
+        """Whether the spec is installed, locally or in an upstream."""
+        from spack.store import STORE
+
+        return STORE.db.installed(self)
+
+    @property
+    def installed_upstream(self):
+        """Whether the spec is installed in an upstream database."""
+        from spack.store import STORE
+
+        return STORE.db.installed_upstream(self)
+
     @overload
     def traverse(
         self,

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -2076,16 +2076,30 @@ class Spec:
     @property
     def installed(self):
         """Whether the spec is installed, locally or in an upstream."""
-        from spack.store import STORE
+        if not self.concrete:
+            return False
 
-        return STORE.db.installed(self)
+        try:
+            # If the spec is in the DB, check the installed
+            # attribute of the record
+            from spack.store import STORE
+
+            return STORE.db.get_record(self).installed
+        except KeyError:
+            # If the spec is not in the DB, the method
+            #  above raises a Key error
+            return False
 
     @property
     def installed_upstream(self):
         """Whether the spec is installed in an upstream database."""
+        if not self.concrete:
+            return False
+
         from spack.store import STORE
 
-        return STORE.db.installed_upstream(self)
+        upstream, record = STORE.db.query_by_spec_hash(self.dag_hash())
+        return upstream and record and record.installed
 
     @overload
     def traverse(

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -2809,30 +2809,6 @@ class Spec:
 
         return True
 
-    @staticmethod
-    def ensure_no_deprecated(root: "Spec") -> None:
-        """Raise if a deprecated spec is in the dag of the given root spec.
-
-        Raises:
-            spack.spec.SpecDeprecatedError: if any deprecated spec is found
-        """
-        deprecated = []
-        from spack.store import STORE
-
-        with STORE.db.read_transaction():
-            for x in root.traverse():
-                _, rec = STORE.db.query_by_spec_hash(x.dag_hash())
-                if rec and rec.deprecated_for:
-                    deprecated.append(rec)
-        if deprecated:
-            msg = "\n    The following specs have been deprecated"
-            msg += " in favor of specs with the hashes shown:\n"
-            for rec in deprecated:
-                msg += "        %s  --> %s\n" % (rec.spec, rec.deprecated_for)
-            msg += "\n"
-            msg += "    For each package listed, choose another spec\n"
-            raise SpecDeprecatedError(msg)
-
     def _mark_root_concrete(self, value=True):
         """Mark just this spec (not dependencies) concrete."""
         self._concrete = value
@@ -4479,38 +4455,6 @@ class Spec:
     def __str__(self) -> str:
         """String representation of this spec."""
         return self._str(color=False)
-
-    def install_status(self) -> InstallStatus:
-        """Helper for tree to print DB install status."""
-        if not self.concrete:
-            return InstallStatus.absent
-
-        if self.external:
-            return InstallStatus.external
-
-        from spack.store import STORE
-
-        upstream, record = STORE.db.query_by_spec_hash(self.dag_hash())
-        if not record:
-            return InstallStatus.absent
-        elif upstream and record.installed:
-            return InstallStatus.upstream
-        elif record.installed:
-            return InstallStatus.installed
-        else:
-            return InstallStatus.missing
-
-    def _installed_explicitly(self):
-        """Helper for tree to print DB install status."""
-        if not self.concrete:
-            return None
-        try:
-            from spack.store import STORE
-
-            record = STORE.db.get_record(self)
-            return record.explicit
-        except KeyError:
-            return None
 
     def tree(
         self,

--- a/lib/spack/spack/test/cmd/env.py
+++ b/lib/spack/spack/test/cmd/env.py
@@ -516,7 +516,7 @@ def test_env_install_all(install_mockery, mock_fetch):
     e.concretize()
     e.install_all(fake=True)
     spec = next(x for x in e.all_specs_generator() if x.name == "cmake-client")
-    assert spec.installed
+    assert spack.store.STORE.db.installed(spec)
 
 
 def test_env_install_single_spec(install_mockery, mock_fetch, installer_variant):
@@ -558,7 +558,7 @@ def test_env_install_include_concrete_env(
     test2_user_spec_hashes = [x.hash for x in test2.concretized_roots]
 
     for spec in combined.all_specs():
-        assert spec.installed
+        assert spack.store.STORE.db.installed(spec)
 
     assert test1_user_spec_hashes == [
         x.hash for x in combined.included_concretized_roots[test1.path]
@@ -1873,7 +1873,7 @@ def test_uninstall_keeps_in_env(mock_stage, mock_fetch, install_mockery):
     assert {x.hash for x in test.concretized_roots} == user_spec_hashes_before
     assert test.user_specs.specs == user_specs_before.specs
     assert mpileaks_hash in test.specs_by_hash
-    assert not test.specs_by_hash[mpileaks_hash].installed
+    assert not spack.store.STORE.db.installed(test.specs_by_hash[mpileaks_hash])
 
 
 def test_uninstall_removes_from_env(mock_stage, mock_fetch, install_mockery):
@@ -3994,8 +3994,8 @@ def test_environment_query_spec_by_hash(mock_stage, mock_fetch, install_mockery)
         spec = e.matching_spec("libelf")
         install("--fake", f"/{spec.dag_hash()}")
     with ev.read("test") as e:
-        assert not e.matching_spec("libdwarf").installed
-        assert e.matching_spec("libelf").installed
+        assert not spack.store.STORE.db.installed(e.matching_spec("libdwarf"))
+        assert spack.store.STORE.db.installed(e.matching_spec("libelf"))
 
 
 @pytest.mark.parametrize("lockfile", ["v1", "v2", "v3"])

--- a/lib/spack/spack/test/cmd/gc.py
+++ b/lib/spack/spack/test/cmd/gc.py
@@ -11,6 +11,7 @@ import spack.deptypes as dt
 import spack.environment as ev
 import spack.main
 import spack.spec
+import spack.store
 import spack.traverse
 from spack.old_installer import PackageInstaller
 
@@ -113,7 +114,7 @@ def test_gc_except_any_environments(mutable_database, mutable_mock_env_path):
 
     # All runtime specs in this env should still be installed.
     assert all(
-        s.installed
+        spack.store.STORE.db.installed(s)
         for s in spack.traverse.traverse_nodes(e.concrete_roots(), deptype=dt.LINK | dt.RUN)
     )
 

--- a/lib/spack/spack/test/cmd/install.py
+++ b/lib/spack/spack/test/cmd/install.py
@@ -850,7 +850,16 @@ def test_install_no_add_in_env(
 
         # Without --add, ensure that two packages "a" get installed
         inst_out = install("--fake", "pkg-a")
-        assert len([x for x in e.all_specs() if x.installed and x.name == "pkg-a"]) == 2
+        assert (
+            len(
+                [
+                    x
+                    for x in e.all_specs()
+                    if spack.store.STORE.db.installed(x) and x.name == "pkg-a"
+                ]
+            )
+            == 2
+        )
 
         # Install an unambiguous dependency spec (that already exists as a dep
         # in the environment) and make sure it gets installed (w/ deps),

--- a/lib/spack/spack/test/cmd/logs.py
+++ b/lib/spack/spack/test/cmd/logs.py
@@ -16,6 +16,7 @@ import spack.concretize
 import spack.error
 import spack.main
 import spack.spec
+import spack.store
 from spack.main import SpackCommand
 
 logs = SpackCommand("logs")
@@ -49,7 +50,7 @@ def _rewind_collect_and_decode(rw_stream):
 
 def test_logs_cmd_errors(install_mockery, mock_fetch, mock_archive, mock_packages):
     spec = spack.concretize.concretize_one("pkg-c")
-    assert not spec.installed
+    assert not spack.store.STORE.db.installed(spec)
 
     with pytest.raises(spack.error.SpackError, match="is not installed or staged"):
         logs("pkg-c")
@@ -82,7 +83,7 @@ def test_dump_logs(install_mockery, mock_fetch, mock_archive, mock_packages):
 
     # Sanity check, make sure this test is checking what we want: to
     # start with
-    assert not concrete_spec.installed
+    assert not spack.store.STORE.db.installed(concrete_spec)
 
     stage_log_content = "test_log stage output\nanother line"
     installed_log_content = "test_log install output\nhere to test multiple lines"

--- a/lib/spack/spack/test/cmd/spec.py
+++ b/lib/spack/spack/test/cmd/spec.py
@@ -236,7 +236,7 @@ def test_spec_unification_from_cli(
 def test_buildcache_status_fn_marks_absent_spec(install_mockery, mock_packages):
     """Tests the basic semantics of build_cache_status_fn."""
     s = spack.concretize.concretize_one("mpileaks")
-    assert s.install_status() == spack.spec.InstallStatus.absent
+    assert spack.store.STORE.db.install_status(s) == spack.spec.InstallStatus.absent
 
     status_fn = spack.cmd.buildcache_status_fn({s.dag_hash()})
     assert status_fn(s) == spack.spec.InstallStatus.buildcache
@@ -248,7 +248,7 @@ def test_buildcache_status_fn_marks_absent_spec(install_mockery, mock_packages):
 def test_buildcache_status_fn_installed_not_overridden(mutable_database):
     """Tests that an installed spec stays installed even if its hash is in the cache."""
     s = spack.store.STORE.db.query_one("mpileaks^mpich")
-    assert s.install_status() == spack.spec.InstallStatus.installed
+    assert spack.store.STORE.db.install_status(s) == spack.spec.InstallStatus.installed
 
     status_fn = spack.cmd.buildcache_status_fn({s.dag_hash()})
     assert status_fn(s) == spack.spec.InstallStatus.installed

--- a/lib/spack/spack/test/cmd/stage.py
+++ b/lib/spack/spack/test/cmd/stage.py
@@ -7,8 +7,10 @@ import pathlib
 import pytest
 
 import spack.config
+import spack.database
 import spack.environment as ev
 import spack.package_base
+import spack.store
 import spack.traverse
 from spack.cmd.stage import StageFilter
 from spack.main import SpackCommand, SpackCommandError
@@ -154,11 +156,11 @@ def test_stage_spec_filters(
     e.concretize()
     all_specs = e.all_specs()
 
-    def is_installed(self):
-        return self.name in installed
+    def is_installed(self, spec):
+        return spec.name in installed
 
     if skip_installed:
-        monkeypatch.setattr(Spec, "installed", is_installed)
+        monkeypatch.setattr(spack.database.Database, "installed", is_installed)
 
     should_be_filtered = []
     for spec in all_specs:
@@ -169,7 +171,7 @@ def test_stage_spec_filters(
                 should_be_filtered.append(spec)
         for ins in installed:
             if skip_installed and spec.satisfies(Spec(ins)):
-                assert spec.installed
+                assert spack.store.STORE.db.installed(spec)
                 should_be_filtered.append(spec)
         for exc in exclusions:
             if spec.satisfies(Spec(exc)):

--- a/lib/spack/spack/test/cmd/uninstall.py
+++ b/lib/spack/spack/test/cmd/uninstall.py
@@ -244,7 +244,7 @@ class TestUninstallFromEnv:
             e = spack.environment.read(env_name)
             with e:
                 for _, concretized_spec in e.concretized_specs():
-                    assert concretized_spec.installed
+                    assert spack.store.STORE.db.installed(concretized_spec)
 
     def test_uninstall_force_dependency_shared_between_envs(self, environment_setup):
         """If you "spack uninstall -f --dependents diamond-link-bottom" from
@@ -262,7 +262,7 @@ class TestUninstallFromEnv:
             )
 
             for _, concretized_spec in e1.concretized_specs():
-                assert not concretized_spec.installed
+                assert not spack.store.STORE.db.installed(concretized_spec)
 
         # Everything in e2 depended on diamond-link-bottom, so should also
         # have been uninstalled. The roots should be unchanged though.
@@ -272,7 +272,7 @@ class TestUninstallFromEnv:
                 ["diamond-link-right", "diamond-link-bottom"]
             )
             for _, concretized_spec in e2.concretized_specs():
-                assert not concretized_spec.installed
+                assert not spack.store.STORE.db.installed(concretized_spec)
 
     def test_uninstall_remove_dependency_shared_between_envs(self, environment_setup):
         """If you "spack uninstall --dependents --remove diamond-link-bottom" from
@@ -290,7 +290,7 @@ class TestUninstallFromEnv:
             output = uninstall("-y", "--dependents", "--remove", "diamond-link-bottom")
             assert "The following specs will be removed but not uninstalled" in output
             assert not list(e1.roots())
-            assert not dtdiamondleft.installed
+            assert not spack.store.STORE.db.installed(dtdiamondleft)
 
         # Since -f was not specified, all specs in e2 should still be installed
         # (and e2 should be unchanged)
@@ -300,7 +300,7 @@ class TestUninstallFromEnv:
                 ["diamond-link-right", "diamond-link-bottom"]
             )
             for _, concretized_spec in e2.concretized_specs():
-                assert concretized_spec.installed
+                assert spack.store.STORE.db.installed(concretized_spec)
 
     def test_uninstall_dependency_shared_between_envs_fail(self, environment_setup):
         """If you "spack uninstall --dependents diamond-link-bottom" from
@@ -319,7 +319,7 @@ class TestUninstallFromEnv:
             ["diamond-link-left", "diamond-link-bottom"]
         )
         for _, concretized_spec in e1.concretized_specs():
-            assert concretized_spec.installed
+            assert spack.store.STORE.db.installed(concretized_spec)
 
     def test_uninstall_force_and_remove_dependency_shared_between_envs(self, environment_setup):
         """If you "spack uninstall -f --dependents --remove diamond-link-bottom" from
@@ -336,7 +336,7 @@ class TestUninstallFromEnv:
             )
             uninstall("-f", "-y", "--dependents", "--remove", "diamond-link-bottom")
             assert not list(e1.roots())
-            assert not dtdiamondleft.installed
+            assert not spack.store.STORE.db.installed(dtdiamondleft)
 
         e2 = spack.environment.read("e2")
         with e2:
@@ -344,7 +344,7 @@ class TestUninstallFromEnv:
                 ["diamond-link-right", "diamond-link-bottom"]
             )
             for _, concretized_spec in e2.concretized_specs():
-                assert not concretized_spec.installed
+                assert not spack.store.STORE.db.installed(concretized_spec)
 
     def test_uninstall_keep_dependents_dependency_shared_between_envs(self, environment_setup):
         """If you "spack uninstall -f --remove diamond-link-bottom" from
@@ -363,7 +363,7 @@ class TestUninstallFromEnv:
             # diamond-link-bottom was removed from the list of roots (note that
             # it would still be installed since diamond-link-left depends on it)
             assert {x.name for x in e1.roots()} == set(["diamond-link-left"])
-            assert dtdiamondleft.installed
+            assert spack.store.STORE.db.installed(dtdiamondleft)
 
         e2 = spack.environment.read("e2")
         with e2:
@@ -375,10 +375,10 @@ class TestUninstallFromEnv:
                 for (_, concrete) in e2.concretized_specs()
                 if concrete.name == "diamond-link-right"
             )
-            assert dtdiamondright.installed
+            assert spack.store.STORE.db.installed(dtdiamondright)
             dtdiamondbottom = next(
                 concrete
                 for (_, concrete) in e2.concretized_specs()
                 if concrete.name == "diamond-link-bottom"
             )
-            assert not dtdiamondbottom.installed
+            assert not spack.store.STORE.db.installed(dtdiamondbottom)

--- a/lib/spack/spack/test/concretization/compiler_runtimes.py
+++ b/lib/spack/spack/test/concretization/compiler_runtimes.py
@@ -11,6 +11,7 @@ import spack.vendor.archspec.cpu
 
 import spack.concretize
 import spack.config
+import spack.database
 import spack.paths
 import spack.repo
 import spack.solver.asp
@@ -166,7 +167,7 @@ def test_views_can_handle_duplicate_runtime_nodes(
     )
 
     # Mock the installation status to allow selecting nodes for the view
-    monkeypatch.setattr(spack.spec.Spec, "installed", True)
+    monkeypatch.setattr(spack.database.Database, "installed", lambda self, spec: True)
     nodes = list(root.traverse())
 
     view = ViewDescriptor(str(tmp_path), str(tmp_path))

--- a/lib/spack/spack/test/concretization/core.py
+++ b/lib/spack/spack/test/concretization/core.py
@@ -39,6 +39,7 @@ import spack.solver.input_analysis
 import spack.solver.reuse
 import spack.spec
 import spack.spec_filter
+import spack.store
 import spack.traverse
 import spack.util.file_cache
 import spack.util.hash
@@ -1734,7 +1735,7 @@ spack:
         # the answer set produced by clingo.
         with spack.config.override("concretizer:reuse", True):
             s = spack.concretize.concretize_one(spec_str)
-        assert s.installed is expect_installed
+        assert spack.store.STORE.db.installed(s) is expect_installed
         assert s.satisfies(spec_str)
 
     @pytest.mark.regression("26721,19736")
@@ -2370,7 +2371,7 @@ spack:
         # If we concretize with --reuse it is not, since "mpich~debug" was already installed
         with spack.config.override("concretizer:reuse", True):
             s = spack.concretize.concretize_one("mpich")
-            assert s.installed
+            assert spack.store.STORE.db.installed(s)
             assert s.satisfies("~debug"), s
 
     @pytest.mark.regression("32471")
@@ -2565,7 +2566,7 @@ packages:
         """Tests that when we reuse a spec, virtual on edges are reconstructed correctly"""
         with spack.config.override("concretizer:reuse", True):
             spec = spack.concretize.concretize_one(spec_str)
-            assert spec.installed
+            assert spack.store.STORE.db.installed(spec)
             mpi_edges = spec.edges_to_dependencies(mpi_name)
             assert len(mpi_edges) == 1
             assert "mpi" in mpi_edges[0].virtuals

--- a/lib/spack/spack/test/database.py
+++ b/lib/spack/spack/test/database.py
@@ -1362,3 +1362,31 @@ def test_querying_reindexed_database_specfilev5(tmp_path: pathlib.Path):
     assert len(specs) == 8
     assert len([x for x in specs if x.external]) == 2
     assert len([x for x in specs if x.original_spec_format() < 5]) == 8
+
+
+def test_database_installed(
+    upstream_and_downstream_db, mock_custom_repository, config, monkeypatch
+):
+    """Test the owner-side Database.installed / installed_upstream API."""
+    upstream_db, downstream_db = upstream_and_downstream_db
+
+    with spack.repo.use_repositories(mock_custom_repository):
+        spec = spack.concretize.concretize_one("pkg-c")
+
+        # a concrete but not-yet-installed spec is not installed anywhere
+        assert not downstream_db.installed(spec)
+        assert not downstream_db.installed_upstream(spec)
+
+        with writable(upstream_db):
+            upstream_db.add(spec)
+        upstream_db._read()
+
+        # once installed upstream, both queries report it, and copies match
+        assert downstream_db.installed(spec)
+        assert downstream_db.installed_upstream(spec)
+        assert downstream_db.installed(spec.copy())
+
+    # an abstract spec is never installed
+    abstract = spack.spec.Spec("not-a-real-package")
+    assert not downstream_db.installed(abstract)
+    assert not downstream_db.installed_upstream(abstract)

--- a/lib/spack/spack/test/database.py
+++ b/lib/spack/spack/test/database.py
@@ -77,33 +77,6 @@ def test_query_by_install_tree(
     assert {s.name for s in specs} == set(result)
 
 
-def test_spec_installed_upstream(
-    upstream_and_downstream_db, mock_custom_repository, config, monkeypatch
-):
-    """Test whether Spec.installed_upstream() works."""
-    upstream_db, downstream_db = upstream_and_downstream_db
-
-    # a known installed spec should say that it's installed
-    with spack.repo.use_repositories(mock_custom_repository):
-        spec = spack.concretize.concretize_one("pkg-c")
-        assert not spec.installed
-        assert not spec.installed_upstream
-
-        with writable(upstream_db):
-            upstream_db.add(spec)
-        upstream_db._read()
-
-        monkeypatch.setattr(spack.store.STORE, "db", downstream_db)
-        assert spec.installed
-        assert spec.installed_upstream
-        assert spec.copy().installed
-
-    # an abstract spec should say it's not installed
-    spec = spack.spec.Spec("not-a-real-package")
-    assert not spec.installed
-    assert not spec.installed_upstream
-
-
 @pytest.mark.usefixtures("config")
 def test_installed_upstream(upstream_and_downstream_db, repo_builder: RepoBuilder):
     upstream_db, downstream_db = upstream_and_downstream_db
@@ -175,11 +148,11 @@ def test_missing_upstream_build_dep(
         assert upstream
         assert not record.installed
 
-        assert y.installed
-        assert y.installed_upstream
+        assert downstream_db.installed(y)
+        assert downstream_db.installed_upstream(y)
 
-        assert not z_y.installed
-        assert not z_y.installed_upstream
+        assert not downstream_db.installed(z_y)
+        assert not downstream_db.installed_upstream(z_y)
 
         # Now add z to downstream with non-triggering prefix
         # and make sure z *is* installed
@@ -188,8 +161,8 @@ def test_missing_upstream_build_dep(
         z_new.set_prefix(str(tmp_path / "z-new"))
         downstream_db.add(z_new)
 
-        assert z_new.installed
-        assert not z_new.installed_upstream
+        assert downstream_db.installed(z_new)
+        assert not downstream_db.installed_upstream(z_new)
 
 
 def test_removed_upstream_dep(
@@ -845,11 +818,11 @@ def test_regression_issue_8036(mutable_database, usr_folder_exists):
     # not be considered installed until it is added to the database by
     # the installer with install().
     s = spack.concretize.concretize_one("externaltool@0.9")
-    assert not s.installed
+    assert not spack.store.STORE.db.installed(s)
 
-    # Now install the external package and check again the `installed` property
+    # Now install the external package and check again the `installed` status
     PackageInstaller([s.package], fake=True, explicit=True).install()
-    assert s.installed
+    assert spack.store.STORE.db.installed(s)
 
 
 @pytest.mark.regression("11118")
@@ -879,7 +852,7 @@ def test_old_external_entries_prefix(mutable_database: spack.database.Database):
 def test_uninstall_by_spec(mutable_database):
     with mutable_database.write_transaction():
         for spec in mutable_database.query():
-            if spec.installed:
+            if mutable_database.installed(spec):
                 spack.package_base.PackageBase.uninstall_by_spec(spec, force=True)
             else:
                 mutable_database.remove(spec)
@@ -1198,8 +1171,8 @@ def test_query_installed_when_package_unknown(database, repo_builder: RepoBuilde
         for s in specs:
             # Assert that we can query the installation methods even though we
             # don't have the package.py available
-            assert s.installed
-            assert not s.installed_upstream
+            assert database.installed(s)
+            assert not database.installed_upstream(s)
             with pytest.raises(spack.repo.UnknownNamespaceError):
                 s.package
 

--- a/lib/spack/spack/test/install.py
+++ b/lib/spack/spack/test/install.py
@@ -46,10 +46,10 @@ def test_install_and_uninstall(install_mockery, mock_fetch, monkeypatch):
     spec = spack.concretize.concretize_one("trivial-install-test-package")
 
     PackageInstaller([spec.package], explicit=True).install()
-    assert spec.installed
+    assert spack.store.STORE.db.installed(spec)
 
     spec.package.do_uninstall()
-    assert not spec.installed
+    assert not spack.store.STORE.db.installed(spec)
 
 
 @pytest.mark.regression("11870")
@@ -58,7 +58,7 @@ def test_uninstall_non_existing_package(install_mockery, mock_fetch, monkeypatch
     spec = spack.concretize.concretize_one("trivial-install-test-package")
 
     PackageInstaller([spec.package], explicit=True).install()
-    assert spec.installed
+    assert spack.store.STORE.db.installed(spec)
 
     # Mock deletion of the package
     spec._package = None
@@ -68,7 +68,7 @@ def test_uninstall_non_existing_package(install_mockery, mock_fetch, monkeypatch
 
     # Ensure we can uninstall it
     PackageBase.uninstall_by_spec(spec)
-    assert not spec.installed
+    assert not spack.store.STORE.db.installed(spec)
 
 
 def test_pkg_attributes(install_mockery, mock_fetch, monkeypatch):
@@ -148,7 +148,7 @@ def test_partial_install_delete_prefix_and_stage(install_mockery, mock_fetch, wo
 
     PackageInstaller([s.package], explicit=True, restage=True).install()
     assert rm_prefix_checker.removed
-    assert s.package.spec.installed
+    assert spack.store.STORE.db.installed(s.package.spec)
 
 
 @pytest.mark.not_on_windows("Fails spuriously on Windows")
@@ -173,7 +173,7 @@ def test_failing_overwrite_install_should_keep_previous_installation(
     with pytest.raises(Exception):
         PackageInstaller([s.package], explicit=True, **kwargs).install()
 
-    assert s.package.spec.installed
+    assert spack.store.STORE.db.installed(s.package.spec)
     assert os.path.exists(s.prefix)
 
 
@@ -276,7 +276,7 @@ def test_installed_upstream(install_upstream, mock_fetch):
         dependent = spack.concretize.concretize_one("dependent-install")
 
         new_dependency = dependent["dependency-install"]
-        assert new_dependency.installed_upstream
+        assert spack.store.STORE.db.installed_upstream(new_dependency)
         assert new_dependency.prefix == upstream_layout.path_for_spec(dependency)
 
         PackageInstaller([dependent.package], explicit=True).install()
@@ -302,7 +302,7 @@ def test_partial_install_keep_prefix(install_mockery, mock_fetch, monkeypatch, w
     s.package.succeed = True
     spack.builder._BUILDERS.clear()  # the builder is cached with a copy of the pkg's __dict__.
     PackageInstaller([s.package], explicit=True, keep_prefix=True).install()
-    assert s.package.spec.installed
+    assert spack.store.STORE.db.installed(s.package.spec)
 
 
 def test_second_install_no_overwrite_first(install_mockery, mock_fetch, monkeypatch):
@@ -311,7 +311,7 @@ def test_second_install_no_overwrite_first(install_mockery, mock_fetch, monkeypa
 
     s.package.succeed = True
     PackageInstaller([s.package], explicit=True).install()
-    assert s.package.spec.installed
+    assert spack.store.STORE.db.installed(s.package.spec)
 
     # If Package.install is called after this point, it will fail
     s.package.succeed = False

--- a/lib/spack/spack/test/installer.py
+++ b/lib/spack/spack/test/installer.py
@@ -239,11 +239,11 @@ def test_installer_prune_built_build_deps(install_mockery, monkeypatch, repo_bui
     only include four packages. [(a), (b), (c), (d), (e)]
     """
 
-    def _mock_installed(self):
-        return self.name == "pkg-c"
+    def _mock_installed(self, spec):
+        return spec.name == "pkg-c"
 
-    # Mock the installed property to say that (c) is installed
-    monkeypatch.setattr(spack.spec.Spec, "installed", property(_mock_installed))
+    # Mock the database to say that (c) is installed
+    monkeypatch.setattr(spack.database.Database, "installed", _mock_installed)
 
     # Create mock repository with packages (a), (b), (c), (d), and (e)
     repo_builder.add_package(
@@ -307,14 +307,14 @@ def test_installer_ensure_ready_errors(install_mockery, monkeypatch):
 
     # Force an upstream package error
     spec.external_path, spec.external_modules = path, modules
-    monkeypatch.setattr(spack.spec.Spec, "installed_upstream", True)
+    monkeypatch.setattr(spack.database.Database, "installed_upstream", lambda self, spec: True)
     msg = fmt.format("is upstream")
     with pytest.raises(inst.UpstreamPackageError, match=msg):
         installer._ensure_install_ready(spec.package)
 
     # Force an install lock error, which should occur naturally since
     # we are calling an internal method prior to any lock-related setup
-    monkeypatch.setattr(spack.spec.Spec, "installed_upstream", False)
+    monkeypatch.setattr(spack.database.Database, "installed_upstream", lambda self, spec: False)
     assert len(installer.locks) == 0
     with pytest.raises(inst.InstallLockError, match=fmt.format("not locked")):
         installer._ensure_install_ready(spec.package)
@@ -615,7 +615,7 @@ def test_check_deps_status_upstream(install_mockery, monkeypatch):
     request = installer.build_requests[0]
 
     # Mock the known dependencies as installed upstream
-    monkeypatch.setattr(spack.spec.Spec, "installed_upstream", True)
+    monkeypatch.setattr(spack.database.Database, "installed_upstream", lambda self, spec: True)
     installer._check_deps_status(request)
 
     for dep in request.spec.traverse(root=False):
@@ -675,8 +675,8 @@ def test_install_spliced(install_mockery, mock_fetch, monkeypatch, transitive, i
     )
     installer.install()
     for node in out.traverse():
-        assert node.installed
-        assert node.build_spec.installed
+        assert spack.store.STORE.db.installed(node)
+        assert spack.store.STORE.db.installed(node.build_spec)
 
 
 @pytest.mark.parametrize("transitive", [True, False])
@@ -696,8 +696,8 @@ def test_install_spliced_build_spec_installed(
     )
     installer.install()
     for node in out.traverse():
-        assert node.installed
-        assert node.build_spec.installed
+        assert spack.store.STORE.db.installed(node)
+        assert spack.store.STORE.db.installed(node.build_spec)
 
 
 # Unit tests should not be affected by the user's managed environments
@@ -1363,7 +1363,7 @@ def test_overwrite_install_does_install_build_deps(install_mockery, mock_fetch):
     create_installer([s], {"overwrite": [s.dag_hash()]}).install()
 
     # Verify that the build dep was also installed.
-    assert build_dep.installed
+    assert spack.store.STORE.db.installed(build_dep)
 
 
 @pytest.mark.parametrize("run_tests", [True, False])

--- a/lib/spack/spack/test/modules/common.py
+++ b/lib/spack/spack/test/modules/common.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 import os
 import stat
+import types
 
 import pytest
 
@@ -16,6 +17,7 @@ import spack.modules.tcl
 import spack.package_base
 import spack.package_prefs
 import spack.repo
+import spack.store
 from spack.modules.common import UpstreamModuleIndex
 from spack.old_installer import PackageInstaller
 from spack.util.filesystem import readlink
@@ -95,6 +97,9 @@ class MockDb:
     def db_for_spec_hash(self, spec_hash):
         return self.spec_hash_to_db.get(spec_hash)
 
+    def installed_upstream(self, spec):
+        return self.spec_hash_to_db.get(spec.dag_hash()) is not None
+
 
 class MockSpec:
     def __init__(self, unique_id):
@@ -143,7 +148,7 @@ module_index:
         upstream_index.upstream_module(s4, "tcl")
 
 
-def test_get_module_upstream():
+def test_get_module_upstream(monkeypatch):
     s1 = MockSpec("spec-1")
 
     tcl_module_index = """\
@@ -160,7 +165,7 @@ module_index:
     mock_db = MockDb(dbs, {s1.dag_hash(): "d1"})
     upstream_index = UpstreamModuleIndex(mock_db, module_indices)
 
-    setattr(s1, "installed_upstream", True)
+    monkeypatch.setattr(spack.store, "STORE", types.SimpleNamespace(db=mock_db))
     try:
         old_index = spack.modules.common.upstream_module_index
         spack.modules.common.upstream_module_index = upstream_index

--- a/lib/spack/spack/test/oci/integration_test.py
+++ b/lib/spack/spack/test/oci/integration_test.py
@@ -22,6 +22,7 @@ import spack.environment as ev
 import spack.error
 import spack.oci.opener
 import spack.spec
+import spack.store
 import spack.traverse
 from spack.main import SpackCommand
 from spack.oci.image import Digest, ImageReference, default_config, default_manifest
@@ -60,7 +61,7 @@ def test_buildcache_push_command(mutable_database):
         buildcache("install", "--unsigned", "mpileaks^mpich")
 
         # Now it should be installed again
-        assert spec.installed
+        assert spack.store.STORE.db.installed(spec)
 
         # And let's check that the bin/mpileaks executable is there
         assert os.path.exists(os.path.join(spec.prefix, "bin", "mpileaks"))

--- a/lib/spack/spack/test/spec_dag.py
+++ b/lib/spack/spack/test/spec_dag.py
@@ -8,6 +8,7 @@ These tests check Spec DAG operations using dummy packages.
 import pytest
 
 import spack.concretize
+import spack.database
 import spack.deptypes as dt
 import spack.error
 import spack.old_installer
@@ -135,7 +136,9 @@ def test_specify_preinstalled_dep(monkeypatch, repo_builder: RepoBuilder):
 
     with spack.repo.use_repositories(repo_builder.root):
         b_spec = spack.concretize.concretize_one("pkg-b")
-        monkeypatch.setattr(Spec, "installed", property(lambda x: x.name != "pkg-a"))
+        monkeypatch.setattr(
+            spack.database.Database, "installed", lambda self, spec: spec.name != "pkg-a"
+        )
 
         a_spec = Spec("pkg-a")
         a_spec._add_dependency(b_spec, depflag=dt.BUILD | dt.LINK, virtuals=())

--- a/lib/spack/spack/test/spec_semantics.py
+++ b/lib/spack/spack/test/spec_semantics.py
@@ -1805,20 +1805,20 @@ def test_merge_anonymous_spec_with_named_spec(anonymous, named, expected):
 
 
 def test_spec_installed(default_mock_concretization, database):
-    """Test whether Spec.installed works."""
+    """Test whether Database.installed works."""
     # a known installed spec should say that it's installed
     specs = database.query()
     spec = specs[0]
-    assert spec.installed
-    assert spec.copy().installed
+    assert database.installed(spec)
+    assert database.installed(spec.copy())
 
     # an abstract spec should say it's not installed
     spec = Spec("not-a-real-package")
-    assert not spec.installed
+    assert not database.installed(spec)
 
     # pkg-a is not in the mock DB and is not installed
     spec = default_mock_concretization("pkg-a")
-    assert not spec.installed
+    assert not database.installed(spec)
 
 
 @pytest.mark.regression("30678")

--- a/lib/spack/spack/test/test_suite.py
+++ b/lib/spack/spack/test/test_suite.py
@@ -10,6 +10,7 @@ import pytest
 
 import spack.concretize
 import spack.config
+import spack.database
 import spack.install_test
 import spack.spec
 import spack.util.executable
@@ -106,7 +107,7 @@ def test_test_external(
     spec = spack.concretize.concretize_one(name)
     spec.external_path = "/path/to/external/{0}".format(name)
 
-    monkeypatch.setattr(spack.spec.Spec, "installed", _true)
+    monkeypatch.setattr(spack.database.Database, "installed", _true)
 
     test_suite = spack.install_test.TestSuite([spec])
     test_suite(**arguments)
@@ -153,7 +154,7 @@ def test_test_spec_run_once(mock_packages, install_mockery, mock_test_stage):
 @pytest.mark.not_on_windows("Cannot find echo executable")
 def test_test_spec_passes(mock_packages, install_mockery, mock_test_stage, monkeypatch):
     spec = spack.concretize.concretize_one("simple-standalone-test")
-    monkeypatch.setattr(spack.spec.Spec, "installed", _true)
+    monkeypatch.setattr(spack.database.Database, "installed", _true)
     test_suite = spack.install_test.TestSuite([spec])
     test_suite()
 


### PR DESCRIPTION
`Spec.installed`, `Spec.installed_upstream`, `Spec.install_status` read the global store from inside the `property` or method. This is bad design for two reasons:
1. A dependency on `STORE` is hidden behind a property, and more importantly
2. It should not be a concern of the `Spec` to know about the `STORE`

This PR adds `Database.installed` and `Database.installed_upstream` and inverts every core/internal call site to go through the `Database` directly instead of the `Spec` members. Install-status printing in `Spec.tree` now takes an injected `status_fn` callback, and the deprecation check moves to `asp._ensure_no_deprecated(root, store)` with the store passed explicitly.

In this PR we remove any core access to `Spec.installed`, `Spec.installed_upstream` and `Spec.install_status` and move the functionality to corresponding `Database` methods accepting a spec as argument.

The `Spec.installed` and `Spec.installed_upstream` properties will be removed in a dedicated follow-up PR.