### PR TITLE
modules: fix spec matching with suffixes

### DIFF
--- a/lib/spack/spack/modules/common.py
+++ b/lib/spack/spack/modules/common.py
@@ -445,7 +445,7 @@ class BaseConfiguration:
         """
         suffixes = []
         for constraint, suffix in self.conf.get("suffixes", {}).items():
-            if constraint in self.spec:
+            if self.spec.satisfies(constraint):
                 suffixes.append(suffix)
         suffixes = list(dedupe(suffixes))
         # For hidden modules we can always add a fixed length hash as suffix, since it guards

--- a/lib/spack/spack/test/data/modules/tcl/suffix_propagation.yaml
+++ b/lib/spack/spack/test/data/modules/tcl/suffix_propagation.yaml
@@ -1,0 +1,8 @@
+enable:
+  - tcl
+tcl:
+  all:
+    autoload: none
+    suffixes:
+      'mpich': namematch
+      '^mpich': depmatch

--- a/lib/spack/spack/test/modules/tcl.py
+++ b/lib/spack/spack/test/modules/tcl.py
@@ -824,3 +824,20 @@ class TestTcl:
                 assert "${lapack_name} ${lapack_version}" in line, (
                     f"Expected Tcl syntax '${{lapack_name}} ${{lapack_version}}' but got: {line!r}"
                 )
+
+    @pytest.mark.regression("7487")
+    def test_suffix_does_not_propagate_to_dependents(self, factory, module_configuration):
+        """A bare package-name suffix key matches only the root spec, while a '^name'
+        key matches specs that depend on that package. The two must not overlap.
+        """
+        module_configuration("suffix_propagation")
+
+        # mpileaks depends on mpich but is not mpich, so only the '^mpich' key applies
+        writer, _ = factory("mpileaks ^mpich@3.0.4")
+        assert "depmatch" in writer.layout.use_name
+        assert "namematch" not in writer.layout.use_name
+
+        # mpich itself is matched only by the bare 'mpich' key
+        writer, _ = factory("mpich@3.0.4")
+        assert "namematch" in writer.layout.use_name
+        assert "depmatch" not in writer.layout.use_name


### PR DESCRIPTION
fixes #7487

Before we were incorrectly using `constraint in spec` instead of `spec.satisfies(constraint)`, which would cause double matches when full names are used. Fix that and add a regression test.