### PR TITLE
Reduce unneeded config file writes

### DIFF
--- a/lib/spack/spack/config.py
+++ b/lib/spack/spack/config.py
@@ -235,7 +235,7 @@ class DirectoryConfigScope(ConfigScope):
         self.path = path
         self.writable = writable
         self.prefer_modify = prefer_modify
-        self.last_read: Dict[str,Any] = {}
+        self.last_read: Dict[str, Any] = {}
 
     @property
     def exists(self) -> bool:

--- a/lib/spack/spack/config.py
+++ b/lib/spack/spack/config.py
@@ -235,7 +235,7 @@ class DirectoryConfigScope(ConfigScope):
         self.path = path
         self.writable = writable
         self.prefer_modify = prefer_modify
-        self.last_read = {}
+        self.last_read: Dict[str,Any] = {}
 
     @property
     def exists(self) -> bool:

--- a/lib/spack/spack/config.py
+++ b/lib/spack/spack/config.py
@@ -235,6 +235,7 @@ class DirectoryConfigScope(ConfigScope):
         self.path = path
         self.writable = writable
         self.prefer_modify = prefer_modify
+        self.last_read = {}
 
     @property
     def exists(self) -> bool:
@@ -259,6 +260,10 @@ class DirectoryConfigScope(ConfigScope):
             schema = SECTION_SCHEMAS[section]
             data = read_config_file(path, schema)
             self.sections[section] = data
+            if data:
+                self.last_read[section] = data.copy()
+            else:
+                self.last_read[section] = None
         return self.sections[section]
 
     def _write_section(self, section: str) -> None:
@@ -268,6 +273,12 @@ class DirectoryConfigScope(ConfigScope):
         filename = self.get_section_filename(section)
         data = self._get_section(section)
         if data is None:
+            return
+
+        if data == self.last_read.get(section, None):
+            # data is unchanged since we last read it
+            # no need to write it again
+            tty.debug("Skipping unneded write of unmodified %s" % filename)
             return
 
         validate(data, SECTION_SCHEMAS[section])

--- a/lib/spack/spack/config.py
+++ b/lib/spack/spack/config.py
@@ -278,7 +278,7 @@ class DirectoryConfigScope(ConfigScope):
         if data == self.last_read.get(section, None):
             # data is unchanged since we last read it
             # no need to write it again
-            tty.debug("Skipping unneded write of unmodified %s" % filename)
+            tty.debug("Skipping unneeded write of unmodified %s" % filename)
             return
 
         validate(data, SECTION_SCHEMAS[section])


### PR DESCRIPTION
Currently, Spack re-writes configs like `config/bootstrap.yaml`  one or more times during  concretization, with the exact data that was already in it,  which prevents keeping the bootstrap files in a shared, read-only space. 

This patch attempts to detect write requests of unmodified data to config files, and not actually write them. 