### PR TITLE
cmd/list: resolve git info once per repo

### DIFF
--- a/lib/spack/spack/cmd/list.py
+++ b/lib/spack/spack/cmd/list.py
@@ -15,10 +15,8 @@ from typing import Optional, Type
 import spack.deptypes as dt
 import spack.package_base
 import spack.repo
-import spack.util.git
 from spack.cmd.common import arguments
 from spack.util import tty
-from spack.util.filesystem import working_dir
 from spack.util.tty.colify import colify
 from spack.util.url import path_to_file_url
 from spack.version import VersionList
@@ -151,7 +149,6 @@ def github_url(pkg: Type[spack.package_base.PackageBase]) -> Optional[str]:
 
     Returns: URL to the package file on github or the local file path; otherwise, ``None``.
     """
-    git = None
     module_path = f"{pkg.__module__.replace('.', '/')}.py"
     for repo in spack.repo.PATH.repos:
         if not repo.python_path:
@@ -161,39 +158,16 @@ def github_url(pkg: Type[spack.package_base.PackageBase]) -> Optional[str]:
         if not os.path.exists(path):
             continue
 
-        git = git or spack.util.git.git()
-        if not git:
-            tty.debug("Cannot determine package URL for {pkg} without 'git', using path URL")
-            return path_to_file_url(path)
+        # Match spack repositories under any scheme (e.g. ssh) by ignoring the scheme.
+        if repo.remote_info is not None and any(
+            name in repo.remote_info.url for name in ("spack.git", "spack-packages.git")
+        ):
+            git_repo = repo.remote_info.url.split("/")[-1].replace(".git", "").strip()
+            rel = os.path.relpath(path, repo.remote_info.root).replace(os.sep, "/")
+            return f"https://github.com/spack/{git_repo}/blob/develop/{rel}"
 
-        tty.debug(f"Checking git for repository path '{path}'")
-        with working_dir(os.path.dirname(path)):
-            origin_url = git(
-                "config",
-                "--get",
-                "remote.origin.url",
-                output=str,
-                error=os.devnull,
-                fail_on_error=False,
-            )
-
-            if not origin_url:
-                tty.debug("Cannot determine remote origin url, using path URL")
-                return path_to_file_url(path)
-
-            # Handle spack repositories cloned with any scheme (e.g., ssh) by
-            # ignoring the scheme designation.
-            if any([name in origin_url for name in ["spack.git", "spack-packages.git"]]):
-                git_repo = (origin_url.split("/")[-1]).replace(".git", "").strip()
-                prefix = git(
-                    "rev-parse", "--show-prefix", output=str, error=os.devnull, fail_on_error=False
-                )
-                return (
-                    f"https://github.com/spack/{git_repo}/blob/develop/{prefix.strip()}package.py"
-                )
-
-            tty.debug(f"Unrecognized repository for {pkg}, using path URL")
-            return path_to_file_url(path)
+        tty.debug(f"Package repository of {pkg} has no github git url, using path URL")
+        return path_to_file_url(path)
 
     tty.debug(f"Unable to determine the package repository URL for {pkg}")
     return None

--- a/lib/spack/spack/cmd/list.py
+++ b/lib/spack/spack/cmd/list.py
@@ -141,6 +141,14 @@ def name_only(pkgs, out):
         tty.msg("%d packages" % len(pkgs))
 
 
+def _is_spack_packages(url: str) -> bool:
+    """True if ``url`` is likely the official github.com/spack/spack-packages repo."""
+    url = url.rstrip("/")
+    if url.endswith(".git"):
+        url = url[:-4]
+    return url.endswith(("github.com/spack/spack-packages", "github.com:spack/spack-packages"))
+
+
 def github_url(pkg: Type[spack.package_base.PackageBase]) -> Optional[str]:
     """Link to a package file in spack package's github or the path to the file.
 
@@ -158,13 +166,9 @@ def github_url(pkg: Type[spack.package_base.PackageBase]) -> Optional[str]:
         if not os.path.exists(path):
             continue
 
-        # Match spack repositories under any scheme (e.g. ssh) by ignoring the scheme.
-        if repo.remote_info is not None and any(
-            name in repo.remote_info.url for name in ("spack.git", "spack-packages.git")
-        ):
-            git_repo = repo.remote_info.url.split("/")[-1].replace(".git", "").strip()
+        if repo.remote_info is not None and _is_spack_packages(repo.remote_info.url):
             rel = os.path.relpath(path, repo.remote_info.root).replace(os.sep, "/")
-            return f"https://github.com/spack/{git_repo}/blob/develop/{rel}"
+            return f"https://github.com/spack/spack-packages/blob/develop/{rel}"
 
         tty.debug(f"Package repository of {pkg} has no github git url, using path URL")
         return path_to_file_url(path)

--- a/lib/spack/spack/repo.py
+++ b/lib/spack/spack/repo.py
@@ -30,6 +30,7 @@ from typing import (
     Iterator,
     List,
     Mapping,
+    NamedTuple,
     Optional,
     Set,
     Tuple,
@@ -1154,6 +1155,10 @@ class Repo:
         # The parent dir of spack_repo/ which should be added to sys.path for api v2.x
         self.python_path: Optional[str] = None
 
+        #: (git url, checkout root) when this repo was constructed from a git-configured
+        #: repository; None otherwise.
+        self.remote_info: Optional[RemoteInfo] = None
+
         if self.package_api < (2, 0):
             check(
                 "namespace" in config,
@@ -1688,6 +1693,13 @@ def from_path(path: str) -> Repo:
 MaybeExecutable = Optional[spack.util.executable.Executable]
 
 
+class RemoteInfo(NamedTuple):
+    #: authoritative git url of the repository this repo was checked out from
+    url: str
+    #: checkout root (the RemoteRepoDescriptor.destination)
+    root: str
+
+
 class RepoDescriptor:
     """Abstract base class for repository data."""
 
@@ -1933,9 +1945,13 @@ class RemoteRepoDescriptor(RepoDescriptor):
                 continue
             path = os.path.join(self.destination, subpath)
             try:
-                repos[path] = Repo(path, cache=cache, overrides=overrides)
+                repo = Repo(path, cache=cache, overrides=overrides)
             except RepoError as e:
                 repos[path] = e
+                continue
+            if repo.python_path:
+                repo.remote_info = RemoteInfo(self.repository, self.destination)
+            repos[path] = repo
         return repos
 
 

--- a/lib/spack/spack/repo.py
+++ b/lib/spack/spack/repo.py
@@ -694,6 +694,18 @@ class RepoIndex:
         return True
 
 
+def package_attributes_overrides(config: spack.config.Configuration) -> Dict[str, Any]:
+    """Extract per-package attribute overrides from the packages config section."""
+    return {
+        pkg_name: {
+            k: spack.config.substitute_path_variables(v) if isinstance(v, str) else v
+            for k, v in data["package_attributes"].items()
+        }
+        for pkg_name, data in config.get_config("packages").items()
+        if pkg_name != "all" and "package_attributes" in data
+    }
+
+
 class RepoPath:
     """A RepoPath is a list of Repo instances that function as one.
 
@@ -731,19 +743,10 @@ class RepoPath:
     @staticmethod
     def from_config(config: spack.config.Configuration) -> "RepoPath":
         """Create a RepoPath from a configuration object."""
-        overrides = {
-            pkg_name: {
-                k: spack.config.substitute_path_variables(v) if isinstance(v, str) else v
-                for k, v in data["package_attributes"].items()
-            }
-            for pkg_name, data in config.get_config("packages").items()
-            if pkg_name != "all" and "package_attributes" in data
-        }
-
         return RepoPath.from_descriptors(
             descriptors=RepoDescriptors.from_config(lock=package_repository_lock(), config=config),
             cache=spack.caches.MISC_CACHE,
-            overrides=overrides,
+            overrides=package_attributes_overrides(config),
         )
 
     def enable(self) -> None:
@@ -2119,6 +2122,9 @@ def use_repositories(
 ) -> Generator[RepoPath, None, None]:
     """Use the repositories passed as arguments within the context manager.
 
+    ``Repo`` instances are used as-is; paths are constructed into fresh ``Repo`` instances,
+    with ``package_attributes`` overrides from the current configuration applied.
+
     Args:
         *paths_and_repos: paths to the repositories to be used, or
             already constructed Repo objects
@@ -2127,17 +2133,29 @@ def use_repositories(
     Returns:
         Corresponding RepoPath object
     """
-    paths = {getattr(x, "root", x): getattr(x, "root", x) for x in paths_and_repos}
+    # Materialize the lazy PATH singleton before pushing the new scope, since its factory
+    # reads the configuration.
+    old_repo = ensure_unwrapped(PATH)
+    overrides = package_attributes_overrides(spack.config.CONFIG)
+    new_repos = [
+        x
+        if isinstance(x, Repo)
+        else Repo(
+            spack.config.canonicalize_path(x), cache=spack.caches.MISC_CACHE, overrides=overrides
+        )
+        for x in paths_and_repos
+    ]
+    paths = {r.root: r.root for r in new_repos}
+    if not override:
+        new_repos.extend(r for r in old_repo.repos if r.root not in paths)
+    new_repo = RepoPath(*new_repos)
+    # The scope is pushed only to keep the repos config section in sync with the enabled
+    # repositories: subprocess state transfer and environment activation read it.
     scope_name = f"use-repo-{uuid.uuid4()}"
     repos_key = "repos:" if override else "repos"
-    # PATH may be a lazy singleton created from config, so materialize it before pushing the
-    # new scope, otherwise we'd save (and later restore) the new repositories instead of the
-    # current ones.
-    old_repo = ensure_unwrapped(PATH)
     spack.config.CONFIG.push_scope(
         spack.config.InternalConfigScope(name=scope_name, data={repos_key: paths})
     )
-    new_repo = RepoPath.from_config(spack.config.CONFIG)
     old_repo.disable()
     enable_repo(new_repo)
     try:

--- a/lib/spack/spack/test/cmd/list.py
+++ b/lib/spack/spack/test/cmd/list.py
@@ -85,23 +85,25 @@ def test_list_format_html():
 @pytest.mark.parametrize(
     "url",
     [
-        "git@github.com:username/spack-packages.git",
-        "https://github.com/username/spack-packages.git",
-        "git@github.com:username/spack.git",
-        "https://github.com/username/spack.git",
+        "https://github.com/spack/spack-packages.git",
+        "https://github.com/spack/spack-packages",
+        "git@github.com:spack/spack-packages.git",
+        "ssh://git@github.com/spack/spack-packages.git",
+        "https://user:token@github.com/spack/spack-packages.git",
     ],
 )
 def test_list_url_schemes(mock_git_packages_repo, url):
-    """Confirm the github URL is derived from the configured git url of the repository."""
+    """Confirm the official spack-packages repo is recognized in any url scheme."""
     repo = mock_git_packages_repo(url)
     with spack.repo.use_repositories(repo):
         output = list("--format", "version_json", "hdf5")
 
-    repo_name = os.path.basename(url).replace(".git", "")
     assert (
-        f"https://github.com/spack/{repo_name}/blob/develop/"
+        "https://github.com/spack/spack-packages/blob/develop/"
         "spack_repo/builtin_mock/packages/hdf5/package.py" in output
     )
+    # a credentialed url must never leak the credentials into the emitted url
+    assert "token" not in output
 
 
 def test_list_format_local_repo():

--- a/lib/spack/spack/test/cmd/list.py
+++ b/lib/spack/spack/test/cmd/list.py
@@ -10,7 +10,6 @@ import pytest
 import spack.cmd.list
 import spack.paths
 import spack.repo
-import spack.util.git
 from spack.main import SpackCommand
 from spack.test.conftest import RepoBuilder
 
@@ -92,71 +91,34 @@ def test_list_format_html():
         "https://github.com/username/spack.git",
     ],
 )
-def test_list_url_schemes(mock_util_executable, url):
-    """Confirm the command handles supported repository URLs."""
-    pkg_name = "hdf5"
+def test_list_url_schemes(mock_git_packages_repo, url):
+    """Confirm the github URL is derived from the configured git url of the repository."""
+    repo = mock_git_packages_repo(url)
+    with spack.repo.use_repositories(repo):
+        output = list("--format", "version_json", "hdf5")
 
-    _, _, registered_responses = mock_util_executable
-    registered_responses["config"] = url
-    registered_responses["rev-parse"] = f"path/to/builtin/packages/{pkg_name}/"
-
-    output = list("--format", "version_json", pkg_name)
-    assert f"{registered_responses['rev-parse']}package.py" in output
-    assert os.path.basename(url).replace(".git", "") in output
-
-
-def test_list_format_local_repo(tmp_path: pathlib.Path):
-    """Confirm a file path is returned for local repository."""
-    namespace, pkg_name = "local_list_repo", "mypkg"
-    repo_root = tmp_path / "repos" / "spack_repo" / namespace
-    repo_root.mkdir(parents=True)
-    (repo_root / "repo.yaml").write_text(f"repo:\n  namespace: {namespace}\n  api: v2.2\n")
-    package_root = repo_root / "packages" / pkg_name
-    package_root.mkdir(parents=True)
-    (package_root / "package.py").write_text(
-        """\
-from spack.package import *
-
-class Mypkg(Package):
-    pass
-"""
+    repo_name = os.path.basename(url).replace(".git", "")
+    assert (
+        f"https://github.com/spack/{repo_name}/blob/develop/"
+        "spack_repo/builtin_mock/packages/hdf5/package.py" in output
     )
 
-    test_repo = spack.repo.from_path(str(repo_root))
-    with spack.repo.use_repositories(test_repo):
-        # Confirm a path is returned when fail to retrieve the remote origin URL
-        output = list("--format", "version_json", pkg_name)
+
+def test_list_format_local_repo():
+    """Confirm a file path is returned for a path-configured (no remote_info) repository."""
+    output = list("--format", "version_json", "hdf5")
+    assert "github.com" not in output
+    assert "file://" in output
+    assert "packages/hdf5/package.py" in output
+
+
+def test_list_format_non_github_repo(mock_git_packages_repo):
+    """Confirm a file path is returned for a non-github (e.g. gitlab) repository."""
+    repo = mock_git_packages_repo("https://gitlab.com/username/my-packages.git")
+    with spack.repo.use_repositories(repo):
+        output = list("--format", "version_json", "hdf5")
         assert "github.com" not in output
-        assert f"packages/{pkg_name}/package.py" in output
-
-
-def test_list_format_non_github_repo(tmp_path: pathlib.Path, mock_util_executable):
-    """Confirm a file path is returned for a non-github repository."""
-    namespace, pkg_name = "non_github_list_repo", "mypkg"
-    repo_root = tmp_path / "my" / "project" / "spack_repo" / namespace
-    repo_root.mkdir(parents=True)
-    (repo_root / "repo.yaml").write_text(f"repo:\n  namespace: {namespace}\n  api: v2.2\n")
-    package_root = repo_root / "packages" / pkg_name
-    package_root.mkdir(parents=True)
-    package_path = package_root / "package.py"
-    package_path.write_text(
-        """\
-from spack.package import *
-
-class Mypkg(Package):
-    pass
-"""
-    )
-
-    test_repo = spack.repo.from_path(str(repo_root))
-    with spack.repo.use_repositories(test_repo):
-        # Confirm a path is returned for a non-standard spack repository
-        _, _, registered_responses = mock_util_executable
-        registered_responses["config"] = "https://gitlab.com/username/my-packages.git"
-        registered_responses["rev-parse"] = str(package_root) + os.sep
-
-        output = list("--format", "version_json", pkg_name)
-        assert package_path.as_uri() in output
+        assert "file://" in output
 
 
 def test_list_update(tmp_path: pathlib.Path):
@@ -247,9 +209,9 @@ def test_list_github_url_fails(repo_builder: RepoBuilder, monkeypatch):
         finally:
             monkeypatch.setattr(repo, "python_path", old_path)
 
-        # Check that missing git results in the file path
-        monkeypatch.setattr(spack.util.git, "git", lambda: None)
+        # A repository without a configured git url (remote_info is None) yields a file URI
+        assert repo.remote_info is None
         filepath = spack.cmd.list.github_url(pkg)
         assert filepath and filepath.startswith("file://"), (
-            "Expected missing 'git' results in a file URI"
+            "Expected a path-configured repo results in a file URI"
         )

--- a/lib/spack/spack/test/concretization/preferences.py
+++ b/lib/spack/spack/test/concretization/preferences.py
@@ -10,6 +10,7 @@ import pytest
 import spack.concretize
 import spack.config
 import spack.package_prefs
+import spack.paths
 import spack.repo
 import spack.util.module_cmd
 import spack.util.spack_yaml as syaml
@@ -174,15 +175,15 @@ class TestConcretizePreferences:
             ({}, "http://www.spack.llnl.gov/mpileaks-2.3.tar.gz"),
         ],
     )
-    def test_config_set_pkg_property_url(self, update, expected, mock_packages_repo, monkeypatch):
+    def test_config_set_pkg_property_url(self, update, expected, monkeypatch):
         """Test setting an existing attribute in the package class"""
         monkeypatch.setenv("SOMEPATH", "file:///some/where/else")
         update_packages("mpileaks", "package_attributes", update)
-        with spack.repo.use_repositories(mock_packages_repo):
+        with spack.repo.use_repositories(spack.paths.mock_packages_path):
             spec = concretize("mpileaks")
             assert spec.package.fetcher.url == expected
 
-    def test_config_set_pkg_property_new(self, mock_packages_repo):
+    def test_config_set_pkg_property_new(self):
         """Test that you can set arbitrary attributes on the Package class"""
         conf = syaml.load_config(
             """\
@@ -201,7 +202,7 @@ mpileaks:
 """
         )
         spack.config.set("packages", conf, scope="concretize")
-        with spack.repo.use_repositories(mock_packages_repo):
+        with spack.repo.use_repositories(spack.paths.mock_packages_path):
             spec = concretize("mpileaks")
             assert spec.package.v1 == 1
             assert spec.package.v2 is True
@@ -211,7 +212,7 @@ mpileaks:
             assert list(spec.package.v6) == [1, 2]
 
         update_packages("mpileaks", "package_attributes", {})
-        with spack.repo.use_repositories(mock_packages_repo):
+        with spack.repo.use_repositories(spack.paths.mock_packages_path):
             spec = concretize("mpileaks")
             with pytest.raises(AttributeError):
                 spec.package.v1

--- a/lib/spack/spack/test/conftest.py
+++ b/lib/spack/spack/test/conftest.py
@@ -701,6 +701,29 @@ def mock_packages_repo():
     yield spack.repo.from_path(spack.paths.mock_packages_path)
 
 
+@pytest.fixture
+def mock_git_packages_repo(tmp_path, mock_test_cache):
+    """Factory: url -> the builtin_mock repo constructed as a git checkout of ``url``, so
+    remote_info is populated."""
+
+    def _make(url: str) -> spack.repo.Repo:
+        descriptor = spack.repo.RemoteRepoDescriptor(
+            name="builtin_mock",
+            repository=url,
+            destination=spack.paths.test_repos_path,  # dir containing spack_repo/
+            relative_paths=["spack_repo/builtin_mock"],
+            branch=None,
+            tag=None,
+            commit=None,
+            lock=spack.util.lock.Lock(str(tmp_path / "repo.lock"), enable=False),
+        )
+        repo = next(iter(descriptor.construct(cache=mock_test_cache).values()))
+        assert isinstance(repo, spack.repo.Repo), repo
+        return repo
+
+    return _make
+
+
 def _pkg_install_fn(pkg, spec, prefix):
     # sanity_check_prefix requires something in the install directory
     mkdirp(prefix.bin)

--- a/lib/spack/spack/test/package_class.py
+++ b/lib/spack/spack/test/package_class.py
@@ -401,7 +401,7 @@ def test_git_provenance_cant_resolve_commit(mock_packages, monkeypatch, config, 
     "pkg_name,preferred_version",
     [
         # This package has a deprecated v1.1.0 which should not be the preferred
-        ("deprecated_versions", "1.0.0"),
+        ("deprecated-versions", "1.0.0"),
         # Python has v2.7.11 marked as preferred and newer v3 versions
         ("python", "2.7.11"),
         # This package has various versions, some deprecated, plus "main" and "develop"


### PR DESCRIPTION
`spack list --format ...` ran `git config --get remote.origin.url` and
`git rev-parse` for every package to build the source link in the html
and json output.

Instead of querying git, derive the url from the `repos:` configuration.
A RemoteRepoDescriptor already knows the authoritative git url it clones
from `destination`, so it can just store that info.

This also eliminates a heuristic for the associated git url.

To make the tests work, `use_repositories` needs to preserve the Repo
instance instead of "serializing" to config and then reconstructing from
config.