### PR TITLE
Spec: remove STORE access in Spec._mark_concrete

### DIFF
--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -2867,8 +2867,6 @@ class Spec:
 
     def _mark_root_concrete(self, value=True):
         """Mark just this spec (not dependencies) concrete."""
-        if (not value) and self.concrete and self.installed:
-            return
         self._concrete = value
         self._validate_version()
         for variant in self.variants.values():
@@ -2902,9 +2900,7 @@ class Spec:
         # if set to false, clear out all hashes (set to None or remove attr)
         # may need to change references to respect None
         for s in self.traverse():
-            if (not value) and s.concrete and s.installed:
-                continue
-            elif not value:
+            if not value:
                 s.clear_caches()
             s._mark_root_concrete(value)
 

--- a/lib/spack/spack/test/spec_semantics.py
+++ b/lib/spack/spack/test/spec_semantics.py
@@ -9,6 +9,7 @@ import pytest
 import spack.concretize
 import spack.deptypes as dt
 import spack.directives
+import spack.hash_types as ht
 import spack.package_base
 import spack.paths
 import spack.repo
@@ -2590,3 +2591,25 @@ def test_highlighting_spec_parts(spec_str, expected_fmt, default_mock_concretiza
         highlight_variant_fn=spack.package_base.non_default_variant,
     )
     assert expected in colorized_str
+
+
+@pytest.mark.parametrize("spec_str", ["mpileaks", "mpileaks ^zmpi"])
+def test_mark_concrete_roundtrip_preserves_hashes(spec_str, default_mock_concretization):
+    """Tests that clearing concreteness and re-finalizing a spec must preserve the DAG hash of the
+    root and of every transitive dependency.
+    """
+    s = default_mock_concretization(spec_str)
+
+    # Record the DAG hash of every node in the DAG (root and transitive dependencies).
+    original = {node.name: node.dag_hash() for node in s.traverse()}
+    # Sanity check: we are exercising more than the root node.
+    assert len(original) > 1
+
+    # Un-mark concrete: this clears the cached hashes on every node in the DAG.
+    s._mark_concrete(False)
+    assert all(getattr(node, ht.dag_hash.attr) is None for node in s.traverse())
+
+    # Re-finalize the DAG: the cleared hashes must recompute to the original values.
+    s._finalize_concretization()
+    roundtrip = {node.name: node.dag_hash() for node in s.traverse()}
+    assert roundtrip == original


### PR DESCRIPTION
extracted from #52658 

Looking at `_mark_root_concrete` and `_mark_concrete` it doesn't make much sense to do a DB check and refuse to de-concretize a spec that is installed. Therefore, remove the implicit dependency on `spack.store`.