### PR TITLE
concretizer: provide compiler languages from compiler metadata

### DIFF
--- a/lib/spack/docs/requirements.txt
+++ b/lib/spack/docs/requirements.txt
@@ -7,4 +7,4 @@ sphinx-sitemap==2.9.0
 furo==2025.12.19
 docutils==0.22.4
 pygments==2.20.0
-pytest==9.1.0
+pytest==9.1.1

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -1800,6 +1800,31 @@ class SpackSolverSetup:
                     )
             self.gen.newline()
 
+    def compiler_provider_rules(self) -> None:
+        """
+        Configured compilers may be represented by package specs that do not otherwise
+        provide language virtuals, e.g. an external llvm~clang with clang executables.
+        Treat the recorded compiler paths as the source of truth for language support.
+        """
+        for compiler in self.possible_compilers:
+            compilers = compiler.extra_attributes.get("compilers", {})
+            provided_virtuals = {
+                language for language in compilers if language in self.possible_virtuals
+            }
+            if not provided_virtuals:
+                continue
+
+            for vpkg_name in sorted(provided_virtuals):
+                vpkg = spack.spec.Spec(vpkg_name)
+                self.gen.fact(fn.pkg_fact(compiler.name, fn.possible_provider(vpkg_name)))
+                msg = f"{compiler.name} provides {vpkg_name} from configured compiler paths"
+                condition_id = self.condition(compiler, vpkg, required_name=compiler.name, msg=msg)
+                self.gen.fact(
+                    fn.pkg_fact(compiler.name, fn.provider_condition(condition_id, vpkg_name))
+                )
+
+            self.gen.newline()
+
     def package_dependencies_rules(self, pkg):
         """Translate ``depends_on`` directives into ASP logic."""
         for cond, deps_by_name in pkg.dependencies.items():
@@ -2933,8 +2958,15 @@ class SpackSolverSetup:
         reuse_from_compilers = traverse.traverse_nodes(
             [x for x in candidate_compilers if not x.external], deptype=("link", "run")
         )
+        # External compiler specs have no dependency graph to traverse, but the solver still
+        # needs a concrete node for them when they provide compiler language virtuals.
+        external_compilers = [x for x in candidate_compilers if x.external]
         reused_set = set(reuse)
-        reuse += [x for x in reuse_from_compilers if x not in reused_set]
+        reuse += [
+            x
+            for x in itertools.chain(reuse_from_compilers, external_compilers)
+            if x not in reused_set
+        ]
 
         candidate_compilers.update(compilers_from_reuse)
         self.possible_compilers = list(candidate_compilers)
@@ -2954,6 +2986,15 @@ class SpackSolverSetup:
         )
         self.possible_virtuals = node_counter.possible_virtuals()
         self.pkgs = node_counter.possible_dependencies()
+        self.pkgs.update(
+            compiler.name
+            for compiler in self.possible_compilers
+            if compiler.external
+            and any(
+                language in self.possible_virtuals
+                for language in compiler.extra_attributes.get("compilers", {})
+            )
+        )
         self.libcs = sorted(all_libcs())  # type: ignore[type-var]
 
         for node in traverse.traverse_nodes(specs):
@@ -3015,6 +3056,7 @@ class SpackSolverSetup:
 
         self.virtual_requirements_and_weights()
         self.external_packages(packages_with_externals)
+        self.compiler_provider_rules()
 
         # TODO: make a config option for this undocumented feature
         checksummed = "SPACK_CONCRETIZER_REQUIRE_CHECKSUM" in os.environ
@@ -3023,6 +3065,14 @@ class SpackSolverSetup:
         )
         self.define_ad_hoc_versions_from_specs(
             specs, Provenance.SPEC, allow_deprecated=allow_deprecated, require_checksum=checksummed
+        )
+        # Compiler configuration can mention externally detected versions that are not known
+        # from package.py, packages.yaml, or installed specs.
+        self.define_ad_hoc_versions_from_specs(
+            self.possible_compilers,
+            Provenance.COMPILER,
+            allow_deprecated=allow_deprecated,
+            require_checksum=checksummed,
         )
         self.define_ad_hoc_versions_from_specs(
             dev_specs,

--- a/lib/spack/spack/solver/versions.py
+++ b/lib/spack/spack/solver/versions.py
@@ -11,6 +11,8 @@ class Provenance(enum.IntEnum):
     SPEC = enum.auto()
     # A dev spec literal
     DEV_SPEC = enum.auto()
+    # A compiler spec from configuration
+    COMPILER = enum.auto()
     # The 'packages' section of the configuration
     PACKAGES_YAML = enum.auto()
     # A git version in the 'packages' section of the configuration

--- a/lib/spack/spack/test/concretization/core.py
+++ b/lib/spack/spack/test/concretization/core.py
@@ -3586,6 +3586,26 @@ packages:
     assert s["c"].satisfies("gcc@9.4.0")
 
 
+def test_external_compiler_paths_provide_languages(mutable_config, mock_packages):
+    packages_yaml = syaml.load_config(
+        """
+packages:
+  llvm:
+    externals:
+    - spec: "llvm@18.1.8~clang"
+      prefix: /path
+      extra_attributes:
+        compilers:
+          c: /path/bin/clang
+          cxx: /path/bin/clang++
+"""
+    )
+    mutable_config.set("packages", packages_yaml["packages"])
+    s = spack.concretize.concretize_one("libdwarf %c,cxx=llvm@18.1.8")
+    assert s["c"].satisfies("llvm@18.1.8~clang")
+    assert s["cxx"].satisfies("llvm@18.1.8~clang")
+
+
 @pytest.mark.parametrize(
     "spec_str,expected",
     [


### PR DESCRIPTION
This is the solver-side change of:
- spack/spack-packages#5554

Motivation: Currently. llvm+clang is required to provide `c` and `cxx`, but external compilers do not always have full clang-build files installed (e.g. Linux hosts might be missing libclang-dev or other transitive dependencies), but provide working C/C++ compilers. Untangle this current dependency.

Assisted-By: GitHub Copilot GPT 5.5 (Medium effort, 272k context)

Rationale
=========

Spack's concretizer translates package, compiler, and configuration information into facts for the ASP solver. The solver then chooses a consistent build graph from those facts.

Configured compilers are currently represented as package specs in parts of that solve. For example, a detected Clang compiler can be represented by an external llvm package spec.

That representation is useful, but it exposes a semantic mismatch:

  * `llvm+clang` means the libclang development interface is usable.
  * `%clang` only requires working `clang` and `clang++` compiler executables.

Those are related, but they are not the same capability. A system LLVM installation may provide usable clang and clang++ executables while not providing a libclang setup that Spack can build against.

Problem
=======

Before this change, language virtual providers such as c and cxx were derived from ordinary package provider rules.

That meant an external `llvm~clang` spec with detected clang executables could fail to satisfy compiler language requirements, even though the compiler configuration already recorded usable compiler paths in `extra_attributes.compilers`.

In practice, the solver was relying on package variant semantics to infer compiler language capability. That made `llvm+clang` carry too much meaning and coupled libclang usability to %clang usability.

Solution
========

Teach the ASP generator to emit language provider facts for configured compilers from extra_attributes.compilers.

If a configured compiler spec records entries such as:

```yml
  extra_attributes:
    compilers:
      c: /path/to/clang
      cxx: /path/to/clang++
```

then the solver can treat that compiler spec as a provider for the corresponding language virtuals.

This keeps the meanings separate:

  * `llvm+clang` still means libclang is build-usable.
  * compiler executable paths decide whether a configured compiler can provide language virtuals such as c and cxx.

Implementation Details
======================

This patch keeps the current solver representation, where configured compilers are still package specs. It is intentionally a bridge over the existing mechanism, not a redesign of compiler configuration.

The change has three parts:

  * Add provider facts for compiler language virtuals from `extra_attributes.compilers`.

  * Add configured external compiler specs to the reuse set. External compiler specs do not have a dependency graph to traverse, but the solver still needs a concrete node for them when they provide compiler language virtuals.

  * Register versions from compiler configuration as ad hoc versions with Provenance.COMPILER. Detected compiler externals can mention versions that are not declared in `package.py`, `packages.yaml`, or installed specs.

Notes for review
================

The new Provenance.COMPILER origin is only a version provenance label. It does not mean that the package graph treats the package specially because it is a compiler package.

Its purpose is to explain why a version is known to the solver: the version came from compiler configuration. This is analogous to SPEC and DEV_SPEC as an ad hoc spec-origin source, but distinct enough to make the origin clear in generated facts.

The provider rule intentionally uses extra_attributes.compilers as the source of truth for compiler language support. Package provides(...) directives remain the source of truth for normal package-provided virtuals.

This avoids changing LLVM variant semantics and avoids requiring detected compiler executables to imply libclang development usability.