### PR TITLE
builtin_mock: use C sources in garply/quux/corge

### DIFF
--- a/var/spack/test_repos/spack_repo/builtin_mock/packages/corge/package.py
+++ b/var/spack/test_repos/spack_repo/builtin_mock/packages/corge/package.py
@@ -7,6 +7,7 @@ import os
 import sys
 
 from spack_repo.builtin_mock.build_systems.generic import Package
+from spack_repo.builtin_mock.packages.garply.package import c_compiler
 
 from spack.package import *
 
@@ -21,200 +22,52 @@ class Corge(Package):
     depends_on("quux")
 
     def install(self, spec, prefix):
-        corge_cc = """#include <iostream>
-#include <stdexcept>
-#include "corge.h"
-#include "corge_version.h"
-#include "quux/quux.h"
-
-const int Corge::version_major = corge_version_major;
-const int Corge::version_minor = corge_version_minor;
-
-Corge::Corge()
-{
-}
-
-int
-Corge::get_version() const
-{
-    return 10 * version_major + version_minor;
-}
-
-int
-Corge::corgegate() const
-{
-    int corge_version = get_version();
-    std::cout << "Corge::corgegate version " << corge_version
-              << " invoked" << std::endl;
-    std::cout << "Corge config directory = %s" <<std::endl;
-    Quux quux;
-    int quux_version = quux.quuxify();
-
-    if(quux_version != corge_version) {
-        throw std::runtime_error(
-              "Corge found an incompatible version of Garply.");
-    }
-
-    return corge_version;
-}
-"""
-        corge_h = """#ifndef CORGE_H_
-
-class Corge
-{
-private:
-    static const int version_major;
-    static const int version_minor;
-
-public:
-    Corge();
-    int get_version() const;
-    int corgegate() const;
-};
-
-#endif // CORGE_H_
-"""
-        corge_version_h = """
-const int corge_version_major = %s;
-const int corge_version_minor = %s;
-"""
-        corgegator_cc = """
-#include <iostream>
-#include "corge.h"
-
-int
-main(int argc, char* argv[])
-{
-    std::cout << "corgerator called with ";
-    if (argc == 0) {
-        std::cout << "no command-line arguments" << std::endl;
-    } else {
-        std::cout << "command-line arguments:";
-        for (int i = 0; i < argc; ++i) {
-            std::cout << " \"" << argv[i] << "\"";
-        }
-        std::cout << std::endl;
-    }
-    std::cout << "corgegating.."<<std::endl;
-    Corge corge;
-    corge.corgegate();
-    std::cout << "done."<<std::endl;
-    return 0;
-}
-"""
-        mkdirp("%s/corge" % prefix.include)
-        mkdirp("%s/corge" % self.stage.source_path)
-        with open("%s/corge_version.h" % self.stage.source_path, "w", encoding="utf-8") as f:
-            f.write(corge_version_h % (self.version[0], self.version[1:]))
-        with open("%s/corge/corge.cc" % self.stage.source_path, "w", encoding="utf-8") as f:
-            f.write(corge_cc % prefix.config)
-        with open("%s/corge/corge.h" % self.stage.source_path, "w", encoding="utf-8") as f:
-            f.write(corge_h)
-        with open("%s/corge/corgegator.cc" % self.stage.source_path, "w", encoding="utf-8") as f:
-            f.write(corgegator_cc)
-        gpp = which("g++")
-        if sys.platform == "darwin":
-            gpp = which("clang++")
-        gpp(
-            "-Dcorge_EXPORTS",
-            "-I%s" % self.stage.source_path,
-            "-I%s" % spec["quux"].prefix.include,
-            "-I%s" % spec["garply"].prefix.include,
-            "-O2",
-            "-g",
-            "-DNDEBUG",
-            "-fPIC",
-            "-o",
-            "corge.cc.o",
-            "-c",
-            "corge/corge.cc",
-        )
-        gpp(
-            "-Dcorge_EXPORTS",
-            "-I%s" % self.stage.source_path,
-            "-I%s" % spec["quux"].prefix.include,
-            "-I%s" % spec["garply"].prefix.include,
-            "-O2",
-            "-g",
-            "-DNDEBUG",
-            "-fPIC",
-            "-o",
-            "corgegator.cc.o",
-            "-c",
-            "corge/corgegator.cc",
-        )
-        if sys.platform == "darwin":
-            gpp(
-                "-fPIC",
-                "-O2",
-                "-g",
-                "-DNDEBUG",
-                "-dynamiclib",
-                "-install_name",
-                "@rpath/libcorge.dylib",
-                "-o",
-                "libcorge.dylib",
-                "corge.cc.o",
-                "-Wl,-rpath,%s" % spec["quux"].prefix.lib64,
-                "-Wl,-rpath,%s" % spec["garply"].prefix.lib64,
-                "%s/libquux.dylib" % spec["quux"].prefix.lib64,
-                "%s/libgarply.dylib" % spec["garply"].prefix.lib64,
+        # Trivial C sources. The library embeds its install path both as an
+        # rpath (relocated by relocate_elf_binaries) and as a hard-coded
+        # .rodata string (relocated by relocate_text_bin), so both relocation
+        # code paths are exercised.
+        quux = spec["quux"].prefix
+        garply = spec["garply"].prefix
+        with open("corge.h", "w", encoding="utf-8") as f:
+            f.write("int corgegate(void);\n")
+        with open("corge.c", "w", encoding="utf-8") as f:
+            f.write(
+                '#include "corge.h"\n#include "quux/quux.h"\n'
+                'const char *corge_config = "%s";\n'
+                "int corgegate(void) { return quuxify(); }\n" % prefix.config
             )
-            gpp(
-                "-O2",
-                "-g",
-                "-DNDEBUG",
-                "-rdynamic",
-                "corgegator.cc.o",
-                "-o",
-                "corgegator",
-                "-Wl,-rpath,%s" % prefix.lib64,
-                "-Wl,-rpath,%s" % spec["quux"].prefix.lib64,
-                "-Wl,-rpath,%s" % spec["garply"].prefix.lib64,
-                "libcorge.dylib",
-                "%s/libquux.dylib.3.0" % spec["quux"].prefix.lib64,
-                "%s/libgarply.dylib.3.0" % spec["garply"].prefix.lib64,
-            )
-            mkdirp(prefix.lib64)
-            copy("libcorge.dylib", "%s/libcorge.dylib" % prefix.lib64)
-            os.link("%s/libcorge.dylib" % prefix.lib64, "%s/libcorge.dylib.3.0" % prefix.lib64)
+        with open("corgegator.c", "w", encoding="utf-8") as f:
+            f.write('#include "corge.h"\nint main(void) { return corgegate(); }\n')
+
+        cc = c_compiler()
+        cc("-fPIC", "-O0", "-I%s" % quux.include, "-c", "corge.c", "-o", "corge.o")
+
+        mkdirp(prefix.lib64)
+        if sys.platform == "darwin":
+            lib = "libcorge.dylib"
+            quux_lib = os.path.join(quux.lib64, "libquux.dylib")
+            cc("-dynamiclib", "-install_name", "@rpath/" + lib, "-o", lib, "corge.o", quux_lib)
         else:
-            gpp(
-                "-fPIC",
-                "-O2",
-                "-g",
-                "-DNDEBUG",
-                "-shared",
-                "-Wl,-soname,libcorge.so",
-                "-o",
-                "libcorge.so",
-                "corge.cc.o",
-                "-Wl,-rpath,%s:%s::::" % (spec["quux"].prefix.lib64, spec["garply"].prefix.lib64),
-                "%s/libquux.so" % spec["quux"].prefix.lib64,
-                "%s/libgarply.so" % spec["garply"].prefix.lib64,
-            )
-            gpp(
-                "-O2",
-                "-g",
-                "-DNDEBUG",
-                "-rdynamic",
-                "corgegator.cc.o",
-                "-o",
-                "corgegator",
-                "-Wl,-rpath,%s" % prefix.lib64,
-                "-Wl,-rpath,%s" % spec["quux"].prefix.lib64,
-                "-Wl,-rpath,%s" % spec["garply"].prefix.lib64,
-                "libcorge.so",
-                "%s/libquux.so.3.0" % spec["quux"].prefix.lib64,
-                "%s/libgarply.so.3.0" % spec["garply"].prefix.lib64,
-            )
-            mkdirp(prefix.lib64)
-            copy("libcorge.so", "%s/libcorge.so" % prefix.lib64)
-            os.link("%s/libcorge.so" % prefix.lib64, "%s/libcorge.so.3.0" % prefix.lib64)
-        copy("corgegator", "%s/corgegator" % prefix.lib64)
-        copy("%s/corge/corge.h" % self.stage.source_path, "%s/corge/corge.h" % prefix.include)
+            lib = "libcorge.so"
+            quux_lib = os.path.join(quux.lib64, "libquux.so")
+            garply_lib = os.path.join(garply.lib64, "libgarply.so")
+            cc("-shared", "-Wl,-soname,%s" % lib, "-o", lib, "corge.o", quux_lib, garply_lib)
+        cc(
+            "-o",
+            "corgegator",
+            "corgegator.c",
+            "-Wl,-rpath,%s" % prefix.lib64,
+            "-Wl,-rpath,%s" % quux.lib64,
+            "-Wl,-rpath,%s" % garply.lib64,
+            lib,
+        )
+        copy(lib, os.path.join(prefix.lib64, lib))
+        os.link(os.path.join(prefix.lib64, lib), os.path.join(prefix.lib64, lib + ".3.0"))
+        copy("corgegator", os.path.join(prefix.lib64, "corgegator"))
+
+        mkdirp("%s/corge" % prefix.include)
+        copy("corge.h", "%s/corge/corge.h" % prefix.include)
         mkdirp(prefix.bin)
-        copy("corge_version.h", "%s/corge_version.h" % prefix.bin)
         os.symlink("%s/corgegator" % prefix.lib64, "%s/corgegator" % prefix.bin)
-        os.symlink("%s/quuxifier" % spec["quux"].prefix.lib64, "%s/quuxifier" % prefix.bin)
-        os.symlink("%s/garplinator" % spec["garply"].prefix.lib64, "%s/garplinator" % prefix.bin)
+        os.symlink("%s/quuxifier" % quux.lib64, "%s/quuxifier" % prefix.bin)
+        os.symlink("%s/garplinator" % garply.lib64, "%s/garplinator" % prefix.bin)

--- a/var/spack/test_repos/spack_repo/builtin_mock/packages/garply/package.py
+++ b/var/spack/test_repos/spack_repo/builtin_mock/packages/garply/package.py
@@ -11,6 +11,14 @@ from spack_repo.builtin_mock.build_systems.generic import Package
 from spack.package import *
 
 
+def c_compiler():
+    """Return a C compiler, ignoring Spack's compiler wrapper on PATH."""
+    if sys.platform == "darwin":
+        return which("/usr/bin/clang")
+    path = ":".join(s for s in os.environ["PATH"].split(os.pathsep) if "lib/spack/env" not in s)
+    return which("gcc", path=path)
+
+
 class Garply(Package):
     """Toy package for testing dependencies"""
 
@@ -19,160 +27,40 @@ class Garply(Package):
     version("3.0.0")
 
     def install(self, spec, prefix):
-        garply_h = """#ifndef GARPLY_H_
-
-class Garply
-{
-private:
-    static const int version_major;
-    static const int version_minor;
-
-public:
-    Garply();
-    int get_version() const;
-    int garplinate() const;
-};
-
-#endif // GARPLY_H_
-"""
-        garply_cc = """#include "garply.h"
-#include "garply_version.h"
-#include <iostream>
-
-const int Garply::version_major = garply_version_major;
-const int Garply::version_minor = garply_version_minor;
-
-Garply::Garply() {}
-
-int
-Garply::get_version() const
-{
-    return 10 * version_major + version_minor;
-}
-
-int
-Garply::garplinate() const
-{
-    std::cout << "Garply::garplinate version " << get_version()
-              << " invoked" << std::endl;
-    std::cout << "Garply config dir = %s" << std::endl;
-    return get_version();
-}
-"""
-        garplinator_cc = """#include "garply.h"
-#include <iostream>
-
-int
-main()
-{
-    Garply garply;
-    garply.garplinate();
-
-    return 0;
-}
-"""
-        garply_version_h = """const int garply_version_major = %s;
-const int garply_version_minor = %s;
-"""
-        mkdirp("%s/garply" % prefix.include)
-        mkdirp("%s/garply" % self.stage.source_path)
-        with open("%s/garply_version.h" % self.stage.source_path, "w", encoding="utf-8") as f:
-            f.write(garply_version_h % (self.version[0], self.version[1:]))
-        with open("%s/garply/garply.h" % self.stage.source_path, "w", encoding="utf-8") as f:
-            f.write(garply_h)
-        with open("%s/garply/garply.cc" % self.stage.source_path, "w", encoding="utf-8") as f:
-            f.write(garply_cc % prefix.config)
-        with open("%s/garply/garplinator.cc" % self.stage.source_path, "w", encoding="utf-8") as f:
-            f.write(garplinator_cc)
-        gpp = which(
-            "g++",
-            path=":".join(
-                [s for s in os.environ["PATH"].split(os.pathsep) if "lib/spack/env" not in s]
-            ),
-        )
-        if sys.platform == "darwin":
-            gpp = which("/usr/bin/clang++")
-        gpp(
-            "-Dgarply_EXPORTS",
-            "-I%s" % self.stage.source_path,
-            "-O2",
-            "-g",
-            "-DNDEBUG",
-            "-fPIC",
-            "-o",
-            "garply.cc.o",
-            "-c",
-            "%s/garply/garply.cc" % self.stage.source_path,
-        )
-        gpp(
-            "-Dgarply_EXPORTS",
-            "-I%s" % self.stage.source_path,
-            "-O2",
-            "-g",
-            "-DNDEBUG",
-            "-fPIC",
-            "-o",
-            "garplinator.cc.o",
-            "-c",
-            "%s/garply/garplinator.cc" % self.stage.source_path,
-        )
-        if sys.platform == "darwin":
-            gpp(
-                "-fPIC",
-                "-O2",
-                "-g",
-                "-DNDEBUG",
-                "-dynamiclib",
-                "-Wl,-headerpad_max_install_names",
-                "-o",
-                "libgarply.dylib",
-                "-install_name",
-                "@rpath/libgarply.dylib",
-                "garply.cc.o",
+        # The library embeds its install path twice: as an rpath (relocated by
+        # relocate_elf_binaries, in the ELF dynamic section) and as a hard-coded
+        # .rodata string (relocated by relocate_text_bin / BinaryFilePrefixReplacer),
+        # so both relocation code paths are exercised.
+        with open("garply.h", "w", encoding="utf-8") as f:
+            f.write("int garplinate(void);\n")
+        with open("garply.c", "w", encoding="utf-8") as f:
+            f.write(
+                '#include "garply.h"\n'
+                'const char *garply_config = "%s";\n'
+                "int garplinate(void) { return 3; }\n" % prefix.config
             )
-            gpp(
-                "-O2",
-                "-g",
-                "-DNDEBUG",
-                "-Wl,-search_paths_first",
-                "-Wl,-headerpad_max_install_names",
-                "garplinator.cc.o",
-                "-o",
-                "garplinator",
-                "-Wl,-rpath,%s" % prefix.lib64,
-                "libgarply.dylib",
-            )
-            mkdirp(prefix.lib64)
-            copy("libgarply.dylib", "%s/libgarply.dylib" % prefix.lib64)
-            os.link("%s/libgarply.dylib" % prefix.lib64, "%s/libgarply.dylib.3.0" % prefix.lib64)
+        with open("garplinator.c", "w", encoding="utf-8") as f:
+            f.write('#include "garply.h"\nint main(void) { return garplinate(); }\n')
+
+        cc = c_compiler()
+        cc("-fPIC", "-O0", "-c", "garply.c", "-o", "garply.o")
+
+        mkdirp(prefix.lib64)
+        if sys.platform == "darwin":
+            lib = "libgarply.dylib"
+            cc("-dynamiclib", "-install_name", "@rpath/" + lib, "-o", lib, "garply.o")
+            cc("-o", "garplinator", "garplinator.c", "-Wl,-rpath,%s" % prefix.lib64, lib)
+            copy(lib, os.path.join(prefix.lib64, lib))
+            os.link(os.path.join(prefix.lib64, lib), os.path.join(prefix.lib64, lib + ".3.0"))
         else:
-            gpp(
-                "-fPIC",
-                "-O2",
-                "-g",
-                "-DNDEBUG",
-                "-shared",
-                "-Wl,-soname,libgarply.so",
-                "-o",
-                "libgarply.so",
-                "garply.cc.o",
-            )
-            gpp(
-                "-O2",
-                "-g",
-                "-DNDEBUG",
-                "-rdynamic",
-                "garplinator.cc.o",
-                "-o",
-                "garplinator",
-                "-Wl,-rpath,%s" % prefix.lib64,
-                "libgarply.so",
-            )
-            mkdirp(prefix.lib64)
-            copy("libgarply.so", "%s/libgarply.so" % prefix.lib64)
-            os.link("%s/libgarply.so" % prefix.lib64, "%s/libgarply.so.3.0" % prefix.lib64)
-        copy("garplinator", "%s/garplinator" % prefix.lib64)
-        copy("%s/garply/garply.h" % self.stage.source_path, "%s/garply/garply.h" % prefix.include)
+            lib = "libgarply.so"
+            cc("-shared", "-Wl,-soname,%s" % lib, "-o", lib, "garply.o")
+            cc("-o", "garplinator", "garplinator.c", "-Wl,-rpath,%s" % prefix.lib64, lib)
+            copy(lib, os.path.join(prefix.lib64, lib))
+            os.link(os.path.join(prefix.lib64, lib), os.path.join(prefix.lib64, lib + ".3.0"))
+        copy("garplinator", os.path.join(prefix.lib64, "garplinator"))
+
+        mkdirp("%s/garply" % prefix.include)
+        copy("garply.h", "%s/garply/garply.h" % prefix.include)
         mkdirp(prefix.bin)
-        copy("garply_version.h", "%s/garply_version.h" % prefix.bin)
         os.symlink("%s/garplinator" % prefix.lib64, "%s/garplinator" % prefix.bin)

--- a/var/spack/test_repos/spack_repo/builtin_mock/packages/quux/package.py
+++ b/var/spack/test_repos/spack_repo/builtin_mock/packages/quux/package.py
@@ -7,6 +7,7 @@ import os
 import sys
 
 from spack_repo.builtin_mock.build_systems.generic import Package
+from spack_repo.builtin_mock.packages.garply.package import c_compiler
 
 from spack.package import *
 
@@ -21,181 +22,65 @@ class Quux(Package):
     depends_on("garply")
 
     def install(self, spec, prefix):
-        quux_cc = """#include "quux.h"
-#include "garply/garply.h"
-#include "quux_version.h"
-#include <iostream>
-#include <stdexcept>
+        # Trivial C sources. The library embeds its install path both as an
+        # rpath (relocated by relocate_elf_binaries) and as a hard-coded
+        # .rodata string (relocated by relocate_text_bin), so both relocation
+        # code paths are exercised.
+        garply = spec["garply"].prefix
+        with open("quux.h", "w", encoding="utf-8") as f:
+            f.write("int quuxify(void);\n")
+        with open("quux.c", "w", encoding="utf-8") as f:
+            f.write(
+                '#include "quux.h"\n#include "garply/garply.h"\n'
+                'const char *quux_config = "%s";\n'
+                "int quuxify(void) { return garplinate(); }\n" % prefix.config
+            )
+        with open("quuxifier.c", "w", encoding="utf-8") as f:
+            f.write('#include "quux.h"\nint main(void) { return quuxify(); }\n')
 
-const int Quux::version_major = quux_version_major;
-const int Quux::version_minor = quux_version_minor;
+        cc = c_compiler()
+        cc("-fPIC", "-O0", "-I%s" % garply.include, "-c", "quux.c", "-o", "quux.o")
 
-Quux::Quux() {}
-
-int
-Quux::get_version() const
-{
-    return 10 * version_major + version_minor;
-}
-
-int
-Quux::quuxify() const
-{
-    int quux_version = get_version();
-    std::cout << "Quux::quuxify version " << quux_version
-              << " invoked" <<std::endl;
-    std::cout << "Quux config directory is %s" <<std::endl;
-    Garply garply;
-    int garply_version = garply.garplinate();
-
-    if (garply_version != quux_version) {
-        throw std::runtime_error(
-            "Quux found an incompatible version of Garply.");
-    }
-
-    return quux_version;
-}
-"""
-        quux_h = """#ifndef QUUX_H_
-
-class Quux
-{
-private:
-    static const int version_major;
-    static const int version_minor;
-
-public:
-    Quux();
-    int get_version() const;
-    int quuxify() const;
-};
-
-#endif // QUUX_H_
-"""
-        quuxifier_cc = """
-#include "quux.h"
-#include <iostream>
-
-int
-main()
-{
-    Quux quux;
-    quux.quuxify();
-
-    return 0;
-}
-"""
-        quux_version_h = """const int quux_version_major = %s;
-const int quux_version_minor = %s;
-"""
-        mkdirp("%s/quux" % prefix.include)
-        mkdirp("%s/quux" % self.stage.source_path)
-        with open("%s/quux_version.h" % self.stage.source_path, "w", encoding="utf-8") as f:
-            f.write(quux_version_h % (self.version[0], self.version[1:]))
-        with open("%s/quux/quux.cc" % self.stage.source_path, "w", encoding="utf-8") as f:
-            f.write(quux_cc % (prefix.config))
-        with open("%s/quux/quux.h" % self.stage.source_path, "w", encoding="utf-8") as f:
-            f.write(quux_h)
-        with open("%s/quux/quuxifier.cc" % self.stage.source_path, "w", encoding="utf-8") as f:
-            f.write(quuxifier_cc)
-        gpp = which(
-            "g++",
-            path=":".join(
-                [s for s in os.environ["PATH"].split(os.pathsep) if "lib/spack/env" not in s]
-            ),
-        )
+        mkdirp(prefix.lib64)
         if sys.platform == "darwin":
-            gpp = which("/usr/bin/clang++")
-        gpp(
-            "-Dquux_EXPORTS",
-            "-I%s" % self.stage.source_path,
-            "-I%s" % spec["garply"].prefix.include,
-            "-O2",
-            "-g",
-            "-DNDEBUG",
-            "-fPIC",
-            "-o",
-            "quux.cc.o",
-            "-c",
-            "quux/quux.cc",
-        )
-        gpp(
-            "-Dquux_EXPORTS",
-            "-I%s" % self.stage.source_path,
-            "-I%s" % spec["garply"].prefix.include,
-            "-O2",
-            "-g",
-            "-DNDEBUG",
-            "-fPIC",
-            "-o",
-            "quuxifier.cc.o",
-            "-c",
-            "quux/quuxifier.cc",
-        )
-        if sys.platform == "darwin":
-            gpp(
-                "-fPIC",
-                "-O2",
-                "-g",
-                "-DNDEBUG",
+            lib = "libquux.dylib"
+            garply_lib = os.path.join(garply.lib64, "libgarply.dylib")
+            cc(
                 "-dynamiclib",
-                "-Wl,-headerpad_max_install_names",
-                "-o",
-                "libquux.dylib",
                 "-install_name",
-                "@rpath/libquux.dylib",
-                "quux.cc.o",
-                "-Wl,-rpath,%s" % prefix.lib64,
-                "-Wl,-rpath,%s" % spec["garply"].prefix.lib64,
-                "%s/libgarply.dylib" % spec["garply"].prefix.lib64,
-            )
-            gpp(
-                "-O2",
-                "-g",
-                "-DNDEBUG",
-                "quuxifier.cc.o",
+                "@rpath/" + lib,
                 "-o",
-                "quuxifier",
-                "-Wl,-rpath,%s" % prefix.lib64,
-                "-Wl,-rpath,%s" % spec["garply"].prefix.lib64,
-                "libquux.dylib",
-                "%s/libgarply.dylib" % spec["garply"].prefix.lib64,
+                lib,
+                "quux.o",
+                "-Wl,-rpath,%s" % garply.lib64,
+                garply_lib,
             )
-            mkdirp(prefix.lib64)
-            copy("libquux.dylib", "%s/libquux.dylib" % prefix.lib64)
-            os.link("%s/libquux.dylib" % prefix.lib64, "%s/libquux.dylib.3.0" % prefix.lib64)
         else:
-            gpp(
-                "-fPIC",
-                "-O2",
-                "-g",
-                "-DNDEBUG",
+            lib = "libquux.so"
+            garply_lib = os.path.join(garply.lib64, "libgarply.so")
+            cc(
                 "-shared",
-                "-Wl,-soname,libquux.so",
+                "-Wl,-soname,%s" % lib,
                 "-o",
-                "libquux.so",
-                "quux.cc.o",
-                "-Wl,-rpath,%s:%s::::" % (prefix.lib64, spec["garply"].prefix.lib64),
-                "%s/libgarply.so" % spec["garply"].prefix.lib64,
+                lib,
+                "quux.o",
+                "-Wl,-rpath,%s" % garply.lib64,
+                garply_lib,
             )
-            gpp(
-                "-O2",
-                "-g",
-                "-DNDEBUG",
-                "-rdynamic",
-                "quuxifier.cc.o",
-                "-o",
-                "quuxifier",
-                "-Wl,-rpath,%s:%s::::" % (prefix.lib64, spec["garply"].prefix.lib64),
-                "libquux.so",
-                "%s/libgarply.so" % spec["garply"].prefix.lib64,
-            )
-            mkdirp(prefix.lib64)
-            copy("libquux.so", "%s/libquux.so" % prefix.lib64)
-            os.link("%s/libquux.so" % prefix.lib64, "%s/libquux.so.3.0" % prefix.lib64)
-        copy("quuxifier", "%s/quuxifier" % prefix.lib64)
-        copy("%s/quux/quux.h" % self.stage.source_path, "%s/quux/quux.h" % prefix.include)
+        cc(
+            "-o",
+            "quuxifier",
+            "quuxifier.c",
+            "-Wl,-rpath,%s" % prefix.lib64,
+            "-Wl,-rpath,%s" % garply.lib64,
+            lib,
+        )
+        copy(lib, os.path.join(prefix.lib64, lib))
+        os.link(os.path.join(prefix.lib64, lib), os.path.join(prefix.lib64, lib + ".3.0"))
+        copy("quuxifier", os.path.join(prefix.lib64, "quuxifier"))
+
+        mkdirp("%s/quux" % prefix.include)
+        copy("quux.h", "%s/quux/quux.h" % prefix.include)
         mkdirp(prefix.bin)
-        copy("quux_version.h", "%s/quux_version.h" % prefix.bin)
         os.symlink("%s/quuxifier" % prefix.lib64, "%s/quuxifier" % prefix.bin)
-        os.symlink("%s/garplinator" % spec["garply"].prefix.lib64, "%s/garplinator" % prefix.bin)
+        os.symlink("%s/garplinator" % garply.lib64, "%s/garplinator" % prefix.bin)


### PR DESCRIPTION
These mock packages compiled elaborate C++ sources at install time. The
only thing the tests care about is that the resulting binaries embed
their install paths as constants and rpaths.

Using C makes the tests run faster and drops a dependency.

