### PR TITLE
docs: update code formatter

### DIFF
--- a/lib/spack/docs/contribution_guide.rst
+++ b/lib/spack/docs/contribution_guide.rst
@@ -152,7 +152,6 @@ Style Tests
 ^^^^^^^^^^^^
 
 Spack uses `Ruff <https://docs.astral.sh/ruff/>`_ for code formatting and linting, and `mypy <https://mypy.readthedocs.io/en/stable/>`_ for type checking.
-Ruff enforces `PEP 8 <https://www.python.org/dev/peps/pep-0008/>`_ conformance, which is a series of style guides for Python that provide suggestions for everything from variable naming to indentation.
 In order to limit the number of PRs that were mostly style changes, we decided to enforce PEP 8 conformance.
 Your PR needs to comply with PEP 8 in order to be accepted, and if it modifies the Spack library, it needs to successfully type-check with mypy as well.
 

--- a/lib/spack/docs/contribution_guide.rst
+++ b/lib/spack/docs/contribution_guide.rst
@@ -175,10 +175,6 @@ To automatically fix formatting and linting issues, use the ``--fix`` flag:
 
 #. It works regardless of what directory you are in.
 
-#. It automatically adds approved exemptions from style checks.
-   For example, URLs are often longer than 80 characters, so we exempt them from line length checks.
-   We also exempt lines that start with ``homepage =``, ``url =``, ``version()``, ``variant()``, ``depends_on()``, and ``extends()`` in ``package.py`` files.
-
 If all is well, you'll see something like this:
 
 .. code-block:: console

--- a/lib/spack/docs/contribution_guide.rst
+++ b/lib/spack/docs/contribution_guide.rst
@@ -151,8 +151,8 @@ Check out the `pytest documentation <http://pytest.org/>`_ and feel free to ask 
 Style Tests
 ^^^^^^^^^^^^
 
-Spack uses `Flake8 <http://flake8.pycqa.org/en/latest/>`_ to test for `PEP 8 <https://www.python.org/dev/peps/pep-0008/>`_ conformance and `mypy <https://mypy.readthedocs.io/en/stable/>`_ for type checking.
-PEP 8 is a series of style guides for Python that provide suggestions for everything from variable naming to indentation.
+Spack uses `Ruff <https://docs.astral.sh/ruff/>`_ for code formatting and linting, and `mypy <https://mypy.readthedocs.io/en/stable/>`_ for type checking.
+Ruff enforces `PEP 8 <https://www.python.org/dev/peps/pep-0008/>`_ conformance, which is a series of style guides for Python that provide suggestions for everything from variable naming to indentation.
 In order to limit the number of PRs that were mostly style changes, we decided to enforce PEP 8 conformance.
 Your PR needs to comply with PEP 8 in order to be accepted, and if it modifies the Spack library, it needs to successfully type-check with mypy as well.
 
@@ -163,51 +163,60 @@ Simply run the ``spack style`` command:
 
    $ spack style
 
+To automatically fix formatting and linting issues, use the ``--fix`` flag:
+
+.. code-block:: console
+
+   $ spack style --fix
+
 ``spack style`` has a couple advantages over running the tools by hand:
 
 #. It only tests files that you have modified since branching off of ``develop``.
 
 #. It works regardless of what directory you are in.
 
-#. It automatically adds approved exemptions from the ``flake8`` checks.
+#. It automatically adds approved exemptions from style checks.
    For example, URLs are often longer than 80 characters, so we exempt them from line length checks.
    We also exempt lines that start with ``homepage =``, ``url =``, ``version()``, ``variant()``, ``depends_on()``, and ``extends()`` in ``package.py`` files.
-   This is now also possible when directly running Flake8 if you can use the ``spack`` formatter plugin included with Spack.
-
-More approved Flake8 exemptions can be found `here <https://github.com/spack/spack/blob/develop/.flake8>`_.
 
 If all is well, you'll see something like this:
 
 .. code-block:: console
 
-   $ run-flake8-tests
-   Dependencies found.
-   =======================================================
-   flake8: running flake8 code checks on spack.
+   $ spack style
+   ==> Running style checks on spack
+     selected: import, ruff-format, ruff-check, mypy
+   ==> Checking Files:
+     var/spack/repos/builtin/packages/hdf5/package.py
+     var/spack/repos/builtin/packages/hdf/package.py
+     var/spack/repos/builtin/packages/netcdf/package.py
+   ==> Running import checks
+     import checks were clean
+   ==> Running ruff-format checks
+     ruff-format checks were clean
+   ==> Running ruff-check checks
+     ruff-check checks were clean
+   ==> Running mypy checks
+     mypy checks were clean
+   ==> spack style checks were clean
 
-   Modified files:
-
-     var/spack/repos/spack_repo/builtin/packages/hdf5/package.py
-     var/spack/repos/spack_repo/builtin/packages/hdf/package.py
-     var/spack/repos/spack_repo/builtin/packages/netcdf/package.py
-   =======================================================
-   Flake8 checks were clean.
-
-However, if you are not compliant with PEP 8, Flake8 will complain:
+However, if you are not compliant with PEP 8, Ruff will report errors:
 
 .. code-block:: console
 
-   var/spack/repos/spack_repo/builtin/packages/netcdf/package.py:26: [F401] 'os' imported but unused
-   var/spack/repos/spack_repo/builtin/packages/netcdf/package.py:61: [E303] too many blank lines (2)
-   var/spack/repos/spack_repo/builtin/packages/netcdf/package.py:106: [E501] line too long (92 > 79 characters)
-   Flake8 found errors.
+   $ spack style
+   ==> Running style checks on spack
+   var/spack/repos/builtin/packages/netcdf/package.py:26:1: F401 'os' imported but unused
+   var/spack/repos/builtin/packages/netcdf/package.py:61:1: E303 too many blank lines (2)
+   var/spack/repos/builtin/packages/netcdf/package.py:106:80: E501 line too long (92 > 79 characters)
 
 Most of the error messages are straightforward, but if you do not understand what they mean, just ask questions about them when you submit your PR.
 The line numbers will change if you add or delete lines, so simply run ``spack style`` again to update them.
+Many errors can be automatically fixed by running ``spack style --fix``.
 
 .. tip::
 
-   Try fixing Flake8 errors in reverse order.
+   Try fixing style errors in reverse order.
    This eliminates the need for multiple runs of ``spack style`` just to re-compute line numbers and makes it much easier to fix errors directly off of the CI output.
 
 

--- a/lib/spack/docs/contribution_guide.rst
+++ b/lib/spack/docs/contribution_guide.rst
@@ -175,6 +175,10 @@ To automatically fix formatting and linting issues, use the ``--fix`` flag:
 
 #. It works regardless of what directory you are in.
 
+#. It automatically adds approved exemptions from style checks.
+   For example, URLs are often longer than 99 characters, so we exempt them from line length checks.
+   We also exempt certain import-related checks in ``package.py`` files (e.g., ``from spack.package import *``).
+
 If all is well, you'll see something like this:
 
 .. code-block:: console
@@ -204,7 +208,7 @@ However, if you are not compliant with PEP 8, Ruff will report errors:
    ==> Running style checks on spack
    var/spack/repos/builtin/packages/netcdf/package.py:26:1: F401 'os' imported but unused
    var/spack/repos/builtin/packages/netcdf/package.py:61:1: E303 too many blank lines (2)
-   var/spack/repos/builtin/packages/netcdf/package.py:106:80: E501 line too long (92 > 79 characters)
+   var/spack/repos/builtin/packages/netcdf/package.py:106:100: E501 line too long (105 > 99 characters)
 
 Most of the error messages are straightforward, but if you do not understand what they mean, just ask questions about them when you submit your PR.
 The line numbers will change if you add or delete lines, so simply run ``spack style`` again to update them.

--- a/lib/spack/docs/developer_guide.rst
+++ b/lib/spack/docs/developer_guide.rst
@@ -519,14 +519,14 @@ Developer commands
 ``spack style``
 ^^^^^^^^^^^^^^^
 
-``spack style`` exists to help the developer check imports and style with mypy, Flake8, isort, and (soon) Black.
+``spack style`` exists to help the developer check imports and style with mypy and Ruff (for formatting and linting).
 To run all style checks, simply do:
 
 .. code-block:: console
 
     $ spack style
 
-To run automatic fixes for isort, you can do:
+To automatically fix formatting and linting issues, you can do:
 
 .. code-block:: console
 

--- a/lib/spack/docs/package_review_guide.rst
+++ b/lib/spack/docs/package_review_guide.rst
@@ -335,7 +335,7 @@ Style failures
 The PR may fail one or more style checks.
 
 **Action.**
-If the failure is due to issues raised by the ``black`` style checker *and* the PR is otherwise ready to be merged, you can add ``@spackbot fix style`` in a comment to see if Spack will fix the errors.
+If the failure is due to style issues that can be automatically fixed *and* the PR is otherwise ready to be merged, you can add ``@spackbot fix style`` in a comment to see if Spack will fix the errors.
 Otherwise, inform the Contributor that the style failures need to be addressed.
 
 CI stack failures

--- a/lib/spack/spack/cmd/style.py
+++ b/lib/spack/spack/cmd/style.py
@@ -168,7 +168,7 @@ def setup_parser(subparser: argparse.ArgumentParser) -> None:
         "--fix",
         action="store_true",
         default=False,
-        help="format automatically if possible (e.g., with isort, black)",
+        help="format and fix issues automatically (e.g., with ruff)",
     )
     subparser.add_argument(
         "--root", action="store", default=None, help="style check a different spack instance"
@@ -486,7 +486,7 @@ def print_style_header(file_list: List[Path], args, tools_to_run):
 
 def validate_toolset(arg_value):
     """Validate ``--tool`` and ``--skip`` arguments (sets of optionally comma-separated tools)."""
-    tools = set(",".join(arg_value).split(","))  # allow args like 'isort,flake8'
+    tools = set(",".join(arg_value).split(","))  # allow args like 'ruff-check,mypy'
     for tool in tools:
         if tool not in tool_names:
             tty.die("Invalid tool: '%s'" % tool, "Choose from: %s" % ", ".join(tool_names))

--- a/share/spack/spack-completion.fish
+++ b/share/spack/spack-completion.fish
@@ -3150,7 +3150,7 @@ complete -c spack -n '__fish_spack_using_command style' -s r -l root-relative -d
 complete -c spack -n '__fish_spack_using_command style' -s U -l no-untracked -f -a untracked
 complete -c spack -n '__fish_spack_using_command style' -s U -l no-untracked -d 'exclude untracked files from checks'
 complete -c spack -n '__fish_spack_using_command style' -s f -l fix -f -a fix
-complete -c spack -n '__fish_spack_using_command style' -s f -l fix -d 'format automatically if possible (e.g., with isort, black)'
+complete -c spack -n '__fish_spack_using_command style' -s f -l fix -d 'format and fix issues automatically (e.g., with ruff)'
 complete -c spack -n '__fish_spack_using_command style' -l root -r -f -a root
 complete -c spack -n '__fish_spack_using_command style' -l root -r -d 'style check a different spack instance'
 complete -c spack -n '__fish_spack_using_command style' -s t -l tool -r -f -a tool


### PR DESCRIPTION
Update docs to reflect that Spack has moved from flake8 and black to ruff for code formatting and      
  linting.