### PR TITLE
builtin_mock: remove sleep from parallel-package

### DIFF
--- a/var/spack/test_repos/spack_repo/builtin_mock/packages/parallel_package_a/package.py
+++ b/var/spack/test_repos/spack_repo/builtin_mock/packages/parallel_package_a/package.py
@@ -2,8 +2,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-import time
-
 from spack_repo.builtin_mock.build_systems.generic import Package
 
 from spack.package import *
@@ -22,5 +20,4 @@ class ParallelPackageA(Package):
     version("1.0")
 
     def install(self, spec, prefix):
-        time.sleep(2)
         touch(prefix.dummy_file)

--- a/var/spack/test_repos/spack_repo/builtin_mock/packages/parallel_package_b/package.py
+++ b/var/spack/test_repos/spack_repo/builtin_mock/packages/parallel_package_b/package.py
@@ -2,8 +2,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-import time
-
 from spack_repo.builtin_mock.build_systems.generic import Package
 
 from spack.package import *
@@ -19,5 +17,4 @@ class ParallelPackageB(Package):
     version("1.0")
 
     def install(self, spec, prefix):
-        time.sleep(6)
         touch(prefix.dummy_file)

--- a/var/spack/test_repos/spack_repo/builtin_mock/packages/parallel_package_c/package.py
+++ b/var/spack/test_repos/spack_repo/builtin_mock/packages/parallel_package_c/package.py
@@ -2,8 +2,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-import time
-
 from spack_repo.builtin_mock.build_systems.generic import Package
 
 from spack.package import *
@@ -19,5 +17,4 @@ class ParallelPackageC(Package):
     version("1.0")
 
     def install(self, spec, prefix):
-        time.sleep(2)
         touch(prefix.dummy_file)


### PR DESCRIPTION
The parallel-package-a/b/c mock packages slept 2, 6 and 2 seconds in
their install method to simulate build duration.

This property is not used in tests :).

