### PR TITLE
tests: fix stateful tests

### DIFF
--- a/lib/spack/spack/test/mirror.py
+++ b/lib/spack/spack/test/mirror.py
@@ -42,7 +42,7 @@ def _clear_repos():
     yield
 
 
-def set_up_package(name, repository, url_attr):
+def set_up_package(name, repository, url_attr, monkeypatch):
     """Set up a mock package to be mirrored.
     Each package needs us to:
 
@@ -53,11 +53,13 @@ def set_up_package(name, repository, url_attr):
     s = spack.concretize.concretize_one(name)
     repos[name] = repository
 
-    # change the fetch args of the first (only) version.
+    # change the fetch args of the first (only) version. versions is a class-level dict shared
+    # across instances and cached with the package module, so mutate it via monkeypatch to
+    # restore it after the test instead of leaking the mock URL into later tests.
     assert len(s.package.versions) == 1
 
     v = next(iter(s.package.versions))
-    s.package.versions[v][url_attr] = repository.url
+    monkeypatch.setitem(s.package.versions[v], url_attr, repository.url)
 
 
 def check_mirror():
@@ -109,31 +111,33 @@ def check_mirror():
                         assert all(left in exclude for left in dcmp.left_only)
 
 
-def test_url_mirror(mock_archive):
-    set_up_package("trivial-install-test-package", mock_archive, "url")
+def test_url_mirror(mock_archive, monkeypatch):
+    set_up_package("trivial-install-test-package", mock_archive, "url", monkeypatch)
     check_mirror()
 
 
-def test_git_mirror(git, mock_git_repository):
-    set_up_package("git-test", mock_git_repository, "git")
+def test_git_mirror(git, mock_git_repository, monkeypatch):
+    set_up_package("git-test", mock_git_repository, "git", monkeypatch)
     check_mirror()
 
 
-def test_svn_mirror(mock_svn_repository):
-    set_up_package("svn-test", mock_svn_repository, "svn")
+def test_svn_mirror(mock_svn_repository, monkeypatch):
+    set_up_package("svn-test", mock_svn_repository, "svn", monkeypatch)
     check_mirror()
 
 
-def test_hg_mirror(mock_hg_repository):
-    set_up_package("hg-test", mock_hg_repository, "hg")
+def test_hg_mirror(mock_hg_repository, monkeypatch):
+    set_up_package("hg-test", mock_hg_repository, "hg", monkeypatch)
     check_mirror()
 
 
-def test_all_mirror(mock_git_repository, mock_svn_repository, mock_hg_repository, mock_archive):
-    set_up_package("git-test", mock_git_repository, "git")
-    set_up_package("svn-test", mock_svn_repository, "svn")
-    set_up_package("hg-test", mock_hg_repository, "hg")
-    set_up_package("trivial-install-test-package", mock_archive, "url")
+def test_all_mirror(
+    mock_git_repository, mock_svn_repository, mock_hg_repository, mock_archive, monkeypatch
+):
+    set_up_package("git-test", mock_git_repository, "git", monkeypatch)
+    set_up_package("svn-test", mock_svn_repository, "svn", monkeypatch)
+    set_up_package("hg-test", mock_hg_repository, "hg", monkeypatch)
+    set_up_package("trivial-install-test-package", mock_archive, "url", monkeypatch)
     check_mirror()
 
 

--- a/lib/spack/spack/test/spec_semantics.py
+++ b/lib/spack/spack/test/spec_semantics.py
@@ -2031,7 +2031,7 @@ def test_intersects_and_satisfies(mock_packages, factory, lhs_str, rhs_str, resu
         ),
     ],
 )
-def test_constrain(factory, lhs_str, rhs_str, result, constrained_str):
+def test_constrain(factory, lhs_str, rhs_str, result, constrained_str, mock_packages):
     lhs = factory(lhs_str)
     rhs = factory(rhs_str)
 

--- a/lib/spack/spack/test/spec_syntax.py
+++ b/lib/spack/spack/test/spec_syntax.py
@@ -1216,7 +1216,7 @@ def test_cli_spec_roundtrip(args, expected):
         ),
     ],
 )
-def test_parse_toolchain(spec_str, toolchain, expected_roundtrip, mutable_config):
+def test_parse_toolchain(spec_str, toolchain, expected_roundtrip, mutable_config, mock_packages):
     """Tests that toolchains are expanded correctly"""
     parser = SpecParser(spec_str)
     for expected in expected_roundtrip:

--- a/lib/spack/spack/test/spec_yaml.py
+++ b/lib/spack/spack/test/spec_yaml.py
@@ -411,7 +411,7 @@ ordered_spec = collections.OrderedDict(
         ("specfiles/hdf5.v020.json.gz", "vlirlcgazhvsvtundz4kug75xkkqqgou", spack.spec.SpecfileV4),
     ],
 )
-def test_load_json_specfiles(specfile, expected_hash, reader_cls):
+def test_load_json_specfiles(specfile, expected_hash, reader_cls, mock_packages):
     fullpath = os.path.join(spack.paths.test_path, "data", specfile)
     with gzip.open(fullpath, "rt", encoding="utf-8") as f:
         data = json.load(f)

--- a/lib/spack/spack/test/url_fetch.py
+++ b/lib/spack/spack/test/url_fetch.py
@@ -158,20 +158,25 @@ if sys.platform != "win32":
 @pytest.mark.parametrize("secure", [True, False])
 @pytest.mark.parametrize("_fetch_method", ["curl", "urllib"])
 @pytest.mark.parametrize("mock_archive", files, indirect=True)
-def test_fetch(mock_archive, secure, _fetch_method, checksum_type, config, mutable_mock_repo):
+def test_fetch(
+    mock_archive, secure, _fetch_method, checksum_type, config, mutable_mock_repo, monkeypatch
+):
     """Fetch an archive and make sure we can checksum it."""
     algo = crypto.hash_fun_for_algo(checksum_type)()
     with open(mock_archive.archive_file, "rb") as f:
         algo.update(f.read())
     checksum = algo.hexdigest()
 
-    # Get a spec and tweak the test package with new checksum params
+    # Get a spec and tweak the test package with new checksum params. versions is a class-level
+    # dict shared across instances and cached with the package module, so add the version via
+    # monkeypatch to restore it after the test instead of leaking it into later tests.
     s = spack.concretize.concretize_one("url-test")
     s.package.url = mock_archive.url
-    s.package.versions[spack.version.Version("test")] = {
-        checksum_type: checksum,
-        "url": s.package.url,
-    }
+    monkeypatch.setitem(
+        s.package.versions,
+        spack.version.Version("test"),
+        {checksum_type: checksum, "url": s.package.url},
+    )
 
     # Enter the stage directory and check some properties
     with s.package.stage:


### PR DESCRIPTION
Some tests resolved packages without a repo fixture and imported
`spack_repo.builtin` instead

`mirror.py` and `url_fetch.py` tests mutated the class-level `versions` dict of
cached package classes in place. Use `monkeypatch.setitem` so the mock archive
URL does not leak into later tests.
