### PR TITLE
new_installer.py: decouple ui from event loop

### DIFF
--- a/lib/spack/spack/new_installer.py
+++ b/lib/spack/spack/new_installer.py
@@ -51,7 +51,7 @@ from typing import (
     cast,
 )
 
-from spack.vendor.typing_extensions import Literal, Protocol
+from spack.vendor.typing_extensions import Literal
 
 import spack.binary_distribution
 import spack.build_environment
@@ -109,6 +109,23 @@ if TYPE_CHECKING:
 
 #: Type for specifying installation source modes
 InstallPolicy = Literal["auto", "cache_only", "source_only"]
+
+
+class SetEcho(NamedTuple):
+    """Command asking the event loop to enable/disable log forwarding from a build."""
+
+    build_id: str
+    echo: bool
+
+
+class ChangeJobs(NamedTuple):
+    """Command asking the event loop to change build parallelism by ``delta`` (+1 / -1)."""
+
+    delta: int
+
+
+#: A command produced by the UI (view) and executed by the event loop.
+UiCommand = Union[SetEcho, ChangeJobs]
 
 #: How often to update a spinner in seconds
 SPINNER_INTERVAL = 0.1
@@ -950,49 +967,14 @@ class BuildInfo:
         self.log_summary: Optional[str] = None
 
 
-class LoopController(Protocol):
-    """The event-loop operations a frontend may invoke: toggling a build's log echo and changing
-    build parallelism. Implemented by the event loop, which owns the build channels and the
-    jobserver. This is the view->controller half of the frontend contract; a frontend calls these
-    only for state it does not own itself."""
-
-    def set_echo(self, build_id: str, echo: bool) -> None: ...
-
-    def increase_jobs(self) -> None: ...
-
-    def decrease_jobs(self) -> None: ...
-
-
-class EventLoopController:
-    """Concrete :class:`LoopController` wiring the view's actions to the event loop's jobserver
-    and build channels. Constructed once the jobserver exists (see PackageInstaller._installer)."""
-
-    def __init__(self, installer: "PackageInstaller", jobserver: JobServerBase) -> None:
-        self._installer = installer
-        self._jobserver = jobserver
-
-    def set_echo(self, build_id: str, echo: bool) -> None:
-        self._installer._set_echo(build_id, echo)
-
-    def increase_jobs(self) -> None:
-        self._jobserver.increase_parallelism()
-        self._installer.ui.on_jobs_changed(self._jobserver.num_jobs, self._jobserver.target_jobs)
-
-    def decrease_jobs(self) -> None:
-        self._jobserver.decrease_parallelism()
-        self._installer.ui.on_jobs_changed(self._jobserver.num_jobs, self._jobserver.target_jobs)
-
-
 class InstallerUI:
     """Interface between the installer event loop and a frontend. The methods are no-ops, which
     makes this class usable as a headless frontend.
 
     The contract is single-threaded: notifications are invoked on the event loop thread, and the
-    ``controller`` methods must be called from that thread as well. A frontend running its own
-    thread (e.g. a GUI) currently has no way to post calls into the event loop."""
-
-    #: Assigned by the event loop, used to communicate from the frontend to the event loop.
-    controller: LoopController
+    frontend appends any resulting :data:`UiCommand` objects to ``self.commands`` from that thread.
+    A frontend running its own thread (e.g. a GUI) currently has no way to post commands into the
+    event loop."""
 
     def __init__(self) -> None:
         #: Whether the frontend renders interactively; determines the event loop wake interval.
@@ -1001,6 +983,9 @@ class InstallerUI:
         #: terminal. If True, the event loop manages terminal state (cbreak mode, suspend/resume
         #: signals, stdin registration) and feeds keyboard input to ``on_input``.
         self.reads_terminal_input = False
+        #: Commands the frontend has produced for the event loop to execute. The loop drains this
+        #: once per iteration; a frontend appends to it instead of calling into the loop directly.
+        self.commands: List[UiCommand] = []
 
     def on_build_added(self, info: BuildInfo) -> None:
         """A build was started, or a spec was found installed by another process."""
@@ -1140,7 +1125,7 @@ class TerminalUI(InstallerUI):
         # only in non-TTY verbose mode.
         if self.verbose and not self.tracked_build_id:
             self.tracked_build_id = info.id
-            self.controller.set_echo(info.id, True)
+            self.commands.append(SetEcho(info.id, True))
 
     def on_build_removed(self, build_id: str) -> None:
         """Remove a build from the display (e.g. after a binary cache miss before retry)."""
@@ -1164,7 +1149,7 @@ class TerminalUI(InstallerUI):
             self.search_mode = False
             self.overview_mode = True
             self.dirty = True
-            self.controller.set_echo(self.tracked_build_id, False)
+            self.commands.append(SetEcho(self.tracked_build_id, False))
             self.tracked_build_id = ""
 
     def search_input(self, input: str) -> None:
@@ -1202,9 +1187,9 @@ class TerminalUI(InstallerUI):
             elif char == "p" or char == "N":
                 self.next(-1)
             elif char == "+":
-                self.controller.increase_jobs()
+                self.commands.append(ChangeJobs(1))
             elif char == "-":
-                self.controller.decrease_jobs()
+                self.commands.append(ChangeJobs(-1))
 
     def _is_displayed(self, build: BuildInfo) -> bool:
         """Returns true if the build matches the search term, or when no search term is set."""
@@ -1243,7 +1228,7 @@ class TerminalUI(InstallerUI):
 
         # Stop following the previous and start following the new build.
         if self.tracked_build_id:
-            self.controller.set_echo(self.tracked_build_id, False)
+            self.commands.append(SetEcho(self.tracked_build_id, False))
 
         self.tracked_build_id = new_build_id
 
@@ -1270,7 +1255,7 @@ class TerminalUI(InstallerUI):
             self.stdout.write(f"{prefix}==> Following logs of {new_build.name}{version_str}\n")
             self.log_ends_with_newline = True
             self.stdout.flush()
-            self.controller.set_echo(new_build_id, True)
+            self.commands.append(SetEcho(new_build_id, True))
 
     def on_blocked_changed(self, blocked: bool) -> None:
         """Set whether all pending builds are blocked by another Spack process."""
@@ -2291,10 +2276,6 @@ class PackageInstaller:
         jobserver = JobServer(self.jobs, os.environ.get("MAKEFLAGS", ""))
         selector = selectors.DefaultSelector()
 
-        # The view -> event loop half of the frontend contract (see LoopController): assigned here
-        # because the event loop owns the build channels and the jobserver.
-        self.ui.controller = EventLoopController(self, jobserver)
-
         # Terminal handling (cbreak, suspend/resume signals, stdin registration) is event loop
         # plumbing, enabled only for frontends that read the controlling terminal.
         terminal: Optional[BaseTerminalState] = None
@@ -2322,6 +2303,9 @@ class PackageInstaller:
                 blocked = self._schedule_builds(
                     selector, jobserver, retained_read_locks, database_actions
                 )
+                # Execute commands from scheduling (e.g. a verbose first-build echo) promptly.
+                if self.ui.commands:
+                    self._run_ui_commands(jobserver)
                 self._flush_db_if_due(time.monotonic(), database_actions, retained_read_locks)
 
             while (
@@ -2419,6 +2403,11 @@ class PackageInstaller:
                 # scheduling so that a final mark-explicit action does not wait for the next
                 # select() timeout.
                 self._flush_db_if_due(current_time, database_actions, retained_read_locks)
+
+                # Execute commands the UI produced this iteration (input, toggle-on-finish, verbose
+                # echo) before the redraw, so their effect (e.g. the job counter) is painted now.
+                if self.ui.commands:
+                    self._run_ui_commands(jobserver)
 
                 # Finally update the UI
                 self.ui.render()
@@ -2767,9 +2756,25 @@ class PackageInstaller:
             log_path=log_path,
         )
 
+    def _run_ui_commands(self, jobserver: JobServerBase) -> None:
+        """Execute the commands the UI produced. Callers guard on a non-empty buffer, so the common
+        no-command iteration skips this call. The buffer is swapped out first so a command that
+        re-enters the UI cannot mutate the list we are iterating (any new command drains next
+        iteration)."""
+        commands, self.ui.commands = self.ui.commands, []
+        for cmd in commands:
+            if isinstance(cmd, SetEcho):
+                self._set_echo(cmd.build_id, cmd.echo)
+            else:  # ChangeJobs
+                if cmd.delta > 0:
+                    jobserver.increase_parallelism()
+                else:
+                    jobserver.decrease_parallelism()
+                self.ui.on_jobs_changed(jobserver.num_jobs, jobserver.target_jobs)
+
     def _set_echo(self, build_id: str, echo: bool) -> None:
-        """Enable or disable log forwarding from a running build to this process. Backs the
-        controller's ``set_echo``; the event loop owns the control channels and their lifetime."""
+        """Enable or disable log forwarding from a running build to this process. Executes a
+        :class:`SetEcho` command; the event loop owns the control channels and their lifetime."""
         child = self.running_builds.get(build_id)
         if child is None:
             return

--- a/lib/spack/spack/new_installer.py
+++ b/lib/spack/spack/new_installer.py
@@ -119,9 +119,9 @@ class SetEcho(NamedTuple):
 
 
 class ChangeJobs(NamedTuple):
-    """Command that increments/decrements job server parallelism."""
+    """Command that increments/decrements job server tokens when positive/negative respectively."""
 
-    delta: Literal[-1, 1]
+    delta: int
 
 
 #: A command produced by the UI and executed by the event loop.

--- a/lib/spack/spack/new_installer.py
+++ b/lib/spack/spack/new_installer.py
@@ -921,7 +921,7 @@ def start_build(
 
 class BuildInfo:
     """Plain data about a package being built: the payload of ``InstallerUI.on_build_added`` and
-    the per-build record of the terminal UI. Conceptually a dataclass."""
+    the per-build record of the terminal UI."""
 
     __slots__ = (
         "id",
@@ -1007,8 +1007,10 @@ class InstallerUI:
         """Raw log output received from a build whose echoing is enabled."""
 
     def on_finished(self, failures: List[str]) -> None:
-        """Installation finished; ``failures`` holds the build ids of failed builds (empty on
-        success). The frontend may print failure details."""
+        """The whole installation finished. Called once at the end of the run, and is different
+        from ``on_state_changed(build_id, "finished")`` which is called after each successful
+        package installation. ``failures`` is a list of failed build ids (empty on success). The
+        frontend may print a failure summary."""
 
     def on_jobs_changed(self, actual: int, target: int) -> None:
         """The actual and/or target number of concurrent jobs changed."""

--- a/lib/spack/spack/new_installer.py
+++ b/lib/spack/spack/new_installer.py
@@ -51,7 +51,7 @@ from typing import (
     cast,
 )
 
-from spack.vendor.typing_extensions import Literal
+from spack.vendor.typing_extensions import Literal, Protocol
 
 import spack.binary_distribution
 import spack.build_environment
@@ -905,9 +905,11 @@ def start_build(
 
 
 class BuildInfo:
-    """Information about a package being built."""
+    """Plain data about a package being built: the payload of ``InstallerUI.add_build`` and the
+    per-build record of the terminal UI. Conceptually a dataclass."""
 
     __slots__ = (
+        "id",
         "state",
         "explicit",
         "version",
@@ -919,37 +921,137 @@ class BuildInfo:
         "start_time",
         "duration",
         "progress_percent",
-        "control_w_conn",
         "log_path",
         "log_summary",
     )
 
     def __init__(
         self,
-        spec: spack.spec.Spec,
+        build_id: str,
+        *,
+        name: str,
+        version: str,
+        external: bool,
+        prefix: str,
         explicit: bool,
-        control_w_conn: Optional[IpcChannel],
         log_path: Optional[str] = None,
-        start_time: float = 0.0,
     ) -> None:
+        self.id: str = build_id
         self.state: str = "starting"
         self.explicit: bool = explicit
-        self.version: str = str(spec.version)
-        self.hash: str = spec.dag_hash(7)
-        self.name: str = spec.name
-        self.external: bool = spec.external
-        self.prefix: str = spec.prefix
+        self.version: str = version
+        self.hash: str = build_id[:7]
+        self.name: str = name
+        self.external: bool = external
+        self.prefix: str = prefix
         self.finished_time: Optional[float] = None
-        self.start_time: float = start_time
+        self.start_time: float = 0.0
         self.duration: Optional[float] = None
         self.progress_percent: Optional[int] = None
-        self.control_w_conn = control_w_conn
         self.log_path = log_path
         self.log_summary: Optional[str] = None
 
 
-class BuildStatus:
-    """Tracks the build status display for terminal output."""
+class LoopController(Protocol):
+    """The event-loop operations a frontend may invoke: toggling a build's log echo and changing
+    build parallelism. Implemented by the event loop, which owns the build channels and the
+    jobserver. This is the view->controller half of the frontend contract; a frontend calls these
+    only for state it does not own itself."""
+
+    def set_echo(self, build_id: str, echo: bool) -> None: ...
+
+    def increase_jobs(self) -> None: ...
+
+    def decrease_jobs(self) -> None: ...
+
+
+class EventLoopController:
+    """Concrete :class:`LoopController` wiring the view's actions to the event loop's jobserver
+    and build channels. Constructed once the jobserver exists (see PackageInstaller._installer)."""
+
+    def __init__(self, installer: "PackageInstaller", jobserver: JobServerBase) -> None:
+        self._installer = installer
+        self._jobserver = jobserver
+
+    def set_echo(self, build_id: str, echo: bool) -> None:
+        self._installer._set_echo(build_id, echo)
+
+    def increase_jobs(self) -> None:
+        self._jobserver.increase_parallelism()
+        self._installer.ui.set_jobs(self._jobserver.num_jobs, self._jobserver.target_jobs)
+
+    def decrease_jobs(self) -> None:
+        self._jobserver.decrease_parallelism()
+        self._installer.ui.set_jobs(self._jobserver.num_jobs, self._jobserver.target_jobs)
+
+
+class InstallerUI:
+    """Interface between the installer event loop and a frontend. The methods are no-ops, which
+    makes this class usable as a headless frontend.
+
+    The contract is single-threaded: notifications are invoked on the event loop thread, and the
+    ``controller`` methods must be called from that thread as well. A frontend running its own
+    thread (e.g. a GUI) currently has no way to post calls into the event loop."""
+
+    #: Assigned by the event loop, used to communicate from the frontend to the event loop.
+    controller: LoopController
+
+    def __init__(self) -> None:
+        #: Whether the frontend renders interactively; determines the event loop wake interval.
+        self.is_tty = False
+        #: Whether the frontend renders to and reads keyboard input from the controlling
+        #: terminal. If True, the event loop manages terminal state (cbreak mode, suspend/resume
+        #: signals, stdin registration) and feeds keyboard input to ``handle_input``.
+        self.reads_terminal_input = False
+
+    def add_build(self, info: BuildInfo) -> None:
+        """A build was started, or a spec was found installed by another process."""
+
+    def remove_build(self, build_id: str) -> None:
+        """A build was removed (e.g. after a binary cache miss before a source retry)."""
+
+    def update_state(self, build_id: str, state: str) -> None:
+        """A build transitioned to a new state (e.g. ``"staging"``, ``"finished"``)."""
+
+    def update_progress(self, build_id: str, current: int, total: int) -> None:
+        """Fetch progress of a build changed."""
+
+    def increase_total(self, count: int) -> None:
+        """The total number of scheduled builds increased (e.g. build dep expansion)."""
+
+    def print_logs(self, build_id: str, data: bytes) -> None:
+        """Raw log output received from a build whose echoing is enabled."""
+
+    def print_failure_summaries(self, build_ids: List[str]) -> None:
+        """Installation is ending with failed builds; the frontend may print failure details."""
+
+    def set_jobs(self, actual: int, target: int) -> None:
+        """The actual and/or target number of concurrent jobs changed."""
+
+    def set_blocked(self, blocked: bool) -> None:
+        """Whether all pending builds are blocked by another Spack process."""
+
+    def handle_input(self, chars: str) -> None:
+        """Keyboard input received (only called for interactive frontends)."""
+
+    def on_resize(self) -> None:
+        """The terminal was resized (only called for interactive frontends)."""
+
+    def set_headless(self, headless: bool) -> None:
+        """The process moved to the background (True) or foreground (False); the frontend should
+        suppress rendering while headless. Called only through the terminal path."""
+
+    def render(self, finalize: bool = False) -> None:
+        """Periodic tick to redraw; ``finalize`` is True for the final render."""
+
+    def refresh_interval(self) -> Optional[float]:
+        """How often the frontend needs a periodic ``render`` tick, or None if it never does. The
+        event loop bounds its sleep by this together with its own database-flush cadence."""
+        return None
+
+
+class TerminalUI(InstallerUI):
+    """Terminal frontend: renders an interactive build overview and follows build logs."""
 
     def __init__(
         self,
@@ -962,8 +1064,14 @@ class BuildStatus:
         verbose: bool = False,
         filter_padding: bool = False,
     ) -> None:
+        super().__init__()
+        self.reads_terminal_input = True
         if stdout is None:
             stdout = cast(io.TextIOWrapper, sys.stdout)
+            if is_tty is None:
+                # For the real stdout, use GetConsoleMode-based detection on Windows, which is
+                # correct through ConPTY where isatty() is not.
+                is_tty = TerminalState.stdout_is_interactive()
         #: Ordered dict of build ID -> info
         self.total = total
         self.completed = 0
@@ -999,7 +1107,6 @@ class BuildStatus:
         self.verbose = verbose and not self.is_tty
         self.filter_padding = filter_padding
         #: When True, suppress all terminal output (process is in background).
-        #: Controlling code is responsible for modifying this variable based on process state
         self.headless = False
         self.term_title = spack.config.get("config:install_status", True) and self.is_tty
 
@@ -1008,25 +1115,32 @@ class BuildStatus:
         self.terminal_size_changed = True
         self.dirty = True
 
-    def add_build(
-        self,
-        spec: spack.spec.Spec,
-        explicit: bool,
-        control_w_conn: Optional[IpcChannel] = None,
-        log_path: Optional[str] = None,
-    ) -> None:
+    def set_headless(self, headless: bool) -> None:
+        if headless:
+            # The display is invalidated: the shell may print over it while we're suspended or in
+            # the background, so the next render must append instead of moving the cursor up.
+            self.active_area_rows = 0
+        else:
+            self.dirty = True
+        self.headless = headless
+
+    def refresh_interval(self) -> Optional[float]:
+        # Only an interactive, foreground terminal animates the spinner; a suppressed (headless)
+        # or non-tty frontend needs no periodic redraw.
+        if self.headless or not self.is_tty:
+            return None
+        return SPINNER_INTERVAL
+
+    def add_build(self, info: BuildInfo) -> None:
         """Add a new build to the display and mark the display as dirty."""
-        build_info = BuildInfo(spec, explicit, control_w_conn, log_path, int(self.get_time()))
-        self.builds[spec.dag_hash()] = build_info
+        info.start_time = int(self.get_time())
+        self.builds[info.id] = info
         self.dirty = True
         # Track the new build's logs when we're not already following another build. This applies
         # only in non-TTY verbose mode.
-        if self.verbose and not self.tracked_build_id and control_w_conn is not None:
-            self.tracked_build_id = spec.dag_hash()
-            try:
-                write_connection(control_w_conn, b"1")
-            except OSError:
-                pass
+        if self.verbose and not self.tracked_build_id:
+            self.tracked_build_id = info.id
+            self.controller.set_echo(info.id, True)
 
     def remove_build(self, build_id: str) -> None:
         """Remove a build from the display (e.g. after a binary cache miss before retry)."""
@@ -1050,12 +1164,7 @@ class BuildStatus:
             self.search_mode = False
             self.overview_mode = True
             self.dirty = True
-            try:
-                conn = self.builds[self.tracked_build_id].control_w_conn
-                if conn is not None:
-                    write_connection(conn, b"0")
-            except (KeyError, OSError):
-                pass
+            self.controller.set_echo(self.tracked_build_id, False)
             self.tracked_build_id = ""
 
     def search_input(self, input: str) -> None:
@@ -1077,6 +1186,25 @@ class BuildStatus:
     def enter_search(self) -> None:
         self.search_mode = True
         self.dirty = True
+
+    def handle_input(self, chars: str) -> None:
+        """Dispatch keyboard input to search, navigation, and parallelism actions."""
+        for char in chars:
+            overview = self.overview_mode
+            if overview and self.search_mode:
+                self.search_input(char)
+            elif overview and char == "/":
+                self.enter_search()
+            elif char == "v" or char in ("q", "\x1b") and not overview:
+                self.toggle()
+            elif char == "n":
+                self.next(1)
+            elif char == "p" or char == "N":
+                self.next(-1)
+            elif char == "+":
+                self.controller.increase_jobs()
+            elif char == "-":
+                self.controller.decrease_jobs()
 
     def _is_displayed(self, build: BuildInfo) -> bool:
         """Returns true if the build matches the search term, or when no search term is set."""
@@ -1115,12 +1243,7 @@ class BuildStatus:
 
         # Stop following the previous and start following the new build.
         if self.tracked_build_id:
-            try:
-                conn = self.builds[self.tracked_build_id].control_w_conn
-                if conn is not None:
-                    write_connection(conn, b"0")
-            except (KeyError, OSError):
-                pass
+            self.controller.set_echo(self.tracked_build_id, False)
 
         self.tracked_build_id = new_build_id
 
@@ -1147,12 +1270,7 @@ class BuildStatus:
             self.stdout.write(f"{prefix}==> Following logs of {new_build.name}{version_str}\n")
             self.log_ends_with_newline = True
             self.stdout.flush()
-            try:
-                conn = new_build.control_w_conn
-                if conn is not None:
-                    write_connection(conn, b"1")
-            except (KeyError, OSError):
-                pass
+            self.controller.set_echo(new_build_id, True)
 
     def set_blocked(self, blocked: bool) -> None:
         """Set whether all pending builds are blocked by another Spack process."""
@@ -1188,6 +1306,10 @@ class BuildStatus:
         build_info.state = state
         build_info.progress_percent = None
 
+        if state == "failed":
+            # Store the log summary for interactive browsing and the final failure printout.
+            self._parse_log_summary(build_info)
+
         if state in ("finished", "failed"):
             self.completed += 1
             now = self.get_time()
@@ -1212,9 +1334,8 @@ class BuildStatus:
             self.stdout.write(line + "\n")
             self.stdout.flush()
 
-    def parse_log_summary(self, build_id: str) -> None:
+    def _parse_log_summary(self, build_info: BuildInfo) -> None:
         """Parse the build log for errors/warnings and store the summary."""
-        build_info = self.builds[build_id]
         if not build_info.log_path or not os.path.exists(build_info.log_path):
             return
         errors, warnings, tail_event = parse_log_events(build_info.log_path, tail=20)
@@ -1224,6 +1345,16 @@ class BuildStatus:
         if events:
             build_info.log_summary = make_log_context(events)
 
+    def print_failure_summaries(self, build_ids: List[str]) -> None:
+        """Write the stored log summaries of the failed builds to stderr."""
+        for build_id in build_ids:
+            build_info = self.builds.get(build_id)
+            if build_info is not None and build_info.log_summary:
+                sys.stderr.write(build_info.log_summary)
+
+    def increase_total(self, count: int) -> None:
+        self.total += count
+
     def update_progress(self, build_id: str, current: int, total: int) -> None:
         """Update the progress of a package and mark the display as dirty."""
         percent = int((current / total) * 100)
@@ -1232,8 +1363,10 @@ class BuildStatus:
             build_info.progress_percent = percent
             self.dirty = True
 
-    def update(self, finalize: bool = False) -> None:
+    def render(self, finalize: bool = False) -> None:
         """Redraw the interactive display."""
+        if finalize:
+            self.overview_mode = True
         if self.headless or not self.is_tty or not self.overview_mode:
             return
 
@@ -2044,6 +2177,7 @@ class PackageInstaller:
         root_policy: InstallPolicy = "auto",
         dependencies_policy: InstallPolicy = "auto",
         create_reports: bool = False,
+        ui: Optional[InstallerUI] = None,
         store: Optional[spack.store.Store] = None,
     ) -> None:
         assert install_package or install_deps, "Must install package, dependencies or both"
@@ -2090,18 +2224,8 @@ class PackageInstaller:
             self.has_mirrors,
         )
 
-        #: check what specs we could fetch from binaries (checks against cache, not remotely)
-        try:
-            spack.binary_distribution.BINARY_INDEX.update()
-        except spack.binary_distribution.FetchCacheError:
-            pass
-
-        self.binary_cache_for_spec = {
-            s.dag_hash(): spack.binary_distribution.BINARY_INDEX.find_by_hash(
-                s.build_spec.dag_hash()
-            )
-            for s in self.build_graph.nodes.values()
-        }
+        #: Per-spec buildcache mirrors; populated in install() from the binary index.
+        self.binary_cache_for_spec: Dict[str, List[spack.url_buildcache.MirrorMetadata]] = {}
         self.unsigned = unsigned
         self.dirty = dirty
         self.fake = fake
@@ -2120,15 +2244,12 @@ class PackageInstaller:
         self.verbose = verbose
         self.running_builds: Dict[str, ChildInfo] = {}
         self.log_paths: Dict[str, str] = {}
-        self.build_status = BuildStatus(
-            len(self.build_graph.nodes),
-            verbose=verbose,
-            filter_padding=self.store.has_padding(),
-            is_tty=TerminalState.stdout_is_interactive(),
+        self.ui = ui or TerminalUI(
+            total=0, verbose=verbose, filter_padding=self.store.has_padding()
         )
+        self.ui.increase_total(len(self.build_graph.nodes))
         self.jobs = spack.config.determine_number_of_jobs(parallel=True)
-        self.build_status.actual_jobs = self.jobs
-        self.build_status.target_jobs = self.jobs
+        self.ui.set_jobs(self.jobs, self.jobs)
         if concurrent_packages is None:
             concurrent_packages_config = spack.config.get("config:concurrent_packages", 0)
             # The value 0 in config means no limit (other than self.jobs)
@@ -2150,20 +2271,38 @@ class PackageInstaller:
         self.next_database_write = 0.0
 
     def install(self) -> None:
+        #: check what specs we could fetch from binaries (checks against cache, not remotely)
+        try:
+            spack.binary_distribution.BINARY_INDEX.update()
+        except spack.binary_distribution.FetchCacheError:
+            pass
+
+        self.binary_cache_for_spec = {
+            s.dag_hash(): spack.binary_distribution.BINARY_INDEX.find_by_hash(
+                s.build_spec.dag_hash()
+            )
+            for s in self.build_graph.nodes.values()
+        }
+
         self._installer()
 
     def _installer(self) -> None:
         self.store.install_sbang()
-        jobserver = JobServer(self.jobs)
+        jobserver = JobServer(self.jobs, os.environ.get("MAKEFLAGS", ""))
         selector = selectors.DefaultSelector()
 
-        # Set up terminal handling (cbreak, signals, stdin registration)
-        terminal: Optional[BaseTerminalState] = None
+        # The view -> event loop half of the frontend contract (see LoopController): assigned here
+        # because the event loop owns the build channels and the jobserver.
+        self.ui.controller = EventLoopController(self, jobserver)
+
+        # Terminal handling (cbreak, suspend/resume signals, stdin registration) is event loop
+        # plumbing, enabled only for frontends that read the controlling terminal.
         stdin_reader: Optional[StdinReader] = None
-        if TerminalState.stdin_is_interactive():
+        terminal: Optional[BaseTerminalState] = None
+        if self.ui.reads_terminal_input and TerminalState.stdin_is_interactive():
             terminal = TerminalState(
                 selector,
-                self.build_status,
+                self.ui,
                 on_suspend=lambda: _signal_children(self.running_builds, signal.SIGSTOP),
                 on_resume=lambda: _signal_children(self.running_builds, signal.SIGCONT),
             )
@@ -2180,11 +2319,11 @@ class PackageInstaller:
 
         try:
             # Try to schedule builds immediately. The first job does not require a token.
+            blocked = False
             if self.pending_builds:
                 blocked = self._schedule_builds(
                     selector, jobserver, retained_read_locks, database_actions
                 )
-                self.build_status.set_blocked(blocked and not self.running_builds)
                 self._flush_db_if_due(time.monotonic(), database_actions, retained_read_locks)
 
             while (
@@ -2206,14 +2345,16 @@ class PackageInstaller:
 
                 stdin_ready = False
 
-                if self.build_status.headless:
-                    # no UI to update, but check background to foreground transition periodically
-                    timeout = HEADLESS_WAKE_INTERVAL
-                elif self.build_status.is_tty:
-                    timeout = SPINNER_INTERVAL
-                else:
-                    # when not in interactive mode, wake least often (no spinner/terminal updates)
-                    timeout = DATABASE_WRITE_INTERVAL
+                # How long the loop may sleep, bounded by whichever owner needs attention soonest:
+                # the frontend's redraw cadence (UI-owned), the database flush interval
+                # (loop-owned), and, while backgrounded, a poll for the foreground transition
+                # (terminal-owned).
+                timeout = DATABASE_WRITE_INTERVAL
+                refresh_interval = self.ui.refresh_interval()
+                if refresh_interval is not None:
+                    timeout = min(timeout, refresh_interval)
+                if terminal is not None and terminal.headless:
+                    timeout = min(timeout, HEADLESS_WAKE_INTERVAL)
                 events = selector.select(timeout=timeout)
 
                 finished_builds.clear()
@@ -2222,7 +2363,7 @@ class PackageInstaller:
                 # handler, but there's no SIGCONT event in the transition of background to
                 # foreground, so we conditionally poll for that here (headless case). In the
                 # headless case the event loop only fires once per second, so this is cheap enough.
-                if terminal and self.build_status.headless and terminal.should_enter_foreground():
+                if terminal and terminal.headless and terminal.should_enter_foreground():
                     terminal.enter_foreground()
 
                 for key, _ in events:
@@ -2241,10 +2382,10 @@ class PackageInstaller:
                     elif data == "sigwinch":
                         assert terminal is not None
                         terminal.drain_sigwinch()
-                        self.build_status.on_resize()
+                        self.ui.on_resize()
                     elif data == "jobserver" and not jobserver.has_target_parallelism():
                         jobserver._maybe_discard_tokens()
-                        self.build_status.set_jobs(jobserver.num_jobs, jobserver.target_jobs)
+                        self.ui.set_jobs(jobserver.num_jobs, jobserver.target_jobs)
 
                 current_time = time.monotonic()
                 for build_id in finished_builds:
@@ -2261,24 +2402,7 @@ class PackageInstaller:
                     self.pending_expansions.clear()
 
                 if stdin_ready and stdin_reader is not None:
-                    for char in stdin_reader.read():
-                        overview = self.build_status.overview_mode
-                        if overview and self.build_status.search_mode:
-                            self.build_status.search_input(char)
-                        elif overview and char == "/":
-                            self.build_status.enter_search()
-                        elif char == "v" or char in ("q", "\x1b") and not overview:
-                            self.build_status.toggle()
-                        elif char == "n":
-                            self.build_status.next(1)
-                        elif char == "p" or char == "N":
-                            self.build_status.next(-1)
-                        elif char == "+":
-                            jobserver.increase_parallelism()
-                            self.build_status.set_jobs(jobserver.num_jobs, jobserver.target_jobs)
-                        elif char == "-":
-                            jobserver.decrease_parallelism()
-                            self.build_status.set_jobs(jobserver.num_jobs, jobserver.target_jobs)
+                    self.ui.handle_input(stdin_reader.read())
 
                 # Try to expand build deps for cache-miss specs. This requires a read lock on the
                 # database, meaning that it can take several iterations of the event loop in case
@@ -2291,7 +2415,6 @@ class PackageInstaller:
                     blocked = self._schedule_builds(
                         selector, jobserver, retained_read_locks, database_actions
                     )
-                    self.build_status.set_blocked(blocked and not self.running_builds)
 
                 # Flush finished builds to the database if a write is due. This runs after
                 # scheduling so that a final mark-explicit action does not wait for the next
@@ -2299,7 +2422,7 @@ class PackageInstaller:
                 self._flush_db_if_due(current_time, database_actions, retained_read_locks)
 
                 # Finally update the UI
-                self.build_status.update()
+                self.ui.render()
         finally:
             # Restore input settings and signal handlers. On POSIX this runs TCSADRAIN,
             # ensuring buffered cursor-movement codes from the event loop are transmitted
@@ -2351,8 +2474,7 @@ class PackageInstaller:
                 action.release_prefix_lock()
 
             try:
-                self.build_status.overview_mode = True
-                self.build_status.update(finalize=True)
+                self.ui.render(finalize=True)
                 selector.close()
                 jobserver.close()
             except Exception:
@@ -2384,10 +2506,7 @@ class PackageInstaller:
                     pass
 
         if failures:
-            for s in failures:
-                build_info = self.build_status.builds[s.dag_hash()]
-                if build_info and build_info.log_summary:
-                    sys.stderr.write(build_info.log_summary)
+            self.ui.print_failure_summaries([s.dag_hash() for s in failures])
             lines = [f"{s}: {self.log_paths[s.dag_hash()]}" for s in failures]
             raise spack.error.InstallError(
                 "The following packages failed to install:\n" + "\n".join(lines)
@@ -2408,7 +2527,7 @@ class PackageInstaller:
         build = self.running_builds.pop(dag_hash)
         self.capacity += 1
         jobserver.release()
-        self.build_status.set_jobs(jobserver.num_jobs, jobserver.target_jobs)
+        self.ui.set_jobs(jobserver.num_jobs, jobserver.target_jobs)
         self._drain_child_output(build, selector)
         self._drain_child_state(build, selector)
         exitcode = build.close(selector)
@@ -2424,7 +2543,7 @@ class PackageInstaller:
             build.prefix_lock = None
             self.build_graph.enqueue_parents(dag_hash, self.pending_builds)
             self.next_database_write = current_time + DATABASE_WRITE_INTERVAL
-            self.build_status.update_state(dag_hash, "finished")
+            self.ui.update_state(dag_hash, "finished")
             return
 
         # When we don't have to do a db write, we can release the lock immediately.
@@ -2439,7 +2558,7 @@ class PackageInstaller:
             # Check if we can reschedule this as a source build after a build cache miss. If so,
             # return early without recording a failure.
             self.build_graph.force_source.add(dag_hash)
-            self.build_status.remove_build(dag_hash)
+            self.ui.remove_build(dag_hash)
             if self.build_graph.has_unexpanded_build_deps(dag_hash):
                 self.pending_expansions.append(dag_hash)
             else:
@@ -2448,8 +2567,7 @@ class PackageInstaller:
             # Record a failure. In fail-fast mode, only record the first failure; subsequent
             # failures may be a consequence of us terminating other builds.
             failures.append(build.spec)
-            self.build_status.update_state(dag_hash, "failed")
-            self.build_status.parse_log_summary(dag_hash)
+            self.ui.update_state(dag_hash, "failed")
 
     def _try_expand_build_deps(self) -> None:
         """Try to expand build deps for specs with cache misses. Non-blocking: returns immediately
@@ -2470,7 +2588,7 @@ class PackageInstaller:
                 self.binary_cache_for_spec[h] = (
                     spack.binary_distribution.BINARY_INDEX.find_by_hash(h)
                 )
-            self.build_status.total += len(newly_added)
+            self.ui.increase_total(len(newly_added))
             self.pending_expansions.clear()
 
     def _flush_db_if_due(
@@ -2529,8 +2647,9 @@ class PackageInstaller:
         """Try to schedule as many pending builds as possible.
 
         Delegates to the module-level schedule_builds() function and then performs the
-        side-effects that require the selector and running-build state: updating build_status for
-        specs that were found already installed, and launching new builds via _start().
+        side-effects that require the selector and running-build state: updating the UI for
+        specs that were found already installed, updating the UI's blocked indicator, and
+        launching new builds via _start().
 
         Preconditions: self.capacity > 0 and self.pending_builds is not empty.
 
@@ -2554,12 +2673,12 @@ class PackageInstaller:
         # Specs installed by another process.
         for dag_hash, spec, lock in result.newly_installed:
             retained_read_locks.append(lock)
-            explicit = dag_hash in self.explicit
-            self.build_status.add_build(spec, explicit=explicit)
-            self.build_status.update_state(dag_hash, "finished")
+            self.ui.add_build(self._build_info(spec, explicit=dag_hash in self.explicit))
+            self.ui.update_state(dag_hash, "finished")
         # Specs we can start building ourselves.
         for dag_hash, lock in result.to_start:
             self._start(selector, jobserver, dag_hash, lock)
+        self.ui.set_blocked(blocked and not self.running_builds)
         return blocked
 
     def _effective_install_policy(self, dag_hash: str, is_root: bool) -> InstallPolicy:
@@ -2629,13 +2748,35 @@ class PackageInstaller:
         child_info.prefix_lock = prefix_lock
         self.running_builds[dag_hash] = child_info
         child_info.register_with_selector(selector, dag_hash)
-        self.build_status.add_build(
-            child_info.spec,
-            explicit=explicit,
-            control_w_conn=child_info.control_w_conn,
-            log_path=child_info.log_path,
+        self.ui.add_build(
+            self._build_info(child_info.spec, explicit=explicit, log_path=child_info.log_path)
         )
         self.report_data.start_record(spec)
+
+    def _build_info(
+        self, spec: spack.spec.Spec, explicit: bool, log_path: Optional[str] = None
+    ) -> BuildInfo:
+        """Create the UI payload for a build: plain data extracted from the spec."""
+        return BuildInfo(
+            spec.dag_hash(),
+            name=spec.name,
+            version=str(spec.version),
+            external=spec.external,
+            prefix=spec.prefix,
+            explicit=explicit,
+            log_path=log_path,
+        )
+
+    def _set_echo(self, build_id: str, echo: bool) -> None:
+        """Enable or disable log forwarding from a running build to this process. Backs the
+        controller's ``set_echo``; the event loop owns the control channels and their lifetime."""
+        child = self.running_builds.get(build_id)
+        if child is None:
+            return
+        try:
+            write_connection(child.control_w_conn, b"1" if echo else b"0")
+        except OSError:
+            pass
 
     def _handle_child_logs(self, child_info: ChildInfo, selector: selectors.BaseSelector) -> bool:
         """Handle reading output logs from a child process pipe. Returns False once the channel
@@ -2657,7 +2798,7 @@ class PackageInstaller:
                 pass
             return False
 
-        self.build_status.print_logs(child_info.spec.dag_hash(), data)
+        self.ui.print_logs(child_info.spec.dag_hash(), data)
         return True
 
     def _drain_child_output(self, child_info: ChildInfo, selector: selectors.BaseSelector) -> None:
@@ -2709,9 +2850,9 @@ class PackageInstaller:
             except ValueError:
                 continue
             if "state" in message:
-                self.build_status.update_state(dag_hash, message["state"])
+                self.ui.update_state(dag_hash, message["state"])
             elif "progress" in message and "total" in message:
-                self.build_status.update_progress(dag_hash, message["progress"], message["total"])
+                self.ui.update_progress(dag_hash, message["progress"], message["total"])
             elif "installed_from_binary_cache" in message:
                 child_info.spec.package.installed_from_binary_cache = True
 

--- a/lib/spack/spack/new_installer.py
+++ b/lib/spack/spack/new_installer.py
@@ -112,19 +112,19 @@ InstallPolicy = Literal["auto", "cache_only", "source_only"]
 
 
 class SetEcho(NamedTuple):
-    """Command asking the event loop to enable/disable log forwarding from a build."""
+    """Command that enables/disables log forwarding from a build."""
 
     build_id: str
     echo: bool
 
 
 class ChangeJobs(NamedTuple):
-    """Command asking the event loop to change build parallelism by ``delta`` (+1 / -1)."""
+    """Command that increments/decrements job server parallelism."""
 
-    delta: int
+    delta: Literal[-1, 1]
 
 
-#: A command produced by the UI (view) and executed by the event loop.
+#: A command produced by the UI and executed by the event loop.
 UiCommand = Union[SetEcho, ChangeJobs]
 
 #: How often to update a spinner in seconds
@@ -971,10 +971,8 @@ class InstallerUI:
     """Interface between the installer event loop and a frontend. The methods are no-ops, which
     makes this class usable as a headless frontend.
 
-    The contract is single-threaded: notifications are invoked on the event loop thread, and the
-    frontend appends any resulting :data:`UiCommand` objects to ``self.commands`` from that thread.
-    A frontend running its own thread (e.g. a GUI) currently has no way to post commands into the
-    event loop."""
+    The event loop calls methods to notify the frontend of build events, and the frontend can
+    append to ``self.commands`` to request actions from the event loop."""
 
     def __init__(self) -> None:
         #: Whether the frontend renders interactively; determines the event loop wake interval.
@@ -2305,7 +2303,6 @@ class PackageInstaller:
                 blocked = self._schedule_builds(
                     selector, jobserver, retained_read_locks, database_actions
                 )
-                # Execute commands from scheduling (e.g. a verbose first-build echo) promptly.
                 if self.ui.commands:
                     self._run_ui_commands(jobserver)
                 self._flush_db_if_due(time.monotonic(), database_actions, retained_read_locks)
@@ -2406,8 +2403,7 @@ class PackageInstaller:
                 # select() timeout.
                 self._flush_db_if_due(current_time, database_actions, retained_read_locks)
 
-                # Execute commands the UI produced this iteration (input, toggle-on-finish, verbose
-                # echo) before the redraw, so their effect (e.g. the job counter) is painted now.
+                # Execute commands produced by the UI ahead of rendering.
                 if self.ui.commands:
                     self._run_ui_commands(jobserver)
 
@@ -2759,11 +2755,9 @@ class PackageInstaller:
         )
 
     def _run_ui_commands(self, jobserver: JobServerBase) -> None:
-        """Execute the commands the UI produced. Callers guard on a non-empty buffer, so the common
-        no-command iteration skips this call. The buffer is swapped out first so a command that
-        re-enters the UI cannot mutate the list we are iterating (any new command drains next
-        iteration)."""
-        commands, self.ui.commands = self.ui.commands, []
+        """Execute the commands produced by the UI."""
+        commands = self.ui.commands.copy()
+        self.ui.commands.clear()
         for cmd in commands:
             if isinstance(cmd, SetEcho):
                 self._set_echo(cmd.build_id, cmd.echo)
@@ -2775,8 +2769,7 @@ class PackageInstaller:
                 self.ui.on_jobs_changed(jobserver.num_jobs, jobserver.target_jobs)
 
     def _set_echo(self, build_id: str, echo: bool) -> None:
-        """Enable or disable log forwarding from a running build to this process. Executes a
-        :class:`SetEcho` command; the event loop owns the control channels and their lifetime."""
+        """Enable or disable log forwarding from a running build to this process."""
         child = self.running_builds.get(build_id)
         if child is None:
             return

--- a/lib/spack/spack/new_installer.py
+++ b/lib/spack/spack/new_installer.py
@@ -981,8 +981,7 @@ class InstallerUI:
         #: terminal. If True, the event loop manages terminal state (cbreak mode, suspend/resume
         #: signals, stdin registration) and feeds keyboard input to ``on_input``.
         self.reads_terminal_input = False
-        #: Commands the frontend has produced for the event loop to execute. The loop drains this
-        #: once per iteration; a frontend appends to it instead of calling into the loop directly.
+        #: The frontend appends commands to this list to request actions from the event loop.
         self.commands: List[UiCommand] = []
 
     def on_build_added(self, info: BuildInfo) -> None:
@@ -2303,8 +2302,7 @@ class PackageInstaller:
                 blocked = self._schedule_builds(
                     selector, jobserver, retained_read_locks, database_actions
                 )
-                if self.ui.commands:
-                    self._run_ui_commands(jobserver)
+                self._run_ui_commands(jobserver)
                 self._flush_db_if_due(time.monotonic(), database_actions, retained_read_locks)
 
             while (
@@ -2404,8 +2402,7 @@ class PackageInstaller:
                 self._flush_db_if_due(current_time, database_actions, retained_read_locks)
 
                 # Execute commands produced by the UI ahead of rendering.
-                if self.ui.commands:
-                    self._run_ui_commands(jobserver)
+                self._run_ui_commands(jobserver)
 
                 # Finally update the UI
                 self.ui.render()
@@ -2756,8 +2753,9 @@ class PackageInstaller:
 
     def _run_ui_commands(self, jobserver: JobServerBase) -> None:
         """Execute the commands produced by the UI."""
-        commands = self.ui.commands.copy()
-        self.ui.commands.clear()
+        if not self.ui.commands:
+            return
+        commands, self.ui.commands = self.ui.commands, []
         for cmd in commands:
             if isinstance(cmd, SetEcho):
                 self._set_echo(cmd.build_id, cmd.echo)

--- a/lib/spack/spack/new_installer.py
+++ b/lib/spack/spack/new_installer.py
@@ -77,12 +77,13 @@ import spack.util.lock
 from spack.installer import _do_fake_install, dump_packages
 from spack.new_installer_base import (
     OUTPUT_BUFFER_SIZE,
+    SIGWINCH_EVENT,
+    STDIN_EVENT,
     BaseTerminalState,
     FdInfo,
     IpcChannel,
     JobServerBase,
     ProcessExitNotifier,
-    StdinReader,
 )
 from spack.subprocess_context import GlobalStateMarshaler
 from spack.util.executable import ProcessError
@@ -111,9 +112,6 @@ InstallPolicy = Literal["auto", "cache_only", "source_only"]
 
 #: How often to update a spinner in seconds
 SPINNER_INTERVAL = 0.1
-
-#: How often to wake up in headless mode to check for background->foreground transition (seconds)
-HEADLESS_WAKE_INTERVAL = 1.0
 
 #: How long to display finished packages before graying them out
 CLEANUP_TIMEOUT = 2.0
@@ -2297,17 +2295,15 @@ class PackageInstaller:
 
         # Terminal handling (cbreak, suspend/resume signals, stdin registration) is event loop
         # plumbing, enabled only for frontends that read the controlling terminal.
-        stdin_reader: Optional[StdinReader] = None
         terminal: Optional[BaseTerminalState] = None
         if self.ui.reads_terminal_input and TerminalState.stdin_is_interactive():
             terminal = TerminalState(
                 selector,
-                self.ui,
+                on_headless=self.ui.set_headless,
                 on_suspend=lambda: _signal_children(self.running_builds, signal.SIGSTOP),
                 on_resume=lambda: _signal_children(self.running_builds, signal.SIGCONT),
             )
             terminal.setup()
-            stdin_reader = terminal.create_stdin_reader()
 
         # Finished builds that have not yet been written to the database.
         database_actions: List[DatabaseAction] = []
@@ -2353,18 +2349,19 @@ class PackageInstaller:
                 refresh_interval = self.ui.refresh_interval()
                 if refresh_interval is not None:
                     timeout = min(timeout, refresh_interval)
-                if terminal is not None and terminal.headless:
-                    timeout = min(timeout, HEADLESS_WAKE_INTERVAL)
+                wake_interval = terminal.wake_interval() if terminal is not None else None
+                if wake_interval is not None:
+                    timeout = min(timeout, wake_interval)
                 events = selector.select(timeout=timeout)
 
                 finished_builds.clear()
 
                 # The transition "suspended to foreground/background" is handled in the signal
                 # handler, but there's no SIGCONT event in the transition of background to
-                # foreground, so we conditionally poll for that here (headless case). In the
-                # headless case the event loop only fires once per second, so this is cheap enough.
-                if terminal and terminal.headless and terminal.should_enter_foreground():
-                    terminal.enter_foreground()
+                # foreground, so the terminal polls for that here (headless case, where the wake
+                # interval above bounds the poll rate).
+                if terminal is not None:
+                    terminal.poll_foreground()
 
                 for key, _ in events:
                     data = key.data
@@ -2377,9 +2374,9 @@ class PackageInstaller:
                             self._handle_child_state(child_info, selector)
                         elif data.name == "sentinel":
                             finished_builds.append(data.build_id)
-                    elif data == "stdin":
+                    elif data == STDIN_EVENT:
                         stdin_ready = True
-                    elif data == "sigwinch":
+                    elif data == SIGWINCH_EVENT:
                         assert terminal is not None
                         terminal.drain_sigwinch()
                         self.ui.on_resize()
@@ -2401,8 +2398,8 @@ class PackageInstaller:
                     self.pending_builds.clear()
                     self.pending_expansions.clear()
 
-                if stdin_ready and stdin_reader is not None:
-                    self.ui.handle_input(stdin_reader.read())
+                if stdin_ready and terminal is not None:
+                    self.ui.handle_input(terminal.read_input())
 
                 # Try to expand build deps for cache-miss specs. This requires a read lock on the
                 # database, meaning that it can take several iterations of the event loop in case

--- a/lib/spack/spack/new_installer.py
+++ b/lib/spack/spack/new_installer.py
@@ -903,8 +903,8 @@ def start_build(
 
 
 class BuildInfo:
-    """Plain data about a package being built: the payload of ``InstallerUI.add_build`` and the
-    per-build record of the terminal UI. Conceptually a dataclass."""
+    """Plain data about a package being built: the payload of ``InstallerUI.on_build_added`` and
+    the per-build record of the terminal UI. Conceptually a dataclass."""
 
     __slots__ = (
         "id",
@@ -976,11 +976,11 @@ class EventLoopController:
 
     def increase_jobs(self) -> None:
         self._jobserver.increase_parallelism()
-        self._installer.ui.set_jobs(self._jobserver.num_jobs, self._jobserver.target_jobs)
+        self._installer.ui.on_jobs_changed(self._jobserver.num_jobs, self._jobserver.target_jobs)
 
     def decrease_jobs(self) -> None:
         self._jobserver.decrease_parallelism()
-        self._installer.ui.set_jobs(self._jobserver.num_jobs, self._jobserver.target_jobs)
+        self._installer.ui.on_jobs_changed(self._jobserver.num_jobs, self._jobserver.target_jobs)
 
 
 class InstallerUI:
@@ -999,43 +999,45 @@ class InstallerUI:
         self.is_tty = False
         #: Whether the frontend renders to and reads keyboard input from the controlling
         #: terminal. If True, the event loop manages terminal state (cbreak mode, suspend/resume
-        #: signals, stdin registration) and feeds keyboard input to ``handle_input``.
+        #: signals, stdin registration) and feeds keyboard input to ``on_input``.
         self.reads_terminal_input = False
 
-    def add_build(self, info: BuildInfo) -> None:
+    def on_build_added(self, info: BuildInfo) -> None:
         """A build was started, or a spec was found installed by another process."""
 
-    def remove_build(self, build_id: str) -> None:
-        """A build was removed (e.g. after a binary cache miss before a source retry)."""
+    def on_build_removed(self, build_id: str) -> None:
+        """A build was removed after a binary cache miss; it is added back via
+        ``on_build_added`` once it is rescheduled as a source build."""
 
-    def update_state(self, build_id: str, state: str) -> None:
+    def on_state_changed(self, build_id: str, state: str) -> None:
         """A build transitioned to a new state (e.g. ``"staging"``, ``"finished"``)."""
 
-    def update_progress(self, build_id: str, current: int, total: int) -> None:
+    def on_progress(self, build_id: str, current: int, total: int) -> None:
         """Fetch progress of a build changed."""
 
-    def increase_total(self, count: int) -> None:
+    def on_total_increased(self, count: int) -> None:
         """The total number of scheduled builds increased (e.g. build dep expansion)."""
 
-    def print_logs(self, build_id: str, data: bytes) -> None:
+    def on_log_output(self, build_id: str, data: bytes) -> None:
         """Raw log output received from a build whose echoing is enabled."""
 
-    def print_failure_summaries(self, build_ids: List[str]) -> None:
-        """Installation is ending with failed builds; the frontend may print failure details."""
+    def on_finished(self, failures: List[str]) -> None:
+        """Installation finished; ``failures`` holds the build ids of failed builds (empty on
+        success). The frontend may print failure details."""
 
-    def set_jobs(self, actual: int, target: int) -> None:
+    def on_jobs_changed(self, actual: int, target: int) -> None:
         """The actual and/or target number of concurrent jobs changed."""
 
-    def set_blocked(self, blocked: bool) -> None:
+    def on_blocked_changed(self, blocked: bool) -> None:
         """Whether all pending builds are blocked by another Spack process."""
 
-    def handle_input(self, chars: str) -> None:
+    def on_input(self, chars: str) -> None:
         """Keyboard input received (only called for interactive frontends)."""
 
     def on_resize(self) -> None:
         """The terminal was resized (only called for interactive frontends)."""
 
-    def set_headless(self, headless: bool) -> None:
+    def on_headless_changed(self, headless: bool) -> None:
         """The process moved to the background (True) or foreground (False); the frontend should
         suppress rendering while headless. Called only through the terminal path."""
 
@@ -1113,7 +1115,7 @@ class TerminalUI(InstallerUI):
         self.terminal_size_changed = True
         self.dirty = True
 
-    def set_headless(self, headless: bool) -> None:
+    def on_headless_changed(self, headless: bool) -> None:
         if headless:
             # The display is invalidated: the shell may print over it while we're suspended or in
             # the background, so the next render must append instead of moving the cursor up.
@@ -1129,7 +1131,7 @@ class TerminalUI(InstallerUI):
             return None
         return SPINNER_INTERVAL
 
-    def add_build(self, info: BuildInfo) -> None:
+    def on_build_added(self, info: BuildInfo) -> None:
         """Add a new build to the display and mark the display as dirty."""
         info.start_time = int(self.get_time())
         self.builds[info.id] = info
@@ -1140,7 +1142,7 @@ class TerminalUI(InstallerUI):
             self.tracked_build_id = info.id
             self.controller.set_echo(info.id, True)
 
-    def remove_build(self, build_id: str) -> None:
+    def on_build_removed(self, build_id: str) -> None:
         """Remove a build from the display (e.g. after a binary cache miss before retry)."""
         self.builds.pop(build_id, None)
         if self.tracked_build_id == build_id:
@@ -1185,7 +1187,7 @@ class TerminalUI(InstallerUI):
         self.search_mode = True
         self.dirty = True
 
-    def handle_input(self, chars: str) -> None:
+    def on_input(self, chars: str) -> None:
         """Dispatch keyboard input to search, navigation, and parallelism actions."""
         for char in chars:
             overview = self.overview_mode
@@ -1270,7 +1272,7 @@ class TerminalUI(InstallerUI):
             self.stdout.flush()
             self.controller.set_echo(new_build_id, True)
 
-    def set_blocked(self, blocked: bool) -> None:
+    def on_blocked_changed(self, blocked: bool) -> None:
         """Set whether all pending builds are blocked by another Spack process."""
         if blocked == self.blocked:
             return
@@ -1289,7 +1291,7 @@ class TerminalUI(InstallerUI):
         self.stdout.write(f"\x1b]0;{term_title}\x07")
         self.stdout.flush()
 
-    def set_jobs(self, actual: int, target: int) -> None:
+    def on_jobs_changed(self, actual: int, target: int) -> None:
         """Set the actual and target number of jobs to run concurrently."""
         if actual == self.actual_jobs and target == self.target_jobs:
             return
@@ -1298,7 +1300,7 @@ class TerminalUI(InstallerUI):
         self.dirty = True
         self._update_terminal_title()
 
-    def update_state(self, build_id: str, state: str) -> None:
+    def on_state_changed(self, build_id: str, state: str) -> None:
         """Update the state of a package and mark the display as dirty."""
         build_info = self.builds[build_id]
         build_info.state = state
@@ -1343,17 +1345,17 @@ class TerminalUI(InstallerUI):
         if events:
             build_info.log_summary = make_log_context(events)
 
-    def print_failure_summaries(self, build_ids: List[str]) -> None:
+    def on_finished(self, failures: List[str]) -> None:
         """Write the stored log summaries of the failed builds to stderr."""
-        for build_id in build_ids:
+        for build_id in failures:
             build_info = self.builds.get(build_id)
             if build_info is not None and build_info.log_summary:
                 sys.stderr.write(build_info.log_summary)
 
-    def increase_total(self, count: int) -> None:
+    def on_total_increased(self, count: int) -> None:
         self.total += count
 
-    def update_progress(self, build_id: str, current: int, total: int) -> None:
+    def on_progress(self, build_id: str, current: int, total: int) -> None:
         """Update the progress of a package and mark the display as dirty."""
         percent = int((current / total) * 100)
         build_info = self.builds[build_id]
@@ -1504,7 +1506,7 @@ class TerminalUI(InstallerUI):
         else:
             buffer.write("\033[0m\033[K\033[1B\r")  # reset, clear to EOL, move to next line
 
-    def print_logs(self, build_id: str, data: bytes) -> None:
+    def on_log_output(self, build_id: str, data: bytes) -> None:
         if self.headless:
             return
         # Discard logs we are not following. Generally this should not happen as we tell the child
@@ -2245,9 +2247,9 @@ class PackageInstaller:
         self.ui = ui or TerminalUI(
             total=0, verbose=verbose, filter_padding=self.store.has_padding()
         )
-        self.ui.increase_total(len(self.build_graph.nodes))
+        self.ui.on_total_increased(len(self.build_graph.nodes))
         self.jobs = spack.config.determine_number_of_jobs(parallel=True)
-        self.ui.set_jobs(self.jobs, self.jobs)
+        self.ui.on_jobs_changed(self.jobs, self.jobs)
         if concurrent_packages is None:
             concurrent_packages_config = spack.config.get("config:concurrent_packages", 0)
             # The value 0 in config means no limit (other than self.jobs)
@@ -2299,7 +2301,7 @@ class PackageInstaller:
         if self.ui.reads_terminal_input and TerminalState.stdin_is_interactive():
             terminal = TerminalState(
                 selector,
-                on_headless=self.ui.set_headless,
+                on_headless=self.ui.on_headless_changed,
                 on_suspend=lambda: _signal_children(self.running_builds, signal.SIGSTOP),
                 on_resume=lambda: _signal_children(self.running_builds, signal.SIGCONT),
             )
@@ -2382,7 +2384,7 @@ class PackageInstaller:
                         self.ui.on_resize()
                     elif data == "jobserver" and not jobserver.has_target_parallelism():
                         jobserver._maybe_discard_tokens()
-                        self.ui.set_jobs(jobserver.num_jobs, jobserver.target_jobs)
+                        self.ui.on_jobs_changed(jobserver.num_jobs, jobserver.target_jobs)
 
                 current_time = time.monotonic()
                 for build_id in finished_builds:
@@ -2399,7 +2401,7 @@ class PackageInstaller:
                     self.pending_expansions.clear()
 
                 if stdin_ready and terminal is not None:
-                    self.ui.handle_input(terminal.read_input())
+                    self.ui.on_input(terminal.read_input())
 
                 # Try to expand build deps for cache-miss specs. This requires a read lock on the
                 # database, meaning that it can take several iterations of the event loop in case
@@ -2502,8 +2504,9 @@ class PackageInstaller:
                 except OSError:
                     pass
 
+        self.ui.on_finished([s.dag_hash() for s in failures])
+
         if failures:
-            self.ui.print_failure_summaries([s.dag_hash() for s in failures])
             lines = [f"{s}: {self.log_paths[s.dag_hash()]}" for s in failures]
             raise spack.error.InstallError(
                 "The following packages failed to install:\n" + "\n".join(lines)
@@ -2524,7 +2527,7 @@ class PackageInstaller:
         build = self.running_builds.pop(dag_hash)
         self.capacity += 1
         jobserver.release()
-        self.ui.set_jobs(jobserver.num_jobs, jobserver.target_jobs)
+        self.ui.on_jobs_changed(jobserver.num_jobs, jobserver.target_jobs)
         self._drain_child_output(build, selector)
         self._drain_child_state(build, selector)
         exitcode = build.close(selector)
@@ -2540,7 +2543,7 @@ class PackageInstaller:
             build.prefix_lock = None
             self.build_graph.enqueue_parents(dag_hash, self.pending_builds)
             self.next_database_write = current_time + DATABASE_WRITE_INTERVAL
-            self.ui.update_state(dag_hash, "finished")
+            self.ui.on_state_changed(dag_hash, "finished")
             return
 
         # When we don't have to do a db write, we can release the lock immediately.
@@ -2555,7 +2558,7 @@ class PackageInstaller:
             # Check if we can reschedule this as a source build after a build cache miss. If so,
             # return early without recording a failure.
             self.build_graph.force_source.add(dag_hash)
-            self.ui.remove_build(dag_hash)
+            self.ui.on_build_removed(dag_hash)
             if self.build_graph.has_unexpanded_build_deps(dag_hash):
                 self.pending_expansions.append(dag_hash)
             else:
@@ -2564,7 +2567,7 @@ class PackageInstaller:
             # Record a failure. In fail-fast mode, only record the first failure; subsequent
             # failures may be a consequence of us terminating other builds.
             failures.append(build.spec)
-            self.ui.update_state(dag_hash, "failed")
+            self.ui.on_state_changed(dag_hash, "failed")
 
     def _try_expand_build_deps(self) -> None:
         """Try to expand build deps for specs with cache misses. Non-blocking: returns immediately
@@ -2585,7 +2588,7 @@ class PackageInstaller:
                 self.binary_cache_for_spec[h] = (
                     spack.binary_distribution.BINARY_INDEX.find_by_hash(h)
                 )
-            self.ui.increase_total(len(newly_added))
+            self.ui.on_total_increased(len(newly_added))
             self.pending_expansions.clear()
 
     def _flush_db_if_due(
@@ -2670,12 +2673,12 @@ class PackageInstaller:
         # Specs installed by another process.
         for dag_hash, spec, lock in result.newly_installed:
             retained_read_locks.append(lock)
-            self.ui.add_build(self._build_info(spec, explicit=dag_hash in self.explicit))
-            self.ui.update_state(dag_hash, "finished")
+            self.ui.on_build_added(self._build_info(spec, explicit=dag_hash in self.explicit))
+            self.ui.on_state_changed(dag_hash, "finished")
         # Specs we can start building ourselves.
         for dag_hash, lock in result.to_start:
             self._start(selector, jobserver, dag_hash, lock)
-        self.ui.set_blocked(blocked and not self.running_builds)
+        self.ui.on_blocked_changed(blocked and not self.running_builds)
         return blocked
 
     def _effective_install_policy(self, dag_hash: str, is_root: bool) -> InstallPolicy:
@@ -2745,7 +2748,7 @@ class PackageInstaller:
         child_info.prefix_lock = prefix_lock
         self.running_builds[dag_hash] = child_info
         child_info.register_with_selector(selector, dag_hash)
-        self.ui.add_build(
+        self.ui.on_build_added(
             self._build_info(child_info.spec, explicit=explicit, log_path=child_info.log_path)
         )
         self.report_data.start_record(spec)
@@ -2795,7 +2798,7 @@ class PackageInstaller:
                 pass
             return False
 
-        self.ui.print_logs(child_info.spec.dag_hash(), data)
+        self.ui.on_log_output(child_info.spec.dag_hash(), data)
         return True
 
     def _drain_child_output(self, child_info: ChildInfo, selector: selectors.BaseSelector) -> None:
@@ -2847,9 +2850,9 @@ class PackageInstaller:
             except ValueError:
                 continue
             if "state" in message:
-                self.ui.update_state(dag_hash, message["state"])
+                self.ui.on_state_changed(dag_hash, message["state"])
             elif "progress" in message and "total" in message:
-                self.ui.update_progress(dag_hash, message["progress"], message["total"])
+                self.ui.on_progress(dag_hash, message["progress"], message["total"])
             elif "installed_from_binary_cache" in message:
                 child_info.spec.package.installed_from_binary_cache = True
 

--- a/lib/spack/spack/new_installer_base.py
+++ b/lib/spack/spack/new_installer_base.py
@@ -21,7 +21,7 @@ import spack.spec
 from spack.llnl.util.tty.log import redirect_stdio, restore_stdio
 
 if TYPE_CHECKING:
-    from spack.new_installer import BuildStatus
+    import spack.new_installer
 
 # Inter-process communication type
 if sys.platform == "win32":
@@ -70,14 +70,21 @@ class BaseTerminalState(abc.ABC):
     def __init__(
         self,
         selector: selectors.BaseSelector,
-        build_status: "BuildStatus",
+        ui: "spack.new_installer.InstallerUI",
         on_suspend: Optional[Callable[[], None]] = None,
         on_resume: Optional[Callable[[], None]] = None,
     ) -> None:
         self.selector = selector
-        self.build_status = build_status
+        self.ui = ui
         self.on_suspend = on_suspend
         self.on_resume = on_resume
+        #: True while the process is backgrounded/suspended and the terminal is not ours
+        self.headless = False
+
+    def _set_headless(self, headless: bool) -> None:
+        """Record headless state and tell the UI to suppress (True) or resume (False) rendering."""
+        self.headless = headless
+        self.ui.set_headless(headless)
 
     @classmethod
     def stdout_is_interactive(cls) -> bool:
@@ -155,9 +162,15 @@ class ProcessExitNotifier(abc.ABC):
 
 
 class JobServerBase(abc.ABC):
-    """Abstract base for controlling build concurrency."""
+    """Abstract base for controlling build concurrency.
 
-    def __init__(self, num_jobs: int) -> None:
+    Args:
+        num_jobs: The number of jobs to run concurrently.
+        makeflags: The MAKEFLAGS value to parse for an existing jobserver to attach to. Pass an
+            empty string to always create a fresh jobserver, or None to read the environment.
+    """
+
+    def __init__(self, num_jobs: int, makeflags: Optional[str] = None) -> None:
         #: The number of jobs to run concurrently
         self.num_jobs = num_jobs
         #: The target number of jobs to run concurrently, which may differ from num_jobs if the

--- a/lib/spack/spack/new_installer_base.py
+++ b/lib/spack/spack/new_installer_base.py
@@ -15,13 +15,10 @@ import socket
 import sys
 import threading
 from multiprocessing.connection import Connection
-from typing import TYPE_CHECKING, Any, Callable, Optional, Tuple, Union
+from typing import Any, Callable, Optional, Tuple, Union
 
 import spack.spec
 from spack.llnl.util.tty.log import redirect_stdio, restore_stdio
-
-if TYPE_CHECKING:
-    import spack.new_installer
 
 # Inter-process communication type
 if sys.platform == "win32":
@@ -34,6 +31,14 @@ OUTPUT_BUFFER_SIZE = 32768
 
 #: Control byte that stops the tee thread
 TEE_STOP = b"2"
+
+#: How often the event loop should wake up to poll for a background-to-foreground transition
+#: while the terminal is headless (there is no signal for it).
+HEADLESS_WAKE_INTERVAL = 1.0
+
+#: Selector data keys registered by the terminal and dispatched by the event loop
+STDIN_EVENT = "stdin"
+SIGWINCH_EVENT = "sigwinch"
 
 
 class StdinReader:
@@ -67,24 +72,29 @@ class StdinReader:
 class BaseTerminalState(abc.ABC):
     """Abstract base for platform-specific terminal state management."""
 
+    #: Non-blocking stdin reader, created by platform-specific subclasses in ``__init__``
+    stdin_reader: StdinReader
+
     def __init__(
         self,
         selector: selectors.BaseSelector,
-        ui: "spack.new_installer.InstallerUI",
+        on_headless: Optional[Callable[[bool], None]] = None,
         on_suspend: Optional[Callable[[], None]] = None,
         on_resume: Optional[Callable[[], None]] = None,
     ) -> None:
         self.selector = selector
-        self.ui = ui
+        self.on_headless = on_headless
         self.on_suspend = on_suspend
         self.on_resume = on_resume
         #: True while the process is backgrounded/suspended and the terminal is not ours
         self.headless = False
 
     def _set_headless(self, headless: bool) -> None:
-        """Record headless state and tell the UI to suppress (True) or resume (False) rendering."""
+        """Record headless state and notify the frontend to suppress (True) or resume (False)
+        rendering."""
         self.headless = headless
-        self.ui.set_headless(headless)
+        if self.on_headless is not None:
+            self.on_headless(headless)
 
     @classmethod
     def stdout_is_interactive(cls) -> bool:
@@ -94,9 +104,9 @@ class BaseTerminalState(abc.ABC):
     def stdin_is_interactive(cls) -> bool:
         return sys.stdin.isatty()
 
-    @abc.abstractmethod
-    def create_stdin_reader(self) -> StdinReader:
-        pass
+    def read_input(self) -> str:
+        """Read available keyboard input as decoded text."""
+        return self.stdin_reader.read()
 
     @abc.abstractmethod
     def setup(self) -> None:
@@ -123,6 +133,16 @@ class BaseTerminalState(abc.ABC):
         """Drain the platform-specific sigwinch notification channel."""
         pass
 
+    def wake_interval(self) -> Optional[float]:
+        """Extra wake-up cadence the terminal needs from the event loop, or None. While headless
+        we poll for the background-to-foreground transition, since there is no signal for it."""
+        return HEADLESS_WAKE_INTERVAL if self.headless else None
+
+    def poll_foreground(self) -> None:
+        """Switch to foreground mode if the process is no longer backgrounded."""
+        if self.headless and self._should_enter_foreground():
+            self.enter_foreground()
+
     # The methods below are job-control hooks: a platform with suspend/resume support (SIGTSTP/
     # SIGCONT on POSIX) overrides them to transition between foreground and headless mode. The
     # defaults are for platforms without job control, where the process never goes headless after
@@ -134,7 +154,7 @@ class BaseTerminalState(abc.ABC):
     def handle_continue(self) -> None:
         pass
 
-    def should_enter_foreground(self) -> bool:
+    def _should_enter_foreground(self) -> bool:
         """Return True if the process should switch from headless to foreground mode."""
         return False
 

--- a/lib/spack/spack/new_installer_posix.py
+++ b/lib/spack/spack/new_installer_posix.py
@@ -39,7 +39,7 @@ from spack.new_installer_base import (
 )
 
 if TYPE_CHECKING:
-    from spack.new_installer import BuildStatus
+    import spack.new_installer
 
 
 class PosixTerminalState(BaseTerminalState):
@@ -55,11 +55,11 @@ class PosixTerminalState(BaseTerminalState):
     def __init__(
         self,
         selector: selectors.BaseSelector,
-        build_status: "BuildStatus",
+        ui: "spack.new_installer.InstallerUI",
         on_suspend: Optional[Callable[[], None]] = None,
         on_resume: Optional[Callable[[], None]] = None,
     ) -> None:
-        super().__init__(selector, build_status, on_suspend, on_resume)
+        super().__init__(selector, ui, on_suspend, on_resume)
         self.old_stdin_settings = termios.tcgetattr(sys.stdin)
         self.sigwinch_r = -1
         self.sigwinch_w = -1
@@ -83,7 +83,7 @@ class PosixTerminalState(BaseTerminalState):
         self.old_sigtstp = signal.signal(signal.SIGTSTP, self._handle_sigtstp)
 
         # Start correctly depending on whether we're foregrounded or backgrounded
-        self.build_status.headless = True
+        self._set_headless(True)
         if not _is_background_tty(sys.stdin):
             self.enter_foreground()
 
@@ -115,17 +115,15 @@ class PosixTerminalState(BaseTerminalState):
     def _handle_sigtstp(self, signum: int, frame: object) -> None:
         """Restore terminal before suspending, then re-install handler after resume."""
 
-        # Reset so the first redraw after resume doesn't overwrite the shell's
-        # prompt / "$ fg" line.
-        self.build_status.active_area_rows = 0
-
         # Restore terminal so the user's shell works normally while we're stopped.
         with ignore_signal(signal.SIGTTOU):
             termios.tcsetattr(sys.stdin, termios.TCSANOW, self.old_stdin_settings)
 
         # Force headless mode before suspending so that enter_foreground() doesn't
-        # exit early when we resume, ensuring terminal settings are re-applied.
-        self.build_status.headless = True
+        # exit early when we resume, ensuring terminal settings are re-applied. This also
+        # invalidates the display so the first redraw after resume doesn't overwrite the
+        # shell's prompt / "$ fg" line.
+        self._set_headless(True)
 
         # Actually suspend: reset to default handler then re-send SIGTSTP.
         if self.on_suspend is not None:
@@ -148,7 +146,7 @@ class PosixTerminalState(BaseTerminalState):
 
     def enter_foreground(self) -> None:
         """Restore interactive terminal mode."""
-        if not self.build_status.headless:
+        if not self.headless:
             return
 
         # We save old settings right before applying cbreak.
@@ -162,14 +160,13 @@ class PosixTerminalState(BaseTerminalState):
 
         if sys.stdin.fileno() not in self.selector.get_map():
             self.selector.register(sys.stdin.fileno(), selectors.EVENT_READ, "stdin")
-        self.build_status.headless = False
-        self.build_status.dirty = True
+        self._set_headless(False)
 
     def enter_background(self) -> None:
         """Suppress output and stop reading stdin to avoid SIGTTIN/SIGTTOU."""
         if sys.stdin.fileno() in self.selector.get_map():
             self.selector.unregister(sys.stdin.fileno())
-        self.build_status.headless = True
+        self._set_headless(True)
 
     def handle_continue(self) -> None:
         """Detect whether the process is in the foreground or background and adjust accordingly."""
@@ -245,13 +242,13 @@ class PosixTee(Tee):
 class PosixJobServer(JobServerBase):
     """Attach to an existing POSIX jobserver or create a FIFO-based one."""
 
-    def __init__(self, num_jobs: int) -> None:
-        super().__init__(num_jobs)
+    def __init__(self, num_jobs: int, makeflags: Optional[str] = None) -> None:
+        super().__init__(num_jobs, makeflags)
         #: Keep track of how many tokens Spack itself has acquired, which is used to release them.
         self.tokens_acquired = 0
         self.fifo_path: Optional[str] = None
         self.created = False
-        self._setup()
+        self._setup(makeflags)
         # Ensure that Executable()(...) in build processes ultimately inherit jobserver fds.
         os.set_inheritable(self.r, True)
         os.set_inheritable(self.w, True)
@@ -260,9 +257,9 @@ class PosixJobServer(JobServerBase):
         self.r_conn = Connection(self.r)
         self.w_conn = Connection(self.w)
 
-    def _setup(self) -> None:
+    def _setup(self, makeflags: Optional[str] = None) -> None:
 
-        fifo_config = get_jobserver_config()
+        fifo_config = get_jobserver_config(makeflags)
 
         if type(fifo_config) is str:
             # FIFO-based jobserver. Try to open the FIFO.

--- a/lib/spack/spack/new_installer_posix.py
+++ b/lib/spack/spack/new_installer_posix.py
@@ -23,13 +23,15 @@ import tty
 import warnings
 from multiprocessing import Process
 from multiprocessing.connection import Connection
-from typing import TYPE_CHECKING, Any, Callable, Optional, Tuple, Union
+from typing import Any, Callable, Optional, Tuple, Union
 
 import spack.llnl.util.tty
 import spack.spec
 from spack.llnl.util.tty.log import _is_background_tty, ignore_signal
 from spack.new_installer_base import (
     OUTPUT_BUFFER_SIZE,
+    SIGWINCH_EVENT,
+    STDIN_EVENT,
     TEE_STOP,
     BaseTerminalState,
     JobServerBase,
@@ -37,9 +39,6 @@ from spack.new_installer_base import (
     StdinReader,
     Tee,
 )
-
-if TYPE_CHECKING:
-    import spack.new_installer
 
 
 class PosixTerminalState(BaseTerminalState):
@@ -55,17 +54,15 @@ class PosixTerminalState(BaseTerminalState):
     def __init__(
         self,
         selector: selectors.BaseSelector,
-        ui: "spack.new_installer.InstallerUI",
+        on_headless: Optional[Callable[[bool], None]] = None,
         on_suspend: Optional[Callable[[], None]] = None,
         on_resume: Optional[Callable[[], None]] = None,
     ) -> None:
-        super().__init__(selector, ui, on_suspend, on_resume)
+        super().__init__(selector, on_headless, on_suspend, on_resume)
         self.old_stdin_settings = termios.tcgetattr(sys.stdin)
         self.sigwinch_r = -1
         self.sigwinch_w = -1
-
-    def create_stdin_reader(self) -> StdinReader:
-        return StdinReader(functools.partial(os.read, sys.stdin.fileno(), 1024))
+        self.stdin_reader = StdinReader(functools.partial(os.read, sys.stdin.fileno(), 1024))
 
     def setup(self) -> None:
         """Set cbreak mode, register stdin and signal pipes in the selector."""
@@ -75,7 +72,7 @@ class PosixTerminalState(BaseTerminalState):
             self.sigwinch_r, self.sigwinch_w = os.pipe()
             os.set_blocking(self.sigwinch_r, False)
             os.set_blocking(self.sigwinch_w, False)
-            self.selector.register(self.sigwinch_r, selectors.EVENT_READ, "sigwinch")
+            self.selector.register(self.sigwinch_r, selectors.EVENT_READ, SIGWINCH_EVENT)
             self.old_sigwinch = signal.signal(signal.SIGWINCH, self._handle_sigwinch)
         else:
             self.old_sigwinch = None
@@ -159,7 +156,7 @@ class PosixTerminalState(BaseTerminalState):
             tty.setcbreak(sys.stdin.fileno())
 
         if sys.stdin.fileno() not in self.selector.get_map():
-            self.selector.register(sys.stdin.fileno(), selectors.EVENT_READ, "stdin")
+            self.selector.register(sys.stdin.fileno(), selectors.EVENT_READ, STDIN_EVENT)
         self._set_headless(False)
 
     def enter_background(self) -> None:
@@ -178,7 +175,7 @@ class PosixTerminalState(BaseTerminalState):
     def drain_sigwinch(self) -> None:
         os.read(self.sigwinch_r, 64)
 
-    def should_enter_foreground(self) -> bool:
+    def _should_enter_foreground(self) -> bool:
         return not _is_background_tty(sys.stdin)
 
 

--- a/lib/spack/spack/new_installer_windows.py
+++ b/lib/spack/spack/new_installer_windows.py
@@ -33,7 +33,7 @@ from spack.new_installer_base import (
 )
 
 if TYPE_CHECKING:
-    from spack.new_installer import BuildStatus
+    from spack.new_installer import InstallerUI
 
 # Windows console mode flags
 ENABLE_LINE_INPUT = 0x0002
@@ -74,11 +74,11 @@ class WindowsTerminalState(BaseTerminalState):
     def __init__(
         self,
         selector: selectors.BaseSelector,
-        build_status: "BuildStatus",
+        ui: "InstallerUI",
         on_suspend: Optional[Callable[[], None]] = None,
         on_resume: Optional[Callable[[], None]] = None,
     ) -> None:
-        super().__init__(selector, build_status, on_suspend, on_resume)
+        super().__init__(selector, ui, on_suspend, on_resume)
         self.kernel32 = ctypes.windll.kernel32
         self.hStdin = self.kernel32.GetStdHandle(-10)
         self.hStdout = self.kernel32.GetStdHandle(-11)
@@ -101,7 +101,7 @@ class WindowsTerminalState(BaseTerminalState):
         self.kernel32.SetConsoleMode(self.hStdout, new_out_mode)
 
         self.selector.register(self.sigwinch_r, selectors.EVENT_READ, "sigwinch")
-        self.build_status.headless = True
+        self._set_headless(True)
 
         self._running = True
         threading.Thread(target=self._input_thread, daemon=True).start()
@@ -124,7 +124,7 @@ class WindowsTerminalState(BaseTerminalState):
         self.kernel32.SetConsoleMode(self.hStdout, self.old_stdout_settings.value)
 
     def enter_foreground(self) -> None:
-        if not self.build_status.headless:
+        if not self.headless:
             return
 
         self.kernel32.GetConsoleMode(self.hStdin, ctypes.byref(self.old_stdin_settings))
@@ -136,15 +136,14 @@ class WindowsTerminalState(BaseTerminalState):
         if self.stdin_is_interactive() and self.stdin_r.fileno() not in self.selector.get_map():
             self.selector.register(self.stdin_r, selectors.EVENT_READ, "stdin")
 
-        self.build_status.headless = False
-        self.build_status.dirty = True
+        self._set_headless(False)
 
     def drain_sigwinch(self) -> None:
         self.sigwinch_r.recv(64)
 
     def _input_thread(self) -> None:
         while self._running:
-            if self.build_status.headless:
+            if self.headless:
                 time.sleep(0.1)
                 continue
             if msvcrt.kbhit():

--- a/lib/spack/spack/new_installer_windows.py
+++ b/lib/spack/spack/new_installer_windows.py
@@ -22,18 +22,17 @@ import threading
 import time
 from ctypes import wintypes
 from multiprocessing import Process
-from typing import TYPE_CHECKING, Callable, Optional
+from typing import Callable, Optional
 
 from spack.new_installer_base import (
     OUTPUT_BUFFER_SIZE,
+    SIGWINCH_EVENT,
+    STDIN_EVENT,
     BaseTerminalState,
     ProcessExitNotifier,
     StdinReader,
     Tee,
 )
-
-if TYPE_CHECKING:
-    from spack.new_installer import InstallerUI
 
 # Windows console mode flags
 ENABLE_LINE_INPUT = 0x0002
@@ -74,11 +73,11 @@ class WindowsTerminalState(BaseTerminalState):
     def __init__(
         self,
         selector: selectors.BaseSelector,
-        ui: "InstallerUI",
+        on_headless: Optional[Callable[[bool], None]] = None,
         on_suspend: Optional[Callable[[], None]] = None,
         on_resume: Optional[Callable[[], None]] = None,
     ) -> None:
-        super().__init__(selector, ui, on_suspend, on_resume)
+        super().__init__(selector, on_headless, on_suspend, on_resume)
         self.kernel32 = ctypes.windll.kernel32
         self.hStdin = self.kernel32.GetStdHandle(-10)
         self.hStdout = self.kernel32.GetStdHandle(-11)
@@ -91,16 +90,14 @@ class WindowsTerminalState(BaseTerminalState):
         self.stdin_r.setblocking(False)
         self.sigwinch_r, self.sigwinch_w = socket.socketpair()
         self.sigwinch_r.setblocking(False)
-
-    def create_stdin_reader(self) -> StdinReader:
-        return StdinReader(functools.partial(self.stdin_r.recv, 1024))
+        self.stdin_reader = StdinReader(functools.partial(self.stdin_r.recv, 1024))
 
     def setup(self) -> None:
         # Enable VT100 ANSI escapes on stdout
         new_out_mode = self.old_stdout_settings.value | ENABLE_VIRTUAL_TERMINAL_PROCESSING
         self.kernel32.SetConsoleMode(self.hStdout, new_out_mode)
 
-        self.selector.register(self.sigwinch_r, selectors.EVENT_READ, "sigwinch")
+        self.selector.register(self.sigwinch_r, selectors.EVENT_READ, SIGWINCH_EVENT)
         self._set_headless(True)
 
         self._running = True
@@ -134,7 +131,7 @@ class WindowsTerminalState(BaseTerminalState):
         self.kernel32.SetConsoleMode(self.hStdin, new_in_mode)
 
         if self.stdin_is_interactive() and self.stdin_r.fileno() not in self.selector.get_map():
-            self.selector.register(self.stdin_r, selectors.EVENT_READ, "stdin")
+            self.selector.register(self.stdin_r, selectors.EVENT_READ, STDIN_EVENT)
 
         self._set_headless(False)
 

--- a/lib/spack/spack/test/installer_tui.py
+++ b/lib/spack/spack/test/installer_tui.py
@@ -22,7 +22,7 @@ from spack.new_installer_base import StdinReader
 
 
 def _fd_reader(fd: int) -> StdinReader:
-    """StdinReader reading from a raw fd, as PosixTerminalState.create_stdin_reader does."""
+    """StdinReader reading from a raw fd, as PosixTerminalState's stdin_reader does."""
     return StdinReader(functools.partial(os.read, fd, 1024))
 
 

--- a/lib/spack/spack/test/installer_tui.py
+++ b/lib/spack/spack/test/installer_tui.py
@@ -77,19 +77,8 @@ def create_tui(
         filter_padding=filter_padding,
         color=color,
     )
-    tui.controller = _NoopController()
 
     return tui, time_values, fake_stdout
-
-
-class _NoopController:
-    """No-op controller for view tests that don't inspect controller calls."""
-
-    def set_echo(self, build_id: str, echo: bool) -> None: ...
-
-    def increase_jobs(self) -> None: ...
-
-    def decrease_jobs(self) -> None: ...
 
 
 def on_build_added(
@@ -124,22 +113,6 @@ def add_mock_builds(tui: TerminalUI, count: int) -> List[str]:
     for i, build_id in enumerate(build_ids):
         on_build_added(tui, build_id, version=f"{i}.0")
     return build_ids
-
-
-def record_echo(tui: TerminalUI) -> List[Tuple[str, bool]]:
-    """Replace the tui's controller with one that records set_echo calls."""
-    calls: List[Tuple[str, bool]] = []
-
-    class Recorder:
-        def set_echo(self, build_id: str, echo: bool) -> None:
-            calls.append((build_id, echo))
-
-        def increase_jobs(self) -> None: ...
-
-        def decrease_jobs(self) -> None: ...
-
-    tui.controller = Recorder()
-    return calls
 
 
 class TestBasicStateManagement:
@@ -867,7 +840,6 @@ class TestNavigationIntegration:
         """Test that next() switches from overview mode to log-following mode"""
         tui, _, fake_stdout = create_tui(total=2)
         build_ids = add_mock_builds(tui, 2)
-        echo_calls = record_echo(tui)
 
         # Start in overview mode
         assert tui.overview_mode is True
@@ -879,7 +851,7 @@ class TestNavigationIntegration:
         # Should have switched to log-following mode
         assert tui.overview_mode is False
         assert tui.tracked_build_id == build_ids[0]
-        assert echo_calls == [(build_ids[0], True)]
+        assert tui.commands == [inst.SetEcho(build_ids[0], True)]
 
         # Should have printed "Following logs" message
         output = fake_stdout.getvalue()
@@ -890,7 +862,6 @@ class TestNavigationIntegration:
         """Test that next() cycles through multiple builds"""
         tui, _, fake_stdout = create_tui(total=3)
         build_ids = add_mock_builds(tui, 3)
-        echo_calls = record_echo(tui)
 
         # Start following first build
         tui.next()
@@ -903,7 +874,10 @@ class TestNavigationIntegration:
         assert tui.tracked_build_id == build_ids[1]
         assert "pkg1" in fake_stdout.getvalue()
         # Echoing stopped for the previous build and started for the new one
-        assert echo_calls[-2:] == [(build_ids[0], False), (build_ids[1], True)]
+        assert tui.commands[-2:] == [
+            inst.SetEcho(build_ids[0], False),
+            inst.SetEcho(build_ids[1], True),
+        ]
 
         fake_stdout.clear()
 
@@ -996,7 +970,6 @@ class TestToggle:
         """Test that toggle() from log-following mode returns to overview"""
         tui, _, _ = create_tui(total=2)
         add_mock_builds(tui, 2)
-        echo_calls = record_echo(tui)
 
         # Switch to log-following mode first
         tui.next()
@@ -1020,7 +993,7 @@ class TestToggle:
         assert tui.active_area_rows == 0
         assert tui.dirty is True
         # Echoing was stopped for the previously tracked build
-        assert echo_calls[-1] == (tracked_id, False)
+        assert tui.commands[-1] == inst.SetEcho(tracked_id, False)
 
     def test_update_state_finished_triggers_toggle_when_tracking(self):
         """Test that finishing a tracked build triggers toggle back to overview"""
@@ -1276,17 +1249,15 @@ class TestTerminalUIVerbose:
     def test_verbose_tracks_first_build(self):
         """First on_build_added for verbose non-TTY sets tracked_build_id and enables echoing."""
         tui, _, _ = create_tui(is_tty=False, verbose=True, total=4)
-        echo_calls = record_echo(tui)
 
         on_build_added(tui, "trivial-install-test-package")
 
         assert tui.tracked_build_id == "trivial-install-test-package"
-        assert echo_calls == [("trivial-install-test-package", True)]
+        assert tui.commands == [inst.SetEcho("trivial-install-test-package", True)]
 
     def test_verbose_does_not_track_when_already_tracking(self):
         """Second on_build_added() while already tracking does not switch tracking."""
         tui, _, _ = create_tui(is_tty=False, verbose=True, total=4)
-        echo_calls = record_echo(tui)
 
         on_build_added(tui, "pkg1")
         first_tracked = tui.tracked_build_id
@@ -1296,7 +1267,7 @@ class TestTerminalUIVerbose:
         assert tui.tracked_build_id == "pkg1"
 
         # Echoing should not have been enabled for the second build
-        assert echo_calls == [("pkg1", True)]
+        assert tui.commands == [inst.SetEcho("pkg1", True)]
 
     def test_verbose_switches_on_finish(self):
         """After the tracked build finishes, tracked_build_id is cleared."""
@@ -1334,11 +1305,10 @@ class TestTerminalUIVerbose:
     def test_verbose_tty_no_effect(self):
         """In TTY mode, on_build_added() does not set tracked_build_id automatically."""
         tui, _, _ = create_tui(is_tty=True, verbose=True, total=4)
-        echo_calls = record_echo(tui)
 
         on_build_added(tui, "trivial-install-test-package")
         assert tui.tracked_build_id == ""
-        assert echo_calls == []
+        assert tui.commands == []
 
 
 class TestTerminalUIColor:

--- a/lib/spack/spack/test/installer_tui.py
+++ b/lib/spack/spack/test/installer_tui.py
@@ -92,7 +92,7 @@ class _NoopController:
     def decrease_jobs(self) -> None: ...
 
 
-def add_build(
+def on_build_added(
     tui: TerminalUI,
     build_id: str,
     *,
@@ -105,7 +105,7 @@ def add_build(
 ) -> None:
     """Add a build with plain data, defaulting name and prefix from the build id."""
     name = name if name is not None else build_id
-    tui.add_build(
+    tui.on_build_added(
         inst.BuildInfo(
             build_id,
             name=name,
@@ -122,7 +122,7 @@ def add_mock_builds(tui: TerminalUI, count: int) -> List[str]:
     """Helper function to add builds to a TerminalUI instance. Returns the build ids."""
     build_ids = [f"pkg{i}" for i in range(count)]
     for i, build_id in enumerate(build_ids):
-        add_build(tui, build_id, version=f"{i}.0")
+        on_build_added(tui, build_id, version=f"{i}.0")
     return build_ids
 
 
@@ -167,34 +167,34 @@ class TestBasicStateManagement:
         assert tui.terminal_size_changed is False
 
     def test_add_build(self):
-        """Test that add_build adds builds correctly"""
+        """Test that on_build_added adds builds correctly"""
         tui, _, _ = create_tui(total=2)
 
-        add_build(tui, "pkg1", explicit=True)
+        on_build_added(tui, "pkg1", explicit=True)
         assert len(tui.builds) == 1
         assert "pkg1" in tui.builds
         assert tui.builds["pkg1"].name == "pkg1"
         assert tui.builds["pkg1"].explicit is True
         assert tui.dirty is True
 
-        add_build(tui, "pkg2", version="2.0", explicit=False)
+        on_build_added(tui, "pkg2", version="2.0", explicit=False)
         assert len(tui.builds) == 2
         assert "pkg2" in tui.builds
         assert tui.builds["pkg2"].explicit is False
 
     def test_update_state_transitions(self):
-        """Test that update_state transitions states properly"""
+        """Test that on_state_changed transitions states properly"""
         tui, fake_time, _ = create_tui()
         [build_id] = add_mock_builds(tui, 1)
 
         # Update to 'building' state
-        tui.update_state(build_id, "building")
+        tui.on_state_changed(build_id, "building")
         assert tui.builds[build_id].state == "building"
         assert tui.builds[build_id].progress_percent is None
         assert tui.completed == 0
 
         # Update to 'finished' state
-        tui.update_state(build_id, "finished")
+        tui.on_state_changed(build_id, "finished")
         assert tui.builds[build_id].state == "finished"
         assert tui.completed == 1
         assert tui.builds[build_id].finished_time == fake_time[0] + inst.CLEANUP_TIMEOUT
@@ -204,18 +204,18 @@ class TestBasicStateManagement:
         tui, fake_time, _ = create_tui()
         [build_id] = add_mock_builds(tui, 1)
 
-        tui.update_state(build_id, "failed")
+        tui.on_state_changed(build_id, "failed")
         assert tui.builds[build_id].state == "failed"
         assert tui.completed == 1
         assert tui.builds[build_id].finished_time == fake_time[0] + inst.CLEANUP_TIMEOUT
 
     def test_remove_build(self):
-        """Test that remove_build removes the build from the display."""
+        """Test that on_build_removed removes the build from the display."""
         tui, _, _ = create_tui(total=2)
         build_ids = add_mock_builds(tui, 2)
 
         tui.dirty = False
-        tui.remove_build(build_ids[0])
+        tui.on_build_removed(build_ids[0])
         assert build_ids[0] not in tui.builds
         assert len(tui.builds) == 1
         assert tui.dirty is True
@@ -227,7 +227,7 @@ class TestBasicStateManagement:
 
         tui.tracked_build_id = build_id
         tui.overview_mode = False
-        tui.remove_build(build_id)
+        tui.on_build_removed(build_id)
         assert tui.tracked_build_id == ""
         assert tui.overview_mode is True
 
@@ -241,7 +241,7 @@ class TestBasicStateManagement:
         log_file.write_text("error: something went wrong\n")
 
         tui.builds[build_id].log_path = str(log_file)
-        tui.update_state(build_id, "failed")
+        tui.on_state_changed(build_id, "failed")
         assert tui.builds[build_id].log_summary is not None
         assert "error" in tui.builds[build_id].log_summary.lower()
 
@@ -250,7 +250,7 @@ class TestBasicStateManagement:
         tui, _, _ = create_tui()
         [build_id] = add_mock_builds(tui, 1)
 
-        tui.update_state(build_id, "failed")
+        tui.on_state_changed(build_id, "failed")
         assert tui.builds[build_id].log_summary is None
 
     def test_failed_state_missing_log_file(self, tmp_path):
@@ -259,26 +259,26 @@ class TestBasicStateManagement:
         [build_id] = add_mock_builds(tui, 1)
 
         tui.builds[build_id].log_path = str(tmp_path / "nonexistent.log")
-        tui.update_state(build_id, "failed")
+        tui.on_state_changed(build_id, "failed")
         assert tui.builds[build_id].log_summary is None
 
     def test_update_progress(self):
-        """Test that update_progress updates percentages"""
+        """Test that on_progress updates percentages"""
         tui, _, _ = create_tui()
         [build_id] = add_mock_builds(tui, 1)
 
         # Update progress
-        tui.update_progress(build_id, 50, 100)
+        tui.on_progress(build_id, 50, 100)
         assert tui.builds[build_id].progress_percent == 50
         assert tui.dirty is True
 
         # Same percentage shouldn't mark dirty again
         tui.dirty = False
-        tui.update_progress(build_id, 50, 100)
+        tui.on_progress(build_id, 50, 100)
         assert tui.dirty is False
 
         # Different percentage should mark dirty
-        tui.update_progress(build_id, 75, 100)
+        tui.on_progress(build_id, 75, 100)
         assert tui.builds[build_id].progress_percent == 75
         assert tui.dirty is True
 
@@ -289,13 +289,13 @@ class TestBasicStateManagement:
 
         assert tui.completed == 0
 
-        tui.update_state(build_ids[0], "finished")
+        tui.on_state_changed(build_ids[0], "finished")
         assert tui.completed == 1
 
-        tui.update_state(build_ids[1], "failed")
+        tui.on_state_changed(build_ids[1], "failed")
         assert tui.completed == 2
 
-        tui.update_state(build_ids[2], "finished")
+        tui.on_state_changed(build_ids[2], "finished")
         assert tui.completed == 3
 
 
@@ -306,8 +306,8 @@ class TestOutputRendering:
         """Test that non-TTY mode prints simple state changes"""
         tui, _, fake_stdout = create_tui(is_tty=False)
 
-        add_build(tui, "mypackage")
-        tui.update_state("mypackage", "finished")
+        on_build_added(tui, "mypackage")
+        tui.on_state_changed("mypackage", "finished")
 
         output = fake_stdout.getvalue()
         assert "[+]" in output
@@ -391,11 +391,11 @@ class TestOutputRendering:
         # Now finish 2 builds and add 2 more
         fake_stdout.clear()
         fake_time[0] = inst.CLEANUP_TIMEOUT + 0.1
-        tui.update_state(build_ids[0], "finished")
-        tui.update_state(build_ids[1], "finished")
+        tui.on_state_changed(build_ids[0], "finished")
+        tui.on_state_changed(build_ids[1], "finished")
 
-        add_build(tui, "pkg3", version="3.0")
-        add_build(tui, "pkg4", version="4.0")
+        on_build_added(tui, "pkg3", version="3.0")
+        on_build_added(tui, "pkg4", version="4.0")
 
         # Second update: finished builds persist (newlines), active area updates (cursor moves)
         tui.render()
@@ -439,7 +439,7 @@ class TestTimeBasedBehavior:
 
         # Mark as finished
         fake_time[0] = 0.0
-        tui.update_state(build_id, "finished")
+        tui.on_state_changed(build_id, "finished")
 
         # Build should still be in active builds
         assert build_id in tui.builds
@@ -461,7 +461,7 @@ class TestTimeBasedBehavior:
 
         # Mark as failed
         fake_time[0] = 0.0
-        tui.update_state(build_id, "failed")
+        tui.on_state_changed(build_id, "failed")
 
         # Advance time past cleanup timeout
         fake_time[0] = inst.CLEANUP_TIMEOUT + 0.01
@@ -527,9 +527,9 @@ class TestSearchAndFilter:
         """Test that _is_displayed filters by package name"""
         tui, _, _ = create_tui(total=3)
 
-        add_build(tui, "package-foo")
-        add_build(tui, "package-bar")
-        add_build(tui, "other")
+        on_build_added(tui, "package-foo")
+        on_build_added(tui, "package-bar")
+        on_build_added(tui, "other")
 
         build1 = tui.builds["package-foo"]
         build2 = tui.builds["package-bar"]
@@ -557,8 +557,8 @@ class TestSearchAndFilter:
         """Test that _is_displayed filters by hash prefix"""
         tui, _, _ = create_tui(total=2)
 
-        add_build(tui, "abc123", name="pkg1")
-        add_build(tui, "def456", name="pkg2")
+        on_build_added(tui, "abc123", name="pkg1")
+        on_build_added(tui, "def456", name="pkg2")
 
         build1 = tui.builds["abc123"]
         build2 = tui.builds["def456"]
@@ -623,7 +623,7 @@ class TestNavigation:
 
         build_ids = ["package-a", "package-b", "other-c", "package-d"]
         for build_id in build_ids:
-            add_build(tui, build_id)
+            on_build_added(tui, build_id)
 
         # Filter to only "package-*"
         tui.search_term = "package"
@@ -647,7 +647,7 @@ class TestNavigation:
         build_ids = add_mock_builds(tui, 3)
 
         # Mark middle build as finished
-        tui.update_state(build_ids[1], "finished")
+        tui.on_state_changed(build_ids[1], "finished")
 
         # Navigate from first
         tui.tracked_build_id = build_ids[0]
@@ -662,7 +662,7 @@ class TestNavigation:
 
         # Mark both as finished
         for build_id in build_ids:
-            tui.update_state(build_id, "finished")
+            tui.on_state_changed(build_id, "finished")
 
         # Should return None since no unfinished builds
         result = tui._get_next(1)
@@ -674,7 +674,7 @@ class TestNavigation:
 
         build_ids = ["package-a", "package-b", "other-c"]
         for build_id in build_ids:
-            add_build(tui, build_id)
+            on_build_added(tui, build_id)
 
         # Start tracking "other-c"
         tui.tracked_build_id = build_ids[2]
@@ -773,7 +773,7 @@ class TestBuildInfo:
 
 
 class TestLogFollowing:
-    """Test log following and print_logs functionality"""
+    """Test log following and on_log_output functionality"""
 
     def test_print_logs_when_following(self):
         """Test that logs are printed when following a specific build"""
@@ -786,7 +786,7 @@ class TestLogFollowing:
 
         # Send some log data
         log_data = b"Building package...\nRunning tests...\n"
-        tui.print_logs(build_id, log_data)
+        tui.on_log_output(build_id, log_data)
 
         # Check that logs were echoed to stdout
         assert fake_stdout._buffer.getvalue() == log_data
@@ -801,7 +801,7 @@ class TestLogFollowing:
 
         # Try to print logs
         log_data = b"Should not be printed\n"
-        tui.print_logs(build_id, log_data)
+        tui.on_log_output(build_id, log_data)
 
         # Nothing should be printed
         assert fake_stdout.getvalue() == ""
@@ -817,7 +817,7 @@ class TestLogFollowing:
 
         # Try to print logs from the second build (not tracked)
         log_data = b"Logs from pkg2\n"
-        tui.print_logs(build_ids[1], log_data)
+        tui.on_log_output(build_ids[1], log_data)
 
         # Nothing should be printed since we're tracking pkg0, not pkg1
         assert fake_stdout.getvalue() == ""
@@ -828,7 +828,7 @@ class TestLogFollowing:
         build_ids = add_mock_builds(tui, 3)
 
         # Mark the middle build as failed and set log info
-        tui.update_state(build_ids[1], "failed")
+        tui.on_state_changed(build_ids[1], "failed")
         build_info = tui.builds[build_ids[1]]
         build_info.log_summary = "Error: something went wrong\n"
         build_info.log_path = "/tmp/spack/pkg1.log"
@@ -851,7 +851,7 @@ class TestLogFollowing:
         build_ids = add_mock_builds(tui, 3)
 
         # Mark the middle build as finished (successful)
-        tui.update_state(build_ids[1], "finished")
+        tui.on_state_changed(build_ids[1], "finished")
 
         # Try to get next build, should skip the finished one
         tui.tracked_build_id = build_ids[0]
@@ -942,7 +942,7 @@ class TestNavigationIntegration:
         [build_id] = add_mock_builds(tui, 1)
 
         # Mark as finished
-        tui.update_state(build_id, "finished")
+        tui.on_state_changed(build_id, "finished")
 
         # Try to navigate
         initial_mode = tui.overview_mode
@@ -1033,7 +1033,7 @@ class TestToggle:
         assert tui.tracked_build_id == build_ids[0]
 
         # Mark the tracked build as finished
-        tui.update_state(build_ids[0], "finished")
+        tui.on_state_changed(build_ids[0], "finished")
 
         # Should have toggled back to overview mode
         assert tui.overview_mode is True
@@ -1047,12 +1047,12 @@ class TestToggle:
         # Follow a build, toggle back and forth between logs and overview mode, and receive logs
         # that may or may not end with newlines.
         tui.next()
-        tui.print_logs(build_a, b"checking for foo...")
+        tui.on_log_output(build_a, b"checking for foo...")
         tui.toggle()
         tui.next()
-        tui.print_logs(build_a, b"checking for bar... yes\n")
+        tui.on_log_output(build_a, b"checking for bar... yes\n")
         tui.next(1)
-        tui.print_logs(build_b, b"checking for baz...")
+        tui.on_log_output(build_b, b"checking for baz...")
         tui.next(-1)
 
         written = fake_stdout.getvalue()
@@ -1067,7 +1067,7 @@ class TestToggle:
 
     @pytest.mark.parametrize("filter_padding", [True, False])
     def test_print_logs_filters_padding(self, filter_padding):
-        """print_logs strips path-padding placeholders before writing to stdout."""
+        """on_log_output strips path-padding placeholders before writing to stdout."""
         tui, _, fake_stdout = create_tui(filter_padding=filter_padding)
         [build_id] = add_mock_builds(tui, 1)
         log_output = b"--with-foo=/base/__spack_path_placeholder__/__spack_path_placeholder__/bin"
@@ -1075,7 +1075,7 @@ class TestToggle:
         # track the build and print logs with the relevant path.
         tui.overview_mode = False
         tui.tracked_build_id = build_id
-        tui.print_logs(build_id, log_output)
+        tui.on_log_output(build_id, log_output)
         written = fake_stdout._buffer.getvalue()
 
         if filter_padding:
@@ -1089,8 +1089,8 @@ class TestToggle:
         padded_prefix = "/base/__spack_path_placeholder__/__spack_path_placeholder__/mypackage"
         tui, _, fake_stdout = create_tui(is_tty=False, filter_padding=filter_padding)
         build_id = "mypackage"
-        add_build(tui, build_id, prefix=padded_prefix)
-        tui.update_state(build_id, "finished")
+        on_build_added(tui, build_id, prefix=padded_prefix)
+        tui.on_state_changed(build_id, "finished")
         output = fake_stdout.getvalue()
         common = f"[+] {build_id[:7]} mypackage@1.0"
         if filter_padding:
@@ -1106,10 +1106,10 @@ class TestSearchFilteringIntegration:
         """Test that search mode actually filters what's displayed"""
         tui, _, fake_stdout = create_tui(total=4)
 
-        add_build(tui, "package-foo")
-        add_build(tui, "package-bar", version="2.0")
-        add_build(tui, "other-thing", version="3.0")
-        add_build(tui, "package-baz", version="4.0")
+        on_build_added(tui, "package-foo")
+        on_build_added(tui, "package-bar", version="2.0")
+        on_build_added(tui, "other-thing", version="3.0")
+        on_build_added(tui, "package-baz", version="4.0")
 
         # Enter search mode and search for "package"
         tui.enter_search()
@@ -1141,7 +1141,7 @@ class TestSearchFilteringIntegration:
 
         build_ids = ["package-a", "other-b", "package-c", "other-d"]
         for build_id in build_ids:
-            add_build(tui, build_id)
+            on_build_added(tui, build_id)
 
         # Set search term to filter for "package"
         tui.search_term = "package"
@@ -1179,9 +1179,9 @@ class TestSearchFilteringIntegration:
         """Test that clearing search term shows all builds again"""
         tui, _, fake_stdout = create_tui(total=3)
 
-        add_build(tui, "package-a")
-        add_build(tui, "other-b", version="2.0")
-        add_build(tui, "package-c", version="3.0")
+        on_build_added(tui, "package-a")
+        on_build_added(tui, "other-b", version="2.0")
+        on_build_added(tui, "package-c", version="3.0")
 
         # Enter search and type something
         tui.enter_search()
@@ -1224,8 +1224,8 @@ class TestEdgeCases:
         """Test that we don't print a header with finalize=True"""
         tui, _, fake_stdout = create_tui(total=2, color=False)
         build_a, build_b = add_mock_builds(tui, 2)
-        tui.update_state(build_a, "finished")
-        tui.update_state(build_b, "failed")
+        tui.on_state_changed(build_a, "finished")
+        tui.on_state_changed(build_b, "failed")
         tui.render(finalize=True)
 
         output = fake_stdout.getvalue()
@@ -1244,7 +1244,7 @@ class TestEdgeCases:
 
         # Mark all as finished
         for build_id in build_ids:
-            tui.update_state(build_id, "finished")
+            tui.on_state_changed(build_id, "finished")
 
         # Advance time and update
         fake_time[0] = inst.CLEANUP_TIMEOUT + 0.01
@@ -1260,13 +1260,13 @@ class TestEdgeCases:
         [build_id] = add_mock_builds(tui, 1)
 
         # Test rounding
-        tui.update_progress(build_id, 1, 3)
+        tui.on_progress(build_id, 1, 3)
         assert tui.builds[build_id].progress_percent == 33  # int(100/3)
 
-        tui.update_progress(build_id, 2, 3)
+        tui.on_progress(build_id, 2, 3)
         assert tui.builds[build_id].progress_percent == 66  # int(200/3)
 
-        tui.update_progress(build_id, 3, 3)
+        tui.on_progress(build_id, 3, 3)
         assert tui.builds[build_id].progress_percent == 100
 
 
@@ -1274,24 +1274,24 @@ class TestTerminalUIVerbose:
     """Tests for verbose non-TTY log tracking in TerminalUI."""
 
     def test_verbose_tracks_first_build(self):
-        """First add_build() in verbose non-TTY mode sets tracked_build_id and enables echoing."""
+        """First on_build_added for verbose non-TTY sets tracked_build_id and enables echoing."""
         tui, _, _ = create_tui(is_tty=False, verbose=True, total=4)
         echo_calls = record_echo(tui)
 
-        add_build(tui, "trivial-install-test-package")
+        on_build_added(tui, "trivial-install-test-package")
 
         assert tui.tracked_build_id == "trivial-install-test-package"
         assert echo_calls == [("trivial-install-test-package", True)]
 
     def test_verbose_does_not_track_when_already_tracking(self):
-        """Second add_build() while already tracking does not switch tracking."""
+        """Second on_build_added() while already tracking does not switch tracking."""
         tui, _, _ = create_tui(is_tty=False, verbose=True, total=4)
         echo_calls = record_echo(tui)
 
-        add_build(tui, "pkg1")
+        on_build_added(tui, "pkg1")
         first_tracked = tui.tracked_build_id
 
-        add_build(tui, "pkg2", explicit=False)
+        on_build_added(tui, "pkg2", explicit=False)
         assert tui.tracked_build_id == first_tracked
         assert tui.tracked_build_id == "pkg1"
 
@@ -1302,41 +1302,41 @@ class TestTerminalUIVerbose:
         """After the tracked build finishes, tracked_build_id is cleared."""
         tui, _, _ = create_tui(is_tty=False, verbose=True, total=4)
 
-        add_build(tui, "trivial-install-test-package")
+        on_build_added(tui, "trivial-install-test-package")
         assert tui.tracked_build_id == "trivial-install-test-package"
 
-        tui.update_state("trivial-install-test-package", "finished")
+        tui.on_state_changed("trivial-install-test-package", "finished")
         assert tui.tracked_build_id == ""
 
     def test_verbose_print_logs_tracked(self):
-        """print_logs() for the tracked build writes to stdout."""
+        """on_log_output() for the tracked build writes to stdout."""
         tui, _, stdout = create_tui(is_tty=False, verbose=True, total=1)
 
-        add_build(tui, "trivial-install-test-package")
-        tui.print_logs("trivial-install-test-package", b"hello log\n")
+        on_build_added(tui, "trivial-install-test-package")
+        tui.on_log_output("trivial-install-test-package", b"hello log\n")
 
         stdout.flush()
         assert stdout.buffer.getvalue() == b"hello log\n"
 
     def test_verbose_print_logs_untracked(self):
-        """print_logs() for an untracked build discards data."""
+        """on_log_output() for an untracked build discards data."""
         tui, _, stdout = create_tui(is_tty=False, verbose=True, total=2)
 
-        add_build(tui, "pkg1")
-        add_build(tui, "pkg2", explicit=False)
+        on_build_added(tui, "pkg1")
+        on_build_added(tui, "pkg2", explicit=False)
 
         # Only pkg1 is tracked; pkg2 logs should be discarded
-        tui.print_logs("pkg2", b"ignored\n")
+        tui.on_log_output("pkg2", b"ignored\n")
 
         stdout.flush()
         assert stdout.buffer.getvalue() == b""
 
     def test_verbose_tty_no_effect(self):
-        """In TTY mode, add_build() does not set tracked_build_id automatically."""
+        """In TTY mode, on_build_added() does not set tracked_build_id automatically."""
         tui, _, _ = create_tui(is_tty=True, verbose=True, total=4)
         echo_calls = record_echo(tui)
 
-        add_build(tui, "trivial-install-test-package")
+        on_build_added(tui, "trivial-install-test-package")
         assert tui.tracked_build_id == ""
         assert echo_calls == []
 
@@ -1347,55 +1347,55 @@ class TestTerminalUIColor:
     def test_non_tty_finished_color_true_emits_green(self):
         """color=True in non-TTY mode: finished line has per-component ANSI colors."""
         tui, _, stdout = create_tui(is_tty=False, total=1, color=True)
-        add_build(tui, "pkg")
-        tui.update_state("pkg", "finished")
+        on_build_added(tui, "pkg")
+        tui.on_state_changed("pkg", "finished")
         # green indicator, reset, dark-gray hash
         assert stdout.getvalue().startswith("\033[32m[+]\033[0m \033[0;90m")
 
     def test_non_tty_failed_color_true_emits_red(self):
         """color=True in non-TTY mode: failed line has per-component ANSI colors."""
         tui, _, stdout = create_tui(is_tty=False, total=1, color=True)
-        add_build(tui, "pkg")
-        tui.update_state("pkg", "failed")
+        on_build_added(tui, "pkg")
+        tui.on_state_changed("pkg", "failed")
         # red indicator, reset, dark-gray hash
         assert stdout.getvalue().startswith("\033[31m[x]\033[0m \033[0;90m")
 
     def test_non_tty_finished_color_false_no_ansi(self):
         """color=False in non-TTY mode: finished line has no ANSI escape codes."""
         tui, _, stdout = create_tui(is_tty=False, total=1, color=False)
-        add_build(tui, "pkg")
-        tui.update_state("pkg", "finished")
+        on_build_added(tui, "pkg")
+        tui.on_state_changed("pkg", "finished")
         assert "\033[" not in stdout.getvalue()
 
 
 class TestTargetJobs:
-    """Test set_jobs and its effect on the header."""
+    """Test on_jobs_changed and its effect on the header."""
 
     def test_set_jobs_marks_dirty(self):
-        """set_jobs with a new value should update target_jobs and mark dirty."""
+        """on_jobs_changed with a new value should update target_jobs and mark dirty."""
         tui, _, _ = create_tui()
         tui.dirty = False
-        tui.set_jobs(3, 2)
+        tui.on_jobs_changed(3, 2)
         assert tui.actual_jobs == 3
         assert tui.target_jobs == 2
         assert tui.dirty is True
-        tui.set_jobs(2, 2)
+        tui.on_jobs_changed(2, 2)
         assert tui.actual_jobs == 2
         assert tui.target_jobs == 2
 
     def test_set_jobs_same_value_no_dirty(self):
-        """set_jobs with the same value should not mark dirty."""
+        """on_jobs_changed with the same value should not mark dirty."""
         tui, _, _ = create_tui()
-        tui.set_jobs(5, 5)
+        tui.on_jobs_changed(5, 5)
         tui.dirty = False
-        tui.set_jobs(5, 5)
+        tui.on_jobs_changed(5, 5)
         assert tui.dirty is False
 
     def test_header_shows_target_jobs(self):
         """The rendered header should contain the target_jobs count and the word 'jobs'."""
         tui, _, fake_stdout = create_tui(total=1)
         add_mock_builds(tui, 1)
-        tui.set_jobs(4, 4)
+        tui.on_jobs_changed(4, 4)
         tui.render()
         output = fake_stdout.getvalue()
         assert "4" in output
@@ -1405,7 +1405,7 @@ class TestTargetJobs:
         """When actual != target, the header should show 'actual=>target jobs'."""
         tui, _, fake_stdout = create_tui(total=1)
         add_mock_builds(tui, 1)
-        tui.set_jobs(4, 2)
+        tui.on_jobs_changed(4, 2)
         tui.render()
         output = fake_stdout.getvalue()
         assert "4=>2" in output
@@ -1424,21 +1424,21 @@ class TestHeadlessMode:
         assert stdout.getvalue() == ""
 
     def test_print_logs_suppressed_when_headless(self):
-        """print_logs() should discard data when headless is True."""
+        """on_log_output() should discard data when headless is True."""
         tui, _, stdout = create_tui(is_tty=True, total=1)
         build_ids = add_mock_builds(tui, 1)
         tui.tracked_build_id = build_ids[0]
         tui.headless = True
-        tui.print_logs(build_ids[0], b"hello world\n")
+        tui.on_log_output(build_ids[0], b"hello world\n")
         assert stdout.getvalue() == ""
 
     def test_update_state_non_tty_suppressed_when_headless(self):
-        """update_state() non-TTY output should be suppressed when headless."""
+        """on_state_changed() non-TTY output should be suppressed when headless."""
         tui, _, stdout = create_tui(is_tty=False, total=1)
-        add_build(tui, "pkg")
+        on_build_added(tui, "pkg")
         tui.headless = True
         stdout.clear()
-        tui.update_state("pkg", "finished")
+        tui.on_state_changed("pkg", "finished")
         assert stdout.getvalue() == ""
 
     def test_update_works_after_headless_cleared(self):

--- a/lib/spack/spack/test/installer_tui.py
+++ b/lib/spack/spack/test/installer_tui.py
@@ -1,7 +1,7 @@
 # Copyright Spack Project Developers. See COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
-"""Tests for the BuildStatus terminal UI in new_installer.py"""
+"""Tests for the TerminalUI terminal UI in new_installer.py"""
 
 import sys
 
@@ -14,42 +14,16 @@ if sys.platform == "win32":
 import functools
 import io
 import os
-from multiprocessing import Pipe
 from typing import List, Optional, Tuple
 
 import spack.new_installer as inst
-from spack.new_installer import BuildStatus
+from spack.new_installer import TerminalUI
 from spack.new_installer_base import StdinReader
 
 
 def _fd_reader(fd: int) -> StdinReader:
     """StdinReader reading from a raw fd, as PosixTerminalState.create_stdin_reader does."""
     return StdinReader(functools.partial(os.read, fd, 1024))
-
-
-class MockConnection:
-    """Mock multiprocessing.Connection for testing"""
-
-    def fileno(self):
-        return -1
-
-
-class MockSpec:
-    """Minimal mock for spack.spec.Spec"""
-
-    def __init__(
-        self, name: str, version: str = "1.0", external: bool = False, prefix: Optional[str] = None
-    ) -> None:
-        self.name = name
-        self.version = version
-        self.external = external
-        self.prefix = prefix or f"/fake/prefix/{name}"
-        self._hash = name  # Simple hash based on name
-
-    def dag_hash(self, length: Optional[int] = None) -> str:
-        if length:
-            return self._hash[:length]
-        return self._hash
 
 
 class SimpleTextIOWrapper(io.TextIOWrapper):
@@ -73,7 +47,7 @@ class SimpleTextIOWrapper(io.TextIOWrapper):
         self._buffer.seek(0)
 
 
-def create_build_status(
+def create_tui(
     is_tty: bool = True,
     terminal_cols: int = 80,
     terminal_rows: int = 24,
@@ -81,8 +55,8 @@ def create_build_status(
     verbose: bool = False,
     filter_padding: bool = False,
     color: Optional[bool] = None,
-) -> Tuple[BuildStatus, List[float], SimpleTextIOWrapper]:
-    """Helper function to create BuildStatus with mocked dependencies"""
+) -> Tuple[TerminalUI, List[float], SimpleTextIOWrapper]:
+    """Helper function to create TerminalUI with mocked dependencies"""
     fake_stdout = SimpleTextIOWrapper(tty=is_tty)
     # Easy way to set the current time in tests before running UI updates
     time_values = [0.0]
@@ -93,7 +67,7 @@ def create_build_status(
     def mock_get_terminal_size():
         return os.terminal_size((terminal_cols, terminal_rows))
 
-    status = BuildStatus(
+    tui = TerminalUI(
         total=total,
         stdout=fake_stdout,
         get_terminal_size=mock_get_terminal_size,
@@ -103,16 +77,69 @@ def create_build_status(
         filter_padding=filter_padding,
         color=color,
     )
+    tui.controller = _NoopController()
 
-    return status, time_values, fake_stdout
+    return tui, time_values, fake_stdout
 
 
-def add_mock_builds(status: BuildStatus, count: int) -> List[MockSpec]:
-    """Helper function to add builds to a BuildStatus instance"""
-    specs = [MockSpec(f"pkg{i}", f"{i}.0") for i in range(count)]
-    for spec in specs:
-        status.add_build(spec, explicit=True, control_w_conn=MockConnection())  # type: ignore
-    return specs
+class _NoopController:
+    """No-op controller for view tests that don't inspect controller calls."""
+
+    def set_echo(self, build_id: str, echo: bool) -> None: ...
+
+    def increase_jobs(self) -> None: ...
+
+    def decrease_jobs(self) -> None: ...
+
+
+def add_build(
+    tui: TerminalUI,
+    build_id: str,
+    *,
+    name: Optional[str] = None,
+    version: str = "1.0",
+    external: bool = False,
+    prefix: Optional[str] = None,
+    explicit: bool = True,
+    log_path: Optional[str] = None,
+) -> None:
+    """Add a build with plain data, defaulting name and prefix from the build id."""
+    name = name if name is not None else build_id
+    tui.add_build(
+        inst.BuildInfo(
+            build_id,
+            name=name,
+            version=version,
+            external=external,
+            prefix=prefix if prefix is not None else f"/fake/prefix/{name}",
+            explicit=explicit,
+            log_path=log_path,
+        )
+    )
+
+
+def add_mock_builds(tui: TerminalUI, count: int) -> List[str]:
+    """Helper function to add builds to a TerminalUI instance. Returns the build ids."""
+    build_ids = [f"pkg{i}" for i in range(count)]
+    for i, build_id in enumerate(build_ids):
+        add_build(tui, build_id, version=f"{i}.0")
+    return build_ids
+
+
+def record_echo(tui: TerminalUI) -> List[Tuple[str, bool]]:
+    """Replace the tui's controller with one that records set_echo calls."""
+    calls: List[Tuple[str, bool]] = []
+
+    class Recorder:
+        def set_echo(self, build_id: str, echo: bool) -> None:
+            calls.append((build_id, echo))
+
+        def increase_jobs(self) -> None: ...
+
+        def decrease_jobs(self) -> None: ...
+
+    tui.controller = Recorder()
+    return calls
 
 
 class TestBasicStateManagement:
@@ -122,164 +149,154 @@ class TestBasicStateManagement:
         """Test that on_resize sets terminal_size_changed and update() fetches lazily"""
         sizes = [os.terminal_size((80, 24))]
         fake_stdout = SimpleTextIOWrapper(tty=True)
-        status = BuildStatus(
+        tui = TerminalUI(
             total=0, stdout=fake_stdout, get_terminal_size=lambda: sizes[-1], is_tty=True
         )
         # terminal_size_changed is True from __init__; terminal_size is placeholder
-        assert status.terminal_size_changed is True
+        assert tui.terminal_size_changed is True
 
         # After on_resize the flag stays set and dirty is True
         sizes.append(os.terminal_size((120, 40)))
-        status.on_resize()
-        assert status.terminal_size_changed is True
-        assert status.dirty is True
+        tui.on_resize()
+        assert tui.terminal_size_changed is True
+        assert tui.dirty is True
 
         # The actual size is fetched lazily on the first update()
-        status.update()
-        assert status.terminal_size == os.terminal_size((120, 40))
-        assert status.terminal_size_changed is False
+        tui.render()
+        assert tui.terminal_size == os.terminal_size((120, 40))
+        assert tui.terminal_size_changed is False
 
     def test_add_build(self):
         """Test that add_build adds builds correctly"""
-        status, _, _ = create_build_status(total=2)
-        spec1 = MockSpec("pkg1", "1.0")
-        spec2 = MockSpec("pkg2", "2.0")
+        tui, _, _ = create_tui(total=2)
 
-        status.add_build(spec1, explicit=True, control_w_conn=MockConnection())
-        assert len(status.builds) == 1
-        assert spec1.dag_hash() in status.builds
-        assert status.builds[spec1.dag_hash()].name == "pkg1"
-        assert status.builds[spec1.dag_hash()].explicit is True
-        assert status.dirty is True
+        add_build(tui, "pkg1", explicit=True)
+        assert len(tui.builds) == 1
+        assert "pkg1" in tui.builds
+        assert tui.builds["pkg1"].name == "pkg1"
+        assert tui.builds["pkg1"].explicit is True
+        assert tui.dirty is True
 
-        status.add_build(spec2, explicit=False, control_w_conn=MockConnection())
-        assert len(status.builds) == 2
-        assert spec2.dag_hash() in status.builds
-        assert status.builds[spec2.dag_hash()].explicit is False
+        add_build(tui, "pkg2", version="2.0", explicit=False)
+        assert len(tui.builds) == 2
+        assert "pkg2" in tui.builds
+        assert tui.builds["pkg2"].explicit is False
 
     def test_update_state_transitions(self):
         """Test that update_state transitions states properly"""
-        status, fake_time, _ = create_build_status()
-        (spec,) = add_mock_builds(status, 1)
-        build_id = spec.dag_hash()
+        tui, fake_time, _ = create_tui()
+        [build_id] = add_mock_builds(tui, 1)
 
         # Update to 'building' state
-        status.update_state(build_id, "building")
-        assert status.builds[build_id].state == "building"
-        assert status.builds[build_id].progress_percent is None
-        assert status.completed == 0
+        tui.update_state(build_id, "building")
+        assert tui.builds[build_id].state == "building"
+        assert tui.builds[build_id].progress_percent is None
+        assert tui.completed == 0
 
         # Update to 'finished' state
-        status.update_state(build_id, "finished")
-        assert status.builds[build_id].state == "finished"
-        assert status.completed == 1
-        assert status.builds[build_id].finished_time == fake_time[0] + inst.CLEANUP_TIMEOUT
+        tui.update_state(build_id, "finished")
+        assert tui.builds[build_id].state == "finished"
+        assert tui.completed == 1
+        assert tui.builds[build_id].finished_time == fake_time[0] + inst.CLEANUP_TIMEOUT
 
     def test_update_state_failed(self):
         """Test that failed state increments completed counter"""
-        status, fake_time, _ = create_build_status()
-        (spec,) = add_mock_builds(status, 1)
-        build_id = spec.dag_hash()
+        tui, fake_time, _ = create_tui()
+        [build_id] = add_mock_builds(tui, 1)
 
-        status.update_state(build_id, "failed")
-        assert status.builds[build_id].state == "failed"
-        assert status.completed == 1
-        assert status.builds[build_id].finished_time == fake_time[0] + inst.CLEANUP_TIMEOUT
+        tui.update_state(build_id, "failed")
+        assert tui.builds[build_id].state == "failed"
+        assert tui.completed == 1
+        assert tui.builds[build_id].finished_time == fake_time[0] + inst.CLEANUP_TIMEOUT
 
     def test_remove_build(self):
         """Test that remove_build removes the build from the display."""
-        status, _, _ = create_build_status(total=2)
-        specs = add_mock_builds(status, 2)
-        build_id = specs[0].dag_hash()
+        tui, _, _ = create_tui(total=2)
+        build_ids = add_mock_builds(tui, 2)
 
-        status.dirty = False
-        status.remove_build(build_id)
-        assert build_id not in status.builds
-        assert len(status.builds) == 1
-        assert status.dirty is True
+        tui.dirty = False
+        tui.remove_build(build_ids[0])
+        assert build_ids[0] not in tui.builds
+        assert len(tui.builds) == 1
+        assert tui.dirty is True
 
     def test_remove_build_resets_tracked(self):
         """Test that removing the tracked build resets tracking to overview mode."""
-        status, _, _ = create_build_status(total=1)
-        (spec,) = add_mock_builds(status, 1)
-        build_id = spec.dag_hash()
+        tui, _, _ = create_tui(total=1)
+        [build_id] = add_mock_builds(tui, 1)
 
-        status.tracked_build_id = build_id
-        status.overview_mode = False
-        status.remove_build(build_id)
-        assert status.tracked_build_id == ""
-        assert status.overview_mode is True
+        tui.tracked_build_id = build_id
+        tui.overview_mode = False
+        tui.remove_build(build_id)
+        assert tui.tracked_build_id == ""
+        assert tui.overview_mode is True
 
-    def test_parse_log_summary(self, tmp_path):
-        """Test that parse_log_summary parses the build log and stores the summary."""
-        status, _, _ = create_build_status()
-        (spec,) = add_mock_builds(status, 1)
-        build_id = spec.dag_hash()
+    def test_failed_state_parses_log_summary(self, tmp_path):
+        """A build transitioning to "failed" parses the build log and stores the summary."""
+        tui, _, _ = create_tui()
+        [build_id] = add_mock_builds(tui, 1)
 
         # Create a fake log file with an error
         log_file = tmp_path / "build.log"
         log_file.write_text("error: something went wrong\n")
 
-        status.builds[build_id].log_path = str(log_file)
-        status.parse_log_summary(build_id)
-        assert status.builds[build_id].log_summary is not None
-        assert "error" in status.builds[build_id].log_summary.lower()
+        tui.builds[build_id].log_path = str(log_file)
+        tui.update_state(build_id, "failed")
+        assert tui.builds[build_id].log_summary is not None
+        assert "error" in tui.builds[build_id].log_summary.lower()
 
-    def test_parse_log_summary_no_log_path(self):
-        """Test that parse_log_summary is a no-op when log_path is not set."""
-        status, _, _ = create_build_status()
-        (spec,) = add_mock_builds(status, 1)
-        build_id = spec.dag_hash()
+    def test_failed_state_no_log_path(self):
+        """No summary is stored for a failed build without a log path."""
+        tui, _, _ = create_tui()
+        [build_id] = add_mock_builds(tui, 1)
 
-        status.parse_log_summary(build_id)
-        assert status.builds[build_id].log_summary is None
+        tui.update_state(build_id, "failed")
+        assert tui.builds[build_id].log_summary is None
 
-    def test_parse_log_summary_missing_file(self, tmp_path):
-        """Test that parse_log_summary is a no-op when log file doesn't exist."""
-        status, _, _ = create_build_status()
-        (spec,) = add_mock_builds(status, 1)
-        build_id = spec.dag_hash()
+    def test_failed_state_missing_log_file(self, tmp_path):
+        """No summary is stored for a failed build whose log file doesn't exist."""
+        tui, _, _ = create_tui()
+        [build_id] = add_mock_builds(tui, 1)
 
-        status.builds[build_id].log_path = str(tmp_path / "nonexistent.log")
-        status.parse_log_summary(build_id)
-        assert status.builds[build_id].log_summary is None
+        tui.builds[build_id].log_path = str(tmp_path / "nonexistent.log")
+        tui.update_state(build_id, "failed")
+        assert tui.builds[build_id].log_summary is None
 
     def test_update_progress(self):
         """Test that update_progress updates percentages"""
-        status, _, _ = create_build_status()
-        (spec,) = add_mock_builds(status, 1)
-        build_id = spec.dag_hash()
+        tui, _, _ = create_tui()
+        [build_id] = add_mock_builds(tui, 1)
 
         # Update progress
-        status.update_progress(build_id, 50, 100)
-        assert status.builds[build_id].progress_percent == 50
-        assert status.dirty is True
+        tui.update_progress(build_id, 50, 100)
+        assert tui.builds[build_id].progress_percent == 50
+        assert tui.dirty is True
 
         # Same percentage shouldn't mark dirty again
-        status.dirty = False
-        status.update_progress(build_id, 50, 100)
-        assert status.dirty is False
+        tui.dirty = False
+        tui.update_progress(build_id, 50, 100)
+        assert tui.dirty is False
 
         # Different percentage should mark dirty
-        status.update_progress(build_id, 75, 100)
-        assert status.builds[build_id].progress_percent == 75
-        assert status.dirty is True
+        tui.update_progress(build_id, 75, 100)
+        assert tui.builds[build_id].progress_percent == 75
+        assert tui.dirty is True
 
     def test_completion_counter(self):
         """Test that completion counter increments correctly"""
-        status, _, _ = create_build_status(total=3)
-        specs = add_mock_builds(status, 3)
+        tui, _, _ = create_tui(total=3)
+        build_ids = add_mock_builds(tui, 3)
 
-        assert status.completed == 0
+        assert tui.completed == 0
 
-        status.update_state(specs[0].dag_hash(), "finished")
-        assert status.completed == 1
+        tui.update_state(build_ids[0], "finished")
+        assert tui.completed == 1
 
-        status.update_state(specs[1].dag_hash(), "failed")
-        assert status.completed == 2
+        tui.update_state(build_ids[1], "failed")
+        assert tui.completed == 2
 
-        status.update_state(specs[2].dag_hash(), "finished")
-        assert status.completed == 3
+        tui.update_state(build_ids[2], "finished")
+        assert tui.completed == 3
 
 
 class TestOutputRendering:
@@ -287,13 +304,10 @@ class TestOutputRendering:
 
     def test_non_tty_output(self):
         """Test that non-TTY mode prints simple state changes"""
-        status, _, fake_stdout = create_build_status(is_tty=False)
-        spec = MockSpec("mypackage", "1.0")
+        tui, _, fake_stdout = create_tui(is_tty=False)
 
-        status.add_build(spec, explicit=True, control_w_conn=MockConnection())
-        build_id = spec.dag_hash()
-
-        status.update_state(build_id, "finished")
+        add_build(tui, "mypackage")
+        tui.update_state("mypackage", "finished")
 
         output = fake_stdout.getvalue()
         assert "[+]" in output
@@ -305,11 +319,11 @@ class TestOutputRendering:
 
     def test_tty_output_contains_ansi(self):
         """Test that TTY mode produces ANSI codes"""
-        status, _, fake_stdout = create_build_status()
-        add_mock_builds(status, 1)
+        tui, _, fake_stdout = create_tui()
+        add_mock_builds(tui, 1)
 
         # Call update to render
-        status.update()
+        tui.render()
 
         output = fake_stdout.getvalue()
         # Should contain ANSI escape sequences
@@ -319,51 +333,51 @@ class TestOutputRendering:
 
     def test_no_output_when_not_dirty(self):
         """Test that update() skips rendering when not dirty"""
-        status, _, fake_stdout = create_build_status()
-        add_mock_builds(status, 1)
-        status.update()
+        tui, _, fake_stdout = create_tui()
+        add_mock_builds(tui, 1)
+        tui.render()
 
         # Clear stdout and mark not dirty
         fake_stdout.clear()
-        status.dirty = False
+        tui.dirty = False
 
         # Update should not produce output
-        status.update()
+        tui.render()
         assert fake_stdout.getvalue() == ""
 
     def test_update_throttling(self):
         """Test that update() throttles redraws"""
-        status, fake_time, fake_stdout = create_build_status()
-        add_mock_builds(status, 1)
+        tui, fake_time, fake_stdout = create_tui()
+        add_mock_builds(tui, 1)
 
         # First update at time 0
         fake_time[0] = 0.0
-        status.update()
+        tui.render()
         first_output = fake_stdout.getvalue()
         assert first_output != ""
 
         # Mark dirty and try to update immediately
         fake_stdout.clear()
-        status.dirty = True
+        tui.dirty = True
         fake_time[0] = 0.01  # Very small time advance
 
         # Should be throttled (next_update not reached)
-        status.update()
+        tui.render()
         assert fake_stdout.getvalue() == ""
 
         # Advance time past throttle and try again
         fake_time[0] = 1.0
-        status.update()
+        tui.render()
         assert fake_stdout.getvalue() != ""
 
     def test_cursor_movement_vs_newlines(self):
         """Test that finished builds get newlines, active builds get cursor movements"""
-        status, fake_time, fake_stdout = create_build_status(total=5)
-        specs = add_mock_builds(status, 3)
+        tui, fake_time, fake_stdout = create_tui(total=5)
+        build_ids = add_mock_builds(tui, 3)
 
         # First update renders 3 active builds
         fake_time[0] = 0.0
-        status.update()
+        tui.render()
         output1 = fake_stdout.getvalue()
 
         # Count newlines (\n) and cursor movements (\033[1B\r = move down 1 line)
@@ -377,16 +391,14 @@ class TestOutputRendering:
         # Now finish 2 builds and add 2 more
         fake_stdout.clear()
         fake_time[0] = inst.CLEANUP_TIMEOUT + 0.1
-        status.update_state(specs[0].dag_hash(), "finished")
-        status.update_state(specs[1].dag_hash(), "finished")
+        tui.update_state(build_ids[0], "finished")
+        tui.update_state(build_ids[1], "finished")
 
-        spec4 = MockSpec("pkg3", "3.0")
-        spec5 = MockSpec("pkg4", "4.0")
-        status.add_build(spec4, explicit=True, control_w_conn=MockConnection())
-        status.add_build(spec5, explicit=True, control_w_conn=MockConnection())
+        add_build(tui, "pkg3", version="3.0")
+        add_build(tui, "pkg4", version="4.0")
 
         # Second update: finished builds persist (newlines), active area updates (cursor moves)
-        status.update()
+        tui.render()
         output2 = fake_stdout.getvalue()
 
         newlines2 = output2.count("\n")
@@ -407,58 +419,56 @@ class TestTimeBasedBehavior:
 
     def test_spinner_updates(self):
         """Test that spinner advances over time"""
-        status, fake_time, _ = create_build_status()
-        add_mock_builds(status, 1)
+        tui, fake_time, _ = create_tui()
+        add_mock_builds(tui, 1)
 
         # Initial spinner index
-        initial_index = status.spinner_index
+        initial_index = tui.spinner_index
 
         # Advance time past spinner interval
         fake_time[0] = inst.SPINNER_INTERVAL + 0.01
-        status.update()
+        tui.render()
 
         # Spinner should have advanced
-        assert status.spinner_index == (initial_index + 1) % len(status.spinner_chars)
+        assert tui.spinner_index == (initial_index + 1) % len(tui.spinner_chars)
 
     def test_finished_package_cleanup(self):
         """Test that finished packages are cleaned up after timeout"""
-        status, fake_time, _ = create_build_status()
-        (spec,) = add_mock_builds(status, 1)
-        build_id = spec.dag_hash()
+        tui, fake_time, _ = create_tui()
+        [build_id] = add_mock_builds(tui, 1)
 
         # Mark as finished
         fake_time[0] = 0.0
-        status.update_state(build_id, "finished")
+        tui.update_state(build_id, "finished")
 
         # Build should still be in active builds
-        assert build_id in status.builds
-        assert len(status.finished_builds) == 0
+        assert build_id in tui.builds
+        assert len(tui.finished_builds) == 0
 
         # Advance time past cleanup timeout
         fake_time[0] = inst.CLEANUP_TIMEOUT + 0.01
-        status.update()
+        tui.render()
 
         # Build should now be moved to finished_builds and removed from active
-        assert build_id not in status.builds
+        assert build_id not in tui.builds
         # Note: finished_builds is cleared after rendering, so check it happened via side effects
-        assert status.dirty or build_id not in status.builds
+        assert tui.dirty or build_id not in tui.builds
 
     def test_failed_packages_not_cleaned_up(self):
         """Test that failed packages stay in active builds"""
-        status, fake_time, _ = create_build_status()
-        (spec,) = add_mock_builds(status, 1)
-        build_id = spec.dag_hash()
+        tui, fake_time, _ = create_tui()
+        [build_id] = add_mock_builds(tui, 1)
 
         # Mark as failed
         fake_time[0] = 0.0
-        status.update_state(build_id, "failed")
+        tui.update_state(build_id, "failed")
 
         # Advance time past cleanup timeout
         fake_time[0] = inst.CLEANUP_TIMEOUT + 0.01
-        status.update()
+        tui.render()
 
         # Failed build should remain in active builds
-        assert build_id in status.builds
+        assert build_id in tui.builds
 
 
 class TestSearchAndFilter:
@@ -466,110 +476,101 @@ class TestSearchAndFilter:
 
     def test_enter_search_mode(self):
         """Test that enter_search enables search mode"""
-        status, _, _ = create_build_status()
-        assert status.search_mode is False
+        tui, _, _ = create_tui()
+        assert tui.search_mode is False
 
-        status.enter_search()
-        assert status.search_mode is True
-        assert status.dirty is True
+        tui.enter_search()
+        assert tui.search_mode is True
+        assert tui.dirty is True
 
     def test_search_input_printable(self):
         """Test that printable characters are added to search term"""
-        status, _, _ = create_build_status()
-        status.enter_search()
+        tui, _, _ = create_tui()
+        tui.enter_search()
 
-        status.search_input("a")
-        assert status.search_term == "a"
+        tui.search_input("a")
+        assert tui.search_term == "a"
 
-        status.search_input("b")
-        assert status.search_term == "ab"
+        tui.search_input("b")
+        assert tui.search_term == "ab"
 
-        status.search_input("c")
-        assert status.search_term == "abc"
+        tui.search_input("c")
+        assert tui.search_term == "abc"
 
     def test_search_input_backspace(self):
         """Test that backspace removes characters"""
-        status, _, _ = create_build_status()
-        status.enter_search()
+        tui, _, _ = create_tui()
+        tui.enter_search()
 
-        status.search_input("a")
-        status.search_input("b")
-        status.search_input("c")
-        assert status.search_term == "abc"
+        tui.search_input("a")
+        tui.search_input("b")
+        tui.search_input("c")
+        assert tui.search_term == "abc"
 
-        status.search_input("\x7f")  # Backspace
-        assert status.search_term == "ab"
+        tui.search_input("\x7f")  # Backspace
+        assert tui.search_term == "ab"
 
-        status.search_input("\b")  # Alternative backspace
-        assert status.search_term == "a"
+        tui.search_input("\b")  # Alternative backspace
+        assert tui.search_term == "a"
 
     def test_search_input_escape(self):
         """Test that escape exits search mode"""
-        status, _, _ = create_build_status()
-        status.enter_search()
-        status.search_input("test")
+        tui, _, _ = create_tui()
+        tui.enter_search()
+        tui.search_input("test")
 
-        status.search_input("\x1b")  # Escape
-        assert status.search_mode is False
-        assert status.search_term == ""
+        tui.search_input("\x1b")  # Escape
+        assert tui.search_mode is False
+        assert tui.search_term == ""
 
     def test_is_displayed_filters_by_name(self):
         """Test that _is_displayed filters by package name"""
-        status, _, _ = create_build_status(total=3)
+        tui, _, _ = create_tui(total=3)
 
-        spec1 = MockSpec("package-foo", "1.0")
-        spec2 = MockSpec("package-bar", "1.0")
-        spec3 = MockSpec("other", "1.0")
+        add_build(tui, "package-foo")
+        add_build(tui, "package-bar")
+        add_build(tui, "other")
 
-        status.add_build(spec1, explicit=True, control_w_conn=MockConnection())
-        status.add_build(spec2, explicit=True, control_w_conn=MockConnection())
-        status.add_build(spec3, explicit=True, control_w_conn=MockConnection())
-
-        build1 = status.builds[spec1.dag_hash()]
-        build2 = status.builds[spec2.dag_hash()]
-        build3 = status.builds[spec3.dag_hash()]
+        build1 = tui.builds["package-foo"]
+        build2 = tui.builds["package-bar"]
+        build3 = tui.builds["other"]
 
         # No search term: all displayed
-        status.search_term = ""
-        assert status._is_displayed(build1)
-        assert status._is_displayed(build2)
-        assert status._is_displayed(build3)
+        tui.search_term = ""
+        assert tui._is_displayed(build1)
+        assert tui._is_displayed(build2)
+        assert tui._is_displayed(build3)
 
         # Search for "package"
-        status.search_term = "package"
-        assert status._is_displayed(build1)
-        assert status._is_displayed(build2)
-        assert not status._is_displayed(build3)
+        tui.search_term = "package"
+        assert tui._is_displayed(build1)
+        assert tui._is_displayed(build2)
+        assert not tui._is_displayed(build3)
 
         # Search for "foo"
-        status.search_term = "foo"
-        assert status._is_displayed(build1)
-        assert not status._is_displayed(build2)
-        assert not status._is_displayed(build3)
+        tui.search_term = "foo"
+        assert tui._is_displayed(build1)
+        assert not tui._is_displayed(build2)
+        assert not tui._is_displayed(build3)
 
     def test_is_displayed_filters_by_hash(self):
         """Test that _is_displayed filters by hash prefix"""
-        status, _, _ = create_build_status(total=2)
+        tui, _, _ = create_tui(total=2)
 
-        spec1 = MockSpec("pkg1", "1.0")
-        spec1._hash = "abc123"
-        spec2 = MockSpec("pkg2", "1.0")
-        spec2._hash = "def456"
+        add_build(tui, "abc123", name="pkg1")
+        add_build(tui, "def456", name="pkg2")
 
-        status.add_build(spec1, explicit=True, control_w_conn=MockConnection())
-        status.add_build(spec2, explicit=True, control_w_conn=MockConnection())
-
-        build1 = status.builds[spec1.dag_hash()]
-        build2 = status.builds[spec2.dag_hash()]
+        build1 = tui.builds["abc123"]
+        build2 = tui.builds["def456"]
 
         # Search by hash prefix
-        status.search_term = "abc"
-        assert status._is_displayed(build1)
-        assert not status._is_displayed(build2)
+        tui.search_term = "abc"
+        assert tui._is_displayed(build1)
+        assert not tui._is_displayed(build2)
 
-        status.search_term = "def"
-        assert not status._is_displayed(build1)
-        assert status._is_displayed(build2)
+        tui.search_term = "def"
+        assert not tui._is_displayed(build1)
+        assert tui._is_displayed(build2)
 
 
 class TestNavigation:
@@ -577,127 +578,118 @@ class TestNavigation:
 
     def test_get_next_basic(self):
         """Test basic next/previous navigation"""
-        status, _, _ = create_build_status(total=3)
-        specs = add_mock_builds(status, 3)
+        tui, _, _ = create_tui(total=3)
+        build_ids = add_mock_builds(tui, 3)
 
         # Get first build
-        first_id = status._get_next(1)
-        assert first_id == specs[0].dag_hash()
+        first_id = tui._get_next(1)
+        assert first_id == build_ids[0]
 
         # Set tracked and get next
-        status.tracked_build_id = first_id
-        next_id = status._get_next(1)
-        assert next_id == specs[1].dag_hash()
+        tui.tracked_build_id = first_id
+        next_id = tui._get_next(1)
+        assert next_id == build_ids[1]
 
         # Get next again
-        status.tracked_build_id = next_id
-        next_id = status._get_next(1)
-        assert next_id == specs[2].dag_hash()
+        tui.tracked_build_id = next_id
+        next_id = tui._get_next(1)
+        assert next_id == build_ids[2]
 
         # Wrap around
-        status.tracked_build_id = next_id
-        next_id = status._get_next(1)
-        assert next_id == specs[0].dag_hash()
+        tui.tracked_build_id = next_id
+        next_id = tui._get_next(1)
+        assert next_id == build_ids[0]
 
     def test_get_next_previous(self):
         """Test backward navigation"""
-        status, _, _ = create_build_status(total=3)
-        specs = add_mock_builds(status, 3)
+        tui, _, _ = create_tui(total=3)
+        build_ids = add_mock_builds(tui, 3)
 
         # Start at second build
-        status.tracked_build_id = specs[1].dag_hash()
+        tui.tracked_build_id = build_ids[1]
 
         # Go backward
-        prev_id = status._get_next(-1)
-        assert prev_id == specs[0].dag_hash()
+        prev_id = tui._get_next(-1)
+        assert prev_id == build_ids[0]
 
         # Go backward again (wrap around)
-        status.tracked_build_id = prev_id
-        prev_id = status._get_next(-1)
-        assert prev_id == specs[2].dag_hash()
+        tui.tracked_build_id = prev_id
+        prev_id = tui._get_next(-1)
+        assert prev_id == build_ids[2]
 
     def test_get_next_with_filter(self):
         """Test navigation respects search filter"""
-        status, _, _ = create_build_status(total=4)
+        tui, _, _ = create_tui(total=4)
 
-        specs = [
-            MockSpec("package-a", "1.0"),
-            MockSpec("package-b", "1.0"),
-            MockSpec("other-c", "1.0"),
-            MockSpec("package-d", "1.0"),
-        ]
-        for spec in specs:
-            status.add_build(spec, explicit=True, control_w_conn=MockConnection())
+        build_ids = ["package-a", "package-b", "other-c", "package-d"]
+        for build_id in build_ids:
+            add_build(tui, build_id)
 
         # Filter to only "package-*"
-        status.search_term = "package"
+        tui.search_term = "package"
 
         # Should only navigate through matching builds
-        first_id = status._get_next(1)
-        assert first_id and first_id == specs[0].dag_hash()
+        first_id = tui._get_next(1)
+        assert first_id and first_id == build_ids[0]
 
-        status.tracked_build_id = first_id
-        next_id = status._get_next(1)
-        assert next_id and next_id == specs[1].dag_hash()
+        tui.tracked_build_id = first_id
+        next_id = tui._get_next(1)
+        assert next_id and next_id == build_ids[1]
 
-        status.tracked_build_id = next_id
-        next_id = status._get_next(1)
+        tui.tracked_build_id = next_id
+        next_id = tui._get_next(1)
         # Should skip "other-c" and go to "package-d"
-        assert next_id and next_id == specs[3].dag_hash()
+        assert next_id and next_id == build_ids[3]
 
     def test_get_next_skips_finished(self):
         """Test that navigation skips finished builds"""
-        status, _, _ = create_build_status(total=3)
-        specs = add_mock_builds(status, 3)
+        tui, _, _ = create_tui(total=3)
+        build_ids = add_mock_builds(tui, 3)
 
         # Mark middle build as finished
-        status.update_state(specs[1].dag_hash(), "finished")
+        tui.update_state(build_ids[1], "finished")
 
         # Navigate from first
-        status.tracked_build_id = specs[0].dag_hash()
-        next_id = status._get_next(1)
+        tui.tracked_build_id = build_ids[0]
+        next_id = tui._get_next(1)
         # Should skip finished build and go to third
-        assert next_id == specs[2].dag_hash()
+        assert next_id == build_ids[2]
 
     def test_get_next_no_matching(self):
         """Test that _get_next returns None when no builds match"""
-        status, _, _ = create_build_status(total=2)
-        specs = add_mock_builds(status, 2)
+        tui, _, _ = create_tui(total=2)
+        build_ids = add_mock_builds(tui, 2)
 
         # Mark both as finished
-        for spec in specs:
-            status.update_state(spec.dag_hash(), "finished")
+        for build_id in build_ids:
+            tui.update_state(build_id, "finished")
 
         # Should return None since no unfinished builds
-        result = status._get_next(1)
+        result = tui._get_next(1)
         assert result is None
 
     def test_get_next_fallback_when_tracked_filtered_out(self):
         """Test that _get_next falls back correctly when tracked build no longer matches filter"""
-        status, _, _ = create_build_status(total=3)
+        tui, _, _ = create_tui(total=3)
 
-        specs = [
-            MockSpec("package-a", "1.0"),
-            MockSpec("package-b", "1.0"),
-            MockSpec("other-c", "1.0"),
-        ]
-        for spec in specs:
-            status.add_build(spec, explicit=True, control_w_conn=MockConnection())
+        build_ids = ["package-a", "package-b", "other-c"]
+        for build_id in build_ids:
+            add_build(tui, build_id)
 
         # Start tracking "other-c"
-        status.tracked_build_id = specs[2].dag_hash()
+        tui.tracked_build_id = build_ids[2]
 
         # Now apply a filter that excludes the tracked build
-        status.search_term = "package"
+        tui.search_term = "package"
 
         # _get_next should fall back to first matching build (forward)
-        next_id = status._get_next(1)
-        assert next_id == specs[0].dag_hash()
+        next_id = tui._get_next(1)
+        assert next_id == build_ids[0]
 
         # Test backward direction, should fall back to last matching build
-        status.tracked_build_id = specs[2].dag_hash()  # Reset to filtered-out build
-        prev_id = status._get_next(-1)
-        assert prev_id == specs[1].dag_hash()
+        tui.tracked_build_id = build_ids[2]  # Reset to filtered-out build
+        prev_id = tui._get_next(-1)
+        assert prev_id == build_ids[1]
 
 
 class TestTerminalSizes:
@@ -705,12 +697,12 @@ class TestTerminalSizes:
 
     def test_small_terminal_truncation(self):
         """Test that output is truncated for small terminals"""
-        status, _, fake_stdout = create_build_status(total=10, terminal_cols=80, terminal_rows=10)
+        tui, _, fake_stdout = create_tui(total=10, terminal_cols=80, terminal_rows=10)
 
         # Add more builds than can fit on screen
-        add_mock_builds(status, 10)
+        add_mock_builds(tui, 10)
 
-        status.update()
+        tui.render()
         output = fake_stdout.getvalue()
 
         # Should contain "more..." message indicating truncation
@@ -718,10 +710,10 @@ class TestTerminalSizes:
 
     def test_large_terminal_no_truncation(self):
         """Test that all builds shown on large terminal"""
-        status, _, fake_stdout = create_build_status(total=3, terminal_cols=120)
-        add_mock_builds(status, 3)
+        tui, _, fake_stdout = create_tui(total=3, terminal_cols=120)
+        add_mock_builds(tui, 3)
 
-        status.update()
+        tui.render()
         output = fake_stdout.getvalue()
 
         # Should not contain truncation message
@@ -732,10 +724,10 @@ class TestTerminalSizes:
 
     def test_narrow_terminal_short_header(self):
         """Test that narrow terminals get shortened header"""
-        status, _, fake_stdout = create_build_status(total=1, terminal_cols=40)
-        add_mock_builds(status, 1)
+        tui, _, fake_stdout = create_tui(total=1, terminal_cols=40)
+        add_mock_builds(tui, 1)
 
-        status.update()
+        tui.render()
         output = fake_stdout.getvalue()
 
         # Should not contain the full header with hints
@@ -749,9 +741,14 @@ class TestBuildInfo:
 
     def test_build_info_creation(self):
         """Test that BuildInfo is created correctly"""
-        spec = MockSpec("mypackage", "1.0")
-
-        build_info = inst.BuildInfo(spec, explicit=True, control_w_conn=MockConnection())
+        build_info = inst.BuildInfo(
+            "mypackage",
+            name="mypackage",
+            version="1.0",
+            external=False,
+            prefix="/fake/prefix/mypackage",
+            explicit=True,
+        )
 
         assert build_info.name == "mypackage"
         assert build_info.version == "1.0"
@@ -763,9 +760,14 @@ class TestBuildInfo:
 
     def test_build_info_external_package(self):
         """Test BuildInfo for external package"""
-        spec = MockSpec("external-pkg", "1.0", external=True)
-
-        build_info = inst.BuildInfo(spec, explicit=False, control_w_conn=MockConnection())
+        build_info = inst.BuildInfo(
+            "external-pkg",
+            name="external-pkg",
+            version="1.0",
+            external=True,
+            prefix="/usr",
+            explicit=False,
+        )
 
         assert build_info.external is True
 
@@ -775,71 +777,69 @@ class TestLogFollowing:
 
     def test_print_logs_when_following(self):
         """Test that logs are printed when following a specific build"""
-        status, _, fake_stdout = create_build_status()
-        (spec,) = add_mock_builds(status, 1)
-        build_id = spec.dag_hash()
+        tui, _, fake_stdout = create_tui()
+        [build_id] = add_mock_builds(tui, 1)
 
         # Switch to log-following mode
-        status.overview_mode = False
-        status.tracked_build_id = build_id
+        tui.overview_mode = False
+        tui.tracked_build_id = build_id
 
         # Send some log data
         log_data = b"Building package...\nRunning tests...\n"
-        status.print_logs(build_id, log_data)
+        tui.print_logs(build_id, log_data)
 
         # Check that logs were echoed to stdout
         assert fake_stdout._buffer.getvalue() == log_data
 
     def test_print_logs_discarded_when_in_overview_mode(self):
         """Test that logs are discarded when in overview mode"""
-        status, _, fake_stdout = create_build_status()
-        (spec,) = add_mock_builds(status, 1)
-        build_id = spec.dag_hash()
+        tui, _, fake_stdout = create_tui()
+        [build_id] = add_mock_builds(tui, 1)
 
         # Stay in overview mode
-        assert status.overview_mode is True
+        assert tui.overview_mode is True
 
         # Try to print logs
         log_data = b"Should not be printed\n"
-        status.print_logs(build_id, log_data)
+        tui.print_logs(build_id, log_data)
 
         # Nothing should be printed
         assert fake_stdout.getvalue() == ""
 
     def test_print_logs_discarded_when_not_tracked(self):
         """Test that logs from non-tracked builds are discarded"""
-        status, _, fake_stdout = create_build_status(total=2)
-        spec1, spec2 = add_mock_builds(status, 2)
+        tui, _, fake_stdout = create_tui(total=2)
+        build_ids = add_mock_builds(tui, 2)
 
-        # Switch to log-following mode for spec1
-        status.overview_mode = False
-        status.tracked_build_id = spec1.dag_hash()
+        # Switch to log-following mode for the first build
+        tui.overview_mode = False
+        tui.tracked_build_id = build_ids[0]
 
-        # Try to print logs from spec2 (not tracked)
+        # Try to print logs from the second build (not tracked)
         log_data = b"Logs from pkg2\n"
-        status.print_logs(spec2.dag_hash(), log_data)
+        tui.print_logs(build_ids[1], log_data)
 
-        # Nothing should be printed since we're tracking pkg1, not pkg2
+        # Nothing should be printed since we're tracking pkg0, not pkg1
         assert fake_stdout.getvalue() == ""
 
     def test_can_navigate_to_failed_build(self):
         """Test that navigating to a failed build shows log summary and path"""
-        status, _, fake_stdout = create_build_status(total=3)
-        specs = add_mock_builds(status, 3)
+        tui, _, fake_stdout = create_tui(total=3)
+        build_ids = add_mock_builds(tui, 3)
 
         # Mark the middle build as failed and set log info
-        status.update_state(specs[1].dag_hash(), "failed")
-        build_info = status.builds[specs[1].dag_hash()]
+        tui.update_state(build_ids[1], "failed")
+        build_info = tui.builds[build_ids[1]]
         build_info.log_summary = "Error: something went wrong\n"
         build_info.log_path = "/tmp/spack/pkg1.log"
 
         # Navigate from pkg0 to next -- should land on failed pkg1
-        status.tracked_build_id = specs[0].dag_hash()
-        next_id = status._get_next(1)
-        assert next_id == specs[1].dag_hash()
+        tui.tracked_build_id = build_ids[0]
+        next_id = tui._get_next(1)
+        assert next_id == build_ids[1]
 
         # Actually navigate to it
-        status.next(1)
+        tui.next(1)
         output = fake_stdout.getvalue()
         assert "Log summary of pkg1" in output
         assert "Error: something went wrong" in output
@@ -847,17 +847,17 @@ class TestLogFollowing:
 
     def test_navigation_skips_finished_build(self):
         """Test that navigation skips successfully finished builds"""
-        status, _, _ = create_build_status(total=3)
-        specs = add_mock_builds(status, 3)
+        tui, _, _ = create_tui(total=3)
+        build_ids = add_mock_builds(tui, 3)
 
         # Mark the middle build as finished (successful)
-        status.update_state(specs[1].dag_hash(), "finished")
+        tui.update_state(build_ids[1], "finished")
 
         # Try to get next build, should skip the finished one
-        status.tracked_build_id = specs[0].dag_hash()
-        next_id = status._get_next(1)
+        tui.tracked_build_id = build_ids[0]
+        next_id = tui._get_next(1)
 
-        assert next_id == specs[2].dag_hash()
+        assert next_id == build_ids[2]
 
 
 class TestNavigationIntegration:
@@ -865,19 +865,21 @@ class TestNavigationIntegration:
 
     def test_next_switches_from_overview_to_logs(self):
         """Test that next() switches from overview mode to log-following mode"""
-        status, _, fake_stdout = create_build_status(total=2)
-        specs = add_mock_builds(status, 2)
+        tui, _, fake_stdout = create_tui(total=2)
+        build_ids = add_mock_builds(tui, 2)
+        echo_calls = record_echo(tui)
 
         # Start in overview mode
-        assert status.overview_mode is True
-        assert status.tracked_build_id == ""
+        assert tui.overview_mode is True
+        assert tui.tracked_build_id == ""
 
         # Call next() to start following first build
-        status.next()
+        tui.next()
 
         # Should have switched to log-following mode
-        assert status.overview_mode is False
-        assert status.tracked_build_id == specs[0].dag_hash()
+        assert tui.overview_mode is False
+        assert tui.tracked_build_id == build_ids[0]
+        assert echo_calls == [(build_ids[0], True)]
 
         # Should have printed "Following logs" message
         output = fake_stdout.getvalue()
@@ -886,83 +888,86 @@ class TestNavigationIntegration:
 
     def test_next_cycles_through_builds(self):
         """Test that next() cycles through multiple builds"""
-        status, _, fake_stdout = create_build_status(total=3)
-        specs = add_mock_builds(status, 3)
+        tui, _, fake_stdout = create_tui(total=3)
+        build_ids = add_mock_builds(tui, 3)
+        echo_calls = record_echo(tui)
 
         # Start following first build
-        status.next()
-        assert status.tracked_build_id == specs[0].dag_hash()
+        tui.next()
+        assert tui.tracked_build_id == build_ids[0]
 
         fake_stdout.clear()
 
         # Navigate to next
-        status.next(1)
-        assert status.tracked_build_id == specs[1].dag_hash()
+        tui.next(1)
+        assert tui.tracked_build_id == build_ids[1]
         assert "pkg1" in fake_stdout.getvalue()
+        # Echoing stopped for the previous build and started for the new one
+        assert echo_calls[-2:] == [(build_ids[0], False), (build_ids[1], True)]
 
         fake_stdout.clear()
 
         # Navigate to next (third build)
-        status.next(1)
-        assert status.tracked_build_id == specs[2].dag_hash()
+        tui.next(1)
+        assert tui.tracked_build_id == build_ids[2]
         assert "pkg2" in fake_stdout.getvalue()
 
         fake_stdout.clear()
 
         # Navigate to next (should wrap to first)
-        status.next(1)
-        assert status.tracked_build_id == specs[0].dag_hash()
+        tui.next(1)
+        assert tui.tracked_build_id == build_ids[0]
         assert "pkg0" in fake_stdout.getvalue()
 
     def test_next_backward_navigation(self):
         """Test that next(-1) navigates backward"""
-        status, _, _ = create_build_status(total=3)
-        specs = add_mock_builds(status, 3)
+        tui, _, _ = create_tui(total=3)
+        build_ids = add_mock_builds(tui, 3)
 
         # Start at first build
-        status.next()
-        assert status.tracked_build_id == specs[0].dag_hash()
+        tui.next()
+        assert tui.tracked_build_id == build_ids[0]
 
         # Go backward (should wrap to last)
-        status.next(-1)
-        assert status.tracked_build_id == specs[2].dag_hash()
+        tui.next(-1)
+        assert tui.tracked_build_id == build_ids[2]
 
         # Go backward again
-        status.next(-1)
-        assert status.tracked_build_id == specs[1].dag_hash()
+        tui.next(-1)
+        assert tui.tracked_build_id == build_ids[1]
 
     def test_next_does_nothing_when_no_builds(self):
         """Test that next() does nothing when no unfinished builds exist"""
-        status, _, _ = create_build_status(total=1)
-        (spec,) = add_mock_builds(status, 1)
+        tui, _, _ = create_tui(total=1)
+        [build_id] = add_mock_builds(tui, 1)
 
         # Mark as finished
-        status.update_state(spec.dag_hash(), "finished")
+        tui.update_state(build_id, "finished")
 
         # Try to navigate
-        initial_mode = status.overview_mode
-        initial_tracked = status.tracked_build_id
+        initial_mode = tui.overview_mode
+        initial_tracked = tui.tracked_build_id
 
-        status.next()
+        tui.next()
 
         # Nothing should change
-        assert status.overview_mode == initial_mode
-        assert status.tracked_build_id == initial_tracked
+        assert tui.overview_mode == initial_mode
+        assert tui.tracked_build_id == initial_tracked
 
     def test_next_does_nothing_when_same_build(self):
         """Test that next() doesn't re-print when already on the same build"""
-        status, _, fake_stdout = create_build_status(total=1)
-        (spec,) = add_mock_builds(status, 1)
+        tui, _, fake_stdout = create_tui(total=1)
+        [build_id] = add_mock_builds(tui, 1)
 
         # Start following
-        status.next()
-        assert status.tracked_build_id == spec.dag_hash()
+        tui.next()
+        assert tui.tracked_build_id == build_id
 
         # Clear output
         fake_stdout.clear()
 
         # Try to navigate to "next" (which is the same build)
-        status.next()
+        tui.next()
 
         # Should not print anything
         assert fake_stdout.getvalue() == ""
@@ -973,80 +978,82 @@ class TestToggle:
 
     def test_toggle_from_overview_calls_next(self):
         """Test that toggle() from overview mode calls next()"""
-        status, _, fake_stdout = create_build_status(total=2)
-        add_mock_builds(status, 2)
+        tui, _, fake_stdout = create_tui(total=2)
+        add_mock_builds(tui, 2)
 
         # Start in overview mode
-        assert status.overview_mode is True
+        assert tui.overview_mode is True
 
         # Toggle should call next()
-        status.toggle()
+        tui.toggle()
 
         # Should now be following logs
-        assert status.overview_mode is False
-        assert status.tracked_build_id != ""
+        assert tui.overview_mode is False
+        assert tui.tracked_build_id != ""
         assert "Following logs of" in fake_stdout.getvalue()
 
     def test_toggle_from_logs_returns_to_overview(self):
         """Test that toggle() from log-following mode returns to overview"""
-        status, _, _ = create_build_status(total=2)
-        add_mock_builds(status, 2)
+        tui, _, _ = create_tui(total=2)
+        add_mock_builds(tui, 2)
+        echo_calls = record_echo(tui)
 
         # Switch to log-following mode first
-        status.next()
-        assert status.overview_mode is False
-        tracked_id = status.tracked_build_id
+        tui.next()
+        assert tui.overview_mode is False
+        tracked_id = tui.tracked_build_id
         assert tracked_id != ""
 
         # Set some search state to verify cleanup
-        status.search_term = "test"
-        status.search_mode = True
-        status.active_area_rows = 5
+        tui.search_term = "test"
+        tui.search_mode = True
+        tui.active_area_rows = 5
 
         # Toggle back to overview
-        status.toggle()
+        tui.toggle()
 
         # Should be back in overview mode with cleaned state
-        assert status.overview_mode is True
-        assert status.tracked_build_id == ""
-        assert status.search_term == ""
-        assert status.search_mode is False
-        assert status.active_area_rows == 0
-        assert status.dirty is True
+        assert tui.overview_mode is True
+        assert tui.tracked_build_id == ""
+        assert tui.search_term == ""
+        assert tui.search_mode is False
+        assert tui.active_area_rows == 0
+        assert tui.dirty is True
+        # Echoing was stopped for the previously tracked build
+        assert echo_calls[-1] == (tracked_id, False)
 
     def test_update_state_finished_triggers_toggle_when_tracking(self):
         """Test that finishing a tracked build triggers toggle back to overview"""
-        status, _, _ = create_build_status(total=2)
-        specs = add_mock_builds(status, 2)
+        tui, _, _ = create_tui(total=2)
+        build_ids = add_mock_builds(tui, 2)
 
         # Start tracking first build
-        status.next()
-        assert status.overview_mode is False
-        assert status.tracked_build_id == specs[0].dag_hash()
+        tui.next()
+        assert tui.overview_mode is False
+        assert tui.tracked_build_id == build_ids[0]
 
         # Mark the tracked build as finished
-        status.update_state(specs[0].dag_hash(), "finished")
+        tui.update_state(build_ids[0], "finished")
 
         # Should have toggled back to overview mode
-        assert status.overview_mode is True
-        assert status.tracked_build_id == ""
+        assert tui.overview_mode is True
+        assert tui.tracked_build_id == ""
 
     def test_partial_line_newline_on_toggle_and_next(self):
         """Ensure newline is inserted before mode transitions when log doesn't end with newline."""
-        status, _, fake_stdout = create_build_status(total=2)
-        specs = add_mock_builds(status, 2)
-        build_a, build_b = specs[0].dag_hash(), specs[1].dag_hash()
+        tui, _, fake_stdout = create_tui(total=2)
+        build_a, build_b = add_mock_builds(tui, 2)
 
         # Follow a build, toggle back and forth between logs and overview mode, and receive logs
         # that may or may not end with newlines.
-        status.next()
-        status.print_logs(build_a, b"checking for foo...")
-        status.toggle()
-        status.next()
-        status.print_logs(build_a, b"checking for bar... yes\n")
-        status.next(1)
-        status.print_logs(build_b, b"checking for baz...")
-        status.next(-1)
+        tui.next()
+        tui.print_logs(build_a, b"checking for foo...")
+        tui.toggle()
+        tui.next()
+        tui.print_logs(build_a, b"checking for bar... yes\n")
+        tui.next(1)
+        tui.print_logs(build_b, b"checking for baz...")
+        tui.next(-1)
 
         written = fake_stdout.getvalue()
 
@@ -1061,15 +1068,14 @@ class TestToggle:
     @pytest.mark.parametrize("filter_padding", [True, False])
     def test_print_logs_filters_padding(self, filter_padding):
         """print_logs strips path-padding placeholders before writing to stdout."""
-        status, _, fake_stdout = create_build_status(filter_padding=filter_padding)
-        (spec,) = add_mock_builds(status, 1)
-        build_id = spec.dag_hash()
+        tui, _, fake_stdout = create_tui(filter_padding=filter_padding)
+        [build_id] = add_mock_builds(tui, 1)
         log_output = b"--with-foo=/base/__spack_path_placeholder__/__spack_path_placeholder__/bin"
 
         # track the build and print logs with the relevant path.
-        status.overview_mode = False
-        status.tracked_build_id = build_id
-        status.print_logs(build_id, log_output)
+        tui.overview_mode = False
+        tui.tracked_build_id = build_id
+        tui.print_logs(build_id, log_output)
         written = fake_stdout._buffer.getvalue()
 
         if filter_padding:
@@ -1081,13 +1087,12 @@ class TestToggle:
     def test_prefix_padding_filter_in_status(self, filter_padding):
         """Test that prefix in status indicator applies padding filter."""
         padded_prefix = "/base/__spack_path_placeholder__/__spack_path_placeholder__/mypackage"
-        status, _, fake_stdout = create_build_status(is_tty=False, filter_padding=filter_padding)
-        spec = MockSpec("mypackage", "1.0", prefix=padded_prefix)
-        status.add_build(spec, explicit=True, control_w_conn=MockConnection())
-        build_id = spec.dag_hash()
-        status.update_state(build_id, "finished")
+        tui, _, fake_stdout = create_tui(is_tty=False, filter_padding=filter_padding)
+        build_id = "mypackage"
+        add_build(tui, build_id, prefix=padded_prefix)
+        tui.update_state(build_id, "finished")
         output = fake_stdout.getvalue()
-        common = f"[+] {spec.dag_hash(7)} {spec.name}@{spec.version}"
+        common = f"[+] {build_id[:7]} mypackage@1.0"
         if filter_padding:
             assert output == f"{common} /base/[padded-to-59-chars]/mypackage\n"
         else:
@@ -1099,28 +1104,24 @@ class TestSearchFilteringIntegration:
 
     def test_search_mode_filters_displayed_builds(self):
         """Test that search mode actually filters what's displayed"""
-        status, _, fake_stdout = create_build_status(total=4)
+        tui, _, fake_stdout = create_tui(total=4)
 
-        specs = [
-            MockSpec("package-foo", "1.0"),
-            MockSpec("package-bar", "2.0"),
-            MockSpec("other-thing", "3.0"),
-            MockSpec("package-baz", "4.0"),
-        ]
-        for spec in specs:
-            status.add_build(spec, explicit=True, control_w_conn=MockConnection())
+        add_build(tui, "package-foo")
+        add_build(tui, "package-bar", version="2.0")
+        add_build(tui, "other-thing", version="3.0")
+        add_build(tui, "package-baz", version="4.0")
 
         # Enter search mode and search for "package"
-        status.enter_search()
-        assert status.search_mode is True
+        tui.enter_search()
+        assert tui.search_mode is True
 
         for character in "package":
-            status.search_input(character)
+            tui.search_input(character)
 
-        assert status.search_term == "package"
+        assert tui.search_term == "package"
 
         # Update to render
-        status.update()
+        tui.render()
         output = fake_stdout.getvalue()
 
         # Should contain filtered builds
@@ -1132,80 +1133,71 @@ class TestSearchFilteringIntegration:
 
         # Should show filter prompt
         assert "filter>" in output
-        assert status.search_term in output
+        assert tui.search_term in output
 
     def test_search_mode_with_navigation(self):
         """Test that navigation respects search filter"""
-        status, _, _ = create_build_status(total=4)
+        tui, _, _ = create_tui(total=4)
 
-        specs = [
-            MockSpec("package-a", "1.0"),
-            MockSpec("other-b", "2.0"),
-            MockSpec("package-c", "3.0"),
-            MockSpec("other-d", "4.0"),
-        ]
-        for spec in specs:
-            status.add_build(spec, explicit=True, control_w_conn=MockConnection())
+        build_ids = ["package-a", "other-b", "package-c", "other-d"]
+        for build_id in build_ids:
+            add_build(tui, build_id)
 
         # Set search term to filter for "package"
-        status.search_term = "package"
+        tui.search_term = "package"
 
         # Start navigating,  should only go through "package-a" and "package-c"
-        status.next()
-        assert status.tracked_build_id == specs[0].dag_hash()  # package-a
+        tui.next()
+        assert tui.tracked_build_id == build_ids[0]  # package-a
 
-        status.next(1)
+        tui.next(1)
         # Should skip other-b and go to package-c
-        assert status.tracked_build_id == specs[2].dag_hash()  # package-c
+        assert tui.tracked_build_id == build_ids[2]  # package-c
 
-        status.next(1)
+        tui.next(1)
         # Should wrap around to package-a
-        assert status.tracked_build_id == specs[0].dag_hash()  # package-a
+        assert tui.tracked_build_id == build_ids[0]  # package-a
 
     def test_search_input_enter_navigates_to_next(self):
         """Test that pressing enter in search mode navigates to next match"""
-        status, _, _ = create_build_status(total=3)
-        specs = add_mock_builds(status, 3)
+        tui, _, _ = create_tui(total=3)
+        build_ids = add_mock_builds(tui, 3)
 
         # Enter search mode
-        status.enter_search()
+        tui.enter_search()
         for character in "pkg":
-            status.search_input(character)
+            tui.search_input(character)
 
         # Press enter (should navigate to first match)
-        status.search_input("\r")
+        tui.search_input("\r")
 
         # Should have started following first matching build
-        assert status.overview_mode is False
-        assert status.tracked_build_id == specs[0].dag_hash()
+        assert tui.overview_mode is False
+        assert tui.tracked_build_id == build_ids[0]
 
     def test_clearing_search_shows_all_builds(self):
         """Test that clearing search term shows all builds again"""
-        status, _, fake_stdout = create_build_status(total=3)
+        tui, _, fake_stdout = create_tui(total=3)
 
-        specs = [
-            MockSpec("package-a", "1.0"),
-            MockSpec("other-b", "2.0"),
-            MockSpec("package-c", "3.0"),
-        ]
-        for spec in specs:
-            status.add_build(spec, explicit=True, control_w_conn=MockConnection())
+        add_build(tui, "package-a")
+        add_build(tui, "other-b", version="2.0")
+        add_build(tui, "package-c", version="3.0")
 
         # Enter search and type something
-        status.enter_search()
-        status.search_input("p")
-        status.search_input("a")
-        status.search_input("c")
-        assert status.search_term == "pac"
+        tui.enter_search()
+        tui.search_input("p")
+        tui.search_input("a")
+        tui.search_input("c")
+        assert tui.search_term == "pac"
 
         # Clear it with backspace
-        status.search_input("\x7f")  # backspace
-        status.search_input("\x7f")  # backspace
-        status.search_input("\x7f")  # backspace
-        assert status.search_term == ""
+        tui.search_input("\x7f")  # backspace
+        tui.search_input("\x7f")  # backspace
+        tui.search_input("\x7f")  # backspace
+        assert tui.search_term == ""
 
         # Update to render
-        status.update()
+        tui.render()
         output = fake_stdout.getvalue()
 
         # All builds should be visible now
@@ -1219,9 +1211,9 @@ class TestEdgeCases:
 
     def test_empty_build_list(self):
         """Test update with no builds"""
-        status, _, fake_stdout = create_build_status(total=0)
+        tui, _, fake_stdout = create_tui(total=0)
 
-        status.update()
+        tui.render()
         output = fake_stdout.getvalue()
 
         # Should render header but no builds
@@ -1230,11 +1222,11 @@ class TestEdgeCases:
 
     def test_no_header_with_finalize(self):
         """Test that we don't print a header with finalize=True"""
-        status, _, fake_stdout = create_build_status(total=2, color=False)
-        spec_a, spec_b = add_mock_builds(status, 2)
-        status.update_state(spec_a.dag_hash(), "finished")
-        status.update_state(spec_b.dag_hash(), "failed")
-        status.update(finalize=True)
+        tui, _, fake_stdout = create_tui(total=2, color=False)
+        build_a, build_b = add_mock_builds(tui, 2)
+        tui.update_state(build_a, "finished")
+        tui.update_state(build_b, "failed")
+        tui.render(finalize=True)
 
         output = fake_stdout.getvalue()
 
@@ -1242,164 +1234,137 @@ class TestEdgeCases:
         assert "Progress:" not in output
 
         # Should contain final status lines for both builds
-        assert f"[+] {spec_a.dag_hash(7)} {spec_a.name}@{spec_a.version}" in output
-        assert f"[x] {spec_b.dag_hash(7)} {spec_b.name}@{spec_b.version}" in output
+        assert f"[+] {build_a[:7]} pkg0@0.0" in output
+        assert f"[x] {build_b[:7]} pkg1@1.0" in output
 
     def test_all_builds_finished(self):
         """Test when all builds are finished"""
-        status, fake_time, _ = create_build_status(total=2)
-        specs = add_mock_builds(status, 2)
+        tui, fake_time, _ = create_tui(total=2)
+        build_ids = add_mock_builds(tui, 2)
 
         # Mark all as finished
-        for spec in specs:
-            status.update_state(spec.dag_hash(), "finished")
+        for build_id in build_ids:
+            tui.update_state(build_id, "finished")
 
         # Advance time and update
         fake_time[0] = inst.CLEANUP_TIMEOUT + 0.01
-        status.update()
+        tui.render()
 
         # All should be cleaned up
-        assert len(status.builds) == 0
-        assert status.completed == 2
+        assert len(tui.builds) == 0
+        assert tui.completed == 2
 
     def test_update_progress_rounds_correctly(self):
         """Test that progress percentage rounding works"""
-        status, _, _ = create_build_status()
-        (spec,) = add_mock_builds(status, 1)
-        build_id = spec.dag_hash()
+        tui, _, _ = create_tui()
+        [build_id] = add_mock_builds(tui, 1)
 
         # Test rounding
-        status.update_progress(build_id, 1, 3)
-        assert status.builds[build_id].progress_percent == 33  # int(100/3)
+        tui.update_progress(build_id, 1, 3)
+        assert tui.builds[build_id].progress_percent == 33  # int(100/3)
 
-        status.update_progress(build_id, 2, 3)
-        assert status.builds[build_id].progress_percent == 66  # int(200/3)
+        tui.update_progress(build_id, 2, 3)
+        assert tui.builds[build_id].progress_percent == 66  # int(200/3)
 
-        status.update_progress(build_id, 3, 3)
-        assert status.builds[build_id].progress_percent == 100
+        tui.update_progress(build_id, 3, 3)
+        assert tui.builds[build_id].progress_percent == 100
 
 
-class TestBuildStatusVerbose:
-    """Tests for verbose non-TTY log tracking in BuildStatus."""
+class TestTerminalUIVerbose:
+    """Tests for verbose non-TTY log tracking in TerminalUI."""
 
     def test_verbose_tracks_first_build(self):
         """First add_build() in verbose non-TTY mode sets tracked_build_id and enables echoing."""
-        bs, _, _ = create_build_status(is_tty=False, verbose=True, total=4)
-        spec = MockSpec("trivial-install-test-package", "1.0")
+        tui, _, _ = create_tui(is_tty=False, verbose=True, total=4)
+        echo_calls = record_echo(tui)
 
-        r_conn, w_conn = Pipe(duplex=False)
+        add_build(tui, "trivial-install-test-package")
 
-        with r_conn, w_conn:
-            bs.add_build(spec, explicit=True, control_w_conn=w_conn)
-
-            assert bs.tracked_build_id == spec.dag_hash()
-            written = os.read(r_conn.fileno(), 1)
-            assert written == b"1"
+        assert tui.tracked_build_id == "trivial-install-test-package"
+        assert echo_calls == [("trivial-install-test-package", True)]
 
     def test_verbose_does_not_track_when_already_tracking(self):
         """Second add_build() while already tracking does not switch tracking."""
-        bs, _, _ = create_build_status(is_tty=False, verbose=True, total=4)
-        spec1 = MockSpec("pkg1", "1.0")
-        spec2 = MockSpec("pkg2", "1.0")
+        tui, _, _ = create_tui(is_tty=False, verbose=True, total=4)
+        echo_calls = record_echo(tui)
 
-        r1, w1 = Pipe(duplex=False)
-        r2, w2 = Pipe(duplex=False)
-        with r1, w1, r2, w2:
-            bs.add_build(spec1, explicit=True, control_w_conn=w1)
-            first_tracked = bs.tracked_build_id
+        add_build(tui, "pkg1")
+        first_tracked = tui.tracked_build_id
 
-            bs.add_build(spec2, explicit=False, control_w_conn=w2)
-            assert bs.tracked_build_id == first_tracked
-            assert bs.tracked_build_id == spec1.dag_hash()
+        add_build(tui, "pkg2", explicit=False)
+        assert tui.tracked_build_id == first_tracked
+        assert tui.tracked_build_id == "pkg1"
 
-            # Second build should not have received b"1"
-            assert not r2.poll(), "Second build should not be enabled"
+        # Echoing should not have been enabled for the second build
+        assert echo_calls == [("pkg1", True)]
 
     def test_verbose_switches_on_finish(self):
         """After the tracked build finishes, tracked_build_id is cleared."""
-        bs, _, _ = create_build_status(is_tty=False, verbose=True, total=4)
-        spec = MockSpec("trivial-install-test-package", "1.0")
+        tui, _, _ = create_tui(is_tty=False, verbose=True, total=4)
 
-        r_conn, w_conn = Pipe(duplex=False)
+        add_build(tui, "trivial-install-test-package")
+        assert tui.tracked_build_id == "trivial-install-test-package"
 
-        with r_conn, w_conn:
-            bs.add_build(spec, explicit=True, control_w_conn=w_conn)
-            assert bs.tracked_build_id == spec.dag_hash()
-
-            bs.update_state(spec.dag_hash(), "finished")
-            assert bs.tracked_build_id == ""
+        tui.update_state("trivial-install-test-package", "finished")
+        assert tui.tracked_build_id == ""
 
     def test_verbose_print_logs_tracked(self):
         """print_logs() for the tracked build writes to stdout."""
-        bs, _, stdout = create_build_status(is_tty=False, verbose=True, total=1)
-        spec = MockSpec("trivial-install-test-package", "1.0")
+        tui, _, stdout = create_tui(is_tty=False, verbose=True, total=1)
 
-        r_conn, w_conn = Pipe(duplex=False)
+        add_build(tui, "trivial-install-test-package")
+        tui.print_logs("trivial-install-test-package", b"hello log\n")
 
-        with r_conn, w_conn:
-            bs.add_build(spec, explicit=True, control_w_conn=w_conn)
-            bs.print_logs(spec.dag_hash(), b"hello log\n")
-
-            stdout.flush()
-            assert stdout.buffer.getvalue() == b"hello log\n"
+        stdout.flush()
+        assert stdout.buffer.getvalue() == b"hello log\n"
 
     def test_verbose_print_logs_untracked(self):
         """print_logs() for an untracked build discards data."""
-        bs, _, stdout = create_build_status(is_tty=False, verbose=True, total=2)
-        spec1 = MockSpec("pkg1", "1.0")
-        spec2 = MockSpec("pkg2", "1.0")
+        tui, _, stdout = create_tui(is_tty=False, verbose=True, total=2)
 
-        r1, w1 = Pipe(duplex=False)
+        add_build(tui, "pkg1")
+        add_build(tui, "pkg2", explicit=False)
 
-        with r1, w1:
-            bs.add_build(spec1, explicit=True, control_w_conn=w1)
-            bs.add_build(spec2, explicit=False, control_w_conn=None)
+        # Only pkg1 is tracked; pkg2 logs should be discarded
+        tui.print_logs("pkg2", b"ignored\n")
 
-            # Only spec1 is tracked; spec2 logs should be discarded
-            bs.print_logs(spec2.dag_hash(), b"ignored\n")
-
-            stdout.flush()
-            assert stdout.buffer.getvalue() == b""
+        stdout.flush()
+        assert stdout.buffer.getvalue() == b""
 
     def test_verbose_tty_no_effect(self):
         """In TTY mode, add_build() does not set tracked_build_id automatically."""
-        bs, _, _ = create_build_status(is_tty=True, verbose=True, total=4)
-        spec = MockSpec("trivial-install-test-package", "1.0")
+        tui, _, _ = create_tui(is_tty=True, verbose=True, total=4)
+        echo_calls = record_echo(tui)
 
-        r_conn, w_conn = Pipe(duplex=False)
-
-        with r_conn, w_conn:
-            bs.add_build(spec, explicit=True, control_w_conn=w_conn)
-            assert bs.tracked_build_id == ""
+        add_build(tui, "trivial-install-test-package")
+        assert tui.tracked_build_id == ""
+        assert echo_calls == []
 
 
-class TestBuildStatusColor:
-    """Tests that BuildStatus respects the explicit color=True/False parameter."""
+class TestTerminalUIColor:
+    """Tests that TerminalUI respects the explicit color=True/False parameter."""
 
     def test_non_tty_finished_color_true_emits_green(self):
         """color=True in non-TTY mode: finished line has per-component ANSI colors."""
-        spec = MockSpec("pkg", "1.0")
-        status, _, stdout = create_build_status(is_tty=False, total=1, color=True)
-        status.add_build(spec, explicit=True)
-        status.update_state(spec.dag_hash(), "finished")
+        tui, _, stdout = create_tui(is_tty=False, total=1, color=True)
+        add_build(tui, "pkg")
+        tui.update_state("pkg", "finished")
         # green indicator, reset, dark-gray hash
         assert stdout.getvalue().startswith("\033[32m[+]\033[0m \033[0;90m")
 
     def test_non_tty_failed_color_true_emits_red(self):
         """color=True in non-TTY mode: failed line has per-component ANSI colors."""
-        spec = MockSpec("pkg", "1.0")
-        status, _, stdout = create_build_status(is_tty=False, total=1, color=True)
-        status.add_build(spec, explicit=True)
-        status.update_state(spec.dag_hash(), "failed")
+        tui, _, stdout = create_tui(is_tty=False, total=1, color=True)
+        add_build(tui, "pkg")
+        tui.update_state("pkg", "failed")
         # red indicator, reset, dark-gray hash
         assert stdout.getvalue().startswith("\033[31m[x]\033[0m \033[0;90m")
 
     def test_non_tty_finished_color_false_no_ansi(self):
         """color=False in non-TTY mode: finished line has no ANSI escape codes."""
-        spec = MockSpec("pkg", "1.0")
-        status, _, stdout = create_build_status(is_tty=False, total=1, color=False)
-        status.add_build(spec, explicit=True)
-        status.update_state(spec.dag_hash(), "finished")
+        tui, _, stdout = create_tui(is_tty=False, total=1, color=False)
+        add_build(tui, "pkg")
+        tui.update_state("pkg", "finished")
         assert "\033[" not in stdout.getvalue()
 
 
@@ -1408,40 +1373,40 @@ class TestTargetJobs:
 
     def test_set_jobs_marks_dirty(self):
         """set_jobs with a new value should update target_jobs and mark dirty."""
-        status, _, _ = create_build_status()
-        status.dirty = False
-        status.set_jobs(3, 2)
-        assert status.actual_jobs == 3
-        assert status.target_jobs == 2
-        assert status.dirty is True
-        status.set_jobs(2, 2)
-        assert status.actual_jobs == 2
-        assert status.target_jobs == 2
+        tui, _, _ = create_tui()
+        tui.dirty = False
+        tui.set_jobs(3, 2)
+        assert tui.actual_jobs == 3
+        assert tui.target_jobs == 2
+        assert tui.dirty is True
+        tui.set_jobs(2, 2)
+        assert tui.actual_jobs == 2
+        assert tui.target_jobs == 2
 
     def test_set_jobs_same_value_no_dirty(self):
         """set_jobs with the same value should not mark dirty."""
-        status, _, _ = create_build_status()
-        status.set_jobs(5, 5)
-        status.dirty = False
-        status.set_jobs(5, 5)
-        assert status.dirty is False
+        tui, _, _ = create_tui()
+        tui.set_jobs(5, 5)
+        tui.dirty = False
+        tui.set_jobs(5, 5)
+        assert tui.dirty is False
 
     def test_header_shows_target_jobs(self):
         """The rendered header should contain the target_jobs count and the word 'jobs'."""
-        status, _, fake_stdout = create_build_status(total=1)
-        add_mock_builds(status, 1)
-        status.set_jobs(4, 4)
-        status.update()
+        tui, _, fake_stdout = create_tui(total=1)
+        add_mock_builds(tui, 1)
+        tui.set_jobs(4, 4)
+        tui.render()
         output = fake_stdout.getvalue()
         assert "4" in output
         assert "jobs" in output
 
     def test_header_shows_arrow_when_pending(self):
         """When actual != target, the header should show 'actual=>target jobs'."""
-        status, _, fake_stdout = create_build_status(total=1)
-        add_mock_builds(status, 1)
-        status.set_jobs(4, 2)
-        status.update()
+        tui, _, fake_stdout = create_tui(total=1)
+        add_mock_builds(tui, 1)
+        tui.set_jobs(4, 2)
+        tui.render()
         output = fake_stdout.getvalue()
         assert "4=>2" in output
 
@@ -1451,44 +1416,43 @@ class TestHeadlessMode:
 
     def test_update_suppressed_when_headless(self):
         """update() should not write anything when headless is True."""
-        status, time_values, stdout = create_build_status(is_tty=True, total=1)
-        add_mock_builds(status, 1)
-        status.headless = True
+        tui, time_values, stdout = create_tui(is_tty=True, total=1)
+        add_mock_builds(tui, 1)
+        tui.headless = True
         time_values.append(10.0)
-        status.update()
+        tui.render()
         assert stdout.getvalue() == ""
 
     def test_print_logs_suppressed_when_headless(self):
         """print_logs() should discard data when headless is True."""
-        status, _, stdout = create_build_status(is_tty=True, total=1)
-        specs = add_mock_builds(status, 1)
-        status.tracked_build_id = specs[0].dag_hash()
-        status.headless = True
-        status.print_logs(specs[0].dag_hash(), b"hello world\n")
+        tui, _, stdout = create_tui(is_tty=True, total=1)
+        build_ids = add_mock_builds(tui, 1)
+        tui.tracked_build_id = build_ids[0]
+        tui.headless = True
+        tui.print_logs(build_ids[0], b"hello world\n")
         assert stdout.getvalue() == ""
 
     def test_update_state_non_tty_suppressed_when_headless(self):
         """update_state() non-TTY output should be suppressed when headless."""
-        status, _, stdout = create_build_status(is_tty=False, total=1)
-        spec = MockSpec("pkg", "1.0")
-        status.add_build(spec, explicit=True)
-        status.headless = True
+        tui, _, stdout = create_tui(is_tty=False, total=1)
+        add_build(tui, "pkg")
+        tui.headless = True
         stdout.clear()
-        status.update_state(spec.dag_hash(), "finished")
+        tui.update_state("pkg", "finished")
         assert stdout.getvalue() == ""
 
     def test_update_works_after_headless_cleared(self):
         """update() should work normally once headless is cleared."""
-        status, time_values, stdout = create_build_status(is_tty=True, total=1, color=False)
-        add_mock_builds(status, 1)
-        status.headless = True
+        tui, time_values, stdout = create_tui(is_tty=True, total=1, color=False)
+        add_mock_builds(tui, 1)
+        tui.headless = True
         time_values.append(10.0)
-        status.update()
+        tui.render()
         assert stdout.getvalue() == ""
         # Clear headless and verify output resumes
-        status.headless = False
-        status.dirty = True
-        status.update()
+        tui.headless = False
+        tui.dirty = True
+        tui.render()
         assert "[/] pkg0 pkg0@0.0 starting" in stdout.getvalue()
 
 

--- a/lib/spack/spack/test/jobserver.py
+++ b/lib/spack/spack/test/jobserver.py
@@ -136,7 +136,7 @@ class TestJobServer:
 
     def test_creates_new_jobserver(self):
         """Should create a new FIFO-based jobserver when none exists."""
-        js = PosixJobServer(4)
+        js = PosixJobServer(4, makeflags="")
 
         try:
             assert js.created is True
@@ -150,7 +150,7 @@ class TestJobServer:
 
     def test_attaches_to_existing_fifo(self):
         """Should attach to existing FIFO jobserver from environment."""
-        js1 = PosixJobServer(4)
+        js1 = PosixJobServer(4, makeflags="")
         assert js1.fifo_path
 
         try:
@@ -169,7 +169,7 @@ class TestJobServer:
 
     def test_acquire_tokens(self):
         """Should acquire tokens from jobserver."""
-        js = PosixJobServer(5)
+        js = PosixJobServer(5, makeflags="")
 
         try:
             assert js.acquire(2) == 2
@@ -186,7 +186,7 @@ class TestJobServer:
 
     def test_release_tokens(self):
         """Should release tokens back to jobserver."""
-        js = PosixJobServer(5)
+        js = PosixJobServer(5, makeflags="")
 
         try:
             assert js.acquire(2) == 2
@@ -203,7 +203,7 @@ class TestJobServer:
 
     def test_release_without_tokens_is_noop(self):
         """Releasing without acquired tokens should be a no-op."""
-        js = PosixJobServer(4)
+        js = PosixJobServer(4, makeflags="")
 
         try:
             assert js.tokens_acquired == 0
@@ -214,7 +214,7 @@ class TestJobServer:
 
     def test_makeflags_fifo_gmake_44(self):
         """Should return FIFO format for gmake >= 4.4."""
-        js = PosixJobServer(8)
+        js = PosixJobServer(8, makeflags="")
 
         try:
             flags, data = js.makeflags_and_data(Spec("gmake@=4.4"))
@@ -225,7 +225,7 @@ class TestJobServer:
 
     def test_makeflags_pipe_gmake_40(self):
         """Should return pipe format for gmake 4.0-4.3."""
-        js = PosixJobServer(8)
+        js = PosixJobServer(8, makeflags="")
 
         try:
             flags, data = js.makeflags_and_data(Spec("gmake@=4.0"))
@@ -236,7 +236,7 @@ class TestJobServer:
 
     def test_makeflags_old_format_gmake_3(self):
         """Should return old --jobserver-fds format for gmake < 4.0."""
-        js = PosixJobServer(8)
+        js = PosixJobServer(8, makeflags="")
 
         try:
             flags, data = js.makeflags_and_data(Spec("gmake@=3.9"))
@@ -247,7 +247,7 @@ class TestJobServer:
 
     def test_makeflags_no_gmake(self):
         """Should return FIFO format when no gmake (modern default)."""
-        js = PosixJobServer(6)
+        js = PosixJobServer(6, makeflags="")
 
         try:
             flags, data = js.makeflags_and_data(None)
@@ -258,7 +258,7 @@ class TestJobServer:
 
     def test_close_removes_created_fifo(self):
         """Should remove FIFO and directory if created by this instance."""
-        js = PosixJobServer(4)
+        js = PosixJobServer(4, makeflags="")
         fifo_path = js.fifo_path
         assert fifo_path and os.path.exists(fifo_path)
         js.close()
@@ -266,7 +266,7 @@ class TestJobServer:
 
     def test_file_descriptors_are_inheritable(self):
         """Should set file descriptors as inheritable for child processes."""
-        js = PosixJobServer(4)
+        js = PosixJobServer(4, makeflags="")
 
         try:
             assert os.get_inheritable(js.r)
@@ -276,7 +276,7 @@ class TestJobServer:
 
     def test_connection_objects_exist(self):
         """Should create Connection objects for fd inheritance."""
-        js = PosixJobServer(4)
+        js = PosixJobServer(4, makeflags="")
 
         try:
             assert js.r_conn is not None and js.r_conn.fileno() == js.r
@@ -286,26 +286,26 @@ class TestJobServer:
 
     def test_close_warns_when_spack_holds_tokens(self):
         """Should warn when Spack closes the jobserver while still holding acquired tokens."""
-        js = PosixJobServer(4)
+        js = PosixJobServer(4, makeflags="")
         js.acquire(1)  # Spack acquires a token without releasing it
         with pytest.warns(UserWarning, match="Spack failed to release jobserver tokens"):
             js.close()
 
     def test_close_warns_when_subprocess_holds_tokens(self):
         """Should warn when a subprocess acquired a token but never released it."""
-        js1 = PosixJobServer(4)
+        js1 = PosixJobServer(4, makeflags="")
         os.read(js1.r, 1)  # A subprocess acquires a token without releasing it
         with pytest.warns(UserWarning, match="1 jobserver token was not released"):
             js1.close()
 
-        js2 = PosixJobServer(4)
+        js2 = PosixJobServer(4, makeflags="")
         os.read(js2.r, 2)  # A subprocess acquires two tokens without releasing them
         with pytest.warns(UserWarning, match="2 jobserver tokens were not released"):
             js2.close()
 
     def test_has_target_parallelism(self):
         """has_target_parallelism() should be True initially."""
-        js = PosixJobServer(4)
+        js = PosixJobServer(4, makeflags="")
         try:
             assert js.has_target_parallelism() is True
             js.target_jobs = js.num_jobs - 1
@@ -316,7 +316,7 @@ class TestJobServer:
     def test_increase_parallelism_not_created(self):
         """increase_parallelism() should be a no-op when not self.created."""
         # Simulate an externally attached jobserver by patching created after construction.
-        js = PosixJobServer(3)
+        js = PosixJobServer(3, makeflags="")
         try:
             original_num = js.num_jobs
             original_target = js.target_jobs
@@ -333,7 +333,7 @@ class TestJobServer:
 
     def test_increase_parallelism(self):
         """increase_parallelism() should increment num_jobs and target_jobs and add a token."""
-        js = PosixJobServer(3)
+        js = PosixJobServer(3, makeflags="")
         try:
             original_num = js.num_jobs
             original_target = js.target_jobs
@@ -347,7 +347,7 @@ class TestJobServer:
 
     def test_decrease_parallelism_at_floor(self):
         """decrease_parallelism() should not go below target_jobs == 1."""
-        js = PosixJobServer(1)
+        js = PosixJobServer(1, makeflags="")
         try:
             # target_jobs starts at 1
             assert js.target_jobs == 1
@@ -358,7 +358,7 @@ class TestJobServer:
 
     def test_decrease_parallelism_token_available(self):
         """When pipe has tokens, decrease_parallelism discards one immediately."""
-        js = PosixJobServer(3)
+        js = PosixJobServer(3, makeflags="")
         try:
             # 3-job server starts with 2 tokens in the pipe.
             original_num = js.num_jobs
@@ -372,7 +372,7 @@ class TestJobServer:
     def test_decrease_parallelism_no_token_available(self):
         """When all tokens are held, decrease_parallelism defers the discard.
         A subsequent increase cancels the pending decrease instead of adding a token."""
-        js = PosixJobServer(3)
+        js = PosixJobServer(3, makeflags="")
         try:
             # Drain the pipe so no tokens are available for immediate discard.
             assert js.acquire(ALL_TOKENS) == js.num_jobs - 1
@@ -390,7 +390,7 @@ class TestJobServer:
 
     def test_maybe_discard_tokens_noop_at_target(self):
         """maybe_discard_tokens() should be a no-op when num_jobs == target_jobs."""
-        js = PosixJobServer(3)
+        js = PosixJobServer(3, makeflags="")
         try:
             original_num = js.num_jobs
             js._maybe_discard_tokens()  # to_discard == 0
@@ -400,7 +400,7 @@ class TestJobServer:
 
     def test_maybe_discard_tokens_discards_when_available(self):
         """maybe_discard_tokens() should consume tokens from the pipe."""
-        js = PosixJobServer(4)
+        js = PosixJobServer(4, makeflags="")
         try:
             # Manually set target lower to create a discard requirement.
             js.target_jobs = js.num_jobs - 2
@@ -412,7 +412,7 @@ class TestJobServer:
 
     def test_maybe_discard_tokens_noop_on_blocking(self):
         """maybe_discard_tokens() should not raise when pipe is empty."""
-        js = PosixJobServer(3)
+        js = PosixJobServer(3, makeflags="")
         try:
             # Drain all tokens from the pipe (simulates subprocesses holding them).
             assert js.acquire(ALL_TOKENS) == js.num_jobs - 1
@@ -426,7 +426,7 @@ class TestJobServer:
 
     def test_release_discards_token_when_target_below_num(self):
         """release() should discard a token (not return it) when target_jobs < num_jobs."""
-        js = PosixJobServer(4)
+        js = PosixJobServer(4, makeflags="")
         try:
             # Acquire a token.
             assert js.acquire(1) == 1

--- a/lib/spack/spack/test/new_installer.py
+++ b/lib/spack/spack/test/new_installer.py
@@ -336,7 +336,7 @@ class TestScheduleBuilds:
         spec = self._make_spec("trivial-install-test-package")
         pending = [spec.dag_hash()]
         bg = _FakeBuildGraph([spec])
-        jobserver = PosixJobServer(num_jobs=2)
+        jobserver = PosixJobServer(num_jobs=2, makeflags="")
         try:
             result = schedule_builds(
                 pending,
@@ -365,7 +365,7 @@ class TestScheduleBuilds:
         self._mark_installed(spec, temporary_store)
         pending = [spec.dag_hash()]
         bg = _FakeBuildGraph([spec])
-        jobserver = PosixJobServer(num_jobs=2)
+        jobserver = PosixJobServer(num_jobs=2, makeflags="")
         try:
             result = schedule_builds(
                 pending,
@@ -394,7 +394,7 @@ class TestScheduleBuilds:
         pending = [spec.dag_hash()]
         bg = _FakeBuildGraph([spec])
         # num_jobs=1 writes 0 tokens to the FIFO. Only the implicit token exists.
-        jobserver = PosixJobServer(num_jobs=1)
+        jobserver = PosixJobServer(num_jobs=1, makeflags="")
         try:
             result = schedule_builds(
                 pending,
@@ -419,7 +419,7 @@ class TestScheduleBuilds:
         spec = self._make_spec("trivial-install-test-package")
         pending = [spec.dag_hash()]
         bg = _FakeBuildGraph([spec])
-        jobserver = PosixJobServer(num_jobs=2)
+        jobserver = PosixJobServer(num_jobs=2, makeflags="")
         # Pre-register the lock in the prefix_locker cache, then patch try_acquire to fail.
         lock = temporary_store.prefix_locker.lock(spec)
         monkeypatch.setattr(lock, "try_acquire_write", lambda: False)
@@ -449,7 +449,7 @@ class TestScheduleBuilds:
         self._mark_installed(spec, temporary_store)
         pending = [spec.dag_hash()]
         bg = _FakeBuildGraph([spec])
-        jobserver = PosixJobServer(num_jobs=2)
+        jobserver = PosixJobServer(num_jobs=2, makeflags="")
         try:
             result = schedule_builds(
                 pending,
@@ -477,7 +477,7 @@ class TestScheduleBuilds:
         spec_b = self._make_spec("trivial-smoke-test")
         pending = [spec_a.dag_hash(), spec_b.dag_hash()]
         bg = _FakeBuildGraph([spec_a, spec_b])
-        jobserver = PosixJobServer(num_jobs=4)
+        jobserver = PosixJobServer(num_jobs=4, makeflags="")
         # Patch spec_a's lock to always fail, simulating an external write lock.
         lock_a = temporary_store.prefix_locker.lock(spec_a)
         monkeypatch.setattr(lock_a, "try_acquire_write", lambda: False)
@@ -517,7 +517,7 @@ class TestScheduleBuilds:
         self._mark_installed(spec, temporary_store)
         pending = [spec.dag_hash()]
         bg = _FakeBuildGraph([spec])
-        jobserver = PosixJobServer(num_jobs=2)
+        jobserver = PosixJobServer(num_jobs=2, makeflags="")
         lock = temporary_store.prefix_locker.lock(spec)
         monkeypatch.setattr(lock, "try_acquire_write", lambda: False)
         try:
@@ -555,7 +555,7 @@ class TestScheduleBuilds:
         spec = self._make_spec("trivial-install-test-package")
         pending = [spec.dag_hash()]
         bg = _FakeBuildGraph([spec])
-        jobserver = PosixJobServer(num_jobs=2)
+        jobserver = PosixJobServer(num_jobs=2, makeflags="")
         lock = temporary_store.prefix_locker.lock(spec)
         monkeypatch.setattr(lock, "try_acquire_write", lambda: False)
         try:
@@ -583,7 +583,7 @@ class TestScheduleBuilds:
         self._mark_installed(spec, temporary_store)  # installation_time = now()
         pending = [spec.dag_hash()]
         bg = _FakeBuildGraph([spec])
-        jobserver = PosixJobServer(num_jobs=2)
+        jobserver = PosixJobServer(num_jobs=2, makeflags="")
         try:
             result = schedule_builds(
                 pending,
@@ -614,7 +614,7 @@ class TestScheduleBuilds:
         temporary_store.db.add(spec, explicit=False)
         pending = [spec.dag_hash()]
         bg = _FakeBuildGraph([spec])
-        jobserver = PosixJobServer(num_jobs=2)
+        jobserver = PosixJobServer(num_jobs=2, makeflags="")
         try:
             result = schedule_builds(
                 pending,

--- a/lib/spack/spack/test/windows_tui.py
+++ b/lib/spack/spack/test/windows_tui.py
@@ -24,7 +24,6 @@ if sys.platform != "win32":
 from ctypes import wintypes
 
 import spack.new_installer_windows as _niw
-from spack.new_installer import InstallerUI
 from spack.new_installer_base import StdinReader
 from spack.new_installer_windows import (
     ENABLE_ECHO_INPUT,
@@ -157,12 +156,11 @@ def _make_state(headless=True):
     sockets.
     """
     sel = _FakeSelector()
-    bs = InstallerUI()
     k32 = _FakeKernel32()
 
     state = object.__new__(WindowsTerminalState)
     state.selector = sel
-    state.ui = bs
+    state.on_headless = None
     state.headless = headless
     state.on_suspend = None
     state.on_resume = None
@@ -174,14 +172,15 @@ def _make_state(headless=True):
     state.old_stdout_settings = wintypes.DWORD(0x0003)
     state.stdin_r, state.stdin_w = _fakepair(10, 11)
     state.sigwinch_r, state.sigwinch_w = _fakepair(12, 13)
+    state.stdin_reader = StdinReader(functools.partial(state.stdin_r.recv, 1024))
     state._running = False
-    return state, sel, bs, k32
+    return state, sel, k32
 
 
 class TestSetupTeardown:
     def test_setup_enables_vt100_on_stdout(self, monkeypatch):
         """setup() ORs ENABLE_VIRTUAL_TERMINAL_PROCESSING into the stdout console mode."""
-        state, sel, bs, k32 = _make_state()
+        state, sel, k32 = _make_state()
         monkeypatch.setattr(_niw.threading, "Thread", _NoopThread)
         monkeypatch.setattr(state, "enter_foreground", lambda: None)
 
@@ -193,7 +192,7 @@ class TestSetupTeardown:
 
     def test_setup_registers_sigwinch_socket(self, monkeypatch):
         """setup() registers sigwinch_r in the selector with tag 'sigwinch'."""
-        state, sel, bs, k32 = _make_state()
+        state, sel, k32 = _make_state()
         monkeypatch.setattr(_niw.threading, "Thread", _NoopThread)
         monkeypatch.setattr(state, "enter_foreground", lambda: None)
 
@@ -204,7 +203,7 @@ class TestSetupTeardown:
 
     def test_setup_starts_two_daemon_threads(self, monkeypatch):
         """setup() starts exactly two daemon threads."""
-        state, sel, bs, k32 = _make_state()
+        state, sel, k32 = _make_state()
         threads = []
 
         class _FakeThread:
@@ -225,7 +224,7 @@ class TestSetupTeardown:
 
     def test_teardown_restores_console_mode_with_int_values(self):
         """teardown() passes plain ints (not DWORD structs) to SetConsoleMode."""
-        state, sel, bs, k32 = _make_state()
+        state, sel, k32 = _make_state()
 
         state.teardown()
 
@@ -235,7 +234,7 @@ class TestSetupTeardown:
 
     def test_teardown_closes_stdin_and_sigwinch_sockets(self):
         """teardown() closes stdin_r and sigwinch_r."""
-        state, sel, bs, k32 = _make_state()
+        state, sel, k32 = _make_state()
         stdin_fake = _FakeSocket(99)
         sigwinch_fake = _FakeSocket(100)
         state.stdin_r = stdin_fake
@@ -248,7 +247,7 @@ class TestSetupTeardown:
 
     def test_teardown_sets_running_false(self):
         """teardown() sets _running=False to stop background threads."""
-        state, sel, bs, k32 = _make_state()
+        state, sel, k32 = _make_state()
         state._running = True
 
         state.teardown()
@@ -259,7 +258,7 @@ class TestSetupTeardown:
 class TestForegroundBackground:
     def test_enter_foreground_noop_when_already_foreground(self):
         """enter_foreground() is a no-op when headless is already False."""
-        state, sel, bs, k32 = _make_state(headless=False)
+        state, sel, k32 = _make_state(headless=False)
 
         state.enter_foreground()
 
@@ -267,7 +266,7 @@ class TestForegroundBackground:
 
     def test_enter_foreground_disables_line_echo_quickedit(self, monkeypatch):
         """enter_foreground() clears LINE_INPUT, ECHO_INPUT, QUICK_EDIT_MODE."""
-        state, sel, bs, k32 = _make_state(headless=True)
+        state, sel, k32 = _make_state(headless=True)
         monkeypatch.setattr(
             WindowsTerminalState, "stdin_is_interactive", staticmethod(lambda: True)
         )
@@ -282,7 +281,7 @@ class TestForegroundBackground:
 
     def test_enter_foreground_registers_stdin_when_interactive(self, monkeypatch):
         """enter_foreground() registers stdin_r with tag 'stdin' when interactive."""
-        state, sel, bs, k32 = _make_state(headless=True)
+        state, sel, k32 = _make_state(headless=True)
         monkeypatch.setattr(
             WindowsTerminalState, "stdin_is_interactive", staticmethod(lambda: True)
         )
@@ -295,7 +294,7 @@ class TestForegroundBackground:
 
     def test_enter_foreground_skips_stdin_when_not_interactive(self, monkeypatch):
         """enter_foreground() does not register stdin_r when not interactive."""
-        state, sel, bs, k32 = _make_state(headless=True)
+        state, sel, k32 = _make_state(headless=True)
         monkeypatch.setattr(
             WindowsTerminalState, "stdin_is_interactive", staticmethod(lambda: False)
         )
@@ -320,7 +319,7 @@ class TestInputThread:
 
     def test_keystroke_forwarded_to_stdin_r(self, monkeypatch):
         """A normal keypress is sent to stdin_r."""
-        state, sel, bs, k32 = _make_state()
+        state, sel, k32 = _make_state()
         call_count = [0]
 
         def kbhit():
@@ -337,7 +336,7 @@ class TestInputThread:
 
     def test_extended_key_e0_reads_two_bytes_and_discards(self, monkeypatch):
         """The 0xe0 prefix (arrow/nav keys) reads a second byte but discards both."""
-        state, sel, bs, k32 = _make_state()
+        state, sel, k32 = _make_state()
         call_count = [0]
         getwch_results = ["\xe0", "H"]
         getwch_calls = [0]
@@ -362,7 +361,7 @@ class TestInputThread:
 
     def test_extended_key_null_reads_two_bytes_and_discards(self, monkeypatch):
         """The 0x00 prefix (F-keys) reads a second byte but discards both."""
-        state, sel, bs, k32 = _make_state()
+        state, sel, k32 = _make_state()
         call_count = [0]
         getwch_results = ["\x00", "K"]
         getwch_calls = [0]
@@ -387,7 +386,7 @@ class TestInputThread:
 
     def test_no_keypress_when_headless(self, monkeypatch):
         """_input_thread does not call kbhit when headless=True."""
-        state, sel, bs, k32 = _make_state()
+        state, sel, k32 = _make_state()
         state.headless = True
         kbhit_calls = []
 
@@ -411,7 +410,7 @@ class TestResizeThread:
 
     def test_resize_event_sent_on_size_change(self, monkeypatch):
         """_resize_thread sends b'\\x00' to sigwinch_w when terminal dimensions change."""
-        state, sel, bs, k32 = _make_state()
+        state, sel, k32 = _make_state()
         state._running = True
         call_count = [0]
         sizes = [
@@ -436,7 +435,7 @@ class TestResizeThread:
 
     def test_no_resize_event_on_same_size(self, monkeypatch):
         """_resize_thread does not send if dimensions are unchanged."""
-        state, sel, bs, k32 = _make_state()
+        state, sel, k32 = _make_state()
         state._running = True
         call_count = [0]
 

--- a/lib/spack/spack/test/windows_tui.py
+++ b/lib/spack/spack/test/windows_tui.py
@@ -24,6 +24,7 @@ if sys.platform != "win32":
 from ctypes import wintypes
 
 import spack.new_installer_windows as _niw
+from spack.new_installer import InstallerUI
 from spack.new_installer_base import StdinReader
 from spack.new_installer_windows import (
     ENABLE_ECHO_INPUT,
@@ -156,12 +157,13 @@ def _make_state(headless=True):
     sockets.
     """
     sel = _FakeSelector()
-    bs = types.SimpleNamespace(headless=headless, dirty=False)
+    bs = InstallerUI()
     k32 = _FakeKernel32()
 
     state = object.__new__(WindowsTerminalState)
     state.selector = sel
-    state.build_status = bs
+    state.ui = bs
+    state.headless = headless
     state.on_suspend = None
     state.on_resume = None
     state.kernel32 = k32
@@ -289,7 +291,7 @@ class TestForegroundBackground:
 
         tags = [data for _, _, data in sel.register_calls]
         assert "stdin" in tags
-        assert bs.headless is False
+        assert state.headless is False
 
     def test_enter_foreground_skips_stdin_when_not_interactive(self, monkeypatch):
         """enter_foreground() does not register stdin_r when not interactive."""
@@ -310,7 +312,7 @@ class TestInputThread:
     def _run_thread(self, state, fake_msvcrt, monkeypatch):
         """Call _input_thread directly and return bytes received on stdin_r."""
         state._running = True
-        state.build_status.headless = False
+        state.headless = False
         monkeypatch.setattr(_niw, "msvcrt", fake_msvcrt)
         monkeypatch.setattr(_niw.time, "sleep", lambda _: None)
         state._input_thread()
@@ -386,7 +388,7 @@ class TestInputThread:
     def test_no_keypress_when_headless(self, monkeypatch):
         """_input_thread does not call kbhit when headless=True."""
         state, sel, bs, k32 = _make_state()
-        state.build_status.headless = True
+        state.headless = True
         kbhit_calls = []
 
         def fake_sleep(_):


### PR DESCRIPTION
Replace BuildStatus, which mixed terminal rendering with event loop
bookkeeping, with an explicit UI class:

- InstallerUI defines the interface between the event loop and a
  frontend. Event loop -> UI notifications are methods that receive plain
  data; they are no-ops in the base class, which therefore doubles as a
  "silent" frontend. UI -> event loop requests are done by appending
  events to a list, which is drained by the event loop.
- TerminalUI implements it for our current tui
- PackageInstaller accepts an injected InstallerUI. Terminal state handling
  (cbreak mode, suspend/resume signals, stdin registration) stays in the event
  loop, enabled only for frontends that set `reads_terminal_input`.
- Jobservers take MAKEFLAGS as an argument instead of reading the environment.

This allows event loop logic to be tested without asserting on stdout, and
makes room for non-terminal frontends.

This commit is pure refactor, unit tests for the event loop are added when the
build "launcher" is also decoupled.