### PR TITLE
filesystem: windows_sfn predeclare types for ctypes invocations

### DIFF
--- a/lib/spack/spack/util/filesystem.py
+++ b/lib/spack/spack/util/filesystem.py
@@ -1373,8 +1373,11 @@ def windows_sfn(path: os.PathLike):
     if sys.platform == "win32":
         path = str(path)
         k32 = ctypes.WinDLL("kernel32", use_last_error=True)
+        _GetShortPathNameW = k32.GetShortPathNameW
+        _GetShortPathNameW.argtypes = [wintypes.LPCWSTR, wintypes.LPWSTR, wintypes.DWORD]
+        _GetShortPathNameW.restype = wintypes.DWORD
         # Method with null values returns size of short path name
-        sz = k32.GetShortPathNameW(path, None, 0)
+        sz = _GetShortPathNameW(path, None, 0)
         # stub Windows types TCHAR[LENGTH]
         TCHAR_arr = ctypes.c_wchar * sz
         ret_str = TCHAR_arr()

--- a/lib/spack/spack/util/filesystem.py
+++ b/lib/spack/spack/util/filesystem.py
@@ -1381,7 +1381,7 @@ def windows_sfn(path: os.PathLike):
         # stub Windows types TCHAR[LENGTH]
         TCHAR_arr = ctypes.c_wchar * sz
         ret_str = TCHAR_arr()
-        _GetShortPathNameW(path, ctypes.byref(ret_str), sz)
+        _GetShortPathNameW(path, ret_str, sz)
         return ret_str.value
     return path
 

--- a/lib/spack/spack/util/filesystem.py
+++ b/lib/spack/spack/util/filesystem.py
@@ -1381,7 +1381,7 @@ def windows_sfn(path: os.PathLike):
         # stub Windows types TCHAR[LENGTH]
         TCHAR_arr = ctypes.c_wchar * sz
         ret_str = TCHAR_arr()
-        k32.GetShortPathNameW(path, ctypes.byref(ret_str), sz)
+        _GetShortPathNameW(path, ctypes.byref(ret_str), sz)
         return ret_str.value
     return path
 

--- a/lib/spack/spack/util/filesystem.py
+++ b/lib/spack/spack/util/filesystem.py
@@ -1378,10 +1378,16 @@ def windows_sfn(path: os.PathLike):
         _GetShortPathNameW.restype = wintypes.DWORD
         # Method with null values returns size of short path name
         sz = _GetShortPathNameW(path, None, 0)
+        if not sz:
+            tty.debug(ctypes.WinError(ctypes.get_last_error()))
+            return path
         # stub Windows types TCHAR[LENGTH]
         TCHAR_arr = ctypes.c_wchar * sz
         ret_str = TCHAR_arr()
         _GetShortPathNameW(path, ret_str, sz)
+        if ctypes.get_last_error():
+            tty.debug(ctypes.WinError(ctypes.get_last_error()))
+            return path
         return ret_str.value
     return path
 

--- a/lib/spack/spack/util/filesystem.py
+++ b/lib/spack/spack/util/filesystem.py
@@ -1379,15 +1379,13 @@ def windows_sfn(path: os.PathLike):
         # Method with null values returns size of short path name
         sz = _GetShortPathNameW(path, None, 0)
         if not sz:
-            tty.debug(ctypes.WinError(ctypes.get_last_error()))
-            return path
+            raise ctypes.WinError(ctypes.get_last_error())
         # stub Windows types TCHAR[LENGTH]
         TCHAR_arr = ctypes.c_wchar * sz
         ret_str = TCHAR_arr()
         status = _GetShortPathNameW(path, ret_str, sz)
         if not status:
-            tty.debug(ctypes.WinError(ctypes.get_last_error()))
-            return path
+            raise ctypes.WinError(ctypes.get_last_error())
         return ret_str.value
     return path
 

--- a/lib/spack/spack/util/filesystem.py
+++ b/lib/spack/spack/util/filesystem.py
@@ -1384,8 +1384,8 @@ def windows_sfn(path: os.PathLike):
         # stub Windows types TCHAR[LENGTH]
         TCHAR_arr = ctypes.c_wchar * sz
         ret_str = TCHAR_arr()
-        _GetShortPathNameW(path, ret_str, sz)
-        if ctypes.get_last_error():
+        status = _GetShortPathNameW(path, ret_str, sz)
+        if not status:
             tty.debug(ctypes.WinError(ctypes.get_last_error()))
             return path
         return ret_str.value


### PR DESCRIPTION
Ctypes invocations need typing for both their args and their return types, otherwise the typing is left ambiguous, and spurious errors can occur due to the underlying types `ctypes` will pass to the win32 api. 
Explicitly typing `restype` and `argtypes` prevents this and ensures the correct types are forwarded back and forth from ctypes to the win32 api. 