### PR TITLE
Build cache: Rework list to avoid excessive downloads

### DIFF
--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -750,37 +750,27 @@ def _url_generate_package_index(
     Return:
         None
     """
-    with tempfile.TemporaryDirectory(dir=spack.stage.get_stage_root()) as tmpspecsdir:
-        try:
-            with timer.measure("list"):
-                filename_to_mtime_mapping, read_fn = get_entries_from_cache(
-                    url, tmpspecsdir, component_type=BuildcacheComponent.SPEC
-                )
-            file_list = list(filename_to_mtime_mapping.keys())
-        except ListMirrorSpecsError as e:
-            raise GenerateIndexError(f"Unable to generate package index: {e}") from e
-
-        tty.debug(f"Retrieving spec descriptor files from {url} to build index")
-
-        if not db:
-            db = BuildCacheDatabase(tmpdir)
-            db._write()
-
-        try:
-            _read_specs_and_push_index(
-                file_list,
-                read_fn,
-                name,
-                filter_fn,
-                url,
-                db,
-                str(db.database_directory),
-                timer=timer,
+    try:
+        with timer.measure("list"):
+            filename_to_mtime_mapping, read_fn = get_entries_from_cache(
+                url, component_type=BuildcacheComponent.SPEC
             )
-        except Exception as e:
-            raise GenerateIndexError(
-                f"Encountered problem pushing package index to {url}: {e}"
-            ) from e
+        file_list = list(filename_to_mtime_mapping.keys())
+    except ListMirrorSpecsError as e:
+        raise GenerateIndexError(f"Unable to generate package index: {e}") from e
+
+    tty.debug(f"Retrieving spec descriptor files from {url} to build index")
+
+    if not db:
+        db = BuildCacheDatabase(tmpdir)
+        db._write()
+
+    try:
+        _read_specs_and_push_index(
+            file_list, read_fn, name, filter_fn, url, db, str(db.database_directory), timer=timer
+        )
+    except Exception as e:
+        raise GenerateIndexError(f"Encountered problem pushing package index to {url}: {e}") from e
 
 
 def generate_key_index(mirror_url: str, tmpdir: str) -> None:

--- a/lib/spack/spack/buildcache_prune.py
+++ b/lib/spack/spack/buildcache_prune.py
@@ -23,7 +23,7 @@ from .url_buildcache import BuildcacheComponent, URLBuildcacheEntry, get_entries
 
 
 def _fetch_manifests(
-    mirror: Mirror, tmpspecsdir: str
+    mirror: Mirror,
 ) -> Tuple[Dict[str, float], Callable[[str], URLBuildcacheEntry], List[str]]:
     """
     Fetch all manifests from the buildcache for a given mirror.
@@ -37,7 +37,7 @@ def _fetch_manifests(
              callable to read each manifest, and a list of blobs in the mirror.
     """
     manifest_file_to_mtime_mapping, read_fn = get_entries_from_cache(
-        mirror.fetch_url, tmpspecsdir, BuildcacheComponent.MANIFEST
+        mirror.fetch_url, BuildcacheComponent.MANIFEST
     )
     url_to_list = url_util.join(
         mirror.fetch_url, spack.binary_distribution.buildcache_relative_blobs_path()
@@ -123,7 +123,6 @@ def _prune_orphans(
     read_fn: Callable[[str], URLBuildcacheEntry],
     blobs: List[str],
     pruning_started_at: float,
-    tmpspecsdir: str,
     dry_run: bool,
 ) -> int:
     """
@@ -217,7 +216,6 @@ def prune_direct(
     manifest_to_mtime_mapping: Dict[str, float],
     read_fn: Callable[[str], URLBuildcacheEntry],
     blob_list: List[str],
-    tmpspecsdir: str,
     pruning_started_at: float,
     dry_run: bool,
 ) -> None:
@@ -250,10 +248,6 @@ def prune_direct(
 
     tty.info(f"Loaded {len(keep_hashes)} hashes to keep from {keeplist_file}")
     total_pruned: Optional[int] = None
-    manifests_url = url_util.join(
-        mirror.fetch_url,
-        *URLBuildcacheEntry.get_relative_path_components(BuildcacheComponent.MANIFEST),
-    )
 
     # Determine which manifests correspond to specs we want to prune
     manifests_to_prune: List[str] = []
@@ -262,8 +256,6 @@ def prune_direct(
     tty.info(f"Found {len(manifest_to_mtime_mapping)} total manifests in mirror")
 
     for manifest in manifest_to_mtime_mapping.keys():
-        # Convert back from local to remote path.
-        manifest = manifest.replace(tmpspecsdir, manifests_url)
         if not fnmatch(
             manifest,
             URLBuildcacheEntry.get_buildcache_component_include_pattern(BuildcacheComponent.SPEC),
@@ -323,7 +315,6 @@ def prune_orphan(
     manifest_to_mtime_mapping: Dict[str, float],
     read_fn: Callable[[str], URLBuildcacheEntry],
     blob_list: List[str],
-    tmpspecsdir: str,
     pruning_started_at: float,
     dry_run: bool,
 ) -> None:
@@ -346,7 +337,6 @@ def prune_orphan(
             read_fn=read_fn,
             blobs=blob_list,
             pruning_started_at=pruning_started_at,
-            tmpspecsdir=tmpspecsdir,
             dry_run=dry_run,
         )
         if pruned == 0:
@@ -415,27 +405,23 @@ def prune_buildcache(mirror: Mirror, keeplist: Optional[str] = None, dry_run: bo
     else:
         started_at = get_buildcache_normalized_time(mirror)
 
-    with tempfile.TemporaryDirectory(dir=spack.stage.get_stage_root()) as tmpspecsdir:
-        try:
-            manifest_to_mtime_mapping, read_fn, blob_list = _fetch_manifests(mirror, tmpspecsdir)
-        except Exception as e:
-            raise BuildcachePruningException("Error getting entries from buildcache") from e
+    try:
+        manifest_to_mtime_mapping, read_fn, blob_list = _fetch_manifests(mirror)
+    except Exception as e:
+        raise BuildcachePruningException("Error getting entries from buildcache") from e
 
-        if keeplist:
-            prune_direct(
-                mirror,
-                pathlib.Path(keeplist),
-                manifest_to_mtime_mapping,
-                read_fn,
-                blob_list,
-                tmpspecsdir,
-                started_at,
-                dry_run,
-            )
-
-        prune_orphan(
-            mirror, manifest_to_mtime_mapping, read_fn, blob_list, tmpspecsdir, started_at, dry_run
+    if keeplist:
+        prune_direct(
+            mirror,
+            pathlib.Path(keeplist),
+            manifest_to_mtime_mapping,
+            read_fn,
+            blob_list,
+            started_at,
+            dry_run,
         )
+
+    prune_orphan(mirror, manifest_to_mtime_mapping, read_fn, blob_list, started_at, dry_run)
 
 
 class BuildcachePruningException(spack.error.SpackError):

--- a/lib/spack/spack/cmd/buildcache.py
+++ b/lib/spack/spack/cmd/buildcache.py
@@ -1078,7 +1078,7 @@ def check_index_fn(args):
         manifest_files = []
         if "manifests" in verify or "blobs" in verify:
             manifest_files, read_fn = get_entries_from_cache(
-                mirror.fetch_url, tmpdir, BuildcacheComponent.SPEC
+                mirror.fetch_url, BuildcacheComponent.SPEC
             )
         if "manifests" in verify and index_exists:
             # Read the index file

--- a/lib/spack/spack/test/binary_distribution.py
+++ b/lib/spack/spack/test/binary_distribution.py
@@ -14,6 +14,7 @@ import urllib.error
 import urllib.request
 import urllib.response
 import warnings
+from datetime import datetime
 from pathlib import Path, PurePath
 from typing import Any, Callable, Dict, NamedTuple, Optional
 
@@ -51,6 +52,7 @@ from spack.url_buildcache import (
     get_url_buildcache_class,
     get_valid_spec_file,
 )
+from spack.util.executable import ProcessError
 from spack.util.filesystem import join_path, readlink, working_dir
 
 pytestmark = pytest.mark.not_on_windows("does not run on windows")
@@ -461,6 +463,25 @@ def test_generate_package_index_failure(monkeypatch, tmp_path: pathlib.Path, cap
         "Warning: Encountered problem listing packages at "
         f"{test_url}: Some HTTP error" in capfd.readouterr().err
     )
+
+
+def test_generate_package_index_push_failure(monkeypatch, tmp_path: pathlib.Path):
+    monkeypatch.setattr(
+        spack.binary_distribution,
+        "get_entries_from_cache",
+        lambda url, component_type: ({"some-manifest": 0.0}, lambda x: x),
+    )
+
+    def broken_read_specs_and_push_index(*args, **kwargs):
+        raise RuntimeError("Couldn't push the index")
+
+    monkeypatch.setattr(
+        spack.binary_distribution, "_read_specs_and_push_index", broken_read_specs_and_push_index
+    )
+
+    test_url = "file:///fake/keys/dir"
+    with pytest.raises(GenerateIndexError, match="problem pushing package index"):
+        spack.binary_distribution._url_generate_package_index(test_url, str(tmp_path))
 
 
 def test_generate_indices_exception(monkeypatch, tmp_path: pathlib.Path, capfd):
@@ -1509,6 +1530,99 @@ def test_get_entries_from_cache_nested_mirrors(monkeypatch, tmp_path: pathlib.Pa
     # Expected specs in nested mirror
     #   - zlib
     assert len(spec_manifests_nested) == 1
+
+
+class FakeAwsCli:
+    """Stand-in for the ``aws`` Executable used by _entries_from_cache_aws_cli."""
+
+    def __init__(self, output="", error=None):
+        self.output = output
+        self.error = error
+        self.calls = []
+
+    def __call__(self, *args, **kwargs):
+        self.calls.append(args)
+        if self.error is not None:
+            raise self.error
+        return self.output
+
+
+def test_entries_from_cache_aws_cli(monkeypatch):
+    """Verify that _entries_from_cache_aws_cli:
+    * Lists manifests using `aws s3 ls` (not downloading them)
+    * Filters out non-matching keys
+    * Properly reconstructs the full s3:// url for each matching manifest."""
+    ls_output = "\n".join(
+        [
+            "2022-08-15 17:54:40    3717621 "
+            "mirror/v3/manifests/spec/zlib/zlib-1.2.13-abcdefabcdefabcdefabcdefabcdefab"
+            ".spec.manifest.json",
+            # Does not match the "*.spec.manifest.json" include pattern, should be skipped.
+            "2022-08-15 17:54:41         42 mirror/v3/layout.json",
+            # Does not match `aws s3 ls` output format, should be ignored.
+            "not a valid aws s3 ls line",
+        ]
+    )
+    fake_aws = FakeAwsCli(output=ls_output)
+    monkeypatch.setattr(spack.url_buildcache, "which", lambda name: fake_aws)
+
+    filename_to_mtime, read_fn = spack.url_buildcache._entries_from_cache_aws_cli(
+        "s3://my-bucket/mirror", BuildcacheComponent.SPEC
+    )
+
+    assert read_fn is not None
+    assert filename_to_mtime == {
+        "s3://my-bucket/mirror/v3/manifests/spec/zlib/zlib-1.2.13-"
+        "abcdefabcdefabcdefabcdefabcdefab.spec.manifest.json": datetime(
+            2022, 8, 15, 17, 54, 40
+        ).timestamp()
+    }
+    assert len(fake_aws.calls) == 1
+    assert fake_aws.calls[0][:2] == ("s3", "ls")
+
+
+def test_entries_from_cache_aws_cli_no_aws(monkeypatch):
+    """Verify that we fall back gracefully (rather than erroring) when awscli is not available."""
+    monkeypatch.setattr(spack.url_buildcache, "which", lambda name: None)
+
+    filename_to_mtime, read_fn = spack.url_buildcache._entries_from_cache_aws_cli(
+        "s3://my-bucket/mirror", BuildcacheComponent.SPEC
+    )
+
+    assert filename_to_mtime is None
+    assert read_fn is None
+
+
+def test_entries_from_cache_aws_cli_process_error(monkeypatch):
+    """Verify that an `aws s3 ls` failure gets raised as ProcessError."""
+    fake_aws = FakeAwsCli(error=ProcessError("aws s3 ls failed"))
+    monkeypatch.setattr(spack.url_buildcache, "which", lambda name: fake_aws)
+
+    with pytest.raises(ProcessError):
+        spack.url_buildcache._entries_from_cache_aws_cli(
+            "s3://my-bucket/mirror", BuildcacheComponent.SPEC
+        )
+
+
+def test_get_entries_from_cache_falls_back_from_aws_cli(monkeypatch):
+    """Verify that get_entries_from_cache catches a failure from the aws-cli
+    listing strategy and falls back to the next strategy instead of re-raising."""
+    fallback_result = ({"the-manifest": 123.0}, lambda x: x)
+
+    def broken_aws_cli(url, component_type):
+        raise ProcessError("aws s3 ls failed")
+
+    def fake_fallback(url, component_type):
+        return fallback_result
+
+    monkeypatch.setattr(spack.url_buildcache, "_entries_from_cache_aws_cli", broken_aws_cli)
+    monkeypatch.setattr(spack.url_buildcache, "_entries_from_cache_fallback", fake_fallback)
+
+    result = spack.url_buildcache.get_entries_from_cache(
+        "s3://my-bucket/mirror", BuildcacheComponent.SPEC
+    )
+
+    assert result == fallback_result
 
 
 def test_mirror_metadata():

--- a/lib/spack/spack/test/binary_distribution.py
+++ b/lib/spack/spack/test/binary_distribution.py
@@ -45,6 +45,7 @@ from spack.url_buildcache import (
     INDEX_MANIFEST_FILE,
     BuildcacheComponent,
     BuildcacheEntryError,
+    ListMirrorSpecsError,
     URLBuildcacheEntry,
     URLBuildcacheEntryV2,
     compression_writer,
@@ -1598,7 +1599,7 @@ def test_entries_from_cache_aws_cli_process_error(monkeypatch):
     fake_aws = FakeAwsCli(error=ProcessError("aws s3 ls failed"))
     monkeypatch.setattr(spack.url_buildcache, "which", lambda name: fake_aws)
 
-    with pytest.raises(ProcessError):
+    with pytest.raises(ListMirrorSpecsError):
         spack.url_buildcache._entries_from_cache_aws_cli(
             "s3://my-bucket/mirror", BuildcacheComponent.SPEC
         )
@@ -1610,7 +1611,7 @@ def test_get_entries_from_cache_falls_back_from_aws_cli(monkeypatch):
     fallback_result = ({"the-manifest": 123.0}, lambda x: x)
 
     def broken_aws_cli(url, component_type):
-        raise ProcessError("aws s3 ls failed")
+        raise ListMirrorSpecsError("aws s3 ls failed")
 
     def fake_fallback(url, component_type):
         return fallback_result

--- a/lib/spack/spack/test/binary_distribution.py
+++ b/lib/spack/spack/test/binary_distribution.py
@@ -448,7 +448,7 @@ def test_generate_key_index_failure(monkeypatch, tmp_path: pathlib.Path):
 
 def test_generate_package_index_failure(monkeypatch, tmp_path: pathlib.Path, capfd):
     def mock_list_url(url, recursive=False):
-        raise Exception("Some HTTP error")
+        raise OSError("Some HTTP error")
 
     monkeypatch.setattr(web_util, "list_url", mock_list_url)
 
@@ -465,7 +465,7 @@ def test_generate_package_index_failure(monkeypatch, tmp_path: pathlib.Path, cap
 
 def test_generate_indices_exception(monkeypatch, tmp_path: pathlib.Path, capfd):
     def mock_list_url(url, recursive=False):
-        raise Exception("Test Exception handling")
+        raise OSError("Test Exception handling")
 
     monkeypatch.setattr(web_util, "list_url", mock_list_url)
 
@@ -1493,13 +1493,11 @@ def test_get_entries_from_cache_nested_mirrors(monkeypatch, tmp_path: pathlib.Pa
     install_cmd("--fake", s.name)
     buildcache_cmd("push", "-u", str(mirror_dir / "nested"), s.name)
 
-    spec_manifests, _ = get_entries_from_cache(
-        str(mirror_url), str(tmp_path / "stage"), BuildcacheComponent.SPEC
-    )
+    spec_manifests, _ = get_entries_from_cache(str(mirror_url), BuildcacheComponent.SPEC)
 
     nested_mirror_url = url_util.path_to_file_url(str(mirror_dir / "nested"))
     spec_manifests_nested, _ = get_entries_from_cache(
-        str(nested_mirror_url), str(tmp_path / "stage"), BuildcacheComponent.SPEC
+        str(nested_mirror_url), BuildcacheComponent.SPEC
     )
 
     # Expected specs in root mirror

--- a/lib/spack/spack/test/util/gcs.py
+++ b/lib/spack/spack/test/util/gcs.py
@@ -1,0 +1,96 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+import io
+import sys
+import types
+import urllib.error
+import urllib.request
+
+import pytest
+
+import spack.util.gcs as gcs
+
+
+@pytest.fixture
+def fake_google_api_core(monkeypatch):
+    """Stand in for google.api_core.exceptions.GoogleAPIError."""
+
+    class GoogleAPIError(Exception):
+        pass
+
+    api_core_exceptions = types.ModuleType("google.api_core.exceptions")
+    api_core_exceptions.GoogleAPIError = GoogleAPIError
+    api_core = types.ModuleType("google.api_core")
+    api_core.exceptions = api_core_exceptions
+    google_pkg = types.ModuleType("google")
+    google_pkg.api_core = api_core
+
+    monkeypatch.setitem(sys.modules, "google", google_pkg)
+    monkeypatch.setitem(sys.modules, "google.api_core", api_core)
+    monkeypatch.setitem(sys.modules, "google.api_core.exceptions", api_core_exceptions)
+
+    return GoogleAPIError
+
+
+def test_gcs_open_wraps_google_api_error(monkeypatch, fake_google_api_core):
+    """Verify that gcs_open catches GoogleAPIError and re-raises it as URLError."""
+
+    class BoomBlob:
+        def __init__(self, url):
+            pass
+
+        def exists(self):
+            raise fake_google_api_core("permission denied")
+
+    monkeypatch.setattr(gcs, "GCSBlob", BoomBlob)
+
+    req = urllib.request.Request("gs://my-bucket/my-file")
+
+    with pytest.raises(urllib.error.URLError):
+        gcs.gcs_open(req)
+
+
+def test_gcs_open_returns_response_for_existing_blob(monkeypatch, fake_google_api_core):
+    """Verify success path: an existing blob gets returned as an addinfourl
+    wrapping its byte stream and headers."""
+
+    class ExistingBlob:
+        def __init__(self, url):
+            pass
+
+        def exists(self):
+            return True
+
+        def get_blob_byte_stream(self):
+            return io.BytesIO(b"the-data")
+
+        def get_blob_headers(self):
+            return {"Content-type": "text/plain"}
+
+    monkeypatch.setattr(gcs, "GCSBlob", ExistingBlob)
+
+    req = urllib.request.Request("gs://my-bucket/my-file")
+    response = gcs.gcs_open(req)
+
+    assert response.fp.read() == b"the-data"
+    assert response.headers == {"Content-type": "text/plain"}
+
+
+def test_gcs_open_raises_url_error_for_missing_blob(monkeypatch, fake_google_api_core):
+    """Verify that gcs_open raises URLError for "blob does not exist"."""
+
+    class MissingBlob:
+        def __init__(self, url):
+            self.blob_path = "my-file"
+
+        def exists(self):
+            return False
+
+    monkeypatch.setattr(gcs, "GCSBlob", MissingBlob)
+
+    req = urllib.request.Request("gs://my-bucket/my-file")
+
+    with pytest.raises(urllib.error.URLError):
+        gcs.gcs_open(req)

--- a/lib/spack/spack/test/web.py
+++ b/lib/spack/spack/test/web.py
@@ -9,6 +9,7 @@ import pickle
 import ssl
 import urllib.error
 import urllib.request
+from datetime import datetime
 from typing import Any, Dict, List, Tuple
 
 import pytest
@@ -43,7 +44,12 @@ root_with_javascript = _create_url("index_with_javascript.html")
 
 class MockPages:
     def search(self, *args, **kwargs):
-        return [{"Key": "keyone"}, {"Key": "keytwo"}, {"Key": "keythree"}]
+        return [
+            {"Key": "prefix/keyone"},
+            {"Key": "prefix/keytwo"},
+            {"Key": "prefix/keythree"},
+            {"Key": "prefix/nested/keyfour"},
+        ]
 
 
 class MockPaginator:
@@ -84,8 +90,8 @@ class MockS3Client:
 
     def delete_objects(self, *args, **kwargs):
         return {
-            "Errors": [{"Key": "keyone", "Message": "Access Denied"}],
-            "Deleted": [{"Key": "keytwo"}, {"Key": "keythree"}],
+            "Errors": [{"Key": "prefix/keyone", "Message": "Access Denied"}],
+            "Deleted": [{"Key": "prefix/keytwo"}, {"Key": "prefix/keythree"}],
         }
 
     def delete_object(self, *args, **kwargs):
@@ -98,15 +104,25 @@ class MockS3Client:
 
     def head_object(self, Bucket=None, Key=None):
         if Bucket == "my-bucket" and Key == "subdirectory/my-file":
-            return {"ResponseMetadata": {"HTTPHeaders": {}}}
+            return {
+                "ResponseMetadata": {"HTTPHeaders": {}},
+                "LastModified": datetime.fromtimestamp(1360799444.0),
+                "ContentLength": 0,
+            }
         raise self.ClientError
 
 
 @pytest.fixture
 def mock_s3_client(monkeypatch):
     client = MockS3Client("s3://my-bucket/")
-    monkeypatch.setattr(spack.util.s3, "get_s3_session", lambda url, method="fetch": client)
-    monkeypatch.setattr(spack.util.web, "get_s3_session", lambda url, method="fetch": client)
+
+    def get_s3_session(url, method="fetch"):
+        if not isinstance(url, urllib.parse.ParseResult):
+            url = urllib.parse.urlparse(url)
+        return client, url
+
+    monkeypatch.setattr(spack.util.s3, "get_s3_session", get_s3_session)
+
     return client
 
 
@@ -339,7 +355,6 @@ def test_gather_s3_information(monkeypatch):
 
 def test_remove_s3_url(mock_s3_client, capfd):
     fake_s3_url = "s3://my-bucket/subdirectory/mirror"
-
     current_debug_level = tty.debug_level()
     tty.set_debug(1)
 
@@ -348,9 +363,35 @@ def test_remove_s3_url(mock_s3_client, capfd):
 
     tty.set_debug(current_debug_level)
 
-    assert "Failed to delete keyone (Access Denied)" in err
-    assert "Deleted keythree" in err
-    assert "Deleted keytwo" in err
+    assert "Failed to delete prefix/keyone (Access Denied)" in err
+    assert "Deleted prefix/keythree" in err
+    assert "Deleted prefix/keytwo" in err
+
+
+def test_list_s3_url(mock_s3_client):
+    fake_s3_url = "s3://my-bucket/prefix/"
+    listing = spack.util.web.list_url(fake_s3_url, recursive=False)
+    assert "keyone" in listing
+    assert "keytwo" in listing
+    assert "keythree" in listing
+    assert "nested/keyfour" not in listing
+
+    listing = spack.util.web.list_url(fake_s3_url, recursive=True)
+    assert "keyone" in listing
+    assert "keytwo" in listing
+    assert "keythree" in listing
+    assert "nested/keyfour" in listing
+
+
+def test_stat_s3_url(mock_s3_client):
+    fake_s3_url = "s3://my-bucket/subdirectory/my-file"
+    size, mtime = spack.util.web.stat_url(fake_s3_url)
+    assert 0 == size
+    assert 1360799444.0 == mtime
+
+    with pytest.raises(OSError):
+        fake_s3_url = "s3://my-bucket/subdirectory/my-notfound-file"
+        spack.util.web.stat_url(fake_s3_url)
 
 
 def test_s3_url_exists(mock_s3_client):

--- a/lib/spack/spack/test/web.py
+++ b/lib/spack/spack/test/web.py
@@ -60,10 +60,7 @@ class MockPaginator:
 
 class MockClientError(Exception):
     def __init__(self, code="NoSuchKey"):
-        self.response = {
-            "Error": {"Code": code},
-            "ResponseMetadata": {"HTTPStatusCode": 404},
-        }
+        self.response = {"Error": {"Code": code}, "ResponseMetadata": {"HTTPStatusCode": 404}}
 
 
 class MockS3Client:

--- a/lib/spack/spack/test/web.py
+++ b/lib/spack/spack/test/web.py
@@ -7,6 +7,8 @@ import os
 import pathlib
 import pickle
 import ssl
+import sys
+import types
 import urllib.error
 import urllib.request
 from datetime import datetime
@@ -557,7 +559,51 @@ def test_s3_url_parsing():
     assert spack.util.s3._parse_s3_endpoint_url("http://example.com") == "http://example.com"
 
 
-def test_get_s3_session_normalizes_method_and_returns_parsed_url(monkeypatch):
+@pytest.fixture
+def fake_boto3(monkeypatch):
+    """Stand in for the boto3/botocore packages.
+
+    get_s3_session imports boto3/botocore lazily so that they remain optional
+    dependencies; stub them out here so tests can exercise the real
+    get_s3_session logic without requiring those packages to be installed.
+    """
+
+    class FakeClientError(Exception):
+        pass
+
+    class FakeSession:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+
+        def get_credentials(self):
+            return None
+
+        def client(self, service_name, **kwargs):
+            return types.SimpleNamespace(service_name=service_name, kwargs=kwargs)
+
+    class FakeConfig:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+
+    boto3_module = types.ModuleType("boto3")
+    boto3_module.Session = FakeSession
+
+    botocore_module = types.ModuleType("botocore")
+    botocore_module.UNSIGNED = object()
+
+    botocore_client_module = types.ModuleType("botocore.client")
+    botocore_client_module.Config = FakeConfig
+
+    botocore_exceptions_module = types.ModuleType("botocore.exceptions")
+    botocore_exceptions_module.ClientError = FakeClientError
+
+    monkeypatch.setitem(sys.modules, "boto3", boto3_module)
+    monkeypatch.setitem(sys.modules, "botocore", botocore_module)
+    monkeypatch.setitem(sys.modules, "botocore.client", botocore_client_module)
+    monkeypatch.setitem(sys.modules, "botocore.exceptions", botocore_exceptions_module)
+
+
+def test_get_s3_session_normalizes_method_and_returns_parsed_url(monkeypatch, fake_boto3):
     """Verify that "GET" and "HEAD" are treated as "fetch", and everything else
     is treated as "push"."""
     monkeypatch.setattr(spack.util.s3, "s3_client_cache", {})

--- a/lib/spack/spack/test/web.py
+++ b/lib/spack/spack/test/web.py
@@ -493,6 +493,44 @@ def test_list_s3_url_skips_directory_marker_keys(monkeypatch):
     assert listing == ["real-key"]
 
 
+def test_list_s3_url_at_bucket_root(monkeypatch):
+    """Verify that a mirror with no sub-path (e.g. s3://my-bucket) gets listed with an
+    empty Prefix (not "/")."""
+
+    class RootPages:
+        def search(self, *args, **kwargs):
+            return [{"Key": "some/object.txt"}]
+
+    class RootPaginator:
+        def __init__(self):
+            self.paginate_calls = []
+
+        def paginate(self, *args, **kwargs):
+            self.paginate_calls.append(kwargs)
+            return RootPages()
+
+    class RootClient:
+        def __init__(self):
+            self.paginator = RootPaginator()
+
+        def get_paginator(self, *args, **kwargs):
+            return self.paginator
+
+    client = RootClient()
+
+    def get_s3_session(url, method="fetch"):
+        if not isinstance(url, urllib.parse.ParseResult):
+            url = urllib.parse.urlparse(url)
+        return client, url
+
+    monkeypatch.setattr(spack.util.s3, "get_s3_session", get_s3_session)
+
+    listing = spack.util.web.list_url("s3://my-bucket", recursive=True)
+
+    assert client.paginator.paginate_calls == [{"Bucket": "my-bucket", "Prefix": ""}]
+    assert listing == ["some/object.txt"]
+
+
 def test_stat_s3_url(mock_s3_client):
     fake_s3_url = "s3://my-bucket/subdirectory/my-file"
     size, mtime = spack.util.web.stat_url(fake_s3_url)

--- a/lib/spack/spack/test/web.py
+++ b/lib/spack/spack/test/web.py
@@ -14,6 +14,7 @@ from typing import Any, Dict, List, Tuple
 
 import pytest
 
+import spack.error
 import spack.mirrors.mirror
 import spack.paths
 import spack.url
@@ -58,9 +59,9 @@ class MockPaginator:
 
 
 class MockClientError(Exception):
-    def __init__(self):
+    def __init__(self, code="NoSuchKey"):
         self.response = {
-            "Error": {"Code": "NoSuchKey"},
+            "Error": {"Code": code},
             "ResponseMetadata": {"HTTPStatusCode": 404},
         }
 
@@ -73,6 +74,7 @@ class MockS3Client:
         KWArgs = Dict[str, Any]
         self.put_object_calls: List[Tuple[Args, KWArgs]] = []
         self.upload_file_calls: List[Tuple[Args, KWArgs]] = []
+        self.delete_object_calls: List[Tuple[Args, KWArgs]] = []
         self.ClientError = MockClientError
 
     def put_object(self, *args, **kwargs):
@@ -95,7 +97,7 @@ class MockS3Client:
         }
 
     def delete_object(self, *args, **kwargs):
-        pass
+        self.delete_object_calls.append((args, kwargs))
 
     def get_object(self, Bucket=None, Key=None):
         if Bucket == "my-bucket" and Key == "subdirectory/my-file":
@@ -109,6 +111,10 @@ class MockS3Client:
                 "LastModified": datetime.fromtimestamp(1360799444.0),
                 "ContentLength": 0,
             }
+        if Bucket == "my-bucket" and Key == "subdirectory/actually-missing-file":
+            # HeadObject reports a missing key as "404", as opposed to other
+            # S3 APIs that include more specific information like "NoSuchKey".
+            raise self.ClientError(code="404")
         raise self.ClientError
 
 
@@ -368,6 +374,55 @@ def test_remove_s3_url(mock_s3_client, capfd):
     assert "Deleted prefix/keytwo" in err
 
 
+def test_remove_s3_url_non_recursive(mock_s3_client):
+    fake_s3_url = "s3://my-bucket/subdirectory/mirror"
+
+    spack.util.web.remove_url(fake_s3_url, recursive=False)
+
+    assert len(mock_s3_client.delete_object_calls) == 1
+    _, kwargs = mock_s3_client.delete_object_calls[0]
+    assert kwargs == {"Bucket": "my-bucket", "Key": "subdirectory/mirror"}
+
+
+def test_delete_objects_batches_over_1000_keys(monkeypatch):
+    """Verify that delete_objects flushes its delete request in batches of
+    <=1000 keys, since that's the limit enforced by the underlying S3 API."""
+
+    class ManyKeysPages:
+        def search(self, *args, **kwargs):
+            return ({"Key": f"prefix/key{i}"} for i in range(1500))
+
+    class ManyKeysPaginator:
+        def paginate(self, *args, **kwargs):
+            return ManyKeysPages()
+
+    class BatchTrackingS3Client:
+        ClientError = MockClientError
+
+        def __init__(self):
+            self.delete_objects_calls = []
+
+        def get_paginator(self, *args, **kwargs):
+            return ManyKeysPaginator()
+
+        def delete_objects(self, Bucket, Delete):
+            self.delete_objects_calls.append(list(Delete["Objects"]))
+            return {}
+
+    client = BatchTrackingS3Client()
+
+    def get_s3_session(url, method="fetch"):
+        if not isinstance(url, urllib.parse.ParseResult):
+            url = urllib.parse.urlparse(url)
+        return client, url
+
+    monkeypatch.setattr(spack.util.s3, "get_s3_session", get_s3_session)
+
+    spack.util.web.remove_url("s3://my-bucket/prefix", recursive=True)
+
+    assert [len(batch) for batch in client.delete_objects_calls] == [1000, 500]
+
+
 def test_list_s3_url(mock_s3_client):
     fake_s3_url = "s3://my-bucket/prefix/"
     listing = spack.util.web.list_url(fake_s3_url, recursive=False)
@@ -383,6 +438,61 @@ def test_list_s3_url(mock_s3_client):
     assert "nested/keyfour" in listing
 
 
+def test_list_s3_url_wraps_client_error(monkeypatch):
+    """Verify that list_url normalizes ClientError to OSError."""
+
+    class FailingPaginator:
+        def paginate(self, *args, **kwargs):
+            raise MockClientError()
+
+    class FailingClient:
+        ClientError = MockClientError
+
+        def get_paginator(self, *args, **kwargs):
+            return FailingPaginator()
+
+    client = FailingClient()
+
+    def get_s3_session(url, method="fetch"):
+        if not isinstance(url, urllib.parse.ParseResult):
+            url = urllib.parse.urlparse(url)
+        return client, url
+
+    monkeypatch.setattr(spack.util.s3, "get_s3_session", get_s3_session)
+
+    with pytest.raises(OSError):
+        spack.util.web.list_url("s3://my-bucket/prefix/", recursive=True)
+
+
+def test_list_s3_url_skips_directory_marker_keys(monkeypatch):
+    """Verify that a key which exactly matches the specified prefix
+    is skipped instead of getting listed as an empty relative path."""
+
+    class MarkerPages:
+        def search(self, *args, **kwargs):
+            return [{"Key": "prefix/"}, {"Key": "prefix/real-key"}]
+
+    class MarkerPaginator:
+        def paginate(self, *args, **kwargs):
+            return MarkerPages()
+
+    class MarkerClient:
+        def get_paginator(self, *args, **kwargs):
+            return MarkerPaginator()
+
+    client = MarkerClient()
+
+    def get_s3_session(url, method="fetch"):
+        if not isinstance(url, urllib.parse.ParseResult):
+            url = urllib.parse.urlparse(url)
+        return client, url
+
+    monkeypatch.setattr(spack.util.s3, "get_s3_session", get_s3_session)
+
+    listing = spack.util.web.list_url("s3://my-bucket/prefix/", recursive=True)
+    assert listing == ["real-key"]
+
+
 def test_stat_s3_url(mock_s3_client):
     fake_s3_url = "s3://my-bucket/subdirectory/my-file"
     size, mtime = spack.util.web.stat_url(fake_s3_url)
@@ -392,6 +502,11 @@ def test_stat_s3_url(mock_s3_client):
     with pytest.raises(OSError):
         fake_s3_url = "s3://my-bucket/subdirectory/my-notfound-file"
         spack.util.web.stat_url(fake_s3_url)
+
+
+def test_stat_s3_url_returns_none_for_404(mock_s3_client):
+    fake_s3_url = "s3://my-bucket/subdirectory/actually-missing-file"
+    assert spack.util.web.stat_url(fake_s3_url) is None
 
 
 def test_s3_url_exists(mock_s3_client):
@@ -405,6 +520,23 @@ def test_s3_url_exists(mock_s3_client):
 def test_s3_url_parsing():
     assert spack.util.s3._parse_s3_endpoint_url("example.com") == "https://example.com"
     assert spack.util.s3._parse_s3_endpoint_url("http://example.com") == "http://example.com"
+
+
+def test_get_s3_session_normalizes_method_and_returns_parsed_url(monkeypatch):
+    """Verify that "GET" and "HEAD" are treated as "fetch", and everything else
+    is treated as "push"."""
+    monkeypatch.setattr(spack.util.s3, "s3_client_cache", {})
+
+    fetch_client, parsed_url = spack.util.s3.get_s3_session("s3://my-bucket/prefix", method="GET")
+    assert parsed_url.geturl() == "s3://my-bucket/prefix"
+    assert (None, "fetch") in spack.util.s3.s3_client_cache
+
+    head_client, _ = spack.util.s3.get_s3_session("s3://my-bucket/prefix", method="head")
+    assert head_client is fetch_client
+
+    push_client, _ = spack.util.s3.get_s3_session("s3://my-bucket/prefix", method="anything-else")
+    assert (None, "push") in spack.util.s3.s3_client_cache
+    assert push_client is not fetch_client
 
 
 def test_detailed_http_error_pickle(tmp_path: pathlib.Path):
@@ -697,3 +829,37 @@ def test_push_to_url_s3(keep_original, mock_s3_client, tmp_path):
     call = mock_s3_client.upload_file_calls[0]
     assert 3 == len(call[0])
     assert {"ContentType": "text/plain"} == call[1]["ExtraArgs"]
+
+
+def test_push_object_defaults_extra_args_to_empty_dict(mock_s3_client, tmp_path):
+    local_data = tmp_path / "data.txt"
+    local_data.write_text("hello")
+
+    spack.util.s3.push_object("s3://bucket/and/path/data.txt", str(local_data), None)
+
+    assert 1 == len(mock_s3_client.upload_file_calls)
+    call = mock_s3_client.upload_file_calls[0]
+    assert call[1]["ExtraArgs"] == {}
+
+
+def test_push_object_rejects_oversized_file_for_if_match(monkeypatch, mock_s3_client, tmp_path):
+    """IfMatch is only supported via put_object, which can't handle files >= 5GB."""
+    local_data = tmp_path / "data.txt"
+    local_data.write_text("hello")
+
+    class HugeStatResult:
+        st_size = int(6e9)
+
+    real_stat = os.stat
+
+    def fake_stat(path, *args, **kwargs):
+        if str(path) == str(local_data):
+            return HugeStatResult()
+        return real_stat(path, *args, **kwargs)
+
+    monkeypatch.setattr(spack.util.s3.os, "stat", fake_stat)
+
+    with pytest.raises(spack.error.SpackError, match="File too large"):
+        spack.util.s3.push_object(
+            "s3://bucket/and/path/data.txt", str(local_data), {"IfMatch": "etag1234"}
+        )

--- a/lib/spack/spack/test/web.py
+++ b/lib/spack/spack/test/web.py
@@ -126,7 +126,7 @@ def mock_s3_client(monkeypatch):
             url = urllib.parse.urlparse(url)
         return client, url
 
-    monkeypatch.setattr(spack.util.s3, "get_s3_session", get_s3_session)
+    monkeypatch.setattr(spack.util.s3, "_get_s3_session", get_s3_session)
 
     return client
 
@@ -415,7 +415,7 @@ def test_delete_objects_batches_over_1000_keys(monkeypatch):
             url = urllib.parse.urlparse(url)
         return client, url
 
-    monkeypatch.setattr(spack.util.s3, "get_s3_session", get_s3_session)
+    monkeypatch.setattr(spack.util.s3, "_get_s3_session", get_s3_session)
 
     spack.util.web.remove_url("s3://my-bucket/prefix", recursive=True)
 
@@ -457,7 +457,7 @@ def test_list_s3_url_wraps_client_error(monkeypatch):
             url = urllib.parse.urlparse(url)
         return client, url
 
-    monkeypatch.setattr(spack.util.s3, "get_s3_session", get_s3_session)
+    monkeypatch.setattr(spack.util.s3, "_get_s3_session", get_s3_session)
 
     with pytest.raises(OSError):
         spack.util.web.list_url("s3://my-bucket/prefix/", recursive=True)
@@ -486,7 +486,7 @@ def test_list_s3_url_skips_directory_marker_keys(monkeypatch):
             url = urllib.parse.urlparse(url)
         return client, url
 
-    monkeypatch.setattr(spack.util.s3, "get_s3_session", get_s3_session)
+    monkeypatch.setattr(spack.util.s3, "_get_s3_session", get_s3_session)
 
     listing = spack.util.web.list_url("s3://my-bucket/prefix/", recursive=True)
     assert listing == ["real-key"]
@@ -522,7 +522,7 @@ def test_list_s3_url_at_bucket_root(monkeypatch):
             url = urllib.parse.urlparse(url)
         return client, url
 
-    monkeypatch.setattr(spack.util.s3, "get_s3_session", get_s3_session)
+    monkeypatch.setattr(spack.util.s3, "_get_s3_session", get_s3_session)
 
     listing = spack.util.web.list_url("s3://my-bucket", recursive=True)
 
@@ -610,14 +610,14 @@ def test_get_s3_session_normalizes_method_and_returns_parsed_url(monkeypatch, fa
     is treated as "push"."""
     monkeypatch.setattr(spack.util.s3, "s3_client_cache", {})
 
-    fetch_client, parsed_url = spack.util.s3.get_s3_session("s3://my-bucket/prefix", method="GET")
+    fetch_client, parsed_url = spack.util.s3._get_s3_session("s3://my-bucket/prefix", method="GET")
     assert parsed_url.geturl() == "s3://my-bucket/prefix"
     assert (None, "fetch") in spack.util.s3.s3_client_cache
 
-    head_client, _ = spack.util.s3.get_s3_session("s3://my-bucket/prefix", method="head")
+    head_client, _ = spack.util.s3._get_s3_session("s3://my-bucket/prefix", method="head")
     assert head_client is fetch_client
 
-    push_client, _ = spack.util.s3.get_s3_session("s3://my-bucket/prefix", method="anything-else")
+    push_client, _ = spack.util.s3._get_s3_session("s3://my-bucket/prefix", method="anything-else")
     assert (None, "push") in spack.util.s3.s3_client_cache
     assert push_client is not fetch_client
 

--- a/lib/spack/spack/test/web.py
+++ b/lib/spack/spack/test/web.py
@@ -526,7 +526,9 @@ def test_list_s3_url_at_bucket_root(monkeypatch):
 
     listing = spack.util.web.list_url("s3://my-bucket", recursive=True)
 
-    assert client.paginator.paginate_calls == [{"Bucket": "my-bucket", "Prefix": ""}]
+    assert client.paginator.paginate_calls == [
+        {"Bucket": "my-bucket", "Prefix": "", "MaxKeys": 1024}
+    ]
     assert listing == ["some/object.txt"]
 
 

--- a/lib/spack/spack/test/web.py
+++ b/lib/spack/spack/test/web.py
@@ -946,3 +946,16 @@ def test_push_object_rejects_oversized_file_for_if_match(monkeypatch, mock_s3_cl
         spack.util.s3.push_object(
             "s3://bucket/and/path/data.txt", str(local_data), {"IfMatch": "etag1234"}
         )
+
+
+@pytest.mark.parametrize(
+    "exception", [RuntimeError("runtime"), Exception("e"), OSError(1, "dummy")]
+)
+def test_url_exists_no_raise(monkeypatch, exception):
+    """URL Exist check should return False for kind of exception."""
+
+    def _raising(*args, **kwargs):
+        raise exception
+
+    monkeypatch.setattr(spack.util.web, "_url_exists_urllib", _raising)
+    assert not spack.util.web.url_exists("https://not.real.io")

--- a/lib/spack/spack/url_buildcache.py
+++ b/lib/spack/spack/url_buildcache.py
@@ -1192,8 +1192,7 @@ def _entries_from_cache_fallback(url: str, component_type: BuildcacheComponent):
                     filename_to_mtime[entry_url] = stat_result[1]  # mtime is second element
         read_fn = url_read_method
     except OSError as err:
-        # If we got some kind of S3 (access denied or other connection error), the first non
-        # boto-specific class in the exception is Exception.  Just print a warning and return
+        # Backend-specific errors (e.g. those from S3 and GCS) get normalized to OSError.
         tty.warn(f"Encountered problem listing packages at {url}: {err}")
 
     return filename_to_mtime, read_fn

--- a/lib/spack/spack/url_buildcache.py
+++ b/lib/spack/spack/url_buildcache.py
@@ -13,7 +13,6 @@ import shutil
 import urllib.parse
 from contextlib import closing, contextmanager
 from datetime import datetime
-from pathlib import Path
 from tempfile import TemporaryDirectory
 from typing import Any, Callable, Dict, List, Optional, Tuple, Type
 
@@ -35,7 +34,7 @@ from spack.schema.url_buildcache_manifest import schema as buildcache_manifest_s
 from spack.util import tty
 from spack.util.archive import ChecksumWriter
 from spack.util.crypto import hash_fun_for_algo
-from spack.util.executable import which
+from spack.util.executable import ProcessError, which
 
 #: The build cache layout version that this version of Spack creates.
 #: Version 3: Introduces content-addressable tarballs
@@ -1095,12 +1094,11 @@ def check_mirror_for_layout(mirror: spack.mirrors.mirror.Mirror):
         tty.warn(msg)
 
 
-def _entries_from_cache_aws_cli(url: str, tmpspecsdir: str, component_type: BuildcacheComponent):
+def _entries_from_cache_aws_cli(url: str, component_type: BuildcacheComponent):
     """Use aws cli to sync all manifests into a local temporary directory.
 
     Args:
         url: prefix of the build cache on s3
-        tmpspecsdir: path to temporary directory to use for writing files
         component_type: type of buildcache component to sync (spec, index, key, etc.)
 
     Return:
@@ -1115,7 +1113,7 @@ def _entries_from_cache_aws_cli(url: str, tmpspecsdir: str, component_type: Buil
 
     cache_class = get_url_buildcache_class(layout_version=CURRENT_BUILD_CACHE_LAYOUT_VERSION)
     if not aws:
-        tty.warn("Failed to use aws s3 sync to retrieve specs, falling back to parallel fetch")
+        tty.warn("Failed to use aws CLI to retrieve specs, falling back to parallel fetch")
         return file_list, read_fn
 
     def file_read_method(manifest_path: str) -> URLBuildcacheEntry:
@@ -1123,65 +1121,46 @@ def _entries_from_cache_aws_cli(url: str, tmpspecsdir: str, component_type: Buil
         cache_entry.read_manifest(manifest_url=manifest_path)
         return cache_entry
 
-    include_pattern = cache_class.get_buildcache_component_include_pattern(component_type)
-    component_prefix = cache_class.get_relative_path_components(component_type)
-
-    component_url = url_util.join(url, *component_prefix)
-
-    sync_command_args = [
-        "s3",
-        "sync",
-        "--exclude",
-        "*",
-        "--include",
-        include_pattern,
-        component_url,
-        tmpspecsdir,
-    ]
-
     # Use aws s3 ls to get mtimes of manifests
-    ls_command_args = ["s3", "ls", "--recursive", component_url]
+    include_pattern = re.compile(
+        fnmatch.translate(cache_class.get_buildcache_component_include_pattern(component_type))
+    )
+    component_prefix = cache_class.get_relative_path_components(component_type)
+    ls_command_args = ["s3", "ls", "--recursive", url_util.join(url, *component_prefix)]
+    # 2022-08-15 17:54:40    3717621 aws/s3/prefix/to/the/object.json.txt.tar.gz
     s3_ls_regex = re.compile(r"^(\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2})\s+\d+\s+(.+)$")
 
     filename_to_mtime: Dict[str, float] = {}
 
-    tty.debug(f"Using aws s3 sync to download manifests from {component_url} to {tmpspecsdir}")
-
     try:
-        aws(*sync_command_args, output=os.devnull, error=os.devnull)
-        file_list = fsys.find(tmpspecsdir, [include_pattern])
+        parsed_url = urllib.parse.urlparse(url)
         read_fn = file_read_method
 
-        # Use `aws s3 ls` to get mtimes of manifests
+        # Use `aws s3 ls` to get mtimes of manifests as it is tends to be faster than
+        # list_objects_v2
         for line in aws(*ls_command_args, output=str, error=os.devnull).splitlines():
             match = s3_ls_regex.match(line)
             if match:
-                # Parse the url and use the S3 path of the file to derive the
-                # local path of the file (i.e. where `aws s3 sync` put it).
-                parsed_url = urllib.parse.urlparse(url)
-                s3_path = parsed_url.path.lstrip("/")
                 filename = match.group(2)
-                if s3_path and filename.startswith(s3_path):
-                    filename = filename[len(s3_path) :].lstrip("/")
-                local_path = url_util.join(tmpspecsdir, filename)
+                if not include_pattern.fullmatch(filename):
+                    continue
 
-                if Path(local_path).exists():
-                    filename_to_mtime[url_util.path_to_file_url(local_path)] = datetime.strptime(
-                        match.group(1), "%Y-%m-%d %H:%M:%S"
-                    ).timestamp()
-    except Exception as e:
-        tty.warn("Failed to use aws s3 sync to retrieve specs, falling back to parallel fetch")
+                filename = urllib.parse.urlunparse(parsed_url._replace(path=filename))
+                filename_to_mtime[filename] = datetime.strptime(
+                    match.group(1), "%Y-%m-%d %H:%M:%S"
+                ).timestamp()
+    except ProcessError as e:
+        tty.warn("Failed to use aws s3 ls to retrieve spec list, falling back to parallel fetch")
         raise e
 
     return filename_to_mtime, read_fn
 
 
-def _entries_from_cache_fallback(url: str, tmpspecsdir: str, component_type: BuildcacheComponent):
+def _entries_from_cache_fallback(url: str, component_type: BuildcacheComponent):
     """Use spack.util.web module to get a list of all the manifests at the remote url.
 
     Args:
         url: Base url of mirror (location of manifest files)
-        tmpspecsdir: path to temporary directory to use for writing files
         component_type: type of buildcache component to sync (spec, index, key, etc.)
 
     Return:
@@ -1212,7 +1191,7 @@ def _entries_from_cache_fallback(url: str, tmpspecsdir: str, component_type: Bui
                 if stat_result is not None:
                     filename_to_mtime[entry_url] = stat_result[1]  # mtime is second element
         read_fn = url_read_method
-    except Exception as err:
+    except OSError as err:
         # If we got some kind of S3 (access denied or other connection error), the first non
         # boto-specific class in the exception is Exception.  Just print a warning and return
         tty.warn(f"Encountered problem listing packages at {url}: {err}")
@@ -1220,12 +1199,11 @@ def _entries_from_cache_fallback(url: str, tmpspecsdir: str, component_type: Bui
     return filename_to_mtime, read_fn
 
 
-def get_entries_from_cache(url: str, tmpspecsdir: str, component_type: BuildcacheComponent):
+def get_entries_from_cache(url: str, component_type: BuildcacheComponent):
     """Get a list of all the manifests in the mirror and a function to read them.
 
     Args:
         url: Base url of mirror (location of spec files)
-        tmpspecsdir: Temporary location for writing files
         component_type: type of buildcache component to sync (spec, index, key, etc.)
 
     Return:
@@ -1241,9 +1219,12 @@ def get_entries_from_cache(url: str, tmpspecsdir: str, component_type: Buildcach
     callbacks.append(_entries_from_cache_fallback)
 
     for specs_from_cache_fn in callbacks:
-        file_to_mtime_mapping, read_fn = specs_from_cache_fn(url, tmpspecsdir, component_type)
-        if file_to_mtime_mapping:
-            return file_to_mtime_mapping, read_fn
+        try:
+            file_to_mtime_mapping, read_fn = specs_from_cache_fn(url, component_type)
+            if file_to_mtime_mapping:
+                return file_to_mtime_mapping, read_fn
+        except Exception:
+            continue
 
     raise ListMirrorSpecsError("Failed to get list of entries from {0}".format(url))
 

--- a/lib/spack/spack/url_buildcache.py
+++ b/lib/spack/spack/url_buildcache.py
@@ -1191,9 +1191,9 @@ def _entries_from_cache_fallback(url: str, component_type: BuildcacheComponent):
                 if stat_result is not None:
                     filename_to_mtime[entry_url] = stat_result[1]  # mtime is second element
         read_fn = url_read_method
-    except OSError as err:
+    except OSError as e:
         # Backend-specific errors (e.g. those from S3 and GCS) get normalized to OSError.
-        raise ListMirrorSpecsError(f"Encountered problem listing packages at {url}") from e
+        raise ListMirrorSpecsError(f"Encountered problem listing packages at {url}: {e}") from e
 
     return filename_to_mtime, read_fn
 

--- a/lib/spack/spack/url_buildcache.py
+++ b/lib/spack/spack/url_buildcache.py
@@ -1095,7 +1095,7 @@ def check_mirror_for_layout(mirror: spack.mirrors.mirror.Mirror):
 
 
 def _entries_from_cache_aws_cli(url: str, component_type: BuildcacheComponent):
-    """Use aws cli to sync all manifests into a local temporary directory.
+    """Use aws cli to list manifests for a component type.
 
     Args:
         url: prefix of the build cache on s3
@@ -1150,8 +1150,8 @@ def _entries_from_cache_aws_cli(url: str, component_type: BuildcacheComponent):
                     match.group(1), "%Y-%m-%d %H:%M:%S"
                 ).timestamp()
     except ProcessError as e:
-        tty.warn("Failed to use aws s3 ls to retrieve spec list, falling back to parallel fetch")
-        raise e
+        msg = "Failed to use aws s3 ls to retrieve spec list, falling back to parallel fetch"
+        raise ListMirrorSpecsError(msg) from e
 
     return filename_to_mtime, read_fn
 
@@ -1193,7 +1193,7 @@ def _entries_from_cache_fallback(url: str, component_type: BuildcacheComponent):
         read_fn = url_read_method
     except OSError as err:
         # Backend-specific errors (e.g. those from S3 and GCS) get normalized to OSError.
-        tty.warn(f"Encountered problem listing packages at {url}: {err}")
+        raise ListMirrorSpecsError(f"Encountered problem listing packages at {url}") from e
 
     return filename_to_mtime, read_fn
 
@@ -1217,15 +1217,18 @@ def get_entries_from_cache(url: str, component_type: BuildcacheComponent):
 
     callbacks.append(_entries_from_cache_fallback)
 
+    last_error = None
     for specs_from_cache_fn in callbacks:
         try:
             file_to_mtime_mapping, read_fn = specs_from_cache_fn(url, component_type)
             if file_to_mtime_mapping:
                 return file_to_mtime_mapping, read_fn
-        except Exception:
+        except ListMirrorSpecsError as e:
+            tty.warn(f"{e}")
+            last_error = e
             continue
 
-    raise ListMirrorSpecsError("Failed to get list of entries from {0}".format(url))
+    raise ListMirrorSpecsError(f"Failed to list specs in url {url}") from last_error
 
 
 def validate_checksum(file_path, checksum_algorithm, expected_checksum) -> None:

--- a/lib/spack/spack/util/gcs.py
+++ b/lib/spack/spack/util/gcs.py
@@ -228,13 +228,18 @@ class GCSBlob:
 
 def gcs_open(req, *args, **kwargs):
     """Open a reader stream to a blob object on GCS"""
-    url = urllib.parse.urlparse(req.get_full_url())
-    gcsblob = GCSBlob(url)
+    from google.api_core.exceptions import GoogleAPIError
 
-    if not gcsblob.exists():
-        raise URLError("GCS blob {0} does not exist".format(gcsblob.blob_path))
-    stream = gcsblob.get_blob_byte_stream()
-    headers = gcsblob.get_blob_headers()
+    url = urllib.parse.urlparse(req.get_full_url())
+    try:
+        gcsblob = GCSBlob(url)
+
+        if not gcsblob.exists():
+            raise URLError("GCS blob {0} does not exist".format(gcsblob.blob_path))
+        stream = gcsblob.get_blob_byte_stream()
+        headers = gcsblob.get_blob_headers()
+    except GoogleAPIError as e:
+        raise URLError(e) from e
 
     return urllib.response.addinfourl(stream, headers, url)
 

--- a/lib/spack/spack/util/s3.py
+++ b/lib/spack/spack/util/s3.py
@@ -7,9 +7,10 @@ import urllib.parse
 import urllib.request
 import urllib.response
 from io import BufferedReader, BytesIO, IOBase
-from typing import Any, Dict, Tuple
+from typing import Any, Dict, Optional, Tuple
 
 import spack.config
+from spack.util import tty
 
 #: Map (mirror name, method) tuples to s3 client instances.
 s3_client_cache: Dict[Tuple[str, str], Any] = dict()
@@ -22,6 +23,11 @@ def get_s3_session(url, method="fetch"):
     from botocore import UNSIGNED
     from botocore.client import Config
     from botocore.exceptions import ClientError
+
+    # translate method to fetch/push
+    method = method.lower()
+    if method not in ("fetch", "push"):
+        method = "fetch" if method in ("get", "head") else "push"
 
     # Circular dependency
     from spack.mirrors.mirror import MirrorCollection
@@ -58,7 +64,7 @@ def get_s3_session(url, method="fetch"):
 
     # Did we already create a client for this? Then return it.
     if key in s3_client_cache:
-        return s3_client_cache[key]
+        return s3_client_cache[key], url
 
     # Otherwise, create it.
     s3_connection, s3_client_args = get_mirror_s3_connection_info(mirror, method)
@@ -73,7 +79,7 @@ def get_s3_session(url, method="fetch"):
 
     # Cache the client.
     s3_client_cache[key] = client
-    return client
+    return client, url
 
 
 def _parse_s3_endpoint_url(endpoint_url):
@@ -112,7 +118,6 @@ def get_mirror_s3_connection_info(mirror, method):
 
     if endpoint_url:
         s3_client_args["endpoint_url"] = _parse_s3_endpoint_url(endpoint_url)
-
     return s3_connection, s3_client_args
 
 
@@ -147,8 +152,7 @@ class WrapStream(BufferedReader):
 
 
 def _s3_open(url, method="GET"):
-    parsed = urllib.parse.urlparse(url)
-    s3 = get_s3_session(url, method="fetch")
+    s3, parsed = get_s3_session(url, method=method)
 
     bucket = parsed.netloc
     key = parsed.path
@@ -177,8 +181,152 @@ def _s3_open(url, method="GET"):
     return url, headers, stream
 
 
+def s3_command(method: str):
+    """Bind the correct S3 session and capture errors from Boto3."""
+
+    def _s3_decorate_command(command):
+        def _s3_command_wrapped(url, *args, **kwargs):
+            s3, url = get_s3_session(url, method=method)
+            try:
+                return command(s3, url, *args, **kwargs)
+            except s3.ClientError as e:
+                raise urllib.error.URLError(e) from e
+
+        return _s3_command_wrapped
+
+    return _s3_decorate_command
+
+
 class UrllibS3Handler(urllib.request.BaseHandler):
     def s3_open(self, req):
         orig_url = req.get_full_url()
         url, headers, stream = _s3_open(orig_url, method=req.get_method())
         return urllib.response.addinfourl(stream, headers, url)
+
+
+def _relative_key(key, prefix):
+    if not key.startswith("/"):
+        key = "/" + key
+
+    if not prefix.startswith("/"):
+        prefix = "/" + prefix
+
+    key = os.path.relpath(key, prefix)
+
+    if key == ".":
+        return None
+
+    return key
+
+
+def _iter_s3_prefix(s3, url, num_entries=1024):
+    bucket = url.netloc
+    prefix = url.path.strip("/") + "/"
+    paginator = s3.get_paginator("list_objects_v2")
+    pages = paginator.paginate(Bucket=bucket, Prefix=prefix)
+
+    for item in pages.search("Contents"):
+        key = _relative_key(item["Key"], prefix)
+        if key is not None:
+            yield key
+
+
+@s3_command("fetch")
+def list_objects(s3, url: urllib.parse.ParseResult, recursive: bool = False):
+    """List contents under a url.
+
+    Args:
+        url: S3 URL (ie. s3://bucket/some/prefix/)
+        recursive: List prefix recursively.
+    Returns:
+        List of keys under the bucket/prefix.
+    """
+    if recursive:
+        return list(_iter_s3_prefix(s3, url))
+
+    return list({key.split("/", 1)[0] for key in _iter_s3_prefix(s3, url)})
+
+
+def _debug_print_delete_results(result):
+    if "Deleted" in result:
+        for d in result["Deleted"]:
+            tty.debug("Deleted {0}".format(d["Key"]))
+    if "Errors" in result:
+        for e in result["Errors"]:
+            tty.debug("Failed to delete {0} ({1})".format(e["Key"], e["Message"]))
+
+
+@s3_command("push")
+def delete_objects(s3, url: urllib.parse.ParseResult, recursive: bool = False):
+    # Try to find a mirror for potential connection information
+    bucket = url.netloc
+    if recursive:
+        # Because list_objects_v2 can only return up to 1000 items
+        # at a time, we have to paginate to make sure we get it all
+        prefix = url.path.strip("/")
+        paginator = s3.get_paginator("list_objects_v2")
+        pages = paginator.paginate(Bucket=bucket, Prefix=prefix)
+
+        delete_request = {"Objects": []}
+        for item in pages.search("Contents"):
+            if not item:
+                continue
+
+            delete_request["Objects"].append({"Key": item["Key"]})
+
+            # Make sure we do not try to hit S3 with a list of more
+            # than 1000 items
+            if len(delete_request["Objects"]) >= 1000:
+                r = s3.delete_objects(Bucket=bucket, Delete=delete_request)
+                _debug_print_delete_results(r)
+                delete_request = {"Objects": []}
+
+        # Delete any items that remain
+        if len(delete_request["Objects"]):
+            r = s3.delete_objects(Bucket=bucket, Delete=delete_request)
+            _debug_print_delete_results(r)
+    else:
+        s3.delete_object(Bucket=bucket, Key=url.path.lstrip("/"))
+
+
+@s3_command("fetch")
+def stat_object(s3, url: urllib.parse.ParseResult) -> Optional[Tuple[int, float]]:
+    """Get stat result for a URL.
+
+    Args:
+        url: URL to get stat result for
+    Returns:
+        A tuple of (size, mtime) if the URL exists, None otherwise.
+    """
+    s3_bucket = url.netloc
+    s3_key = url.path.lstrip("/")
+    try:
+        head_request = s3.head_object(Bucket=s3_bucket, Key=s3_key)
+    except s3.ClientError as e:
+        if e.response["Error"]["Code"] == "404":
+            return None
+        raise e
+
+    mtime = head_request["LastModified"].timestamp()
+    size = head_request["ContentLength"]
+    return size, mtime
+
+
+@s3_command("psuh")
+def push_object(s3, url: urllib.parse.ParseResult, local_file_path, extra_args):
+    if extra_args is None:
+        extra_args = {}
+
+    remote_path = url.path
+    while remote_path.startswith("/"):
+        remote_path = remote_path[1:]
+
+    if extra_args.get("IfMatch") is not None:
+        # IfMatch is only supported by put_object which has additional limitations
+        if os.stat(local_file_path).st_size >= 5e9:
+            raise spack.error.SpackError(f"File too large (max. 5GB): {local_file_path}")
+
+        with open(local_file_path, "rb") as fd:
+            s3.put_object(Bucket=url.netloc, Key=remote_path, Body=fd, **extra_args)
+    else:
+        s3.upload_file(local_file_path, url.netloc, remote_path, ExtraArgs=extra_args)

--- a/lib/spack/spack/util/s3.py
+++ b/lib/spack/spack/util/s3.py
@@ -224,7 +224,8 @@ def _relative_key(key, prefix):
 
 def _iter_s3_prefix(s3, url, num_entries=1024):
     bucket = url.netloc
-    prefix = url.path.strip("/") + "/"
+    stripped_path = url.path.strip("/")
+    prefix = f"{stripped_path}/" if stripped_path else ""
     paginator = s3.get_paginator("list_objects_v2")
     pages = paginator.paginate(Bucket=bucket, Prefix=prefix)
 

--- a/lib/spack/spack/util/s3.py
+++ b/lib/spack/spack/util/s3.py
@@ -7,9 +7,10 @@ import urllib.parse
 import urllib.request
 import urllib.response
 from io import BufferedReader, BytesIO, IOBase
-from typing import Any, Dict, Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple
 
 import spack.config
+import spack.error
 from spack.util import tty
 
 #: Map (mirror name, method) tuples to s3 client instances.
@@ -267,7 +268,7 @@ def delete_objects(s3, url: urllib.parse.ParseResult, recursive: bool = False):
         paginator = s3.get_paginator("list_objects_v2")
         pages = paginator.paginate(Bucket=bucket, Prefix=prefix)
 
-        delete_request = {"Objects": []}
+        delete_request: Dict[str, List[Dict[str, str]]] = {"Objects": []}
         for item in pages.search("Contents"):
             if not item:
                 continue

--- a/lib/spack/spack/util/s3.py
+++ b/lib/spack/spack/util/s3.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 import os
+import posixpath
 import urllib.error
 import urllib.parse
 import urllib.request
@@ -212,7 +213,8 @@ def _relative_key(key, prefix):
     if not prefix.startswith("/"):
         prefix = "/" + prefix
 
-    key = os.path.relpath(key, prefix)
+    # S3 keys are always POSIX-style, regardless of the host OS.
+    key = posixpath.relpath(key, prefix)
 
     if key == ".":
         return None

--- a/lib/spack/spack/util/s3.py
+++ b/lib/spack/spack/util/s3.py
@@ -315,7 +315,7 @@ def stat_object(s3, url: urllib.parse.ParseResult) -> Optional[Tuple[int, float]
     return size, mtime
 
 
-@s3_command("psuh")
+@s3_command("push")
 def push_object(s3, url: urllib.parse.ParseResult, local_file_path, extra_args):
     if extra_args is None:
         extra_args = {}

--- a/lib/spack/spack/util/s3.py
+++ b/lib/spack/spack/util/s3.py
@@ -222,15 +222,22 @@ def _relative_key(key, prefix):
     return key
 
 
-def _iter_s3_prefix(s3, url, num_entries=1024):
+def _iter_s3_prefix(s3, url, relative: bool = False, num_entries: int = 1024):
     bucket = url.netloc
     stripped_path = url.path.strip("/")
     prefix = f"{stripped_path}/" if stripped_path else ""
     paginator = s3.get_paginator("list_objects_v2")
-    pages = paginator.paginate(Bucket=bucket, Prefix=prefix)
+    pages = paginator.paginate(Bucket=bucket, Prefix=prefix, MaxKeys=num_entries)
 
     for item in pages.search("Contents"):
-        key = _relative_key(item["Key"], prefix)
+        if not item:
+            continue
+
+        if relative:
+            key = _relative_key(item["Key"], prefix)
+        else:
+            key = item["Key"]
+
         if key is not None:
             yield key
 
@@ -246,9 +253,9 @@ def list_objects(s3, url: urllib.parse.ParseResult, recursive: bool = False):
         List of keys under the bucket/prefix.
     """
     if recursive:
-        return list(_iter_s3_prefix(s3, url))
+        return list(_iter_s3_prefix(s3, url, relative=True))
 
-    return list({key.split("/", 1)[0] for key in _iter_s3_prefix(s3, url)})
+    return list({key.split("/", 1)[0] for key in _iter_s3_prefix(s3, url, relative=True)})
 
 
 def _debug_print_delete_results(result):
@@ -267,16 +274,9 @@ def delete_objects(s3, url: urllib.parse.ParseResult, recursive: bool = False):
     if recursive:
         # Because list_objects_v2 can only return up to 1000 items
         # at a time, we have to paginate to make sure we get it all
-        prefix = url.path.strip("/")
-        paginator = s3.get_paginator("list_objects_v2")
-        pages = paginator.paginate(Bucket=bucket, Prefix=prefix)
-
         delete_request: Dict[str, List[Dict[str, str]]] = {"Objects": []}
-        for item in pages.search("Contents"):
-            if not item:
-                continue
-
-            delete_request["Objects"].append({"Key": item["Key"]})
+        for key in _iter_s3_prefix(s3, url, relative=False):
+            delete_request["Objects"].append({"Key": key})
 
             # Make sure we do not try to hit S3 with a list of more
             # than 1000 items

--- a/lib/spack/spack/util/s3.py
+++ b/lib/spack/spack/util/s3.py
@@ -19,7 +19,7 @@ from spack.util import tty
 s3_client_cache: Dict[Tuple[str, str], Any] = dict()
 
 
-def get_s3_session(url, method="fetch"):
+def _get_s3_session(url, method="fetch"):
     # import boto and friends as late as possible.  We don't want to require boto as a
     # dependency unless the user actually wants to access S3 mirrors.
     from boto3 import Session
@@ -155,7 +155,7 @@ class WrapStream(BufferedReader):
 
 
 def _s3_open(url, method="GET"):
-    s3, parsed = get_s3_session(url, method=method)
+    s3, parsed = _get_s3_session(url, method=method)
 
     bucket = parsed.netloc
     key = parsed.path
@@ -190,7 +190,7 @@ def s3_command(method: str):
     def _s3_decorate_command(command):
         @functools.wraps(command)
         def _s3_command_wrapped(url, *args, **kwargs):
-            s3, url = get_s3_session(url, method=method)
+            s3, url = _get_s3_session(url, method=method)
             try:
                 return command(s3, url, *args, **kwargs)
             except s3.ClientError as e:

--- a/lib/spack/spack/util/s3.py
+++ b/lib/spack/spack/util/s3.py
@@ -1,6 +1,7 @@
 # Copyright Spack Project Developers. See COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
+import functools
 import os
 import posixpath
 import urllib.error
@@ -187,6 +188,7 @@ def s3_command(method: str):
     """Bind the correct S3 session and capture errors from Boto3."""
 
     def _s3_decorate_command(command):
+        @functools.wraps(command)
         def _s3_command_wrapped(url, *args, **kwargs):
             s3, url = get_s3_session(url, method=method)
             try:
@@ -271,26 +273,27 @@ def _debug_print_delete_results(result):
 def delete_objects(s3, url: urllib.parse.ParseResult, recursive: bool = False):
     # Try to find a mirror for potential connection information
     bucket = url.netloc
-    if recursive:
-        # Because list_objects_v2 can only return up to 1000 items
-        # at a time, we have to paginate to make sure we get it all
-        delete_request: Dict[str, List[Dict[str, str]]] = {"Objects": []}
-        for key in _iter_s3_prefix(s3, url, relative=False):
-            delete_request["Objects"].append({"Key": key})
+    if not recursive:
+        s3.delete_object(Bucket=bucket, Key=url.path.lstrip("/"))
+        return
 
-            # Make sure we do not try to hit S3 with a list of more
-            # than 1000 items
-            if len(delete_request["Objects"]) >= 1000:
-                r = s3.delete_objects(Bucket=bucket, Delete=delete_request)
-                _debug_print_delete_results(r)
-                delete_request = {"Objects": []}
+    # Because list_objects_v2 can only return up to 1000 items
+    # at a time, we have to paginate to make sure we get it all
+    delete_request: Dict[str, List[Dict[str, str]]] = {"Objects": []}
+    for key in _iter_s3_prefix(s3, url, relative=False):
+        delete_request["Objects"].append({"Key": key})
 
-        # Delete any items that remain
-        if len(delete_request["Objects"]):
+        # Make sure we do not try to hit S3 with a list of more
+        # than 1000 items
+        if len(delete_request["Objects"]) >= 1000:
             r = s3.delete_objects(Bucket=bucket, Delete=delete_request)
             _debug_print_delete_results(r)
-    else:
-        s3.delete_object(Bucket=bucket, Key=url.path.lstrip("/"))
+            delete_request = {"Objects": []}
+
+    # Delete any items that remain
+    if len(delete_request["Objects"]):
+        r = s3.delete_objects(Bucket=bucket, Delete=delete_request)
+        _debug_print_delete_results(r)
 
 
 @s3_command("fetch")

--- a/lib/spack/spack/util/web.py
+++ b/lib/spack/spack/util/web.py
@@ -36,11 +36,11 @@ import spack.util.parallel
 import spack.util.url
 import spack.util.url as url_util
 from spack.util import lang, tty
+from spack.util import s3 as s3_util
 from spack.util.filesystem import mkdirp, working_dir
 
 from .executable import CommandNotFoundError, Executable
 from .gcs import GCSBlob, GCSBucket, GCSHandler
-from .s3 import UrllibS3Handler, get_s3_session
 
 
 class Retry:
@@ -258,7 +258,7 @@ def set_curl_env_for_ssl_certs(curl: Executable) -> None:
 
 
 def _urlopen():
-    s3 = UrllibS3Handler()
+    s3 = s3_util.UrllibS3Handler()
     gcs = GCSHandler()
     error_handler = SpackHTTPDefaultErrorHandler()
 
@@ -392,7 +392,7 @@ def read_text(url: str) -> str:
     """Fetch url and return the response body decoded as UTF-8 text."""
     try:
         return _read_text_with_retry(url)
-    except Exception as e:
+    except OSError as e:
         raise SpackWebError(f"Download of {url} failed: {e.__class__.__name__}: {e}")
 
 
@@ -400,7 +400,7 @@ def read_json(url: str):
     """Fetch url and return the response body parsed as JSON."""
     try:
         return _read_json_with_retry(url)
-    except Exception as e:
+    except OSError as e:
         raise SpackWebError(f"Download of {url} failed: {e.__class__.__name__}: {e}")
 
 
@@ -445,20 +445,7 @@ def push_to_url(
         if content_type is not None:
             extra_args.update({"ContentType": content_type})
 
-        remote_path = remote_url.path
-        while remote_path.startswith("/"):
-            remote_path = remote_path[1:]
-
-        s3 = get_s3_session(remote_url, method="push")
-        if if_match is not None:
-            # IfMatch is only supported by put_object which has additional limitations
-            if os.stat(local_file_path).st_size >= 5e9:
-                raise spack.error.SpackError(f"File too large (max. 5GB): {local_file_path}")
-
-            with open(local_file_path, "rb") as fd:
-                s3.put_object(Bucket=remote_url.netloc, Key=remote_path, Body=fd, **extra_args)
-        else:
-            s3.upload_file(local_file_path, remote_url.netloc, remote_path, ExtraArgs=extra_args)
+        s3_util.push_object(remote_path, local_file_path, extra_args)
 
         if not keep_original:
             os.remove(local_file_path)
@@ -661,18 +648,9 @@ def url_exists(url, curl=None):
     try:
         _url_exists_urllib(url)
         return True
-    except Exception as e:
+    except OSError as e:
         tty.debug(f"Failure reading {url}: {e}")
         return False
-
-
-def _debug_print_delete_results(result):
-    if "Deleted" in result:
-        for d in result["Deleted"]:
-            tty.debug("Deleted {0}".format(d["Key"]))
-    if "Errors" in result:
-        for e in result["Errors"]:
-            tty.debug("Failed to delete {0} ({1})".format(e["Key"], e["Message"]))
 
 
 def remove_url(url, recursive=False):
@@ -687,36 +665,7 @@ def remove_url(url, recursive=False):
         return
 
     if url.scheme == "s3":
-        # Try to find a mirror for potential connection information
-        s3 = get_s3_session(url, method="push")
-        bucket = url.netloc
-        if recursive:
-            # Because list_objects_v2 can only return up to 1000 items
-            # at a time, we have to paginate to make sure we get it all
-            prefix = url.path.strip("/")
-            paginator = s3.get_paginator("list_objects_v2")
-            pages = paginator.paginate(Bucket=bucket, Prefix=prefix)
-
-            delete_request = {"Objects": []}
-            for item in pages.search("Contents"):
-                if not item:
-                    continue
-
-                delete_request["Objects"].append({"Key": item["Key"]})
-
-                # Make sure we do not try to hit S3 with a list of more
-                # than 1000 items
-                if len(delete_request["Objects"]) >= 1000:
-                    r = s3.delete_objects(Bucket=bucket, Delete=delete_request)
-                    _debug_print_delete_results(r)
-                    delete_request = {"Objects": []}
-
-            # Delete any items that remain
-            if len(delete_request["Objects"]):
-                r = s3.delete_objects(Bucket=bucket, Delete=delete_request)
-                _debug_print_delete_results(r)
-        else:
-            s3.delete_object(Bucket=bucket, Key=url.path.lstrip("/"))
+        s3_util.delete_objects(url, recursive)
         return
 
     elif url.scheme == "gs":
@@ -729,53 +678,6 @@ def remove_url(url, recursive=False):
         return
 
     # Don't even try for other URL schemes.
-
-
-def _iter_s3_contents(contents, prefix):
-    for entry in contents:
-        key = entry["Key"]
-
-        if not key.startswith("/"):
-            key = "/" + key
-
-        key = os.path.relpath(key, prefix)
-
-        if key == ".":
-            continue
-
-        yield key
-
-
-def _list_s3_objects(client, bucket, prefix, num_entries, start_after=None):
-    list_args = dict(Bucket=bucket, Prefix=prefix[1:], MaxKeys=num_entries)
-
-    if start_after is not None:
-        list_args["StartAfter"] = start_after
-
-    result = client.list_objects_v2(**list_args)
-
-    last_key = None
-    if result["IsTruncated"]:
-        last_key = result["Contents"][-1]["Key"]
-
-    iter = _iter_s3_contents(result["Contents"], prefix)
-
-    return iter, last_key
-
-
-def _iter_s3_prefix(client, url, num_entries=1024):
-    key = None
-    bucket = url.netloc
-    prefix = re.sub(r"^/*", "/", url.path)
-
-    while True:
-        contents, key = _list_s3_objects(client, bucket, prefix, num_entries, start_after=key)
-
-        for x in contents:
-            yield x
-
-        if not key:
-            break
 
 
 def _iter_local_prefix(path):
@@ -799,11 +701,7 @@ def list_url(url, recursive=False):
         ]
 
     if url.scheme == "s3":
-        s3 = get_s3_session(url, method="fetch")
-        if recursive:
-            return list(_iter_s3_prefix(s3, url))
-
-        return list({key.split("/", 1)[0] for key in _iter_s3_prefix(s3, url)})
+        return s3_util.list_objects(url, recursive)
 
     elif url.scheme == "gs":
         gcs = GCSBucket(url)
@@ -830,22 +728,7 @@ def stat_url(url: str) -> Optional[Tuple[int, float]]:
         return url_stat.st_size, url_stat.st_mtime
 
     elif parsed_url.scheme == "s3":
-        s3_bucket = parsed_url.netloc
-        s3_key = parsed_url.path.lstrip("/")
-
-        s3 = get_s3_session(url, method="fetch")
-
-        try:
-            head_request = s3.head_object(Bucket=s3_bucket, Key=s3_key)
-        except s3.ClientError as e:
-            if e.response["Error"]["Code"] == "404":
-                return None
-            raise e
-
-        mtime = head_request["LastModified"].timestamp()
-        size = head_request["ContentLength"]
-        return size, mtime
-
+        return s3_util.stat_object(url)
     else:
         raise NotImplementedError(f"Unrecognized URL scheme: {parsed_url.scheme}")
 

--- a/lib/spack/spack/util/web.py
+++ b/lib/spack/spack/util/web.py
@@ -648,7 +648,7 @@ def url_exists(url, curl=None):
     try:
         _url_exists_urllib(url)
         return True
-    except OSError as e:
+    except Exception as e:
         tty.debug(f"Failure reading {url}: {e}")
         return False
 


### PR DESCRIPTION
Extract from #52117 

aws s3 sync downloads all of the manifests. This is potentially significantly more downloads when using build cache index views and provides only a minor performance improvement to downloading each manifest individually.

This will be followed by additional optimizations that avoid downloads when possible.