### PR TITLE
module_cmd: allow loading already-loaded modules

### DIFF
--- a/lib/spack/spack/test/util/module_cmd.py
+++ b/lib/spack/spack/test/util/module_cmd.py
@@ -39,6 +39,22 @@ def test_load_module_success(monkeypatch, working_env):
 
 
 @pytest.mark.not_on_windows("Module files are not supported on Windows")
+def test_load_module_already_loaded(monkeypatch, working_env):
+    """Test that loading an already-loaded module succeeds without reloading it."""
+
+    os.environ["LOADEDMODULES"] = "test_module"
+
+    def mock_module(*args, **kwargs):
+        if args[0] == "show":
+            return ""
+        pytest.fail("load should not be called for an already-loaded module")
+
+    monkeypatch.setattr(spack.util.module_cmd, "module", mock_module)
+
+    spack.util.module_cmd.load_module("test_module")
+
+
+@pytest.mark.not_on_windows("Module files are not supported on Windows")
 def test_load_module_failure(monkeypatch, working_env):
     """Test that load_module raises an exception when a module load fails."""
 

--- a/lib/spack/spack/util/module_cmd.py
+++ b/lib/spack/spack/util/module_cmd.py
@@ -108,6 +108,12 @@ def load_module(mod):
     # Store the LOADEDMODULES before trying to load the new module
     loaded_modules_before = os.environ.get("LOADEDMODULES", "")
 
+    # Loading a module that is already loaded is a successful no-op for
+    # module systems such as Lmod. In that case LOADEDMODULES is unchanged,
+    # so treating an unchanged value below as a failure would be incorrect.
+    if mod in loaded_modules_before.split(":"):
+        return
+
     # Load the module now that there are no conflicts
     # Some module systems use stdout and some use stderr
     module("load", mod)


### PR DESCRIPTION
## Summary

Make `spack.util.module_cmd.load_module()` return successfully when its requested module is already listed in `LOADEDMODULES`.

Add a regression test covering this idempotent module-load behavior.

## Problem

`load_module()` uses a change in `LOADEDMODULES` as evidence that a module load succeeded:

1. Record `LOADEDMODULES`.
2. Run `module load <module>`.
3. Raise `ModuleLoadError` if `LOADEDMODULES` is unchanged.

That assumption is not valid for an already-loaded module. With Lmod, asking to load a module that is already present succeeds as a no-op: the command exits with status zero and `LOADEDMODULES` remains unchanged.

For example:

```console
$ module load comp/intel/2025.3.0 mpi/impi/2021.17
$ before=$LOADEDMODULES
$ module load mpi/impi/2021.17
$ echo $?
0
$ test "$before" = "$LOADEDMODULES"; echo $?
0
```

Previously, Spack treated this successful no-op as a failed module load.

## Fix

Return successfully when the requested module is already listed in `LOADEDMODULES`. The existing unchanged-environment check remains in place for modules that were not already loaded, where it continues to detect a failed load.

## Context

This was found while investigating an Intel MPI module hierarchy on a site system. Correctly configuring module prerequisites is a separate concern; this change fixes the general false-failure case when Spack retries an already-loaded module.

## Testing

- Added a regression test that verifies an already-loaded module does not call module load.
- Reproduced the successful no-op behavior with both supported module-system styles:
  - **Lmod:** reloading `mpi/impi/2021.17` returned exit status 0 and left `LOADEDMODULES` unchanged.
  - **Tcl Modules:** reloading `mpi-impi/2021.17` returned exit status 0 and left `LOADEDMODULES` unchanged.
- Ran git diff --check.

## Disclosure

This change was developed with assistance from OpenAI GPT-5.6 Terra and reviewed by the contributor.