### PR TITLE
tests: retire default_mock_concretization

### DIFF
--- a/.github/workflows/unit_tests.yaml
+++ b/.github/workflows/unit_tests.yaml
@@ -8,6 +8,12 @@ concurrency:
   group: unit_tests-${{github.ref}}-${{github.event.pull_request.number || github.run_number}}
   cancel-in-progress: true
 
+env:
+  # RUNNER_TEMP is set by the runner on every platform, and is the only temporary directory
+  # Windows runners guarantee to be writable. The runner context is not available here, so
+  # the plugin expands the variable itself.
+  SPACK_TEST_CONCRETIZATION_CACHE: ${RUNNER_TEMP}/spack-concretization-cache
+
 jobs:
   # Run unit tests with different configurations on linux
   ubuntu:

--- a/lib/spack/spack/test/architecture.py
+++ b/lib/spack/spack/test/architecture.py
@@ -65,11 +65,11 @@ def test_user_input_combination(config, target_str, os_str):
     assert spec.architecture.target == TEST_PLATFORM.target(target_str)
 
 
-def test_default_os_and_target(default_mock_concretization):
+def test_default_os_and_target(config, mock_packages):
     """Test that is we don't specify `os=` or `target=` we get the default values
     after concretization.
     """
-    spec = default_mock_concretization("libelf")
+    spec = spack.concretize.concretize_one("libelf")
     assert spec.architecture.os == str(TEST_PLATFORM.default_operating_system())
     assert spec.architecture.target == TEST_PLATFORM.default_target()
 

--- a/lib/spack/spack/test/build_environment.py
+++ b/lib/spack/spack/test/build_environment.py
@@ -486,12 +486,12 @@ dt-diamond-left:
     assert not ({os.path.normpath(x) for x in link_dirs[:-2]} & external_lib_paths)
 
 
-def test_parallel_false_is_not_propagating(default_mock_concretization):
+def test_parallel_false_is_not_propagating(config, mock_packages):
     """Test that parallel=False is not propagating to dependencies"""
     # a foobar=bar (parallel = False)
     # |
     # b (parallel =True)
-    s = default_mock_concretization("pkg-a foobar=bar")
+    s = spack.concretize.concretize_one("pkg-a foobar=bar")
 
     spack.build_environment.set_package_py_globals(s.package, context=Context.BUILD)
     assert s["pkg-a"].package.module.make_jobs == 1
@@ -611,13 +611,13 @@ def test_build_jobs_defaults():
 
 
 class TestModuleMonkeyPatcher:
-    def test_getting_attributes(self, default_mock_concretization):
-        s = default_mock_concretization("libelf")
+    def test_getting_attributes(self, config, mock_packages):
+        s = spack.concretize.concretize_one("libelf")
         module_wrapper = spack.build_environment.ModuleChangePropagator(s.package)
         assert module_wrapper.Libelf == s.package.module.Libelf
 
-    def test_setting_attributes(self, default_mock_concretization):
-        s = default_mock_concretization("libelf")
+    def test_setting_attributes(self, config, mock_packages):
+        s = spack.concretize.concretize_one("libelf")
         module = s.package.module
         module_wrapper = spack.build_environment.ModuleChangePropagator(s.package)
 
@@ -634,8 +634,8 @@ class TestModuleMonkeyPatcher:
             assert current_module.SOME_ATTRIBUTE == 1
 
 
-def test_effective_deptype_build_environment(default_mock_concretization):
-    s = default_mock_concretization("dttop")
+def test_effective_deptype_build_environment(config, mock_packages):
+    s = spack.concretize.concretize_one("dttop")
 
     #  [    ]  dttop@1.0                    #
     #  [b   ]      ^dtbuild1@1.0            # <- direct build dep
@@ -668,8 +668,8 @@ def test_effective_deptype_build_environment(default_mock_concretization):
     assert not expected_flags, f"Missing {expected_flags.keys()} from effective_deptypes"
 
 
-def test_effective_deptype_run_environment(default_mock_concretization):
-    s = default_mock_concretization("dttop")
+def test_effective_deptype_run_environment(config, mock_packages):
+    s = spack.concretize.concretize_one("dttop")
 
     #  [    ]  dttop@1.0                    #
     #  [b   ]      ^dtbuild1@1.0            # <- direct build-only dep is pruned
@@ -700,21 +700,21 @@ def test_effective_deptype_run_environment(default_mock_concretization):
     assert not expected_flags, f"Missing {expected_flags.keys()} from effective_deptypes"
 
 
-def test_monkey_patching_works_across_virtual(default_mock_concretization):
+def test_monkey_patching_works_across_virtual(config, mock_packages):
     """Assert that a monkeypatched attribute is found regardless we access through the
     real name or the virtual name.
     """
-    s = default_mock_concretization("mpileaks ^mpich")
+    s = spack.concretize.concretize_one("mpileaks ^mpich")
     s["mpich"].foo = "foo"
     assert s["mpich"].foo == "foo"
     assert s["mpi"].foo == "foo"
 
 
-def test_clear_compiler_related_runtime_variables_of_build_deps(default_mock_concretization):
+def test_clear_compiler_related_runtime_variables_of_build_deps(config, mock_packages):
     """Verify that Spack drops CC, CXX, FC and F77 from the dependencies related build environment
     variable changes if they are set in setup_run_environment. Spack manages those variables
     elsewhere."""
-    s = default_mock_concretization("build-env-compiler-var-a")
+    s = spack.concretize.concretize_one("build-env-compiler-var-a")
     ctx = spack.build_environment.SetupContext(s, context=Context.BUILD)
     result = {}
     ctx.get_env_modifications().apply_modifications(result)
@@ -772,12 +772,12 @@ def test_optimization_flags(compiler_spec, target_name, expected_flags, compiler
     reason="tests check specific x86_64 uarch flags",
 )
 @pytest.mark.not_on_windows("Windows doesn't support the compiler wrapper")
-def test_optimization_flags_are_using_node_target(default_mock_concretization, monkeypatch):
+def test_optimization_flags_are_using_node_target(config, mock_packages, monkeypatch):
     """Tests that we are using the target on the node to be compiled to retrieve the uarch
     specific flags, and not the target of the compiler.
     """
-    compiler_wrapper_pkg = default_mock_concretization("compiler-wrapper target=core2").package
-    mpileaks = default_mock_concretization("mpileaks target=x86_64")
+    compiler_wrapper_pkg = spack.concretize.concretize_one("compiler-wrapper target=core2").package
+    mpileaks = spack.concretize.concretize_one("mpileaks target=x86_64")
 
     env = EnvironmentModifications()
     compiler_wrapper_pkg.setup_dependent_build_environment(env, mpileaks)

--- a/lib/spack/spack/test/ci.py
+++ b/lib/spack/spack/test/ci.py
@@ -232,13 +232,11 @@ def test_download_and_extract_artifacts(tmp_path: pathlib.Path, monkeypatch):
         ci.download_and_extract_artifacts(url, str(working_dir))
 
 
-def test_ci_copy_stage_logs_to_artifacts_fail(
-    tmp_path: pathlib.Path, default_mock_concretization, capfd
-):
+def test_ci_copy_stage_logs_to_artifacts_fail(tmp_path: pathlib.Path, config, capfd):
     """The copy will fail because the spec is not concrete so does not have
     a package."""
     log_dir = tmp_path / "log_dir"
-    concrete_spec = default_mock_concretization("printing-package")
+    concrete_spec = spack.concretize.concretize_one("printing-package")
     ci.copy_stage_logs_to_artifacts(concrete_spec, str(log_dir))
     _, err = capfd.readouterr()
     assert "Unable to copy files" in err
@@ -466,15 +464,13 @@ def test_ci_create_buildcache(working_env, config, monkeypatch):
     assert results[0].url == "file:///fake-url-one"
 
 
-def test_ci_run_standalone_tests_missing_requirements(
-    working_env, default_mock_concretization, capfd
-):
+def test_ci_run_standalone_tests_missing_requirements(working_env, config, capfd):
     """This test case checks for failing prerequisite checks."""
     ci.run_standalone_tests()
     err = capfd.readouterr()[1]
     assert "Job spec is required" in err
 
-    args = {"job_spec": default_mock_concretization("printing-package")}
+    args = {"job_spec": spack.concretize.concretize_one("printing-package")}
     ci.run_standalone_tests(**args)
     err = capfd.readouterr()[1]
     assert "Reproduction directory is required" in err

--- a/lib/spack/spack/test/cmd/buildcache.py
+++ b/lib/spack/spack/test/cmd/buildcache.py
@@ -419,10 +419,11 @@ def test_correct_specs_are_pushed(
     expected,
     tmp_path: pathlib.Path,
     monkeypatch,
-    default_mock_concretization,
+    config,
+    mock_packages,
     temporary_store,
 ):
-    spec = default_mock_concretization("dttop")
+    spec = spack.concretize.concretize_one("dttop")
     PackageInstaller([spec.package], explicit=True, fake=True).install()
     slash_hash = f"/{spec.dag_hash()}"
 

--- a/lib/spack/spack/test/cmd/checksum.py
+++ b/lib/spack/spack/test/cmd/checksum.py
@@ -309,7 +309,7 @@ def test_checksum_url(mock_packages, config):
         spack_checksum(f"{pkg_cls.url}")
 
 
-def test_checksum_verification_fails(default_mock_concretization, capfd, can_fetch_versions):
+def test_checksum_verification_fails(config, mock_packages, capfd, can_fetch_versions):
     spec = spack.concretize.concretize_one("zlib")
     pkg = spec.package
     versions = list(pkg.versions.keys())

--- a/lib/spack/spack/test/concretization/conditional_dependencies.py
+++ b/lib/spack/spack/test/concretization/conditional_dependencies.py
@@ -58,11 +58,9 @@ import spack.spec
         ("hdf5~mpi %[when='+mpi' virtuals=mpi] zmpi", [], ["%[virtuals=mpi] zmpi", "^mpi"]),
     ],
 )
-def test_conditional_mpi_dependency(
-    abstract_spec, expected, not_expected, default_mock_concretization
-):
+def test_conditional_mpi_dependency(abstract_spec, expected, not_expected, config, mock_packages):
     """Test concretizing conditional mpi dependencies."""
-    concrete = default_mock_concretization(abstract_spec)
+    concrete = spack.concretize.concretize_one(abstract_spec)
 
     for x in expected:
         assert concrete.satisfies(x), x

--- a/lib/spack/spack/test/concretization/core.py
+++ b/lib/spack/spack/test/concretization/core.py
@@ -3104,7 +3104,7 @@ class TestConcreteSpecsByHash:
     @pytest.mark.parametrize(
         "input_specs", [["pkg-a"], ["pkg-a foobar=bar", "pkg-b"], ["pkg-a foobar=baz", "pkg-b"]]
     )
-    def test_adding_specs(self, input_specs, default_mock_concretization):
+    def test_adding_specs(self, input_specs, config, mock_packages):
         """Tests that concrete specs in the container are equivalent, but stored as different
         objects in memory.
         """
@@ -3600,11 +3600,9 @@ packages:
         ("gcc@14", ["gcc@14", "%c,cxx=gcc@10", "^gcc-runtime@10"]),
     ],
 )
-def test_compiler_can_depend_on_themselves_to_build(
-    spec_str, expected, default_mock_concretization
-):
+def test_compiler_can_depend_on_themselves_to_build(spec_str, expected, config, mock_packages):
     """Tests that a compiler can depend on "itself" to bootstrap."""
-    s = default_mock_concretization(spec_str)
+    s = spack.concretize.concretize_one(spec_str)
     assert not s.external
     for c in expected:
         assert s.satisfies(c)
@@ -3706,17 +3704,17 @@ packages:
     assert libelf.external and libelf.external_path == str(tmp_path / expected)
 
 
-def test_specifying_compilers_with_virtuals_syntax(default_mock_concretization):
+def test_specifying_compilers_with_virtuals_syntax(config, mock_packages):
     """Tests that we can pin compilers to nodes using the %[virtuals=...] syntax"""
     # clang will be used for both C and C++, since they are provided together
-    mpich = default_mock_concretization("mpich %[virtuals=fortran] gcc %clang")
+    mpich = spack.concretize.concretize_one("mpich %[virtuals=fortran] gcc %clang")
 
     assert mpich["fortran"].satisfies("gcc")
     assert mpich["c"].satisfies("llvm")
     assert mpich["cxx"].satisfies("llvm")
 
     # gcc is the default compiler
-    mpileaks = default_mock_concretization(
+    mpileaks = spack.concretize.concretize_one(
         "mpileaks ^libdwarf %gcc ^mpich %[virtuals=fortran] gcc %clang"
     )
 
@@ -3764,7 +3762,7 @@ def test_reuse_when_requiring_build_dep(install_mockery, mutable_config):
 
 
 @pytest.mark.regression("50167")
-def test_input_analysis_and_conditional_requirements(default_mock_concretization):
+def test_input_analysis_and_conditional_requirements(config, mock_packages):
     """Tests that input analysis doesn't account for conditional requirement
     to discard possible dependencies.
 
@@ -3772,7 +3770,7 @@ def test_input_analysis_and_conditional_requirements(default_mock_concretization
     platform, the valid search space is still the complement of the condition that
     activates the requirement.
     """
-    libceed = default_mock_concretization("libceed")
+    libceed = spack.concretize.concretize_one("libceed")
     assert libceed["libxsmm"].satisfies("@main")
     assert libceed["libxsmm"].satisfies("platform=test")
 
@@ -3895,9 +3893,9 @@ packages:
     assert s["c"].satisfies("languages=c,c++") and not s["c"].satisfies("languages=fortran")
 
 
-def test_concrete_multi_valued_in_input_specs(default_mock_concretization):
+def test_concrete_multi_valued_in_input_specs(config, mock_packages):
     """Tests that we can use := to specify exactly multivalued variants in input specs."""
-    s = default_mock_concretization("gcc languages:=fortran")
+    s = spack.concretize.concretize_one("gcc languages:=fortran")
     assert not s.external and s["c"].external
     assert s.satisfies("languages:=fortran")
     assert not s.satisfies("languages=c") and not s.satisfies("languages=c++")
@@ -3924,34 +3922,34 @@ packages:
     assert not s.satisfies("libs=shared")
 
 
-def test_concrete_multi_valued_variants_in_depends_on(default_mock_concretization):
+def test_concrete_multi_valued_variants_in_depends_on(config, mock_packages):
     """Tests the use of := in depends_on directives"""
     with pytest.raises(spack.solver.asp.UnsatisfiableSpecError):
-        default_mock_concretization("gmt-concrete-mv-dependency ^mvdefaults foo:=c")
-        default_mock_concretization("gmt-concrete-mv-dependency ^mvdefaults foo:=a,c")
-        default_mock_concretization("gmt-concrete-mv-dependency ^mvdefaults foo:=b,c")
+        spack.concretize.concretize_one("gmt-concrete-mv-dependency ^mvdefaults foo:=c")
+        spack.concretize.concretize_one("gmt-concrete-mv-dependency ^mvdefaults foo:=a,c")
+        spack.concretize.concretize_one("gmt-concrete-mv-dependency ^mvdefaults foo:=b,c")
 
-    s = default_mock_concretization("gmt-concrete-mv-dependency")
+    s = spack.concretize.concretize_one("gmt-concrete-mv-dependency")
     assert s.satisfies("^mvdefaults foo:=a,b"), s.tree()
     assert not s.satisfies("^mvdefaults foo=c")
 
 
-def test_concrete_multi_valued_variants_when_args(default_mock_concretization):
+def test_concrete_multi_valued_variants_when_args(config, mock_packages):
     """Tests the use of := in conflicts and when= arguments"""
     # Check conflicts("foo:=a,b", when="@0.9")
     with pytest.raises(spack.solver.asp.UnsatisfiableSpecError):
-        default_mock_concretization("mvdefaults@0.9 foo:=a,b")
+        spack.concretize.concretize_one("mvdefaults@0.9 foo:=a,b")
 
     for c in ("foo:=a", "foo:=a,b,c", "foo:=a,c", "foo:=b,c"):
-        s = default_mock_concretization(f"mvdefaults@0.9 {c}")
+        s = spack.concretize.concretize_one(f"mvdefaults@0.9 {c}")
         assert s.satisfies(c)
 
     # Check depends_on("pkg-b", when="foo:=b,c")
-    s = default_mock_concretization("mvdefaults foo:=b,c")
+    s = spack.concretize.concretize_one("mvdefaults foo:=b,c")
     assert s.satisfies("^pkg-b")
 
     for c in ("foo:=a", "foo:=a,b,c", "foo:=a,b", "foo:=a,c"):
-        s = default_mock_concretization(f"mvdefaults {c}")
+        s = spack.concretize.concretize_one(f"mvdefaults {c}")
         assert not s.satisfies("^pkg-b")
 
 
@@ -4143,11 +4141,9 @@ def test_use_compiler_by_hash(mock_packages, mutable_database, mutable_config):
         ("llvm-client %c,cxx=llvm", ["%[virtuals=c,cxx deptypes=build,link] llvm"], ["%gcc"]),
     ],
 )
-def test_specifying_direct_dependencies(
-    spec_str, expected, not_expected, default_mock_concretization
-):
+def test_specifying_direct_dependencies(spec_str, expected, not_expected, config, mock_packages):
     """Tests solving % in different scenarios, either for runtime or buildtime dependencies."""
-    concrete_spec = default_mock_concretization(spec_str)
+    concrete_spec = spack.concretize.concretize_one(spec_str)
 
     for c in expected:
         assert concrete_spec.satisfies(c)
@@ -4204,14 +4200,12 @@ def test_specifying_direct_dependencies(
         ),
     ],
 )
-def test_satisfies_conditional_spec(
-    spec_str, conditional_spec, expected, default_mock_concretization
-):
+def test_satisfies_conditional_spec(spec_str, conditional_spec, expected, config, mock_packages):
     """Tests satisfies semantic when testing an abstract spec and its concretized counterpart
     with a conditional spec.
     """
     abstract_spec = Spec(spec_str)
-    concrete_spec = default_mock_concretization(spec_str)
+    concrete_spec = spack.concretize.concretize_one(spec_str)
     expected_abstract, expected_concrete = expected
 
     assert abstract_spec.satisfies(conditional_spec) is expected_abstract
@@ -4345,12 +4339,12 @@ packages:
 
 
 @pytest.mark.regression("51146,51067")
-def test_caret_in_input_cannot_set_transitive_build_dependencies(default_mock_concretization):
+def test_caret_in_input_cannot_set_transitive_build_dependencies(config, mock_packages):
     """Tests that a caret in the input spec does not set transitive build dependencies, and errors
     with an appropriate message.
     """
     with pytest.raises(spack.solver.asp.UnsatisfiableSpecError, match="transitive 'link' or"):
-        _ = default_mock_concretization("multivalue-variant ^gmake")
+        _ = spack.concretize.concretize_one("multivalue-variant ^gmake")
 
 
 @pytest.mark.regression("51167")
@@ -5051,38 +5045,38 @@ def test_concrete_specs_skip_prechecks(config, mock_packages):
 
 
 @pytest.mark.regression("51683")
-def test_activating_variant_for_conditional_language_dependency(default_mock_concretization):
+def test_activating_variant_for_conditional_language_dependency(config, mock_packages):
     """Tests that a dependency on a conditional language can be concretized, and that the solver
     turn on the correct variant to enable the language dependency
     """
     # To trigger the bug, we need at least another node needing fortran, in this case mpich
-    s = default_mock_concretization("mpileaks %fortran=gcc %mpi=mpich")
+    s = spack.concretize.concretize_one("mpileaks %fortran=gcc %mpi=mpich")
     assert s.satisfies("+fortran")
 
     # Try just asking for fortran, without the provider
-    s = default_mock_concretization("mpileaks %fortran %mpi=mpich")
+    s = spack.concretize.concretize_one("mpileaks %fortran %mpi=mpich")
     assert s.satisfies("+fortran")
 
 
-def test_when_condition_with_direct_dependency_on_virtual_provider(default_mock_concretization):
+def test_when_condition_with_direct_dependency_on_virtual_provider(config, mock_packages):
     """If a when condition contains a direct dependency on a provider of a virtual, it should only
     trigger if the provider is used for that current package, and not if the provider happens to be
     a dependency, without its virtual being depended on."""
-    s = default_mock_concretization("direct-dep-virtuals-one")
+    s = spack.concretize.concretize_one("direct-dep-virtuals-one")
     assert s.satisfies("%netlib-blas")
     assert s["direct-dep-virtuals-two"].satisfies("%blas=netlib-blas")
 
 
-def test_conflict_with_direct_dependency_on_virtual_provider(default_mock_concretization):
+def test_conflict_with_direct_dependency_on_virtual_provider(config, mock_packages):
     """Test that conflicts on virtual providers as direct dependencies work"""
-    s = default_mock_concretization("conflict-virtual")
+    s = spack.concretize.concretize_one("conflict-virtual")
     assert s.satisfies("%blas=netlib-blas")
 
     with pytest.raises(spack.solver.asp.UnsatisfiableSpecError):
-        default_mock_concretization("conflict-virtual +conflict_direct")
+        spack.concretize.concretize_one("conflict-virtual +conflict_direct")
 
     with pytest.raises(spack.solver.asp.UnsatisfiableSpecError):
-        default_mock_concretization("conflict-virtual +conflict_transitive")
+        spack.concretize.concretize_one("conflict-virtual +conflict_transitive")
 
 
 def test_imposed_spec_dependency_duplication(mock_packages: spack.repo.Repo):
@@ -5119,13 +5113,11 @@ def test_imposed_spec_dependency_duplication(mock_packages: spack.repo.Repo):
         ("variant-function-validator generator=other", "generator=other %adios2+bzip2"),
     ],
 )
-def test_penalties_for_variant_defined_by_function(
-    default_mock_concretization, spec_str, expected
-):
+def test_penalties_for_variant_defined_by_function(config, mock_packages, spec_str, expected):
     """Tests that we have penalties for variants defined by functions, and that variant values
     are consistent with defaults and optimization rules.
     """
-    s = default_mock_concretization(spec_str)
+    s = spack.concretize.concretize_one(spec_str)
     assert s.satisfies(expected)
 
 

--- a/lib/spack/spack/test/concretization/flag_mixing.py
+++ b/lib/spack/spack/test/concretization/flag_mixing.py
@@ -295,11 +295,11 @@ def test_flag_injection_different_compilers(mock_packages, mutable_config):
         ),
     ],
 )
-def test_flags_and_duplicate_nodes(spec_str, expected, not_expected, default_mock_concretization):
+def test_flags_and_duplicate_nodes(spec_str, expected, not_expected, config, mock_packages):
     """Tests that we can concretize a spec with flags on a node that is present with duplicates
     in the DAG. For instance, a compiler built with a previous version of itself.
     """
-    s = default_mock_concretization(spec_str)
+    s = spack.concretize.concretize_one(spec_str)
     assert all(s.satisfies(x) for x in expected)
     assert all(not s.satisfies(x) for x in not_expected)
 

--- a/lib/spack/spack/test/concretization_cache_plugin.py
+++ b/lib/spack/spack/test/concretization_cache_plugin.py
@@ -34,9 +34,15 @@ _initial_entries = 0
 
 
 def cache_dir(config) -> Optional[str]:
-    """Absolute path of the persistent concretization cache, or None when disabled."""
+    """Absolute path of the persistent concretization cache, or None when disabled.
+
+    ``~`` and environment variables are expanded, so DIR can be given as e.g.
+    ``${RUNNER_TEMP}/cache`` and stay correct on Windows, where the temporary directory
+    lives on a different drive."""
     path = config.getoption("--spack-concretization-cache")
-    return os.path.abspath(os.path.expanduser(path)) if path else None
+    if not path:
+        return None
+    return os.path.abspath(os.path.expandvars(os.path.expanduser(path)))
 
 
 def pytest_addoption(parser):
@@ -49,7 +55,8 @@ def pytest_addoption(parser):
         help="enable a persistent concretization cache in DIR: tests whose concretization "
         "problem was already solved by an earlier test or pytest invocation skip the solver "
         "entirely. Entries are keyed by the full solver input, so DIR can be shared across "
-        "branches and CI runs (default: $SPACK_TEST_CONCRETIZATION_CACHE)",
+        "branches and CI runs. ~ and environment variables in DIR are expanded "
+        "(default: $SPACK_TEST_CONCRETIZATION_CACHE)",
     )
 
 

--- a/lib/spack/spack/test/conftest.py
+++ b/lib/spack/spack/test/conftest.py
@@ -22,7 +22,7 @@ import tempfile
 import textwrap
 import xml.etree.ElementTree
 from pathlib import Path
-from typing import Callable, List, Optional, Tuple, Union
+from typing import List, Optional, Tuple, Union
 
 import pytest
 
@@ -2323,34 +2323,6 @@ def binary_with_rpaths(prefix_tmpdir: Path):
         return executable
 
     return _factory
-
-
-@pytest.fixture(scope="session")
-def concretized_specs_cache():
-    """Cache for mock concrete specs"""
-    return {}
-
-
-@pytest.fixture
-def default_mock_concretization(
-    config, mock_packages, concretized_specs_cache
-) -> Callable[[str], spack.spec.Spec]:
-    """Return the default mock concretization of a spec literal, obtained using the mock
-    repository and the mock configuration.
-
-    This fixture is unsafe to call in a test when either the default configuration or mock
-    repository are not used or have been modified.
-    """
-
-    def _func(spec_str, tests=False):
-        key = spec_str, tests
-        if key not in concretized_specs_cache:
-            concretized_specs_cache[key] = spack.concretize.concretize_one(
-                spack.spec.Spec(spec_str), tests=tests
-            )
-        return concretized_specs_cache[key].copy()
-
-    return _func
 
 
 @pytest.fixture

--- a/lib/spack/spack/test/database.py
+++ b/lib/spack/spack/test/database.py
@@ -1204,13 +1204,11 @@ def test_database_construction_doesnt_use_globals(
     assert os.path.exists(db.database_directory)
 
 
-def test_database_read_works_with_trailing_data(
-    tmp_path: pathlib.Path, default_mock_concretization
-):
+def test_database_read_works_with_trailing_data(tmp_path: pathlib.Path, config, mock_packages):
     # Populate a database
     root = str(tmp_path)
     db = spack.database.Database(root, layout=None)
-    spec = default_mock_concretization("pkg-a")
+    spec = spack.concretize.concretize_one("pkg-a")
     db.add(spec)
     specs_in_db = db.query_local()
     assert spec in specs_in_db

--- a/lib/spack/spack/test/directory_layout.py
+++ b/lib/spack/spack/test/directory_layout.py
@@ -25,10 +25,10 @@ from spack.util.path import path_to_os_path
 max_packages = 10
 
 
-def test_yaml_directory_layout_parameters(tmp_path: pathlib.Path, default_mock_concretization):
+def test_yaml_directory_layout_parameters(tmp_path: pathlib.Path, config, mock_packages):
     """This tests the various parameters that can be used to configure
     the install location"""
-    spec = default_mock_concretization("python")
+    spec = spack.concretize.concretize_one("python")
 
     # Ensure default layout matches expected spec format
     layout_default = DirectoryLayout(str(tmp_path))
@@ -215,9 +215,9 @@ def test_find(temporary_store, config, mock_packages):
         assert found_specs[name].eq_dag(spec)
 
 
-def test_yaml_directory_layout_build_path(tmp_path: pathlib.Path, default_mock_concretization):
+def test_yaml_directory_layout_build_path(tmp_path: pathlib.Path, config, mock_packages):
     """This tests build path method."""
-    spec = default_mock_concretization("python")
+    spec = spack.concretize.concretize_one("python")
     layout = DirectoryLayout(str(tmp_path))
     rel_path = os.path.join(layout.metadata_dir, layout.packages_dir)
     assert layout.build_packages_path(spec) == os.path.join(spec.prefix, rel_path)

--- a/lib/spack/spack/test/git_fetch.py
+++ b/lib/spack/spack/test/git_fetch.py
@@ -85,7 +85,7 @@ def test_fetch(
     type_of_test,
     secure,
     mock_git_repository,
-    default_mock_concretization,
+    config,
     mutable_mock_repo,
     git_version,
     monkeypatch,
@@ -109,7 +109,7 @@ def test_fetch(
     monkeypatch.delattr(pkg_class, "git")
 
     # Construct the package under test
-    s = default_mock_concretization("git-test")
+    s = spack.concretize.concretize_one("git-test")
     monkeypatch.setitem(s.package.versions, Version("git"), t.args)
 
     if type_of_test == "commit":
@@ -144,7 +144,7 @@ def test_fetch(
 
 @pytest.mark.disable_clean_stage_check
 def test_fetch_pkg_attr_submodule_init(
-    mock_git_repository, default_mock_concretization, mutable_mock_repo, monkeypatch, mock_stage
+    mock_git_repository, config, mutable_mock_repo, monkeypatch, mock_stage
 ):
     """In this case the version() args do not contain a 'git' URL, so
     the fetcher must be assembled using the Package-level 'git' attribute.
@@ -159,7 +159,7 @@ def test_fetch_pkg_attr_submodule_init(
     monkeypatch.setattr(pkg_class, "git", mock_git_repository.url)
 
     # Construct the package under test
-    s = default_mock_concretization("git-test")
+    s = spack.concretize.concretize_one("git-test")
     monkeypatch.setitem(s.package.versions, Version("git"), t.args)
 
     s.package.do_stage()
@@ -206,15 +206,13 @@ def test_adhoc_version_submodules(
 
 
 @pytest.mark.parametrize("type_of_test", ["branch", "commit"])
-def test_debug_fetch(
-    mock_packages, type_of_test, mock_git_repository, default_mock_concretization, monkeypatch
-):
+def test_debug_fetch(mock_packages, type_of_test, mock_git_repository, config, monkeypatch):
     """Fetch the repo with debug enabled."""
     # Retrieve the right test parameters
     t = mock_git_repository.checks[type_of_test]
 
     # Construct the package under test
-    s = default_mock_concretization("git-test")
+    s = spack.concretize.concretize_one("git-test")
     monkeypatch.setitem(s.package.versions, Version("git"), t.args)
 
     # Fetch then ensure source path exists
@@ -251,7 +249,7 @@ def test_get_full_repo(
     use_commit,
     git_version,
     mock_git_repository,
-    default_mock_concretization,
+    config,
     mutable_mock_repo,
     monkeypatch,
 ):
@@ -270,7 +268,7 @@ def test_get_full_repo(
 
     spec_string = "git-test"
 
-    s = default_mock_concretization(spec_string)
+    s = spack.concretize.concretize_one(spec_string)
 
     args = copy.copy(t.args)
     args["get_full_repo"] = get_full_repo
@@ -326,9 +324,7 @@ def test_get_full_repo(
 
 @pytest.mark.disable_clean_stage_check
 @pytest.mark.parametrize("submodules", [True, False])
-def test_gitsubmodule(
-    submodules, mock_git_repository, default_mock_concretization, mutable_mock_repo, monkeypatch
-):
+def test_gitsubmodule(submodules, mock_git_repository, config, mutable_mock_repo, monkeypatch):
     """
     Test GitFetchStrategy behavior with submodules. This package
     has a `submodules` property which is always True: when a specific
@@ -341,7 +337,7 @@ def test_gitsubmodule(
     t = mock_git_repository.checks[type_of_test]
 
     # Construct the package under test
-    s = default_mock_concretization("git-test")
+    s = spack.concretize.concretize_one("git-test")
     args = copy.copy(t.args)
     args["submodules"] = submodules
     monkeypatch.setitem(s.package.versions, Version("git"), args)
@@ -359,9 +355,7 @@ def test_gitsubmodule(
 
 
 @pytest.mark.disable_clean_stage_check
-def test_gitsubmodules_callable(
-    mock_git_repository, default_mock_concretization, mutable_mock_repo, monkeypatch
-):
+def test_gitsubmodules_callable(mock_git_repository, config, mutable_mock_repo, monkeypatch):
     """
     Test GitFetchStrategy behavior with submodules selected after concretization
     """
@@ -375,7 +369,7 @@ def test_gitsubmodules_callable(
     t = mock_git_repository.checks[type_of_test]
 
     # Construct the package under test
-    s = default_mock_concretization("git-test")
+    s = spack.concretize.concretize_one("git-test")
     args = copy.copy(t.args)
     args["submodules"] = submodules_callback
     monkeypatch.setitem(s.package.versions, Version("git"), args)
@@ -388,9 +382,7 @@ def test_gitsubmodules_callable(
 
 
 @pytest.mark.disable_clean_stage_check
-def test_gitsubmodules_delete(
-    mock_git_repository, default_mock_concretization, mutable_mock_repo, monkeypatch
-):
+def test_gitsubmodules_delete(mock_git_repository, config, mutable_mock_repo, monkeypatch):
     """
     Test GitFetchStrategy behavior with submodules_delete
     """
@@ -398,7 +390,7 @@ def test_gitsubmodules_delete(
     t = mock_git_repository.checks[type_of_test]
 
     # Construct the package under test
-    s = default_mock_concretization("git-test")
+    s = spack.concretize.concretize_one("git-test")
     args = copy.copy(t.args)
     args["submodules"] = True
     args["submodules_delete"] = ["third_party/submodule0", "third_party/submodule1"]
@@ -412,9 +404,7 @@ def test_gitsubmodules_delete(
 
 
 @pytest.mark.disable_clean_stage_check
-def test_gitsubmodules_falsey(
-    mock_git_repository, default_mock_concretization, mutable_mock_repo, monkeypatch
-):
+def test_gitsubmodules_falsey(mock_git_repository, config, mutable_mock_repo, monkeypatch):
     """
     Test GitFetchStrategy behavior when callable submodules returns Falsey
     """
@@ -427,7 +417,7 @@ def test_gitsubmodules_falsey(
     t = mock_git_repository.checks[type_of_test]
 
     # Construct the package under test
-    s = default_mock_concretization("git-test")
+    s = spack.concretize.concretize_one("git-test")
     args = copy.copy(t.args)
     args["submodules"] = submodules_callback
     monkeypatch.setitem(s.package.versions, Version("git"), args)
@@ -441,7 +431,7 @@ def test_gitsubmodules_falsey(
 
 @pytest.mark.disable_clean_stage_check
 def test_git_sparse_paths_partial_clone(
-    mock_git_repository, git_version, default_mock_concretization, mutable_mock_repo, monkeypatch
+    mock_git_repository, git_version, config, mutable_mock_repo, monkeypatch
 ):
     """
     Test partial clone of repository when using git_sparse_paths property
@@ -452,7 +442,7 @@ def test_git_sparse_paths_partial_clone(
     t = mock_git_repository.checks[type_of_test]
     args = copy.copy(t.args)
     args["git_sparse_paths"] = sparse_paths
-    s = default_mock_concretization("git-test")
+    s = spack.concretize.concretize_one("git-test")
     monkeypatch.setitem(s.package.versions, Version("git"), args)
     s.package.do_stage()
     with working_dir(s.package.stage.source_path):
@@ -494,13 +484,11 @@ def test_git_sparse_path_have_unique_mirror_projections(
 
 
 @pytest.mark.disable_clean_stage_check
-def test_commit_variant_clone(
-    git, default_mock_concretization, mutable_mock_repo, mock_git_version_info, monkeypatch
-):
+def test_commit_variant_clone(git, config, mutable_mock_repo, mock_git_version_info, monkeypatch):
 
     repo_path, filename, commits = mock_git_version_info
     test_commit = commits[-2]
-    s = default_mock_concretization("git-test")
+    s = spack.concretize.concretize_one("git-test")
     args = {"git": pathlib.Path(repo_path).as_uri()}
     monkeypatch.setitem(s.package.versions, Version("git"), args)
     s.variants["commit"] = SingleValuedVariant("commit", test_commit)

--- a/lib/spack/spack/test/graph.py
+++ b/lib/spack/spack/test/graph.py
@@ -7,9 +7,9 @@ import spack.concretize
 import spack.graph
 
 
-def test_dynamic_dot_graph_mpileaks(default_mock_concretization):
+def test_dynamic_dot_graph_mpileaks(config, mock_packages):
     """Test dynamically graphing the mpileaks package."""
-    s = default_mock_concretization("mpileaks")
+    s = spack.concretize.concretize_one("mpileaks")
     stream = io.StringIO()
     spack.graph.graph_dot([s], out=stream)
     dot = stream.getvalue()

--- a/lib/spack/spack/test/multimethod.py
+++ b/lib/spack/spack/test/multimethod.py
@@ -66,10 +66,8 @@ def test_no_version_match(pkg_name):
         ("", "boolean_false_first", "True"),
     ],
 )
-def test_multimethod_calls(
-    pkg_name, constraint_str, method_name, expected_result, default_mock_concretization
-):
-    s = default_mock_concretization(f"{pkg_name}{constraint_str}")
+def test_multimethod_calls(pkg_name, constraint_str, method_name, expected_result):
+    s = spack.concretize.concretize_one(f"{pkg_name}{constraint_str}")
     msg = f"Method {method_name} from {s} is giving a wrong result"
     assert getattr(s.package, method_name)() == expected_result, msg
 

--- a/lib/spack/spack/test/old_installer.py
+++ b/lib/spack/spack/test/old_installer.py
@@ -648,9 +648,9 @@ def false(*args, **kwargs):
     return False
 
 
-def test_rewire_task_no_tarball(default_mock_concretization, monkeypatch):
-    spec = default_mock_concretization("splice-t")
-    dep = default_mock_concretization("splice-h+foo")
+def test_rewire_task_no_tarball(config, mock_packages, monkeypatch):
+    spec = spack.concretize.concretize_one("splice-t")
+    dep = spack.concretize.concretize_one("splice-h+foo")
     out = spec.splice(dep)
 
     rewire_task = inst.RewireTask(out.package, inst.BuildRequest(out.package, {}))

--- a/lib/spack/spack/test/package_class.py
+++ b/lib/spack/spack/test/package_class.py
@@ -317,9 +317,9 @@ def test_package_test_no_compilers(mock_packages, monkeypatch, capfd):
     assert "Skipping tests for package" in error
 
 
-def test_package_subscript(default_mock_concretization):
+def test_package_subscript(config, mock_packages):
     """Tests that we can use the subscript notation on packages, and that it returns a package"""
-    root = default_mock_concretization("mpileaks")
+    root = spack.concretize.concretize_one("mpileaks")
     root_pkg = root.package
 
     # Subscript of a virtual
@@ -330,8 +330,8 @@ def test_package_subscript(default_mock_concretization):
         assert isinstance(root_pkg[d.name], spack.package_base.PackageBase)
 
 
-def test_deserialize_preserves_package_attribute(default_mock_concretization):
-    x = default_mock_concretization("mpileaks").package
+def test_deserialize_preserves_package_attribute(config, mock_packages):
+    x = spack.concretize.concretize_one("mpileaks").package
     assert x.spec._package is x
 
     y = spack.subprocess_context.deserialize(spack.subprocess_context.serialize(x))
@@ -339,8 +339,8 @@ def test_deserialize_preserves_package_attribute(default_mock_concretization):
 
 
 @pytest.mark.require_provenance
-def test_git_provenance_commit_version(default_mock_concretization):
-    spec = default_mock_concretization("git-ref-package@stable")
+def test_git_provenance_commit_version(config, mock_packages):
+    spec = spack.concretize.concretize_one("git-ref-package@stable")
     assert spec.satisfies(f"commit={'c' * 40}")
 
 

--- a/lib/spack/spack/test/packaging.py
+++ b/lib/spack/spack/test/packaging.py
@@ -397,7 +397,7 @@ def mock_download(monkeypatch):
     "manual,instr", [(False, False), (False, True), (True, False), (True, True)]
 )
 @pytest.mark.disable_clean_stage_check
-def test_manual_download(mock_download, default_mock_concretization, monkeypatch, manual, instr):
+def test_manual_download(mock_download, config, mock_packages, monkeypatch, manual, instr):
     """
     Ensure expected fetcher fail message based on manual download and instr.
     """
@@ -406,7 +406,7 @@ def test_manual_download(mock_download, default_mock_concretization, monkeypatch
     def _instr(pkg):
         return f"Download instructions for {pkg.spec.name}"
 
-    spec = default_mock_concretization("pkg-a")
+    spec = spack.concretize.concretize_one("pkg-a")
     spec.package.manual_download = manual
     if instr:
         monkeypatch.setattr(spack.package_base.PackageBase, "download_instr", _instr)
@@ -428,16 +428,16 @@ def fetching_not_allowed(monkeypatch):
     monkeypatch.setattr(spack.package_base.PackageBase, "fetcher", FetchingNotAllowed())
 
 
-def test_fetch_without_code_is_noop(default_mock_concretization, fetching_not_allowed):
+def test_fetch_without_code_is_noop(config, mock_packages, fetching_not_allowed):
     """do_fetch for packages without code should be a no-op"""
-    pkg = default_mock_concretization("pkg-a").package
+    pkg = spack.concretize.concretize_one("pkg-a").package
     pkg.has_code = False
     pkg.do_fetch()
 
 
-def test_fetch_external_package_is_noop(default_mock_concretization, fetching_not_allowed):
+def test_fetch_external_package_is_noop(config, mock_packages, fetching_not_allowed):
     """do_fetch for packages without code should be a no-op"""
-    spec = default_mock_concretization("pkg-a")
+    spec = spack.concretize.concretize_one("pkg-a")
     spec.external_path = "/some/where"
     assert spec.external
     spec.package.do_fetch()

--- a/lib/spack/spack/test/sandbox.py
+++ b/lib/spack/spack/test/sandbox.py
@@ -15,6 +15,7 @@ import pathlib
 import tempfile
 from typing import List, Tuple
 
+import spack.concretize
 import spack.sandbox
 import spack.store
 from spack.installer.build import _enable_sandbox
@@ -136,16 +137,13 @@ class MockSandbox(spack.sandbox.Sandbox):
 
 
 def test_enable_sandbox_paths(
-    default_mock_concretization,
-    monkeypatch,
-    temporary_store: spack.store.Store,
-    tmp_path: pathlib.Path,
+    config, mock_packages, monkeypatch, temporary_store: spack.store.Store, tmp_path: pathlib.Path
 ):
     """Test that _enable_sandbox in the installer calls allow_read/allow_write correctly."""
     mock_sandbox = MockSandbox()
     monkeypatch.setattr(spack.sandbox, "get_sandbox", lambda: mock_sandbox)
 
-    spec = default_mock_concretization("dependent-install")
+    spec = spack.concretize.concretize_one("dependent-install")
 
     # Create prefix directories so resolved.exists() passes
     pathlib.Path(spec.prefix).mkdir(parents=True, exist_ok=True)

--- a/lib/spack/spack/test/spec_dag.py
+++ b/lib/spack/spack/test/spec_dag.py
@@ -382,7 +382,7 @@ class TestSpecDag:
             ),
         ],
     )
-    def test_traversal(self, pairs, traverse_kwargs, default_mock_concretization):
+    def test_traversal(self, pairs, traverse_kwargs):
         r"""Tests different traversals of the following graph
 
         o mpileaks@2.3/3qeg7jx
@@ -433,7 +433,7 @@ class TestSpecDag:
         |
         o glibc@2.31/tbyn33w
         """
-        dag = default_mock_concretization("mpileaks ^zmpi")
+        dag = spack.concretize.concretize_one("mpileaks ^zmpi")
         names = [x for _, x in pairs]
 
         traversal = dag.traverse(**traverse_kwargs, depth=True)
@@ -891,9 +891,7 @@ class TestSpecDag:
             ({"virtuals": ["lapack"]}, 0, []),
         ],
     )
-    def test_query_dependency_edges(
-        self, default_mock_concretization, query, expected_length, expected_satisfies
-    ):
+    def test_query_dependency_edges(self, query, expected_length, expected_satisfies):
         """Tests querying edges to dependencies on the following DAG:
 
          -   [    ]  mpileaks@2.3
@@ -905,15 +903,15 @@ class TestSpecDag:
          -   [ l  ]      ^gcc-runtime@10.1.0
          -   [bl  ]      ^mpich@3.0.4~debug
         """
-        mpileaks = default_mock_concretization("mpileaks")
+        mpileaks = spack.concretize.concretize_one("mpileaks")
         edges = mpileaks.edges_to_dependencies(**query)
         assert len(edges) == expected_length
         for constraint in expected_satisfies:
             assert any(x.spec.satisfies(constraint) for x in edges)
 
-    def test_query_dependents_edges(self, default_mock_concretization):
+    def test_query_dependents_edges(self):
         """Tests querying edges from dependents"""
-        mpileaks = default_mock_concretization("mpileaks")
+        mpileaks = spack.concretize.concretize_one("mpileaks")
         mpich = mpileaks["mpich"]
 
         # Recover the root with 2 different queries

--- a/lib/spack/spack/test/spec_semantics.py
+++ b/lib/spack/spack/test/spec_semantics.py
@@ -444,14 +444,14 @@ class TestSpecSemantics:
         assert set(propagated_lhs) <= _propagated_flags(c1)
         assert set(propagated_rhs) <= _propagated_flags(c2)
 
-    def test_constrain_specs_by_hash(self, default_mock_concretization, database):
+    def test_constrain_specs_by_hash(self, database):
         """Test that Specs specified only by their hashes can constrain each other."""
         mpich_dag_hash = "/" + database.query_one("mpich").dag_hash()
         spec = Spec(mpich_dag_hash[:7])
         assert spec.constrain(Spec(mpich_dag_hash)) is False
         assert spec.abstract_hash == mpich_dag_hash[1:]
 
-    def test_mismatched_constrain_spec_by_hash(self, default_mock_concretization, database):
+    def test_mismatched_constrain_spec_by_hash(self, database):
         """Test that Specs specified only by their incompatible hashes fail appropriately."""
         lhs = "/" + database.query_one("callpath ^mpich").dag_hash()
         rhs = "/" + database.query_one("callpath ^mpich2").dag_hash()
@@ -463,11 +463,11 @@ class TestSpecSemantics:
     @pytest.mark.parametrize(
         "lhs,rhs", [("libelf", Spec()), ("libelf", "@0:1"), ("libelf", "@0:1 %gcc")]
     )
-    def test_concrete_specs_which_satisfies_abstract(self, lhs, rhs, default_mock_concretization):
+    def test_concrete_specs_which_satisfies_abstract(self, lhs, rhs):
         """Test that constraining an abstract spec by a compatible concrete one makes the
         abstract spec concrete, and equal to the one it was constrained with.
         """
-        lhs, rhs = default_mock_concretization(lhs), Spec(rhs)
+        lhs, rhs = spack.concretize.concretize_one(lhs), Spec(rhs)
 
         assert lhs.intersects(rhs)
         assert rhs.intersects(lhs)
@@ -541,10 +541,8 @@ class TestSpecSemantics:
             ("multivalue-variant fee=bar", "multivalue-variant fee=baz"),
         ],
     )
-    def test_concrete_specs_which_do_not_satisfy_abstract(
-        self, lhs, rhs, default_mock_concretization
-    ):
-        lhs, rhs = default_mock_concretization(lhs), Spec(rhs)
+    def test_concrete_specs_which_do_not_satisfy_abstract(self, lhs, rhs):
+        lhs, rhs = spack.concretize.concretize_one(lhs), Spec(rhs)
 
         assert lhs.intersects(rhs) is False
         assert rhs.intersects(lhs) is False
@@ -560,8 +558,8 @@ class TestSpecSemantics:
     @pytest.mark.parametrize(
         "lhs,rhs", [("mpich", "mpich++foo"), ("mpich", "mpich~~foo"), ("mpich", "mpich foo==1")]
     )
-    def test_concrete_specs_which_satisfy_abstract(self, lhs, rhs, default_mock_concretization):
-        lhs, rhs = default_mock_concretization(lhs), Spec(rhs)
+    def test_concrete_specs_which_satisfy_abstract(self, lhs, rhs):
+        lhs, rhs = spack.concretize.concretize_one(lhs), Spec(rhs)
 
         assert lhs.intersects(rhs)
         assert rhs.intersects(lhs)
@@ -609,9 +607,9 @@ class TestSpecSemantics:
         c.constrain(lhs)
         assert c == constrained
 
-    def test_basic_satisfies_conditional_dep(self, default_mock_concretization):
+    def test_basic_satisfies_conditional_dep(self):
         """Tests basic semantic of satisfies with conditional dependencies, on a concrete spec"""
-        concrete = default_mock_concretization("mpileaks ^mpich")
+        concrete = spack.concretize.concretize_one("mpileaks ^mpich")
 
         # This branch exists, so the condition is met, and is satisfied
         assert concrete.satisfies("^[virtuals=mpi] mpich")
@@ -623,13 +621,11 @@ class TestSpecSemantics:
         assert concrete.satisfies("^[when='^notapackage'] zmpi")
         assert not concrete.satisfies("^[when='^mpi'] zmpi")
 
-    def test_concrete_satisfies_does_not_consult_repo(
-        self, default_mock_concretization, monkeypatch
-    ):
+    def test_concrete_satisfies_does_not_consult_repo(self, monkeypatch):
         """Tests that `satisfies()` on a concrete lhs doesn't need the provider index, when the rhs
         contains a virtual name.
         """
-        concrete = default_mock_concretization("mpileaks ^mpich")
+        concrete = spack.concretize.concretize_one("mpileaks ^mpich")
 
         # Reset the index, will raise if the `_provider_index` is ever removed as an attribute
         monkeypatch.setattr(spack.repo.PATH, "_provider_index", None)
@@ -658,13 +654,11 @@ class TestSpecSemantics:
         # We should not create again the index
         assert spack.repo.PATH._provider_index is None
 
-    def test_concrete_contains_does_not_consult_repo(
-        self, default_mock_concretization, monkeypatch
-    ):
+    def test_concrete_contains_does_not_consult_repo(self, monkeypatch):
         """Tests that `foo in spec` on a concrete spec doesn't need the provider index, when the
         item contains a virtual name.
         """
-        concrete = default_mock_concretization("mpileaks ^mpich")
+        concrete = spack.concretize.concretize_one("mpileaks ^mpich")
 
         # Reset the index, will raise if the `_provider_index` is ever removed as an attribute
         monkeypatch.setattr(spack.repo.PATH, "_provider_index", None)
@@ -685,11 +679,9 @@ class TestSpecSemantics:
         assert Spec("mpileaks %[virtuals=mpi] mpich").satisfies("mpileaks ^mpi")
         assert Spec("mpileaks %[virtuals=mpi] mpich").satisfies("mpileaks %mpi")
 
-    def test_concrete_checks_on_virtual_names_dont_need_repo(
-        self, default_mock_concretization, monkeypatch
-    ):
+    def test_concrete_checks_on_virtual_names_dont_need_repo(self, monkeypatch):
         """Tests that ``%mpi`` or similar on a concrete spec doesn't need the repo"""
-        concrete = default_mock_concretization("mpileaks ^mpich")
+        concrete = spack.concretize.concretize_one("mpileaks ^mpich")
 
         # We don't need the repo
         monkeypatch.setattr(spack.repo, "PATH", None)
@@ -754,11 +746,11 @@ class TestSpecSemantics:
         with pytest.raises(spack.spec_parser.SpecParsingError, match="Propagation"):
             Spec(spec_string)
 
-    def test_multivalued_variant_1(self, default_mock_concretization):
+    def test_multivalued_variant_1(self):
         # Semantics for a multi-valued variant is different
         # Depending on whether the spec is concrete or not
 
-        a = default_mock_concretization("multivalue-variant foo=bar")
+        a = spack.concretize.concretize_one("multivalue-variant foo=bar")
         b = Spec("multivalue-variant foo=bar,baz")
         assert not a.satisfies(b)
 
@@ -770,8 +762,8 @@ class TestSpecSemantics:
         # An abstract spec can instead be constrained
         assert a.constrain(b)
 
-    def test_multivalued_variant_3(self, default_mock_concretization):
-        a = default_mock_concretization("multivalue-variant foo=bar,baz")
+    def test_multivalued_variant_3(self):
+        a = spack.concretize.concretize_one("multivalue-variant foo=bar,baz")
         b = Spec("multivalue-variant foo=bar,baz,quux")
         assert not a.satisfies(b)
 
@@ -849,9 +841,9 @@ class TestSpecSemantics:
         s = Spec("callpath")
         assert s["callpath"] == s
 
-    def test_dep_index(self, default_mock_concretization):
+    def test_dep_index(self):
         """Tests __getitem__ and __contains__ for specs."""
-        s = default_mock_concretization("callpath")
+        s = spack.concretize.concretize_one("callpath")
 
         assert s["callpath"] == s
 
@@ -954,8 +946,8 @@ class TestSpecSemantics:
         with pytest.raises(ValueError):
             Spec("libelf foo")
 
-    def test_spec_formatting(self, default_mock_concretization):
-        spec = default_mock_concretization("multivalue-variant cflags=-O2")
+    def test_spec_formatting(self):
+        spec = spack.concretize.concretize_one("multivalue-variant cflags=-O2")
 
         # Testing named strings ie {string} and whether we get
         # the correct component
@@ -1061,8 +1053,8 @@ class TestSpecSemantics:
         spec = spack.spec.Spec()
         assert spec.format(fmt_str) == ""
 
-    def test_spec_formatting_spaces_in_key(self, default_mock_concretization):
-        spec = default_mock_concretization("multivalue-variant cflags=-O2")
+    def test_spec_formatting_spaces_in_key(self):
+        spec = spack.concretize.concretize_one("multivalue-variant cflags=-O2")
 
         # test that spaces are preserved, if they come after some other text, otherwise
         # they are trimmed.
@@ -1075,8 +1067,8 @@ class TestSpecSemantics:
     @pytest.mark.parametrize(
         "fmt_str", ["{@name}", "{@version.concrete}", "{%compiler.version}", "{/hashd}"]
     )
-    def test_spec_formatting_sigil_mismatches(self, default_mock_concretization, fmt_str):
-        spec = default_mock_concretization("multivalue-variant cflags=-O2")
+    def test_spec_formatting_sigil_mismatches(self, fmt_str):
+        spec = spack.concretize.concretize_one("multivalue-variant cflags=-O2")
 
         with pytest.raises(SpecFormatSigilError):
             spec.format(fmt_str)
@@ -1097,8 +1089,8 @@ class TestSpecSemantics:
             r"{variants.this_variant_does_not_exist}",
         ],
     )
-    def test_spec_formatting_bad_formats(self, default_mock_concretization, fmt_str):
-        spec = default_mock_concretization("multivalue-variant cflags=-O2")
+    def test_spec_formatting_bad_formats(self, fmt_str):
+        spec = spack.concretize.concretize_one("multivalue-variant cflags=-O2")
         with pytest.raises(SpecFormatStringError):
             spec.format(fmt_str)
 
@@ -1165,11 +1157,11 @@ class TestSpecSemantics:
         assert spec.target < "broadwell"
 
     @pytest.mark.parametrize("transitive", [True, False])
-    def test_splice(self, transitive, default_mock_concretization):
+    def test_splice(self, transitive):
         # Tests the new splice function in Spec using a somewhat simple case
         # with a variant with a conditional dependency.
-        spec = default_mock_concretization("splice-t")
-        dep = default_mock_concretization("splice-h+foo")
+        spec = spack.concretize.concretize_one("splice-t")
+        dep = spack.concretize.concretize_one("splice-h+foo")
 
         # Sanity checking that these are not the same thing.
         assert dep.dag_hash() != spec["splice-h"].dag_hash()
@@ -1350,9 +1342,9 @@ class TestSpecSemantics:
                 assert edge.depflag == depflag
 
     @pytest.mark.parametrize("transitive", [True, False])
-    def test_splice_with_cached_hashes(self, default_mock_concretization, transitive):
-        spec = default_mock_concretization("splice-t")
-        dep = default_mock_concretization("splice-h+foo")
+    def test_splice_with_cached_hashes(self, transitive):
+        spec = spack.concretize.concretize_one("splice-t")
+        dep = spack.concretize.concretize_one("splice-h+foo")
 
         # monkeypatch hashes so we can test that they are cached
         spec._hash = "aaaaaa"
@@ -1369,9 +1361,9 @@ class TestSpecSemantics:
         assert out["splice-z"].dag_hash() == out_z_expected.dag_hash()
 
     @pytest.mark.parametrize("transitive", [True, False])
-    def test_splice_input_unchanged(self, default_mock_concretization, transitive):
-        spec = default_mock_concretization("splice-t")
-        dep = default_mock_concretization("splice-h+foo")
+    def test_splice_input_unchanged(self, transitive):
+        spec = spack.concretize.concretize_one("splice-t")
+        dep = spack.concretize.concretize_one("splice-h+foo")
         orig_spec_hash = spec.dag_hash()
         orig_dep_hash = dep.dag_hash()
         spec.splice(dep, transitive)
@@ -1381,13 +1373,13 @@ class TestSpecSemantics:
         assert dep.dag_hash() == orig_dep_hash
 
     @pytest.mark.parametrize("transitive", [True, False])
-    def test_splice_subsequent(self, default_mock_concretization, transitive):
-        spec = default_mock_concretization("splice-t")
-        dep = default_mock_concretization("splice-h+foo")
+    def test_splice_subsequent(self, transitive):
+        spec = spack.concretize.concretize_one("splice-t")
+        dep = spack.concretize.concretize_one("splice-h+foo")
         out = spec.splice(dep, transitive)
 
         # Now we attempt a second splice.
-        dep = default_mock_concretization("splice-z+bar")
+        dep = spack.concretize.concretize_one("splice-z+bar")
 
         # Transitivity shouldn't matter since Splice Z has no dependencies.
         out2 = out.splice(dep, transitive)
@@ -1398,9 +1390,9 @@ class TestSpecSemantics:
         assert out2.spliced
 
     @pytest.mark.parametrize("transitive", [True, False])
-    def test_splice_dict(self, default_mock_concretization, transitive):
-        spec = default_mock_concretization("splice-t")
-        dep = default_mock_concretization("splice-h+foo")
+    def test_splice_dict(self, transitive):
+        spec = spack.concretize.concretize_one("splice-t")
+        dep = spack.concretize.concretize_one("splice-h+foo")
         out = spec.splice(dep, transitive)
 
         # Sanity check all hashes are unique...
@@ -1415,9 +1407,9 @@ class TestSpecSemantics:
         assert len(build_spec_nodes) == 1
 
     @pytest.mark.parametrize("transitive", [True, False])
-    def test_splice_dict_roundtrip(self, default_mock_concretization, transitive):
-        spec = default_mock_concretization("splice-t")
-        dep = default_mock_concretization("splice-h+foo")
+    def test_splice_dict_roundtrip(self, transitive):
+        spec = spack.concretize.concretize_one("splice-t")
+        dep = spack.concretize.concretize_one("splice-h+foo")
         out = spec.splice(dep, transitive)
 
         # Sanity check all hashes are unique...
@@ -1480,17 +1472,17 @@ class TestSpecSemantics:
         assert s.satisfies("mpileaks ^zmpi ^fake")
 
     @pytest.mark.parametrize("transitive", [True, False])
-    def test_splice_swap_names(self, default_mock_concretization, transitive):
-        spec = default_mock_concretization("splice-vt")
-        dep = default_mock_concretization("splice-a+foo")
+    def test_splice_swap_names(self, transitive):
+        spec = spack.concretize.concretize_one("splice-vt")
+        dep = spack.concretize.concretize_one("splice-a+foo")
         out = spec.splice(dep, transitive)
         assert dep.name in out
         assert transitive == ("+foo" in out["splice-z"])
 
     @pytest.mark.parametrize("transitive", [True, False])
-    def test_splice_swap_names_mismatch_virtuals(self, default_mock_concretization, transitive):
-        vt = default_mock_concretization("splice-vt")
-        vh = default_mock_concretization("splice-vh+foo")
+    def test_splice_swap_names_mismatch_virtuals(self, transitive):
+        vt = spack.concretize.concretize_one("splice-vt")
+        vh = spack.concretize.concretize_one("splice-vh+foo")
         with pytest.raises(spack.spec.SpliceError, match="virtual"):
             vt.splice(vh, transitive)
 
@@ -1604,8 +1596,8 @@ class TestSpecSemantics:
             ),
         ],
     )
-    def test_virtual_deps_bindings(self, default_mock_concretization, spec_str, specs_in_dag):
-        s = default_mock_concretization(spec_str)
+    def test_virtual_deps_bindings(self, spec_str, specs_in_dag):
+        s = spack.concretize.concretize_one(spec_str)
         for label, expected in specs_in_dag:
             assert label in s
             assert s[label].satisfies(expected), label
@@ -1646,15 +1638,13 @@ class TestSpecSemantics:
             ),
         ],
     )
-    def test_conditional_dependencies_satisfies(
-        self, spec_str, abstract_tests, concrete_tests, default_mock_concretization
-    ):
+    def test_conditional_dependencies_satisfies(self, spec_str, abstract_tests, concrete_tests):
         """Tests satisfaction semantics for conditional specs, in different scenarios."""
         s = Spec(spec_str)
         for c, result in abstract_tests:
             assert s.satisfies(c) is result
 
-        concrete = default_mock_concretization(spec_str)
+        concrete = spack.concretize.concretize_one(spec_str)
         for c, result in concrete_tests:
             assert concrete.satisfies(c) is result
 
@@ -1801,7 +1791,7 @@ def test_merge_anonymous_spec_with_named_spec(anonymous, named, expected):
     assert s == Spec(expected)
 
 
-def test_spec_installed(default_mock_concretization, database):
+def test_spec_installed(database):
     """Test whether Database.installed works."""
     # a known installed spec should say that it's installed
     specs = database.query()
@@ -1814,14 +1804,14 @@ def test_spec_installed(default_mock_concretization, database):
     assert not database.installed(spec)
 
     # pkg-a is not in the mock DB and is not installed
-    spec = default_mock_concretization("pkg-a")
+    spec = spack.concretize.concretize_one("pkg-a")
     assert not database.installed(spec)
 
 
 @pytest.mark.regression("30678")
-def test_call_dag_hash_on_old_dag_hash_spec(mock_packages, default_mock_concretization):
+def test_call_dag_hash_on_old_dag_hash_spec(mock_packages, config):
     # create a concrete spec
-    a = default_mock_concretization("pkg-a")
+    a = spack.concretize.concretize_one("pkg-a")
     dag_hashes = {spec.name: spec.dag_hash() for spec in a.traverse()}
 
     # make it look like an old DAG hash spec with no package hash on the spec.
@@ -1881,9 +1871,9 @@ def test_concretize_partial_old_dag_hash_spec(mock_packages, config):
     assert not getattr(spec["dt-diamond-bottom"], "_package_hash", None)
 
 
-def test_package_hash_affects_dunder_and_dag_hash(mock_packages, default_mock_concretization):
-    a1 = default_mock_concretization("pkg-a")
-    a2 = default_mock_concretization("pkg-a")
+def test_package_hash_affects_dunder_and_dag_hash(mock_packages, config):
+    a1 = spack.concretize.concretize_one("pkg-a")
+    a2 = spack.concretize.concretize_one("pkg-a")
 
     assert hash(a1) == hash(a2)
     assert a1.dag_hash() == a2.dag_hash()
@@ -1901,11 +1891,11 @@ def test_package_hash_affects_dunder_and_dag_hash(mock_packages, default_mock_co
     assert a1.dag_hash() != a2.dag_hash()
 
 
-def test_intersects_and_satisfies_on_concretized_spec(default_mock_concretization):
+def test_intersects_and_satisfies_on_concretized_spec(config, mock_packages):
     """Test that a spec obtained by concretizing an abstract spec, satisfies the abstract spec
     but not vice-versa.
     """
-    a1 = default_mock_concretization("pkg-a@1.0")
+    a1 = spack.concretize.concretize_one("pkg-a@1.0")
     a2 = Spec("pkg-a@1.0")
 
     assert a1.intersects(a2)
@@ -1924,8 +1914,8 @@ def test_intersects_and_satisfies_on_concretized_spec(default_mock_concretizatio
     ],
 )
 @pytest.mark.regression("35597")
-def test_abstract_provider_in_spec(abstract_spec, spec_str, default_mock_concretization):
-    s = default_mock_concretization(spec_str)
+def test_abstract_provider_in_spec(abstract_spec, spec_str, config, mock_packages):
+    s = spack.concretize.concretize_one(spec_str)
     assert abstract_spec in s
 
 
@@ -2070,8 +2060,8 @@ def test_constrain_dependencies_copies(mock_packages):
     assert y == Spec("^foo")
 
 
-def test_abstract_hash_intersects_and_satisfies(default_mock_concretization):
-    concrete: Spec = default_mock_concretization("pkg-a")
+def test_abstract_hash_intersects_and_satisfies(config, mock_packages):
+    concrete: Spec = spack.concretize.concretize_one("pkg-a")
     hash = concrete.dag_hash()
     hash_5 = hash[:5]
     hash_6 = hash[:6]
@@ -2148,7 +2138,7 @@ def test_virtual_queries_work_for_strings_and_lists():
         assert parent.edges_to_dependencies(virtuals=[lang])  # string arg
 
 
-def test_old_format_strings_trigger_error(default_mock_concretization):
+def test_old_format_strings_trigger_error(config, mock_packages):
     s = spack.concretize.concretize_one("pkg-a")
     with pytest.raises(SpecFormatStringError):
         s.format("${PACKAGE}-${VERSION}-${HASH}")
@@ -2335,7 +2325,7 @@ def test_comparison_after_breaking_hash_change():
     assert len({x, y}) == 2
 
 
-def test_satisfies_and_subscript_with_compilers(default_mock_concretization):
+def test_satisfies_and_subscript_with_compilers(config, mock_packages):
     """Tests the semantic of "satisfies" and __getitem__ for the following spec:
 
     [    ]  multivalue-variant@2.3
@@ -2350,7 +2340,7 @@ def test_satisfies_and_subscript_with_compilers(default_mock_concretization):
     [b   ]          ^gmake@4.4
     [bl  ]          ^pkg-b@1.0
     """
-    s = default_mock_concretization("multivalue-variant")
+    s = spack.concretize.concretize_one("multivalue-variant")
 
     # Check a direct build/link dependency
     assert s.satisfies("^pkg-a")
@@ -2388,11 +2378,9 @@ def test_satisfies_and_subscript_with_compilers(default_mock_concretization):
         ("pkg-c", "{name}-{compiler.name}-{compiler.version}", "pkg-c-none-none"),
     ],
 )
-def test_spec_format_with_compiler_adaptors(
-    spec_str, spec_fmt, expected, default_mock_concretization
-):
+def test_spec_format_with_compiler_adaptors(spec_str, spec_fmt, expected, config, mock_packages):
     """Tests the output of spec format, when involving `Spec.compiler` adaptors"""
-    s = default_mock_concretization(spec_str)
+    s = spack.concretize.concretize_one(spec_str)
     assert s.format(spec_fmt) == expected
 
 
@@ -2578,9 +2566,9 @@ def test_specs_semantics_on_self(spec_str, mock_packages, config):
         ("mpileaks+debug", "@_R{+debug}"),
     ],
 )
-def test_highlighting_spec_parts(spec_str, expected_fmt, default_mock_concretization):
+def test_highlighting_spec_parts(spec_str, expected_fmt, config, mock_packages):
     """Tests correct highlighting of non-default versions and variants"""
-    s = default_mock_concretization(spec_str)
+    s = spack.concretize.concretize_one(spec_str)
     expected = colorize(expected_fmt, color=True)
     colorized_str = s.format(
         color=True,
@@ -2591,11 +2579,11 @@ def test_highlighting_spec_parts(spec_str, expected_fmt, default_mock_concretiza
 
 
 @pytest.mark.parametrize("spec_str", ["mpileaks", "mpileaks ^zmpi"])
-def test_mark_concrete_roundtrip_preserves_hashes(spec_str, default_mock_concretization):
+def test_mark_concrete_roundtrip_preserves_hashes(spec_str, config, mock_packages):
     """Tests that clearing concreteness and re-finalizing a spec must preserve the DAG hash of the
     root and of every transitive dependency.
     """
-    s = default_mock_concretization(spec_str)
+    s = spack.concretize.concretize_one(spec_str)
 
     # Record the DAG hash of every node in the DAG (root and transitive dependencies).
     original = {node.name: node.dag_hash() for node in s.traverse()}

--- a/lib/spack/spack/test/spec_syntax.py
+++ b/lib/spack/spack/test/spec_syntax.py
@@ -62,9 +62,9 @@ def dependency_with_version(text):
 
 
 @pytest.fixture()
-def specfile_for(default_mock_concretization):
+def specfile_for(config, mock_packages):
     def _specfile_for(spec_str, filename):
-        s = default_mock_concretization(spec_str)
+        s = spack.concretize.concretize_one(spec_str)
         is_json = str(filename).endswith(".json")
         is_yaml = str(filename).endswith(".yaml")
         if not is_json and not is_yaml:
@@ -1642,9 +1642,9 @@ def test_parse_filename_missing_slash_as_spec(specfile_for, tmp_path: pathlib.Pa
     )
 
 
-def test_parse_specfile_dependency(default_mock_concretization, tmp_path: pathlib.Path):
+def test_parse_specfile_dependency(config, mock_packages, tmp_path: pathlib.Path):
     """Ensure we can use a specfile as a dependency"""
-    s = default_mock_concretization("libdwarf")
+    s = spack.concretize.concretize_one("libdwarf")
 
     specfile = tmp_path / "libelf.json"
     with open(specfile, "w", encoding="utf-8") as f:

--- a/lib/spack/spack/test/spec_yaml.py
+++ b/lib/spack/spack/test/spec_yaml.py
@@ -102,10 +102,10 @@ def test_invalid_json_spec(invalid_json, error_message):
         "mpileaks",
     ],
 )
-def test_roundtrip_concrete_specs(abstract_spec, default_mock_concretization):
+def test_roundtrip_concrete_specs(abstract_spec, config, mock_packages):
     check_yaml_round_trip(Spec(abstract_spec))
     check_json_round_trip(Spec(abstract_spec))
-    concrete_spec = default_mock_concretization(abstract_spec)
+    concrete_spec = spack.concretize.concretize_one(abstract_spec)
     check_yaml_round_trip(concrete_spec)
     check_json_round_trip(concrete_spec)
 
@@ -121,7 +121,7 @@ def test_yaml_subdag(config, mock_packages):
 
 
 @pytest.mark.parametrize("spec_str", ["mpileaks ^zmpi", "dttop", "dtuse"])
-def test_using_ordered_dict(default_mock_concretization, spec_str):
+def test_using_ordered_dict(config, mock_packages, spec_str):
     """Checks that we use syaml_dicts for spec serialization.
 
     Necessary to make sure that dag_hash is stable across python
@@ -140,7 +140,7 @@ def test_using_ordered_dict(default_mock_concretization, spec_str):
                     max_level = nlevel
         return max_level
 
-    s = default_mock_concretization(spec_str)
+    s = spack.concretize.concretize_one(spec_str)
     level = descend_and_check(s.to_node_dict())
     # level just makes sure we are doing something here
     assert level >= 5
@@ -542,14 +542,14 @@ def test_specfile_alias_is_updated():
 
 
 @pytest.mark.parametrize("spec_str", ["mpileaks %gcc", "mpileaks ^zmpi ^callpath%gcc"])
-def test_direct_edges_and_round_tripping_to_dict(spec_str, default_mock_concretization):
+def test_direct_edges_and_round_tripping_to_dict(spec_str, config, mock_packages):
     """Tests that we preserve edge information when round-tripping to dict"""
     original = Spec(spec_str)
     reconstructed = Spec.from_dict(original.to_dict())
     assert original == reconstructed
     assert original.to_dict() == reconstructed.to_dict()
 
-    concrete = default_mock_concretization(spec_str)
+    concrete = spack.concretize.concretize_one(spec_str)
     concrete_reconstructed = Spec.from_dict(concrete.to_dict())
     assert concrete == concrete_reconstructed
     assert concrete.to_dict() == concrete_reconstructed.to_dict()
@@ -563,10 +563,10 @@ def test_direct_edges_and_round_tripping_to_dict(spec_str, default_mock_concreti
             assert "direct" not in dependency_data["parameters"]
 
 
-def test_pickle_preserves_identity_and_prefix(default_mock_concretization):
+def test_pickle_preserves_identity_and_prefix(config, mock_packages):
     """When pickling multiple specs that share dependencies, the identity of those dependencies
     should be preserved when unpickling."""
-    mpileaks_before: Spec = default_mock_concretization("mpileaks")
+    mpileaks_before: Spec = spack.concretize.concretize_one("mpileaks")
     callpath_before = mpileaks_before.dependencies("callpath")[0]
     callpath_before.set_prefix("/fake/prefix/callpath")
     specs_before = [mpileaks_before, callpath_before]

--- a/lib/spack/spack/test/url_fetch.py
+++ b/lib/spack/spack/test/url_fetch.py
@@ -158,14 +158,7 @@ if sys.platform != "win32":
 @pytest.mark.parametrize("secure", [True, False])
 @pytest.mark.parametrize("_fetch_method", ["curl", "urllib"])
 @pytest.mark.parametrize("mock_archive", files, indirect=True)
-def test_fetch(
-    mock_archive,
-    secure,
-    _fetch_method,
-    checksum_type,
-    default_mock_concretization,
-    mutable_mock_repo,
-):
+def test_fetch(mock_archive, secure, _fetch_method, checksum_type, config, mutable_mock_repo):
     """Fetch an archive and make sure we can checksum it."""
     algo = crypto.hash_fun_for_algo(checksum_type)()
     with open(mock_archive.archive_file, "rb") as f:
@@ -173,7 +166,7 @@ def test_fetch(
     checksum = algo.hexdigest()
 
     # Get a spec and tweak the test package with new checksum params
-    s = default_mock_concretization("url-test")
+    s = spack.concretize.concretize_one("url-test")
     s.package.url = mock_archive.url
     s.package.versions[spack.version.Version("test")] = {
         checksum_type: checksum,


### PR DESCRIPTION
`default_mock_concretization` caches input spec -> concrete spec without taking
into account changes in config. Use the proper concretization cache instead,
which also works across xdist processes.

We could consider to make the cache persistent in GitHub Actions, but that's out of
scope for this PR.

