### PR TITLE
Gpg: grant exclusive user access to gpghome

### DIFF
--- a/lib/spack/spack/test/util/win_acl.py
+++ b/lib/spack/spack/test/util/win_acl.py
@@ -22,6 +22,7 @@ from spack.util.win_acl import (
     copy_file_permissions,
     get_file_owner,
     get_file_sddl,
+    set_exclusive_owner_control,
     set_file_sddl,
 )
 
@@ -531,3 +532,45 @@ def test_copy_mode_only_changes_execute_on_windows(tmp_path):
     before = get_file_sddl(str(dst))
     fs.copy_mode(str(src), str(dst))
     assert get_file_sddl(str(dst)) == before
+
+
+def test_set_exclusive_owner_control_file(tmp_path):
+    """set_exclusive_owner_control gives only the owner access on a file (chmod 700)."""
+    f = tmp_path / "secret.txt"
+    f.write_text("hello")
+    owner_sid = SecurityDescriptor.from_file(str(f)).owner
+    # Start with Everyone having read access so we can verify it gets stripped.
+    set_file_sddl(str(f), f"D:P(A;;FA;;;{owner_sid})(A;;FR;;;WD)")
+
+    set_exclusive_owner_control(str(f))
+
+    sd = SecurityDescriptor.from_file(str(f))
+    _FA = int(FileAccessRights.FILE_ALL_ACCESS)
+    assert any(
+        a.sid == owner_sid and a.ace_type == AceType.SDDL_ACCESS_ALLOWED and a.grants(_FA)
+        for a in sd.dacl
+    ), "owner must have an Allow ACE granting FILE_ALL_ACCESS"
+    assert not any(
+        a.sid == "WD" for a in sd.dacl
+    ), "Everyone must have no ACE after set_exclusive_owner_control"
+
+
+def test_set_exclusive_owner_control_directory(tmp_path):
+    """set_exclusive_owner_control gives only the owner access on a directory (chmod 700)."""
+    d = tmp_path / "private"
+    d.mkdir()
+    owner_sid = SecurityDescriptor.from_file(str(d)).owner
+    set_file_sddl(str(d), f"D:P(A;;FA;;;{owner_sid})(A;;FRFX;;;WD)")
+
+    set_exclusive_owner_control(str(d))
+
+    sd = SecurityDescriptor.from_file(str(d))
+    _FA = int(FileAccessRights.FILE_ALL_ACCESS)
+    _FX = int(FileAccessRights.FILE_GENERIC_EXECUTE)
+    assert any(
+        a.sid == owner_sid and a.ace_type == AceType.SDDL_ACCESS_ALLOWED and a.grants(_FA)
+        for a in sd.dacl
+    ), "owner must have an Allow ACE granting FILE_ALL_ACCESS"
+    assert not any(
+        a.sid == "WD" and a.grants(_FX) for a in sd.dacl
+    ), "Everyone must not have execute access after set_exclusive_owner_control"

--- a/lib/spack/spack/test/util/win_acl.py
+++ b/lib/spack/spack/test/util/win_acl.py
@@ -550,9 +550,9 @@ def test_set_exclusive_owner_control_file(tmp_path):
         a.sid == owner_sid and a.ace_type == AceType.SDDL_ACCESS_ALLOWED and a.grants(_FA)
         for a in sd.dacl
     ), "owner must have an Allow ACE granting FILE_ALL_ACCESS"
-    assert not any(
-        a.sid == "WD" for a in sd.dacl
-    ), "Everyone must have no ACE after set_exclusive_owner_control"
+    assert not any(a.sid == "WD" for a in sd.dacl), (
+        "Everyone must have no ACE after set_exclusive_owner_control"
+    )
 
 
 def test_set_exclusive_owner_control_directory(tmp_path):
@@ -571,6 +571,6 @@ def test_set_exclusive_owner_control_directory(tmp_path):
         a.sid == owner_sid and a.ace_type == AceType.SDDL_ACCESS_ALLOWED and a.grants(_FA)
         for a in sd.dacl
     ), "owner must have an Allow ACE granting FILE_ALL_ACCESS"
-    assert not any(
-        a.sid == "WD" and a.grants(_FX) for a in sd.dacl
-    ), "Everyone must not have execute access after set_exclusive_owner_control"
+    assert not any(a.sid == "WD" and a.grants(_FX) for a in sd.dacl), (
+        "Everyone must not have execute access after set_exclusive_owner_control"
+    )

--- a/lib/spack/spack/util/gpg.py
+++ b/lib/spack/spack/util/gpg.py
@@ -514,7 +514,7 @@ class Gpg:
         """Init gnupg home and check permissions."""
         gnupghome = Gpg._init_gnupghome_dir(gnupghome)
         if sys.platform == "win32":
-            wacl.set_exclusive_owner_control(gnupghome)
+            wacl.set_exclusive_owner_control(str(gnupghome))
         else:
             # Ensure safe permissions on posix systems
             st = gnupghome.stat()

--- a/lib/spack/spack/util/gpg.py
+++ b/lib/spack/spack/util/gpg.py
@@ -22,6 +22,9 @@ import spack.version
 from spack.util import tty
 from spack.util.executable import Executable
 
+if sys.platform == "win32":
+    import spack.util.win_acl as wacl
+
 GPG_NAMES = ("gpg", "gpg2")
 GPGCONF_NAMES = ("gpgconf", "gpg2conf", "gpgconf2")
 
@@ -481,11 +484,7 @@ class Gpg:
     """Wrapper for GPG"""
 
     def __init__(self, gnupghome: Optional[str] = None):
-        if sys.platform == "win32":
-            self.home = Gpg._init_gnupghome_dir(gnupghome)
-        else:
-            self.home = Gpg._init_gnupghome_posix(gnupghome)
-
+        self.home = Gpg._init_gnupghome_permissions(gnupghome)
         self._gpg: Optional[Executable] = None
         self._gpgconf: Optional[Executable] = None
         self._version: Optional[spack.version.VersionType] = None
@@ -511,14 +510,16 @@ class Gpg:
         return pathlib.Path(gnupghome)
 
     @staticmethod
-    def _init_gnupghome_posix(gnupghome: Optional[str] = None) -> pathlib.Path:
+    def _init_gnupghome_permissions(gnupghome: Optional[str] = None) -> pathlib.Path:
         """Init gnupg home and check permissions."""
         gnupghome = Gpg._init_gnupghome_dir(gnupghome)
-
-        # Ensure safe permissions on posix systems
-        st = gnupghome.stat()
-        if st.st_mode != (st.st_mode & 0o040700):
-            os.chmod(gnupghome, 0o700)
+        if sys.platform == "win32":
+            wacl.set_exclusive_owner_control(gnupghome)
+        else:
+            # Ensure safe permissions on posix systems
+            st = gnupghome.stat()
+            if st.st_mode != (st.st_mode & 0o040700):
+                os.chmod(gnupghome, 0o700)
 
         return gnupghome
 

--- a/lib/spack/spack/util/win_acl.py
+++ b/lib/spack/spack/util/win_acl.py
@@ -1145,3 +1145,25 @@ def set_file_sddl(path: str, sddl: str) -> None:
         WindowsError: on any Windows API failure.
     """
     SecurityDescriptor(sddl).apply(path)
+
+
+def set_exclusive_owner_control(path: str) -> None:
+    """Set permissions so only the owner has access (chmod 700 equivalent).
+
+    Clears the existing DACL, protects it from parent inheritance, and grants
+    the owner FILE_ALL_ACCESS with OI+CI so subdirectories and files created
+    under a directory inherit the same restriction.
+    """
+    sd = SecurityDescriptor.from_file(path)
+    sd.clear_dacl()
+    sd._parsed["DACL_CONTROL"] = "P"
+    sd._parsed["DACL_PRESENT"] = True
+    sd.add_ace(
+        AccessControlEntry(
+            ace_type=AceType.SDDL_ACCESS_ALLOWED,
+            flags=[AceFlags.SDDL_OBJECT_INHERIT, AceFlags.SDDL_CONTAINER_INHERIT],
+            rights=FileAccessRights.FILE_ALL_ACCESS,
+            sid=sd.owner,
+        )
+    )
+    sd.apply(path)


### PR DESCRIPTION
Previous refactors of the gpg module skipped enforcing exclusive user access to gpghome on Windows because Spack lacked the capabilities to express that. 

We now have full ACL support thanks to #51903  so we now add application of the Windows equivalent of `700` permissions to `gnupghome`