### PR TITLE
Spec: remove `spack_root` and `spack_install` properties

### DIFF
--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -4002,18 +4002,6 @@ class Spec:
     def namespace_if_anonymous(self):
         return self.namespace if not self.name else None
 
-    @property
-    def spack_root(self):
-        """Special field for using ``{spack_root}`` in :meth:`format`."""
-        return spack.paths.spack_root
-
-    @property
-    def spack_install(self):
-        """Special field for using ``{spack_install}`` in :meth:`format`."""
-        from spack.store import STORE
-
-        return STORE.layout.root
-
     def _format_default(self) -> str:
         """Fast path for formatting with DEFAULT_FORMAT and no color.
 
@@ -4093,7 +4081,6 @@ class Spec:
 
            hash[:len]    The DAG hash with optional length argument
            spack_root    The spack root directory
-           spack_install The spack install directory
 
         The ``^`` sigil can be used to access dependencies by name.
         ``s.format({^mpi.name})`` will print the name of the MPI implementation in the
@@ -4204,6 +4191,10 @@ class Spec:
                 raise SpecFormatSigilError(sig, "compilers", attribute)
             elif sig == "/" and attribute != "abstract_hash":
                 raise SpecFormatSigilError(sig, "DAG hashes", attribute)
+
+            # spack_root is a spec-independent special field: Spack's source root.
+            if attribute == "spack_root":
+                return safe_color(sig, spack.paths.spack_root, None)
 
             # Iterate over components using getattr to get next element
             for idx, part in enumerate(parts):

--- a/lib/spack/spack/test/spec_semantics.py
+++ b/lib/spack/spack/test/spec_semantics.py
@@ -16,7 +16,6 @@ import spack.repo
 import spack.solver.asp
 import spack.spec
 import spack.spec_parser
-import spack.store
 import spack.util.lang
 import spack.variant
 import spack.version as vn
@@ -1006,10 +1005,7 @@ class TestSpecSemantics:
             ("{^pkg-a.variants.foo}", spec["pkg-a"], "foo"),
         ]
 
-        other_segments = [
-            ("{spack_root}", spack.paths.spack_root),
-            ("{spack_install}", spack.store.STORE.layout.root),
-        ]
+        other_segments = [("{spack_root}", spack.paths.spack_root)]
 
         def depify(depname, fmt_str, sigil):
             sig = len(sigil)
@@ -1096,6 +1092,7 @@ class TestSpecSemantics:
             r"{_concrete}",
             r"{dag_hash}",
             r"{foo}",
+            r"{spack_install}",
             r"{+variants.debug}",
             r"{variants.this_variant_does_not_exist}",
         ],


### PR DESCRIPTION
Companion to #52658.

This commit removes `Spec.spack_install` and `Spec.spack_root` and reduces the places where `Spec` needs `STORE`.

Removal seems safe for the following reasons:
- Neither token is used by any config, module template, package recipe, view/install-tree projection, or .rst doc anywhere in the tree. The only in-repo consumer is a single unit test.
- `{spack_root}` keeps working: it is resolved directly to spack.paths.spack_root in format().
- `{spack_install}` is dropped rather than preserved because it is meaningless in every context it could appear.

For the latter point, `Spec.spack_install` as a path token in configuration is an absolute install root *joined* onto some other root (store/view/module/stage), so it is redundant or breaks the join.