### PR TITLE
util/path.py: break cycle with spack.config

### DIFF
--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -66,7 +66,6 @@ import spack.util.filesystem as fsys
 import spack.util.gpg
 import spack.util.lang
 import spack.util.parallel
-import spack.util.path
 import spack.util.spack_json as sjson
 import spack.util.spack_yaml as syaml
 import spack.util.url as url_util
@@ -2161,7 +2160,7 @@ def install_root_node(
         raise RuntimeError(msg.format(spec.build_spec.format()))
 
     # don't print long padded paths while extracting/relocating binaries
-    with spack.util.path.filter_padding():
+    with spack.store.filter_padding():
         tty.msg('Installing "{0}" from a buildcache'.format(spec.format()))
         extract_tarball(spec, tarball_stage, force)
         spec.package.windows_establish_runtime_linkage()

--- a/lib/spack/spack/old_installer.py
+++ b/lib/spack/spack/old_installer.py
@@ -463,7 +463,7 @@ def _process_binary_cache_tarball(
 
     tty.msg(f"Extracting {package_id(pkg.spec)} from binary cache")
 
-    with timer.measure("install"), spack.util.path.filter_padding():
+    with timer.measure("install"), spack.store.filter_padding():
         binary_distribution.extract_tarball(pkg.spec, tarball_stage, force=False, timer=timer)
 
         if pkg.spec.spliced:  # overwrite old metadata with new
@@ -2790,7 +2790,7 @@ def build_process(pkg: "spack.package_base.PackageBase", install_args: dict) -> 
     installer = BuildProcessInstaller(pkg, install_args)
 
     # don't print long padded paths in executable debug output.
-    with spack.util.path.filter_padding():
+    with spack.store.filter_padding():
         return installer.run()
 
 

--- a/lib/spack/spack/store.py
+++ b/lib/spack/spack/store.py
@@ -131,6 +131,22 @@ def parse_install_tree(config_dict: dict) -> Tuple[str, str, Dict[str, str]]:
     return root, unpadded_root, projections
 
 
+@contextlib.contextmanager
+def filter_padding():
+    """Context manager to safely disable path padding in all Spack output.
+
+    This is needed because Spack's debug output gets extremely long when we use a
+    long padded installation path.
+    """
+    padding = spack.config.get("config:install_tree:padded_length", None)
+    if padding:
+        # filter out all padding from the install command output
+        with tty.output_filter(spack.util.path.padding_filter):
+            yield
+    else:
+        yield  # no-op: don't filter unless padding is actually enabled
+
+
 class Store:
     """A store is a path full of installed Spack packages.
 

--- a/lib/spack/spack/test/util/path.py
+++ b/lib/spack/spack/test/util/path.py
@@ -8,6 +8,7 @@ import sys
 import pytest
 
 import spack.config
+import spack.store
 import spack.util.path as sup
 from spack.util import tty
 
@@ -90,25 +91,25 @@ def test_output_filtering(capfd, install_mockery, mutable_config):
     # test filtering when padding is enabled
     with spack.config.override("config:install_tree", {"padded_length": 256}):
         # tty.msg with filtering on the first argument
-        with sup.filter_padding():
+        with spack.store.filter_padding():
             tty.msg("here is a long path: %s/with/a/suffix" % long_path)
         out, err = capfd.readouterr()
         assert padding_string in out
 
         # tty.msg with filtering on a laterargument
-        with sup.filter_padding():
+        with spack.store.filter_padding():
             tty.msg("here is a long path:", "%s/with/a/suffix" % long_path)
         out, err = capfd.readouterr()
         assert padding_string in out
 
         # tty.error with filtering on the first argument
-        with sup.filter_padding():
+        with spack.store.filter_padding():
             tty.error("here is a long path: %s/with/a/suffix" % long_path)
         out, err = capfd.readouterr()
         assert padding_string in err
 
         # tty.error with filtering on a later argument
-        with sup.filter_padding():
+        with spack.store.filter_padding():
             tty.error("here is a long path:", "%s/with/a/suffix" % long_path)
         out, err = capfd.readouterr()
         assert padding_string in err

--- a/lib/spack/spack/util/path.py
+++ b/lib/spack/spack/util/path.py
@@ -7,7 +7,6 @@
 TODO: this is really part of spack.config. Consolidate it.
 """
 
-import contextlib
 import functools
 import os
 import re
@@ -335,25 +334,6 @@ padding_filter = _PaddingFilter(as_bytes=False)
 
 #: Callable that filters path-padding placeholders from bytes buffers
 padding_filter_bytes = _PaddingFilter(as_bytes=True)
-
-
-@contextlib.contextmanager
-def filter_padding():
-    """Context manager to safely disable path padding in all Spack output.
-
-    This is needed because Spack's debug output gets extremely long when we use a
-    long padded installation path.
-    """
-    # circular import
-    import spack.config
-
-    padding = spack.config.get("config:install_tree:padded_length", None)
-    if padding:
-        # filter out all padding from the install command output
-        with tty.output_filter(padding_filter):
-            yield
-    else:
-        yield  # no-op: don't filter unless padding is actually enabled
 
 
 def debug_padded_filter(string, level=1):


### PR DESCRIPTION
The filter_padding context manager was the only thing in spack.util.path
that needed spack.config: it reads config:install_tree:padded_length.
Padding is an install-tree concept, so move it to spack.store, which
already imports config and util.path. The pure padding_filter callables
stay in util/path.

The new installer already does this better, the old installer should really ask
the store for its current config, but I don't want to make changes to the old
installer.

