### PR TITLE
traverse.py: break spec.py cycle

### DIFF
--- a/lib/spack/spack/audit.py
+++ b/lib/spack/spack/audit.py
@@ -1298,7 +1298,7 @@ def _analize_propagated_deps_in_directive(
 ):
     errors = []
     summary = f"{requestor}: dependency propagation ('%%') in '{directive}' directive"
-    for edge in constraint.traverse_edges():
+    for edge in constraint.traverse_edges(root=False):
         if edge.propagation != spack.enums.PropagationPolicy.NONE:
             msg = f"'{edge.spec}' contains a propagated dependency"
             errors.append(error_cls(summary=summary, details=[msg, f"in {filename}"]))

--- a/lib/spack/spack/bootstrap/clingo.py
+++ b/lib/spack/spack/bootstrap/clingo.py
@@ -180,7 +180,7 @@ class ClingoBootstrapConcretizer:
         if self.host_python.satisfies("@3.6"):
             s["re2c"].versions.versions = [spack.version.from_string("=2.2")]
 
-        for edge in spack.traverse.traverse_edges([s], cover="edges"):
+        for edge in spack.traverse.traverse_edges([s], cover="edges", root=False):
             if edge.spec.name == "python":
                 edge.spec = self.host_python
 

--- a/lib/spack/spack/database.py
+++ b/lib/spack/spack/database.py
@@ -1025,7 +1025,7 @@ class Database:
         }
         upstream_hashes.difference_update(spec.dag_hash() for spec in known_specs)
 
-        def create_node(edge: spack.spec.DependencySpec, is_upstream: bool):
+        def create_node(edge: tr.EdgeType, is_upstream: bool):
             if is_upstream:
                 return
 
@@ -1070,8 +1070,8 @@ class Database:
                     "but was not found on the file system. It is now marked as missing."
                 )
 
-        def create_edge(edge: spack.spec.DependencySpec, is_upstream: bool):
-            if not edge.parent:
+        def create_edge(edge: tr.EdgeType, is_upstream: bool):
+            if edge.parent is None:
                 return
             parent_record = self._data[edge.parent.dag_hash()]
             if is_upstream:
@@ -1931,11 +1931,7 @@ class Database:
 class NoUpstreamVisitor:
     """Gives edges to upstream specs, but does follow edges from upstream specs."""
 
-    def __init__(
-        self,
-        upstream_hashes: Set[str],
-        on_visit: Callable[["spack.spec.DependencySpec", bool], None],
-    ):
+    def __init__(self, upstream_hashes: Set[str], on_visit: Callable[[tr.EdgeType, bool], None]):
         self.upstream_hashes = upstream_hashes
         self.on_visit = on_visit
 

--- a/lib/spack/spack/graph.py
+++ b/lib/spack/spack/graph.py
@@ -510,7 +510,7 @@ class DAGWithDependencyTypes(DotGraphBuilder):
         super().__init__(node_label_fmt)
         self.main_unified_space: Set[str] = set()
 
-    def visit(self, edge):
+    def visit(self, edge: spack.traverse.EdgeType):
         if edge.parent is None:
             for node in spack.traverse.traverse_nodes([edge.spec], deptype=dt.LINK | dt.RUN):
                 self.main_unified_space.add(node.dag_hash())

--- a/lib/spack/spack/graph.py
+++ b/lib/spack/spack/graph.py
@@ -451,7 +451,7 @@ class DotGraphBuilder:
         self.nodes: Set[Tuple[str, str]] = set()
         self.edges: Set[Tuple[str, str, str]] = set()
 
-    def visit(self, edge: spack.spec.DependencySpec):
+    def visit(self, edge: spack.traverse.EdgeType):
         """Visit an edge and builds up entries to render the graph"""
         if edge.parent is None:
             self.nodes.add(self.node_entry(edge.spec))

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -2843,7 +2843,10 @@ class SpackSolverSetup:
             possible_deps = self.pkgs
             if spack.repo.PATH.is_virtual(edge.spec.name):
                 possible_deps = self.possible_virtuals
-            if edge.spec.name not in possible_deps and not str(edge.when):
+            if edge.spec.name in possible_deps:
+                continue
+            # conditional dependency edges may not apply; roots are unconditional
+            if edge.parent is None or not str(edge.when):
                 raise InvalidDependencyError(
                     f"'{edge.spec.name}' is not a possible dependency of any root spec"
                 )
@@ -3245,7 +3248,7 @@ class SpackSolverSetup:
         the when-spec is added as a subcondition of the trigger to ensure the dependency
         is only activated when the subcondition holds.
         """
-        for dspec in spec.traverse_edges():
+        for dspec in spec.traverse_edges(root=False):
             # Ignore unconditional deps
             if dspec.when == EMPTY_SPEC:
                 continue

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -2206,7 +2206,7 @@ class Spec:
     def traverse_edges(
         self,
         *,
-        root: bool = ...,
+        root: Literal[False],
         order: spack.traverse.OrderType = ...,
         cover: spack.traverse.CoverType = ...,
         direction: spack.traverse.DirectionType = ...,
@@ -2220,7 +2220,7 @@ class Spec:
     def traverse_edges(
         self,
         *,
-        root: bool = ...,
+        root: Literal[False],
         order: spack.traverse.OrderType = ...,
         cover: spack.traverse.CoverType = ...,
         direction: spack.traverse.DirectionType = ...,
@@ -2229,6 +2229,34 @@ class Spec:
         key: Callable[["Spec"], Any] = ...,
         visited: Optional[Set[Any]] = ...,
     ) -> Iterable[Tuple[int, DependencySpec]]: ...
+
+    @overload
+    def traverse_edges(
+        self,
+        *,
+        root: bool = ...,
+        order: spack.traverse.OrderType = ...,
+        cover: spack.traverse.CoverType = ...,
+        direction: spack.traverse.DirectionType = ...,
+        deptype: Union[dt.DepFlag, dt.DepTypes] = ...,
+        depth: Literal[False] = False,
+        key: Callable[["Spec"], Any] = ...,
+        visited: Optional[Set[Any]] = ...,
+    ) -> Iterable[spack.traverse.EdgeType]: ...
+
+    @overload
+    def traverse_edges(
+        self,
+        *,
+        root: bool = ...,
+        order: spack.traverse.OrderType = ...,
+        cover: spack.traverse.CoverType = ...,
+        direction: spack.traverse.DirectionType = ...,
+        deptype: Union[dt.DepFlag, dt.DepTypes] = ...,
+        depth: Literal[True],
+        key: Callable[["Spec"], Any] = ...,
+        visited: Optional[Set[Any]] = ...,
+    ) -> Iterable[Tuple[int, spack.traverse.EdgeType]]: ...
 
     def traverse_edges(
         self,
@@ -2241,7 +2269,7 @@ class Spec:
         depth: bool = False,
         key: Callable[["Spec"], Any] = id,
         visited: Optional[Set[Any]] = None,
-    ) -> Iterable[Union[DependencySpec, Tuple[int, DependencySpec]]]:
+    ) -> Iterable[Union[spack.traverse.EdgeType, Tuple[int, spack.traverse.EdgeType]]]:
         """Shorthand for :meth:`~spack.traverse.traverse_edges`"""
         return spack.traverse.traverse_edges(
             [self],
@@ -4868,8 +4896,8 @@ class Spec:
                 )
             )
 
-        def mask_build_deps(in_spec):
-            for edge in in_spec.traverse_edges(cover="edges"):
+        def mask_build_deps(in_spec: "Spec") -> None:
+            for edge in in_spec.traverse_edges(cover="edges", root=False):
                 edge.depflag &= ~dt.BUILD
 
         if transitive:

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -4026,9 +4026,6 @@ class Spec:
                     yield edge.spec._cmp_node
                     node_ids[id(edge.spec)]
 
-                if edge.parent is None:  # skip fake edge to root
-                    continue
-
                 edge_list.append(
                     (
                         node_ids[id(edge.parent)],

--- a/lib/spack/spack/spec_parser.py
+++ b/lib/spack/spack/spec_parser.py
@@ -664,7 +664,7 @@ def _parse_toolchain_config(toolchain_config: Union[str, List[Dict]]) -> "spack.
 
             if when:
                 when_spec = Spec(when)
-                for edge in toolchain_part.traverse_edges():
+                for edge in toolchain_part.traverse_edges(root=False):
                     if edge.when is EMPTY_SPEC:
                         edge.when = when_spec.copy()
                     else:

--- a/lib/spack/spack/test/traverse.py
+++ b/lib/spack/spack/test/traverse.py
@@ -124,9 +124,12 @@ def test_all_orders_traverse_the_same_edges(direction, root, deptype, abstract_s
     specs = [abstract_specs_dtuse["dtuse"], abstract_specs_dtuse["dtlink5"]]
     kwargs = {"root": root, "direction": direction, "deptype": deptype, "cover": "edges"}
 
+    def edge_key(edge):
+        return (edge.parent.name if edge.parent is not None else "", edge.spec.name)
+
     def edges(order):
         s = traverse.traverse_edges(specs, order=order, **kwargs)
-        return sorted(list(s))
+        return sorted(s, key=edge_key)
 
     assert edges("pre") == edges("post") == edges("breadth") == edges("topo")
 

--- a/lib/spack/spack/traverse.py
+++ b/lib/spack/spack/traverse.py
@@ -577,6 +577,7 @@ def traverse_edges(
 
 def traverse_edges(
     specs: Sequence["spack.spec.Spec"],
+    *,
     root: bool = True,
     order: OrderType = "pre",
     cover: CoverType = "nodes",

--- a/lib/spack/spack/traverse.py
+++ b/lib/spack/spack/traverse.py
@@ -7,6 +7,8 @@ from typing import (
     TYPE_CHECKING,
     Any,
     Callable,
+    Deque,
+    Dict,
     Iterable,
     List,
     NamedTuple,
@@ -21,9 +23,26 @@ from typing import (
 from spack.vendor.typing_extensions import Literal
 
 import spack.deptypes as dt
+from spack.enums import PropagationPolicy
 
 if TYPE_CHECKING:
     import spack.spec
+
+
+class RootEdge(NamedTuple):
+    """Artificial in-edge of a root spec, used as a starting point for traversals. It is
+    distinguished from a real ``DependencySpec`` edge by ``parent is None``."""
+
+    spec: "spack.spec.Spec"
+    parent: None = None
+    depflag: dt.DepFlag = dt.NONE
+    virtuals: Tuple[str, ...] = ()
+    direct: bool = False
+    propagation: PropagationPolicy = PropagationPolicy.NONE
+
+
+#: Artificial root in-edges and real dependency edges yielded by traversals.
+EdgeType = Union["spack.spec.DependencySpec", RootEdge]
 
 
 #: Data class that stores a directed edge together with depth at
@@ -31,12 +50,12 @@ if TYPE_CHECKING:
 #: and ``neighbors`` of visitors, so they can decide whether to
 #: follow the edge or not.
 class EdgeAndDepth(NamedTuple):
-    edge: "spack.spec.DependencySpec"
+    edge: EdgeType
     depth: int
 
 
 # Sort edges by name first, then abstract hash, then full edge comparison to break ties
-def sort_edges(edges):
+def sort_edges(edges: List["spack.spec.DependencySpec"]) -> List["spack.spec.DependencySpec"]:
     if len(edges) > 1:
         edges.sort(key=lambda edge: (edge.spec.name or "", edge.spec.abstract_hash or "", edge))
     return edges
@@ -49,11 +68,10 @@ class BaseVisitor:
     def __init__(self, depflag: dt.DepFlag = dt.ALL):
         self.depflag = depflag
 
-    def accept(self, item):
+    def accept(self, item: EdgeAndDepth) -> bool:
         """
         Arguments:
-            item (EdgeAndDepth): Provides the depth and the edge through which the
-                node was discovered
+            item: Provides the depth and the edge through which the node was discovered
 
         Returns:
             bool: Returns ``True`` if the node is accepted. When ``False``, this
@@ -62,7 +80,7 @@ class BaseVisitor:
         """
         return True
 
-    def neighbors(self, item):
+    def neighbors(self, item: EdgeAndDepth) -> List["spack.spec.DependencySpec"]:
         return sort_edges(item.edge.spec.edges_to_dependencies(depflag=self.depflag))
 
 
@@ -73,10 +91,10 @@ class ReverseVisitor:
         self.visitor = visitor
         self.depflag = depflag
 
-    def accept(self, item):
+    def accept(self, item: EdgeAndDepth) -> bool:
         return self.visitor.accept(item)
 
-    def neighbors(self, item):
+    def neighbors(self, item: EdgeAndDepth) -> List["spack.spec.DependencySpec"]:
         """Return dependents, note that we actually flip the edge direction to allow
         generic programming"""
         spec = item.edge.spec
@@ -93,7 +111,7 @@ class CoverNodesVisitor:
         self.key = key
         self.visited = set() if visited is None else visited
 
-    def accept(self, item):
+    def accept(self, item: EdgeAndDepth) -> bool:
         # Covering nodes means: visit nodes once and only once.
         key = self.key(item.edge.spec)
 
@@ -104,7 +122,7 @@ class CoverNodesVisitor:
         self.visited.add(key)
         return accept
 
-    def neighbors(self, item):
+    def neighbors(self, item: EdgeAndDepth) -> List["spack.spec.DependencySpec"]:
         return self.visitor.neighbors(item)
 
 
@@ -116,10 +134,10 @@ class CoverEdgesVisitor:
         self.visited = set() if visited is None else visited
         self.key = key
 
-    def accept(self, item):
+    def accept(self, item: EdgeAndDepth) -> bool:
         return self.visitor.accept(item)
 
-    def neighbors(self, item):
+    def neighbors(self, item: EdgeAndDepth) -> List["spack.spec.DependencySpec"]:
         # Covering edges means: drop dependencies of visited nodes.
         key = self.key(item.edge.spec)
 
@@ -158,7 +176,7 @@ class MixedDepthVisitor:
             self.seen_roots.add(node_id)
         return True
 
-    def neighbors(self, item: EdgeAndDepth) -> List[EdgeAndDepth]:
+    def neighbors(self, item: EdgeAndDepth) -> List["spack.spec.DependencySpec"]:
         # If we're here through an artificial source node, it's a root, and we return all
         # direct_type  and transitive_type edges. If we're here through a transitive_type edge, we
         # return all transitive_type edges. To avoid returning the same edge twice:
@@ -226,29 +244,29 @@ def get_visitor_from_args(
     return visitor
 
 
-def with_artificial_edges(specs):
+def with_artificial_edges(specs: Sequence["spack.spec.Spec"]) -> Deque[EdgeAndDepth]:
     """Initialize a deque of edges from an artificial root node to the root specs."""
-    from spack.spec import DependencySpec
-
-    return deque(
-        EdgeAndDepth(edge=DependencySpec(parent=None, spec=s, depflag=0, virtuals=()), depth=0)
-        for s in specs
-    )
+    return deque(EdgeAndDepth(edge=RootEdge(spec=s), depth=0) for s in specs)
 
 
-def traverse_depth_first_edges_generator(edges, visitor, post_order=False, root=True, depth=False):
+def traverse_depth_first_edges_generator(
+    edges: Iterable[EdgeAndDepth],
+    visitor,
+    post_order: bool = False,
+    root: bool = True,
+    depth: bool = False,
+) -> Iterable[Union[EdgeType, Tuple[int, EdgeType]]]:
     """Generator that takes explores a DAG in depth-first fashion starting from
     a list of edges. Note that typically DFS would take a vertex not a list of edges,
     but the API is like this so we don't have to create an artificial root node when
     traversing from multiple roots in a DAG.
 
     Arguments:
-        edges (list): List of EdgeAndDepth instances
+        edges: List of EdgeAndDepth instances
         visitor: class instance implementing accept() and neighbors()
-        post_order (bool): Whether to yield nodes when backtracking
-        root (bool): whether to yield at depth 0
-        depth (bool): when ``True`` yield a tuple of depth and edge, otherwise only the
-            edge.
+        post_order: Whether to yield nodes when backtracking
+        root: whether to yield at depth 0
+        depth: when ``True`` yield a tuple of depth and edge, otherwise only the edge.
     """
     for edge in edges:
         if not visitor.accept(edge):
@@ -274,7 +292,21 @@ def traverse_depth_first_edges_generator(edges, visitor, post_order=False, root=
             yield (edge.depth, edge.edge) if depth else edge.edge
 
 
-def traverse_breadth_first_edges_generator(queue: deque, visitor, root=True, depth=False):
+@overload
+def traverse_breadth_first_edges_generator(
+    queue: Deque[EdgeAndDepth], visitor, root: bool = ..., depth: Literal[False] = False
+) -> Iterable[EdgeType]: ...
+
+
+@overload
+def traverse_breadth_first_edges_generator(
+    queue: Deque[EdgeAndDepth], visitor, root: bool, depth: bool
+) -> Iterable[Union[EdgeType, Tuple[int, EdgeType]]]: ...
+
+
+def traverse_breadth_first_edges_generator(
+    queue: Deque[EdgeAndDepth], visitor, root: bool = True, depth: bool = False
+) -> Iterable[Union[EdgeType, Tuple[int, EdgeType]]]:
     while len(queue) > 0:
         edge = queue.popleft()
 
@@ -289,11 +321,11 @@ def traverse_breadth_first_edges_generator(queue: deque, visitor, root=True, dep
             queue.append(EdgeAndDepth(e, edge.depth + 1))
 
 
-def traverse_breadth_first_with_visitor(specs, visitor):
+def traverse_breadth_first_with_visitor(specs: Sequence["spack.spec.Spec"], visitor) -> None:
     """Performs breadth first traversal for a list of specs (not a generator).
 
     Arguments:
-        specs (list): List of Spec instances.
+        specs: List of Spec instances.
         visitor: object that implements accept and neighbors interface, see
             for example BaseVisitor.
     """
@@ -309,14 +341,14 @@ def traverse_breadth_first_with_visitor(specs, visitor):
             queue.append(EdgeAndDepth(e, edge.depth + 1))
 
 
-def traverse_depth_first_with_visitor(edges, visitor):
+def traverse_depth_first_with_visitor(edges: Iterable[EdgeAndDepth], visitor) -> None:
     """Traverse a DAG in depth-first fashion using a visitor, starting from
     a list of edges. Note that typically DFS would take a vertex not a list of edges,
     but the API is like this so we don't have to create an artificial root node when
     traversing from multiple roots in a DAG.
 
     Arguments:
-        edges (list): List of EdgeAndDepth instances
+        edges: List of EdgeAndDepth instances
         visitor: class instance implementing accept(), pre(), post() and neighbors()
     """
     for edge in edges:
@@ -335,14 +367,18 @@ def traverse_depth_first_with_visitor(edges, visitor):
 # Helper functions for generating a tree using breadth-first traversal
 
 
-def breadth_first_to_tree_edges(roots, deptype="all", key=id):
+def breadth_first_to_tree_edges(
+    roots: Sequence["spack.spec.Spec"],
+    deptype: Union[dt.DepFlag, dt.DepTypes] = "all",
+    key: Callable[["spack.spec.Spec"], Any] = id,
+) -> Tuple[Dict[Any, List[EdgeType]], Dict[Any, Any]]:
     """This produces an adjacency list (with edges) and a map of parents.
     There may be nodes that are reached through multiple edges. To print as
     a tree, one should use the parents dict to verify if the path leading to
     the node is through the correct parent. If not, the branch should be
     truncated."""
-    edges = defaultdict(list)
-    parents = dict()
+    edges: Dict[Any, List[EdgeType]] = defaultdict(list)
+    parents: Dict[Any, Any] = dict()
 
     for edge in traverse_edges(roots, order="breadth", cover="edges", deptype=deptype, key=key):
         parent_id = None if edge.parent is None else key(edge.parent)
@@ -354,10 +390,14 @@ def breadth_first_to_tree_edges(roots, deptype="all", key=id):
     return edges, parents
 
 
-def breadth_first_to_tree_nodes(roots, deptype="all", key=id):
+def breadth_first_to_tree_nodes(
+    roots: Sequence["spack.spec.Spec"],
+    deptype: Union[dt.DepFlag, dt.DepTypes] = "all",
+    key: Callable[["spack.spec.Spec"], Any] = id,
+) -> Dict[Any, List[EdgeType]]:
     """This produces a list of edges that forms a tree; every node has no more
     that one incoming edge."""
-    edges = defaultdict(list)
+    edges: Dict[Any, List[EdgeType]] = defaultdict(list)
 
     for edge in traverse_edges(roots, order="breadth", cover="nodes", deptype=deptype, key=key):
         parent_id = None if edge.parent is None else key(edge.parent)
@@ -366,7 +406,13 @@ def breadth_first_to_tree_nodes(roots, deptype="all", key=id):
     return edges
 
 
-def traverse_breadth_first_tree_edges(parent_id, edges, parents, key=id, depth=0):
+def traverse_breadth_first_tree_edges(
+    parent_id: Any,
+    edges: Dict[Any, List[EdgeType]],
+    parents: Dict[Any, Any],
+    key: Callable[["spack.spec.Spec"], Any] = id,
+    depth: int = 0,
+) -> Iterable[Tuple[int, EdgeType]]:
     """Do a depth-first search on edges generated by bread-first traversal,
     which can be used to produce a tree."""
     for edge in edges[parent_id]:
@@ -381,24 +427,35 @@ def traverse_breadth_first_tree_edges(parent_id, edges, parents, key=id, depth=0
         yield from traverse_breadth_first_tree_edges(child_id, edges, parents, key, depth + 1)
 
 
-def traverse_breadth_first_tree_nodes(parent_id, edges, key=id, depth=0):
+def traverse_breadth_first_tree_nodes(
+    parent_id: Any,
+    edges: Dict[Any, List[EdgeType]],
+    key: Callable[["spack.spec.Spec"], Any] = id,
+    depth: int = 0,
+) -> Iterable[Tuple[int, EdgeType]]:
     for edge in edges[parent_id]:
         yield (depth, edge)
         for item in traverse_breadth_first_tree_nodes(key(edge.spec), edges, key, depth + 1):
             yield item
 
 
-def traverse_topo_edges_generator(edges, visitor, key=id, root=True, all_edges=False):
+def traverse_topo_edges_generator(
+    edges: Deque[EdgeAndDepth],
+    visitor,
+    key: Callable[["spack.spec.Spec"], Any] = id,
+    root: bool = True,
+    all_edges: bool = False,
+) -> Iterable[EdgeType]:
     """
     Returns a list of edges in topological order, in the sense that all in-edges of a vertex appear
     before all out-edges.
 
     Arguments:
-        edges (list): List of EdgeAndDepth instances
+        edges: List of EdgeAndDepth instances
         visitor: visitor that produces unique edges defining the (sub)DAG of interest.
         key: function that takes a spec and outputs a key for uniqueness test.
-        root (bool): Yield the root nodes themselves
-        all_edges (bool): When ``False`` only one in-edge per node is returned, when
+        root: Yield the root nodes themselves
+        all_edges: When ``False`` only one in-edge per node is returned, when
             ``True`` all reachable edges are returned.
     """
     # Topo order used to be implemented using a DFS visitor, which was relatively efficient in that
@@ -409,10 +466,10 @@ def traverse_topo_edges_generator(edges, visitor, key=id, root=True, all_edges=F
     # of interest and then compute a topological order that is the most breadth-first possible.
 
     # maps node identifier to the number of remaining in-edges
-    in_edge_count = defaultdict(int)
+    in_edge_count: Dict[Any, int] = defaultdict(int)
     # maps parent identifier to a list of edges, where None is a special identifier
     # for the artificial root/source.
-    node_to_edges = defaultdict(list)
+    node_to_edges: Dict[Any, List[EdgeType]] = defaultdict(list)
     for edge in traverse_breadth_first_edges_generator(edges, visitor, root=True, depth=False):
         in_edge_count[key(edge.spec)] += 1
         parent_id = key(edge.parent) if edge.parent is not None else None
@@ -447,7 +504,7 @@ DirectionType = Literal["children", "parents"]
 def traverse_edges(
     specs: Sequence["spack.spec.Spec"],
     *,
-    root: bool = ...,
+    root: Literal[False],
     order: OrderType = ...,
     cover: CoverType = ...,
     direction: DirectionType = ...,
@@ -462,7 +519,7 @@ def traverse_edges(
 def traverse_edges(
     specs: Sequence["spack.spec.Spec"],
     *,
-    root: bool = ...,
+    root: Literal[False],
     order: OrderType = ...,
     cover: CoverType = ...,
     direction: DirectionType = ...,
@@ -482,10 +539,40 @@ def traverse_edges(
     cover: CoverType = ...,
     direction: DirectionType = ...,
     deptype: Union[dt.DepFlag, dt.DepTypes] = ...,
+    depth: Literal[False] = False,
+    key: Callable[["spack.spec.Spec"], Any] = ...,
+    visited: Optional[Set[Any]] = ...,
+) -> Iterable[EdgeType]: ...
+
+
+@overload
+def traverse_edges(
+    specs: Sequence["spack.spec.Spec"],
+    *,
+    root: bool = ...,
+    order: OrderType = ...,
+    cover: CoverType = ...,
+    direction: DirectionType = ...,
+    deptype: Union[dt.DepFlag, dt.DepTypes] = ...,
+    depth: Literal[True],
+    key: Callable[["spack.spec.Spec"], Any] = ...,
+    visited: Optional[Set[Any]] = ...,
+) -> Iterable[Tuple[int, EdgeType]]: ...
+
+
+@overload
+def traverse_edges(
+    specs: Sequence["spack.spec.Spec"],
+    *,
+    root: bool = ...,
+    order: OrderType = ...,
+    cover: CoverType = ...,
+    direction: DirectionType = ...,
+    deptype: Union[dt.DepFlag, dt.DepTypes] = ...,
     depth: bool,
     key: Callable[["spack.spec.Spec"], Any] = ...,
     visited: Optional[Set[Any]] = ...,
-) -> Iterable[Union["spack.spec.DependencySpec", Tuple[int, "spack.spec.DependencySpec"]]]: ...
+) -> Iterable[Union[EdgeType, Tuple[int, EdgeType]]]: ...
 
 
 def traverse_edges(
@@ -498,7 +585,7 @@ def traverse_edges(
     depth: bool = False,
     key: Callable[["spack.spec.Spec"], Any] = id,
     visited: Optional[Set[Any]] = None,
-) -> Iterable[Union["spack.spec.DependencySpec", Tuple[int, "spack.spec.DependencySpec"]]]:
+) -> Iterable[Union[EdgeType, Tuple[int, EdgeType]]]:
     """
     Iterable of edges from the DAG, starting from a list of root specs.
 
@@ -660,7 +747,7 @@ def traverse_tree(
     deptype: Union[dt.DepFlag, dt.DepTypes] = "all",
     key: Callable[["spack.spec.Spec"], Any] = id,
     depth_first: bool = True,
-) -> Iterable[Tuple[int, "spack.spec.DependencySpec"]]:
+) -> Iterable[Tuple[int, EdgeType]]:
     """
     Generator that yields ``(depth, DependencySpec)`` tuples in the depth-first
     pre-order, so that a tree can be printed from it.


### PR DESCRIPTION
Most traversal algorithms work with edges, and need artifical in-edges for roots.
That used to be done with an ad-hoc DependencySpec with parent set to None.
The problem is that DependencySpec is best typed as an edge between Spec
and Spec, otherwise we need tons of defensive runtime assertions on
`edge.parent is not None`.

The solution here is to make the edge type in traversal a union of ordinary
edges DependencySpec and an artificial RootEdge.

Overloads on `root=False` ensure that that type doesn't make its way into call
sites, and even if it does, as long as `.parent` isn't used, it's not a
problem.

Because RootEdge is a named tuple, it also means that typing catches issues when
the artificial edge is unintentionally mutated (hence root=False in some places).
