### PR TITLE
Build cache: Add decompose manifest name function

### DIFF
--- a/lib/spack/spack/cmd/buildcache.py
+++ b/lib/spack/spack/cmd/buildcache.py
@@ -1095,7 +1095,7 @@ def check_index_fn(args):
         for spec_manifest in manifest_files:
             # Spec manifests have a naming format
             # <name>-<version>-<hash>.spec.manifest.json
-            spec_hash = spec_manifest.rsplit("-", 1)[1].split(".", 1)[0]
+            _, _, spec_hash = URLBuildcacheEntry.decompose_manifest_filename(spec_manifest)
             if checking_view_index and spec_hash not in index_hash_list:
                 continue
 

--- a/lib/spack/spack/cmd/buildcache.py
+++ b/lib/spack/spack/cmd/buildcache.py
@@ -1095,7 +1095,7 @@ def check_index_fn(args):
         for spec_manifest in manifest_files:
             # Spec manifests have a naming format
             # <name>-<version>-<hash>.spec.manifest.json
-            _, _, spec_hash = URLBuildcacheEntry.decompose_manifest_filename(spec_manifest)
+            spec_hash = URLBuildcacheEntry.hash_from_manifest_name(spec_manifest)
             if checking_view_index and spec_hash not in index_hash_list:
                 continue
 

--- a/lib/spack/spack/test/binary_distribution.py
+++ b/lib/spack/spack/test/binary_distribution.py
@@ -51,6 +51,7 @@ from spack.url_buildcache import (
     get_valid_spec_file,
 )
 from spack.util.filesystem import join_path, readlink, working_dir
+from spack.version.version_types import Version
 
 pytestmark = pytest.mark.not_on_windows("does not run on windows")
 
@@ -1611,3 +1612,52 @@ def test_load_buildcache_index_degrades_gracefully(monkeypatch, tmp_path):
 
     # Should not raise.
     spack.binary_distribution.load_buildcache_index()
+
+
+decomposed_result = ("package", Version("1.1.1"), "asdf1234asdf1234asdf1234asdf1234")
+
+
+@pytest.mark.parametrize(
+    ("spec_manifest", "result"),
+    [
+        (
+            "mock/prefix/long{:_<256}/manifest/spec/package-1.1.1-asdf1234asdf1234asdf1234asdf1234.spec.manifest.json".format(
+                ""
+            ),
+            decomposed_result,
+        ),
+        (
+            "mock/invalid/prefix/package-1.1.1-asdf1234asdf1234asdf1234asdf1234.spec.manifest.json",
+            decomposed_result,
+        ),
+        (
+            "mock/v3/manifest/spec/package-1.1.1-asdf1234asdf1234asdf1234asdf1234.spec.manifest.json",
+            decomposed_result,
+        ),
+        (
+            "mock/v3/manifest/spec/package-1.1.1-asdf1234asdf1234asdf1234asdf1234",
+            decomposed_result,
+        ),
+        (
+            "mock/v3/manifest/spec/package-with-long-name-and-many-dashes-1.1.1-asdf1234asdf1234asdf1234asdf1234",
+            (
+                "package-with-long-name-and-many-dashes",
+                Version("1.1.1"),
+                "asdf1234asdf1234asdf1234asdf1234",
+            ),
+        ),
+        ("mock/v3/manifest/spec/malformed-package", ValueError),
+        (
+            "mock/v3/manifest/spec/malformed-package-bad?version-asdf1234asdf1234asdf1234asdf1234",
+            ValueError,
+        ),
+        ("mock/v3/manifest/spec/malformed-package-1.1.1-shorthash", ValueError),
+    ],
+)
+def test_url_buildcache_decompose_manifest_filename(spec_manifest, result):
+    if result is ValueError:
+        with pytest.raises(ValueError):
+            result = URLBuildcacheEntry.decompose_manifest_filename(spec_manifest)
+            print(result)
+    else:
+        assert result == URLBuildcacheEntry.decompose_manifest_filename(spec_manifest)

--- a/lib/spack/spack/test/binary_distribution.py
+++ b/lib/spack/spack/test/binary_distribution.py
@@ -51,7 +51,6 @@ from spack.url_buildcache import (
     get_valid_spec_file,
 )
 from spack.util.filesystem import join_path, readlink, working_dir
-from spack.version.version_types import Version
 
 pytestmark = pytest.mark.not_on_windows("does not run on windows")
 
@@ -1614,9 +1613,6 @@ def test_load_buildcache_index_degrades_gracefully(monkeypatch, tmp_path):
     spack.binary_distribution.load_buildcache_index()
 
 
-decomposed_result = ("package", Version("1.1.1"), "asdf1234asdf1234asdf1234asdf1234")
-
-
 @pytest.mark.parametrize(
     ("spec_manifest", "result"),
     [
@@ -1624,40 +1620,31 @@ decomposed_result = ("package", Version("1.1.1"), "asdf1234asdf1234asdf1234asdf1
             "mock/prefix/long{:_<256}/manifest/spec/package-1.1.1-asdf1234asdf1234asdf1234asdf1234.spec.manifest.json".format(
                 ""
             ),
-            decomposed_result,
+            "asdf1234asdf1234asdf1234asdf1234",
         ),
         (
             "mock/invalid/prefix/package-1.1.1-asdf1234asdf1234asdf1234asdf1234.spec.manifest.json",
-            decomposed_result,
+            "asdf1234asdf1234asdf1234asdf1234",
         ),
         (
             "mock/v3/manifest/spec/package-1.1.1-asdf1234asdf1234asdf1234asdf1234.spec.manifest.json",
-            decomposed_result,
+            "asdf1234asdf1234asdf1234asdf1234",
         ),
         (
             "mock/v3/manifest/spec/package-1.1.1-asdf1234asdf1234asdf1234asdf1234",
-            decomposed_result,
+            "asdf1234asdf1234asdf1234asdf1234",
         ),
         (
             "mock/v3/manifest/spec/package-with-long-name-and-many-dashes-1.1.1-asdf1234asdf1234asdf1234asdf1234",
-            (
-                "package-with-long-name-and-many-dashes",
-                Version("1.1.1"),
-                "asdf1234asdf1234asdf1234asdf1234",
-            ),
+            "asdf1234asdf1234asdf1234asdf1234",
         ),
-        ("mock/v3/manifest/spec/malformed-package", ValueError),
-        (
-            "mock/v3/manifest/spec/malformed-package-bad?version-asdf1234asdf1234asdf1234asdf1234",
-            ValueError,
-        ),
+        ("mock/v3/manifest/spec/missing-hash", ValueError),
         ("mock/v3/manifest/spec/malformed-package-1.1.1-shorthash", ValueError),
     ],
 )
-def test_url_buildcache_decompose_manifest_filename(spec_manifest, result):
+def test_url_buildcache_hash_from_manifest_name(spec_manifest, result):
     if result is ValueError:
         with pytest.raises(ValueError):
-            result = URLBuildcacheEntry.decompose_manifest_filename(spec_manifest)
-            print(result)
+            result = URLBuildcacheEntry.hash_from_manifest_name(spec_manifest)
     else:
-        assert result == URLBuildcacheEntry.decompose_manifest_filename(spec_manifest)
+        assert result == URLBuildcacheEntry.hash_from_manifest_name(spec_manifest)

--- a/lib/spack/spack/url_buildcache.py
+++ b/lib/spack/spack/url_buildcache.py
@@ -37,6 +37,7 @@ from spack.util import tty
 from spack.util.archive import ChecksumWriter
 from spack.util.crypto import hash_fun_for_algo
 from spack.util.executable import which
+from spack.version.version_types import Version, VersionType
 
 #: The build cache layout version that this version of Spack creates.
 #: Version 3: Introduces content-addressable tarballs
@@ -44,6 +45,9 @@ CURRENT_BUILD_CACHE_LAYOUT_VERSION = 3
 
 #: The name of the default buildcache index manifest file
 INDEX_MANIFEST_FILE = "index.manifest.json"
+
+#: Simple regex for matching spec hashes
+SPEC_HASH_RE = re.compile(r"^[a-z0-9]{32}$")
 
 
 class BuildcacheComponent(enum.Enum):
@@ -275,6 +279,22 @@ class URLBuildcacheEntry:
         the manifest file representing it"""
         spec_formatted = spec.format_path("{name}-{version}-{hash}")
         return f"{spec_formatted}.spec.manifest.json"
+
+    @classmethod
+    def decompose_manifest_filename(cls, file) -> Tuple[str, VersionType, str]:
+        """Get the spec name, version, and hash from a manifest file name"""
+        # Strip any leading prefix path and file suffix
+        manifest_name = file.split("/")[-1].replace(".spec.manifest.json", "")
+        parts = manifest_name.split("-")
+        if len(parts) < 3:
+            raise ValueError("Expected file with format <package-*>-<version>-<spec_hash>")
+        spec_hash = parts[-1]
+        if not SPEC_HASH_RE.match(spec_hash):
+            raise ValueError(
+                f"Expected spec hash with pattern {SPEC_HASH_RE.pattern} found {spec_hash}"
+            )
+        spec_version = Version(parts[-2])
+        return "-".join(parts[:-2]), spec_version, spec_hash
 
     @classmethod
     def get_manifest_url(cls, spec: spack.spec.Spec, mirror_url: str) -> str:

--- a/lib/spack/spack/url_buildcache.py
+++ b/lib/spack/spack/url_buildcache.py
@@ -37,7 +37,6 @@ from spack.util import tty
 from spack.util.archive import ChecksumWriter
 from spack.util.crypto import hash_fun_for_algo
 from spack.util.executable import which
-from spack.version.version_types import Version, VersionType
 
 #: The build cache layout version that this version of Spack creates.
 #: Version 3: Introduces content-addressable tarballs
@@ -281,8 +280,8 @@ class URLBuildcacheEntry:
         return f"{spec_formatted}.spec.manifest.json"
 
     @classmethod
-    def decompose_manifest_filename(cls, file) -> Tuple[str, VersionType, str]:
-        """Get the spec name, version, and hash from a manifest file name"""
+    def hash_from_manifest_name(cls, file) -> str:
+        """Extract the hash from a manifest file name"""
         # Strip any leading prefix path and file suffix
         manifest_name = file.split("/")[-1].replace(".spec.manifest.json", "")
         parts = manifest_name.split("-")
@@ -293,8 +292,7 @@ class URLBuildcacheEntry:
             raise ValueError(
                 f"Expected spec hash with pattern {SPEC_HASH_RE.pattern} found {spec_hash}"
             )
-        spec_version = Version(parts[-2])
-        return "-".join(parts[:-2]), spec_version, spec_hash
+        return spec_hash
 
     @classmethod
     def get_manifest_url(cls, spec: spack.spec.Spec, mirror_url: str) -> str:


### PR DESCRIPTION
Extracted from #52117 

Add method to parse a manifest name back to its parts.