### PR TITLE
Fix bug with `$env` substitution

### DIFF
--- a/lib/spack/spack/environment/environment.py
+++ b/lib/spack/spack/environment/environment.py
@@ -239,20 +239,19 @@ def activate(env, use_env_repo=False):
         if not isinstance(env, Environment):
             raise TypeError(f"`env` should be of type {Environment.__name__}")
 
-        # Record the active env (and its path, so config "$env" substitutions work) while the
-        # manifest's config scope is being prepared below and for the lifetime of the activation.
-        set_active_environment(env)
-
-        # Check if we need to reinitialize spack.store.STORE and spack.repo.REPO due to
-        # config changes.
         install_tree_before = spack.config.get("config:install_tree")
         upstreams_before = spack.config.get("upstreams")
         repos_before = spack.config.get("repos")
+
+        # Record the active env (and its path, so config "$env" substitutions work)
+        set_active_environment(env)
         env.manifest.prepare_config_scope()
+
         install_tree_after = spack.config.get("config:install_tree")
         upstreams_after = spack.config.get("upstreams")
         repos_after = spack.config.get("repos")
 
+        # Check if we need to reinitialize spack.store.STORE and spack.repo.REPO
         if install_tree_before != install_tree_after or upstreams_before != upstreams_after:
             setattr(env, "store_token", spack.store.reinitialize())
 

--- a/lib/spack/spack/environment/environment.py
+++ b/lib/spack/spack/environment/environment.py
@@ -216,6 +216,13 @@ def validate_env_name(name):
     return name
 
 
+def set_active_environment(env: Optional["Environment"]) -> None:
+    """Set or clear the active environment, keeping the "$env" config substitution in sync."""
+    global _active_environment
+    _active_environment = env
+    spack.config.CONFIG.env_path = env.path if env is not None else None
+
+
 def activate(env, use_env_repo=False):
     """Activate an environment.
 
@@ -227,18 +234,14 @@ def activate(env, use_env_repo=False):
         use_env_repo (bool): use the packages exactly as they appear in the
             environment's repository
     """
-    global _active_environment
-
     try:
-        _active_environment = env
-
         # Fail early to avoid ending in an invalid state
         if not isinstance(env, Environment):
-            raise TypeError("`env` should be of type {0}".format(Environment.__name__))
+            raise TypeError(f"`env` should be of type {Environment.__name__}")
 
-        # Record the env path so config "$env" substitutions work while the manifest's
-        # config scope is being prepared below (and for the lifetime of the activation).
-        spack.config.CONFIG.env_path = env.path
+        # Record the active env (and its path, so config "$env" substitutions work) while the
+        # manifest's config scope is being prepared below and for the lifetime of the activation.
+        set_active_environment(env)
 
         # Check if we need to reinitialize spack.store.STORE and spack.repo.REPO due to
         # config changes.
@@ -263,15 +266,12 @@ def activate(env, use_env_repo=False):
 
         tty.debug(f"Using environment '{env.name}'")
     except Exception:
-        _active_environment = None
-        spack.config.CONFIG.env_path = None
+        set_active_environment(None)
         raise
 
 
 def deactivate():
     """Undo any configuration or repo settings modified by ``activate()``."""
-    global _active_environment
-
     if not _active_environment:
         return
 
@@ -291,8 +291,7 @@ def deactivate():
 
     tty.debug(f"Deactivated environment '{_active_environment.name}'")
 
-    _active_environment = None
-    spack.config.CONFIG.env_path = None
+    set_active_environment(None)
 
 
 def active_environment() -> Optional["Environment"]:

--- a/lib/spack/spack/main.py
+++ b/lib/spack/spack/main.py
@@ -997,8 +997,7 @@ def _main(argv=None):
         # do not call activate here, as it has a lot of expensive function calls to deal
         # with mutation of spack.config.CONFIG -- but we are still building the config.
         env.manifest.prepare_config_scope()
-        spack.config.CONFIG.env_path = env.path
-        spack.environment.environment._active_environment = env
+        spack.environment.environment.set_active_environment(env)
 
     # add the environment
     if env:

--- a/lib/spack/spack/main.py
+++ b/lib/spack/spack/main.py
@@ -997,6 +997,7 @@ def _main(argv=None):
         # do not call activate here, as it has a lot of expensive function calls to deal
         # with mutation of spack.config.CONFIG -- but we are still building the config.
         env.manifest.prepare_config_scope()
+        spack.config.CONFIG.env_path = env.path
         spack.environment.environment._active_environment = env
 
     # add the environment

--- a/lib/spack/spack/test/main.py
+++ b/lib/spack/spack/test/main.py
@@ -339,3 +339,16 @@ include:
         assert mutable_config.get("config:debug") is expected
     except AssertionError:
         pytest.xfail("recursive includes are not processed in the expected order")
+
+
+@pytest.mark.regression("52664")
+def test_env_substitution_via_main_entrypoint(mutable_mock_env_path):
+    """Tests that an environment activated through the CLI entrypoint can substitute ``$env``"""
+    env = ev.create("test")
+    assert spack.config.CONFIG.env_path is None
+
+    # Just call a fast command
+    spack.main._main(["-e", "test", "config", "scopes"])
+
+    assert spack.config.CONFIG.env_path == env.path
+    assert spack.config.substitute_path_variables("$env/foo") == f"{env.path}/foo"


### PR DESCRIPTION
fixes #52664

In #52627 we forgot to update the `_main` function, which duplicates part of env.activation. 

Here we:
- Fix the issue introduced in #52627
- Add a unit test to avoid regression
- Deduplicate the code to keep CONFIG.env_path in sync with `_activate`
