### PR TITLE
bugfix: `spec_dict_to_json` caches bottom-up; disable caching spliced specs

### DIFF
--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -335,39 +335,50 @@ def _reorder_flags(flag_list: List[spack.spec.CompilerFlag]) -> List[spack.spec.
 
 
 def spec_dict_to_json(spec_dict: SpecDict) -> Dict:
-    """Serialize a SpecDict to JSON, taking care to preserve node structure in serialized specs."""
-    # A SpecDict has one entry for each spec in a solution, but some are abstract and some
-    # are concrete. We need DAG hashes for the abstract specs to serialize them, so force-cache
-    # them to avoid lots of redundant computation.
-    # TODO: spec serialization was really designed for concrete and small abstract specs.
-    # This should really be handled by Spec, but it will take some work to adjust the format.
-    for spec in spec_dict.values():
-        if not spec.concrete:
-            spec._cached_hash(ht.dag_hash, force=True)
+    """Serialize a SpecDict to JSON, taking care to preserve node structure in serialized specs.
 
+    Note: this does not yet handle spliced specs and will raise an error if they're passed in.
+
+    Raises:
+        SpliceSerializationError: if any node in ``spec_dict`` has a ``build_spec``.
+    """
     # Specs are keyed in spec_dict by their solver-assigned NodeId, but reused concrete
-    # specs may have transitive dependencies or build_specs that do not have a NodeId.
+    # specs may have transitive dependencies that do not have a NodeId.
     # Make a dictionary preserving the NodeIds from input.
     node_id_for: Dict[int, NodeId] = {id(spec): nid for nid, spec in spec_dict.items()}
 
-    # make a list of all nodes in specs and their build_specs
     specs = list(spec_dict.values())
-    specs += [spec.build_spec for spec in specs if spec.build_spec is not spec]
 
-    # Traverse every spec reachable from spec_dict's values, deduped by hash, and add them
-    # to the serialized entries either a) with their original NodeId, or b) with None if they
-    # don't have a NodeId. This ensures that all nodes are added and NodeIds are preserved.
-    entries = []
-    for dep in spack.traverse.traverse_nodes(specs, key=lambda s: s.dag_hash()):
-        node = dep.to_node_dict()
-        node["hash"] = dep.dag_hash()
-        entries.append((node_id_for.get(id(dep)), node))
+    try:
+        # A SpecDict has one entry for each spec in a solution, but some are abstract and some
+        # are concrete. We need DAG hashes for the abstract specs to serialize them, so
+        # force-cache them, taking care to do so bottom-up, to avoid exponential recomputation.
+        # TODO: spec serialization was really designed for concrete and small abstract specs.
+        # This should really be handled by Spec, but it will take some work to adjust the format.
+        for spec in spack.traverse.traverse_nodes(specs, key=id, order="post"):
+            if spec.build_spec is not spec:
+                raise SpliceSerializationError(
+                    f"cannot serialize spliced spec {spec.name}; SpecDicts with spliced "
+                    "specs are not serializable."
+                )
+            if not spec.concrete:
+                spec._cached_hash(ht.dag_hash, force=True)
 
-    # Clear the hashes cached above, as they will need to be recomputed after post-concretization.
-    # They're only used here as keys for reading and writing spec DAGs.
-    for spec in spec_dict.values():
-        if not spec.concrete:
-            spec.clear_caches()
+        # Traverse every spec reachable from spec_dict's values, deduped by hash, and add them
+        # to the serialized entries either a) with their original NodeId, or b) with None if they
+        # don't have a NodeId. This ensures that all nodes are added and NodeIds are preserved.
+        entries = []
+        for dep in spack.traverse.traverse_nodes(specs, key=lambda s: s.dag_hash()):
+            node = dep.to_node_dict()
+            node["hash"] = dep.dag_hash()
+            entries.append((node_id_for.get(id(dep)), node))
+
+    finally:
+        # Clear hashes cached above, which must be recomputed in post-concretization
+        # They're only used here as keys for reading and writing spec DAGs.
+        for spec in spack.traverse.traverse_nodes(specs, key=id):
+            if not spec.concrete:
+                spec.clear_caches()
 
     return {"_meta": {"spec_version": spack.spec.SpecfileLatest.SPEC_VERSION}, "specs": entries}
 
@@ -596,9 +607,7 @@ class ConcretizationCache:
         entry_limit = spack.config.get("concretizer:concretization_cache:entry_limit", 1000)
 
         try:
-            with os.scandir(self.root) as it:
-                # skip dotfiles and old-style directory entries
-                entries = [e for e in it if not e.name.startswith(".") and e.is_file()]
+            entries = list(self.cache_entries())
         except FileNotFoundError:
             return
 
@@ -621,6 +630,17 @@ class ConcretizationCache:
         # Try to remove the oldest half of the cache.
         for _, path in removal_queue[: entry_limit // 2]:
             self._remove_entry(pathlib.Path(path))
+
+    def cache_entries(self) -> Iterator["os.DirEntry"]:
+        """Yield a ``DirEntry`` for every entry in the cache.
+
+        Raises ``FileNotFoundError`` if the cache root doesn't exist.
+        """
+        with os.scandir(self.root) as it:
+            for entry in it:
+                # skip dotfiles and old-style directory entries
+                if not entry.name.startswith(".") and entry.is_file():
+                    yield entry
 
     def _prefix_digest(self, problem: str) -> str:
         """Return the first two characters of, and the full, sha256 of the given asp problem"""
@@ -650,9 +670,16 @@ class ConcretizationCache:
         """
         cache_path = self._cache_path_from_problem(problem)
 
+        try:
+            results_dict = result.to_dict()
+        except SpliceSerializationError:
+            # Results with spliced specs can't be serialized (yet).
+            tty.debug(f"Not caching result with spliced specs for {cache_path}")
+            return
+
         cache_dict = {
             "_meta": {"version": ConcretizationCache.VERSION},
-            "results": result.to_dict(),
+            "results": results_dict,
             "statistics": statistics,
         }
 
@@ -728,7 +755,13 @@ class ConcretizationCache:
 
         try:
             result = Result.from_dict(results, specs)
-        except (KeyError, TypeError, ValueError, spack.error.SpecSyntaxError) as e:
+        except (
+            KeyError,
+            TypeError,
+            ValueError,
+            spack.error.SpecError,
+            spack.error.SpecSyntaxError,
+        ) as e:
             tty.debug(
                 f"ConcretizationCache.fetch(): force-removing {cache_path}. "
                 f"Valid JSON but spec data is malformed or incompatible: {e}"
@@ -4204,6 +4237,10 @@ class SolverError(InternalConcretizerError):
 
 class InvalidSpliceError(spack.error.SpackError):
     """For cases in which the splice configuration is invalid."""
+
+
+class SpliceSerializationError(spack.error.SpackError):
+    """Attempt to serialize a SpecDict that contains spliced specs (currently unsupported)."""
 
 
 class NoCompilerFoundError(spack.error.SpackError):

--- a/lib/spack/spack/test/concretization/core.py
+++ b/lib/spack/spack/test/concretization/core.py
@@ -4524,6 +4524,44 @@ def test_spec_dict_roundtrip(mock_packages, config, spec_str):
     assert roundtrip[nid] == spec
 
 
+def test_concretization_cache_store_skips_spliced_results(mock_packages, use_concretization_cache):
+    """store() must not cache results containing spliced specs, even nested ones.
+
+    Spliced nodes carry a build_spec DAG that is reachable only through the build_spec
+    link -- dependency traversal never visits it, so spec_dict_to_json() would serialize
+    a dangling build_spec hash. It raises SpliceSerializationError instead, and store()
+    skips the entry, so spliced results are just re-solved every time.
+    """
+    t = spack.concretize.concretize_one("splice-t")
+    h = spack.concretize.concretize_one("splice-h+foo")
+    spliced = t.splice(h, transitive=True)
+    assert spliced.build_spec is not spliced
+
+    # an abstract parent that reuses the spliced spec as a plain dependency. The parent has
+    # no build_spec of its own, and the spliced node has no NodeId, so the splice can only
+    # be found by traversing the whole DAG. The abstract dep is added first so that its
+    # hash is force-cached before the splice is found.
+    root = Spec("pkg-a")
+    abstract_dep = Spec("pkg-b")
+    root._add_dependency(abstract_dep, depflag=dt.LINK, virtuals=())
+    root._add_dependency(spliced, depflag=dt.LINK, virtuals=())
+    nid = spack.solver.asp.SpecBuilder.make_node(pkg=root.name)
+
+    # serialization refuses spliced specs, and must clean up any force-cached hashes
+    with pytest.raises(spack.solver.asp.SpliceSerializationError):
+        spack.solver.asp.spec_dict_to_json({nid: root})
+    assert abstract_dep._hash is None
+    assert root._hash is None
+
+    result = Result(specs=[Spec("pkg-a")])
+    result.answers = [(0, 0, {nid: root})]
+
+    cache = spack.solver.asp.ConcretizationCache(str(use_concretization_cache))
+    cache.store("spliced problem", result, statistics=[])
+
+    assert not cache._cache_path_from_problem("spliced problem").exists()
+
+
 @pytest.mark.parametrize(
     "spec,reused_dep",
     [
@@ -5331,10 +5369,15 @@ def test_concretization_cache_store_cleans_temp_on_error(use_concretization_cach
     assert temps == []
 
 
-def test_concretization_cache_roundtrip_with_automatic_splice(
+def test_concretization_cache_skips_automatic_splice(
     use_concretization_cache, mutable_config, monkeypatch, install_mockery
 ):
-    """Test that cache entries written after an automatic splice are readable on the next solve."""
+    """Solves that produce an automatic splice are not cached and re-solve correctly.
+
+    spec_dict_to_json() cannot serialize the build_spec DAGs that spliced specs carry, so
+    store() skips results containing them. The second solve must be a cache miss that
+    re-runs clingo and produces the same result.
+    """
     mutable_config.set("concretizer:reuse", True)
 
     # Install the old version.  splice-t depends on splice-h, which has:
@@ -5351,8 +5394,11 @@ def test_concretization_cache_roundtrip_with_automatic_splice(
 
     goal = "splice-t@1 ^splice-h@1.0.1+compat ^splice-z@1.0.0+compat"
 
+    # The solve for ``old`` above was cached; snapshot so we can tell nothing new appears.
+    cache = spack.solver.asp.ConcretizationCache(str(use_concretization_cache))
+    entries_before = {entry.name for entry in cache.cache_entries()}
+
     # First solve: the auto-splice fires, producing a spec with ._build_spec set.
-    # The result is stored in the cache by spec_dict_to_json().
     spec1 = spack.concretize.concretize_one(goal)
 
     # Confirm the splice actually occurred -- if it didn't, the test doesn't cover the bug.
@@ -5361,16 +5407,20 @@ def test_concretization_cache_roundtrip_with_automatic_splice(
         "the test premise is wrong if no splice occurred"
     )
 
-    # Second solve must be a pure cache hit: clingo must not run again.
-    # If the cache entry is unreadable (the bug), fetch() deletes it and falls through
-    # to _run_clingo, which calls store() -- triggering this assertion.
-    def _assert_no_store(self, problem, result, statistics):
-        raise AssertionError(
-            "cache should have been hit on the second solve, "
-            "but the cache entry was unreadable and clingo ran again"
-        )
+    # The spliced result must not have been written to the cache.
+    assert {entry.name for entry in cache.cache_entries()} == entries_before
 
-    monkeypatch.setattr(spack.solver.asp.ConcretizationCache, "store", _assert_no_store)
+    # Second solve: a cache miss that re-runs clingo and gets the same answer.
+    fetches = []
+    original_fetch = spack.solver.asp.ConcretizationCache.fetch
+
+    def counting_fetch(self, *args, **kwargs):
+        outcome = original_fetch(self, *args, **kwargs)
+        fetches.append(outcome)
+        return outcome
+
+    monkeypatch.setattr(spack.solver.asp.ConcretizationCache, "fetch", counting_fetch)
 
     spec2 = spack.concretize.concretize_one(goal)
+    assert fetches and all(outcome == (None, None) for outcome in fetches)
     assert spec1 == spec2


### PR DESCRIPTION
`spec_dict_to_json` avoids making yet another node identifier for specs by using DAG hashes, but it neglected to cache them bottom-up. If there are many abstract specs in a DAG/env/etc., this means we get exponential recomputation of hashes. This could cause extremely long concretization times for large DAGs.

Also, spliced specs can potentially encounter a traversal bug where reused spliced specs can have dangling hashes. Avoid spliced specs for now and just disable caching for them since they are rare.

Effect on the E4S stack in CI:

<img width="1820" height="910" alt="image" src="https://github.com/user-attachments/assets/65192cd6-c097-402d-a11b-ce9e48c157c7" />

See https://github.com/spack/spack-packages/pull/5097.

`spec_dict_to_json` time for diamond DAGs before, with recomputation issues:

```
depth= 1 nodes=  4 paths=2  0.001s
depth=14 nodes= 43 paths=16384  9.629s
...
😬
```

After:

```
depth= 1 nodes=  4 paths=2  0.000s
depth=14 nodes= 43 paths=16384  0.001s
depth=39 nodes=118 paths=549755813888  0.004s
```

This is a minimal backport; a full refactor of `traverse_*` can go on `develop`, but this is intended to be low-risk for `1.2.2`.

- [x] Cache hashes bottom-up in ``spec_dict_to_json`` using `traverse_nodes()`
- [x]  ``spec_dict_to_json`` now raises if it encounters spliced specs, and the result is not cached.
- [x] Add a test.