### PR TITLE
concretization cache: use user input spec

### DIFF
--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -488,6 +488,8 @@ class Result:
             "optimal": self.optimal,
             "warnings": self.warnings,
             "nmodels": self.nmodels,
+            # abstract specs are not used for deserialization, but dropping them is
+            # forward-incompatible with Spack 1.2 and earlier.
             "abstract_specs": [s.to_dict() for s in self.abstract_specs],
             "satisfiable": self.satisfiable,
             "answers": [
@@ -496,12 +498,14 @@ class Result:
         }
 
     @staticmethod
-    def from_dict(obj: dict):
-        """Returns Result object from compatible dictionary"""
+    def from_dict(obj: dict, specs: List[spack.spec.Spec]):
+        """Returns Result object from compatible dictionary, for the given input specs.
 
-        abstract_specs = [spack.spec.Spec.from_dict(s) for s in obj["abstract_specs"]]
-
-        result = Result(abstract_specs)
+        The stored abstract specs are troubleshooting metadata and are deliberately not
+        deserialized: the caller's input specs are authoritative. This also keeps cache
+        entries with unreadable abstract spec data usable.
+        """
+        result = Result(specs)
         result.criteria = [OptimizationCriteria(*t) for t in obj["criteria"]]
         result.optimal = obj["optimal"]
         result.warnings = obj["warnings"]
@@ -644,12 +648,18 @@ class ConcretizationCache:
         # every solve, let alone cache hits.
         self.cleanup()
 
-    def fetch(self, problem: str) -> Union[Tuple[Result, Dict], Tuple[None, None]]:
+    def fetch(
+        self, problem: str, specs: List[spack.spec.Spec]
+    ) -> Union[Tuple[Result, Dict], Tuple[None, None]]:
         """Returns the concretization cache result for a lookup based on the given problem.
 
         Checks the concretization cache for the given problem, and either returns the
         Python objects cached on disk representing the concretization results and statistics
         or returns none if no cache entry was found.
+
+        The returned Result is associated with ``specs``, the input specs of the caller:
+        the problem hash guarantees they are equivalent to the ones the entry was stored
+        with.
         """
         cache_path = self._cache_path_from_problem(problem)
 
@@ -685,7 +695,7 @@ class ConcretizationCache:
             return None, None
 
         try:
-            result = Result.from_dict(results)
+            result = Result.from_dict(results, specs)
         except (KeyError, TypeError, ValueError, spack.error.SpecSyntaxError) as e:
             tty.debug(
                 f"ConcretizationCache.fetch(): force-removing {cache_path}. "
@@ -1084,11 +1094,11 @@ class PyclingoDriver:
         # try to fetch from the cache
         result = None
         if cache:
-            result, concretization_stats = cache.fetch(cache_key)
+            result, concretization_stats = cache.fetch(cache_key, specs)
         timer.stop("cache-check")
 
         # run the solver
-        if not result:
+        if result is None:
             tty.debug("Starting concretizer")
             result = self._run_clingo(specs, setup, "\n".join(problem), control_file_paths, timer)
             result.raise_if_unsat()

--- a/lib/spack/spack/test/concretization/core.py
+++ b/lib/spack/spack/test/concretization/core.py
@@ -4450,7 +4450,7 @@ def test_result_roundtrip(mock_packages, config, specs):
     """Test that a solve result can be serialized and brought back."""
     solver = spack.solver.asp.Solver()
     result = solver.solve(specs)
-    roundtrip = spack.solver.asp.Result.from_dict(result.to_dict())
+    roundtrip = spack.solver.asp.Result.from_dict(result.to_dict(), specs)
 
     # ensure that we didn't duplicate spec objects during the round trip -- specs need
     # to come back as exactly the same graph they were before.
@@ -4546,8 +4546,8 @@ def test_concretization_cache_roundtrip(
     # Assert that we're actually hitting the cache
     cache_fetch = spack.solver.asp.ConcretizationCache.fetch
 
-    def _ensure_cache_hits(self, problem: str):
-        result, statistics = cache_fetch(self, problem)
+    def _ensure_cache_hits(self, problem: str, specs):
+        result, statistics = cache_fetch(self, problem, specs)
         assert result, "Expected successful concretization cache hit"
         assert statistics, "Expected statistics to be non null on cache hit"
         return result, statistics
@@ -4673,7 +4673,7 @@ def corrupt_cache_entry(use_concretization_cache):
     yield cache, cache_path, write_gzip_json
 
     assert cache_path.exists(), "test should have written a corrupt file"
-    result, stats = cache.fetch(problem)
+    result, stats = cache.fetch(problem, [])
     assert result is None
     assert stats is None
     assert not cache_path.exists(), "corrupt cache entry should have been removed"

--- a/lib/spack/spack/test/concretization/core.py
+++ b/lib/spack/spack/test/concretization/core.py
@@ -4501,6 +4501,7 @@ def test_spec_dict_roundtrip(mock_packages, config, spec_str):
         # fresh solves
         ("hdf5", None),
         ("hdf5^zmpi", None),
+        ("mpileaks ~debug ^[when=+debug] zmpi", None),
         ("zmpi", None),
         ("pkg-with-zlib-dep", None),
         ("hypre^openblas-with-lapack", None),


### PR DESCRIPTION
Workaround for "Conditional specs do not round trip as dict #52720".

That issue should be fixed independently, but I don't see why
the concretization cache swaps the user input for the abstract spec
from a file. It feels like it could result in more subtle issues, so this
commit avoids possible future issues.