### PR TITLE
tests: use store/repo fixtures instead of the STORE and PATH globals

### DIFF
--- a/lib/spack/spack/test/cmd/checksum.py
+++ b/lib/spack/spack/test/cmd/checksum.py
@@ -11,7 +11,6 @@ import spack.cmd.checksum
 import spack.concretize
 import spack.error
 import spack.package_base
-import spack.repo
 import spack.stage
 import spack.util.web
 from spack.main import SpackCommand
@@ -280,7 +279,7 @@ def test_checksum_interactive_unrecognized_command():
 
 
 def test_checksum_versions(mock_packages, can_fetch_versions, monkeypatch):
-    pkg_cls = spack.repo.PATH.get_pkg_class("zlib")
+    pkg_cls = mock_packages.get_pkg_class("zlib")
     versions = [str(v) for v in pkg_cls.versions]
     output = spack_checksum("zlib", *versions)
     assert "Found 3 versions" in output
@@ -304,7 +303,7 @@ def test_checksum_deprecated_version(mock_packages, can_fetch_versions):
 
 
 def test_checksum_url(mock_packages, config):
-    pkg_cls = spack.repo.PATH.get_pkg_class("zlib")
+    pkg_cls = mock_packages.get_pkg_class("zlib")
     with pytest.raises(spack.error.SpecSyntaxError):
         spack_checksum(f"{pkg_cls.url}")
 
@@ -325,7 +324,7 @@ def test_checksum_verification_fails(config, mock_packages, capfd, can_fetch_ver
 def test_checksum_manual_download_fails(mock_packages, monkeypatch):
     """Confirm that checksumming a manually downloadable package fails."""
     name = "zlib"
-    pkg_cls = spack.repo.PATH.get_pkg_class(name)
+    pkg_cls = mock_packages.get_pkg_class(name)
     versions = [str(v) for v in pkg_cls.versions]
     monkeypatch.setattr(spack.package_base.PackageBase, "manual_download", True)
 

--- a/lib/spack/spack/test/cmd/ci.py
+++ b/lib/spack/spack/test/cmd/ci.py
@@ -2067,7 +2067,7 @@ def fetch_versions_invalid(monkeypatch):
 @pytest.mark.parametrize("versions", [["2.1.4"], ["2.1.4", "2.1.5"]])
 def test_ci_validate_standard_versions_valid(capfd, mock_packages, fetch_versions_match, versions):
     spec = spack.spec.Spec("diff-test")
-    pkg = spack.repo.PATH.get_pkg_class(spec.name)(spec)
+    pkg = mock_packages.get_pkg_class(spec.name)(spec)
     version_list = [spack.version.Version(v) for v in versions]
 
     assert spack.cmd.ci.validate_standard_versions(pkg, version_list)
@@ -2082,7 +2082,7 @@ def test_ci_validate_standard_versions_invalid(
     capfd, mock_packages, fetch_versions_invalid, versions
 ):
     spec = spack.spec.Spec("diff-test")
-    pkg = spack.repo.PATH.get_pkg_class(spec.name)(spec)
+    pkg = mock_packages.get_pkg_class(spec.name)(spec)
     version_list = [spack.version.Version(v) for v in versions]
 
     assert spack.cmd.ci.validate_standard_versions(pkg, version_list) is False
@@ -2097,7 +2097,7 @@ def test_ci_validate_git_versions_valid(
     capfd, monkeypatch, mock_packages, mock_git_version_info, versions
 ):
     spec = spack.spec.Spec("diff-test")
-    pkg_class = spack.repo.PATH.get_pkg_class(spec.name)
+    pkg_class = mock_packages.get_pkg_class(spec.name)
     pkg = pkg_class(spec)
     version_list = [spack.version.Version(v) for v, _ in versions]
 
@@ -2121,7 +2121,7 @@ def test_ci_validate_git_versions_bad_tag(
     capfd, monkeypatch, mock_packages, mock_git_version_info, versions
 ):
     spec = spack.spec.Spec("diff-test")
-    pkg_class = spack.repo.PATH.get_pkg_class(spec.name)
+    pkg_class = mock_packages.get_pkg_class(spec.name)
     pkg = pkg_class(spec)
     version_list = [spack.version.Version(v) for v, _ in versions]
 
@@ -2145,7 +2145,7 @@ def test_ci_validate_git_versions_invalid(
     capfd, monkeypatch, mock_packages, mock_git_version_info, versions
 ):
     spec = spack.spec.Spec("diff-test")
-    pkg_class = spack.repo.PATH.get_pkg_class(spec.name)
+    pkg_class = mock_packages.get_pkg_class(spec.name)
     pkg = pkg_class(spec)
     version_list = [spack.version.Version(v) for v, _ in versions]
 
@@ -2278,10 +2278,10 @@ def test_ci_verify_versions_standard_duplicates(
 
 def test_ci_verify_versions_manual_package(monkeypatch, mock_packages, mock_git_package_changes):
     repo, _, commits = mock_git_package_changes
-    with spack.repo.use_repositories(repo):
+    with spack.repo.use_repositories(repo) as repos:
         monkeypatch.setattr(spack.repo, "builtin_repo", lambda: repo)
 
-        pkg_class = spack.repo.PATH.get_pkg_class("diff-test")
+        pkg_class = repos.get_pkg_class("diff-test")
         monkeypatch.setattr(pkg_class, "manual_download", True)
 
         out = ci_cmd("verify-versions", commits[-1], commits[-2])

--- a/lib/spack/spack/test/cmd/config.py
+++ b/lib/spack/spack/test/cmd/config.py
@@ -17,7 +17,6 @@ import spack.database
 import spack.environment as ev
 import spack.main
 import spack.schema.config
-import spack.store
 import spack.util.filesystem as fs
 import spack.util.spack_yaml as syaml
 
@@ -663,6 +662,7 @@ def test_config_update_shared_linking(mutable_config):
 
 def test_config_prefer_upstream(
     tmp_path_factory: pytest.TempPathFactory,
+    temporary_store,
     install_mockery,
     mock_fetch,
     mutable_config,
@@ -682,7 +682,7 @@ def test_config_prefer_upstream(
 
     downstream_db_root = str(tmp_path_factory.mktemp("mock_downstream_db_root"))
     db_for_test = spack.database.Database(downstream_db_root, upstream_dbs=[prepared_db])
-    monkeypatch.setattr(spack.store.STORE, "db", db_for_test)
+    monkeypatch.setattr(temporary_store, "db", db_for_test)
 
     output = config("prefer-upstream")
     scope = spack.config.default_modify_scope("packages")

--- a/lib/spack/spack/test/cmd/dependencies.py
+++ b/lib/spack/spack/test/cmd/dependencies.py
@@ -6,7 +6,6 @@ import re
 
 import pytest
 
-import spack.store
 from spack.main import SpackCommand
 from spack.util.tty.color import color_when
 
@@ -55,7 +54,7 @@ def test_direct_installed_dependencies(mock_packages, database):
     with color_when(False):
         out = dependencies("--installed", "mpileaks^mpich")
 
-    root = spack.store.STORE.db.query_one("mpileaks ^mpich")
+    root = database.query_one("mpileaks ^mpich")
 
     lines = [line for line in out.strip().split("\n") if line and not line.startswith("--")]
     hashes = {re.split(r"\s+", line)[0] for line in lines}
@@ -69,7 +68,7 @@ def test_transitive_installed_dependencies(mock_packages, database):
     with color_when(False):
         out = dependencies("--installed", "--transitive", "mpileaks^zmpi")
 
-    root = spack.store.STORE.db.query_one("mpileaks ^zmpi")
+    root = database.query_one("mpileaks ^zmpi")
 
     lines = [line for line in out.strip().split("\n") if line and not line.startswith("--")]
     hashes = {re.split(r"\s+", line)[0] for line in lines}

--- a/lib/spack/spack/test/cmd/dependents.py
+++ b/lib/spack/spack/test/cmd/dependents.py
@@ -6,7 +6,6 @@ import re
 
 import pytest
 
-import spack.store
 from spack.main import SpackCommand
 from spack.util.tty.color import color_when
 
@@ -55,11 +54,9 @@ def test_immediate_installed_dependents(mock_packages, database):
     lines = [li for li in out.strip().split("\n") if not li.startswith("--")]
     hashes = set([re.split(r"\s+", li)[0] for li in lines if li])
 
-    expected = set(
-        [spack.store.STORE.db.query_one(s).dag_hash(7) for s in ["dyninst", "libdwarf"]]
-    )
+    expected = set([database.query_one(s).dag_hash(7) for s in ["dyninst", "libdwarf"]])
 
-    libelf = spack.store.STORE.db.query_one("libelf")
+    libelf = database.query_one("libelf")
     expected = set([d.dag_hash(7) for d in libelf.dependents()])
 
     assert expected == hashes
@@ -74,10 +71,7 @@ def test_transitive_installed_dependents(mock_packages, database):
     hashes = set([re.split(r"\s+", li)[0] for li in lines])
 
     expected = set(
-        [
-            spack.store.STORE.db.query_one(s).dag_hash(7)
-            for s in ["zmpi", "callpath^zmpi", "mpileaks^zmpi"]
-        ]
+        [database.query_one(s).dag_hash(7) for s in ["zmpi", "callpath^zmpi", "mpileaks^zmpi"]]
     )
 
     assert expected == hashes

--- a/lib/spack/spack/test/cmd/deprecate.py
+++ b/lib/spack/spack/test/cmd/deprecate.py
@@ -8,7 +8,6 @@ import pytest
 
 import spack.concretize
 import spack.spec
-import spack.store
 from spack.enums import InstallRecordStatus
 from spack.main import SpackCommand
 
@@ -21,19 +20,19 @@ find = SpackCommand("find")
 pytestmark = pytest.mark.usefixtures("mutable_mock_env_path")
 
 
-def test_deprecate(mock_packages, mock_archive, mock_fetch, install_mockery):
+def test_deprecate(mock_packages, mock_archive, mock_fetch, temporary_store, install_mockery):
     install("--fake", "libelf@0.8.13")
     install("--fake", "libelf@0.8.10")
 
-    all_installed = spack.store.STORE.db.query("libelf")
+    all_installed = temporary_store.db.query("libelf")
     assert len(all_installed) == 2
 
     deprecate("-y", "libelf@0.8.10", "libelf@0.8.13")
 
-    non_deprecated = spack.store.STORE.db.query("libelf")
-    all_available = spack.store.STORE.db.query("libelf", installed=InstallRecordStatus.ANY)
+    non_deprecated = temporary_store.db.query("libelf")
+    all_available = temporary_store.db.query("libelf", installed=InstallRecordStatus.ANY)
     assert all_available == all_installed
-    assert non_deprecated == spack.store.STORE.db.query("libelf@0.8.13")
+    assert non_deprecated == temporary_store.db.query("libelf@0.8.13")
 
 
 def test_deprecate_fails_no_such_package(mock_packages, mock_archive, mock_fetch, install_mockery):
@@ -50,24 +49,26 @@ def test_deprecate_fails_no_such_package(mock_packages, mock_archive, mock_fetch
     assert "Spec 'libelf@0.8.13' matches no installed packages" in output
 
 
-def test_deprecate_install(mock_packages, mock_archive, mock_fetch, install_mockery, monkeypatch):
+def test_deprecate_install(
+    mock_packages, mock_archive, mock_fetch, temporary_store, install_mockery, monkeypatch
+):
     """Tests that the -i option allows us to deprecate in favor of a spec
     that is not yet installed.
     """
     install("--fake", "libelf@0.8.10")
-    to_deprecate = spack.store.STORE.db.query("libelf")
+    to_deprecate = temporary_store.db.query("libelf")
     assert len(to_deprecate) == 1
 
     deprecate("-y", "-i", "libelf@0.8.10", "libelf@0.8.13")
 
-    non_deprecated = spack.store.STORE.db.query("libelf")
-    deprecated = spack.store.STORE.db.query("libelf", installed=InstallRecordStatus.DEPRECATED)
+    non_deprecated = temporary_store.db.query("libelf")
+    deprecated = temporary_store.db.query("libelf", installed=InstallRecordStatus.DEPRECATED)
     assert deprecated == to_deprecate
     assert len(non_deprecated) == 1
     assert non_deprecated[0].satisfies("libelf@0.8.13")
 
 
-def test_deprecate_deps(mock_packages, mock_archive, mock_fetch, install_mockery):
+def test_deprecate_deps(mock_packages, mock_archive, mock_fetch, temporary_store, install_mockery):
     """Test that the deprecate command deprecates all dependencies properly."""
     install("--fake", "libdwarf@20130729 ^libelf@0.8.13")
     install("--fake", "libdwarf@20130207 ^libelf@0.8.10")
@@ -75,13 +76,13 @@ def test_deprecate_deps(mock_packages, mock_archive, mock_fetch, install_mockery
     new_spec = spack.concretize.concretize_one("libdwarf@20130729^libelf@0.8.13")
     old_spec = spack.concretize.concretize_one("libdwarf@20130207^libelf@0.8.10")
 
-    all_installed = spack.store.STORE.db.query()
+    all_installed = temporary_store.db.query()
 
     deprecate("-y", "-d", "libdwarf@20130207", "libdwarf@20130729")
 
-    non_deprecated = spack.store.STORE.db.query()
-    all_available = spack.store.STORE.db.query(installed=InstallRecordStatus.ANY)
-    deprecated = spack.store.STORE.db.query(installed=InstallRecordStatus.DEPRECATED)
+    non_deprecated = temporary_store.db.query()
+    all_available = temporary_store.db.query(installed=InstallRecordStatus.ANY)
+    deprecated = temporary_store.db.query(installed=InstallRecordStatus.DEPRECATED)
 
     assert all_available == all_installed
     assert sorted(all_available) == sorted(deprecated + non_deprecated)
@@ -90,24 +91,28 @@ def test_deprecate_deps(mock_packages, mock_archive, mock_fetch, install_mockery
     assert sorted(deprecated) == sorted([old_spec, old_spec["libelf"]])
 
 
-def test_uninstall_deprecated(mock_packages, mock_archive, mock_fetch, install_mockery):
+def test_uninstall_deprecated(
+    mock_packages, mock_archive, mock_fetch, temporary_store, install_mockery
+):
     """Tests that we can still uninstall deprecated packages."""
     install("--fake", "libelf@0.8.13")
     install("--fake", "libelf@0.8.10")
 
     deprecate("-y", "libelf@0.8.10", "libelf@0.8.13")
 
-    non_deprecated = spack.store.STORE.db.query()
+    non_deprecated = temporary_store.db.query()
 
     uninstall("-y", "libelf@0.8.10")
 
-    assert spack.store.STORE.db.query() == spack.store.STORE.db.query(
+    assert temporary_store.db.query() == temporary_store.db.query(
         installed=InstallRecordStatus.ANY
     )
-    assert spack.store.STORE.db.query() == non_deprecated
+    assert temporary_store.db.query() == non_deprecated
 
 
-def test_deprecate_already_deprecated(mock_packages, mock_archive, mock_fetch, install_mockery):
+def test_deprecate_already_deprecated(
+    mock_packages, mock_archive, mock_fetch, temporary_store, install_mockery
+):
     """Tests that we can re-deprecate a spec to change its deprecator."""
     install("--fake", "libelf@0.8.13")
     install("--fake", "libelf@0.8.12")
@@ -117,21 +122,23 @@ def test_deprecate_already_deprecated(mock_packages, mock_archive, mock_fetch, i
 
     deprecate("-y", "libelf@0.8.10", "libelf@0.8.12")
 
-    deprecator = spack.store.STORE.db.deprecator(deprecated_spec)
+    deprecator = temporary_store.db.deprecator(deprecated_spec)
     assert deprecator == spack.concretize.concretize_one("libelf@0.8.12")
 
     deprecate("-y", "libelf@0.8.10", "libelf@0.8.13")
 
-    non_deprecated = spack.store.STORE.db.query("libelf")
-    all_available = spack.store.STORE.db.query("libelf", installed=InstallRecordStatus.ANY)
+    non_deprecated = temporary_store.db.query("libelf")
+    all_available = temporary_store.db.query("libelf", installed=InstallRecordStatus.ANY)
     assert len(non_deprecated) == 2
     assert len(all_available) == 3
 
-    deprecator = spack.store.STORE.db.deprecator(deprecated_spec)
+    deprecator = temporary_store.db.deprecator(deprecated_spec)
     assert deprecator == spack.concretize.concretize_one("libelf@0.8.13")
 
 
-def test_deprecate_deprecator(mock_packages, mock_archive, mock_fetch, install_mockery):
+def test_deprecate_deprecator(
+    mock_packages, mock_archive, mock_fetch, temporary_store, install_mockery
+):
     """Tests that when a deprecator spec is deprecated, its deprecatee specs
     are updated to point to the new deprecator."""
     install("--fake", "libelf@0.8.13")
@@ -144,19 +151,19 @@ def test_deprecate_deprecator(mock_packages, mock_archive, mock_fetch, install_m
 
     deprecate("-y", "libelf@0.8.10", "libelf@0.8.12")
 
-    deprecator = spack.store.STORE.db.deprecator(first_deprecated_spec)
+    deprecator = temporary_store.db.deprecator(first_deprecated_spec)
     assert deprecator == second_deprecated_spec
 
     deprecate("-y", "libelf@0.8.12", "libelf@0.8.13")
 
-    non_deprecated = spack.store.STORE.db.query("libelf")
-    all_available = spack.store.STORE.db.query("libelf", installed=InstallRecordStatus.ANY)
+    non_deprecated = temporary_store.db.query("libelf")
+    all_available = temporary_store.db.query("libelf", installed=InstallRecordStatus.ANY)
     assert len(non_deprecated) == 1
     assert len(all_available) == 3
 
-    first_deprecator = spack.store.STORE.db.deprecator(first_deprecated_spec)
+    first_deprecator = temporary_store.db.deprecator(first_deprecated_spec)
     assert first_deprecator == final_deprecator
-    second_deprecator = spack.store.STORE.db.deprecator(second_deprecated_spec)
+    second_deprecator = temporary_store.db.deprecator(second_deprecated_spec)
     assert second_deprecator == final_deprecator
 
 

--- a/lib/spack/spack/test/cmd/dev_build.py
+++ b/lib/spack/spack/test/cmd/dev_build.py
@@ -13,7 +13,6 @@ import spack.error
 import spack.main
 import spack.repo
 import spack.spec
-import spack.store
 import spack.util.filesystem as fs
 from spack.main import SpackCommand
 
@@ -63,7 +62,9 @@ def test_dev_build_before(tmp_path: pathlib.Path, install_mockery, installer_var
 
 
 @pytest.mark.parametrize("last_phase", ["edit", "install"])
-def test_dev_build_until(tmp_path: pathlib.Path, install_mockery, last_phase, installer_variant):
+def test_dev_build_until(
+    tmp_path: pathlib.Path, temporary_store, install_mockery, last_phase, installer_variant
+):
     spec = spack.concretize.concretize_one(
         spack.spec.Spec(f"dev-build-test-install@0.0.0 dev_path={tmp_path}")
     )
@@ -79,7 +80,7 @@ def test_dev_build_until(tmp_path: pathlib.Path, install_mockery, last_phase, in
             assert f.read() == spec.package.replacement_string  # type: ignore
 
     assert not os.path.exists(spec.prefix)
-    assert not spack.store.STORE.db.query(spec, installed=True)
+    assert not temporary_store.db.query(spec, installed=True)
 
 
 def test_dev_build_before_until(tmp_path: pathlib.Path, install_mockery, installer_variant):

--- a/lib/spack/spack/test/cmd/env.py
+++ b/lib/spack/spack/test/cmd/env.py
@@ -511,13 +511,13 @@ def test_env_specs_partition(install_mockery, mock_fetch):
     assert roots_to_install[0].name == "mpileaks"
 
 
-def test_env_install_all(install_mockery, mock_fetch):
+def test_env_install_all(temporary_store, install_mockery, mock_fetch):
     e = ev.create("test")
     e.add("cmake-client")
     e.concretize()
     e.install_all(fake=True)
     spec = next(x for x in e.all_specs_generator() if x.name == "cmake-client")
-    assert spack.store.STORE.db.installed(spec)
+    assert temporary_store.db.installed(spec)
 
 
 def test_env_install_single_spec(install_mockery, mock_fetch, installer_variant):
@@ -540,7 +540,7 @@ def test_env_install_single_spec(install_mockery, mock_fetch, installer_variant)
 @pytest.mark.parametrize("unify", [True, False, "when_possible"])
 @pytest.mark.parametrize("reuse", [True, False])
 def test_env_install_include_concrete_env(
-    unify, reuse, install_mockery, mock_fetch, mutable_config
+    unify, reuse, temporary_store, install_mockery, mock_fetch, mutable_config
 ):
     test1, test2, combined = setup_combined_multiple_env()
 
@@ -559,7 +559,7 @@ def test_env_install_include_concrete_env(
     test2_user_spec_hashes = [x.hash for x in test2.concretized_roots]
 
     for spec in combined.all_specs():
-        assert spack.store.STORE.db.installed(spec)
+        assert temporary_store.db.installed(spec)
 
     assert test1_user_spec_hashes == [
         x.hash for x in combined.included_concretized_roots[test1.path]
@@ -578,13 +578,15 @@ def test_env_install_include_concrete_env(
         assert mpileaks["libelf"].dag_hash() in test2_user_spec_hashes
 
 
-def test_env_roots_marked_explicit(install_mockery, mock_fetch, installer_variant):
+def test_env_roots_marked_explicit(
+    temporary_store, install_mockery, mock_fetch, installer_variant
+):
     install = SpackCommand("install")
     install("--fake", "dependent-install")
 
     # Check one explicit, one implicit install
-    dependent = spack.store.STORE.db.query(explicit=True)
-    dependency = spack.store.STORE.db.query(explicit=False)
+    dependent = temporary_store.db.query(explicit=True)
+    dependency = temporary_store.db.query(explicit=False)
     assert len(dependent) == 1
     assert len(dependency) == 1
 
@@ -595,7 +597,7 @@ def test_env_roots_marked_explicit(install_mockery, mock_fetch, installer_varian
         e.concretize()
         e.install_all()
 
-    explicit = spack.store.STORE.db.query(explicit=True)
+    explicit = temporary_store.db.query(explicit=True)
     assert len(explicit) == 2
 
 
@@ -653,7 +655,7 @@ def test_env_definition_symlink(install_mockery, mock_fetch, tmp_path: pathlib.P
 
 
 def test_env_install_two_specs_same_dep(
-    install_mockery, mock_fetch, tmp_path: pathlib.Path, monkeypatch
+    temporary_store, install_mockery, mock_fetch, tmp_path: pathlib.Path, monkeypatch
 ):
     """Test installation of two packages that share a dependency with no
     connection and the second specifying the dependency as a 'build'
@@ -682,10 +684,10 @@ spack:
     assert "depb: Successfully installed" in out
     assert "pkg-a: Successfully installed" in out
 
-    depb = spack.store.STORE.db.query_one("depb", installed=True)
+    depb = temporary_store.db.query_one("depb", installed=True)
     assert depb, "Expected depb to be installed"
 
-    a = spack.store.STORE.db.query_one("pkg-a", installed=True)
+    a = temporary_store.db.query_one("pkg-a", installed=True)
     assert a, "Expected pkg-a to be installed"
 
 
@@ -1852,7 +1854,7 @@ def test_roots_display_with_variants():
     assert "boost+shared" in out
 
 
-def test_uninstall_keeps_in_env(mock_stage, mock_fetch, install_mockery):
+def test_uninstall_keeps_in_env(mock_stage, mock_fetch, temporary_store, install_mockery):
     # 'spack uninstall' without --remove should not change the environment
     # spack.yaml file, just uninstall specs
     env("create", "test")
@@ -1874,7 +1876,7 @@ def test_uninstall_keeps_in_env(mock_stage, mock_fetch, install_mockery):
     assert {x.hash for x in test.concretized_roots} == user_spec_hashes_before
     assert test.user_specs.specs == user_specs_before.specs
     assert mpileaks_hash in test.specs_by_hash
-    assert not spack.store.STORE.db.installed(test.specs_by_hash[mpileaks_hash])
+    assert not temporary_store.db.installed(test.specs_by_hash[mpileaks_hash])
 
 
 def test_uninstall_removes_from_env(mock_stage, mock_fetch, install_mockery):
@@ -3986,7 +3988,7 @@ def test_environment_view_target_already_exists(
     assert os.path.isfile(os.path.join(orphan_dir, "orphan_file"))
 
 
-def test_environment_query_spec_by_hash(mock_stage, mock_fetch, install_mockery):
+def test_environment_query_spec_by_hash(mock_stage, mock_fetch, temporary_store, install_mockery):
     env("create", "test")
     with ev.read("test"):
         add("libdwarf")
@@ -3995,8 +3997,8 @@ def test_environment_query_spec_by_hash(mock_stage, mock_fetch, install_mockery)
         spec = e.matching_spec("libelf")
         install("--fake", f"/{spec.dag_hash()}")
     with ev.read("test") as e:
-        assert not spack.store.STORE.db.installed(e.matching_spec("libdwarf"))
-        assert spack.store.STORE.db.installed(e.matching_spec("libelf"))
+        assert not temporary_store.db.installed(e.matching_spec("libdwarf"))
+        assert temporary_store.db.installed(e.matching_spec("libelf"))
 
 
 @pytest.mark.parametrize("lockfile", ["v1", "v2", "v3"])

--- a/lib/spack/spack/test/cmd/find.py
+++ b/lib/spack/spack/test/cmd/find.py
@@ -18,7 +18,6 @@ import spack.package_base
 import spack.paths
 import spack.repo
 import spack.spec
-import spack.store
 import spack.user_environment as uenv
 from spack.enums import InstallRecordStatus
 from spack.main import SpackCommand
@@ -435,7 +434,7 @@ def test_find_loaded(database, working_env):
     assert output == ""
 
     os.environ[uenv.spack_loaded_hashes_var] = os.pathsep.join(
-        [x.dag_hash() for x in spack.store.STORE.db.query()]
+        [x.dag_hash() for x in database.query()]
     )
     output = find("--loaded")
     expected = find()

--- a/lib/spack/spack/test/cmd/gc.py
+++ b/lib/spack/spack/test/cmd/gc.py
@@ -11,7 +11,6 @@ import spack.deptypes as dt
 import spack.environment as ev
 import spack.main
 import spack.spec
-import spack.store
 import spack.traverse
 from spack.old_installer import PackageInstaller
 
@@ -114,7 +113,7 @@ def test_gc_except_any_environments(mutable_database, mutable_mock_env_path):
 
     # All runtime specs in this env should still be installed.
     assert all(
-        spack.store.STORE.db.installed(s)
+        mutable_database.installed(s)
         for s in spack.traverse.traverse_nodes(e.concrete_roots(), deptype=dt.LINK | dt.RUN)
     )
 

--- a/lib/spack/spack/test/cmd/init_py_functions.py
+++ b/lib/spack/spack/test/cmd/init_py_functions.py
@@ -8,7 +8,6 @@ import pytest
 import spack.config
 import spack.environment as ev
 import spack.error
-import spack.store
 from spack.cmd import (
     CommandNameError,
     PythonNameError,
@@ -69,7 +68,7 @@ def test_special_cases_concretization_parse_specs(
 
     spack.config.set("concretizer:unify", unify)
 
-    args = [f"/{spack.store.STORE.db.query(s)[0].dag_hash()}" for s in spec_strs]
+    args = [f"/{mutable_database.query(s)[0].dag_hash()}" for s in spec_strs]
     if len(args) > 1:
         # We convert the last one to a specfile input
         filename = tmp_path / "spec.json"
@@ -121,7 +120,7 @@ def test_special_cases_concretization_matching_specs_from_env(
     ev.create("test")
     env = ev.read("test")
 
-    args = [f"/{spack.store.STORE.db.query(s)[0].dag_hash()}" for s in spec_strs]
+    args = [f"/{mutable_database.query(s)[0].dag_hash()}" for s in spec_strs]
     if len(args) > 1:
         # We convert the last one to a specfile input
         filename = tmp_path / "spec.json"

--- a/lib/spack/spack/test/cmd/install.py
+++ b/lib/spack/spack/test/cmd/install.py
@@ -26,7 +26,6 @@ import spack.hooks.sbom_generate
 import spack.old_installer
 import spack.package_base
 import spack.reporters.cdash
-import spack.store
 import spack.util.filesystem as fs
 from spack.error import SpackError, SpecSyntaxError
 from spack.main import SpackCommand
@@ -230,7 +229,7 @@ def test_show_log_on_error(mock_packages, mock_archive, mock_fetch, install_mock
 
 
 def test_install_overwrite(
-    mock_packages, mock_archive, mock_fetch, install_mockery, installer_variant
+    mock_packages, mock_archive, mock_fetch, temporary_store, install_mockery, installer_variant
 ):
     """Tests installing a spec, and then re-installing it in the same prefix."""
     spec = spack.concretize.concretize_one("pkg-c")
@@ -238,9 +237,7 @@ def test_install_overwrite(
 
     # Ignore manifest, install times, and sbom
     manifest = os.path.join(
-        spec.prefix,
-        spack.store.STORE.layout.metadata_dir,
-        spack.store.STORE.layout.manifest_file_name,
+        spec.prefix, temporary_store.layout.metadata_dir, temporary_store.layout.manifest_file_name
     )
     ignores = [
         manifest,
@@ -302,7 +299,7 @@ def test_install_commit(mock_git_version_info, install_mockery, mock_packages, m
 
 
 def test_install_overwrite_multiple(
-    mock_packages, mock_archive, mock_fetch, install_mockery, installer_variant
+    mock_packages, mock_archive, mock_fetch, temporary_store, install_mockery, installer_variant
 ):
     # Try to install a spec and then to reinstall it.
     libdwarf = spack.concretize.concretize_one("libdwarf")
@@ -314,8 +311,8 @@ def test_install_overwrite_multiple(
     # Ignore manifest, install times, and sbom
     ld_manifest = os.path.join(
         libdwarf.prefix,
-        spack.store.STORE.layout.metadata_dir,
-        spack.store.STORE.layout.manifest_file_name,
+        temporary_store.layout.metadata_dir,
+        temporary_store.layout.manifest_file_name,
     )
 
     ld_ignores = [
@@ -329,8 +326,8 @@ def test_install_overwrite_multiple(
 
     cm_manifest = os.path.join(
         cmake.prefix,
-        spack.store.STORE.layout.metadata_dir,
-        spack.store.STORE.layout.manifest_file_name,
+        temporary_store.layout.metadata_dir,
+        temporary_store.layout.manifest_file_name,
     )
 
     cm_ignores = [
@@ -523,13 +520,13 @@ def test_install_mix_cli_and_files(spec_format, clispecs, filespecs, tmp_path: p
 
 
 def test_extra_files_are_archived(
-    mock_packages, mock_archive, mock_fetch, install_mockery, installer_variant
+    mock_packages, mock_archive, mock_fetch, temporary_store, install_mockery, installer_variant
 ):
     s = spack.concretize.concretize_one("archive-files")
 
     install("archive-files")
 
-    archive_dir = os.path.join(spack.store.STORE.layout.metadata_path(s), "archived-files")
+    archive_dir = os.path.join(temporary_store.layout.metadata_path(s), "archived-files")
     config_log = os.path.join(archive_dir, mock_archive.expanded_archive_basedir, "config.log")
     assert os.path.exists(config_log)
 
@@ -704,13 +701,13 @@ def test_build_warning_output(mock_fetch, install_mockery):
 
 
 @pytest.mark.disable_clean_stage_check  # new installer keeps a log for build cache installs
-def test_cache_only_fails(mock_fetch, install_mockery, installer_variant):
+def test_cache_only_fails(mock_fetch, temporary_store, install_mockery, installer_variant):
     # libelf from cache fails to install, which automatically removes the
     # the libdwarf build task
     out = install("--cache-only", "libdwarf", fail_on_error=False)
     assert isinstance(install.error, spack.error.InstallError)
-    assert not spack.store.STORE.db.query_local("libdwarf")
-    assert not spack.store.STORE.db.query_local("libelf")
+    assert not temporary_store.db.query_local("libdwarf")
+    assert not temporary_store.db.query_local("libelf")
 
     if installer_variant == "old":
         assert "Failed to install gcc-runtime" in out
@@ -719,8 +716,7 @@ def test_cache_only_fails(mock_fetch, install_mockery, installer_variant):
 
         # Check that failure prefix locks are still cached
         failed_packages = [
-            pkg_name
-            for dag_hash, pkg_name in spack.store.STORE.failure_tracker.locker.locks.keys()
+            pkg_name for dag_hash, pkg_name in temporary_store.failure_tracker.locker.locks.keys()
         ]
         assert "libelf" in failed_packages
         assert "libdwarf" in failed_packages
@@ -802,7 +798,12 @@ def test_install_only_dependencies_of_all_in_env(
 
 # Unit tests should not be affected by the user's managed environments
 def test_install_no_add_in_env(
-    tmp_path: pathlib.Path, mutable_mock_env_path, mock_fetch, install_mockery, installer_variant
+    tmp_path: pathlib.Path,
+    mutable_mock_env_path,
+    mock_fetch,
+    temporary_store,
+    install_mockery,
+    installer_variant,
 ):
     # To test behavior of --add option, we create the following environment:
     #
@@ -860,11 +861,7 @@ def test_install_no_add_in_env(
         inst_out = install("--fake", "pkg-a")
         assert (
             len(
-                [
-                    x
-                    for x in e.all_specs()
-                    if spack.store.STORE.db.installed(x) and x.name == "pkg-a"
-                ]
+                [x for x in e.all_specs() if temporary_store.db.installed(x) and x.name == "pkg-a"]
             )
             == 2
         )

--- a/lib/spack/spack/test/cmd/logs.py
+++ b/lib/spack/spack/test/cmd/logs.py
@@ -16,7 +16,6 @@ import spack.concretize
 import spack.error
 import spack.main
 import spack.spec
-import spack.store
 from spack.main import SpackCommand
 
 logs = SpackCommand("logs")
@@ -48,9 +47,11 @@ def _rewind_collect_and_decode(rw_stream):
     return rw_stream.read().decode("utf-8")
 
 
-def test_logs_cmd_errors(install_mockery, mock_fetch, mock_archive, mock_packages):
+def test_logs_cmd_errors(
+    temporary_store, install_mockery, mock_fetch, mock_archive, mock_packages
+):
     spec = spack.concretize.concretize_one("pkg-c")
-    assert not spack.store.STORE.db.installed(spec)
+    assert not temporary_store.db.installed(spec)
 
     with pytest.raises(spack.error.SpackError, match="is not installed or staged"):
         logs("pkg-c")
@@ -71,7 +72,7 @@ def _write_string_to_path(string, path):
         f.write(string.encode("utf-8"))
 
 
-def test_dump_logs(install_mockery, mock_fetch, mock_archive, mock_packages):
+def test_dump_logs(temporary_store, install_mockery, mock_fetch, mock_archive, mock_packages):
     """Test that ``spack log`` can find (and print) the logs for partial
     builds and completed installs.
 
@@ -83,7 +84,7 @@ def test_dump_logs(install_mockery, mock_fetch, mock_archive, mock_packages):
 
     # Sanity check, make sure this test is checking what we want: to
     # start with
-    assert not spack.store.STORE.db.installed(concrete_spec)
+    assert not temporary_store.db.installed(concrete_spec)
 
     stage_log_content = "test_log stage output\nanother line"
     installed_log_content = "test_log install output\nhere to test multiple lines"

--- a/lib/spack/spack/test/cmd/pkg.py
+++ b/lib/spack/spack/test/cmd/pkg.py
@@ -241,7 +241,7 @@ def test_pkg_source_requires_one_arg(mock_packages):
 def test_pkg_source(mock_packages):
     fake_source = pkg("source", "fake")
 
-    fake_file = spack.repo.PATH.filename_for_package_name("fake")
+    fake_file = mock_packages.filename_for_package_name("fake")
     with open(fake_file, encoding="utf-8") as f:
         contents = f.read()
         assert fake_source == contents
@@ -348,7 +348,7 @@ def test_pkg_grep(mock_packages):
     # only splice-* mock packages have the string "splice" in them
     pkg("grep", "-l", "splice")
     assert pkg.output.strip() == "\n".join(
-        spack.repo.PATH.get_pkg_class(name).module.__file__
+        mock_packages.get_pkg_class(name).module.__file__
         for name in [
             "depends-on-manyvariants",
             "manyvariants",

--- a/lib/spack/spack/test/cmd/reindex.py
+++ b/lib/spack/spack/test/cmd/reindex.py
@@ -14,12 +14,12 @@ deprecate = SpackCommand("deprecate")
 reindex = SpackCommand("reindex")
 
 
-def test_reindex_basic(mock_packages, mock_archive, mock_fetch, install_mockery):
+def test_reindex_basic(mock_packages, mock_archive, mock_fetch, temporary_store, install_mockery):
     install("--fake", "libelf@0.8.13")
     install("--fake", "libelf@0.8.12")
-    all_installed = spack.store.STORE.db.query()
+    all_installed = temporary_store.db.query()
     reindex()
-    assert spack.store.STORE.db.query() == all_installed
+    assert temporary_store.db.query() == all_installed
 
 
 def _clear_db(tmp_path: pathlib.Path):
@@ -33,25 +33,35 @@ def _clear_db(tmp_path: pathlib.Path):
 
 
 def test_reindex_db_deleted(
-    mock_packages, mock_archive, mock_fetch, install_mockery, tmp_path: pathlib.Path
+    mock_packages,
+    mock_archive,
+    mock_fetch,
+    temporary_store,
+    install_mockery,
+    tmp_path: pathlib.Path,
 ):
     install("--fake", "libelf@0.8.13")
     install("--fake", "libelf@0.8.12")
-    all_installed = spack.store.STORE.db.query()
+    all_installed = temporary_store.db.query()
     _clear_db(tmp_path)
     reindex()
-    assert spack.store.STORE.db.query() == all_installed
+    assert temporary_store.db.query() == all_installed
 
 
 def test_reindex_with_deprecated_packages(
-    mock_packages, mock_archive, mock_fetch, install_mockery, tmp_path: pathlib.Path
+    mock_packages,
+    mock_archive,
+    mock_fetch,
+    temporary_store,
+    install_mockery,
+    tmp_path: pathlib.Path,
 ):
     install("--fake", "libelf@0.8.13")
     install("--fake", "libelf@0.8.12")
 
     deprecate("-y", "libelf@0.8.12", "libelf@0.8.13")
 
-    db = spack.store.STORE.db
+    db = temporary_store.db
 
     all_installed = db.query(installed=InstallRecordStatus.ANY)
     non_deprecated = db.query(installed=True)

--- a/lib/spack/spack/test/cmd/spec.py
+++ b/lib/spack/spack/test/cmd/spec.py
@@ -12,7 +12,6 @@ import spack.config
 import spack.environment as ev
 import spack.error
 import spack.spec
-import spack.store
 from spack.main import SpackCommand, SpackCommandError
 
 buildcache = SpackCommand("buildcache")
@@ -53,7 +52,7 @@ def test_spec_concretizer_args(mutable_database):
     uninstall("-y", "mpileaks^mpich2")
 
     # get the hash of mpileaks^zmpi
-    mpileaks_zmpi = spack.store.STORE.db.query_one("mpileaks^zmpi")
+    mpileaks_zmpi = mutable_database.query_one("mpileaks^zmpi")
     h = mpileaks_zmpi.dag_hash()[:7]
 
     output = spec("--fresh", "-l", "mpileaks")
@@ -217,7 +216,7 @@ def test_spec_unification_from_cli(
     """Ensure specs grouped together on the CLI are concretized together when unify:true."""
     spack.config.set("concretizer:unify", unify)
 
-    db = spack.store.STORE.db
+    db = mutable_database
     spec_lookup = {
         "mpileaks_mpich": db.query_one("mpileaks ^mpich").dag_hash(),
         "mpileaks_zmpi": db.query_one("mpileaks ^zmpi").dag_hash(),
@@ -233,10 +232,10 @@ def test_spec_unification_from_cli(
         assert match in output
 
 
-def test_buildcache_status_fn_marks_absent_spec(install_mockery, mock_packages):
+def test_buildcache_status_fn_marks_absent_spec(temporary_store, install_mockery, mock_packages):
     """Tests the basic semantics of build_cache_status_fn."""
     s = spack.concretize.concretize_one("mpileaks")
-    assert spack.store.STORE.db.install_status(s) == spack.spec.InstallStatus.absent
+    assert temporary_store.db.install_status(s) == spack.spec.InstallStatus.absent
 
     status_fn = spack.cmd.buildcache_status_fn({s.dag_hash()})
     assert status_fn(s) == spack.spec.InstallStatus.buildcache
@@ -247,8 +246,8 @@ def test_buildcache_status_fn_marks_absent_spec(install_mockery, mock_packages):
 
 def test_buildcache_status_fn_installed_not_overridden(mutable_database):
     """Tests that an installed spec stays installed even if its hash is in the cache."""
-    s = spack.store.STORE.db.query_one("mpileaks^mpich")
-    assert spack.store.STORE.db.install_status(s) == spack.spec.InstallStatus.installed
+    s = mutable_database.query_one("mpileaks^mpich")
+    assert mutable_database.install_status(s) == spack.spec.InstallStatus.installed
 
     status_fn = spack.cmd.buildcache_status_fn({s.dag_hash()})
     assert status_fn(s) == spack.spec.InstallStatus.installed

--- a/lib/spack/spack/test/cmd/style.py
+++ b/lib/spack/spack/test/cmd/style.py
@@ -130,7 +130,7 @@ def test_changed_files_all_files(mock_packages):
     assert len(files) > 500
 
     # a builtin package
-    zlib = spack.repo.PATH.get_pkg_class("zlib")
+    zlib = mock_packages.get_pkg_class("zlib")
     zlib_file = zlib.module.__file__
     if zlib_file.endswith("pyc"):
         zlib_file = zlib_file[:-1]

--- a/lib/spack/spack/test/cmd/uninstall.py
+++ b/lib/spack/spack/test/cmd/uninstall.py
@@ -47,7 +47,7 @@ def test_correct_installed_dependents(mutable_database):
     # Test whether we return the right dependents.
 
     # Take callpath from the database
-    callpath = spack.store.STORE.db.query_local("callpath")[0]
+    callpath = mutable_database.query_local("callpath")[0]
 
     # Ensure it still has dependents and dependencies
     dependents = callpath.dependents(deptype=("run", "link"))
@@ -115,7 +115,7 @@ def test_force_uninstall_spec_with_ref_count_not_zero(
 def test_force_uninstall_and_reinstall_by_hash(mutable_database):
     """Test forced uninstall and reinstall of old specs."""
     # this is the spec to be removed
-    callpath_spec = spack.store.STORE.db.query_one("callpath ^mpich")
+    callpath_spec = mutable_database.query_one("callpath ^mpich")
     dag_hash = callpath_spec.dag_hash()
 
     # ensure can look up by hash and that it's a dependent of mpileaks

--- a/lib/spack/spack/test/concretization/core.py
+++ b/lib/spack/spack/test/concretization/core.py
@@ -38,7 +38,6 @@ import spack.solver.input_analysis
 import spack.solver.reuse
 import spack.spec
 import spack.spec_filter
-import spack.store
 import spack.traverse
 import spack.util.file_cache
 import spack.util.hash
@@ -1769,7 +1768,7 @@ spack:
         # the answer set produced by clingo.
         with spack.config.override("concretizer:reuse", True):
             s = spack.concretize.concretize_one(spec_str)
-        assert spack.store.STORE.db.installed(s) is expect_installed
+        assert mutable_database.installed(s) is expect_installed
         assert s.satisfies(spec_str)
 
     @pytest.mark.regression("26721,19736")
@@ -2405,7 +2404,7 @@ spack:
         # If we concretize with --reuse it is not, since "mpich~debug" was already installed
         with spack.config.override("concretizer:reuse", True):
             s = spack.concretize.concretize_one("mpich")
-            assert spack.store.STORE.db.installed(s)
+            assert mutable_database.installed(s)
             assert s.satisfies("~debug"), s
 
     @pytest.mark.regression("32471")
@@ -2600,7 +2599,7 @@ packages:
         """Tests that when we reuse a spec, virtual on edges are reconstructed correctly"""
         with spack.config.override("concretizer:reuse", True):
             spec = spack.concretize.concretize_one(spec_str)
-            assert spack.store.STORE.db.installed(spec)
+            assert mutable_database.installed(spec)
             mpi_edges = spec.edges_to_dependencies(mpi_name)
             assert len(mpi_edges) == 1
             assert "mpi" in mpi_edges[0].virtuals

--- a/lib/spack/spack/test/concretization/core.py
+++ b/lib/spack/spack/test/concretization/core.py
@@ -5196,7 +5196,7 @@ def test_virtual_gets_multiple_dupes(mock_packages, config):
     """
     specs = [spack.spec.Spec("pkg-with-c-link-dep")]
     possible_graph = spack.solver.input_analysis.NoStaticAnalysis(
-        configuration=spack.config.CONFIG, repo=spack.repo.PATH
+        configuration=spack.config.CONFIG, repo=mock_packages
     )
     counter = spack.solver.input_analysis.MinimalDuplicatesCounter(
         specs, tests=False, possible_graph=possible_graph

--- a/lib/spack/spack/test/config.py
+++ b/lib/spack/spack/test/config.py
@@ -21,7 +21,6 @@ import spack.error
 import spack.package_base
 import spack.paths
 import spack.platforms
-import spack.repo
 import spack.schema.compilers
 import spack.schema.config
 import spack.schema.env
@@ -1184,13 +1183,13 @@ def test_license_dir_config(mutable_config, mock_packages, tmp_path):
     expected_dir = spack.paths.default_license_dir
     assert spack.config.get("config:license_dir") == expected_dir
     assert spack.package_base.PackageBase.global_license_dir == expected_dir
-    assert spack.repo.PATH.get_pkg_class("pkg-a").global_license_dir == expected_dir
+    assert mock_packages.get_pkg_class("pkg-a").global_license_dir == expected_dir
 
     abs_path = str(tmp_path / "foo" / "bar" / "baz")
     spack.config.set("config:license_dir", abs_path)
     assert spack.config.get("config:license_dir") == abs_path
     assert spack.package_base.PackageBase.global_license_dir == abs_path
-    assert spack.repo.PATH.get_pkg_class("pkg-a").global_license_dir == abs_path
+    assert mock_packages.get_pkg_class("pkg-a").global_license_dir == abs_path
 
 
 @pytest.mark.regression("22547")

--- a/lib/spack/spack/test/conftest.py
+++ b/lib/spack/spack/test/conftest.py
@@ -1897,7 +1897,7 @@ def mock_git_repository(git, tmp_path_factory: pytest.TempPathFactory):
 @pytest.fixture(scope="function")
 def mock_git_test_package(mock_git_repository, mutable_mock_repo, monkeypatch):
     # install a fake git version in the package class
-    pkg_class = spack.repo.PATH.get_pkg_class("git-test")
+    pkg_class = mutable_mock_repo.get_pkg_class("git-test")
     monkeypatch.delattr(pkg_class, "git")
     monkeypatch.setitem(pkg_class.versions, spack.version.Version("git"), mock_git_repository.url)
     return pkg_class

--- a/lib/spack/spack/test/cray_manifest.py
+++ b/lib/spack/spack/test/cray_manifest.py
@@ -25,7 +25,6 @@ import spack.platforms
 import spack.platforms.test
 import spack.solver.reuse
 import spack.spec
-import spack.store
 from spack.cray_manifest import compiler_from_entry, entries_to_specs
 
 pytestmark = [
@@ -345,7 +344,7 @@ def test_read_cray_manifest_add_compiler_failure(temporary_store, manifest_file,
     monkeypatch.setattr(spack.cray_manifest, "compiler_from_entry", _mock)
 
     spack.cray_manifest.read(str(manifest_file), True)
-    query_specs = spack.store.STORE.db.query("openmpi")
+    query_specs = temporary_store.db.query("openmpi")
     assert any(x.dag_hash() == "openmpifakehasha" for x in query_specs)
 
 

--- a/lib/spack/spack/test/database.py
+++ b/lib/spack/spack/test/database.py
@@ -505,12 +505,12 @@ def test_010_all_install_sanity(database):
 
 def test_015_write_and_read(mutable_database):
     # write and read DB
-    with spack.store.STORE.db.write_transaction():
-        specs = spack.store.STORE.db.query()
-        recs = [spack.store.STORE.db.get_record(s) for s in specs]
+    with mutable_database.write_transaction():
+        specs = mutable_database.query()
+        recs = [mutable_database.get_record(s) for s in specs]
 
     for spec, rec in zip(specs, recs):
-        new_rec = spack.store.STORE.db.get_record(spec)
+        new_rec = mutable_database.get_record(spec)
         assert new_rec.ref_count == rec.ref_count
         assert new_rec.spec == rec.spec
         assert new_rec.path == rec.path
@@ -522,11 +522,11 @@ def test_016_roundtrip_spliced_spec(mutable_database):
     replacement = spack.concretize.concretize_one("splice-h+foo")
     spec = build_spec.splice(replacement)
 
-    spack.store.STORE.db.add(spec)
-    spack.store.STORE.db._state_is_inconsistent = True  # force re-read
+    mutable_database.add(spec)
+    mutable_database._state_is_inconsistent = True  # force re-read
 
-    _, spec_record = spack.store.STORE.db.query_by_spec_hash(spec.dag_hash())
-    _, buildspec_record = spack.store.STORE.db.query_by_spec_hash(spec.build_spec.dag_hash())
+    _, spec_record = mutable_database.query_by_spec_hash(spec.dag_hash())
+    _, buildspec_record = mutable_database.query_by_spec_hash(spec.build_spec.dag_hash())
 
     assert spec_record.spec == spec
     assert spec_record.spec.build_spec == spec.build_spec
@@ -536,12 +536,12 @@ def test_016_roundtrip_spliced_spec(mutable_database):
 def test_017_write_and_read_without_uuid(mutable_database, monkeypatch):
     monkeypatch.setattr(spack.database, "_use_uuid", False)
     # write and read DB
-    with spack.store.STORE.db.write_transaction():
-        specs = spack.store.STORE.db.query()
-        recs = [spack.store.STORE.db.get_record(s) for s in specs]
+    with mutable_database.write_transaction():
+        specs = mutable_database.query()
+        recs = [mutable_database.get_record(s) for s in specs]
 
     for spec, rec in zip(specs, recs):
-        new_rec = spack.store.STORE.db.get_record(spec)
+        new_rec = mutable_database.get_record(spec)
         assert new_rec.ref_count == rec.ref_count
         assert new_rec.spec == rec.spec
         assert new_rec.path == rec.path
@@ -551,7 +551,7 @@ def test_017_write_and_read_without_uuid(mutable_database, monkeypatch):
 def test_try_write_transaction(mutable_database, monkeypatch):
     """try_write_transaction persists changes on success and yields False without doing anything
     when acquiring the lock would block."""
-    db = spack.store.STORE.db
+    db = mutable_database
 
     spec = db.query_one("mpileaks ^zmpi")
     with db.try_write_transaction() as acquired:
@@ -570,7 +570,7 @@ def test_try_write_transaction(mutable_database, monkeypatch):
 def test_try_write_transaction_does_not_flush_on_exception(mutable_database):
     """Regression test: an exception inside try_write_transaction must not flush the possibly
     inconsistent in-memory database to disk; the next transaction re-reads it instead."""
-    db = spack.store.STORE.db
+    db = mutable_database
 
     with pytest.raises(ValueError):
         with db.try_write_transaction() as acquired:
@@ -584,7 +584,7 @@ def test_try_write_transaction_does_not_flush_on_exception(mutable_database):
 
 
 def test_try_read_transaction(mutable_database, monkeypatch):
-    db = spack.store.STORE.db
+    db = mutable_database
 
     with db.try_read_transaction() as acquired:
         assert acquired
@@ -656,7 +656,7 @@ def test_041_ref_counts_deprecate(mutable_database):
 def test_050_basic_query(database):
     """Ensure querying database is consistent with what is installed."""
     # query everything
-    total_specs = len(spack.store.STORE.db.query())
+    total_specs = len(database.query())
     assert total_specs == 20
 
     # query specs with multiple configurations
@@ -818,16 +818,16 @@ def test_regression_issue_8036(mutable_database, usr_folder_exists):
     # not be considered installed until it is added to the database by
     # the installer with install().
     s = spack.concretize.concretize_one("externaltool@0.9")
-    assert not spack.store.STORE.db.installed(s)
+    assert not mutable_database.installed(s)
 
     # Now install the external package and check again the `installed` status
     PackageInstaller([s.package], fake=True, explicit=True).install()
-    assert spack.store.STORE.db.installed(s)
+    assert mutable_database.installed(s)
 
 
 @pytest.mark.regression("11118")
 def test_old_external_entries_prefix(mutable_database: spack.database.Database):
-    with open(spack.store.STORE.db._index_path, "r", encoding="utf-8") as f:
+    with open(mutable_database._index_path, "r", encoding="utf-8") as f:
         db_obj = json.loads(f.read())
 
     spack.vendor.jsonschema.validate(db_obj, schema)
@@ -836,13 +836,13 @@ def test_old_external_entries_prefix(mutable_database: spack.database.Database):
 
     db_obj["database"]["installs"][s.dag_hash()]["path"] = "None"
 
-    with open(spack.store.STORE.db._index_path, "w", encoding="utf-8") as f:
+    with open(mutable_database._index_path, "w", encoding="utf-8") as f:
         f.write(json.dumps(db_obj))
     if _use_uuid:
-        with open(spack.store.STORE.db._verifier_path, "w", encoding="utf-8") as f:
+        with open(mutable_database._verifier_path, "w", encoding="utf-8") as f:
             f.write(str(uuid.uuid4()))
 
-    record = spack.store.STORE.db.get_record(s)
+    record = mutable_database.get_record(s)
     assert record is not None
     assert record.path is None
     assert record.spec._prefix is None
@@ -865,11 +865,11 @@ def test_query_unused_specs(mutable_database):
     PackageInstaller([s.package], fake=True, explicit=True).install()
 
     si = s.dag_hash()
-    ml_mpich = spack.store.STORE.db.query_one("mpileaks ^mpich").dag_hash()
-    ml_mpich2 = spack.store.STORE.db.query_one("mpileaks ^mpich2").dag_hash()
-    ml_zmpi = spack.store.STORE.db.query_one("mpileaks ^zmpi").dag_hash()
-    externaltest = spack.store.STORE.db.query_one("externaltest").dag_hash()
-    trivial_smoke_test = spack.store.STORE.db.query_one("trivial-smoke-test").dag_hash()
+    ml_mpich = mutable_database.query_one("mpileaks ^mpich").dag_hash()
+    ml_mpich2 = mutable_database.query_one("mpileaks ^mpich2").dag_hash()
+    ml_zmpi = mutable_database.query_one("mpileaks ^zmpi").dag_hash()
+    externaltest = mutable_database.query_one("externaltest").dag_hash()
+    trivial_smoke_test = mutable_database.query_one("trivial-smoke-test").dag_hash()
 
     def check_unused(roots, deptype, expected):
         unused = spack.store.STORE.db.unused_specs(root_hashes=roots, deptype=deptype)
@@ -914,7 +914,7 @@ def test_query_spec_with_conditional_dependency(mutable_database):
     s = spack.concretize.concretize_one("hdf5~mpi")
     PackageInstaller([s.package], fake=True, explicit=True).install()
 
-    results = spack.store.STORE.db.query_local("hdf5 ^mpich")
+    results = mutable_database.query_local("hdf5 ^mpich")
     assert not results
 
 
@@ -922,13 +922,13 @@ def test_query_spec_with_conditional_dependency(mutable_database):
 def test_query_spec_with_non_conditional_virtual_dependency(database):
     # Ensure the same issue doesn't come up for virtual
     # dependency that are not conditional on variants
-    results = spack.store.STORE.db.query_local("mpileaks ^mpich")
+    results = database.query_local("mpileaks ^mpich")
     assert len(results) == 1
 
 
 def test_query_virtual_spec(database):
     """Make sure we can query for virtuals in the DB"""
-    results = spack.store.STORE.db.query_local("mpi")
+    results = database.query_local("mpi")
     assert len(results) == 3
     names = [s.name for s in results]
     assert all(name in names for name in ["mpich", "mpich2", "zmpi"])
@@ -1095,7 +1095,7 @@ def test_reindex_removed_prefix_is_not_installed(mutable_database, mock_store, c
 
 def test_reindex_when_all_prefixes_are_removed(mutable_database, mock_store):
     # Remove all non-external installations from the filesystem
-    for spec in spack.store.STORE.db.query_local():
+    for spec in mutable_database.query_local():
         if not spec.external:
             assert spec.prefix.startswith(str(mock_store))
             shutil.rmtree(spec.prefix)

--- a/lib/spack/spack/test/directives.py
+++ b/lib/spack/spack/test/directives.py
@@ -7,7 +7,6 @@ import pytest
 
 import spack.concretize
 import spack.directives
-import spack.repo
 import spack.spec
 import spack.version
 from spack.directives import _make_when_spec, depends_on, extends, patch
@@ -19,7 +18,7 @@ def test_false_directives_do_not_exist(mock_packages):
     """Ensure directives that evaluate to False at import time are added to
     dicts on packages.
     """
-    cls = spack.repo.PATH.get_pkg_class("when-directives-false")
+    cls = mock_packages.get_pkg_class("when-directives-false")
     assert not cls.dependencies
     assert not cls.resources
     assert not cls.patches
@@ -29,7 +28,7 @@ def test_true_directives_exist(mock_packages):
     """Ensure directives that evaluate to True at import time are added to
     dicts on packages.
     """
-    cls = spack.repo.PATH.get_pkg_class("when-directives-true")
+    cls = mock_packages.get_pkg_class("when-directives-true")
 
     assert cls.dependencies
     assert "extendee" in cls.dependencies[spack.spec.Spec()]
@@ -43,7 +42,7 @@ def test_true_directives_exist(mock_packages):
 
 
 def test_constraints_from_context(mock_packages):
-    pkg_cls = spack.repo.PATH.get_pkg_class("with-constraint-met")
+    pkg_cls = mock_packages.get_pkg_class("with-constraint-met")
 
     assert pkg_cls.dependencies
     assert "pkg-b" in pkg_cls.dependencies[spack.spec.Spec("@1.0")]
@@ -54,7 +53,7 @@ def test_constraints_from_context(mock_packages):
 
 @pytest.mark.regression("26656")
 def test_constraints_from_context_are_merged(mock_packages):
-    pkg_cls = spack.repo.PATH.get_pkg_class("with-constraint-met")
+    pkg_cls = mock_packages.get_pkg_class("with-constraint-met")
 
     assert pkg_cls.dependencies
     assert "pkg-c" in pkg_cls.dependencies[spack.spec.Spec("@0.14:15 ^pkg-b@3.8:4.0")]
@@ -85,7 +84,7 @@ def test_conditionally_extends_direct_dep(config, mock_packages):
 
 @pytest.mark.regression("34368")
 def test_error_on_anonymous_dependency(config, mock_packages):
-    pkg = spack.repo.PATH.get_pkg_class("pkg-a")
+    pkg = mock_packages.get_pkg_class("pkg-a")
     with pytest.raises(spack.directives.DependencyError):
         spack.directives._execute_depends_on(pkg, spack.spec.Spec("@4.5"))
 
@@ -102,7 +101,7 @@ def test_error_on_anonymous_dependency(config, mock_packages):
     ],
 )
 def test_maintainer_directive(config, mock_packages, package_name, expected_maintainers):
-    pkg_cls = spack.repo.PATH.get_pkg_class(package_name)
+    pkg_cls = mock_packages.get_pkg_class(package_name)
     assert pkg_cls.maintainers == expected_maintainers
 
 
@@ -110,7 +109,7 @@ def test_maintainer_directive(config, mock_packages, package_name, expected_main
     "package_name,expected_licenses", [("licenses-1", [("MIT", "+foo"), ("Apache-2.0", "~foo")])]
 )
 def test_license_directive(config, mock_packages, package_name, expected_licenses):
-    pkg_cls = spack.repo.PATH.get_pkg_class(package_name)
+    pkg_cls = mock_packages.get_pkg_class(package_name)
     for license in expected_licenses:
         assert spack.spec.Spec(license[1]) in pkg_cls.licenses
         assert license[0] == pkg_cls.licenses[spack.spec.Spec(license[1])]
@@ -175,7 +174,7 @@ def test_version_type_validation():
 )
 def test_redistribute_directive(config, mock_packages, spec_str, distribute_src, distribute_bin):
     spec = spack.spec.Spec(spec_str)
-    assert spack.repo.PATH.get_pkg_class(spec.fullname).redistribute_source(spec) == distribute_src
+    assert mock_packages.get_pkg_class(spec.fullname).redistribute_source(spec) == distribute_src
     concretized_spec = spack.concretize.concretize_one(spec)
     assert concretized_spec.package.redistribute_binary == distribute_bin
 
@@ -206,7 +205,7 @@ def test_direct_dependencies_from_when_context_are_retained(mock_packages):
     """Tests that direct dependencies from the "when" context manager don't lose the "direct"
     attribute when turned into directives on the package class.
     """
-    pkg_cls = spack.repo.PATH.get_pkg_class("with-constraint-met")
+    pkg_cls = mock_packages.get_pkg_class("with-constraint-met")
     # Direct dependency in a "when" single context manager
     assert spack.spec.Spec("%pkg-b") in pkg_cls.dependencies
     # Direct dependency in a "when" nested context manager

--- a/lib/spack/spack/test/directory_layout.py
+++ b/lib/spack/spack/test/directory_layout.py
@@ -83,7 +83,7 @@ def test_read_and_write_spec(temporary_store, config, mock_packages):
     layout.
     """
     layout = temporary_store.layout
-    pkg_names = list(spack.repo.PATH.all_package_names())[:max_packages]
+    pkg_names = list(mock_packages.all_package_names())[:max_packages]
 
     for name in pkg_names:
         if name.startswith("external"):
@@ -195,7 +195,7 @@ def test_handle_unknown_package(temporary_store, config, mock_packages, tmp_path
 def test_find(temporary_store, config, mock_packages):
     """Test that finding specs within an install layout works."""
     layout = temporary_store.layout
-    package_names = list(spack.repo.PATH.all_package_names())[:max_packages]
+    package_names = list(mock_packages.all_package_names())[:max_packages]
 
     # Create install prefixes for all packages in the list
     installed_specs = {}

--- a/lib/spack/spack/test/git_fetch.py
+++ b/lib/spack/spack/test/git_fetch.py
@@ -15,7 +15,6 @@ import spack.error
 import spack.fetch_strategy
 import spack.package_base
 import spack.platforms
-import spack.repo
 import spack.util.git
 from spack.fetch_strategy import GitFetchStrategy
 from spack.package_base import PackageBase
@@ -103,7 +102,7 @@ def test_fetch(
     t = mock_git_repository.checks[type_of_test]
     h = mock_git_repository.hash
 
-    pkg_class = spack.repo.PATH.get_pkg_class("git-test")
+    pkg_class = mutable_mock_repo.get_pkg_class("git-test")
     # This would fail using the default-no-per-version-git check but that
     # isn't included in this test
     monkeypatch.delattr(pkg_class, "git")
@@ -153,7 +152,7 @@ def test_fetch_pkg_attr_submodule_init(
     """
 
     t = mock_git_repository.checks["default-no-per-version-git"]
-    pkg_class = spack.repo.PATH.get_pkg_class("git-test")
+    pkg_class = mutable_mock_repo.get_pkg_class("git-test")
     # For this test, the version args don't specify 'git' (which is
     # the majority of version specifications)
     monkeypatch.setattr(pkg_class, "git", mock_git_repository.url)
@@ -190,7 +189,7 @@ def test_adhoc_version_submodules(
 ):
     t = mock_git_repository.checks["tag"]
     # Construct the package under test
-    pkg_class = spack.repo.PATH.get_pkg_class("git-test")
+    pkg_class = mutable_mock_repo.get_pkg_class("git-test")
     monkeypatch.setitem(pkg_class.versions, Version("git"), t.args)
     monkeypatch.setattr(pkg_class, "git", mock_git_repository.url, raising=False)
 

--- a/lib/spack/spack/test/install.py
+++ b/lib/spack/spack/test/install.py
@@ -540,7 +540,7 @@ def test_log_install_with_build_files(install_mockery, monkeypatch):
 def test_unconcretized_install(install_mockery, mock_fetch, mock_packages):
     """Test attempts to perform install phases with unconcretized spec."""
     spec = Spec("trivial-install-test-package")
-    pkg_cls = spack.repo.PATH.get_pkg_class(spec.name)
+    pkg_cls = mock_packages.get_pkg_class(spec.name)
 
     with pytest.raises(ValueError, match="must have a concrete spec"):
         PackageInstaller([pkg_cls(spec)], explicit=True).install()

--- a/lib/spack/spack/test/install.py
+++ b/lib/spack/spack/test/install.py
@@ -44,23 +44,23 @@ def find_nothing(*args):
     raise spack.repo.UnknownPackageError("Repo package access is disabled for test")
 
 
-def test_install_and_uninstall(install_mockery, mock_fetch, monkeypatch):
+def test_install_and_uninstall(temporary_store, install_mockery, mock_fetch, monkeypatch):
     spec = spack.concretize.concretize_one("trivial-install-test-package")
 
     PackageInstaller([spec.package], explicit=True).install()
-    assert spack.store.STORE.db.installed(spec)
+    assert temporary_store.db.installed(spec)
 
     spec.package.do_uninstall()
-    assert not spack.store.STORE.db.installed(spec)
+    assert not temporary_store.db.installed(spec)
 
 
 @pytest.mark.regression("11870")
-def test_uninstall_non_existing_package(install_mockery, mock_fetch, monkeypatch):
+def test_uninstall_non_existing_package(temporary_store, install_mockery, mock_fetch, monkeypatch):
     """Ensure that we can uninstall a package that has been deleted from the repo"""
     spec = spack.concretize.concretize_one("trivial-install-test-package")
 
     PackageInstaller([spec.package], explicit=True).install()
-    assert spack.store.STORE.db.installed(spec)
+    assert temporary_store.db.installed(spec)
 
     # Mock deletion of the package
     spec._package = None
@@ -70,7 +70,7 @@ def test_uninstall_non_existing_package(install_mockery, mock_fetch, monkeypatch
 
     # Ensure we can uninstall it
     PackageBase.uninstall_by_spec(spec)
-    assert not spack.store.STORE.db.installed(spec)
+    assert not temporary_store.db.installed(spec)
 
 
 def test_pkg_attributes(install_mockery, mock_fetch, monkeypatch):
@@ -129,7 +129,9 @@ class RemovePrefixChecker:
         self.wrapped_rm_prefix()
 
 
-def test_partial_install_delete_prefix_and_stage(install_mockery, mock_fetch, working_env):
+def test_partial_install_delete_prefix_and_stage(
+    temporary_store, install_mockery, mock_fetch, working_env
+):
     s = spack.concretize.concretize_one("canfail")
     s.package.succeed = False
 
@@ -143,20 +145,20 @@ def test_partial_install_delete_prefix_and_stage(install_mockery, mock_fetch, wo
     s.package.remove_prefix = rm_prefix_checker.remove_prefix
 
     # must clear failure markings for the package before re-installing it
-    spack.store.STORE.failure_tracker.clear(s, True)
+    temporary_store.failure_tracker.clear(s, True)
 
     s.package.succeed = True
     spack.builder._BUILDERS.clear()  # the builder is cached with a copy of the pkg's __dict__.
 
     PackageInstaller([s.package], explicit=True, restage=True).install()
     assert rm_prefix_checker.removed
-    assert spack.store.STORE.db.installed(s.package.spec)
+    assert temporary_store.db.installed(s.package.spec)
 
 
 @pytest.mark.not_on_windows("Fails spuriously on Windows")
 @pytest.mark.disable_clean_stage_check
 def test_failing_overwrite_install_should_keep_previous_installation(
-    mock_fetch, install_mockery, working_env
+    mock_fetch, temporary_store, install_mockery, working_env
 ):
     """
     Make sure that whenever `spack install --overwrite` fails, spack restores
@@ -175,7 +177,7 @@ def test_failing_overwrite_install_should_keep_previous_installation(
     with pytest.raises(Exception):
         PackageInstaller([s.package], explicit=True, **kwargs).install()
 
-    assert spack.store.STORE.db.installed(s.package.spec)
+    assert temporary_store.db.installed(s.package.spec)
     assert os.path.exists(s.prefix)
 
 
@@ -288,7 +290,9 @@ def test_installed_upstream(install_upstream, mock_fetch):
 
 
 @pytest.mark.disable_clean_stage_check
-def test_partial_install_keep_prefix(install_mockery, mock_fetch, monkeypatch, working_env):
+def test_partial_install_keep_prefix(
+    temporary_store, install_mockery, mock_fetch, monkeypatch, working_env
+):
     s = spack.concretize.concretize_one("canfail")
     s.package.succeed = False
 
@@ -299,21 +303,23 @@ def test_partial_install_keep_prefix(install_mockery, mock_fetch, monkeypatch, w
     assert os.path.exists(s.package.prefix)
 
     # must clear failure markings for the package before re-installing it
-    spack.store.STORE.failure_tracker.clear(s, True)
+    temporary_store.failure_tracker.clear(s, True)
 
     s.package.succeed = True
     spack.builder._BUILDERS.clear()  # the builder is cached with a copy of the pkg's __dict__.
     PackageInstaller([s.package], explicit=True, keep_prefix=True).install()
-    assert spack.store.STORE.db.installed(s.package.spec)
+    assert temporary_store.db.installed(s.package.spec)
 
 
-def test_second_install_no_overwrite_first(install_mockery, mock_fetch, monkeypatch):
+def test_second_install_no_overwrite_first(
+    temporary_store, install_mockery, mock_fetch, monkeypatch
+):
     s = spack.concretize.concretize_one("canfail")
     monkeypatch.setattr(spack.package_base.PackageBase, "remove_prefix", mock_remove_prefix)
 
     s.package.succeed = True
     PackageInstaller([s.package], explicit=True).install()
-    assert spack.store.STORE.db.installed(s.package.spec)
+    assert temporary_store.db.installed(s.package.spec)
 
     # If Package.install is called after this point, it will fail
     s.package.succeed = False
@@ -613,7 +619,9 @@ def test_install_from_binary_with_missing_patch_succeeds(
 
 
 @pytest.mark.parametrize("transitive", [True, False])
-def test_install_spliced(install_mockery, mock_fetch, monkeypatch, transitive, installer_variant):
+def test_install_spliced(
+    temporary_store, install_mockery, mock_fetch, monkeypatch, transitive, installer_variant
+):
     """Test installing a spliced spec"""
     spec = spack.concretize.concretize_one("splice-t")
     dep = spack.concretize.concretize_one("splice-h+foo")
@@ -625,13 +633,13 @@ def test_install_spliced(install_mockery, mock_fetch, monkeypatch, transitive, i
     )
     installer.install()
     for node in out.traverse():
-        assert spack.store.STORE.db.installed(node)
-        assert spack.store.STORE.db.installed(node.build_spec)
+        assert temporary_store.db.installed(node)
+        assert temporary_store.db.installed(node.build_spec)
 
 
 @pytest.mark.parametrize("transitive", [True, False])
 def test_install_spliced_build_spec_installed(
-    install_mockery, mock_fetch, transitive, installer_variant
+    temporary_store, install_mockery, mock_fetch, transitive, installer_variant
 ):
     """Test installing a spliced spec with the build spec already installed"""
     spec = spack.concretize.concretize_one("splice-t")
@@ -646,8 +654,8 @@ def test_install_spliced_build_spec_installed(
     )
     installer.install()
     for node in out.traverse():
-        assert spack.store.STORE.db.installed(node)
-        assert spack.store.STORE.db.installed(node.build_spec)
+        assert temporary_store.db.installed(node)
+        assert temporary_store.db.installed(node.build_spec)
 
 
 # Unit tests should not be affected by the user's managed environments
@@ -658,6 +666,7 @@ def test_install_spliced_build_spec_installed(
 )
 def test_install_splice_root_from_binary(
     mutable_mock_env_path,
+    temporary_store,
     install_mockery,
     mock_fetch,
     temporary_mirror,
@@ -691,7 +700,7 @@ def test_install_splice_root_from_binary(
 
     spack.installer_dispatch.create_installer([out.package], unsigned=True).install()
 
-    assert len(spack.store.STORE.db.query()) == len(list(out.traverse()))
+    assert len(temporary_store.db.query()) == len(list(out.traverse()))
 
 
 @pytest.mark.disable_clean_stage_check

--- a/lib/spack/spack/test/oci/integration_test.py
+++ b/lib/spack/spack/test/oci/integration_test.py
@@ -22,7 +22,6 @@ import spack.environment as ev
 import spack.error
 import spack.oci.opener
 import spack.spec
-import spack.store
 import spack.traverse
 from spack.main import SpackCommand
 from spack.oci.image import Digest, ImageReference, default_config, default_manifest
@@ -61,7 +60,7 @@ def test_buildcache_push_command(mutable_database):
         buildcache("install", "--unsigned", "mpileaks^mpich")
 
         # Now it should be installed again
-        assert spack.store.STORE.db.installed(spec)
+        assert mutable_database.installed(spec)
 
         # And let's check that the bin/mpileaks executable is there
         assert os.path.exists(os.path.join(spec.prefix, "bin", "mpileaks"))

--- a/lib/spack/spack/test/old_installer.py
+++ b/lib/spack/spack/test/old_installer.py
@@ -24,7 +24,6 @@ import spack.package_prefs as prefs
 import spack.repo
 import spack.report
 import spack.spec
-import spack.store
 import spack.util.filesystem as fs
 import spack.util.lock as lk
 from spack.test.conftest import RepoBuilder
@@ -440,9 +439,11 @@ def test_dump_packages_deps_ok(install_mockery, tmp_path: pathlib.Path, mock_pac
     assert os.path.isfile(dest_pkg)
 
 
-def test_dump_packages_deps_errs(install_mockery, tmp_path: pathlib.Path, monkeypatch, capfd):
+def test_dump_packages_deps_errs(
+    temporary_store, install_mockery, tmp_path: pathlib.Path, monkeypatch, capfd
+):
     """Test error paths for dump_packages with dependencies."""
-    orig_bpp = spack.store.STORE.layout.build_packages_path
+    orig_bpp = temporary_store.layout.build_packages_path
     orig_dirname = spack.repo.Repo.dirname_for_package_name
     repo_err_msg = "Mock dirname_for_package_name"
 
@@ -461,7 +462,7 @@ def test_dump_packages_deps_errs(install_mockery, tmp_path: pathlib.Path, monkey
 
     # Now mock the creation of the required directory structure to cover
     # the try-except block
-    monkeypatch.setattr(spack.store.STORE.layout, "build_packages_path", bpp_path)
+    monkeypatch.setattr(temporary_store.layout, "build_packages_path", bpp_path)
 
     spec = spack.concretize.concretize_one("simple-inheritance")
     path = str(tmp_path)
@@ -580,13 +581,13 @@ def test_combine_phase_logs_does_not_care_about_encoding(tmp_path: pathlib.Path)
         assert f.read() == data * 2
 
 
-def test_check_deps_status_install_failure(install_mockery):
+def test_check_deps_status_install_failure(temporary_store, install_mockery):
     """Tests that checking the dependency status on a request to install
     'a' fails, if we mark the dependency as failed.
     """
     s = spack.concretize.concretize_one("pkg-a")
     for dep in s.traverse(root=False):
-        spack.store.STORE.failure_tracker.mark(dep)
+        temporary_store.failure_tracker.mark(dep)
 
     installer = create_installer(["pkg-a"], {})
     request = installer.build_requests[0]
@@ -809,7 +810,7 @@ def test_cleanup_all_tasks(install_mockery, monkeypatch):
     assert len(installer.build_tasks) == 1
 
 
-def test_setup_install_dir_grp(install_mockery, monkeypatch, capfd):
+def test_setup_install_dir_grp(temporary_store, install_mockery, monkeypatch, capfd):
     """Test _setup_install_dir's group change."""
     mock_group = "mockgroup"
     mock_chgrp_msg = "Changing group for {0} to {1}"
@@ -829,7 +830,7 @@ def test_setup_install_dir_grp(install_mockery, monkeypatch, capfd):
     spec = build_task.request.pkg.spec
 
     fs.touchp(spec.prefix)
-    metadatadir = spack.store.STORE.layout.metadata_path(spec)
+    metadatadir = temporary_store.layout.metadata_path(spec)
     # Regex matching with Windows style paths typically fails
     # so we skip the match check here
     if sys.platform == "win32":
@@ -1199,7 +1200,7 @@ def test_overwrite_install_backup_success(monkeypatch, temporary_store, config, 
     monkeypatch.setattr(inst, "build_process", wipe_prefix)
 
     # Make sure the package is not marked uninstalled
-    monkeypatch.setattr(spack.store.STORE.db, "remove", fail)
+    monkeypatch.setattr(temporary_store.db, "remove", fail)
     # Make sure that the installer does an overwrite install
     monkeypatch.setattr(task, "_install_action", inst.InstallAction.OVERWRITE)
 
@@ -1263,16 +1264,16 @@ def test_term_status_line():
 
 
 @pytest.mark.parametrize("explicit", [True, False])
-def test_single_external_implicit_install(install_mockery, explicit):
+def test_single_external_implicit_install(temporary_store, install_mockery, explicit):
     pkg = "trivial-install-test-package"
     s = spack.concretize.concretize_one(pkg)
     s.external_path = "/usr"
     args = {"explicit": [s.dag_hash()] if explicit else []}
     create_installer([s], args).install()
-    assert spack.store.STORE.db.get_record(pkg).explicit == explicit
+    assert temporary_store.db.get_record(pkg).explicit == explicit
 
 
-def test_overwrite_install_does_install_build_deps(install_mockery, mock_fetch):
+def test_overwrite_install_does_install_build_deps(temporary_store, install_mockery, mock_fetch):
     """When overwrite installing something from sources, build deps should be installed."""
     s = spack.concretize.concretize_one("dtrun3")
     create_installer([s]).install()
@@ -1289,7 +1290,7 @@ def test_overwrite_install_does_install_build_deps(install_mockery, mock_fetch):
     create_installer([s], {"overwrite": [s.dag_hash()]}).install()
 
     # Verify that the build dep was also installed.
-    assert spack.store.STORE.db.installed(build_dep)
+    assert temporary_store.db.installed(build_dep)
 
 
 @pytest.mark.parametrize("run_tests", [True, False])

--- a/lib/spack/spack/test/package_class.py
+++ b/lib/spack/spack/test/package_class.py
@@ -20,7 +20,6 @@ import spack.deptypes as dt
 import spack.error
 import spack.install_test
 import spack.package_base
-import spack.repo
 import spack.spec
 import spack.store
 import spack.subprocess_context
@@ -393,7 +392,7 @@ def test_git_provenance_cant_resolve_commit(mock_packages, monkeypatch, config, 
     # patch the base class for dependencies, and the concrete class, whose own ``git``
     # attribute (a real github URL) shadows the base class one
     monkeypatch.setattr(spack.package_base.PackageBase, "git", repo_path, raising=False)
-    monkeypatch.setattr(spack.repo.PATH.get_pkg_class("git-ref-package"), "git", repo_path)
+    monkeypatch.setattr(mock_packages.get_pkg_class("git-ref-package"), "git", repo_path)
     monkeypatch.setattr(spack.package_base.PackageBase, "do_fetch", lambda *args, **kwargs: None)
     spec = spack.concretize.concretize_one("git-ref-package@develop")
     captured = capfd.readouterr()

--- a/lib/spack/spack/test/packages.py
+++ b/lib/spack/spack/test/packages.py
@@ -130,7 +130,7 @@ def test_urls_for_versions(mock_packages, config):
 
 def test_url_for_version_with_no_urls(mock_packages, config):
     spec = Spec("git-test")
-    pkg_cls = spack.repo.PATH.get_pkg_class(spec.name)
+    pkg_cls = mock_packages.get_pkg_class(spec.name)
     with pytest.raises(spack.error.NoURLError):
         pkg_cls(spec).url_for_version("1.0")
 
@@ -321,7 +321,7 @@ def test_fetch_options(version_str, digest_end, extra_options):
 
 def test_package_deprecated_version(mock_packages, mock_fetch, mock_stage):
     spec = Spec("deprecated-versions")
-    pkg_cls = spack.repo.PATH.get_pkg_class(spec.name)
+    pkg_cls = mock_packages.get_pkg_class(spec.name)
 
     assert spack.package_base.deprecated_version(pkg_cls, "1.1.0")
     assert not spack.package_base.deprecated_version(pkg_cls, "1.0.0")
@@ -329,7 +329,7 @@ def test_package_deprecated_version(mock_packages, mock_fetch, mock_stage):
 
 def test_package_can_have_sparse_checkout_properties(mock_packages, mock_fetch, mock_stage):
     spec = Spec("git-sparsepaths-pkg")
-    pkg_cls = spack.repo.PATH.get_pkg_class(spec.name)
+    pkg_cls = mock_packages.get_pkg_class(spec.name)
     assert hasattr(pkg_cls, "git_sparse_paths")
 
     fetcher = spack.fetch_strategy.for_package_version(pkg_cls(spec), "1.0")
@@ -342,7 +342,7 @@ def test_package_can_have_sparse_checkout_properties_with_commit_version(
     mock_packages, mock_fetch, mock_stage
 ):
     spec = Spec("git-sparsepaths-pkg commit=abcdefg")
-    pkg_cls = spack.repo.PATH.get_pkg_class(spec.name)
+    pkg_cls = mock_packages.get_pkg_class(spec.name)
     assert hasattr(pkg_cls, "git_sparse_paths")
 
     fetcher = spack.fetch_strategy.for_package_version(pkg_cls(spec), "1.0")
@@ -355,7 +355,7 @@ def test_package_can_have_sparse_checkout_properties_with_gitversion(
     mock_packages, mock_fetch, mock_stage
 ):
     spec = Spec("git-sparsepaths-pkg")
-    pkg_cls = spack.repo.PATH.get_pkg_class(spec.name)
+    pkg_cls = mock_packages.get_pkg_class(spec.name)
     assert hasattr(pkg_cls, "git_sparse_paths")
 
     version = "git.foo=1.0"
@@ -369,7 +369,7 @@ def test_package_version_can_have_sparse_checkout_properties(
     mock_packages, mock_fetch, mock_stage
 ):
     spec = Spec("git-sparsepaths-version")
-    pkg_cls = spack.repo.PATH.get_pkg_class(spec.name)
+    pkg_cls = mock_packages.get_pkg_class(spec.name)
 
     fetcher = spack.fetch_strategy.for_package_version(pkg_cls(spec), version="1.0")
     assert isinstance(fetcher, spack.fetch_strategy.GitFetchStrategy)

--- a/lib/spack/spack/test/patch.py
+++ b/lib/spack/spack/test/patch.py
@@ -177,10 +177,10 @@ def test_patch_in_spec(mock_packages, config):
 def test_stale_patch_cache_falls_back_to_fresh(mock_packages, config):
     """spec.patches returns correct patches even when the stale in-memory cache is wrong."""
     spec = spack.concretize.concretize_one("patch@=1.0")
-    pkg_cls = spack.repo.PATH.get_pkg_class("patch")
+    pkg_cls = mock_packages.get_pkg_class("patch")
 
     # Inject a stale PatchCache: foo_sha256 points to a non-existent patch file
-    stale_cache = spack.patch.PatchCache(repository=spack.repo.PATH)
+    stale_cache = spack.patch.PatchCache(repository=mock_packages)
     stale_cache.index = {
         foo_sha256: {
             pkg_cls.fullname: {
@@ -192,8 +192,8 @@ def test_stale_patch_cache_falls_back_to_fresh(mock_packages, config):
             }
         }
     }
-    spack.repo.PATH._patch_index = stale_cache
-    spack.repo.PATH._index_is_fresh = False
+    mock_packages._patch_index = stale_cache
+    mock_packages._index_is_fresh = False
 
     patches = spec.patches
 
@@ -248,7 +248,7 @@ def test_nested_directives(mock_packages):
     """Ensure pkg data structures are set up properly by nested directives."""
     # this ensures that the patch() directive results were removed
     # properly from the DirectiveMeta._directives_to_be_executed list
-    package = spack.repo.PATH.get_pkg_class("patch-several-dependencies")
+    package = mock_packages.get_pkg_class("patch-several-dependencies")
     assert len(package.patches) == 0
 
     # this ensures that results of dependency patches were properly added
@@ -563,8 +563,8 @@ def test_patch_lookup_for_shadowed_package(mock_packages, config, repo_builder):
     package in a higher-precedence repo doesn't shadow the patch owner."""
     repo_builder.add_package("patch")
 
-    with spack.repo.use_repositories(repo_builder.root, override=False):
-        assert spack.repo.PATH.repo_for_pkg("patch").namespace == repo_builder.namespace
+    with spack.repo.use_repositories(repo_builder.root, override=False) as repos:
+        assert repos.repo_for_pkg("patch").namespace == repo_builder.namespace
 
         spec = spack.concretize.concretize_one("builtin_mock.patch@=1.0")
         default = spack.concretize.concretize_one("patch")

--- a/lib/spack/spack/test/provider_index.py
+++ b/lib/spack/spack/test/provider_index.py
@@ -26,19 +26,19 @@ from spack.spec import Spec
 
 
 def test_provider_index_round_trip(mock_packages):
-    p = ProviderIndex(specs=spack.repo.all_package_names(), repository=spack.repo.PATH)
+    p = ProviderIndex(specs=spack.repo.all_package_names(), repository=mock_packages)
 
     ostream = io.StringIO()
     p.to_json(ostream)
 
     istream = io.StringIO(ostream.getvalue())
-    q = ProviderIndex.from_json(istream, repository=spack.repo.PATH)
+    q = ProviderIndex.from_json(istream, repository=mock_packages)
 
     assert p == q
 
 
 def test_providers_for_simple(mock_packages):
-    p = ProviderIndex(specs=spack.repo.all_package_names(), repository=spack.repo.PATH)
+    p = ProviderIndex(specs=spack.repo.all_package_names(), repository=mock_packages)
 
     blas_providers = p.providers_for("blas")
     assert Spec("netlib-blas") in blas_providers
@@ -51,7 +51,7 @@ def test_providers_for_simple(mock_packages):
 
 
 def test_mpi_providers(mock_packages):
-    p = ProviderIndex(specs=spack.repo.all_package_names(), repository=spack.repo.PATH)
+    p = ProviderIndex(specs=spack.repo.all_package_names(), repository=mock_packages)
 
     mpi_2_providers = p.providers_for("mpi@2")
     assert Spec("mpich2") in mpi_2_providers
@@ -64,20 +64,20 @@ def test_mpi_providers(mock_packages):
 
 
 def test_equal(mock_packages):
-    p = ProviderIndex(specs=spack.repo.all_package_names(), repository=spack.repo.PATH)
-    q = ProviderIndex(specs=spack.repo.all_package_names(), repository=spack.repo.PATH)
+    p = ProviderIndex(specs=spack.repo.all_package_names(), repository=mock_packages)
+    q = ProviderIndex(specs=spack.repo.all_package_names(), repository=mock_packages)
     assert p == q
 
 
 def test_copy(mock_packages):
-    p = ProviderIndex(specs=spack.repo.all_package_names(), repository=spack.repo.PATH)
+    p = ProviderIndex(specs=spack.repo.all_package_names(), repository=mock_packages)
     q = p.copy()
     assert p == q
 
 
 def test_remove_providers(mock_packages):
     """Test removing providers from the index."""
-    p = ProviderIndex(specs=["mpich"], repository=spack.repo.PATH)
+    p = ProviderIndex(specs=["mpich"], repository=mock_packages)
     # Check that mpich is a provider for mpi
     providers = p.providers_for("mpi")
     assert any(spec.name == "mpich" for spec in providers)

--- a/lib/spack/spack/test/rewiring.py
+++ b/lib/spack/spack/test/rewiring.py
@@ -11,7 +11,6 @@ import pytest
 import spack.concretize
 import spack.deptypes as dt
 import spack.rewiring
-import spack.store
 from spack.old_installer import PackageInstaller
 from spack.test.relocate import text_in_bin
 
@@ -33,7 +32,7 @@ def check_spliced_spec_prefixes(spliced_spec):
 
 @pytest.mark.requires_executables(*required_executables)
 @pytest.mark.parametrize("transitive", [True, False])
-def test_rewire_db(mock_fetch, install_mockery, transitive):
+def test_rewire_db(mock_fetch, temporary_store, install_mockery, transitive):
     """Tests basic rewiring without binary executables."""
     spec = spack.concretize.concretize_one("splice-t^splice-h~foo")
     dep = spack.concretize.concretize_one("splice-h+foo")
@@ -47,7 +46,7 @@ def test_rewire_db(mock_fetch, install_mockery, transitive):
     assert os.path.exists(spliced_spec.prefix)
 
     # test that it made it into the database
-    rec = spack.store.STORE.db.get_record(spliced_spec)
+    rec = temporary_store.db.get_record(spliced_spec)
     installed_in_db = rec.installed if rec else False
     assert installed_in_db
 
@@ -57,7 +56,7 @@ def test_rewire_db(mock_fetch, install_mockery, transitive):
 
 @pytest.mark.requires_executables(*required_executables)
 @pytest.mark.parametrize("transitive", [True, False])
-def test_rewire_bin(mock_fetch, install_mockery, transitive):
+def test_rewire_bin(mock_fetch, temporary_store, install_mockery, transitive):
     """Tests basic rewiring with binary executables."""
     spec = spack.concretize.concretize_one("quux")
     dep = spack.concretize.concretize_one("garply cflags=-g")
@@ -72,7 +71,7 @@ def test_rewire_bin(mock_fetch, install_mockery, transitive):
     assert os.path.exists(spliced_spec.prefix)
 
     # test that it made it into the database
-    rec = spack.store.STORE.db.get_record(spliced_spec)
+    rec = temporary_store.db.get_record(spliced_spec)
     installed_in_db = rec.installed if rec else False
     assert installed_in_db
 
@@ -85,7 +84,7 @@ def test_rewire_bin(mock_fetch, install_mockery, transitive):
 
 
 @pytest.mark.requires_executables(*required_executables)
-def test_rewire_writes_new_metadata(mock_fetch, install_mockery):
+def test_rewire_writes_new_metadata(mock_fetch, temporary_store, install_mockery):
     """Tests that new metadata was written during a rewire.
     Accuracy of metadata is left to other tests."""
     spec = spack.concretize.concretize_one("quux")
@@ -96,11 +95,11 @@ def test_rewire_writes_new_metadata(mock_fetch, install_mockery):
 
     # test install manifests
     for node in spliced_spec.traverse(root=True):
-        spack.store.STORE.layout.ensure_installed(node)
+        temporary_store.layout.ensure_installed(node)
         manifest_file_path = os.path.join(
             node.prefix,
-            spack.store.STORE.layout.metadata_dir,
-            spack.store.STORE.layout.manifest_file_name,
+            temporary_store.layout.metadata_dir,
+            temporary_store.layout.manifest_file_name,
         )
         assert os.path.exists(manifest_file_path)
         orig_node = spec[node.name]
@@ -108,21 +107,19 @@ def test_rewire_writes_new_metadata(mock_fetch, install_mockery):
             continue
         orig_manifest_file_path = os.path.join(
             orig_node.prefix,
-            spack.store.STORE.layout.metadata_dir,
-            spack.store.STORE.layout.manifest_file_name,
+            temporary_store.layout.metadata_dir,
+            temporary_store.layout.manifest_file_name,
         )
         assert os.path.exists(orig_manifest_file_path)
         assert not filecmp.cmp(orig_manifest_file_path, manifest_file_path, shallow=False)
         specfile_path = os.path.join(
-            node.prefix,
-            spack.store.STORE.layout.metadata_dir,
-            spack.store.STORE.layout.spec_file_name,
+            node.prefix, temporary_store.layout.metadata_dir, temporary_store.layout.spec_file_name
         )
         assert os.path.exists(specfile_path)
         orig_specfile_path = os.path.join(
             orig_node.prefix,
-            spack.store.STORE.layout.metadata_dir,
-            spack.store.STORE.layout.spec_file_name,
+            temporary_store.layout.metadata_dir,
+            temporary_store.layout.spec_file_name,
         )
         assert os.path.exists(orig_specfile_path)
         assert not filecmp.cmp(orig_specfile_path, specfile_path, shallow=False)
@@ -130,7 +127,7 @@ def test_rewire_writes_new_metadata(mock_fetch, install_mockery):
 
 @pytest.mark.requires_executables(*required_executables)
 @pytest.mark.parametrize("transitive", [True, False])
-def test_uninstall_rewired_spec(mock_fetch, install_mockery, transitive):
+def test_uninstall_rewired_spec(mock_fetch, temporary_store, install_mockery, transitive):
     """Test that rewired packages can be uninstalled as normal."""
     spec = spack.concretize.concretize_one("quux")
     dep = spack.concretize.concretize_one("garply cflags=-g")
@@ -138,7 +135,7 @@ def test_uninstall_rewired_spec(mock_fetch, install_mockery, transitive):
     spliced_spec = spec.splice(dep, transitive=transitive)
     spack.rewiring.rewire(spliced_spec)
     spliced_spec.package.do_uninstall()
-    assert len(spack.store.STORE.db.query(spliced_spec)) == 0
+    assert len(temporary_store.db.query(spliced_spec)) == 0
     assert not os.path.exists(spliced_spec.prefix)
 
 

--- a/lib/spack/spack/test/tag.py
+++ b/lib/spack/spack/test/tag.py
@@ -91,7 +91,7 @@ def test_tag_get_installed_packages(mock_packages, mock_archive, mock_fetch, ins
 
 def test_tag_index_round_trip(mock_packages):
     # Assumes at least two packages -- mpich and mpich2 -- have tags
-    mock_index = spack.repo.PATH.tag_index
+    mock_index = mock_packages.tag_index
     assert mock_index.tags
 
     ostream = io.StringIO()

--- a/lib/spack/spack/test/variant.py
+++ b/lib/spack/spack/test/variant.py
@@ -7,7 +7,6 @@ import pytest
 
 import spack.concretize
 import spack.error
-import spack.repo
 import spack.spec
 import spack.variant
 from spack.spec import Spec, VariantMap
@@ -602,7 +601,7 @@ def test_wild_card_valued_variants_equivalent_to_str():
 
 
 def test_variant_definitions(mock_packages):
-    pkg = spack.repo.PATH.get_pkg_class("variant-values")
+    pkg = mock_packages.get_pkg_class("variant-values")
 
     # two variant names
     assert len(pkg.variant_names()) == 2
@@ -653,7 +652,7 @@ def test_variant_definitions(mock_packages):
     ],
 )
 def test_prevalidate_variant_value(mock_packages, pkg_name, value, spec, def_ids):
-    pkg = spack.repo.PATH.get_pkg_class(pkg_name)
+    pkg = mock_packages.get_pkg_class(pkg_name)
 
     all_defs = [vdef for _, vdef in pkg.variant_definitions("v")]
 
@@ -683,7 +682,7 @@ def test_prevalidate_variant_value(mock_packages, pkg_name, value, spec, def_ids
     ],
 )
 def test_strict_invalid_variant_values(mock_packages, pkg_name, value, spec):
-    pkg = spack.repo.PATH.get_pkg_class(pkg_name)
+    pkg = mock_packages.get_pkg_class(pkg_name)
 
     with pytest.raises(spack.variant.InvalidVariantValueError):
         spack.variant.prevalidate_variant_value(
@@ -705,7 +704,7 @@ def test_strict_invalid_variant_values(mock_packages, pkg_name, value, spec):
 def test_concretize_variant_default_with_multiple_defs(
     mock_packages, config, pkg_name, spec, satisfies, def_id
 ):
-    pkg = spack.repo.PATH.get_pkg_class(pkg_name)
+    pkg = mock_packages.get_pkg_class(pkg_name)
     pkg_defs = [vdef for _, vdef in pkg.variant_definitions("v")]
 
     spec = spack.concretize.concretize_one(f"{pkg_name}{spec}")


### PR DESCRIPTION
Tests that already have a store, database or repo fixture in scope reach for
`spack.store.STORE` / `spack.repo.PATH` anyway. This makes them use the value the
fixture already hands them.

This is test-only (no production code changes) and stands on its own, but it is a
prerequisite for injecting the store and repo path rather than reading them as process
globals: as long as the tests read and swap the globals, correctly injected production
code is never actually exercised through the injected path, so the suite cannot detect a
regression.

| global | reads before | after |
| --- | ---: | ---: |
| `spack.store.STORE` | 230 | 90 |
| `spack.repo.PATH` | 120 | 63 |

Notes on the mechanics:

- Fixtures named `database` / `mutable_database` / `database_mutable_config` yield a
  `Database`, so they replace `STORE.db`, not `STORE`.
- Where a test requested `install_mockery` but had no store handle, `temporary_store` is
  added to the signature. `install_mockery` depends on it, so both names refer to the
  same object.
- Tests that exercise the global machinery itself are deliberately left alone: all of
  `test/repo.py` (it tests `PATH` swapping), bootstrap store swapping, custom stores in
  environments, and the upstream/downstream wiring that monkeypatches the global.

Two tests turned out to read `PATH` inside a `with spack.repo.use_repositories(...)`
block, where the fixture value is not the repo path under test. They now bind the
context manager's own value (`as repos`), which is what they meant. The global was
hiding the mismatch.

Instrumenting the suite (a plugin making `spack.store.STORE` a recording property) gives
an objective before/after, counting distinct lines that read the global:

| category | before | after |
| --- | ---: | ---: |
| library | 118 | 118 |
| cmd | 46 | 46 |
| test | 211 | 84 |

`library` and `cmd` are unchanged, which is the evidence that this PR is test-only.

Out of scope: `use_store` / `use_repositories` still swap the globals. Turning them into
a raising sentinel is the enforcement step and belongs in a follow-up, once the reads are
gone.