### PR TITLE
solver: only inject compiler flags when used as a compiler

### DIFF
--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -76,7 +76,7 @@ from .core import AspFunction, AspVar, NodeId, SourceContext, extract_args, fn
 from .input_analysis import create_counter, create_graph_analyzer
 from .requirements import RequirementKind, RequirementOrigin, RequirementParser, RequirementRule
 from .reuse import ReusableSpecsSelector, SpecFiltersFactory
-from .runtimes import COMPILER_LANGUAGES, RuntimePropertyRecorder, all_libcs
+from .runtimes import COMPILER_WRAPPER_LANGUAGES, RuntimePropertyRecorder, all_libcs
 from .versions import Provenance
 
 GitOrStandardVersion = Union[vn.GitVersion, vn.StandardVersion]
@@ -3087,7 +3087,7 @@ class SpackSolverSetup:
         if should_mix is True:
             return
         # anything besides should_mix: true
-        for lang in COMPILER_LANGUAGES:
+        for lang in COMPILER_WRAPPER_LANGUAGES:
             self.gen.fact(fn.no_compiler_mixing(lang))
         # user specified an allow-list
         if isinstance(should_mix, list):
@@ -3113,7 +3113,7 @@ class SpackSolverSetup:
 
             # Add a dependency on the compiler wrapper
             compiler_str = f"{compiler.name} /{compiler.dag_hash()}"
-            for language in COMPILER_LANGUAGES:
+            for language in COMPILER_WRAPPER_LANGUAGES:
                 # Using compiler.name causes a bit of duplication, but that is taken care of by
                 # clingo during grounding.
                 recorder("*").depends_on(

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -76,7 +76,7 @@ from .core import AspFunction, AspVar, NodeId, SourceContext, extract_args, fn
 from .input_analysis import create_counter, create_graph_analyzer
 from .requirements import RequirementKind, RequirementOrigin, RequirementParser, RequirementRule
 from .reuse import ReusableSpecsSelector, SpecFiltersFactory
-from .runtimes import RuntimePropertyRecorder, all_libcs
+from .runtimes import COMPILER_LANGUAGES, RuntimePropertyRecorder, all_libcs
 from .versions import Provenance
 
 GitOrStandardVersion = Union[vn.GitVersion, vn.StandardVersion]
@@ -3087,7 +3087,7 @@ class SpackSolverSetup:
         if should_mix is True:
             return
         # anything besides should_mix: true
-        for lang in ["c", "cxx", "fortran"]:
+        for lang in COMPILER_LANGUAGES:
             self.gen.fact(fn.no_compiler_mixing(lang))
         # user specified an allow-list
         if isinstance(should_mix, list):
@@ -3113,7 +3113,7 @@ class SpackSolverSetup:
 
             # Add a dependency on the compiler wrapper
             compiler_str = f"{compiler.name} /{compiler.dag_hash()}"
-            for language in ("c", "cxx", "fortran"):
+            for language in COMPILER_LANGUAGES:
                 # Using compiler.name causes a bit of duplication, but that is taken care of by
                 # clingo during grounding.
                 recorder("*").depends_on(

--- a/lib/spack/spack/solver/runtimes.py
+++ b/lib/spack/spack/solver/runtimes.py
@@ -15,6 +15,11 @@ import spack.version
 from .core import SourceContext, fn
 from .versions import Provenance
 
+#: Language virtuals a compiler may provide. A compiler's flags are injected into a dependent
+#: only when the compiler is actually used to compile it, i.e. the build edge provides one of
+#: these virtuals.
+COMPILER_LANGUAGES = ("c", "cxx", "fortran")
+
 
 class RuntimePropertyRecorder:
     """An object of this class is injected in callbacks to compilers, to let them declare
@@ -209,9 +214,6 @@ class RuntimePropertyRecorder:
             self.reset()
             return
 
-        when_spec = spack.spec.Spec(f"%[deptypes=build] {spec}")
-        body_str, node_variable = self.rule_body_from(when_spec)
-
         node_placeholder = "XXX"
         flags = spec.extra_attributes["flags"]
         root_spec_str = f"{node_placeholder}"
@@ -222,12 +224,18 @@ class RuntimePropertyRecorder:
             root_spec, body=False, context=SourceContext(source="compiler")
         )
         self.rules.append(f"% Default compiler flags for {spec}\n")
-        for clause in head_clauses:
-            if clause.args[0] == "node":
-                continue
-            head_str = str(clause).replace(f'"{node_placeholder}"', f"{node_variable}")
-            rule = f"{head_str} :-\n{body_str}."
-            self.rules.append(rule)
+
+        # Inject the flags only when the compiler is actually used to compile the dependent,
+        # i.e. the build edge provides one of the language virtuals.
+        for language in COMPILER_LANGUAGES:
+            when_spec = spack.spec.Spec(f"%[deptypes=build virtuals={language}] {spec}")
+            body_str, node_variable = self.rule_body_from(when_spec)
+            for clause in head_clauses:
+                if clause.args[0] == "node":
+                    continue
+                head_str = str(clause).replace(f'"{node_placeholder}"', f"{node_variable}")
+                rule = f"{head_str} :-\n{body_str}."
+                self.rules.append(rule)
 
         self.reset()
 

--- a/lib/spack/spack/solver/runtimes.py
+++ b/lib/spack/spack/solver/runtimes.py
@@ -15,10 +15,8 @@ import spack.version
 from .core import SourceContext, fn
 from .versions import Provenance
 
-#: Language virtuals a compiler may provide. A compiler's flags are injected into a dependent
-#: only when the compiler is actually used to compile it, i.e. the build edge provides one of
-#: these virtuals.
-COMPILER_LANGUAGES = ("c", "cxx", "fortran")
+#: Language virtuals wrapped by the compiler wrapper (same ones for which a flag exists)
+COMPILER_WRAPPER_LANGUAGES = ("c", "cxx", "fortran")
 
 
 class RuntimePropertyRecorder:
@@ -227,7 +225,7 @@ class RuntimePropertyRecorder:
 
         # Inject the flags only when the compiler is actually used to compile the dependent,
         # i.e. the build edge provides one of the language virtuals.
-        for language in COMPILER_LANGUAGES:
+        for language in COMPILER_WRAPPER_LANGUAGES:
             when_spec = spack.spec.Spec(f"%[deptypes=build virtuals={language}] {spec}")
             body_str, node_variable = self.rule_body_from(when_spec)
             for clause in head_clauses:

--- a/lib/spack/spack/test/concretization/flag_mixing.py
+++ b/lib/spack/spack/test/concretization/flag_mixing.py
@@ -302,3 +302,40 @@ def test_flags_and_duplicate_nodes(spec_str, expected, not_expected, default_moc
     s = default_mock_concretization(spec_str)
     assert all(s.satisfies(x) for x in expected)
     assert all(not s.satisfies(x) for x in not_expected)
+
+
+@pytest.mark.regression("52670")
+def test_no_flags_from_compiler_used_only_as_library(concretize_scope, mock_packages):
+    """Tests that we don't attach flags defined on a possible compiler when we have a build
+    dependency on it, but we're using it as a library.
+    """
+    packages_yaml = """
+packages:
+  gcc:
+    externals:
+    - spec: gcc@12.100.100 languages:=c,c++
+      prefix: /fake
+      extra_attributes:
+        compilers:
+          c: /fake/bin/gcc
+          cxx: /fake/bin/g++
+  llvm:
+    externals:
+    - spec: llvm@19.1.0+clang
+      prefix: /fake
+      extra_attributes:
+        compilers:
+          c: /fake/bin/clang
+          cxx: /fake/bin/clang++
+        flags:
+          cflags: -Wall
+"""
+    update_concretize_scope(packages_yaml, "packages")
+
+    s = spack.concretize.concretize_one("llvm-client %c,cxx=gcc@12.100.100")
+
+    # gcc, not llvm, compiles llvm-client, and llvm is pulled in only as a library
+    assert s["c"].name == "gcc"
+    assert s["llvm"].external and s["llvm"].satisfies("@19.1.0")
+    # the external llvm's cflags must not be injected into its dependent
+    assert s.compiler_flags["cflags"] == []


### PR DESCRIPTION
fixes #52670

Flags were previously injected when `%[deptypes-build]<compiler>` but in a few cases a possible compiler is used only as a library. This rule now is gated on the virtual being provided, which solves the original issue.

There are still issues when two compilers bearing flags are used for different languages on the same node. This one is pre-existing and difficult to solve cleanly since there are flags which are language agnostic (`cppflags`, `ldflags`, `ldlibs`).