### PR TITLE
Fix spack isolate --self

### DIFF
--- a/lib/spack/spack/cmd/isolate.py
+++ b/lib/spack/spack/cmd/isolate.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 import os
 import shutil
+import sys
 import textwrap
 from argparse import ArgumentParser
 from typing import cast
@@ -78,12 +79,17 @@ def _isolate_repos_config(new_user_path):
 
 
 def _setup_isolate_scope(new_user_path, overwrite: bool):
+    # Bypass overwriting/pre-existing when using --self
     if os.path.exists(ISOLATE_SCOPE_PATH):
-        if overwrite:
+        if os.path.samefile(new_user_path, ISOLATE_SCOPE_PATH):
+            pass
+        elif overwrite:
             shutil.rmtree(ISOLATE_SCOPE_PATH)
+            os.mkdir(ISOLATE_SCOPE_PATH)
         else:
             raise Exception("An isolation already exists for this Spack instance")
-    os.mkdir(ISOLATE_SCOPE_PATH)
+    else:
+        os.mkdir(ISOLATE_SCOPE_PATH)
     isolate_dict = {}
     isolate_dict["name"] = "isolate"
     isolate_dict["path"] = ISOLATE_SCOPE_PATH
@@ -129,10 +135,9 @@ def setup_parser(subparser: ArgumentParser):
     )
     isolate_group.add_argument(
         "--self",
-        dest="path",
-        action="store_const",
-        const=spack.paths.prefix,
-        help="use spack's own prefix as isolation directory",
+        dest="use_self",
+        action="store_true",
+        help="store isolation directory in Spack's prefix",
     )
     isolate_group.add_argument(
         "--undo", action="store_true", help="undo the result of calling isolate"
@@ -145,19 +150,21 @@ def setup_parser(subparser: ArgumentParser):
 def _do_isolate(args):
     destination = _ensure_destination_setup(args.path, args.overwrite)
     include_config: list = _preserve_and_extract_include()
-    user_index, site_index, system_index, old_isolate_index = _get_scope_indices(include_config)
     isolate_scope = _setup_isolate_scope(destination, args.overwrite)
-    # insert the isolate scope above the below user and site but above system
-    if old_isolate_index is not None:  # first try the old isolate index (--overwrite)
-        include_config[old_isolate_index] = isolate_scope
-    elif site_index is not None:  # otherwise put it below the site scope
-        include_config.insert(site_index + 1, isolate_scope)
-    elif system_index is not None:  # if there is no site scope, put it above the system scope
-        include_config.insert(system_index, isolate_scope)
-    elif user_index is not None:  # if there is no system scope, put it below the user scope
-        include_config.insert(user_index + 1, isolate_scope)
-    else:  # Strange changes have been made if there is no site, system, or user scope
-        include_config.append(isolate_scope)
+    user_index, site_index, system_index, old_isolate_index = _get_scope_indices(include_config)
+    # No need for a separate isolation scope when using --self
+    if not os.path.samefile(destination, ISOLATE_SCOPE_PATH):
+        # insert the isolate scope above the below user and site but above system
+        if old_isolate_index is not None:  # first try the old isolate index (--overwrite)
+            include_config[old_isolate_index] = isolate_scope
+        elif site_index is not None:  # otherwise put it below the site scope
+            include_config.insert(site_index + 1, isolate_scope)
+        elif system_index is not None:  # if there is no site scope, put it above the system scope
+            include_config.insert(system_index, isolate_scope)
+        elif user_index is not None:  # if there is no system scope, put it below the user scope
+            include_config.insert(user_index + 1, isolate_scope)
+        else:  # Strange changes have been made if there is no site, system, or user scope
+            include_config.append(isolate_scope)
 
     new_user_scope = _get_new_user_scope(destination)
     if user_index is not None:
@@ -181,16 +188,21 @@ def _undo_isolate():
 def isolate(parser, args):
     if args.undo:
         _undo_isolate()
+        sys.exit(0)
+    elif args.use_self:
+        if args.path is not None:
+            tty.die("Cannot provide both --self and --path")
+        else:
+            args.path = ISOLATE_SCOPE_PATH
     elif args.path is None:
         tty.die("Must provide one of --path, --self, or --undo")
-    else:
-        _do_isolate(args)
-        tty.warn(
-            "\n".join(
-                textwrap.wrap(
-                    "Due to current limitations in Spack's configuration, adding repos without an"
-                    " explicit destination will default to $SPACK_USER_CACHE_PATH or ~/.spack."
-                    " This behavior will be fixed with shared spack in v1.3."
-                )
+    _do_isolate(args)
+    tty.warn(
+        "\n".join(
+            textwrap.wrap(
+                "Due to current limitations in Spack's configuration, adding repos without an"
+                " explicit destination will default to $SPACK_USER_CACHE_PATH or ~/.spack."
+                " This behavior will be fixed with shared spack in v1.3."
             )
         )
+    )

--- a/lib/spack/spack/test/cmd/isolate.py
+++ b/lib/spack/spack/test/cmd/isolate.py
@@ -60,6 +60,7 @@ def test_isolate_added_config(mock_pre_isolate_config):
     cfg_dir, iso_root = mock_pre_isolate_config
     isolated_path = iso_root / "test-isolation"
     sp_isolate("--path", str(isolated_path))
+    # configuration has changed on disk, this refreshes it in memory
     with spack.config.use_configuration(cfg_dir / "spack"):
         sp_config("add", "config:build_jobs:42")
         assert (isolated_path / "config.yaml").exists()
@@ -82,8 +83,8 @@ def test_isolate_overwrite_same_dir(mock_pre_isolate_config):
 
 def test_isolate_overwrite_different_dir(mock_pre_isolate_config):
     cfg_dir, iso_root = mock_pre_isolate_config
-    isolated_path1 = iso_root / "test-isolation"
-    isolated_path2 = iso_root / "test-isolation"
+    isolated_path1 = iso_root / "test-isolation1"
+    isolated_path2 = iso_root / "test-isolation2"
     sp_isolate("--path", str(isolated_path1))
     with pytest.raises(Exception):
         sp_isolate("--path", str(isolated_path1))
@@ -94,6 +95,59 @@ def test_isolate_overwrite_different_dir(mock_pre_isolate_config):
 bootstrap:
   root: {isolated_path2 / "bootstrap"}"""
     assert text == expected_text
+
+
+def test_self_isolate(mock_pre_isolate_config):
+    cfg_dir, _ = mock_pre_isolate_config
+    sp_isolate("--self")
+    assert os.path.exists(spack.cmd.isolate.ISOLATE_SCOPE_PATH)
+    assert os.path.exists(spack.cmd.isolate.PRESERVED_INCLUDE_PATH)
+    assert os.path.exists(os.path.join(spack.cmd.isolate.ISOLATE_SCOPE_PATH, "bootstrap.yaml"))
+    assert os.path.exists(os.path.join(spack.cmd.isolate.ISOLATE_SCOPE_PATH, "config.yaml"))
+    # configuration has changed on disk, this refreshes it in memory
+    with spack.config.use_configuration(cfg_dir / "spack"):
+        sp_config("add", "packages:gcc:buildable:false")
+        new_config_path = os.path.join(spack.cmd.isolate.ISOLATE_SCOPE_PATH, "packages.yaml")
+        assert os.path.exists(new_config_path)
+        with open(new_config_path, "r", encoding="utf-8") as f:
+            text = f.read().strip()
+        expected_text = """\
+packages:
+  gcc:
+    buildable: false"""
+        assert text == expected_text
+
+
+def test_self_isolate_overwrite(mock_pre_isolate_config):
+    sp_isolate("--self")
+    cfg_dir, _ = mock_pre_isolate_config
+    with pytest.raises(Exception):
+        sp_isolate("--self")
+    new_concr_config_path = os.path.join(spack.cmd.isolate.ISOLATE_SCOPE_PATH, "concretizer.yaml")
+    new_pkgs_config_path = os.path.join(spack.cmd.isolate.ISOLATE_SCOPE_PATH, "packages.yaml")
+    # configuration has changed on disk, this refreshes it in memory
+    with spack.config.use_configuration(cfg_dir / "spack"):
+        sp_config("add", "concretizer:reuse:false")
+        assert os.path.exists(new_concr_config_path)
+        with open(new_concr_config_path, "r", encoding="utf-8") as f:
+            text = f.read().strip()
+        expected_text = """\
+concretizer:
+  reuse: false"""
+        assert text == expected_text
+    sp_isolate("--self", "--overwrite")
+
+    with spack.config.use_configuration(cfg_dir / "spack"):
+        sp_config("add", "packages:gcc:buildable:false")
+        assert not os.path.exists(new_concr_config_path)
+        assert os.path.exists(new_pkgs_config_path)
+        with open(new_pkgs_config_path, "r", encoding="utf-8") as f:
+            text = f.read().strip()
+        expected_text = """\
+packages:
+  gcc:
+    buildable: false"""
+        assert text == expected_text
 
 
 def test_isolate_undo(mock_pre_isolate_config):

--- a/share/spack/spack-completion.fish
+++ b/share/spack/spack-completion.fish
@@ -2222,8 +2222,8 @@ complete -c spack -n '__fish_spack_using_command isolate' -s h -l help -f -a hel
 complete -c spack -n '__fish_spack_using_command isolate' -s h -l help -d 'show this help message and exit'
 complete -c spack -n '__fish_spack_using_command isolate' -l path -r -f -a path
 complete -c spack -n '__fish_spack_using_command isolate' -l path -r -d 'path to data isolation directory'
-complete -c spack -n '__fish_spack_using_command isolate' -l self -f -a path
-complete -c spack -n '__fish_spack_using_command isolate' -l self -d 'use spack'"'"'s own prefix as isolation directory'
+complete -c spack -n '__fish_spack_using_command isolate' -l self -f -a use_self
+complete -c spack -n '__fish_spack_using_command isolate' -l self -d 'store isolation directory in Spack'"'"'s prefix'
 complete -c spack -n '__fish_spack_using_command isolate' -l undo -f -a undo
 complete -c spack -n '__fish_spack_using_command isolate' -l undo -d 'undo the result of calling isolate'
 complete -c spack -n '__fish_spack_using_command isolate' -l overwrite -f -a overwrite


### PR DESCRIPTION
Per a bug reported by @psakievich, `spack isolate --self` would error with a message that the isolation directory already exists and `spack isolate --self --overwrite` would blow away the whole Spack instance. 

The original implementation of `spack isolate --self` set the Spack prefix as the isolation directory, leading to the aforementioned bugs. Now, `spack isolate --self` reuses the isolation scope `spack/etc/spack/isolate` to store all user config. 