### PR TITLE
Spec: stamp prefix at source site

### DIFF
--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -2119,6 +2119,9 @@ def install_root_node(
         warnings.warn("Package for spec {0} already installed.".format(spec.format()))
         return
 
+    # Stamp the destination prefix so extract_tarball can read spec.prefix.
+    spack.store.STORE.set_prefixes([spec])
+
     tarball_stage = download_tarball(spec.build_spec, unsigned)
     if not tarball_stage:
         msg = 'download of binary cache file for spec "{0}" failed'

--- a/lib/spack/spack/database.py
+++ b/lib/spack/spack/database.py
@@ -200,7 +200,8 @@ class InstallRecord:
 
     __slots__ = (
         "spec",
-        "path",
+        # "path" is a property that keeps the record and its spec's prefix in sync
+        "_path",
         "installed",
         "ref_count",
         "explicit",
@@ -223,7 +224,7 @@ class InstallRecord:
         origin: Optional[str] = None,
     ) -> None:
         self.spec = spec
-        self.path = str(path) if path else None
+        self.path = path
         self.installed = bool(installed)
         self.ref_count = ref_count
         self.explicit = explicit
@@ -231,6 +232,18 @@ class InstallRecord:
         self.deprecated_for = deprecated_for
         self.in_buildcache = in_buildcache
         self.origin = origin
+
+    @property
+    def path(self) -> Optional[str]:
+        return self._path
+
+    @path.setter
+    def path(self, value: Optional[str]) -> None:
+        # The install prefix is a property of the record's spec. Keep the two in sync, so that
+        # every spec handed out by a query carries its prefix without reading the store.
+        self._path = str(value) if value else None
+        if self._path is not None:
+            self.spec.set_prefix(self._path)
 
     def install_type_matches(self, installed: InstallRecordStatus) -> bool:
         if self.installed:

--- a/lib/spack/spack/database.py
+++ b/lib/spack/spack/database.py
@@ -1262,6 +1262,10 @@ class Database:
         # Make sure the directory layout agrees whether the spec is installed
         if not spec.external and self.layout:
             path = self.layout.path_for_spec(spec)
+            # Fill in a missing prefix so ensure_installed can read spec.prefix; a spec added
+            # directly (e.g. a spliced spec) may not carry one. A caller-provided prefix wins.
+            if spec._prefix is None:
+                spec.set_prefix(path)
             installed = False
             try:
                 self.layout.ensure_installed(spec)

--- a/lib/spack/spack/environment/environment.py
+++ b/lib/spack/spack/environment/environment.py
@@ -911,7 +911,11 @@ class ViewDescriptor:
         with spack.store.STORE.db.read_transaction():
             result = [s for s in specs if s in self and spack.store.STORE.db.installed(s)]
 
-        return self._exclude_duplicate_runtimes(result)
+        result = self._exclude_duplicate_runtimes(result)
+        # These specs are installed; stamp their prefix so content_hash and view regeneration
+        # can read Spec.prefix without the spec reaching into the store.
+        spack.store.STORE.set_prefixes(result)
+        return result
 
     def regenerate(self, env: "Environment") -> None:
         if self.groups is None:
@@ -2439,6 +2443,13 @@ class Environment:
 
             for env_path, roots in self.included_concretized_roots.items():
                 self.included_specs_by_hash[env_path] = {x.hash: first_seen[x.hash] for x in roots}
+
+        # Specs read from the lockfile carry no install prefix. Stamp it so consumers (views,
+        # modules, user environments) can read Spec.prefix without reaching into the store.
+        stamp = list(self.specs_by_hash.values())
+        for included in self.included_specs_by_hash.values():
+            stamp.extend(included.values())
+        spack.store.STORE.set_prefixes(stamp)
 
     def _filter_specs(self, reader, json_specs_by_hash, order_concretized):
         # Track specs by their lockfile key.  Currently, spack uses the finest

--- a/lib/spack/spack/filesystem_view.py
+++ b/lib/spack/spack/filesystem_view.py
@@ -569,6 +569,8 @@ class YamlFilesystemView(FilesystemView):
                     spec = get_spec_from_file(filename)
                     if spec:
                         specs.append(spec)
+        # Specs read from view metadata carry no prefix. Stamp it so callers can read .prefix.
+        spack.store.STORE.set_prefixes(specs)
         return specs
 
     def get_conflicts(self, *specs):
@@ -591,7 +593,10 @@ class YamlFilesystemView(FilesystemView):
         dotspack = self.get_path_meta_folder(spec)
         filename = os.path.join(dotspack, spack.store.STORE.layout.spec_file_name)
 
-        return get_spec_from_file(filename)
+        result = get_spec_from_file(filename)
+        if result is not None:
+            spack.store.STORE.set_prefixes([result])
+        return result
 
     def link_meta_folder(self, spec):
         src = spack.store.STORE.layout.metadata_path(spec)

--- a/lib/spack/spack/old_installer.py
+++ b/lib/spack/spack/old_installer.py
@@ -1557,6 +1557,10 @@ class PackageInstaller:
         # List of build requests
         self.build_requests = [BuildRequest(pkg, install_args) for pkg in packages]
 
+        # Set the install prefix on every node, so packages can read Spec.prefix during the
+        # build without the spec reaching into the store (mirrors the new installer).
+        spack.store.STORE.set_prefixes([br.spec for br in self.build_requests])
+
         # When no reporter is configured, use NullInstallRecord to skip log file reads.
         if not create_reports:
             for br in self.build_requests:

--- a/lib/spack/spack/rewiring.py
+++ b/lib/spack/spack/rewiring.py
@@ -30,6 +30,9 @@ def rewire_node(spec, explicit):
     """This function rewires a single node, worrying only about references to
     its subgraph. Binaries, text, and links are all changed in accordance with
     the splice. The resulting package is then 'installed.'"""
+    # Stamp the install prefixes: the spliced spec's destination (layout path) and its build
+    # spec's source (the installed record path), so create_tarball and extract can read them.
+    spack.store.STORE.set_prefixes([spec, spec.build_spec])
     tempdir = tempfile.mkdtemp()
 
     # Copy spec.build_spec.prefix to spec.prefix through a temporary tarball

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -3846,6 +3846,10 @@ def post_process_concretization_result(specs: SpecDict) -> None:
     specs.clear()
     specs.update(new_specs)
 
+    # Stamp the install prefix on every concrete node, so consumers can read Spec.prefix
+    # without the spec having to reach into the store itself.
+    spack.store.STORE.set_prefixes(list(specs.values()))
+
 
 def execute_explicit_splices(specs: SpecDict) -> SpecDict:
     splice_config = spack.config.CONFIG.get("concretizer:splice:explicit", [])

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -2229,11 +2229,10 @@ class Spec:
         if self._prefix is None:
             from spack.store import STORE
 
-            _, record = STORE.db.query_by_spec_hash(self.dag_hash())
-            if record and record.path:
-                self.set_prefix(record.path)
-            else:
-                self.set_prefix(STORE.layout.path_for_spec(self))
+            # Installed specs carry their prefix from the database record (set when the
+            # InstallRecord is built). Anything reaching this point is not a stamped record
+            # spec, so its prefix is the deterministic layout path (external_path for externals).
+            self.set_prefix(STORE.layout.path_for_spec(self))
         assert self._prefix is not None
         return self._prefix
 

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -1273,14 +1273,19 @@ class ForwardQueryToPackage:
                 # A callback can return None to trigger an error indicating
                 # that the query failed.
                 if value is None:
+                    try:
+                        prefix = str(instance.prefix)
+                    except spack.error.SpecError:
+                        prefix = "<unset>"
                     msg = "Query of package '{name}' for '{attrib}' failed\n"
-                    msg += "\tprefix : {spec.prefix}\n"
+                    msg += "\tprefix : {prefix}\n"
                     msg += "\tspec : {spec}\n"
                     msg += "\tqueried as : {query.name}\n"
                     msg += "\textra parameters : {query.extra_parameters}"
                     message = msg.format(
                         name=pkg.name,
                         attrib=self.attribute_name,
+                        prefix=prefix,
                         spec=instance,
                         query=instance.last_query,
                     )
@@ -2227,12 +2232,15 @@ class Spec:
             raise spack.error.SpecError(f"Spec is not concrete: {self}")
 
         if self._prefix is None:
-            from spack.store import STORE
-
-            # Installed specs carry their prefix from the database record (set when the
-            # InstallRecord is built). Anything reaching this point is not a stamped record
-            # spec, so its prefix is the deterministic layout path (external_path for externals).
-            self.set_prefix(STORE.layout.path_for_spec(self))
+            if self.external:
+                # An external spec records its prefix on the spec itself, so it needs no store.
+                self.set_prefix(self.external_path)
+            else:
+                raise spack.error.SpecError(
+                    f"cannot determine the prefix of {self.short_spec}: its install prefix has "
+                    "not been set. The prefix of a non-external spec is set from its database "
+                    "record or by the installer; read it only after one of those has run."
+                )
         assert self._prefix is not None
         return self._prefix
 

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -2092,34 +2092,6 @@ class Spec:
         """
         return any(s.build_spec is not s for s in self.traverse(root=True))
 
-    @property
-    def installed(self):
-        """Whether the spec is installed, locally or in an upstream."""
-        if not self.concrete:
-            return False
-
-        try:
-            # If the spec is in the DB, check the installed
-            # attribute of the record
-            from spack.store import STORE
-
-            return STORE.db.get_record(self).installed
-        except KeyError:
-            # If the spec is not in the DB, the method
-            #  above raises a Key error
-            return False
-
-    @property
-    def installed_upstream(self):
-        """Whether the spec is installed in an upstream database."""
-        if not self.concrete:
-            return False
-
-        from spack.store import STORE
-
-        upstream, record = STORE.db.query_by_spec_hash(self.dag_hash())
-        return upstream and record and record.installed
-
     @overload
     def traverse(
         self,

--- a/lib/spack/spack/store.py
+++ b/lib/spack/spack/store.py
@@ -32,7 +32,9 @@ import spack.directory_layout
 import spack.error
 import spack.package_prefs
 import spack.paths
+import spack.repo
 import spack.spec
+import spack.traverse
 import spack.util.lang
 import spack.util.path
 from spack.util import filesystem as fs
@@ -213,6 +215,34 @@ class Store:
     def reindex(self) -> None:
         """Convenience function to reindex the store DB with its own layout."""
         return self.db.reindex()
+
+    def set_prefixes(self, specs: List["spack.spec.Spec"]) -> None:
+        """Set the install prefix on every non-external node reachable from ``specs``.
+
+        Installed specs get the path recorded in the database (which may live in an upstream
+        or a non-default install tree); everything else gets the deterministic layout path.
+        External specs resolve their prefix from ``external_path`` on access, so they are skipped.
+        """
+        # Dedup by identity (not by hash): duplicate objects that share a dag hash -- e.g. an
+        # unbound runtime present in several included concrete environments -- are distinct specs
+        # and each needs its own prefix stamped. Always re-resolve rather than skipping specs that
+        # already have a prefix: the install prefix is relative to *this* store, and a spec may
+        # have been stamped against a different one (e.g. at concretization time).
+        with self.db.read_transaction():
+            for s in spack.traverse.traverse_nodes(specs):
+                if s.external:
+                    continue
+                _, record = self.db.query_by_spec_hash(s.dag_hash())
+                if record and record.path:
+                    s.set_prefix(record.path)
+                    continue
+                try:
+                    # The layout path depends on the package (projections), which may live in a
+                    # repo that is no longer available (e.g. a stale lockfile spec). Leave such a
+                    # spec unstamped rather than failing here; reading its prefix will raise later.
+                    s.set_prefix(self.layout.path_for_spec(s))
+                except spack.repo.UnknownEntityError:
+                    continue
 
     def install_sbang(self) -> None:
         """Install the sbang script in this store's bin directory.

--- a/lib/spack/spack/test/binary_distribution.py
+++ b/lib/spack/spack/test/binary_distribution.py
@@ -455,7 +455,9 @@ def test_update_sbang(tmp_path: pathlib.Path, temporary_mirror, mock_fetch, inst
 
     # Switch the store to the new install tree locations
     with spack.store.use_store(str(tmp_path)):
-        s._prefix = None  # clear the cached old prefix
+        # Re-stamp the prefix from the new store's layout (the spec is not yet installed there).
+        s._prefix = None
+        spack.store.STORE.set_prefixes([s])
         new_prefix, new_sbang_shebang = s.prefix, sbang.sbang_shebang_line()
         assert old_prefix != new_prefix
         assert old_sbang_shebang != new_sbang_shebang

--- a/lib/spack/spack/test/cmd/verify.py
+++ b/lib/spack/spack/test/cmd/verify.py
@@ -160,6 +160,9 @@ def test_verify_versions(mock_packages):
     for spec in specs:
         spec._mark_concrete()
 
+    # In production these specs come from the database with a prefix stamped; do the same here.
+    spack.store.STORE.set_prefixes(specs)
+
     msg_lines = spack.cmd.verify._verify_version(specs)
     assert "3 installed packages have unknown/deprecated" in msg_lines[0]
     assert "thisisnotapackage" in msg_lines[1]

--- a/lib/spack/spack/test/install.py
+++ b/lib/spack/spack/test/install.py
@@ -590,6 +590,7 @@ def test_install_from_binary_with_missing_patch_succeeds(
     s_dict["spec"]["nodes"][0]["patches"] = patches
     s_dict["spec"]["nodes"][0]["parameters"]["patches"] = patches
     s = Spec.from_dict(s_dict)
+    temporary_store.set_prefixes([s])
 
     # Create an install dir for it
     os.makedirs(os.path.join(s.prefix, ".spack"))

--- a/lib/spack/spack/test/installer/core.py
+++ b/lib/spack/spack/test/installer/core.py
@@ -139,6 +139,7 @@ def test_package_installer_with_injected_ui(temporary_store, mock_packages):
     Uses the mark-explicit path (spec installed implicitly, requested explicitly) so the loop
     schedules, reports, and persists to the database without spawning build processes."""
     spec = _make_concrete("trivial-install-test-package")
+    temporary_store.set_prefixes([spec])
     temporary_store.layout.create_install_directory(spec)
     temporary_store.db.add(spec, explicit=False)
 
@@ -237,6 +238,7 @@ def test_overwrite_reinstalls_through_event_loop(temporary_store, mock_packages)
     """An overwrite install of an already-installed spec launches a build and refreshes the
     database record."""
     spec = _make_concrete("trivial-install-test-package")
+    temporary_store.set_prefixes([spec])
     temporary_store.layout.create_install_directory(spec)
     temporary_store.db.add(spec, explicit=True)
     old_time = _record(temporary_store, spec).installation_time

--- a/lib/spack/spack/test/installer/schedule.py
+++ b/lib/spack/spack/test/installer/schedule.py
@@ -881,6 +881,9 @@ def _schedule(
     explicit: Optional[Set[str]] = None,
 ) -> ScheduleResult:
     """Call schedule_builds() with inert defaults, so tests spell out only what they are about."""
+    # The real BuildGraph stamps prefixes on its nodes; mirror that here for specs a test did not
+    # give a deliberate prefix, so schedule_builds() can read Spec.prefix.
+    store.set_prefixes([s for s in build_graph.nodes.values() if s._prefix is None])
     return schedule_builds(
         pending,
         build_graph,
@@ -905,6 +908,7 @@ class TestScheduleBuilds:
 
     def _mark_installed(self, spec, store):
         """Create the install directory structure and register the spec in the DB as installed."""
+        store.set_prefixes([spec])
         store.layout.create_install_directory(spec)
         store.db.add(spec, explicit=True)
 
@@ -1071,6 +1075,7 @@ class TestScheduleBuilds:
     ):
         """An installed-implicit spec in explicit set produces a DbUpdate."""
         spec = self._make_spec("trivial-install-test-package")
+        temporary_store.set_prefixes([spec])
         temporary_store.layout.create_install_directory(spec)
         temporary_store.db.add(spec, explicit=False)
         pending = [spec.dag_hash()]


### PR DESCRIPTION
depends on #52722 and #52658

This PR removes the lazy getter for `Spec.prefix` that reads `spack.store.STORE` and instead stamps the prefix at the points where it originates.

It adds `Store.set_prefixes(specs)`, which resolves each non-external node's prefix (database record path if installed, else layout path) and stamps it on the spec.

This method is called at the points where concrete specs originate, so consumers can read `Spec.prefix` without the spec reaching into the store:
- the solver post-processing step (every concretization),
- environment lockfile reads and view specs_for_view,
- filesystem view metadata reads,
- the old installer, and the direct buildcache-install path,
- Database._add, to fill a missing prefix on a directly-added spec.

`Store.set_prefixes` dedupes by identity (duplicate objects sharing a dag hash across included environments each need stamping) and always re-resolves.

