### PR TITLE
modules: replace class level cache with DI cache

### DIFF
--- a/lib/spack/spack/cmd/modules/__init__.py
+++ b/lib/spack/spack/cmd/modules/__init__.py
@@ -158,6 +158,7 @@ def loads(module_type, specs, args, out=None):
                 ]
             )
 
+    cache: spack.modules.common.ModuleConfigurationCache = {}
     modules = [
         (
             spec,
@@ -167,6 +168,7 @@ def loads(module_type, specs, args, out=None):
                 get_full_path=False,
                 module_set_name=args.module_set_name,
                 required=False,
+                cache=cache,
             ),
         )
         for spec in specs
@@ -208,6 +210,7 @@ def find(module_type, specs, args):
     else:
         dependency_specs_to_retrieve = []
 
+    cache: spack.modules.common.ModuleConfigurationCache = {}
     try:
         modules = [
             spack.modules.get_module(
@@ -216,6 +219,7 @@ def find(module_type, specs, args):
                 args.full_path,
                 module_set_name=args.module_set_name,
                 required=False,
+                cache=cache,
             )
             for spec in dependency_specs_to_retrieve
         ]
@@ -227,6 +231,7 @@ def find(module_type, specs, args):
                 args.full_path,
                 module_set_name=args.module_set_name,
                 required=True,
+                cache=cache,
             )
         )
     except spack.modules.error.ModuleNotFoundError as e:
@@ -245,13 +250,17 @@ def rm(module_type, specs, args):
     check_module_set_name(args.module_set_name)
 
     module_cls = spack.modules.module_types[module_type]
+    cache: spack.modules.common.ModuleConfigurationCache = {}
     module_exist = lambda x: os.path.exists(
-        module_cls.from_spec(x, args.module_set_name).layout.filename
+        module_cls.from_spec(x, args.module_set_name, cache=cache).layout.filename
     )
 
     specs_with_modules = [spec for spec in specs if module_exist(spec)]
 
-    modules = [module_cls.from_spec(spec, args.module_set_name) for spec in specs_with_modules]
+    modules = [
+        module_cls.from_spec(spec, args.module_set_name, cache=cache)
+        for spec in specs_with_modules
+    ]
 
     if not modules:
         tty.die("No module file matches your query")
@@ -297,10 +306,11 @@ def refresh(module_type, specs, args):
     # Cycle over the module types and regenerate module files
 
     cls = spack.modules.module_types[module_type]
+    cache: spack.modules.common.ModuleConfigurationCache = {}
 
     # Skip unknown packages.
     writers = [
-        cls.from_spec(spec, args.module_set_name)
+        cls.from_spec(spec, args.module_set_name, cache=cache)
         for spec in specs
         if spack.repo.PATH.exists(spec.name)
     ]

--- a/lib/spack/spack/cmd/modules/lmod.py
+++ b/lib/spack/spack/cmd/modules/lmod.py
@@ -8,7 +8,6 @@ import spack.cmd.common.arguments
 import spack.cmd.modules
 import spack.config
 import spack.modules
-import spack.modules.lmod
 
 
 def add_command(parser, command_dict):
@@ -38,8 +37,6 @@ def setdefault(module_type, specs, args):
     spack.cmd.modules.one_spec_or_raise(specs)
     spec = specs[0]
     data = {"modules": {args.module_set_name: {"lmod": {"defaults": [str(spec)]}}}}
-    # Need to clear the cache if a SpackCommand is called during scripting
-    spack.modules.lmod.LmodConfiguration._registry = {}
     scope = spack.config.InternalConfigScope("lmod-setdefault", data)
     with spack.config.override(scope):
         writer = spack.modules.module_types["lmod"].from_spec(spec, args.module_set_name)

--- a/lib/spack/spack/cmd/modules/tcl.py
+++ b/lib/spack/spack/cmd/modules/tcl.py
@@ -7,7 +7,6 @@ import spack.cmd.common.arguments
 import spack.cmd.modules
 import spack.config
 import spack.modules
-import spack.modules.tcl
 
 
 def add_command(parser, command_dict):
@@ -34,7 +33,6 @@ def setdefault(module_type, specs, args):
     spack.cmd.modules.one_spec_or_raise(specs)
     spec = specs[0]
     data = {"modules": {args.module_set_name: {"tcl": {"defaults": [str(spec)]}}}}
-    spack.modules.tcl.TclConfiguration._registry = {}
     scope = spack.config.InternalConfigScope("tcl-setdefault", data)
     with spack.config.override(scope):
         writer = spack.modules.module_types["tcl"].from_spec(spec, args.module_set_name)

--- a/lib/spack/spack/modules/__init__.py
+++ b/lib/spack/spack/modules/__init__.py
@@ -34,6 +34,8 @@ def get_module(
     get_full_path: bool,
     module_set_name: str = "default",
     required: bool = True,
+    *,
+    cache: Optional[common.ModuleConfigurationCache] = None,
 ) -> Optional[str]:
     """Retrieve the module file for a given spec and module type.
 
@@ -52,6 +54,8 @@ def get_module(
             Otherwise, this returns the module name.
         module_set_name: the named module configuration set from modules.yaml
             for which to retrieve the module.
+        cache: optional per-operation configuration cache, shared across a batch of specs to
+            avoid recomputing configuration objects for shared dependencies.
 
     Returns:
         The module name or path. May return ``None`` if the module is not
@@ -71,7 +75,7 @@ def get_module(
         else:
             return module.use_name
     else:
-        writer = module_types[module_type].from_spec(spec, module_set_name)
+        writer = module_types[module_type].from_spec(spec, module_set_name, cache=cache)
         if not os.path.isfile(writer.layout.filename):
             fmt_str = "{name}{@version}{/hash:7}"
             if not writer.conf.excluded:

--- a/lib/spack/spack/modules/common.py
+++ b/lib/spack/spack/modules/common.py
@@ -77,6 +77,9 @@ EnvironmentModification = Tuple[
     str, Union[spack.util.environment.NameModifier, spack.util.environment.NameValueModifier]
 ]
 
+#: Cache of configuration objects, keyed by (dag_hash, module_set_name, explicit)
+ModuleConfigurationCache = Dict[Tuple[str, str, bool], "BaseConfiguration"]
+
 #: Valid tokens for naming scheme and env variable names
 _valid_tokens = (
     "name",
@@ -326,8 +329,6 @@ class BaseConfiguration:
     #: Default for the ``hierarchical`` config key when it is absent. Subclasses may override.
     _default_hierarchical: bool = False
 
-    _registry: ClassVar[Dict[Tuple[str, str, bool], "BaseConfiguration"]]
-
     #: File extension for module files (empty string means no extension)
     file_extension: ClassVar[str] = ""
 
@@ -335,30 +336,55 @@ class BaseConfiguration:
         super().__init_subclass__(**kwargs)
         if not hasattr(cls, "module_system"):
             raise AttributeError(f"'{cls.__name__}' must define a 'module_system' class attribute")
-        cls._registry = {}
 
     @classmethod
     def make_configuration(
-        cls, spec: spack.spec.Spec, module_set_name: str, explicit: Optional[bool] = None
+        cls,
+        spec: spack.spec.Spec,
+        module_set_name: str,
+        explicit: Optional[bool] = None,
+        *,
+        cache: Optional[ModuleConfigurationCache] = None,
     ) -> "BaseConfiguration":
-        """Returns the cached configuration object for spec."""
+        """Returns the configuration object for spec, reusing ``cache`` if it already holds one.
+
+        Callers that generate modules for many specs may pass a single shared cache to deduplicate
+        work across specs. When ``cache`` is ``None`` a fresh one is created, so the returned
+        object always reflects the current configuration.
+        """
+        if cache is None:
+            cache = {}
         explicit = bool(spec._installed_explicitly()) if explicit is None else explicit
         key = (spec.dag_hash(), module_set_name, explicit)
-        try:
-            return cls._registry[key]
-        except KeyError:
-            return cls._registry.setdefault(key, cls(spec, module_set_name, explicit))
+        configuration = cache.get(key)
+        if configuration is None:
+            configuration = cls(spec, module_set_name, explicit, cache=cache)
+            cache[key] = configuration
+        return configuration
 
     @classmethod
     def make_layout(
-        cls, spec: spack.spec.Spec, module_set_name: str, explicit: Optional[bool] = None
+        cls,
+        spec: spack.spec.Spec,
+        module_set_name: str,
+        explicit: Optional[bool] = None,
+        *,
+        cache: Optional[ModuleConfigurationCache] = None,
     ) -> "FileLayout":
-        return FileLayout(cls.make_configuration(spec, module_set_name, explicit))
+        return FileLayout(cls.make_configuration(spec, module_set_name, explicit, cache=cache))
 
-    def __init__(self, spec: spack.spec.Spec, module_set_name: str, explicit: bool) -> None:
+    def __init__(
+        self,
+        spec: spack.spec.Spec,
+        module_set_name: str,
+        explicit: bool,
+        *,
+        cache: Optional[ModuleConfigurationCache] = None,
+    ) -> None:
         self.spec = spec
         self.name = module_set_name
         self.explicit = explicit
+        self._configuration_cache: ModuleConfigurationCache = {} if cache is None else cache
         self._cache: Dict[str, Any] = {}
         _modules_cfg = spack.config.CONFIG.get_config("modules")
         _set_cfg = _modules_cfg.get(module_set_name, {})
@@ -399,6 +425,12 @@ class BaseConfiguration:
                             "compiler."
                         )
                     break
+
+    def __getstate__(self) -> Dict[str, Any]:
+        # Exclude cache when serializing
+        state = self.__dict__.copy()
+        state["_configuration_cache"] = {}
+        return state
 
     @property
     def projections(self) -> Dict[str, str]:
@@ -545,7 +577,9 @@ class BaseConfiguration:
         return [
             item
             for item in self.conf[what]
-            if not self.make_configuration(item, self.name).excluded
+            if not self.make_configuration(
+                item, self.name, cache=self._configuration_cache
+            ).excluded
         ]
 
     @property
@@ -1121,7 +1155,10 @@ class ModuleContext(tengine.Context):
 
     def _create_module_list_of(self, what: str) -> List[str]:
         name = self.conf.name
-        return [self.conf.make_layout(x, name).use_name for x in getattr(self.conf, what)]
+        cache = self.conf._configuration_cache
+        return [
+            self.conf.make_layout(x, name, cache=cache).use_name for x in getattr(self.conf, what)
+        ]
 
     @tengine.context_property
     def verbose(self) -> Optional[bool]:
@@ -1215,9 +1252,16 @@ class BaseModuleFileWriter:
 
     @classmethod
     def from_spec(
-        cls, spec: spack.spec.Spec, module_set_name: str, explicit: Optional[bool] = None
+        cls,
+        spec: spack.spec.Spec,
+        module_set_name: str,
+        explicit: Optional[bool] = None,
+        *,
+        cache: Optional[ModuleConfigurationCache] = None,
     ) -> "BaseModuleFileWriter":
-        conf = cls.configuration_class.make_configuration(spec, module_set_name, explicit)
+        conf = cls.configuration_class.make_configuration(
+            spec, module_set_name, explicit, cache=cache
+        )
         return cls(conf)
 
     @property

--- a/lib/spack/spack/modules/common.py
+++ b/lib/spack/spack/modules/common.py
@@ -384,7 +384,7 @@ class BaseConfiguration:
         self.spec = spec
         self.name = module_set_name
         self.explicit = explicit
-        self._configuration_cache: ModuleConfigurationCache = {} if cache is None else cache
+        self._configuration_cache = {} if cache is None else cache
         self._cache: Dict[str, Any] = {}
         _modules_cfg = spack.config.CONFIG.get_config("modules")
         _set_cfg = _modules_cfg.get(module_set_name, {})
@@ -425,12 +425,6 @@ class BaseConfiguration:
                             "compiler."
                         )
                     break
-
-    def __getstate__(self) -> Dict[str, Any]:
-        # Exclude cache when serializing
-        state = self.__dict__.copy()
-        state["_configuration_cache"] = {}
-        return state
 
     @property
     def projections(self) -> Dict[str, str]:
@@ -1298,7 +1292,7 @@ class BaseModuleFileWriter:
         # a module file that is already there (name clash)
         if not overwrite and os.path.exists(self.layout.filename):
             message = "Module file {0.filename} exists and will not be overwritten"
-            tty.warn(message.format(self.layout))
+            warnings.warn(message.format(self.layout))
             return
 
         # If we are here it means it's ok to write the module file

--- a/lib/spack/spack/test/cmd/env.py
+++ b/lib/spack/spack/test/cmd/env.py
@@ -20,8 +20,6 @@ import spack.config
 import spack.environment as ev
 import spack.error
 import spack.main
-import spack.modules
-import spack.modules.tcl
 import spack.package_base
 import spack.paths
 import spack.repo
@@ -3651,9 +3649,7 @@ spack:
     assert spec.prefix not in contents
 
 
-def test_modules_exist_after_env_install(installed_environment, monkeypatch):
-    # Some caching issue
-    monkeypatch.setattr(spack.modules.tcl.TclConfiguration, "_registry", {})
+def test_modules_exist_after_env_install(installed_environment):
     with installed_environment(
         """
 spack:

--- a/lib/spack/spack/test/conftest.py
+++ b/lib/spack/spack/test/conftest.py
@@ -1405,11 +1405,8 @@ def upstream_and_downstream_db(tmp_path: Path, gen_mock_layout):
 
 
 class ConfigUpdate:
-    def __init__(self, root_for_conf, writer_mod, writer_key, monkeypatch):
+    def __init__(self, root_for_conf):
         self.root_for_conf = root_for_conf
-        self.writer_mod = writer_mod
-        self.writer_key = writer_key
-        self.monkeypatch = monkeypatch
 
     def __call__(self, filename):
         file = os.path.join(self.root_for_conf, filename + ".yaml")
@@ -1417,12 +1414,9 @@ class ConfigUpdate:
             config_settings = syaml.load_config(f)
         spack.config.set("modules:default", config_settings)
 
-        conf_cls = getattr(self.writer_mod, self.writer_key.capitalize() + "Configuration")
-        self.monkeypatch.setattr(conf_cls, "_registry", {})
-
 
 @pytest.fixture()
-def module_configuration(monkeypatch, request, mutable_config):
+def module_configuration(request, mutable_config):
     """Reads the module configuration file from the mock ones prepared
     for tests and monkeypatches the right classes to hook it in.
     """
@@ -1437,7 +1431,7 @@ def module_configuration(monkeypatch, request, mutable_config):
 
     # ConfigUpdate, when called, will modify configuration, so we need to use
     # the mutable_config fixture
-    return ConfigUpdate(root_for_conf, writer_mod, writer_key, monkeypatch)
+    return ConfigUpdate(root_for_conf)
 
 
 @pytest.fixture()

--- a/lib/spack/spack/test/modules/common.py
+++ b/lib/spack/spack/test/modules/common.py
@@ -2,7 +2,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 import os
-import pickle
 import stat
 
 import pytest
@@ -219,22 +218,3 @@ def test_check_module_set_name(mutable_config):
 
     with pytest.raises(spack.error.ConfigError, match=msg):
         spack.cmd.modules.check_module_set_name("third")
-
-
-@pytest.mark.parametrize("module_type", ["tcl", "lmod"])
-def test_module_writers_are_pickleable(default_mock_concretization, module_type):
-    s = default_mock_concretization("mpileaks")
-    writer = spack.modules.module_types[module_type].from_spec(s, "default")
-    assert pickle.loads(pickle.dumps(writer)).spec == s
-
-
-@pytest.mark.parametrize("module_type", ["tcl", "lmod"])
-def test_configuration_cache_not_pickled(default_mock_concretization, module_type):
-    """Tests that we don't serialize the cache of a module writer."""
-    # The per-operation configuration cache is transient state and must not be serialized with
-    # the writer, otherwise pickling drags in the whole sibling/dependency configuration graph.
-    s = default_mock_concretization("mpileaks")
-    writer = spack.modules.module_types[module_type].from_spec(s, "default")
-    assert writer.conf._configuration_cache  # populated with at least the root configuration
-    restored = pickle.loads(pickle.dumps(writer))
-    assert restored.conf._configuration_cache == {}

--- a/lib/spack/spack/test/modules/common.py
+++ b/lib/spack/spack/test/modules/common.py
@@ -226,3 +226,15 @@ def test_module_writers_are_pickleable(default_mock_concretization, module_type)
     s = default_mock_concretization("mpileaks")
     writer = spack.modules.module_types[module_type].from_spec(s, "default")
     assert pickle.loads(pickle.dumps(writer)).spec == s
+
+
+@pytest.mark.parametrize("module_type", ["tcl", "lmod"])
+def test_configuration_cache_not_pickled(default_mock_concretization, module_type):
+    """Tests that we don't serialize the cache of a module writer."""
+    # The per-operation configuration cache is transient state and must not be serialized with
+    # the writer, otherwise pickling drags in the whole sibling/dependency configuration graph.
+    s = default_mock_concretization("mpileaks")
+    writer = spack.modules.module_types[module_type].from_spec(s, "default")
+    assert writer.conf._configuration_cache  # populated with at least the root configuration
+    restored = pickle.loads(pickle.dumps(writer))
+    assert restored.conf._configuration_cache == {}


### PR DESCRIPTION
This PR replaces a class level cache with a DI cache. In this way a cache cannot outlive a single "logical operation" and no manual clearing is ever needed in tests.

The new per-instance cache is not serialized.