### PR TITLE
env activate: ensure_unwrapped before swap

### DIFF
--- a/lib/spack/spack/environment/environment.py
+++ b/lib/spack/spack/environment/environment.py
@@ -60,7 +60,7 @@ from spack.spec import Spec
 from spack.spec_filter import SpecFilter
 from spack.util import tty
 from spack.util.filesystem import copy_tree, islink, readlink
-from spack.util.lang import stable_partition
+from spack.util.lang import ensure_unwrapped, stable_partition
 from spack.util.link_tree import ConflictingSpecsError
 
 from .list import SpecList, SpecListError, SpecListParser
@@ -242,6 +242,9 @@ def activate(env, use_env_repo=False):
         install_tree_before = spack.config.get("config:install_tree")
         upstreams_before = spack.config.get("upstreams")
         repos_before = spack.config.get("repos")
+        # PATH may be a lazy singleton created from config, so materialize it before pushing
+        # the env scope, otherwise we'd save (and later restore) the env's repositories.
+        repo_before = ensure_unwrapped(spack.repo.PATH)
 
         # Record the active env (and its path, so config "$env" substitutions work)
         set_active_environment(env)
@@ -256,8 +259,8 @@ def activate(env, use_env_repo=False):
             setattr(env, "store_token", spack.store.reinitialize())
 
         if repos_before != repos_after:
-            setattr(env, "repo_token", spack.repo.PATH)
-            spack.repo.PATH.disable()
+            setattr(env, "repo_token", repo_before)
+            repo_before.disable()
             new_repo = spack.repo.RepoPath.from_config(spack.config.CONFIG)
             if use_env_repo:
                 new_repo.put_first(env.repo)

--- a/lib/spack/spack/test/repo.py
+++ b/lib/spack/spack/test/repo.py
@@ -135,6 +135,33 @@ def test_use_repositories_with_unmaterialized_path(tmp_path: pathlib.Path, confi
     assert [r.root for r in spack.repo.PATH.repos] == [spack.paths.mock_packages_path]
 
 
+def test_env_activate_with_unmaterialized_path(tmp_path: pathlib.Path, config, monkeypatch):
+    """Tests that env deactivation restores the repositories from config even when activation
+    is the first to touch the global PATH singleton. Materializing it after pushing the env
+    config scope would "save" the env's repositories and "restore" them on deactivation."""
+    (tmp_path / "spack.yaml").write_text(
+        """\
+spack:
+  specs: []
+  repos:
+    extra: $spack/var/spack/test_repos/spack_repo/builder_test
+"""
+    )
+
+    monkeypatch.setattr(
+        spack.repo, "PATH", Singleton(lambda: spack.repo.create_and_enable(spack.config.CONFIG))
+    )
+
+    env = spack.environment.Environment(tmp_path)
+    spack.environment.activate(env)
+    try:
+        assert {r.namespace for r in spack.repo.PATH.repos} == {"builder_test", "builtin_mock"}
+    finally:
+        spack.environment.deactivate()
+
+    assert [r.namespace for r in spack.repo.PATH.repos] == ["builtin_mock"]
+
+
 def test_absolute_import_spack_packages_as_python_modules(mock_packages):
     import spack_repo.builtin_mock.packages.mpileaks.package  # type: ignore[import]
 


### PR DESCRIPTION
If env activate is the first to touch the lazy `spack.repo.PATH` singleton, the
saved `repo_token` materializes only after the env scope is pushed, so
deactivate restores the env's own repositories. Same bug as 8bdac91611a6.

