### PR TITLE
ArchSpec: fix to_dict/from_dict for abstract specs

### DIFF
--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -602,9 +602,12 @@ class ArchSpec:
         )
 
     def to_dict(self):
+        # Abstract specs may have no target
+        if self.target is None:
+            target_data = None
         # Generic targets represent either an architecture family (like x86_64)
         # or a custom micro-architecture
-        if self.target.vendor == "generic":
+        elif self.target.vendor == "generic":
             target_data = str(self.target)
         else:
             # Get rid of compiler flag information before turning the uarch into a dict
@@ -617,6 +620,8 @@ class ArchSpec:
         """Import an ArchSpec from raw YAML/JSON data"""
         arch = d["arch"]
         target_name = arch["target"]
+        if target_name is None:
+            return ArchSpec((arch["platform"], arch["platform_os"], None))
         if not isinstance(target_name, str):
             target_name = target_name["name"]
         target = _make_microarchitecture(target_name)

--- a/lib/spack/spack/test/spec_yaml.py
+++ b/lib/spack/spack/test/spec_yaml.py
@@ -522,6 +522,18 @@ def test_pickle_roundtrip_for_abstract_specs(spec_str):
     assert str(s) == str(t)
 
 
+@pytest.mark.parametrize(
+    "spec_str", ["zlib os=redhat6", "zlib platform=test", "zlib os=debian6 target=x86_64"]
+)
+def test_dict_roundtrip_for_abstract_specs_with_partial_arch(spec_str):
+    """Abstract specs with a partial architecture survive to_dict/from_dict.
+    Regression test: ArchSpec.to_dict crashed with AttributeError when target was None."""
+    s = spack.spec.Spec(spec_str)
+    t = spack.spec.Spec.from_dict(s.to_dict())
+    assert s == t
+    assert str(s) == str(t)
+
+
 def test_specfile_alias_is_updated():
     """Tests that the SpecfileLatest alias gets updated on a Specfile version bump"""
     specfile_class_name = f"SpecfileV{spack.spec.SPECFILE_FORMAT_VERSION}"


### PR DESCRIPTION
Serializing an abstract spec with a partial architecture like
`os=redhat6` or `platform=test` crashes with an error like

```
AttributeError: 'NoneType' object has no attribute 'vendor'
```