### PR TITLE
new installer: jobserver cleanups

### DIFF
--- a/lib/spack/spack/installer/base.py
+++ b/lib/spack/spack/installer/base.py
@@ -53,6 +53,7 @@ HEADLESS_WAKE_INTERVAL = 1.0
 #: Selector data keys registered by the terminal and dispatched by the event loop
 STDIN_EVENT = "stdin"
 SIGWINCH_EVENT = "sigwinch"
+JOBSERVER_EVENT = "jobserver"
 
 
 class BuildChannels(NamedTuple):

--- a/lib/spack/spack/installer/base.py
+++ b/lib/spack/spack/installer/base.py
@@ -267,6 +267,10 @@ class JobServerBase(abc.ABC):
         """Decrease the target parallelism by one."""
 
     @abc.abstractmethod
+    def maybe_discard_tokens(self) -> None:
+        """Try to reduce parallelism to the target by discarding tokens."""
+
+    @abc.abstractmethod
     def acquire(self, jobs: int) -> int:
         """Try and acquire at most 'jobs' tokens from the jobserver. Returns the number of tokens
         actually acquired (may be less than requested, or zero)."""
@@ -291,6 +295,8 @@ class NoopJobServer(JobServerBase):
     def increase_parallelism(self) -> None: ...
 
     def decrease_parallelism(self) -> None: ...
+
+    def maybe_discard_tokens(self) -> None: ...
 
     def acquire(self, jobs: int) -> int:
         return jobs

--- a/lib/spack/spack/installer/core.py
+++ b/lib/spack/spack/installer/core.py
@@ -400,7 +400,7 @@ class PackageInstaller:
                         terminal.drain_sigwinch()
                         self.ui.on_resize()
                     elif data == JOBSERVER_EVENT and not jobserver.has_target_parallelism():
-                        jobserver._maybe_discard_tokens()
+                        jobserver.maybe_discard_tokens()
                         self.ui.on_jobs_changed(jobserver.num_jobs, jobserver.target_jobs)
 
                 current_time = time.monotonic()

--- a/lib/spack/spack/installer/core.py
+++ b/lib/spack/spack/installer/core.py
@@ -30,6 +30,7 @@ import spack.util.filesystem as fs
 import spack.util.lock
 import spack.util.tty
 from spack.installer.base import (
+    JOBSERVER_EVENT,
     OUTPUT_BUFFER_SIZE,
     SIGWINCH_EVENT,
     STDIN_EVENT,
@@ -398,7 +399,7 @@ class PackageInstaller:
                         assert terminal is not None
                         terminal.drain_sigwinch()
                         self.ui.on_resize()
-                    elif data == "jobserver" and not jobserver.has_target_parallelism():
+                    elif data == JOBSERVER_EVENT and not jobserver.has_target_parallelism():
                         jobserver._maybe_discard_tokens()
                         self.ui.on_jobs_changed(jobserver.num_jobs, jobserver.target_jobs)
 

--- a/lib/spack/spack/installer/posix.py
+++ b/lib/spack/spack/installer/posix.py
@@ -273,14 +273,14 @@ class PosixJobServer(JobServerBase):
 
         fifo_config = get_jobserver_config(makeflags)
 
-        if type(fifo_config) is str:
+        if isinstance(fifo_config, str):
             # FIFO-based jobserver. Try to open the FIFO.
             open_attempt = open_existing_jobserver_fifo(fifo_config)
             if open_attempt:
                 self.r, self.w = open_attempt
                 self.fifo_path = fifo_config
                 return
-        elif type(fifo_config) is tuple:
+        elif isinstance(fifo_config, tuple):
             # Old style pipe-based jobserver. Validate the fds before using them.
             r, w = fifo_config
             try:
@@ -408,8 +408,7 @@ def get_jobserver_config(makeflags: Optional[str] = None) -> Optional[Union[str,
     matches = re.findall(r" --jobserver-[^=]+=([^ ]+)", makeflags)
     if not matches:
         return None
-    last_match: str = matches[-1]
-    assert isinstance(last_match, str)
+    last_match = matches[-1]
     if last_match.startswith("fifo:"):
         return last_match[5:]
     parts = last_match.split(",", 1)

--- a/lib/spack/spack/installer/posix.py
+++ b/lib/spack/spack/installer/posix.py
@@ -28,6 +28,7 @@ from typing import Callable, Optional, Tuple, Union
 import spack.spec
 import spack.util.tty
 from spack.installer.base import (
+    JOBSERVER_EVENT,
     OUTPUT_BUFFER_SIZE,
     SIGWINCH_EVENT,
     STDIN_EVENT,
@@ -308,7 +309,7 @@ class PosixJobServer(JobServerBase):
 
     def update_selector(self, selector: selectors.BaseSelector, wake: bool) -> None:
         if wake and self.r not in selector.get_map():
-            selector.register(self.r, selectors.EVENT_READ, "jobserver")
+            selector.register(self.r, selectors.EVENT_READ, JOBSERVER_EVENT)
         elif not wake and self.r in selector.get_map():
             selector.unregister(self.r)
 

--- a/lib/spack/spack/installer/posix.py
+++ b/lib/spack/spack/installer/posix.py
@@ -327,10 +327,10 @@ class PosixJobServer(JobServerBase):
         if not self.created or self.target_jobs <= 1:
             return
         self.target_jobs -= 1
-        self._maybe_discard_tokens()
+        self.maybe_discard_tokens()
 
-    def _maybe_discard_tokens(self) -> None:
-        """Try to get reduce parallelism by discarding tokens."""
+    def maybe_discard_tokens(self) -> None:
+        """Try to reduce parallelism to the target by discarding tokens."""
         to_discard = self.num_jobs - self.target_jobs
         if to_discard <= 0:
             return

--- a/lib/spack/spack/test/installer/posix.py
+++ b/lib/spack/spack/test/installer/posix.py
@@ -448,7 +448,7 @@ class TestJobServer:
         js = PosixJobServer(3, makeflags="")
         try:
             original_num = js.num_jobs
-            js._maybe_discard_tokens()  # to_discard == 0
+            js.maybe_discard_tokens()  # to_discard == 0
             assert js.num_jobs == original_num
         finally:
             js.close()
@@ -460,7 +460,7 @@ class TestJobServer:
             # Manually set target lower to create a discard requirement.
             js.target_jobs = js.num_jobs - 2
             original_num = js.num_jobs
-            js._maybe_discard_tokens()
+            js.maybe_discard_tokens()
             assert js.num_jobs < original_num
         finally:
             js.close()
@@ -474,7 +474,7 @@ class TestJobServer:
             original_num = js.num_jobs
             # Artificially lower target so a discard is requested, but pipe is empty.
             js.target_jobs = js.num_jobs - 1
-            js._maybe_discard_tokens()  # Should not raise; num_jobs unchanged.
+            js.maybe_discard_tokens()  # Should not raise; num_jobs unchanged.
             assert js.num_jobs == original_num
         finally:
             js.close()


### PR DESCRIPTION
Small cleanups in the jobserver part of the new installer. The event loop no longer reaches into platform specific internals.