### PR TITLE
module: suppress output from sourcing init file

### DIFF
--- a/lib/spack/spack/util/module_cmd.py
+++ b/lib/spack/spack/util/module_cmd.py
@@ -43,7 +43,9 @@ def module(
     module_cmd = module_template or ("module " + " ".join(args))
     environb = environb or os.environb
     if b"MODULESHOME" in environb:
-        module_cmd = module_src_cmd or "source $MODULESHOME/init/bash; " + module_cmd
+        module_cmd = (
+            module_src_cmd or "source $MODULESHOME/init/bash >/dev/null 2>&1; " + module_cmd
+        )
 
     if args[0] in module_change_commands:
         # Suppress module output


### PR DESCRIPTION
Discovered from spurious failures of:
- test_module_function_change_env_with_module_src_cmd

When `MODULESHOME` is set, module() prepends `source $MODULESHOME/init/bash` to the command whose merged stdout/stderr is parsed as awk's NUL-separated `NAME=VALUE` dump.

That sourcing was not output-suppressed, so if the init script is missing its output can land ahead of the dump in the captured stream, with no NUL separator, corrupting the first parsed variable name.