### PR TITLE
splicing: only give concrete nodes a build_spec, make `.spliced` local

### DIFF
--- a/lib/spack/spack/solver/splicing.py
+++ b/lib/spack/spack/solver/splicing.py
@@ -21,12 +21,12 @@ class Splice(NamedTuple):
 def _resolve_collected_splices(
     specs: List[Spec], splices: Dict[Spec, List[Splice]]
 ) -> Dict[Spec, Spec]:
-    """After all of the specs have been concretized, apply all immediate splices.
+    """After all the specs have been concretized, apply all immediate splices.
     Returns a dict mapping original specs to their resolved counterparts
     """
 
     def splice_cmp(s1: Spec, s2: Spec):
-        """This function can be used to sort a list of specs such that that any
+        """This function can be used to sort a list of specs such that any
         spec which will be spliced into a parent comes after the parent it will
         be spliced into. This order ensures that transitive splices will be
         executed in the correct order.
@@ -53,11 +53,19 @@ def _resolve_collected_splices(
             edge.spec in already_resolved for edge in spec.edges_to_dependencies()
         ):
             continue
+
         new_spec = spec.copy(deps=False)
         new_spec.clear_caches(ignore=("package_hash",))
-        new_spec.build_spec = spec
+
+        is_reused = spec.concrete
+        if is_reused:
+            # The build_spec is meaningful only for reused nodes (it records how specs were built)
+            new_spec.build_spec = spec
+
         for edge in spec.edges_to_dependencies():
-            depflag = edge.depflag & ~dt.BUILD
+            # A reused node is rewired from its build_spec prefix, so its build deps live on the
+            # build_spec and are dropped here; a fresh node is built from source and keeps them.
+            depflag = edge.depflag & ~dt.BUILD if is_reused else edge.depflag
             if any(edge.spec.dag_hash() == splice.child_hash for splice in immediate):
                 splice = [s for s in immediate if s.child_hash == edge.spec.dag_hash()][0]
                 # If the spec being splice in is also spliced

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -2082,10 +2082,8 @@ class Spec:
 
     @property
     def spliced(self):
-        """Returns whether or not this Spec is being deployed as built i.e.
-        whether or not this Spec has ever been spliced.
-        """
-        return any(s.build_spec is not s for s in self.traverse(root=True))
+        """Returns whether this Spec is being deployed as built i.e. whether it has been spliced"""
+        return self.build_spec is not self
 
     @property
     def installed(self):

--- a/lib/spack/spack/test/concretization/splicing.py
+++ b/lib/spack/spack/test/concretization/splicing.py
@@ -275,3 +275,39 @@ def test_spliced_transitive_dependency(install_specs, mutable_config):
     # Spliced build dependencies are removed
     assert len(spliced.dependencies(None, dt.BUILD)) == 0
     assert len(spliced["splice-t"].dependencies(None, dt.BUILD)) == 0
+
+
+def test_fresh_ancestor_of_spliced_dep_is_not_spliced(install_specs, mutable_config):
+    """Tests that a "fresh" node above a spliced reused dependency keeps self as build_spec."""
+    # splice-h is installed (reusable) and built against splice-z@1.0.0. Force its reuse so the
+    # solver must splice its splice-z child up to 1.0.2 rather than rebuild splice-h.
+    install_specs("splice-h@1.0.0+compat ^splice-z@1.0.0+compat")
+    mutable_config.set("packages", _make_specs_non_buildable(["splice-h"]))
+    _enable_splicing()
+
+    # splice-t is a fresh root: it depends on the reused, spliced splice-h.
+    concrete = spack.concretize.concretize_one(
+        "splice-t@1.0 ^splice-h@1.0.0+compat ^splice-z@1.0.2+compat"
+    )
+
+    assert all(node.concrete for node in concrete.traverse())
+
+    # The fresh root is not spliced
+    assert concrete.build_spec is concrete
+    assert not concrete.spliced
+
+    # All build specs are concrete
+    for node in concrete.traverse():
+        assert node.build_spec.concrete
+
+    # Being built from source, the fresh root keeps its build dependencies
+    assert concrete.dependencies(None, dt.BUILD)
+
+    # The genuinely reused dependency is still spliced, with a concrete build_spec
+    splice_h = concrete["splice-h"]
+    assert splice_h.build_spec is not splice_h
+    assert splice_h.spliced
+
+    # The leaf node is not spliced
+    splice_z = concrete["splice-z"]
+    assert splice_z.satisfies("@1.0.2") and not splice_z.spliced


### PR DESCRIPTION
`_resolve_collected_splices` assigned a `build_spec` to every ancestor of a spliced node, including fresh (not-yet-concrete) nodes that depend on a spliced subtree.

This is fixed by setting `build_spec` only when the pre-splice node is concrete. As a consequence every `build_spec` reachable in a solve result is now concrete. This fixes a bug where we serialize an abstract spec as the `.build_spec` of a fresh ancestor of a spliced node.

On top of that the way we compute `.spliced` is made local. This is particularly important for the installer, that would otherwise emit a RewireTask for something that is yet to be built.