### PR TITLE
win_acl: Improve handling of WRITE_OWNER

### DIFF
--- a/lib/spack/spack/test/util/win_acl.py
+++ b/lib/spack/spack/test/util/win_acl.py
@@ -421,10 +421,10 @@ def test_security_descriptor_apply_update_ownership_raises_without_write_owner(t
     f.write_text("hello")
     owner_sid = SecurityDescriptor.from_file(str(f)).owner
     # FR excludes WRITE_OWNER (0x00080000); use P so no inherited ACE sneaks WRITE_OWNER back in.
-    # WRITE_OWNER (WO) is the string alias for the above access mask. 
+    # WRITE_OWNER (WO) is the string alias for the above access mask.
     # As the strings are aliases for bit masks, some strings represent the bitwise OR of other
     # access masks (and their string aliases). I.e FA is an OR of every other access right
-    # Other string access aliases can imply the WO mask, such as FA (FILE_ALL_ACCESS) 
+    # Other string access aliases can imply the WO mask, such as FA (FILE_ALL_ACCESS)
     # so we explicitly set the ACE right to FR (file generic read) which does not include WO
     set_file_sddl(str(f), f"D:P(A;;FR;;;{owner_sid})")
 

--- a/lib/spack/spack/test/util/win_acl.py
+++ b/lib/spack/spack/test/util/win_acl.py
@@ -410,10 +410,28 @@ def test_security_descriptor_apply_null_dacl_is_rejected(tmp_path):
         sd.apply(str(f))
 
 
+def test_security_descriptor_apply_update_ownership_raises_without_write_owner(tmp_path):
+    """apply(update_ownership=True) must raise PermissionError when WRITE_OWNER is absent.
+
+    After set_install_permissions the file DACL grants FILE_ALL_ACCESS to the owner,
+    which includes WRITE_OWNER - to test the error path we must first restrict the
+    DACL to rights that exclude WRITE_OWNER, then attempt the ownership update.
+    """
+    f = tmp_path / "test.txt"
+    f.write_text("hello")
+    owner_sid = SecurityDescriptor.from_file(str(f)).owner
+    # FR excludes WRITE_OWNER (0x00080000); use P so no inherited ACE sneaks WRITE_OWNER back in.
+    set_file_sddl(str(f), f"D:P(A;;FR;;;{owner_sid})")
+
+    sd = SecurityDescriptor.from_file(str(f))
+    with pytest.raises(PermissionError, match="WRITE_OWNER"):
+        sd.apply(str(f), update_ownership=True)
+
+
 def test_set_install_permissions_file_acl(tmp_path):
     """set_install_permissions sets 644-equivalent permissions on a file.
 
-    The owner receives Allow(read+write); Everyone receives Allow(read).
+    The owner receives Allow(full access); Everyone receives Allow(read).
     """
     f = tmp_path / "test.txt"
     f.write_text("hello")
@@ -421,13 +439,13 @@ def test_set_install_permissions_file_acl(tmp_path):
     fs.set_install_permissions(str(f))
 
     sd = SecurityDescriptor.from_file(str(f))
-    _FRFW = int(FileAccessRights.FILE_GENERIC_READ) | int(FileAccessRights.FILE_GENERIC_WRITE)
+    _FA = int(FileAccessRights.FILE_ALL_ACCESS)
     _FR = int(FileAccessRights.FILE_GENERIC_READ)
 
     assert any(
-        a.sid == owner_sid and a.ace_type == AceType.SDDL_ACCESS_ALLOWED and a.grants(_FRFW)
+        a.sid == owner_sid and a.ace_type == AceType.SDDL_ACCESS_ALLOWED and a.grants(_FA)
         for a in sd.dacl
-    ), "owner must have Allow ACE granting read+write"
+    ), "owner must have Allow ACE granting full access"
     assert any(
         a.sid == "WD" and a.ace_type == AceType.SDDL_ACCESS_ALLOWED and a.grants(_FR)
         for a in sd.dacl
@@ -478,6 +496,28 @@ def test_set_install_permissions_expands_restricted_dacl(tmp_path):
         and a.grants(int(FileAccessRights.FILE_GENERIC_READ))
         for a in sd.dacl
     ), "Everyone must have read access after set_install_permissions"
+
+
+def test_set_install_permissions_on_previously_installed_file(tmp_path):
+    """set_install_permissions must succeed on a file already processed by a prior install.
+
+    shutil.copy2 preserves the destination ACL when the file already exists, so a
+    reinstall leaves a file with the FR+FW DACL set by the previous run (no WRITE_OWNER).
+    apply() was previously failing with WinError 5 because it tried to re-set owner/group
+    via SetNamedSecurityInfoW, which requires a WRITE_OWNER not held implicitly by the owner.
+    """
+    f = tmp_path / "test.txt"
+    f.write_text("hello")
+    # Simulate a file left by a previous install: DACL already restricted to FR+FW.
+    fs.set_install_permissions(str(f))
+    # Reinstall overwrites content but not ACL (shutil.copy2 behaviour); then
+    # set_install_permissions is called again — must not raise.
+    fs.set_install_permissions(str(f))
+    sd = SecurityDescriptor.from_file(str(f))
+    owner_sid = sd.owner
+    assert any(
+        a.sid == owner_sid and a.grants(int(FileAccessRights.FILE_ALL_ACCESS)) for a in sd.dacl
+    ), "owner must still have full access after second set_install_permissions"
 
 
 def test_copy_mode_propagates_execute_on_windows(tmp_path):

--- a/lib/spack/spack/test/util/win_acl.py
+++ b/lib/spack/spack/test/util/win_acl.py
@@ -450,7 +450,9 @@ def test_set_install_permissions_file_acl(tmp_path):
     # The owner retains implicit WRITE_DAC so set_install_permissions can still
     # modify the DACL even though FRFW does not include explicit WRITE_DAC.
     set_file_sddl(str(f), f"D:P(A;;FRFW;;;{owner_sid})")
-    assert not any(a.sid == owner_sid and a.grants(_FA) for a in SecurityDescriptor.from_file(str(f)).dacl)
+    assert not any(
+        a.sid == owner_sid and a.grants(_FA) for a in SecurityDescriptor.from_file(str(f)).dacl
+    )
 
     fs.set_install_permissions(str(f))
 
@@ -478,7 +480,9 @@ def test_set_install_permissions_directory_acl(tmp_path):
 
     owner_sid = SecurityDescriptor.from_file(str(d)).owner
     set_file_sddl(str(d), f"D:P(A;;FRFW;;;{owner_sid})")
-    assert not any(a.sid == owner_sid and a.grants(_FA) for a in SecurityDescriptor.from_file(str(d)).dacl)
+    assert not any(
+        a.sid == owner_sid and a.grants(_FA) for a in SecurityDescriptor.from_file(str(d)).dacl
+    )
 
     fs.set_install_permissions(str(d))
 

--- a/lib/spack/spack/test/util/win_acl.py
+++ b/lib/spack/spack/test/util/win_acl.py
@@ -444,11 +444,13 @@ def test_set_install_permissions_file_acl(tmp_path):
     _FA = int(FileAccessRights.FILE_ALL_ACCESS)
     _FR = int(FileAccessRights.FILE_GENERIC_READ)
 
-    initial_sd = SecurityDescriptor.from_file(str(f))
-    owner_sid = initial_sd.owner
-    assert not any(a.sid == owner_sid and a.grants(_FA) for a in initial_sd.dacl), (
-        "precondition: new file must not already grant FILE_ALL_ACCESS to owner"
-    )
+    owner_sid = SecurityDescriptor.from_file(str(f)).owner
+    # Force a known state without FA so the post-call assertion is not a no-op.
+    # P blocks inheritance so the parent directory cannot re-introduce FA.
+    # The owner retains implicit WRITE_DAC so set_install_permissions can still
+    # modify the DACL even though FRFW does not include explicit WRITE_DAC.
+    set_file_sddl(str(f), f"D:P(A;;FRFW;;;{owner_sid})")
+    assert not any(a.sid == owner_sid and a.grants(_FA) for a in SecurityDescriptor.from_file(str(f)).dacl)
 
     fs.set_install_permissions(str(f))
 
@@ -474,11 +476,9 @@ def test_set_install_permissions_directory_acl(tmp_path):
     _FA = int(FileAccessRights.FILE_ALL_ACCESS)
     _FRFX = int(FileAccessRights.FILE_GENERIC_READ) | int(FileAccessRights.FILE_GENERIC_EXECUTE)
 
-    initial_sd = SecurityDescriptor.from_file(str(d))
-    owner_sid = initial_sd.owner
-    assert not any(a.sid == owner_sid and a.grants(_FA) for a in initial_sd.dacl), (
-        "precondition: new directory must not already grant FILE_ALL_ACCESS to owner"
-    )
+    owner_sid = SecurityDescriptor.from_file(str(d)).owner
+    set_file_sddl(str(d), f"D:P(A;;FRFW;;;{owner_sid})")
+    assert not any(a.sid == owner_sid and a.grants(_FA) for a in SecurityDescriptor.from_file(str(d)).dacl)
 
     fs.set_install_permissions(str(d))
 

--- a/lib/spack/spack/test/util/win_acl.py
+++ b/lib/spack/spack/test/util/win_acl.py
@@ -421,6 +421,11 @@ def test_security_descriptor_apply_update_ownership_raises_without_write_owner(t
     f.write_text("hello")
     owner_sid = SecurityDescriptor.from_file(str(f)).owner
     # FR excludes WRITE_OWNER (0x00080000); use P so no inherited ACE sneaks WRITE_OWNER back in.
+    # WRITE_OWNER (WO) is the string alias for the above access mask. 
+    # As the strings are aliases for bit masks, some strings represent the bitwise OR of other
+    # access masks (and their string aliases). I.e FA is an OR of every other access right
+    # Other string access aliases can imply the WO mask, such as FA (FILE_ALL_ACCESS) 
+    # so we explicitly set the ACE right to FR (file generic read) which does not include WO
     set_file_sddl(str(f), f"D:P(A;;FR;;;{owner_sid})")
 
     sd = SecurityDescriptor.from_file(str(f))
@@ -435,13 +440,19 @@ def test_set_install_permissions_file_acl(tmp_path):
     """
     f = tmp_path / "test.txt"
     f.write_text("hello")
-    owner_sid = SecurityDescriptor.from_file(str(f)).owner
-    fs.set_install_permissions(str(f))
 
-    sd = SecurityDescriptor.from_file(str(f))
     _FA = int(FileAccessRights.FILE_ALL_ACCESS)
     _FR = int(FileAccessRights.FILE_GENERIC_READ)
 
+    initial_sd = SecurityDescriptor.from_file(str(f))
+    owner_sid = initial_sd.owner
+    assert not any(a.sid == owner_sid and a.grants(_FA) for a in initial_sd.dacl), (
+        "precondition: new file must not already grant FILE_ALL_ACCESS to owner"
+    )
+
+    fs.set_install_permissions(str(f))
+
+    sd = SecurityDescriptor.from_file(str(f))
     assert any(
         a.sid == owner_sid and a.ace_type == AceType.SDDL_ACCESS_ALLOWED and a.grants(_FA)
         for a in sd.dacl
@@ -459,13 +470,19 @@ def test_set_install_permissions_directory_acl(tmp_path):
     """
     d = tmp_path / "subdir"
     d.mkdir()
-    owner_sid = SecurityDescriptor.from_file(str(d)).owner
-    fs.set_install_permissions(str(d))
 
-    sd = SecurityDescriptor.from_file(str(d))
     _FA = int(FileAccessRights.FILE_ALL_ACCESS)
     _FRFX = int(FileAccessRights.FILE_GENERIC_READ) | int(FileAccessRights.FILE_GENERIC_EXECUTE)
 
+    initial_sd = SecurityDescriptor.from_file(str(d))
+    owner_sid = initial_sd.owner
+    assert not any(a.sid == owner_sid and a.grants(_FA) for a in initial_sd.dacl), (
+        "precondition: new directory must not already grant FILE_ALL_ACCESS to owner"
+    )
+
+    fs.set_install_permissions(str(d))
+
+    sd = SecurityDescriptor.from_file(str(d))
     assert any(
         a.sid == owner_sid and a.ace_type == AceType.SDDL_ACCESS_ALLOWED and a.grants(_FA)
         for a in sd.dacl
@@ -496,28 +513,6 @@ def test_set_install_permissions_expands_restricted_dacl(tmp_path):
         and a.grants(int(FileAccessRights.FILE_GENERIC_READ))
         for a in sd.dacl
     ), "Everyone must have read access after set_install_permissions"
-
-
-def test_set_install_permissions_on_previously_installed_file(tmp_path):
-    """set_install_permissions must succeed on a file already processed by a prior install.
-
-    shutil.copy2 preserves the destination ACL when the file already exists, so a
-    reinstall leaves a file with the FR+FW DACL set by the previous run (no WRITE_OWNER).
-    apply() was previously failing with WinError 5 because it tried to re-set owner/group
-    via SetNamedSecurityInfoW, which requires a WRITE_OWNER not held implicitly by the owner.
-    """
-    f = tmp_path / "test.txt"
-    f.write_text("hello")
-    # Simulate a file left by a previous install: DACL already restricted to FR+FW.
-    fs.set_install_permissions(str(f))
-    # Reinstall overwrites content but not ACL (shutil.copy2 behaviour); then
-    # set_install_permissions is called again — must not raise.
-    fs.set_install_permissions(str(f))
-    sd = SecurityDescriptor.from_file(str(f))
-    owner_sid = sd.owner
-    assert any(
-        a.sid == owner_sid and a.grants(int(FileAccessRights.FILE_ALL_ACCESS)) for a in sd.dacl
-    ), "owner must still have full access after second set_install_permissions"
 
 
 def test_copy_mode_propagates_execute_on_windows(tmp_path):

--- a/lib/spack/spack/util/filesystem.py
+++ b/lib/spack/spack/util/filesystem.py
@@ -602,17 +602,17 @@ def set_install_permissions(path):
         sd.clear_dacl()
         owner_ace = AccessControlEntry(AceType.SDDL_ACCESS_ALLOWED, sid=owner_sid)
         everyone_ace = AccessControlEntry(AceType.SDDL_ACCESS_ALLOWED, sid="WD")
+        # Owner always gets FILE_ALL_ACCESS so they retain DELETE and WRITE_DAC regardless
+        # of whether the implicit owner rights survive a copy or ownership transfer.
+        # Everyone gets the read-only equivalent of the Unix world bits (r-x for dirs, r-- for
+        # files); execute is omitted for files because Windows uses file extensions, not mode bits,
+        # to determine executability.
+        owner_ace.add_right(FileAccessRights.FILE_ALL_ACCESS)
         if os.path.isdir(path):
-            # 755: owner full access, everyone read + traverse
-            owner_ace.add_right(FileAccessRights.FILE_ALL_ACCESS)
             everyone_ace.add_right(
                 FileAccessRights.FILE_GENERIC_READ | FileAccessRights.FILE_GENERIC_EXECUTE
             )
         else:
-            # 644: owner read + write, everyone read
-            owner_ace.add_right(
-                FileAccessRights.FILE_GENERIC_READ | FileAccessRights.FILE_GENERIC_WRITE
-            )
             everyone_ace.add_right(FileAccessRights.FILE_GENERIC_READ)
         sd.add_ace(owner_ace)
         sd.add_ace(everyone_ace)

--- a/lib/spack/spack/util/win_acl.py
+++ b/lib/spack/spack/util/win_acl.py
@@ -952,7 +952,7 @@ class SecurityDescriptor:
         try:
             _set_file_sddl_raw(path, sddl)
         except OSError as exc:
-            if update_ownership and exc.winerror == 5:  # ERROR_ACCESS_DENIED
+            if update_ownership and hasattr(exc, "winerror") and exc.winerror == 5:  # ERROR_ACCESS_DENIED
                 raise PermissionError(
                     f"Cannot update owner/group on {path!r}: the current process lacks "
                     "WRITE_OWNER access to the file and does not hold "

--- a/lib/spack/spack/util/win_acl.py
+++ b/lib/spack/spack/util/win_acl.py
@@ -178,7 +178,7 @@ class ResourceAttributeAceDataType(Enum):
 
 
 # SDDL code: 32-bit access mask for every named right token.  Used by _map_rights to
-# parse SDDL strings ("FRFW", "GR", …) into integer masks during ACE construction.
+# parse SDDL strings ("FRFW", "GR", ...) into integer masks during ACE construction.
 _NAMED_RIGHT_MASKS: Dict[str, int] = {
     # File access rights
     "FA": int(FileAccessRights.FILE_ALL_ACCESS),
@@ -219,7 +219,7 @@ _NAMED_RIGHT_MASKS: Dict[str, int] = {
 
 # Reverse lookup:  SDDL code string to int mask for file/generic rights.
 # Used during SDDL serialisation to convert stored integer masks back to readable tokens.
-# Limited to the 8 file+generic codes since those are what ConvertSecurityDescriptor…
+# Limited to the 8 file+generic codes since those are what ConvertSecurityDescriptor
 # emits for file objects; other masks fall back to hex in _to_ace_string.
 _FILE_GENERIC_SDDL_CODES: Dict[str, int] = {
     k: _NAMED_RIGHT_MASKS[k] for k in ("FA", "FR", "FW", "FX", "GA", "GR", "GW", "GX")

--- a/lib/spack/spack/util/win_acl.py
+++ b/lib/spack/spack/util/win_acl.py
@@ -952,7 +952,9 @@ class SecurityDescriptor:
         try:
             _set_file_sddl_raw(path, sddl)
         except OSError as exc:
-            if update_ownership and hasattr(exc, "winerror") and exc.winerror == 5:  # ERROR_ACCESS_DENIED
+            if (
+                update_ownership and hasattr(exc, "winerror") and exc.winerror == 5
+            ):  # ERROR_ACCESS_DENIED
                 raise PermissionError(
                     f"Cannot update owner/group on {path!r}: the current process lacks "
                     "WRITE_OWNER access to the file and does not hold "

--- a/lib/spack/spack/util/win_acl.py
+++ b/lib/spack/spack/util/win_acl.py
@@ -914,12 +914,20 @@ class SecurityDescriptor:
         """Compile the current state back into an SDDL string."""
         return _SddlHelper.create_sddl(self._parsed)
 
-    def apply(self, path: str) -> None:
+    def apply(self, path: str, update_ownership: bool = False) -> None:
         """Write this security descriptor to *path*.
+
+        By default only the DACL is written (``DACL_SECURITY_INFORMATION``).  Pass
+        ``update_ownership=True`` to also write owner and group fields, which is needed
+        for ``chown``-style operations.  Doing so requires ``WRITE_OWNER`` access to the
+        file or ``SE_TAKE_OWNERSHIP_PRIVILEGE`` in the process token; if neither is
+        present a ``PermissionError`` is raised with an explanation.
 
         Raises:
             ValueError: if the descriptor has an explicit but empty DACL (null DACL).
-            OSError: raised by ``ctypes.WinError`` on Windows API failure (carries ``winerror``).
+            PermissionError: if ``update_ownership=True`` and the caller lacks ``WRITE_OWNER``
+                access or ``SE_TAKE_OWNERSHIP_PRIVILEGE``.
+            OSError: on any other Windows API failure (carries ``winerror``).
         """
         if self._parsed.get("DACL_PRESENT") and not self._parsed["DACL"]:
             raise ValueError(
@@ -930,12 +938,29 @@ class SecurityDescriptor:
         # describe how the *existing* DACL was built.  Passing them back to SetNamedSecurityInfoW
         # causes the kernel to re-process parent inheritance, producing a different (and larger)
         # ACE set than the one we wrote.  Strip them so the kernel treats our ACEs as explicit.
+        # Build a view for serialisation without mutating self._parsed.
+        # Scalar values (Owner, Group, DACL_CONTROL) are reassigned on the copy;
+        # DACL is a shared list reference but create_sddl only reads it.
         parsed = dict(self._parsed)
+        if not update_ownership:
+            parsed["Owner"] = None
+            parsed["Group"] = None
         parsed["DACL_CONTROL"] = re.sub(r"AI|AR", "", parsed.get("DACL_CONTROL", ""))
         sddl = _SddlHelper.create_sddl(parsed)
         if not sddl:
             return
-        _set_file_sddl_raw(path, sddl)
+        try:
+            _set_file_sddl_raw(path, sddl)
+        except OSError as exc:
+            if update_ownership and exc.winerror == 5:  # ERROR_ACCESS_DENIED
+                raise PermissionError(
+                    f"Cannot update owner/group on {path!r}: the current process lacks "
+                    "WRITE_OWNER access to the file and does not hold "
+                    "SE_TAKE_OWNERSHIP_PRIVILEGE.  Acquire the necessary privilege before "
+                    "calling apply(update_ownership=True), or omit update_ownership to "
+                    "update only the DACL."
+                ) from exc
+            raise
 
     def __str__(self) -> str:
         return self.to_sddl()
@@ -1139,7 +1164,9 @@ def get_file_sddl(path: str) -> str:
 def set_file_sddl(path: str, sddl: str) -> None:
     """Apply a security descriptor described by *sddl* to *path*.
 
-    Only the components present in *sddl* (owner, group, DACL) are written.
+    Only the DACL is written; ``O:`` and ``G:`` components in *sddl* are ignored.
+    To also transfer ownership pass ``update_ownership=True`` to
+    :meth:`SecurityDescriptor.apply` directly.
 
     Raises:
         WindowsError: on any Windows API failure.


### PR DESCRIPTION
Current ACL operations assumed that files were avalable with WRITE_OWNER permissions, as that is the default state of files when created by the OS. However if Spack or another program has already modified them, then the WO right may not still be available. Typically we're only interested in writing the DACL, so this is fine, except we assume WO right, and specify the OWNER_SECURITY_INFORMATION flag to the update DACL win32 api if we see a `O:` (owner) or `G:`(group) sid (which we pull from `from_file`), which requires WO. Instead, require a user to actively request ownership updates, and don't try to pass OWNER|GROUP_SECURITY_INFORMATION when we don't intend to chown.

Also updates add_install_permissions to grant FILE_ALL_ACCESS to files, tried to match posix too closely and inadvertently limited file permissions too far