### PR TITLE
tests: no networking in unit tests

### DIFF
--- a/lib/spack/spack/test/ci.py
+++ b/lib/spack/spack/test/ci.py
@@ -13,6 +13,7 @@ import spack.concretize
 import spack.environment as ev
 import spack.error
 import spack.paths
+import spack.reporters.cdash
 import spack.util.filesystem as fs
 import spack.util.git
 from spack import ci, repo
@@ -530,8 +531,10 @@ def test_ci_run_standalone_tests_not_installed_cdash(
     assert "No such file or directory" in err
 
 
-def test_ci_skipped_report(tmp_path: pathlib.Path, config):
+def test_ci_skipped_report(tmp_path: pathlib.Path, config, monkeypatch):
     """Test explicit skipping of report as well as CI's 'package' arg."""
+    # the cdash url is fake; never upload reports to it
+    monkeypatch.setattr(spack.reporters.cdash.CDash, "upload", lambda self, filename: None)
     pkg = "trivial-smoke-test"
     spec = spack.concretize.concretize_one(pkg)
     ci_cdash = {

--- a/lib/spack/spack/test/cmd/ci.py
+++ b/lib/spack/spack/test/cmd/ci.py
@@ -20,6 +20,7 @@ import spack.hash_types as ht
 import spack.main
 import spack.paths
 import spack.repo
+import spack.reporters.cdash
 import spack.spec
 import spack.stage
 import spack.util.spack_yaml as syaml
@@ -640,6 +641,8 @@ def test_ci_rebuild_mock_success(
     rebuild_env = create_rebuild_env(tmp_path, pkg_name, broken_tests)
 
     monkeypatch.setattr(spack.cmd.ci, "SPACK_COMMAND", "echo")
+    # the cdash url in the environment is fake; never upload reports to it
+    monkeypatch.setattr(spack.reporters.cdash.CDash, "upload", lambda self, filename: None)
 
     with working_dir(rebuild_env.env_dir):
         activate_rebuild_env(tmp_path, pkg_name, rebuild_env)
@@ -1723,12 +1726,12 @@ def dynamic_mapping_setup(tmp_path: pathlib.Path):
     filename = str(tmp_path / "spack.yaml")
     with open(filename, "w", encoding="utf-8") as f:
         f.write(
-            """\
+            f"""\
 spack:
   specs:
     - pkg-a
   mirrors:
-    buildcache-destination: https://my.fake.mirror
+    buildcache-destination: {(tmp_path / "buildcache").as_uri()}
   ci:
     pipeline-gen:
     - dynamic-mapping:

--- a/lib/spack/spack/test/cmd/install.py
+++ b/lib/spack/spack/test/cmd/install.py
@@ -25,6 +25,7 @@ import spack.hash_types as ht
 import spack.hooks.sbom_generate
 import spack.old_installer
 import spack.package_base
+import spack.reporters.cdash
 import spack.store
 import spack.util.filesystem as fs
 from spack.error import SpackError, SpecSyntaxError
@@ -86,19 +87,19 @@ def _check_runtests_all(pkg):
 
 
 @pytest.mark.disable_clean_stage_check
-def test_install_runtests_notests(monkeypatch, mock_packages, install_mockery):
+def test_install_runtests_notests(monkeypatch, mock_packages, mock_fetch, install_mockery):
     monkeypatch.setattr(spack.package_base.PackageBase, "_unit_test_check", _check_runtests_none)
     install("-v", "dttop")
 
 
 @pytest.mark.disable_clean_stage_check
-def test_install_runtests_root(monkeypatch, mock_packages, install_mockery):
+def test_install_runtests_root(monkeypatch, mock_packages, mock_fetch, install_mockery):
     monkeypatch.setattr(spack.package_base.PackageBase, "_unit_test_check", _check_runtests_dttop)
     install("--test=root", "dttop")
 
 
 @pytest.mark.disable_clean_stage_check
-def test_install_runtests_all(monkeypatch, mock_packages, install_mockery):
+def test_install_runtests_all(monkeypatch, mock_packages, mock_fetch, install_mockery):
     monkeypatch.setattr(spack.package_base.PackageBase, "_unit_test_check", _check_runtests_all)
     install("--test=all", "pkg-a")
 
@@ -555,11 +556,18 @@ def test_cdash_report_concretization_error(
         assert any(x in content for x in expected_messages)
 
 
+def _noop_cdash_upload(self, filename):
+    """Module-level so it can be pickled into the build child process."""
+    return None
+
+
 @pytest.mark.not_on_windows("Windows log_output logs phase header out of order")
 @pytest.mark.disable_clean_stage_check
 def test_cdash_upload_build_error(
-    capfd, tmp_path: pathlib.Path, mock_fetch, install_mockery, installer_variant
+    capfd, tmp_path: pathlib.Path, mock_fetch, install_mockery, installer_variant, monkeypatch
 ):
+    # the cdash upload url is fake; never upload reports to it
+    monkeypatch.setattr(spack.reporters.cdash.CDash, "upload", _noop_cdash_upload)
     with fs.working_dir(str(tmp_path)):
         with pytest.raises(SpackError):
             install(

--- a/lib/spack/spack/test/package_class.py
+++ b/lib/spack/spack/test/package_class.py
@@ -20,6 +20,7 @@ import spack.deptypes as dt
 import spack.error
 import spack.install_test
 import spack.package_base
+import spack.repo
 import spack.spec
 import spack.store
 import spack.subprocess_context
@@ -389,7 +390,10 @@ def test_git_provenance_find_commit_ls_remote(
 def test_git_provenance_cant_resolve_commit(mock_packages, monkeypatch, config, capfd, tmp_path):
     """Fail all attempts to resolve git commits"""
     repo_path = str(tmp_path / "non_existent")
+    # patch the base class for dependencies, and the concrete class, whose own ``git``
+    # attribute (a real github URL) shadows the base class one
     monkeypatch.setattr(spack.package_base.PackageBase, "git", repo_path, raising=False)
+    monkeypatch.setattr(spack.repo.PATH.get_pkg_class("git-ref-package"), "git", repo_path)
     monkeypatch.setattr(spack.package_base.PackageBase, "do_fetch", lambda *args, **kwargs: None)
     spec = spack.concretize.concretize_one("git-ref-package@develop")
     captured = capfd.readouterr()

--- a/lib/spack/spack/test/url_fetch.py
+++ b/lib/spack/spack/test/url_fetch.py
@@ -375,7 +375,7 @@ def test_url_fetch_text_urllib_web_error(mutable_config, monkeypatch):
     def _raise_web_error(*args, **kwargs):
         raise web_util.SpackWebError("bad url")
 
-    monkeypatch.setattr(web_util, "read_from_url", _raise_web_error)
+    monkeypatch.setattr(web_util, "read_text", _raise_web_error)
     mutable_config.set("config:url_fetch_method", "urllib")
 
     with pytest.raises(spack.error.FetchError, match="fetch failed"):


### PR DESCRIPTION
It's that time of the year again :).

Several unit tests performed DNS lookups and connections:

- `test_ci_dynamic_mapping_*`: the buildcache-destination mirror
  `https://my.fake.mirror` was probed with an HTTPS HEAD request during
  ci generate (`url_exists` on the index). Use a local `file://` mirror.
- `test_ci_rebuild_mock_success`, `test_ci_skipped_report`,
  `test_cdash_upload_build_error`: CDash report uploads went out to
  `my.fake.cdash` / `gethostbyname("fake")` / a connect to `localhost:80`.
- `test_url_fetch_text_urllib_web_error`: the `read_from_url`
  monkeypatch was dead code (`fetch_url_text` uses `read_text` on the
  urllib path), so the test downloaded `https://example.com/` and only
  passed because writing the result to a file named `<nothing>` raised
  OSError. Patch `read_text` instead.
- `test_git_provenance_cant_resolve_commit`: patching `PackageBase.git`
  is shadowed by the git attribute of the `git-ref-package` class, so
  spack ran `git ls-remote` against `https://github.com/dummy/dummy.git`
  three times. Patch the concrete class as well.
- `test_install_runtests_*`: no `mock_fetch`, so every build child
  process fetched `http://www.example.com/...tar.gz` for each package in
  the DAG (27 fetches). Add `mock_fetch`.

