### PR TITLE
show hip-lang provider in spec printout

### DIFF
--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -4464,7 +4464,9 @@ class Spec:
         # TODO: get rid of the space here and make formatting smarter
         return " " + self._format_dependencies(
             "{name}{@version}",
-            include=lambda dep: any(lang in dep.virtuals for lang in ("c", "cxx", "fortran")),
+            include=lambda dep: any(
+                lang in dep.virtuals for lang in ("c", "cxx", "fortran", "hip-lang")
+            ),
             deptypes=False,
             _force_direct=True,
         )


### PR DESCRIPTION
See e.g. https://github.com/spack/spack-packages/pull/4411#discussion_r3553133347

This is an amendment to https://github.com/spack/spack/pull/52145, the effect is cosmetic (displays `%hip-lang=` for specs that need it) and not exciting without https://github.com/spack/spack-packages/pull/4411 