### PR TITLE
platforms: break cycle with spack.config

### DIFF
--- a/lib/spack/spack/config.py
+++ b/lib/spack/spack/config.py
@@ -47,6 +47,7 @@ from spack.vendor import jsonschema
 import spack
 import spack.error
 import spack.paths
+import spack.platforms
 import spack.schema
 import spack.schema.bootstrap
 import spack.schema.cdash
@@ -1574,6 +1575,9 @@ def create() -> Configuration:
 #: This is the singleton configuration instance for Spack.
 CONFIG = cast(Configuration, lang.Singleton(create_incremental))
 
+#: Many cached config values depend on the current platform, so drop them when it changes.
+spack.platforms.on_host_changed.append(lambda: CONFIG.clear_caches())
+
 
 def add_from_file(filename: str, scope: Optional[str] = None) -> None:
     """Add updates to a config from a filename"""
@@ -2250,7 +2254,6 @@ def determine_number_of_jobs(
 
 def architecture():
     # break circular import
-    import spack.platforms
     import spack.spec
 
     host_platform = spack.platforms.host()

--- a/lib/spack/spack/platforms/__init__.py
+++ b/lib/spack/spack/platforms/__init__.py
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 import contextlib
-from typing import Callable
+from typing import Callable, List
 
 from ._functions import _host, by_name, platforms, reset
 from ._platform import Platform
@@ -34,6 +34,11 @@ real_host = _host
 #: context manager.
 host: Callable[[], Platform] = _host
 
+#: Callbacks invoked when the current platform changes through the use_platform context manager.
+#: Higher-level modules that cache host-dependent state (e.g. spack.config) register a callback
+#: here to invalidate it.
+on_host_changed: List[Callable[[], None]] = []
+
 
 class _PickleableCallable:
     """Class used to pickle a callable that may substitute either
@@ -57,17 +62,17 @@ def using_libc_compatibility() -> bool:
 def use_platform(new_platform):
     global host
 
-    import spack.config
-
     assert isinstance(new_platform, Platform), f'"{new_platform}" must be an instance of Platform'
 
     original_host_fn = host
 
     try:
         host = _PickleableCallable(new_platform)
-        spack.config.CONFIG.clear_caches()
+        for callback in on_host_changed:
+            callback()
         yield new_platform
 
     finally:
         host = original_host_fn
-        spack.config.CONFIG.clear_caches()
+        for callback in on_host_changed:
+            callback()


### PR DESCRIPTION
`use_platform` called `spack.config.CONFIG.clear_caches()` through an inline
import, resulting in a circular dependency.

Invert the dependency: `spack.platforms` exposes a list of on-host-changed
callbacks, and `spack.config` registers its cache clearing there.