### PR TITLE
Fixes for web_util.push_to_url

### DIFF
--- a/lib/spack/spack/ci/__init__.py
+++ b/lib/spack/spack/ci/__init__.py
@@ -1286,9 +1286,7 @@ def write_broken_spec(url, pkg_name, stack_name, job_url, pipeline_url, spec_dic
         try:
             with open(file_path, "w", encoding="utf-8") as fd:
                 syaml.dump(broken_spec_details, fd)
-            web_util.push_to_url(
-                file_path, url, keep_original=False, extra_args={"ContentType": "text/plain"}
-            )
+            web_util.push_to_url(file_path, url, keep_original=False, content_type="text/plain")
         except Exception as err:
             # If there is an S3 error (e.g., access denied or connection
             # error), the first non boto-specific class in the exception

--- a/lib/spack/spack/test/web.py
+++ b/lib/spack/spack/test/web.py
@@ -9,7 +9,7 @@ import pickle
 import ssl
 import urllib.error
 import urllib.request
-from typing import Dict
+from typing import Any, Dict, List, Tuple
 
 import pytest
 
@@ -39,6 +39,75 @@ page_4 = _create_url("4.html")
 
 root_with_fragment = _create_url("index_with_fragment.html")
 root_with_javascript = _create_url("index_with_javascript.html")
+
+
+class MockPages:
+    def search(self, *args, **kwargs):
+        return [{"Key": "keyone"}, {"Key": "keytwo"}, {"Key": "keythree"}]
+
+
+class MockPaginator:
+    def paginate(self, *args, **kwargs):
+        return MockPages()
+
+
+class MockClientError(Exception):
+    def __init__(self):
+        self.response = {
+            "Error": {"Code": "NoSuchKey"},
+            "ResponseMetadata": {"HTTPStatusCode": 404},
+        }
+
+
+class MockS3Client:
+    """Mock S3 client with canned responses."""
+
+    def __init__(self, url, method="fetch"):
+        Args = List[Any]
+        KWArgs = Dict[str, Any]
+        self.put_object_calls: List[Tuple[Args, KWArgs]] = []
+        self.upload_file_calls: List[Tuple[Args, KWArgs]] = []
+        self.ClientError = MockClientError
+
+    def put_object(self, *args, **kwargs):
+        # Read and store the contents of the Body filestream
+        if "Body" in kwargs:
+            kwargs["Body"] = kwargs["Body"].read()
+
+        self.put_object_calls.append((args, kwargs))
+
+    def upload_file(self, *args, **kwargs):
+        self.upload_file_calls.append((args, kwargs))
+
+    def get_paginator(self, *args, **kwargs):
+        return MockPaginator()
+
+    def delete_objects(self, *args, **kwargs):
+        return {
+            "Errors": [{"Key": "keyone", "Message": "Access Denied"}],
+            "Deleted": [{"Key": "keytwo"}, {"Key": "keythree"}],
+        }
+
+    def delete_object(self, *args, **kwargs):
+        pass
+
+    def get_object(self, Bucket=None, Key=None):
+        if Bucket == "my-bucket" and Key == "subdirectory/my-file":
+            return {"ResponseMetadata": {"HTTPHeaders": {}}}
+        raise self.ClientError
+
+    def head_object(self, Bucket=None, Key=None):
+        if Bucket == "my-bucket" and Key == "subdirectory/my-file":
+            return {"ResponseMetadata": {"HTTPHeaders": {}}}
+        raise self.ClientError
+
+
+@pytest.fixture
+def mock_s3_client(monkeypatch):
+    client = MockS3Client("s3://my-bucket/")
+    monkeypatch.setattr(spack.util.s3, "get_s3_session", lambda url, method="fetch": client)
+    monkeypatch.setattr(spack.util.web, "get_s3_session", lambda url, method="fetch": client)
+    return client
 
 
 @pytest.mark.parametrize(
@@ -233,50 +302,6 @@ def test_list_url(tmp_path: pathlib.Path):
     assert list_url(True) == ["dir/another-file.txt", "file-0.txt", "file-1.txt", "file-2.txt"]
 
 
-class MockPages:
-    def search(self, *args, **kwargs):
-        return [{"Key": "keyone"}, {"Key": "keytwo"}, {"Key": "keythree"}]
-
-
-class MockPaginator:
-    def paginate(self, *args, **kwargs):
-        return MockPages()
-
-
-class MockClientError(Exception):
-    def __init__(self):
-        self.response = {
-            "Error": {"Code": "NoSuchKey"},
-            "ResponseMetadata": {"HTTPStatusCode": 404},
-        }
-
-
-class MockS3Client:
-    def get_paginator(self, *args, **kwargs):
-        return MockPaginator()
-
-    def delete_objects(self, *args, **kwargs):
-        return {
-            "Errors": [{"Key": "keyone", "Message": "Access Denied"}],
-            "Deleted": [{"Key": "keytwo"}, {"Key": "keythree"}],
-        }
-
-    def delete_object(self, *args, **kwargs):
-        pass
-
-    def get_object(self, Bucket=None, Key=None):
-        self.ClientError = MockClientError
-        if Bucket == "my-bucket" and Key == "subdirectory/my-file":
-            return {"ResponseMetadata": {"HTTPHeaders": {}}}
-        raise self.ClientError
-
-    def head_object(self, Bucket=None, Key=None):
-        self.ClientError = MockClientError
-        if Bucket == "my-bucket" and Key == "subdirectory/my-file":
-            return {"ResponseMetadata": {"HTTPHeaders": {}}}
-        raise self.ClientError
-
-
 def test_gather_s3_information(monkeypatch):
     mirror = spack.mirrors.mirror.Mirror(
         {
@@ -312,13 +337,8 @@ def test_gather_s3_information(monkeypatch):
     assert "endpoint_url" in client_args
 
 
-def test_remove_s3_url(monkeypatch, capfd):
+def test_remove_s3_url(mock_s3_client, capfd):
     fake_s3_url = "s3://my-bucket/subdirectory/mirror"
-
-    def get_s3_session(url, method="fetch"):
-        return MockS3Client()
-
-    monkeypatch.setattr(spack.util.web, "get_s3_session", get_s3_session)
 
     current_debug_level = tty.debug_level()
     tty.set_debug(1)
@@ -333,12 +353,7 @@ def test_remove_s3_url(monkeypatch, capfd):
     assert "Deleted keytwo" in err
 
 
-def test_s3_url_exists(monkeypatch):
-    def get_s3_session(url, method="fetch"):
-        return MockS3Client()
-
-    monkeypatch.setattr(spack.util.s3, "get_s3_session", get_s3_session)
-
+def test_s3_url_exists(mock_s3_client):
     fake_s3_url_exists = "s3://my-bucket/subdirectory/my-file"
     assert spack.util.web.url_exists(fake_s3_url_exists)
 
@@ -579,3 +594,56 @@ def test_retry_on_transient_error_reuse(mock_sleep):
 
     assert retrying() == "ok"
     assert retrying() == "ok"
+
+
+@pytest.mark.parametrize("keep_original", [True, False])
+def test_push_to_url_s3_if_match(keep_original, mock_s3_client, tmp_path):
+    """Test that using if_match with s3 calls put_object."""
+    local_data = tmp_path / "data.txt"
+    local_data.write_text("hello")
+
+    spack.util.web.push_to_url(
+        str(local_data),
+        "s3://bucket/and/path/data.txt",
+        keep_original=keep_original,
+        content_type="text/plain",
+        if_match="etag1234",
+    )
+
+    assert 1 == len(mock_s3_client.put_object_calls)
+    call = mock_s3_client.put_object_calls[0]
+    assert 0 == len(call[0])
+    assert {
+        "Bucket": "bucket",
+        "Key": "and/path/data.txt",
+        "IfMatch": "etag1234",
+        "ContentType": "text/plain",
+        "Body": b"hello",
+    } == call[1]
+    assert local_data.exists() is keep_original
+
+    # We shouldn't have called upload_file
+    assert 0 == len(mock_s3_client.upload_file_calls)
+
+
+@pytest.mark.parametrize("keep_original", [True, False])
+def test_push_to_url_s3(keep_original, mock_s3_client, tmp_path):
+    """Test that using if_match with s3 calls put_object."""
+    local_data = tmp_path / "data.txt"
+    local_data.write_text("hello")
+
+    spack.util.web.push_to_url(
+        str(local_data),
+        "s3://bucket/and/path/data.txt",
+        keep_original=keep_original,
+        content_type="text/plain",
+    )
+
+    assert 0 == len(mock_s3_client.put_object_calls)
+    assert local_data.exists() is keep_original
+
+    # We shouldn't have called upload_file
+    assert 1 == len(mock_s3_client.upload_file_calls)
+    call = mock_s3_client.upload_file_calls[0]
+    assert 3 == len(call[0])
+    assert {"ContentType": "text/plain"} == call[1]["ExtraArgs"]

--- a/lib/spack/spack/util/web.py
+++ b/lib/spack/spack/util/web.py
@@ -18,6 +18,7 @@ import sys
 import time
 import traceback
 import urllib.parse
+import warnings
 from html.parser import HTMLParser
 from http.client import IncompleteRead
 from pathlib import Path, PurePosixPath
@@ -111,6 +112,23 @@ def is_transient_error(e: Exception) -> bool:
         "ResponseStreamingError",
     ):
         return True
+    return False
+
+
+def is_precondition_error(e: Exception) -> bool:
+    """Return True if HTTP/Boto3 error is related to a precondition error.
+
+    Examples of precontition errors:
+        HTTP status code 412
+        Boto error 'PreconditionFailed'
+    """
+    if isinstance(e, HTTPError) and 412 == e.code:
+        return True
+
+    # Handle boto errors types by string name to avoid import
+    if "PreconditionFailed" in str(e):
+        return True
+
     return False
 
 
@@ -386,8 +404,20 @@ def read_json(url: str):
         raise SpackWebError(f"Download of {url} failed: {e.__class__.__name__}: {e}")
 
 
-def push_to_url(local_file_path, remote_path, keep_original=True, extra_args=None):
+def push_to_url(
+    local_file_path,
+    remote_path,
+    keep_original=True,
+    content_type: Optional[str] = None,
+    if_match: Optional[str] = None,
+):
     remote_url = urllib.parse.urlparse(remote_path)
+    if if_match and remote_url.scheme != "s3":
+        warnings.warn(
+            "Pushing to URL with `if_match` is only supported for s3:// URLS\n"
+            "Files may be overwritten unexpectedly."
+        )
+
     if remote_url.scheme == "file":
         remote_file_path = url_util.local_file_path(remote_url)
         mkdirp(os.path.dirname(remote_file_path))
@@ -408,15 +438,27 @@ def push_to_url(local_file_path, remote_path, keep_original=True, extra_args=Non
                     raise
 
     elif remote_url.scheme == "s3":
-        if extra_args is None:
-            extra_args = {}
+        extra_args = {}
+        if if_match is not None:
+            # API ref https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutObject.html
+            extra_args.update({"IfMatch": if_match})
+        if content_type is not None:
+            extra_args.update({"ContentType": content_type})
 
         remote_path = remote_url.path
         while remote_path.startswith("/"):
             remote_path = remote_path[1:]
 
         s3 = get_s3_session(remote_url, method="push")
-        s3.upload_file(local_file_path, remote_url.netloc, remote_path, ExtraArgs=extra_args)
+        if if_match:
+            # IfMatch is only supported by put_object which has additional limitations
+            if os.stat(local_file_path).st_size >= 5e9:
+                raise spack.error.SpackError(f"File too large (max. 5GB): {local_file_path}")
+
+            with open(local_file_path, "rb") as fd:
+                s3.put_object(Bucket=remote_url.netloc, Key=remote_path, Body=fd, **extra_args)
+        else:
+            s3.upload_file(local_file_path, remote_url.netloc, remote_path, ExtraArgs=extra_args)
 
         if not keep_original:
             os.remove(local_file_path)

--- a/lib/spack/spack/util/web.py
+++ b/lib/spack/spack/util/web.py
@@ -450,7 +450,7 @@ def push_to_url(
             remote_path = remote_path[1:]
 
         s3 = get_s3_session(remote_url, method="push")
-        if if_match:
+        if if_match is not None:
             # IfMatch is only supported by put_object which has additional limitations
             if os.stat(local_file_path).st_size >= 5e9:
                 raise spack.error.SpackError(f"File too large (max. 5GB): {local_file_path}")


### PR DESCRIPTION
Extracted from #52117 

Pass `extra_args` as named parameters
Handle if_match using put_object