### PR TITLE
tests: enable shared concretization cache

### DIFF
--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -646,6 +646,11 @@ class ConcretizationCache:
             self._remove_entry(pathlib.Path(tmp_path))
             return
 
+        # Only a newly stored entry can push the cache over its entry limit, so this is the
+        # only place that needs to prune. Listing the entire cache is too expensive to do on
+        # every solve, let alone cache hits.
+        self.cleanup()
+
     def fetch(self, problem: str) -> Union[Tuple[Result, Dict], Tuple[None, None]]:
         """Returns the concretization cache result for a lookup based on the given problem.
 
@@ -4000,7 +4005,6 @@ class Solver:
             output=output,
             allow_deprecated=allow_deprecated,
         )
-        self._conc_cache.cleanup()
         return result
 
     def solve(self, specs: Sequence[spack.spec.Spec], **kwargs) -> Result:
@@ -4070,8 +4074,6 @@ class Solver:
             input_specs = [x for (x, y) in result.unsolved_specs]
             for spec in result.specs:
                 reusable_specs.extend(spec.traverse())
-
-        self._conc_cache.cleanup()
 
 
 class _SkipConcreteVisitor(traverse.BaseVisitor):

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -1089,6 +1089,11 @@ class PyclingoDriver:
         result = None
         if cache:
             result, concretization_stats = cache.fetch(cache_key)
+            if result:
+                # Abstract specs do not round-trip faithfully through JSON (e.g. conditional
+                # dependency edges lose their when= conditions). The problem hash guarantees
+                # the caller's input specs are equivalent to the stored ones, so use them.
+                result.abstract_specs = specs
         timer.stop("cache-check")
 
         # run the solver

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -602,9 +602,12 @@ class ArchSpec:
         )
 
     def to_dict(self):
+        # Abstract specs may have no target
+        if self.target is None:
+            target_data = None
         # Generic targets represent either an architecture family (like x86_64)
         # or a custom micro-architecture
-        if self.target.vendor == "generic":
+        elif self.target.vendor == "generic":
             target_data = str(self.target)
         else:
             # Get rid of compiler flag information before turning the uarch into a dict
@@ -617,6 +620,8 @@ class ArchSpec:
         """Import an ArchSpec from raw YAML/JSON data"""
         arch = d["arch"]
         target_name = arch["target"]
+        if target_name is None:
+            return ArchSpec((arch["platform"], arch["platform_os"], None))
         if not isinstance(target_name, str):
             target_name = target_name["name"]
         target = _make_microarchitecture(target_name)

--- a/lib/spack/spack/test/conftest.py
+++ b/lib/spack/spack/test/conftest.py
@@ -936,6 +936,18 @@ def configuration_dir(tmp_path_factory: pytest.TempPathFactory, linux_os):
     modules_template = test_config / "modules.yaml"
     modules.write_text(modules_template.read_text().format(tcl_root, lmod_root))
 
+    # Use a concretization cache shared by all workers of this pytest invocation: the solver
+    # dominates test time, and about half of the ASP problems recur across tests. Under xdist
+    # each worker's basetemp is a subdirectory of the invocation's temp directory.
+    conc_cache_root = tmp_path_factory.getbasetemp()
+    if os.environ.get("PYTEST_XDIST_WORKER"):
+        conc_cache_root = conc_cache_root.parent
+    conc_cache_dir = conc_cache_root / "concretization-cache"
+    conc_cache_dir.mkdir(exist_ok=True)
+    concretizer = tmp_path / "site" / "concretizer.yaml"
+    concretizer_template = test_config / "concretizer.yaml"
+    concretizer.write_text(concretizer_template.read_text().format(conc_cache_dir=conc_cache_dir))
+
     for scope in ("spack", "user", "site", "system"):
         scope_path = tmp_path / scope
         scope_path.mkdir(exist_ok=True)

--- a/lib/spack/spack/test/data/config/concretizer.yaml
+++ b/lib/spack/spack/test/data/config/concretizer.yaml
@@ -29,4 +29,6 @@ concretizer:
       llvm: 2
 
   concretization_cache:
-    enable: false
+    enable: true
+    url: {conc_cache_dir}
+    entry_limit: 20000


### PR DESCRIPTION
Enable the concretization cache under pytest, and see if that speeds up github
actions.

That's a good integration test, and it uncovered further bugs.

