### PR TITLE
schema/repos.py: remove v1.0 update function

### DIFF
--- a/lib/spack/spack/schema/repos.py
+++ b/lib/spack/spack/schema/repos.py
@@ -13,73 +13,54 @@ from typing import Any, Dict
 #: Properties for inclusion in other schemas
 properties: Dict[str, Any] = {
     "repos": {
-        "description": "Configuration for package repositories that Spack searches for packages",
-        "oneOf": [
-            {
-                # old format: array of strings
-                "type": "array",
-                "items": {
+        "type": "object",
+        "description": "Named repositories mapping configuration names to repository definitions",
+        "additionalProperties": {
+            "oneOf": [
+                {
+                    # local path
                     "type": "string",
-                    "description": "Path to a Spack package repository directory",
+                    "description": "Path to a local Spack package repository directory "
+                    "containing repo.yaml and packages/",
                 },
-                "description": "Legacy format: list of local paths to package repository "
-                "directories",
-            },
-            {
-                # new format: object with named repositories
-                "type": "object",
-                "description": "Named repositories mapping configuration names to repository "
-                "definitions",
-                "additionalProperties": {
-                    "oneOf": [
-                        {
-                            # local path
+                {
+                    # remote git repository
+                    "type": "object",
+                    "properties": {
+                        "git": {
                             "type": "string",
-                            "description": "Path to a local Spack package repository directory "
-                            "containing repo.yaml and packages/",
+                            "description": "Git repository URL for remote package repository",
                         },
-                        {
-                            # remote git repository
-                            "type": "object",
-                            "properties": {
-                                "git": {
-                                    "type": "string",
-                                    "description": "Git repository URL for remote package "
-                                    "repository",
-                                },
-                                "branch": {
-                                    "type": "string",
-                                    "description": "Git branch name to checkout (default branch "
-                                    "if not specified)",
-                                },
-                                "commit": {
-                                    "type": "string",
-                                    "description": "Specific git commit hash to pin the "
-                                    "repository to",
-                                },
-                                "tag": {
-                                    "type": "string",
-                                    "description": "Git tag name to pin the repository to",
-                                },
-                                "destination": {
-                                    "type": "string",
-                                    "description": "Custom local directory path where the Git "
-                                    "repository should be cloned",
-                                },
-                                "paths": {
-                                    "type": "array",
-                                    "items": {"type": "string"},
-                                    "description": "List of relative paths (from the Git "
-                                    "repository root) that contain Spack package repositories "
-                                    "(overrides spack-repo-index.yaml)",
-                                },
-                            },
-                            "additionalProperties": False,
+                        "branch": {
+                            "type": "string",
+                            "description": "Git branch name to checkout (default branch "
+                            "if not specified)",
                         },
-                    ]
+                        "commit": {
+                            "type": "string",
+                            "description": "Specific git commit hash to pin the repository to",
+                        },
+                        "tag": {
+                            "type": "string",
+                            "description": "Git tag name to pin the repository to",
+                        },
+                        "destination": {
+                            "type": "string",
+                            "description": "Custom local directory path where the Git "
+                            "repository should be cloned",
+                        },
+                        "paths": {
+                            "type": "array",
+                            "items": {"type": "string"},
+                            "description": "List of relative paths (from the Git "
+                            "repository root) that contain Spack package repositories "
+                            "(overrides spack-repo-index.yaml)",
+                        },
+                    },
+                    "additionalProperties": False,
                 },
-            },
-        ],
+            ]
+        },
         "default": {},
     }
 }
@@ -92,26 +73,3 @@ schema = {
     "additionalProperties": False,
     "properties": properties,
 }
-
-
-def update(data: Dict[str, Any]) -> bool:
-    """Update the repos.yaml configuration data to the new format."""
-    if not isinstance(data["repos"], list):
-        return False
-
-    from spack.repo import from_path
-    from spack.util import tty
-
-    # Convert old format [paths...] to new format {namespace: path, ...}
-    repos = {}
-    for path in data["repos"]:
-        try:
-            repo = from_path(path)
-        except Exception as e:
-            tty.warn(f"package repository {path} is disabled due to: {e}")
-            continue
-        if repo.namespace is not None:
-            repos[repo.namespace] = path
-
-    data["repos"] = repos
-    return True

--- a/lib/spack/spack/test/config.py
+++ b/lib/spack/spack/test/config.py
@@ -805,7 +805,7 @@ repos:
   d: https://foobar.com/baz
 """,
         )
-        assert "repos.yaml:2" in str(e)
+        assert "repos.yaml:5" in str(e)
 
 
 def test_config_parse_str_not_bool(tmp_path: pathlib.Path):
@@ -999,7 +999,7 @@ spack:
         verify_ssl: False
         dirty: False
     repos:
-        - ~/my/repo/location
+        location: ~/my/repo/location
     mirrors:
         remote: /foo/bar/baz
     compilers:

--- a/lib/spack/spack/test/repo.py
+++ b/lib/spack/spack/test/repo.py
@@ -11,7 +11,6 @@ import spack.environment
 import spack.package_base
 import spack.paths
 import spack.repo
-import spack.schema.repos
 import spack.spec
 import spack.util.executable
 import spack.util.file_cache
@@ -599,17 +598,6 @@ spack:
         assert any(os.path.samefile(repo_root, r.root) for r in spack.repo.PATH.repos)
 
     assert not any(os.path.samefile(repo_root, r.root) for r in spack.repo.PATH.repos)
-
-
-def test_repo_update(tmp_path: pathlib.Path):
-    existing_root, _ = spack.repo.create_repo(str(tmp_path), namespace="foo")
-    nonexisting_root = str(tmp_path / "nonexisting")
-    config = {"repos": [existing_root, nonexisting_root]}
-    assert spack.schema.repos.update(config)
-    assert config["repos"] == {
-        "foo": existing_root
-        # non-existing root is removed for simplicity; would be a warning otherwise.
-    }
 
 
 def test_mock_builtin_repo(mock_packages):


### PR DESCRIPTION
Remove the list version by Spack v1.3? This is motivated from reducing cyclic imports, I can understand if user convenience is more important ;)