### PR TITLE
tests: add concretization cache plugin

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,8 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+# Registered here rather than in lib/spack/spack/test/conftest.py because pytest 7.0.1 -- the
+# latest pytest supporting the oldest Python we test (3.6) -- rejects pytest_plugins in a
+# non-top-level conftest.
+pytest_plugins = ["spack.test.concretization_cache_plugin"]

--- a/lib/spack/spack/test/concretization_cache_plugin.py
+++ b/lib/spack/spack/test/concretization_cache_plugin.py
@@ -1,0 +1,126 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+"""Opt-in pytest plugin that gives the test suite a persistent concretization cache.
+
+Enable with ``--spack-concretization-cache=DIR`` or by setting the
+``SPACK_TEST_CONCRETIZATION_CACHE`` environment variable. The mock configuration most
+tests run under then enables Spack's concretization cache in DIR, so any ASP problem
+that was already solved -- earlier in the run, by another xdist worker, or in a previous
+pytest invocation -- skips clingo entirely. The solver dominates test suite CPU time and
+roughly half of its problems are repeats, so a warm cache cuts wall time substantially.
+
+Entries are keyed by the entire solver input (the ASP problem plus the .lp control
+files), so changes to packages, configuration, or the concretizer miss the cache instead
+of returning stale results: one directory can safely be shared across branches,
+worktrees, and CI runs. Hit/miss statistics are printed at the end of the run. Works
+serially and under pytest-xdist.
+"""
+
+import functools
+import os
+from typing import Optional, Tuple
+
+_stats = {"hits": 0, "misses": 0}
+
+#: Absolute path of the cache directory, or None when the plugin is disabled
+_cache_dir: Optional[str] = None
+
+#: Number of cache entries on disk when the session started
+_initial_entries = 0
+
+
+def cache_dir(config) -> Optional[str]:
+    """Absolute path of the persistent concretization cache, or None when disabled."""
+    path = config.getoption("--spack-concretization-cache")
+    return os.path.abspath(os.path.expanduser(path)) if path else None
+
+
+def pytest_addoption(parser):
+    group = parser.getgroup("Spack specific command line options")
+    group.addoption(
+        "--spack-concretization-cache",
+        action="store",
+        default=os.environ.get("SPACK_TEST_CONCRETIZATION_CACHE"),
+        metavar="DIR",
+        help="enable a persistent concretization cache in DIR: tests whose concretization "
+        "problem was already solved by an earlier test or pytest invocation skip the solver "
+        "entirely. Entries are keyed by the full solver input, so DIR can be shared across "
+        "branches and CI runs (default: $SPACK_TEST_CONCRETIZATION_CACHE)",
+    )
+
+
+def pytest_configure(config):
+    global _cache_dir, _initial_entries
+    _cache_dir = cache_dir(config)
+    if _cache_dir is None:
+        return
+    os.makedirs(_cache_dir, exist_ok=True)
+    _initial_entries, _ = _scan(_cache_dir)
+
+    import spack.solver.asp
+
+    _count_lookups(spack.solver.asp.ConcretizationCache)
+
+
+def _count_lookups(cache_cls):
+    """Wrap ConcretizationCache.fetch to count cache hits and misses."""
+    original = cache_cls.fetch
+    if getattr(original, "_spack_cache_counted", False):
+        return
+
+    @functools.wraps(original)
+    def fetch(self, *args, **kwargs):
+        result, statistics = original(self, *args, **kwargs)
+        _stats["hits" if result is not None else "misses"] += 1
+        return result, statistics
+
+    fetch._spack_cache_counted = True
+    cache_cls.fetch = fetch
+
+
+def _scan(root: str) -> Tuple[int, int]:
+    """Return the entry count and total size in bytes of the cache directory."""
+    entries, size = 0, 0
+    for dirpath, _, filenames in os.walk(root):
+        for name in filenames:
+            # dotfiles are in-flight temporary files, not entries
+            if name.startswith("."):
+                continue
+            try:
+                size += os.stat(os.path.join(dirpath, name)).st_size
+            except OSError:
+                continue
+            entries += 1
+    return entries, size
+
+
+def pytest_sessionfinish(session):
+    # xdist worker: ship this process's counters to the controller
+    workeroutput = getattr(session.config, "workeroutput", None)
+    if workeroutput is not None and _cache_dir is not None:
+        workeroutput["spack_concretization_cache_stats"] = _stats
+
+
+def pytest_testnodedown(node, error):
+    # xdist controller: add the counters of a finished worker
+    stats = getattr(node, "workeroutput", {}).get("spack_concretization_cache_stats")
+    if stats is not None:
+        _stats["hits"] += stats["hits"]
+        _stats["misses"] += stats["misses"]
+
+
+def pytest_terminal_summary(terminalreporter, exitstatus, config):
+    if _cache_dir is None:
+        return
+    lookups = _stats["hits"] + _stats["misses"]
+    hit_rate = 100.0 * _stats["hits"] / lookups if lookups else 0.0
+    entries, size = _scan(_cache_dir)
+    tr = terminalreporter
+    tr.write_sep("=", "spack concretization cache")
+    tr.write_line(f"directory: {_cache_dir} ({entries} entries, {size / 1e6:.1f} MB)")
+    tr.write_line(
+        f"this run: {_stats['hits']} hits / {lookups} lookups ({hit_rate:.0f}%), "
+        f"{entries - _initial_entries} entries added"
+    )

--- a/lib/spack/spack/test/concretization_cache_plugin.py
+++ b/lib/spack/spack/test/concretization_cache_plugin.py
@@ -22,6 +22,8 @@ import functools
 import os
 from typing import Optional, Tuple
 
+import spack.solver.asp
+
 _stats = {"hits": 0, "misses": 0}
 
 #: Absolute path of the cache directory, or None when the plugin is disabled
@@ -58,9 +60,6 @@ def pytest_configure(config):
         return
     os.makedirs(_cache_dir, exist_ok=True)
     _initial_entries, _ = _scan(_cache_dir)
-
-    import spack.solver.asp
-
     _count_lookups(spack.solver.asp.ConcretizationCache)
 
 

--- a/lib/spack/spack/test/conftest.py
+++ b/lib/spack/spack/test/conftest.py
@@ -417,11 +417,6 @@ def archspec_host_is_spack_test_host(monkeypatch):
     monkeypatch.setattr(spack.vendor.archspec.cpu, "host", _host)
 
 
-# Opt-in plugin (--spack-concretization-cache=DIR) that makes tests reuse concretization
-# results across tests, xdist workers, and pytest invocations.
-pytest_plugins = ["spack.test.concretization_cache_plugin"]
-
-
 # Hooks to add command line options or set other custom behaviors.
 # They must be placed here to be found by pytest. See:
 #

--- a/lib/spack/spack/test/conftest.py
+++ b/lib/spack/spack/test/conftest.py
@@ -55,6 +55,7 @@ import spack.stage
 import spack.store
 import spack.subprocess_context
 import spack.tengine
+import spack.test.concretization_cache_plugin
 import spack.util.executable
 import spack.util.file_cache
 import spack.util.git
@@ -414,6 +415,11 @@ def _host():
 @pytest.fixture(scope="function")
 def archspec_host_is_spack_test_host(monkeypatch):
     monkeypatch.setattr(spack.vendor.archspec.cpu, "host", _host)
+
+
+# Opt-in plugin (--spack-concretization-cache=DIR) that makes tests reuse concretization
+# results across tests, xdist workers, and pytest invocations.
+pytest_plugins = ["spack.test.concretization_cache_plugin"]
 
 
 # Hooks to add command line options or set other custom behaviors.
@@ -901,7 +907,7 @@ def mock_targets(mock_uarch_configuration, monkeypatch):
 
 
 @pytest.fixture(scope="session")
-def configuration_dir(tmp_path_factory: pytest.TempPathFactory, linux_os):
+def configuration_dir(request, tmp_path_factory: pytest.TempPathFactory, linux_os):
     """Copies mock configuration files in a temporary directory. Returns the
     directory path.
     """
@@ -935,6 +941,20 @@ def configuration_dir(tmp_path_factory: pytest.TempPathFactory, linux_os):
     modules = tmp_path / "site" / "modules.yaml"
     modules_template = test_config / "modules.yaml"
     modules.write_text(modules_template.read_text().format(tcl_root, lmod_root))
+
+    # The concretization cache is disabled unless --spack-concretization-cache=DIR is
+    # given, in which case all tests, xdist workers, and future pytest invocations share
+    # the cache in DIR. The entry limit stays above the ~1700 distinct problems of a full
+    # suite run so LRU pruning does not thrash within one invocation.
+    cache_url = spack.test.concretization_cache_plugin.cache_dir(request.config)
+    concretizer = tmp_path / "site" / "concretizer.yaml"
+    concretizer_template = test_config / "concretizer.yaml"
+    concretizer.write_text(
+        concretizer_template.read_text().format(
+            cache_enable=str(cache_url is not None).lower(),
+            cache_url=cache_url or str(tmp_path / "concretization-cache"),
+        )
+    )
 
     for scope in ("spack", "user", "site", "system"):
         scope_path = tmp_path / scope

--- a/lib/spack/spack/test/data/config/concretizer.yaml
+++ b/lib/spack/spack/test/data/config/concretizer.yaml
@@ -29,4 +29,6 @@ concretizer:
       llvm: 2
 
   concretization_cache:
-    enable: false
+    enable: {cache_enable}
+    url: {cache_url}
+    entry_limit: 20000


### PR DESCRIPTION
This adds `pytest --spack-concretization-cache=DIR` which can be used in
development as well as CI to speed up unit tests.

The solver dominates unit-test CPU time, and roughly half of the ~3000
ASP problems solved in a full suite run are repeats of an earlier one.

Add a pytest plugin that enables Spack's content-keyed concretization
cache in a developer-chosen directory, shared by all tests, xdist
workers, and future pytest invocations:

    pytest --spack-concretization-cache=/tmp/concretization-cache

or, e.g. from a shell profile:

    export SPACK_TEST_CONCRETIZATION_CACHE=/tmp/concretization-cache

At the end of the run the plugin reports hit/miss counts and the size of
the cache. On a full suite run with -n8, a cold cache hits 46% (the
in-run repeats) and a warm cache 85%, cutting CPU time from 12m50s to
10m0s; the remaining misses are problems that embed per-invocation
temporary paths. Default behavior without the option is unchanged
(cache disabled).