### PR TITLE
new_installer: sanitize version string in log file path

### DIFF
--- a/lib/spack/spack/new_installer.py
+++ b/lib/spack/spack/new_installer.py
@@ -2573,10 +2573,11 @@ class PackageInstaller:
             if spec.external:
                 self.log_paths[dag_hash] = os.devnull
             else:
+                prefix = fs.polite_filename(
+                    f"spack-stage-{spec.name}-{spec.version}-{spec.dag_hash()}-"
+                )
                 log_fd, log_path = tempfile.mkstemp(
-                    prefix=f"spack-stage-{spec.name}-{spec.version}-{spec.dag_hash()}-",
-                    suffix=".log",
-                    dir=spack.stage.get_stage_root(),
+                    prefix=prefix, suffix=".log", dir=spack.stage.get_stage_root()
                 )
                 os.close(log_fd)
                 self.log_paths[dag_hash] = log_path


### PR DESCRIPTION
The new installer builds the temp log-file path with `tempfile.mkstemp(prefix=f"spack-stage-{spec.name}-{spec.version}-...")`. For git-ref versions containing a slash (e.g. `git.release/shs-13.1.0=13.1.0`, used by `cassini-headers`, `cxi-driver`, `libcxi`), the `/` is treated as a directory separator and `mkstemp` fails with `ENOENT`.

Sanitize the prefix with `polite_filename()`, consistent with how stage directory names are already sanitized.

**Reproducer**

```
$ spack install cassini-headers@git.release/shs-13.1.0=13.1.0
Error: [Errno 2] No such file or directory: '.../spack-stage-cassini-headers-git.release/shs-13.1.0=...-....log'
```
  