### PR TITLE
config.py: don't leak scope when override fails

### DIFF
--- a/lib/spack/spack/config.py
+++ b/lib/spack/spack/config.py
@@ -1001,26 +1001,22 @@ def override(
     an internal config scope for it and push/pop that scope.
 
     """
+    path: Optional[str]
     if isinstance(path_or_scope, ConfigScope):
-        overrides = path_or_scope
-        CONFIG.push_scope(path_or_scope, priority=None)
+        overrides, path = path_or_scope, None
     else:
-        base_name = _OVERRIDES_BASE_NAME
         # Ensure the new override gets a unique scope name
-        current_overrides = [s.name for s in CONFIG.matching_scopes(rf"^{base_name}")]
-        num_overrides = len(current_overrides)
-        while True:
-            scope_name = f"{base_name}{num_overrides}"
-            if scope_name in current_overrides:
-                num_overrides += 1
-            else:
-                break
+        existing = {s.name for s in CONFIG.matching_scopes(rf"^{_OVERRIDES_BASE_NAME}")}
+        num_overrides = len(existing)
+        while f"{_OVERRIDES_BASE_NAME}{num_overrides}" in existing:
+            num_overrides += 1
+        overrides = InternalConfigScope(f"{_OVERRIDES_BASE_NAME}{num_overrides}")
+        path = path_or_scope
 
-        overrides = InternalConfigScope(scope_name)
-        CONFIG.push_scope(overrides, priority=None)
-        CONFIG.set(path_or_scope, value, scope=scope_name)
-
+    CONFIG.push_scope(overrides, priority=None)
     try:
+        if path is not None:
+            CONFIG.set(path, value, scope=overrides.name)
         yield CONFIG
     finally:
         scope = CONFIG.remove_scope(overrides.name)

--- a/lib/spack/spack/test/config.py
+++ b/lib/spack/spack/test/config.py
@@ -1169,6 +1169,16 @@ def test_bad_path_double_override(config):
             pass
 
 
+def test_override_error_does_not_leak_scope(config):
+    """A failed override must not leave its internal scope behind."""
+    before = [s.name for s in spack.config.CONFIG.matching_scopes(r"^overrides-")]
+    with pytest.raises(ValueError):
+        with spack.config.override(":bad:path", ""):
+            pass
+    after = [s.name for s in spack.config.CONFIG.matching_scopes(r"^overrides-")]
+    assert after == before
+
+
 def test_license_dir_config(mutable_config, mock_packages, tmp_path):
     """Ensure license directory is customizable"""
     expected_dir = spack.paths.default_license_dir


### PR DESCRIPTION
`CONFIG.set(path_or_scope, value, scope=scope_name)` can raise an exception, and then the temporary scope isn't removed.

