### PR TITLE
Respect lock configuration for prefix locks

### DIFF
--- a/lib/spack/spack/database.py
+++ b/lib/spack/spack/database.py
@@ -332,9 +332,12 @@ def failures_lock_path(root_dir: Union[str, pathlib.Path]) -> pathlib.Path:
 class SpecLocker:
     """Manages acquiring and releasing read or write locks on concrete specs."""
 
-    def __init__(self, lock_path: Union[str, pathlib.Path], default_timeout: Optional[float]):
+    def __init__(
+        self, lock_path: Union[str, pathlib.Path], default_timeout: Optional[float], enable: bool = True
+    ):
         self.lock_path = pathlib.Path(lock_path)
         self.default_timeout = default_timeout
+        self.enable = enable
 
         # Maps (spec.dag_hash(), spec.name) to the corresponding lock object
         self.locks: Dict[Tuple[str, str], lk.Lock] = {}
@@ -369,6 +372,7 @@ class SpecLocker:
             length=1,
             default_timeout=timeout,
             desc=spec.name,
+            enable=self.enable,
         )
 
     def has_lock(self, spec: "spack.spec.Spec") -> bool:
@@ -428,11 +432,15 @@ class FailureTracker:
     #: File for locking particular concrete spec hashes
     locker: SpecLocker
 
-    def __init__(self, root_dir: Union[str, pathlib.Path], default_timeout: Optional[float]):
+    def __init__(
+        self, root_dir: Union[str, pathlib.Path], default_timeout: Optional[float], enable: bool = True
+    ):
         #: Ensure a persistent location for dealing with parallel installation
         #: failures (e.g., across near-concurrent processes).
         self.dir = pathlib.Path(root_dir) / _DB_DIRNAME / "failures"
-        self.locker = SpecLocker(failures_lock_path(root_dir), default_timeout=default_timeout)
+        self.locker = SpecLocker(
+            failures_lock_path(root_dir), default_timeout=default_timeout, enable=enable
+        )
 
     def _ensure_parent_directories(self) -> None:
         """Ensure that parent directories of the FailureTracker exist.

--- a/lib/spack/spack/store.py
+++ b/lib/spack/spack/store.py
@@ -185,10 +185,12 @@ class Store:
         tty.debug("PACKAGE LOCK TIMEOUT: {0}".format(str(timeout_format_str)))
 
         self.prefix_locker = spack.database.SpecLocker(
-            spack.database.prefix_lock_path(root), default_timeout=lock_cfg.package_timeout
+            spack.database.prefix_lock_path(root),
+            default_timeout=lock_cfg.package_timeout,
+            enable=lock_cfg.enable,
         )
         self.failure_tracker = spack.database.FailureTracker(
-            self.root, default_timeout=lock_cfg.package_timeout
+            self.root, default_timeout=lock_cfg.package_timeout, enable=lock_cfg.enable
         )
 
     def has_padding(self) -> bool:

--- a/lib/spack/spack/test/database.py
+++ b/lib/spack/spack/test/database.py
@@ -1231,6 +1231,16 @@ def test_database_construction_doesnt_use_globals(
     assert os.path.exists(db.database_directory)
 
 
+def test_store_disables_prefix_and_failure_locks(tmp_path: pathlib.Path):
+    """The no-lock configuration applies to every lock used by the store."""
+    store = spack.store.Store(str(tmp_path), lock_cfg=spack.database.NO_LOCK)
+    spec = spack.spec.Spec("pkg-a")
+    spec._mark_concrete()
+
+    assert isinstance(store.prefix_locker.lock(spec).backend, lk.DummyBackend)
+    assert isinstance(store.failure_tracker.locker.lock(spec).backend, lk.DummyBackend)
+
+
 def test_database_read_works_with_trailing_data(
     tmp_path: pathlib.Path, default_mock_concretization
 ):


### PR DESCRIPTION
## Summary

When `config:locks:false` (or `spack --disable-locks`) is used, Spack disables database locks but still creates enabled per-spec prefix locks and failure-tracker locks.

This causes installs to fail on filesystems where POSIX file locking is unavailable, even though locking was explicitly disabled.

Propagate the store lock configuration to `SpecLocker` and `FailureTracker` so all locks created by a no-lock store use the no-op lock backend.

## Testing

Added a regression test verifying that a store created with `spack.database.NO_LOCK` uses no-op backends for both prefix and failure-tracker locks.

```console
PYTHONPATH=lib/spack \
  /usr/local/other/GEOSpyD/26.3.2-0/2026-05-11/envs/py3.14/bin/python3 \
  -m pytest lib/spack/spack/test/database.py \
  -k store_disables_prefix_and_failure_locks -q

Result: 1 passed, 71 deselected.

## AI assistance

This patch was developed with a *lot* of assistance from GPT-5.6 Terra. The author reviewed the change and ran the regression test above.

All this was found when I was trying to build spack on a cluster and it was throwing a lot of Errno 37.