### PR TITLE
use_repositories: ensure_unwrapped before swap

### DIFF
--- a/lib/spack/spack/repo.py
+++ b/lib/spack/spack/repo.py
@@ -2129,10 +2129,14 @@ def use_repositories(
     paths = {getattr(x, "root", x): getattr(x, "root", x) for x in paths_and_repos}
     scope_name = f"use-repo-{uuid.uuid4()}"
     repos_key = "repos:" if override else "repos"
+    # PATH may be a lazy singleton created from config, so materialize it before pushing the
+    # new scope, otherwise we'd save (and later restore) the new repositories instead of the
+    # current ones.
+    old_repo = ensure_unwrapped(PATH)
     spack.config.CONFIG.push_scope(
         spack.config.InternalConfigScope(name=scope_name, data={repos_key: paths})
     )
-    old_repo, new_repo = PATH, RepoPath.from_config(spack.config.CONFIG)
+    new_repo = RepoPath.from_config(spack.config.CONFIG)
     old_repo.disable()
     enable_repo(new_repo)
     try:

--- a/lib/spack/spack/test/repo.py
+++ b/lib/spack/spack/test/repo.py
@@ -6,6 +6,7 @@ import pathlib
 
 import pytest
 
+import spack.config
 import spack.environment
 import spack.package_base
 import spack.paths
@@ -17,6 +18,7 @@ import spack.util.file_cache
 import spack.util.lock
 import spack.util.naming
 from spack.test.conftest import RepoBuilder
+from spack.util.lang import Singleton
 from spack.util.naming import valid_module_name
 
 
@@ -113,6 +115,24 @@ def test_use_repositories_doesnt_change_class(mock_packages):
     with spack.repo.use_repositories(*current_paths):
         zlib_cls_inner = spack.repo.PATH.get_pkg_class("zlib")
     assert id(zlib_cls_inner) == id(zlib_cls_outer)
+
+
+def test_use_repositories_with_unmaterialized_path(tmp_path: pathlib.Path, config, monkeypatch):
+    """Tests that use_repositories restores the repositories from config even when the global
+    PATH singleton is materialized for the first time inside the context manager. Materializing
+    it after pushing the new repos scope onto the config would "save" the new repositories and
+    "restore" those same repositories on exit."""
+    (tmp_path / "packages").mkdir()
+    (tmp_path / "repo.yaml").write_text("repo:\n  namespace: myrepo\n")
+
+    monkeypatch.setattr(
+        spack.repo, "PATH", Singleton(lambda: spack.repo.create_and_enable(spack.config.CONFIG))
+    )
+
+    with spack.repo.use_repositories(str(tmp_path)) as repo:
+        assert [r.root for r in repo.repos] == [str(tmp_path)]
+
+    assert [r.root for r in spack.repo.PATH.repos] == [spack.paths.mock_packages_path]
 
 
 def test_absolute_import_spack_packages_as_python_modules(mock_packages):


### PR DESCRIPTION
When `use_repositories` was the first thing in the process to touch the lazy
spack.repo.PATH singleton, PATH was materialized from spack.config.CONFIG
*after* the new repos scope was already pushed. The "saved" old repo was then
the new repo itself, and on exit `use_repositories` would restore the
repositories it was supposed to remove.

In the test suite this made the module-scoped `mock_test_repo` fixture leak its
since-deleted temporary repository into the global PATH, causing
order-dependent failures such as

```
FileNotFoundError: .../mock_test_repo0/packages
```

in later tests that use spack.repo.PATH without a repo fixture, e.g.
`spec_syntax.py::test_parse_toolchain`. Deterministic reproducer before this
fix:

```
pytest lib/spack/spack/test/cmd/create.py lib/spack/spack/test/spec_syntax.py
```

