### PR TITLE
gha: cleanup

### DIFF
--- a/.github/actions/setup-spack/action.yml
+++ b/.github/actions/setup-spack/action.yml
@@ -1,0 +1,48 @@
+name: Set up Spack for testing
+description: Install Python and test dependencies, configure git and bootstrapping
+
+inputs:
+  python-version:
+    description: Python version to install
+    required: true
+  pip-install:
+    description: Arguments appended to pip install --upgrade
+    required: false
+    default: -r .github/workflows/requirements/unit_tests/requirements.txt
+  bootstrap:
+    description: Either "now" to bootstrap clingo, or "none" to disable all sources
+    required: false
+    default: now
+
+runs:
+  using: composite
+  steps:
+  - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6.3.0
+    with:
+      python-version: ${{ inputs.python-version }}
+  - name: Install Python packages
+    shell: bash
+    run: pip install --upgrade pip ${{ inputs.pip-install }}
+  - name: Setup git configuration
+    shell: bash
+    run: |
+        # Need this for the git tests to succeed.
+        git --version
+        . .github/workflows/bin/setup_git.sh
+  - name: Configure bootstrapping
+    shell: bash
+    run: |
+        . share/spack/setup-env.sh
+        spack bootstrap disable spack-install
+        if [ "${{ inputs.bootstrap }}" = "now" ]; then
+            spack bootstrap now
+        else
+            spack bootstrap disable github-actions-v0.6
+            spack bootstrap disable github-actions-v2
+        fi
+  - name: Smoke tests
+    shell: bash
+    run: |
+        bin/spack -h
+        bin/spack help -a
+        bin/spack python -c "from spack_repo.builtin.packages.mpileaks.package import Mpileaks"

--- a/.github/workflows/requirements/unit_tests/requirements.txt
+++ b/.github/workflows/requirements/unit_tests/requirements.txt
@@ -2,4 +2,3 @@ pytest==9.0.3
 pytest-cov==7.1.0
 pytest-xdist==3.8.0
 coverage[toml]<=7.11.0
-clingo==5.8.0

--- a/.github/workflows/unit_tests.yaml
+++ b/.github/workflows/unit_tests.yaml
@@ -38,9 +38,6 @@ jobs:
     - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
       with:
         fetch-depth: 0
-    - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6.3.0
-      with:
-        python-version: ${{ matrix.python-version }}
     - name: Install System packages
       run: |
           sudo apt-get -y update
@@ -48,27 +45,14 @@ jobs:
           sudo apt-get -y install \
               coreutils cvs gfortran graphviz gnupg2 mercurial ninja-build \
               cmake bison libbison-dev subversion
-    - name: Install Python packages
-      run: |
-          # See https://github.com/coveragepy/coveragepy/issues/2082
-          pip install --upgrade pip pytest pytest-xdist pytest-cov "coverage<=7.11.0"
-          # Needed by the tests covering "spack style"
-          pip install --upgrade "mypy>=0.900" "ruff"
-    - name: Setup git configuration
-      run: |
-          # Need this for the git tests to succeed.
-          git --version
-          . .github/workflows/bin/setup_git.sh
-    - name: Bootstrap clingo
-      run: |
-          . share/spack/setup-env.sh
-          spack bootstrap disable spack-install
-          spack bootstrap now
-    - name: Smoke tests
-      run: |
-          bin/spack -h
-          bin/spack help -a
-          bin/spack python -c "from spack_repo.builtin.packages.mpileaks.package import Mpileaks"
+    # This job tests older Python versions, which the pins in the requirements file do
+    # not support, so it installs unpinned. mypy and ruff are needed by the tests
+    # covering "spack style". See coveragepy issue 2082 for the coverage bound.
+    - uses: ./.github/actions/setup-spack
+      with:
+        python-version: ${{ matrix.python-version }}
+        pip-install: >-
+          pytest pytest-xdist pytest-cov "coverage<=7.11.0" "mypy>=0.900" ruff
     - name: Run unit tests
       env:
           COVERAGE_FILE: coverage/.coverage-${{ matrix.os }}-python${{ matrix.python-version }}
@@ -88,9 +72,6 @@ jobs:
     - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
       with:
         fetch-depth: 0
-    - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6.3.0
-      with:
-        python-version: '3.11'
     - name: Install System packages
       run: |
           sudo apt-get -y update
@@ -102,24 +83,9 @@ jobs:
       uses: Homebrew/actions/setup-homebrew@40e9946c182a64b3db1bf51be0dcb915f7802aa9
     - name: Install kcov with brew
       run: "brew install kcov"
-    - name: Install Python packages
-      run: |
-          pip install --upgrade pip -r .github/workflows/requirements/unit_tests/requirements.txt
-    - name: Setup git configuration
-      run: |
-          # Need this for the git tests to succeed.
-          git --version
-          . .github/workflows/bin/setup_git.sh
-    - name: Bootstrap clingo
-      run: |
-          . share/spack/setup-env.sh
-          spack bootstrap disable spack-install
-          spack bootstrap now
-    - name: Smoke tests
-      run: |
-          bin/spack -h
-          bin/spack help -a
-          bin/spack python -c "from spack_repo.builtin.packages.mpileaks.package import Mpileaks"
+    - uses: ./.github/actions/setup-spack
+      with:
+        python-version: '3.11'
     - name: Run shell tests
       env:
           COVERAGE: true
@@ -189,29 +155,17 @@ jobs:
     - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
       with:
         fetch-depth: 0
-    - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6.3.0
-      with:
-        python-version: '3.13'
     - name: Install System packages
       run: |
           sudo apt-get -y update
           sudo apt-get -y install coreutils gfortran graphviz gnupg2
-    - name: Install Python packages
-      run: |
-          pip install --upgrade pip -r .github/workflows/requirements/unit_tests/requirements.txt
-          pip install --upgrade -r .github/workflows/requirements/style/requirements.txt
-          pip install --upgrade ${{ matrix.install }}
-    - name: Disable bootstrapping
-      run: |
-        . share/spack/setup-env.sh
-        spack bootstrap disable spack-install
-        spack bootstrap disable github-actions-v0.6
-        spack bootstrap disable github-actions-v2
-    - name: Smoke tests
-      run: |
-        bin/spack -h
-        bin/spack help -a
-        bin/spack python -c "from spack_repo.builtin.packages.mpileaks.package import Mpileaks"
+    - uses: ./.github/actions/setup-spack
+      with:
+        python-version: '3.13'
+        pip-install: >-
+          -r .github/workflows/requirements/unit_tests/requirements.txt
+          ${{ matrix.install }}
+        bootstrap: none
     - name: Run unit tests (full suite with coverage)
       env:
           COVERAGE_FILE: coverage/.coverage-clingo-${{ matrix.variant }}
@@ -233,31 +187,12 @@ jobs:
     - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
       with:
         fetch-depth: 0
-    - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6.3.0
-      with:
-        python-version: ${{ matrix.python-version }}
-    - name: Install Python packages
-      run: |
-          pip install --upgrade pip
-          # See https://github.com/coveragepy/coveragepy/issues/2082
-          pip install --upgrade -r .github/workflows/requirements/unit_tests/requirements.txt
     - name: Setup Homebrew packages
       run: |
         brew install dash fish gcc gnupg kcov
-    - name: Setup git configuration
-      run: |
-        git --version
-        . .github/workflows/bin/setup_git.sh
-    - name: Bootstrap clingo
-      run: |
-        . share/spack/setup-env.sh
-        spack bootstrap disable spack-install
-        spack bootstrap now
-    - name: Smoke tests
-      run: |
-        bin/spack -h
-        bin/spack help -a
-        bin/spack python -c "from spack_repo.builtin.packages.mpileaks.package import Mpileaks"
+    - uses: ./.github/actions/setup-spack
+      with:
+        python-version: ${{ matrix.python-version }}
     - name: Run unit tests
       env:
         COVERAGE_FILE: coverage/.coverage-${{ matrix.os }}-python${{ matrix.python-version }}

--- a/.github/workflows/unit_tests.yaml
+++ b/.github/workflows/unit_tests.yaml
@@ -21,26 +21,18 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.14']
-        on_develop:
-        - ${{ github.ref == 'refs/heads/develop' }}
-        include:
-        - python-version: '3.7'
-          os: ubuntu-22.04
-          on_develop: ${{ github.ref == 'refs/heads/develop' }}
-        exclude:
-        - python-version: '3.8'
-          os: ubuntu-latest
-          on_develop: false
-        - python-version: '3.9'
-          os: ubuntu-latest
-          on_develop: false
-        - python-version: '3.10'
-          os: ubuntu-latest
-          on_develop: false
-        - python-version: '3.11'
-          os: ubuntu-latest
-          on_develop: false
+        # On develop test every supported Python, on pull requests only the newest to keep
+        # feedback fast. Python 3.6 is covered at runtime by rhel8-platform-python, since
+        # setup-python cannot provide it on current runners.
+        python-version: >-
+          ${{ github.ref == 'refs/heads/develop'
+          && fromJSON('["3.8", "3.9", "3.10", "3.11", "3.14"]')
+          || fromJSON('["3.14"]') }}
+        # Python 3.7 needs ubuntu-22.04, newer runner images no longer ship it.
+        include: >-
+          ${{ github.ref == 'refs/heads/develop'
+          && fromJSON('[{"python-version": "3.7", "os": "ubuntu-22.04"}]')
+          || fromJSON('[]') }}
 
     steps:
     - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
@@ -60,31 +52,27 @@ jobs:
       run: |
           # See https://github.com/coveragepy/coveragepy/issues/2082
           pip install --upgrade pip pytest pytest-xdist pytest-cov "coverage<=7.11.0"
-          pip install --upgrade "mypy>=0.900" "click" "ruff"
+          # Needed by the tests covering "spack style"
+          pip install --upgrade "mypy>=0.900" "ruff"
     - name: Setup git configuration
       run: |
           # Need this for the git tests to succeed.
           git --version
           . .github/workflows/bin/setup_git.sh
     - name: Bootstrap clingo
-      env:
-          SPACK_PYTHON: python
       run: |
           . share/spack/setup-env.sh
           spack bootstrap disable spack-install
           spack bootstrap now
     - name: Smoke tests
-      env:
-          SPACK_PYTHON: python
       run: |
           bin/spack -h
           bin/spack help -a
           bin/spack python -c "from spack_repo.builtin.packages.mpileaks.package import Mpileaks"
     - name: Run unit tests
       env:
-          SPACK_PYTHON: python
           COVERAGE_FILE: coverage/.coverage-${{ matrix.os }}-python${{ matrix.python-version }}
-          PYTEST_ADDOPTS: ${{ matrix.python-version == '3.14' && '--cov --cov-config=pyproject.toml --cov-report=xml:coverage.xml' || '' }}
+          PYTEST_ADDOPTS: ${{ matrix.python-version == '3.14' && '--cov --cov-config=pyproject.toml' || '' }}
       run: |
           python3 -m pytest -x --verbose --dist worksteal -n4
     - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
@@ -163,28 +151,39 @@ jobs:
           . .github/workflows/bin/setup_git.sh
     - name: Setup a virtual environment with platform-python
       run: |
+          # platform-python is the only runtime coverage we have of Python 3.6
           /usr/libexec/platform-python -m venv ~/platform-spack
-          source ~/platform-spack/bin/activate
-          pip install --upgrade pip pytest coverage[toml] pytest-xdist
+          echo "$HOME/platform-spack/bin" >> $GITHUB_PATH
+          ~/platform-spack/bin/pip install --upgrade pip pytest coverage[toml] pytest-xdist
     - name: Bootstrap Spack development environment
       run: |
-          source ~/platform-spack/bin/activate
           source share/spack/setup-env.sh
           spack debug report
           spack -d bootstrap now
     - name: Smoke tests
       run: |
-          source ~/platform-spack/bin/activate
           bin/spack -h
           bin/spack help -a
           bin/spack python -c "from spack_repo.builtin.packages.mpileaks.package import Mpileaks"
     - name: Run unit tests
       run: |
-          source ~/platform-spack/bin/activate
-          pytest --verbose -x -n3 --dist loadfile -k 'not cvs and not svn and not hg'
-  # Test for the clingo based solver (using clingo-cffi)
-  clingo-cffi:
+          python3 -m pytest --verbose -x -n3 --dist loadfile -k 'not cvs and not svn and not hg'
+  # Test the concretizer against clingo builds published on PyPI, rather than the binaries
+  # we bootstrap. clingo v6 is still pre-release, so that variant is allowed to fail
+  # without blocking the workflow.
+  clingo:
     runs-on: ubuntu-latest
+    continue-on-error: ${{ matrix.experimental }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+        - name: cffi
+          install: clingo==5.8.0
+          experimental: false
+        - name: v6
+          install: --pre --extra-index-url https://test.pypi.org/simple clingo
+          experimental: true
     steps:
     - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
       with:
@@ -200,8 +199,7 @@ jobs:
       run: |
           pip install --upgrade pip -r .github/workflows/requirements/unit_tests/requirements.txt
           pip install --upgrade -r .github/workflows/requirements/style/requirements.txt
-          # This job deliberately tests the clingo build published on PyPI
-          pip install --upgrade clingo==5.8.0
+          pip install --upgrade ${{ matrix.install }}
     - name: Disable bootstrapping
       run: |
         . share/spack/setup-env.sh
@@ -215,54 +213,12 @@ jobs:
         bin/spack python -c "from spack_repo.builtin.packages.mpileaks.package import Mpileaks"
     - name: Run unit tests (full suite with coverage)
       env:
-          COVERAGE_FILE: coverage/.coverage-clingo-cffi
+          COVERAGE_FILE: coverage/.coverage-clingo-${{ matrix.name }}
       run: |
-        pytest --verbose --cov --cov-config=pyproject.toml --cov-report=xml:coverage.xml -x -n3 --dist worksteal lib/spack/spack/test/concretization/
+        python3 -m pytest --verbose --cov --cov-config=pyproject.toml -x -n3 --dist worksteal lib/spack/spack/test/concretization/
     - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
       with:
-        name: coverage-clingo-cffi
-        path: coverage
-        include-hidden-files: true
-  # Test for the clingo based solver (using the development clingo v6 from Test PyPI).
-  # clingo v6 is still pre-release; allow this job to fail without blocking the workflow.
-  clingo-v6:
-    runs-on: ubuntu-latest
-    continue-on-error: true
-    steps:
-    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
-      with:
-        fetch-depth: 0
-    - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6.3.0
-      with:
-        python-version: '3.13'
-    - name: Install System packages
-      run: |
-          sudo apt-get -y update
-          sudo apt-get -y install coreutils gfortran graphviz gnupg2
-    - name: Install Python packages
-      run: |
-          pip install --upgrade pip -r .github/workflows/requirements/unit_tests/requirements.txt
-          pip install --upgrade -r .github/workflows/requirements/style/requirements.txt
-          pip install --upgrade --pre --extra-index-url https://test.pypi.org/simple clingo
-    - name: Disable bootstrapping
-      run: |
-        . share/spack/setup-env.sh
-        spack bootstrap disable spack-install
-        spack bootstrap disable github-actions-v0.6
-        spack bootstrap disable github-actions-v2
-    - name: Smoke tests
-      run: |
-        bin/spack -h
-        bin/spack help -a
-        bin/spack python -c "from spack_repo.builtin.packages.mpileaks.package import Mpileaks"
-    - name: Run unit tests (full suite with coverage)
-      env:
-          COVERAGE_FILE: coverage/.coverage-clingo-v6
-      run: |
-        pytest --verbose --cov --cov-config=pyproject.toml --cov-report=xml:coverage.xml -x -n3 --dist worksteal lib/spack/spack/test/concretization/
-    - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
-      with:
-        name: coverage-clingo-v6
+        name: coverage-clingo-${{ matrix.name }}
         path: coverage
         include-hidden-files: true
   # Run unit tests on MacOS
@@ -305,7 +261,7 @@ jobs:
       env:
         COVERAGE_FILE: coverage/.coverage-${{ matrix.os }}-python${{ matrix.python-version }}
       run: |
-        python3 -m pytest --verbose --cov --cov-config=pyproject.toml --cov-report=xml:coverage.xml --dist worksteal -x -n4
+        python3 -m pytest --verbose --cov --cov-config=pyproject.toml --dist worksteal -x -n4
     - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
       with:
         name: coverage-${{ matrix.os }}-python${{ matrix.python-version }}
@@ -327,8 +283,8 @@ jobs:
         python-version: '3.14'
     - name: Install Python packages
       run: |
-          python -m pip install --upgrade pip -r .github/workflows/requirements/unit_tests/requirements.txt
-          python -m pip install --upgrade pip -r .github/workflows/requirements/style/requirements.txt
+          python -m pip install --upgrade pip
+          python -m pip install --upgrade -r .github/workflows/requirements/unit_tests/requirements.txt -r .github/workflows/requirements/style/requirements.txt
           # There are no prebuilt clingo binaries for Windows to bootstrap from
           python -m pip install --upgrade clingo==5.8.0
     - name: Create local develop

--- a/.github/workflows/unit_tests.yaml
+++ b/.github/workflows/unit_tests.yaml
@@ -48,7 +48,8 @@ jobs:
     # This job tests older Python versions, which the pins in the requirements file do
     # not support, so it installs unpinned. mypy and ruff are needed by the tests
     # covering "spack style". See coveragepy issue 2082 for the coverage bound.
-    - uses: ./.github/actions/setup-spack
+    - name: Setup Spack
+      uses: ./.github/actions/setup-spack
       with:
         python-version: ${{ matrix.python-version }}
         pip-install: >-
@@ -83,7 +84,8 @@ jobs:
       uses: Homebrew/actions/setup-homebrew@40e9946c182a64b3db1bf51be0dcb915f7802aa9
     - name: Install kcov with brew
       run: "brew install kcov"
-    - uses: ./.github/actions/setup-spack
+    - name: Setup Spack
+      uses: ./.github/actions/setup-spack
       with:
         python-version: '3.11'
     - name: Run shell tests
@@ -159,7 +161,8 @@ jobs:
       run: |
           sudo apt-get -y update
           sudo apt-get -y install coreutils gfortran graphviz gnupg2
-    - uses: ./.github/actions/setup-spack
+    - name: Setup Spack
+      uses: ./.github/actions/setup-spack
       with:
         python-version: '3.13'
         pip-install: >-
@@ -190,7 +193,8 @@ jobs:
     - name: Setup Homebrew packages
       run: |
         brew install dash fish gcc gnupg kcov
-    - uses: ./.github/actions/setup-spack
+    - name: Setup Spack
+      uses: ./.github/actions/setup-spack
       with:
         python-version: ${{ matrix.python-version }}
     - name: Run unit tests

--- a/.github/workflows/unit_tests.yaml
+++ b/.github/workflows/unit_tests.yaml
@@ -73,14 +73,12 @@ jobs:
           . share/spack/setup-env.sh
           spack bootstrap disable spack-install
           spack bootstrap now
-          spack -v spec --show opt,solutions zlib
     - name: Smoke tests
       env:
           SPACK_PYTHON: python
       run: |
           bin/spack -h
           bin/spack help -a
-          bin/spack bootstrap status --dev --optional
           bin/spack python -c "from spack_repo.builtin.packages.mpileaks.package import Mpileaks"
     - name: Run unit tests
       env:
@@ -124,6 +122,16 @@ jobs:
           # Need this for the git tests to succeed.
           git --version
           . .github/workflows/bin/setup_git.sh
+    - name: Bootstrap clingo
+      run: |
+          . share/spack/setup-env.sh
+          spack bootstrap disable spack-install
+          spack bootstrap now
+    - name: Smoke tests
+      run: |
+          bin/spack -h
+          bin/spack help -a
+          bin/spack python -c "from spack_repo.builtin.packages.mpileaks.package import Mpileaks"
     - name: Run shell tests
       env:
           COVERAGE: true
@@ -158,12 +166,21 @@ jobs:
           /usr/libexec/platform-python -m venv ~/platform-spack
           source ~/platform-spack/bin/activate
           pip install --upgrade pip pytest coverage[toml] pytest-xdist
-    - name: Bootstrap Spack development environment and run unit tests
+    - name: Bootstrap Spack development environment
       run: |
           source ~/platform-spack/bin/activate
           source share/spack/setup-env.sh
           spack debug report
           spack -d bootstrap now
+    - name: Smoke tests
+      run: |
+          source ~/platform-spack/bin/activate
+          bin/spack -h
+          bin/spack help -a
+          bin/spack python -c "from spack_repo.builtin.packages.mpileaks.package import Mpileaks"
+    - name: Run unit tests
+      run: |
+          source ~/platform-spack/bin/activate
           pytest --verbose -x -n3 --dist loadfile -k 'not cvs and not svn and not hg'
   # Test for the clingo based solver (using clingo-cffi)
   clingo-cffi:
@@ -183,17 +200,23 @@ jobs:
       run: |
           pip install --upgrade pip -r .github/workflows/requirements/unit_tests/requirements.txt
           pip install --upgrade -r .github/workflows/requirements/style/requirements.txt
-    - name: Run unit tests (full suite with coverage)
-      env:
-          COVERAGE: true
-          COVERAGE_FILE: coverage/.coverage-clingo-cffi
+          # This job deliberately tests the clingo build published on PyPI
+          pip install --upgrade clingo==5.8.0
+    - name: Disable bootstrapping
       run: |
         . share/spack/setup-env.sh
         spack bootstrap disable spack-install
         spack bootstrap disable github-actions-v0.6
         spack bootstrap disable github-actions-v2
-        spack bootstrap status
-        spack spec --show opt,solutions zlib
+    - name: Smoke tests
+      run: |
+        bin/spack -h
+        bin/spack help -a
+        bin/spack python -c "from spack_repo.builtin.packages.mpileaks.package import Mpileaks"
+    - name: Run unit tests (full suite with coverage)
+      env:
+          COVERAGE_FILE: coverage/.coverage-clingo-cffi
+      run: |
         pytest --verbose --cov --cov-config=pyproject.toml --cov-report=xml:coverage.xml -x -n3 --dist worksteal lib/spack/spack/test/concretization/
     - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
       with:
@@ -221,17 +244,21 @@ jobs:
           pip install --upgrade pip -r .github/workflows/requirements/unit_tests/requirements.txt
           pip install --upgrade -r .github/workflows/requirements/style/requirements.txt
           pip install --upgrade --pre --extra-index-url https://test.pypi.org/simple clingo
-    - name: Run unit tests (full suite with coverage)
-      env:
-          COVERAGE: true
-          COVERAGE_FILE: coverage/.coverage-clingo-v6
+    - name: Disable bootstrapping
       run: |
         . share/spack/setup-env.sh
         spack bootstrap disable spack-install
         spack bootstrap disable github-actions-v0.6
         spack bootstrap disable github-actions-v2
-        spack bootstrap status
-        spack spec --show opt,solutions zlib
+    - name: Smoke tests
+      run: |
+        bin/spack -h
+        bin/spack help -a
+        bin/spack python -c "from spack_repo.builtin.packages.mpileaks.package import Mpileaks"
+    - name: Run unit tests (full suite with coverage)
+      env:
+          COVERAGE_FILE: coverage/.coverage-clingo-v6
+      run: |
         pytest --verbose --cov --cov-config=pyproject.toml --cov-report=xml:coverage.xml -x -n3 --dist worksteal lib/spack/spack/test/concretization/
     - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
       with:
@@ -260,15 +287,24 @@ jobs:
     - name: Setup Homebrew packages
       run: |
         brew install dash fish gcc gnupg kcov
+    - name: Setup git configuration
+      run: |
+        git --version
+        . .github/workflows/bin/setup_git.sh
+    - name: Bootstrap clingo
+      run: |
+        . share/spack/setup-env.sh
+        spack bootstrap disable spack-install
+        spack bootstrap now
+    - name: Smoke tests
+      run: |
+        bin/spack -h
+        bin/spack help -a
+        bin/spack python -c "from spack_repo.builtin.packages.mpileaks.package import Mpileaks"
     - name: Run unit tests
       env:
         COVERAGE_FILE: coverage/.coverage-${{ matrix.os }}-python${{ matrix.python-version }}
       run: |
-        git --version
-        . .github/workflows/bin/setup_git.sh
-        . share/spack/setup-env.sh
-        spack bootstrap disable spack-install
-        spack spec --show opt,solutions zlib
         python3 -m pytest --verbose --cov --cov-config=pyproject.toml --cov-report=xml:coverage.xml --dist worksteal -x -n4
     - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
       with:
@@ -293,9 +329,19 @@ jobs:
       run: |
           python -m pip install --upgrade pip -r .github/workflows/requirements/unit_tests/requirements.txt
           python -m pip install --upgrade pip -r .github/workflows/requirements/style/requirements.txt
+          # There are no prebuilt clingo binaries for Windows to bootstrap from
+          python -m pip install --upgrade clingo==5.8.0
     - name: Create local develop
       run: |
         ./.github/workflows/bin/setup_git.ps1
+    - name: Smoke tests
+      run: |
+        spack -h
+        ./share/spack/qa/validate_last_exit.ps1
+        spack help -a
+        ./share/spack/qa/validate_last_exit.ps1
+        spack python -c "from spack_repo.builtin.packages.mpileaks.package import Mpileaks"
+        ./share/spack/qa/validate_last_exit.ps1
     - name: Unit Test
       env:
         COVERAGE_FILE: coverage/.coverage-windows

--- a/.github/workflows/unit_tests.yaml
+++ b/.github/workflows/unit_tests.yaml
@@ -172,16 +172,17 @@ jobs:
   # we bootstrap. clingo v6 is still pre-release, so that variant is allowed to fail
   # without blocking the workflow.
   clingo:
+    name: clingo-${{ matrix.variant }}
     runs-on: ubuntu-latest
     continue-on-error: ${{ matrix.experimental }}
     strategy:
       fail-fast: false
       matrix:
         include:
-        - name: cffi
+        - variant: cffi
           install: clingo==5.8.0
           experimental: false
-        - name: v6
+        - variant: v6
           install: --pre --extra-index-url https://test.pypi.org/simple clingo
           experimental: true
     steps:
@@ -213,12 +214,12 @@ jobs:
         bin/spack python -c "from spack_repo.builtin.packages.mpileaks.package import Mpileaks"
     - name: Run unit tests (full suite with coverage)
       env:
-          COVERAGE_FILE: coverage/.coverage-clingo-${{ matrix.name }}
+          COVERAGE_FILE: coverage/.coverage-clingo-${{ matrix.variant }}
       run: |
         python3 -m pytest --verbose --cov --cov-config=pyproject.toml -x -n3 --dist worksteal lib/spack/spack/test/concretization/
     - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
       with:
-        name: coverage-clingo-${{ matrix.name }}
+        name: coverage-clingo-${{ matrix.variant }}
         path: coverage
         include-hidden-files: true
   # Run unit tests on MacOS

--- a/lib/spack/docs/developer_guide.rst
+++ b/lib/spack/docs/developer_guide.rst
@@ -424,20 +424,16 @@ For example, if you were to add this step to the Linux unit test CI, it would lo
 .. code-block:: yaml
 
    - name: Bootstrap clingo
-     env:
-       SPACK_PYTHON: python
      run: |
        . share/spack/setup-env.sh
        spack bootstrap disable spack-install
        spack bootstrap now
-       spack -v spec --show opt,solutions zlib
    - name: Setup tmate session
      uses: mxschmitt/action-tmate@c0afd6f790e3a5564914980036ebf83216678101
    - name: Run unit tests
      env:
-       SPACK_PYTHON: python
        COVERAGE_FILE: coverage/.coverage-${{ matrix.os }}-python${{ matrix.python-version }}
-       PYTEST_ADDOPTS: ${{ matrix.python-version == '3.14' && '--cov --cov-config=pyproject.toml --cov-report=xml:coverage.xml' || '' }}
+       PYTEST_ADDOPTS: ${{ matrix.python-version == '3.14' && '--cov --cov-config=pyproject.toml' || '' }}
      run: |-
        python3 -m pytest -x --verbose --dist worksteal -n4
 

--- a/lib/spack/docs/developer_guide.rst
+++ b/lib/spack/docs/developer_guide.rst
@@ -423,11 +423,9 @@ For example, if you were to add this step to the Linux unit test CI, it would lo
 
 .. code-block:: yaml
 
-   - name: Bootstrap clingo
-     run: |
-       . share/spack/setup-env.sh
-       spack bootstrap disable spack-install
-       spack bootstrap now
+   - uses: ./.github/actions/setup-spack
+     with:
+       python-version: ${{ matrix.python-version }}
    - name: Setup tmate session
      uses: mxschmitt/action-tmate@c0afd6f790e3a5564914980036ebf83216678101
    - name: Run unit tests

--- a/lib/spack/spack/test/conftest.py
+++ b/lib/spack/spack/test/conftest.py
@@ -13,6 +13,7 @@ import inspect
 import io
 import itertools
 import json
+import multiprocessing
 import os
 import re
 import shutil
@@ -437,6 +438,13 @@ def archspec_host_is_spack_test_host(monkeypatch):
 #
 # https://docs.pytest.org/en/latest/writing_plugins.html
 #
+def pytest_configure(config):
+    # improve performance on macOS
+    if sys.platform == "darwin" and multiprocessing.get_start_method(allow_none=True) is None:
+        multiprocessing.set_start_method("forkserver")
+    multiprocessing.set_forkserver_preload(["spack.main", "spack.package", "spack.installer"])
+
+
 def pytest_addoption(parser):
     group = parser.getgroup("Spack specific command line options")
     group.addoption(


### PR DESCRIPTION
* use forkserver on macos
* use our clingo binaries on macos
* uniformly split smoke tests from unit tests
* drop 3.7 from prs (matrix bug?)
* combine clingo ffi and clingo v6 jobs
* drop `SPACK_PYTHON` var
* drop xml coverage report (coverage dir is uploaded, not xml)
* remove unused `pip install click`
* drop `spack spec` smoke test
* extract composite local setup-spack action
