### PR TITLE
projections: check the "all" before satisfies

### DIFF
--- a/lib/spack/spack/projections.py
+++ b/lib/spack/spack/projections.py
@@ -11,8 +11,10 @@ def get_projection(projections, spec):
     """
     all_projection = None
     for spec_like, projection in projections.items():
-        if spec.satisfies(spec_like):
-            return spack.config.substitute_path_variables(projection)
-        elif spec_like == "all":
+        # "all" is a catch-all, not a spec: satisfies("all") would trigger a package lookup
+        # to check whether "all" is a virtual provided by the spec.
+        if spec_like == "all":
             all_projection = spack.config.substitute_path_variables(projection)
+        elif spec.satisfies(spec_like):
+            return spack.config.substitute_path_variables(projection)
     return all_projection


### PR DESCRIPTION
`all` is a catch-all key, not a spec: `satisfies("all")` triggered a
package lookup on every `path_for_spec` call to check whether `all` is a
virtual provided by the spec.

