### PR TITLE
config, store, repo: make global use explicit and reduce it in tests

### DIFF
--- a/lib/spack/spack/audit.py
+++ b/lib/spack/spack/audit.py
@@ -196,7 +196,9 @@ def _search_duplicate_compilers(error_cls):
     """Report compilers with the same spec and two different definitions"""
     errors = []
 
-    compilers = list(sorted(spack.config.get("compilers"), key=lambda x: x["compiler"]["spec"]))
+    compilers = list(
+        sorted(spack.config.CONFIG.get("compilers"), key=lambda x: x["compiler"]["spec"])
+    )
     for spec, group in itertools.groupby(compilers, key=lambda x: x["compiler"]["spec"]):
         group = list(group)
         if len(group) == 1:
@@ -227,7 +229,7 @@ config_repos = AuditClass(
 def _search_duplicate_specs_in_externals(error_cls):
     """Search for duplicate specs declared as externals"""
     errors, externals = [], collections.defaultdict(list)
-    packages_yaml = spack.config.get("packages")
+    packages_yaml = spack.config.CONFIG.get("packages")
 
     for name, pkg_config in packages_yaml.items():
         # No externals can be declared under all

--- a/lib/spack/spack/bootstrap/config.py
+++ b/lib/spack/spack/bootstrap/config.py
@@ -42,13 +42,13 @@ def spec_for_current_python() -> str:
 def root_path() -> str:
     """Root of all the bootstrap related folders"""
     return spack.config.canonicalize_path(
-        spack.config.get("bootstrap:root", spack.paths.default_user_bootstrap_path)
+        spack.config.CONFIG.get("bootstrap:root", spack.paths.default_user_bootstrap_path)
     )
 
 
 def store_path() -> str:
     """Path to the store used for bootstrapped software"""
-    enabled = spack.config.get("bootstrap:enable", True)
+    enabled = spack.config.CONFIG.get("bootstrap:enable", True)
     if not enabled:
         msg = 'bootstrapping is currently disabled. Use "spack bootstrap enable" to enable it'
         raise RuntimeError(msg)
@@ -70,7 +70,7 @@ def spack_python_interpreter() -> Generator:
         "externals": [{"prefix": python_prefix, "spec": str(external_python)}],
     }
 
-    with spack.config.override("packages:python::", entry):
+    with spack.config.CONFIG.override("packages:python::", entry):
         yield
 
 
@@ -112,12 +112,12 @@ def _read_and_sanitize_configuration() -> Dict[str, Any]:
     # Read the "config" section but pop the install tree (the entry will not be
     # considered due to the use_store context manager, so it will be confusing
     # to have it in the configuration).
-    config_yaml = spack.config.get("config")
+    config_yaml = spack.config.CONFIG.get("config")
     config_yaml.pop("install_tree", None)
     return {
-        "bootstrap": spack.config.get("bootstrap"),
+        "bootstrap": spack.config.CONFIG.get("bootstrap"),
         "config": config_yaml,
-        "repos": spack.config.get("repos"),
+        "repos": spack.config.CONFIG.get("repos"),
     }
 
 
@@ -147,8 +147,8 @@ def _ensure_bootstrap_configuration() -> Generator:
         # Default configuration scopes excluding command line and builtin
         *_bootstrap_config_scopes()
     ), spack.store.use_store(bootstrap_store_path, extra_data={"padded_length": 0}):
-        spack.config.set("bootstrap", user_configuration["bootstrap"])
-        spack.config.set("config", user_configuration["config"])
-        spack.config.set("repos", user_configuration["repos"])
+        spack.config.CONFIG.set("bootstrap", user_configuration["bootstrap"])
+        spack.config.CONFIG.set("config", user_configuration["config"])
+        spack.config.CONFIG.set("repos", user_configuration["repos"])
         with spack.modules.disable_modules(), spack_python_interpreter():
             yield

--- a/lib/spack/spack/bootstrap/core.py
+++ b/lib/spack/spack/bootstrap/core.py
@@ -198,7 +198,7 @@ class BuildcacheBootstrapper(Bootstrapper):
         test_fn,
     ) -> bool:
         # Ensure we see only the buildcache being used to bootstrap
-        with spack.config.override(self.mirror_scope):
+        with spack.config.CONFIG.override(self.mirror_scope):
             # This index is currently needed to get the compiler used to build some
             # specs that we know by dag hash.
             spack.binary_distribution.BINARY_INDEX.regenerate_spec_cache()
@@ -289,7 +289,7 @@ class SourceBootstrapper(Bootstrapper):
         tty.debug(msg.format(module, abstract_spec_str))
 
         # Install the spec that should make the module importable
-        with spack.config.override(self.mirror_scope):
+        with spack.config.CONFIG.override(self.mirror_scope):
             spack.installer_dispatch.create_installer(
                 [concrete_spec.package],
                 fail_fast=True,
@@ -317,7 +317,7 @@ class SourceBootstrapper(Bootstrapper):
         concrete_spec = spack.concretize.concretize_one(abstract_spec_str)
         msg = "[BOOTSTRAP] Try installing '{0}' from sources"
         tty.debug(msg.format(abstract_spec_str))
-        with spack.config.override(self.mirror_scope):
+        with spack.config.CONFIG.override(self.mirror_scope):
             spack.installer_dispatch.create_installer([concrete_spec.package]).install()
         if _executables_in_store(executables, concrete_spec, query_info=info):
             self.last_search = info
@@ -333,7 +333,7 @@ def create_bootstrapper(conf: ConfigDictionary):
 
 def source_is_enabled(conf: ConfigDictionary) -> bool:
     """Returns true if the source is not enabled for bootstrapping"""
-    return spack.config.get("bootstrap:trusted").get(conf["name"], False)
+    return spack.config.CONFIG.get("bootstrap:trusted").get(conf["name"], False)
 
 
 def ensure_module_importable_or_raise(module: str, abstract_spec: Optional[str] = None):
@@ -551,7 +551,7 @@ def ensure_winsdk_external_or_raise() -> None:
     This is different from all other current bootstrap dependency
     checks.
     """
-    if set(["win-sdk", "wgl"]).issubset(spack.config.get("packages").keys()):
+    if set(["win-sdk", "wgl"]).issubset(spack.config.CONFIG.get("packages").keys()):
         return
     tty.debug("Detecting Windows SDK and WGL installations")
     # find the externals sequentially to avoid subprocesses being spawned
@@ -594,7 +594,7 @@ def bootstrapping_sources(scope: Optional[str] = None):
         scope: if a valid configuration scope is given, return the
             list only from that scope
     """
-    source_configs = spack.config.get("bootstrap:sources", default=None, scope=scope)
+    source_configs = spack.config.CONFIG.get("bootstrap:sources", default=None, scope=scope)
     source_configs = source_configs or []
     list_of_sources = []
     for entry in source_configs:

--- a/lib/spack/spack/bootstrap/environment.py
+++ b/lib/spack/spack/bootstrap/environment.py
@@ -99,7 +99,7 @@ class BootstrapEnvironment(spack.environment.Environment):
                     download_and_trust_key()
                     fetch_policy = (
                         "cache_only"
-                        if not spack.config.get("bootstrap:dev:enable_source", False)
+                        if not spack.config.CONFIG.get("bootstrap:dev:enable_source", False)
                         else "auto"
                     )
                     try:

--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -379,7 +379,7 @@ def clean_environment():
     for v in mpi_vars:
         env.unset(v)
 
-    build_lang = spack.config.get("config:build_language")
+    build_lang = spack.config.CONFIG.get("config:build_language")
     if build_lang:
         # Override language-related variables. This can be used to force
         # English compiler messages etc., which allows parse_log_events to
@@ -422,7 +422,7 @@ def set_wrapper_environment_variables_for_flags(pkg, env):
     if pkg.keep_werror is not None:
         keep_werror = pkg.keep_werror
     else:
-        keep_werror = spack.config.get("config:flags:keep_werror")
+        keep_werror = spack.config.CONFIG.get("config:flags:keep_werror")
 
     _add_werror_handling(keep_werror, env)
 
@@ -489,13 +489,13 @@ def set_wrapper_variables(pkg, env):
     set_wrapper_environment_variables_for_flags(pkg, env)
 
     # Working directory for the spack command itself, for debug logs.
-    if spack.config.get("config:debug"):
+    if spack.config.CONFIG.get("config:debug"):
         env.set(SPACK_DEBUG, "TRUE")
     env.set(SPACK_SHORT_SPEC, pkg.spec.short_spec)
     env.set(SPACK_DEBUG_LOG_ID, pkg.spec.format("{name}-{hash:7}"))
     env.set(SPACK_DEBUG_LOG_DIR, spack.paths.spack_working_dir)
 
-    if spack.config.get("config:ccache"):
+    if spack.config.CONFIG.get("config:ccache"):
         # Enable ccache in the compiler wrapper
         env.set(SPACK_CCACHE_BINARY, spack.util.executable.which_string("ccache", required=True))
     else:

--- a/lib/spack/spack/caches.py
+++ b/lib/spack/spack/caches.py
@@ -19,7 +19,7 @@ def misc_cache_location():
     Currently the ``MISC_CACHE`` stores indexes for virtual dependency
     providers and for which packages provide which tags.
     """
-    path = spack.config.get("config:misc_cache", spack.paths.default_misc_cache_path)
+    path = spack.config.CONFIG.get("config:misc_cache", spack.paths.default_misc_cache_path)
     return spack.config.canonicalize_path(path)
 
 
@@ -40,7 +40,7 @@ def fetch_cache_location():
     This prevents Spack from repeatedly fetch the same files when
     building the same package different ways or multiple times.
     """
-    path = spack.config.get("config:source_cache")
+    path = spack.config.CONFIG.get("config:source_cache")
     if not path:
         path = spack.paths.default_fetch_cache_path
     path = spack.config.canonicalize_path(path)

--- a/lib/spack/spack/ci/__init__.py
+++ b/lib/spack/spack/ci/__init__.py
@@ -369,9 +369,9 @@ def collect_pipeline_options(env: ev.Environment, args) -> PipelineOptions:
     options.check_index_only = args.index_only
     options.forward_variables = args.forward_variable or []
 
-    ci_config = cfg.get("ci")
+    ci_config = cfg.CONFIG.get("ci")
 
-    cdash_config = cfg.get("cdash")
+    cdash_config = cfg.CONFIG.get("cdash")
     if "build-group" in cdash_config:
         options.cdash_handler = CDashHandler(cdash_config)
 
@@ -479,7 +479,7 @@ def generate_pipeline(env: ev.Environment, args) -> None:
     options = collect_pipeline_options(env, args)
 
     # Get the joined "ci" config with all of the current scopes resolved
-    ci_config = cfg.get("ci")
+    ci_config = cfg.CONFIG.get("ci")
     if not ci_config:
         raise SpackCIError("Environment does not have a `ci` configuration")
 
@@ -544,7 +544,7 @@ def generate_pipeline(env: ev.Environment, args) -> None:
     generate_method(pipeline, spack_ci_config, options)
 
     # Use all unpruned specs to populate the build group for this set
-    cdash_config = cfg.get("cdash")
+    cdash_config = cfg.CONFIG.get("cdash")
     if options.cdash_handler and options.cdash_handler.auth_token:
         options.cdash_handler.create_buildgroup()
     elif cdash_config:

--- a/lib/spack/spack/cmd/__init__.py
+++ b/lib/spack/spack/cmd/__init__.py
@@ -201,7 +201,7 @@ def _concretize_spec_pairs(
     Any spec with a concrete spec associated with it will concretize to that spec. Any spec
     with ``None`` for its concrete spec will be newly concretized. This method respects unification
     rules from config."""
-    unify = spack.config.get("concretizer:unify", False)
+    unify = spack.config.CONFIG.get("concretizer:unify", False)
 
     # Special case for concretizing a single spec
     if len(to_concretize) == 1:

--- a/lib/spack/spack/cmd/bootstrap.py
+++ b/lib/spack/spack/cmd/bootstrap.py
@@ -193,7 +193,7 @@ def _root(args):
     if args.path:
         spack.config.CONFIG.set("bootstrap:root", args.path, scope=args.scope)
     elif args.scope:
-        if args.scope not in spack.config.existing_scope_names():
+        if args.scope not in spack.config.CONFIG.existing_scope_names():
             spack.util.tty.die(
                 f"The argument --scope={args.scope} must refer to an existing scope."
             )
@@ -284,7 +284,7 @@ def _write_bootstrapping_source_status(name, enabled, scope=None):
 
     # Setting the scope explicitly is needed to not copy over to a new scope
     # the entire default configuration for bootstrap.yaml
-    scope = scope or spack.config.default_modify_scope("bootstrap")
+    scope = scope or spack.config.CONFIG.default_modify_scope("bootstrap")
     spack.config.CONFIG.add("bootstrap:trusted:{0}:{1}".format(name, str(enabled)), scope=scope)
 
 
@@ -352,7 +352,7 @@ def _add(args):
         raise RuntimeError('the file "{0}" does not exist'.format(file))
 
     # Insert the new source as the highest priority one
-    write_scope = args.scope or spack.config.default_modify_scope(section="bootstrap")
+    write_scope = args.scope or spack.config.CONFIG.default_modify_scope(section="bootstrap")
     sources = spack.config.CONFIG.get("bootstrap:sources", scope=write_scope) or []
     sources = [{"name": args.name, "metadata": args.metadata_dir}] + sources
     spack.config.CONFIG.set("bootstrap:sources", sources, scope=write_scope)
@@ -373,7 +373,7 @@ def _remove(args):
         )
         raise RuntimeError(msg.format(args.name))
 
-    for current_scope in spack.config.scopes():
+    for current_scope in spack.config.CONFIG.scopes:
         sources = spack.config.CONFIG.get("bootstrap:sources", scope=current_scope) or []
         if args.name in [s["name"] for s in sources]:
             sources = [s for s in sources if s["name"] != args.name]

--- a/lib/spack/spack/cmd/bootstrap.py
+++ b/lib/spack/spack/cmd/bootstrap.py
@@ -144,11 +144,11 @@ def _enable_or_disable(args):
     value = args.subcommand == "enable"
     if args.name is None:
         # Set to True if we called "enable", otherwise set to false
-        old_value = spack.config.get("bootstrap:enable", scope=args.scope)
+        old_value = spack.config.CONFIG.get("bootstrap:enable", scope=args.scope)
         if old_value == value:
             spack.util.tty.msg("Bootstrapping is already {}d".format(args.subcommand))
         else:
-            spack.config.set("bootstrap:enable", value, scope=args.scope)
+            spack.config.CONFIG.set("bootstrap:enable", value, scope=args.scope)
             spack.util.tty.msg("Bootstrapping has been {}d".format(args.subcommand))
         return
 
@@ -176,8 +176,8 @@ def _reset(args):
 
         # If we are in an env scope we can't delete a file, but the best we
         # can do is nullify the corresponding configuration
-        if scope.name.startswith("env") and spack.config.get("bootstrap", scope=scope.name):
-            spack.config.set("bootstrap", {}, scope=scope.name)
+        if scope.name.startswith("env") and spack.config.CONFIG.get("bootstrap", scope=scope.name):
+            spack.config.CONFIG.set("bootstrap", {}, scope=scope.name)
             continue
 
         # If we are outside of an env scope delete the bootstrap.yaml file
@@ -191,14 +191,14 @@ def _reset(args):
 
 def _root(args):
     if args.path:
-        spack.config.set("bootstrap:root", args.path, scope=args.scope)
+        spack.config.CONFIG.set("bootstrap:root", args.path, scope=args.scope)
     elif args.scope:
         if args.scope not in spack.config.existing_scope_names():
             spack.util.tty.die(
                 f"The argument --scope={args.scope} must refer to an existing scope."
             )
 
-    root = spack.config.get("bootstrap:root", default=None, scope=args.scope)
+    root = spack.config.CONFIG.get("bootstrap:root", default=None, scope=args.scope)
     if root:
         root = spack.config.canonicalize_path(root)
     print(root)
@@ -241,7 +241,7 @@ def _list(args):
 
             fmt("  Description", "".join(description_lines))
 
-    trusted = spack.config.get("bootstrap:trusted", {})
+    trusted = spack.config.CONFIG.get("bootstrap:trusted", {})
 
     def sort_fn(x):
         x_trust = trusted.get(x["name"], None)
@@ -264,7 +264,7 @@ def _write_bootstrapping_source_status(name, enabled, scope=None):
         enabled (bool): True if the source is enabled, False if it is disabled.
         scope (None or str): configuration scope to modify. If none use the default scope.
     """
-    sources = spack.config.get("bootstrap:sources")
+    sources = spack.config.CONFIG.get("bootstrap:sources")
 
     matches = [s for s in sources if s["name"] == name]
     if not matches:
@@ -285,7 +285,7 @@ def _write_bootstrapping_source_status(name, enabled, scope=None):
     # Setting the scope explicitly is needed to not copy over to a new scope
     # the entire default configuration for bootstrap.yaml
     scope = scope or spack.config.default_modify_scope("bootstrap")
-    spack.config.add("bootstrap:trusted:{0}:{1}".format(name, str(enabled)), scope=scope)
+    spack.config.CONFIG.add("bootstrap:trusted:{0}:{1}".format(name, str(enabled)), scope=scope)
 
 
 def _enable_source(args):
@@ -353,9 +353,9 @@ def _add(args):
 
     # Insert the new source as the highest priority one
     write_scope = args.scope or spack.config.default_modify_scope(section="bootstrap")
-    sources = spack.config.get("bootstrap:sources", scope=write_scope) or []
+    sources = spack.config.CONFIG.get("bootstrap:sources", scope=write_scope) or []
     sources = [{"name": args.name, "metadata": args.metadata_dir}] + sources
-    spack.config.set("bootstrap:sources", sources, scope=write_scope)
+    spack.config.CONFIG.set("bootstrap:sources", sources, scope=write_scope)
 
     msg = 'New bootstrapping source "{0}" added in the "{1}" configuration scope'
     spack.util.tty.msg(msg.format(args.name, write_scope))
@@ -374,18 +374,18 @@ def _remove(args):
         raise RuntimeError(msg.format(args.name))
 
     for current_scope in spack.config.scopes():
-        sources = spack.config.get("bootstrap:sources", scope=current_scope) or []
+        sources = spack.config.CONFIG.get("bootstrap:sources", scope=current_scope) or []
         if args.name in [s["name"] for s in sources]:
             sources = [s for s in sources if s["name"] != args.name]
-            spack.config.set("bootstrap:sources", sources, scope=current_scope)
+            spack.config.CONFIG.set("bootstrap:sources", sources, scope=current_scope)
             msg = (
                 'Removed the bootstrapping source named "{0}" from the "{1}" configuration scope.'
             )
             spack.util.tty.msg(msg.format(args.name, current_scope))
-        trusted = spack.config.get("bootstrap:trusted", scope=current_scope) or []
+        trusted = spack.config.CONFIG.get("bootstrap:trusted", scope=current_scope) or []
         if args.name in trusted:
             trusted.pop(args.name)
-            spack.config.set("bootstrap:trusted", trusted, scope=current_scope)
+            spack.config.CONFIG.set("bootstrap:trusted", trusted, scope=current_scope)
             msg = 'Deleting information on "{0}" from list of trusted sources'
             spack.util.tty.msg(msg.format(args.name))
 

--- a/lib/spack/spack/cmd/buildcache.py
+++ b/lib/spack/spack/cmd/buildcache.py
@@ -228,7 +228,7 @@ def setup_parser(subparser: argparse.ArgumentParser):
         "--scope",
         action=arguments.ConfigScope,
         type=arguments.config_scope_readable_validator,
-        default=lambda: spack.config.default_modify_scope(),
+        default=lambda: spack.config.CONFIG.default_modify_scope(),
         help="configuration scope containing mirrors to check",
     )
 

--- a/lib/spack/spack/cmd/buildcache.py
+++ b/lib/spack/spack/cmd/buildcache.py
@@ -689,7 +689,7 @@ def check_fn(args: argparse.Namespace):
     specs = [spack.concretize.concretize_one(s) for s in specs]
 
     # Next see if there are any configured binary mirrors
-    configured_mirrors = spack.config.get("mirrors", scope=args.scope)
+    configured_mirrors = spack.config.CONFIG.get("mirrors", scope=args.scope)
 
     if args.mirror_url:
         configured_mirrors = {"additionalMirrorUrl": args.mirror_url}

--- a/lib/spack/spack/cmd/ci.py
+++ b/lib/spack/spack/cmd/ci.py
@@ -554,7 +554,7 @@ def ci_rebuild(args):
                 test_stage = fs.join_path(stage_root, "spack-standalone-tests")
                 tty.debug("Configuring test_stage to {0}".format(test_stage))
                 config_test_path = "config:test_stage:{0}".format(test_stage)
-                cfg.CONFIG.add(config_test_path, scope=cfg.default_modify_scope())
+                cfg.CONFIG.add(config_test_path, scope=cfg.CONFIG.default_modify_scope())
 
                 # Run the tests, resorting to junit results if not using cdash
                 log_file = (

--- a/lib/spack/spack/cmd/ci.py
+++ b/lib/spack/spack/cmd/ci.py
@@ -289,7 +289,7 @@ def ci_rebuild(args):
 
     # Make sure the environment is "gitlab-enabled", or else there's nothing
     # to do.
-    ci_config = cfg.get("ci")
+    ci_config = cfg.CONFIG.get("ci")
     if not ci_config:
         tty.die("spack ci rebuild requires an env containing ci cfg")
 
@@ -335,7 +335,7 @@ def ci_rebuild(args):
     # Query the environment manifest to find out whether we're reporting to a
     # CDash instance, and if so, gather some information from the manifest to
     # support that task.
-    cdash_config = cfg.get("cdash")
+    cdash_config = cfg.CONFIG.get("cdash")
     cdash_handler = None
     if "build-group" in cdash_config:
         cdash_handler = spack_ci.CDashHandler(cdash_config)
@@ -465,7 +465,7 @@ def ci_rebuild(args):
     # Start with spack arguments
     spack_cmd = [SPACK_COMMAND, "--color=always", "install"]
 
-    config = cfg.get("config")
+    config = cfg.CONFIG.get("config")
     if not config["verify_ssl"]:
         spack_cmd.append("-k")
 
@@ -554,7 +554,7 @@ def ci_rebuild(args):
                 test_stage = fs.join_path(stage_root, "spack-standalone-tests")
                 tty.debug("Configuring test_stage to {0}".format(test_stage))
                 config_test_path = "config:test_stage:{0}".format(test_stage)
-                cfg.add(config_test_path, scope=cfg.default_modify_scope())
+                cfg.CONFIG.add(config_test_path, scope=cfg.default_modify_scope())
 
                 # Run the tests, resorting to junit results if not using cdash
                 log_file = (

--- a/lib/spack/spack/cmd/clean.py
+++ b/lib/spack/spack/cmd/clean.py
@@ -126,7 +126,9 @@ def clean(parser, args):
         remove_python_cache()
 
     if args.bootstrap:
-        bootstrap_prefix = spack.config.canonicalize_path(spack.config.get("bootstrap:root"))
+        bootstrap_prefix = spack.config.canonicalize_path(
+            spack.config.CONFIG.get("bootstrap:root")
+        )
         msg = 'Removing bootstrapped software and configuration in "{0}"'
         tty.msg(msg.format(bootstrap_prefix))
         spack.util.filesystem.remove_directory_contents(bootstrap_prefix)

--- a/lib/spack/spack/cmd/commands.py
+++ b/lib/spack/spack/cmd/commands.py
@@ -773,7 +773,7 @@ def names(args: Namespace, out: IO) -> None:
     commands = copy.copy(spack.cmd.all_commands())
 
     if args.aliases:
-        aliases = spack.config.get("config:aliases")
+        aliases = spack.config.CONFIG.get("config:aliases")
         if aliases:
             commands.extend(aliases.keys())
 
@@ -803,7 +803,7 @@ def bash(args: Namespace, out: IO) -> None:
         out: File object to write to.
     """
     parser = get_all_spack_commands(out)
-    aliases_config = spack.config.get("config:aliases")
+    aliases_config = spack.config.CONFIG.get("config:aliases")
     if aliases_config:
         aliases = ";".join(f"{key}:{val}" for key, val in aliases_config.items())
         out.write(f'SPACK_ALIASES="{aliases}"\n\n')

--- a/lib/spack/spack/cmd/common/arguments.py
+++ b/lib/spack/spack/cmd/common/arguments.py
@@ -108,7 +108,7 @@ class SetParallelJobs(argparse.Action):
             msg = 'invalid value for argument "{0}" [expected a positive integer, got "{1}"]'
             raise ValueError(msg.format(option_string, jobs))
 
-        spack.config.set("config:build_jobs", jobs, scope="command_line")
+        spack.config.CONFIG.set("config:build_jobs", jobs, scope="command_line")
 
         setattr(namespace, "jobs", jobs)
 
@@ -125,7 +125,9 @@ class SetConcurrentPackages(argparse.Action):
             msg = 'invalid value for argument "{0}" [expected a positive integer, got "{1}"]'
             raise ValueError(msg.format(option_string, concurrent_packages))
 
-        spack.config.set("config:concurrent_packages", concurrent_packages, scope="command_line")
+        spack.config.CONFIG.set(
+            "config:concurrent_packages", concurrent_packages, scope="command_line"
+        )
 
         setattr(namespace, "concurrent_packages", concurrent_packages)
 
@@ -356,7 +358,7 @@ def clean():
     return Args(
         "--clean",
         action="store_false",
-        default=spack.config.get("config:dirty"),
+        default=spack.config.CONFIG.get("config:dirty"),
         dest="dirty",
         help="unset harmful variables in the build environment (default)",
     )
@@ -377,7 +379,7 @@ def dirty():
     return Args(
         "--dirty",
         action="store_true",
-        default=spack.config.get("config:dirty"),
+        default=spack.config.CONFIG.get("config:dirty"),
         dest="dirty",
         help="preserve user environment in spack's build environment (danger!)",
     )
@@ -581,7 +583,7 @@ class ConfigSetAction(argparse.Action):
 
     This works like a ``store_const`` action but you can set the
     ``dest`` to some Spack configuration path (like ``concretizer:reuse``)
-    and the ``const`` will be stored there using ``spack.config.set()``
+    and the ``const`` will be stored there using ``spack.config.CONFIG.set()``
     """
 
     def __init__(
@@ -625,7 +627,7 @@ class ConfigSetAction(argparse.Action):
         # the const from the constructor or a value from the CLI.
         # Note that this is only called if the argument is actually
         # specified on the command line.
-        spack.config.set(self.config_path, self.const, scope="command_line")
+        spack.config.CONFIG.set(self.config_path, self.const, scope="command_line")
 
 
 def add_concretizer_args(subparser):

--- a/lib/spack/spack/cmd/common/arguments.py
+++ b/lib/spack/spack/cmd/common/arguments.py
@@ -194,7 +194,7 @@ class ConfigScope(argparse.Action):
 
     @property
     def choices(self):
-        return spack.config.scopes().keys()
+        return spack.config.CONFIG.scopes.keys()
 
     @choices.setter
     def choices(self, value):
@@ -205,7 +205,7 @@ class ConfigScope(argparse.Action):
 
 
 def config_scope_readable_validator(value):
-    if value not in spack.config.existing_scope_names():
+    if value not in spack.config.CONFIG.existing_scope_names():
         raise ValueError(
             f"Invalid scope argument {value} "
             "for config read operation, scope context does not exist"

--- a/lib/spack/spack/cmd/compiler.py
+++ b/lib/spack/spack/cmd/compiler.py
@@ -37,7 +37,7 @@ def setup_parser(subparser: argparse.ArgumentParser) -> None:
     find_parser.add_argument(
         "--scope",
         action=arguments.ConfigScope,
-        default=lambda: spack.config.default_modify_scope("packages"),
+        default=lambda: spack.config.CONFIG.default_modify_scope("packages"),
         help="configuration scope to modify",
     )
     arguments.add_common_arguments(find_parser, ["jobs"])

--- a/lib/spack/spack/cmd/config.py
+++ b/lib/spack/spack/cmd/config.py
@@ -248,7 +248,7 @@ def print_flattened_configuration(*, blame: bool, yaml: bool) -> None:
         flattened[spack.schema.env.TOP_LEVEL_KEY] = syaml.syaml_dict()
 
     for config_section in spack.config.SECTION_SCHEMAS:
-        current = spack.config.get(config_section)
+        current = spack.config.CONFIG.get(config_section)
         flattened[spack.schema.env.TOP_LEVEL_KEY][config_section] = current
     if blame or yaml:
         syaml.dump_config(flattened, stream=sys.stdout, default_flow_style=False, blame=blame)
@@ -400,10 +400,10 @@ def config_add(args):
     scope, section = _get_scope_and_section(args)
 
     if args.file:
-        spack.config.add_from_file(args.file, scope=scope)
+        spack.config.CONFIG.add_from_file(args.file, scope=scope)
 
     if args.path:
-        spack.config.add(args.path, scope=scope)
+        spack.config.CONFIG.add(args.path, scope=scope)
 
 
 def config_remove(args):
@@ -413,11 +413,11 @@ def config_remove(args):
     scope, _ = _get_scope_and_section(args)
 
     path, _, value = args.path.rpartition(":")
-    existing = spack.config.get(path, scope=scope)
+    existing = spack.config.CONFIG.get(path, scope=scope)
 
     if not isinstance(existing, (list, dict)):
         path, _, value = path.rpartition(":")
-        existing = spack.config.get(path, scope=scope)
+        existing = spack.config.CONFIG.get(path, scope=scope)
 
     value = syaml.load(value)
 
@@ -431,7 +431,7 @@ def config_remove(args):
         # This should be impossible to reach
         raise spack.error.ConfigError("Config has nested non-dict values")
 
-    spack.config.set(path, existing, scope)
+    spack.config.CONFIG.set(path, existing, scope)
 
 
 def _can_update_config_file(scope: spack.config.ConfigScope, cfg_file):
@@ -444,7 +444,7 @@ def _can_update_config_file(scope: spack.config.ConfigScope, cfg_file):
 
 def _config_change_requires_scope(path, spec, scope, match_spec=None):
     """Return whether or not anything changed."""
-    require = spack.config.get(path, scope=scope)
+    require = spack.config.CONFIG.get(path, scope=scope)
     if not require:
         return False
 
@@ -485,7 +485,7 @@ def _config_change_requires_scope(path, spec, scope, match_spec=None):
                 raise ValueError(f"Unexpected requirement: ({type(item)}) {str(item)}")
             new_require.append(item)
 
-    spack.config.set(path, new_require, scope=scope)
+    spack.config.CONFIG.set(path, new_require, scope=scope)
     return changed
 
 
@@ -511,7 +511,7 @@ def _config_change(config_path, match_spec_str=None):
             changed |= _config_change_requires_scope(key_path, spec, scope, match_spec=match_spec)
 
         if not changed:
-            existing_requirements = spack.config.get(key_path)
+            existing_requirements = spack.config.CONFIG.get(key_path)
             if isinstance(existing_requirements, str):
                 raise spack.error.ConfigError(
                     "'config change' needs to append a requirement,"
@@ -520,7 +520,7 @@ def _config_change(config_path, match_spec_str=None):
 
             ideal_scope_to_modify = None
             for scope in spack.config.writable_scope_names():
-                if spack.config.get(key_path, scope=scope):
+                if spack.config.CONFIG.get(key_path, scope=scope):
                     ideal_scope_to_modify = scope
                     break
             # If we find our key in a specific scope, that's the one we want
@@ -528,7 +528,7 @@ def _config_change(config_path, match_spec_str=None):
             write_scope = ideal_scope_to_modify or spack.config.default_modify_scope()
 
             update_path = f"{key_path}:[{str(spec)}]"
-            spack.config.add(update_path, scope=write_scope)
+            spack.config.CONFIG.add(update_path, scope=write_scope)
     else:
         raise ValueError("'config change' can currently only change 'require' sections")
 
@@ -739,9 +739,9 @@ def config_prefer_upstream(args):
         )
 
     # Simply write the config to the specified file.
-    existing = spack.config.get("packages", scope=scope)
+    existing = spack.config.CONFIG.get("packages", scope=scope)
     new = spack.schema.merge_yaml(existing, pkgs)
-    spack.config.set("packages", new, scope)
+    spack.config.CONFIG.set("packages", new, scope)
     config_file = spack.config.CONFIG.get_config_filename(scope, section)
 
     tty.msg("Updated config at {0}".format(config_file))

--- a/lib/spack/spack/cmd/config.py
+++ b/lib/spack/spack/cmd/config.py
@@ -189,19 +189,19 @@ def _get_scope_and_section(args):
 
     # set scope defaults
     elif not scope:
-        scope = spack.config.default_modify_scope(section)
+        scope = spack.config.CONFIG.default_modify_scope(section)
 
     # special handling for commands that take value instead of section
     if path:
         section = path[: path.find(":")] if ":" in path else path
         if not scope:
-            scope = spack.config.default_modify_scope(section)
+            scope = spack.config.CONFIG.default_modify_scope(section)
 
     return scope, section
 
 
 def print_configuration(args, *, blame: bool) -> None:
-    if args.scope and args.scope not in spack.config.existing_scope_names():
+    if args.scope and args.scope not in spack.config.CONFIG.existing_scope_names():
         args.subparser.error(f"the argument --scope={args.scope} must refer to an existing scope")
     if args.scope and args.section is None:
         args.subparser.error(f"the argument --scope={args.scope} requires specifying a section")
@@ -359,11 +359,11 @@ def _config_basic_scope_types(scope, included):
 
 def config_scopes(args):
     """List configured scopes in descending order of precedence."""
-    included = [i.name for s in spack.config.scopes().values() for i in s.included_scopes]
+    included = [i.name for s in spack.config.CONFIG.scopes.values() for i in s.included_scopes]
     active = [s.name for s in spack.config.CONFIG.active_scopes]
     scopes = [
         s
-        for s in spack.config.scopes().reversed_values()
+        for s in spack.config.CONFIG.scopes.reversed_values()
         if (
             "include" in args.type
             and s.name in included
@@ -507,7 +507,7 @@ def _config_change(config_path, match_spec_str=None):
         spec.name = pkg_name
 
         changed = False
-        for scope in spack.config.writable_scope_names():
+        for scope in spack.config.CONFIG.writable_scope_names():
             changed |= _config_change_requires_scope(key_path, spec, scope, match_spec=match_spec)
 
         if not changed:
@@ -519,13 +519,13 @@ def _config_change(config_path, match_spec_str=None):
                 )
 
             ideal_scope_to_modify = None
-            for scope in spack.config.writable_scope_names():
+            for scope in spack.config.CONFIG.writable_scope_names():
                 if spack.config.CONFIG.get(key_path, scope=scope):
                     ideal_scope_to_modify = scope
                     break
             # If we find our key in a specific scope, that's the one we want
             # to modify. Otherwise we use the default write scope.
-            write_scope = ideal_scope_to_modify or spack.config.default_modify_scope()
+            write_scope = ideal_scope_to_modify or spack.config.CONFIG.default_modify_scope()
 
             update_path = f"{key_path}:[{str(spec)}]"
             spack.config.CONFIG.add(update_path, scope=write_scope)
@@ -686,7 +686,7 @@ def config_prefer_upstream(args):
 
     scope = args.scope
     if scope is None:
-        scope = spack.config.default_modify_scope("packages")
+        scope = spack.config.CONFIG.default_modify_scope("packages")
 
     all_specs = set(spack.store.STORE.db.query(installed=True))
     local_specs = set(spack.store.STORE.db.query_local(installed=True))

--- a/lib/spack/spack/cmd/dev_build.py
+++ b/lib/spack/spack/cmd/dev_build.py
@@ -124,7 +124,7 @@ def dev_build(self, args):
 
     # disable checksumming if requested
     if args.no_checksum:
-        spack.config.set("config:checksum", False, scope="command_line")
+        spack.config.CONFIG.set("config:checksum", False, scope="command_line")
 
     tests = False
     if args.test == "all":

--- a/lib/spack/spack/cmd/develop.py
+++ b/lib/spack/spack/cmd/develop.py
@@ -151,7 +151,7 @@ def _update_config(spec, path):
     def change_fn(section):
         section[spec.name] = entry
 
-    spack.config.change_or_add("develop", find_fn, change_fn)
+    spack.config.CONFIG.change_or_add("develop", find_fn, change_fn)
 
 
 def update_env(

--- a/lib/spack/spack/cmd/develop.py
+++ b/lib/spack/spack/cmd/develop.py
@@ -173,7 +173,7 @@ def update_env(
 
     with env.write_transaction():
         if build_dir is not None:
-            spack.config.add(
+            spack.config.CONFIG.add(
                 f"packages:{spec.name}:package_attributes:build_directory:{build_dir}",
                 env.scope_name,
             )

--- a/lib/spack/spack/cmd/extensions.py
+++ b/lib/spack/spack/cmd/extensions.py
@@ -55,7 +55,7 @@ def extensions(parser, args):
             tty.info("Extendable packages:")
 
         extendable_pkgs = []
-        for name in spack.repo.all_package_names():
+        for name in spack.repo.PATH.all_package_names():
             pkg_cls = spack.repo.PATH.get_pkg_class(name)
             if pkg_cls.extendable:
                 extendable_pkgs.append(name)

--- a/lib/spack/spack/cmd/external.py
+++ b/lib/spack/spack/cmd/external.py
@@ -47,7 +47,7 @@ def setup_parser(subparser: argparse.ArgumentParser) -> None:
     find_parser.add_argument(
         "--scope",
         action=arguments.ConfigScope,
-        default=lambda: spack.config.default_modify_scope("packages"),
+        default=lambda: spack.config.CONFIG.default_modify_scope("packages"),
         help="configuration scope to modify",
     )
     find_parser.add_argument(

--- a/lib/spack/spack/cmd/fetch.py
+++ b/lib/spack/spack/cmd/fetch.py
@@ -37,7 +37,7 @@ def setup_parser(subparser: argparse.ArgumentParser) -> None:
 
 def fetch(parser, args):
     if args.no_checksum:
-        spack.config.set("config:checksum", False, scope="command_line")
+        spack.config.CONFIG.set("config:checksum", False, scope="command_line")
 
     if args.specs:
         specs = spack.cmd.parse_specs(args.specs, concretize=True)

--- a/lib/spack/spack/cmd/find.py
+++ b/lib/spack/spack/cmd/find.py
@@ -221,7 +221,7 @@ def query_arguments(args):
     q_args = {"installed": installed, "predicate_fn": predicate_fn, "explicit": explicit}
 
     install_tree = args.install_tree
-    upstreams = spack.config.get("upstreams", {})
+    upstreams = spack.config.CONFIG.get("upstreams", {})
     if install_tree in upstreams.keys():
         install_tree = upstreams[install_tree]["install_tree"]
     q_args["install_tree"] = install_tree

--- a/lib/spack/spack/cmd/graph.py
+++ b/lib/spack/spack/cmd/graph.py
@@ -100,7 +100,7 @@ def graph(parser, args):
         return
 
     # ascii is default: user doesn't need to provide it explicitly
-    debug = spack.config.get("config:debug")
+    debug = spack.config.CONFIG.get("config:debug")
     graph_ascii(specs[0], debug=debug, depflag=args.deptype)
     for spec in specs[1:]:
         print()  # extra line bt/w independent graphs

--- a/lib/spack/spack/cmd/install.py
+++ b/lib/spack/spack/cmd/install.py
@@ -315,7 +315,7 @@ def install(parser, args):
         return
 
     if args.no_checksum:
-        spack.config.set("config:checksum", False, scope="command_line")
+        spack.config.CONFIG.set("config:checksum", False, scope="command_line")
 
     if args.log_file and not args.log_format:
         msg = "the '--log-format' must be specified when using '--log-file'"

--- a/lib/spack/spack/cmd/isolate.py
+++ b/lib/spack/spack/cmd/isolate.py
@@ -64,7 +64,7 @@ def _isolate_config_config(new_user_path):
 
 
 def _isolate_repos_config(new_user_path):
-    current_repos_config = spack.config.get("repos")
+    current_repos_config = spack.config.CONFIG.get("repos")
     new_repos_config = {}
     for key, value in current_repos_config.items():
         if isinstance(value, str):

--- a/lib/spack/spack/cmd/mirror.py
+++ b/lib/spack/spack/cmd/mirror.py
@@ -380,7 +380,7 @@ def mirror_remove(args):
 
 
 def _configure_mirror(args):
-    mirrors = spack.config.get("mirrors", scope=args.scope)
+    mirrors = spack.config.CONFIG.get("mirrors", scope=args.scope)
 
     if args.name not in mirrors:
         tty.die(f"No mirror found with name {args.name}.")
@@ -432,7 +432,7 @@ def _configure_mirror(args):
 
     if changed:
         mirrors[args.name] = entry.to_dict()
-        spack.config.set("mirrors", mirrors, scope=args.scope)
+        spack.config.CONFIG.set("mirrors", mirrors, scope=args.scope)
     else:
         tty.msg("No changes made to mirror %s." % args.name)
 
@@ -746,6 +746,6 @@ def mirror(parser, args):
     }
 
     if args.no_checksum:
-        spack.config.set("config:checksum", False, scope="command_line")
+        spack.config.CONFIG.set("config:checksum", False, scope="command_line")
 
     action[args.mirror_command](args)

--- a/lib/spack/spack/cmd/mirror.py
+++ b/lib/spack/spack/cmd/mirror.py
@@ -570,7 +570,7 @@ def concrete_specs_from_environment():
 
 
 def all_specs_with_all_versions():
-    specs = [spack.spec.Spec(n) for n in spack.repo.all_package_names()]
+    specs = [spack.spec.Spec(n) for n in spack.repo.PATH.all_package_names()]
     mirror_specs = spack.mirrors.utils.get_all_versions(specs)
     mirror_specs.sort(key=lambda s: (s.name, s.version))
     return mirror_specs

--- a/lib/spack/spack/cmd/mirror.py
+++ b/lib/spack/spack/cmd/mirror.py
@@ -108,7 +108,7 @@ def setup_parser(subparser: argparse.ArgumentParser) -> None:
     add_parser.add_argument(
         "--scope",
         action=arguments.ConfigScope,
-        default=lambda: spack.config.default_modify_scope(),
+        default=lambda: spack.config.CONFIG.default_modify_scope(),
         help="configuration scope to modify",
     )
     add_parser.add_argument(
@@ -176,7 +176,7 @@ def setup_parser(subparser: argparse.ArgumentParser) -> None:
     set_url_parser.add_argument(
         "--scope",
         action=arguments.ConfigScope,
-        default=lambda: spack.config.default_modify_scope(),
+        default=lambda: spack.config.CONFIG.default_modify_scope(),
         help="configuration scope to modify",
     )
     arguments.add_connection_args(set_url_parser, False)
@@ -236,7 +236,7 @@ def setup_parser(subparser: argparse.ArgumentParser) -> None:
     set_parser.add_argument(
         "--scope",
         action=arguments.ConfigScope,
-        default=lambda: spack.config.default_modify_scope(),
+        default=lambda: spack.config.CONFIG.default_modify_scope(),
         help="configuration scope to modify",
     )
     arguments.add_connection_args(set_parser, False)

--- a/lib/spack/spack/cmd/modules/__init__.py
+++ b/lib/spack/spack/cmd/modules/__init__.py
@@ -107,7 +107,7 @@ def one_spec_or_raise(specs):
 
 
 def check_module_set_name(name):
-    modules = spack.config.get("modules")
+    modules = spack.config.CONFIG.get("modules")
     if name != "prefix_inspections" and name in modules:
         return
 

--- a/lib/spack/spack/cmd/modules/lmod.py
+++ b/lib/spack/spack/cmd/modules/lmod.py
@@ -38,6 +38,6 @@ def setdefault(module_type, specs, args):
     spec = specs[0]
     data = {"modules": {args.module_set_name: {"lmod": {"defaults": [str(spec)]}}}}
     scope = spack.config.InternalConfigScope("lmod-setdefault", data)
-    with spack.config.override(scope):
+    with spack.config.CONFIG.override(scope):
         writer = spack.modules.module_types["lmod"].from_spec(spec, args.module_set_name)
         writer.update_module_defaults()

--- a/lib/spack/spack/cmd/modules/tcl.py
+++ b/lib/spack/spack/cmd/modules/tcl.py
@@ -34,6 +34,6 @@ def setdefault(module_type, specs, args):
     spec = specs[0]
     data = {"modules": {args.module_set_name: {"tcl": {"defaults": [str(spec)]}}}}
     scope = spack.config.InternalConfigScope("tcl-setdefault", data)
-    with spack.config.override(scope):
+    with spack.config.CONFIG.override(scope):
         writer = spack.modules.module_types["tcl"].from_spec(spec, args.module_set_name)
         writer.update_module_defaults()

--- a/lib/spack/spack/cmd/patch.py
+++ b/lib/spack/spack/cmd/patch.py
@@ -31,7 +31,7 @@ def patch(parser, args):
         return _patch_env(env)
 
     if args.no_checksum:
-        spack.config.set("config:checksum", False, scope="command_line")
+        spack.config.CONFIG.set("config:checksum", False, scope="command_line")
 
     specs = spack.cmd.parse_specs(args.specs, concretize=False)
     specs = spack.cmd.matching_specs_from_env(specs)

--- a/lib/spack/spack/cmd/repo.py
+++ b/lib/spack/spack/cmd/repo.py
@@ -102,7 +102,7 @@ def setup_parser(subparser: argparse.ArgumentParser):
     add_parser.add_argument(
         "--scope",
         action=arguments.ConfigScope,
-        default=lambda: spack.config.default_modify_scope(),
+        default=lambda: spack.config.CONFIG.default_modify_scope(),
         help="configuration scope to modify",
     )
 
@@ -124,7 +124,7 @@ def setup_parser(subparser: argparse.ArgumentParser):
     set_parser.add_argument(
         "--scope",
         action=arguments.ConfigScope,
-        default=lambda: spack.config.default_modify_scope(),
+        default=lambda: spack.config.CONFIG.default_modify_scope(),
         help="configuration scope to modify",
     )
 
@@ -182,7 +182,7 @@ def setup_parser(subparser: argparse.ArgumentParser):
     update_parser.add_argument(
         "--scope",
         action=arguments.ConfigScope,
-        default=lambda: spack.config.default_modify_scope(),
+        default=lambda: spack.config.CONFIG.default_modify_scope(),
         help="configuration scope to modify",
     )
     update_parser.add_argument(

--- a/lib/spack/spack/cmd/repo.py
+++ b/lib/spack/spack/cmd/repo.py
@@ -320,7 +320,7 @@ def repo_remove(args):
 
 
 def _remove_repo(namespace_or_path, scope):
-    repos: Dict[str, str] = spack.config.get("repos", scope=scope)
+    repos: Dict[str, str] = spack.config.CONFIG.get("repos", scope=scope)
 
     if namespace_or_path in repos:
         # delete by name (from config)
@@ -347,7 +347,7 @@ def _remove_repo(namespace_or_path, scope):
             return False
 
     del repos[key]
-    spack.config.set("repos", repos, scope)
+    spack.config.CONFIG.set("repos", repos, scope)
     tty.msg(f"Removed repository '{namespace_or_path}' from scope '{scope}'.")
     return True
 
@@ -530,7 +530,7 @@ def repo_set(args):
     namespace = args.namespace
 
     # First, check if the repository exists across all scopes for validation
-    all_repos: Dict[str, Any] = spack.config.get("repos", default={})
+    all_repos: Dict[str, Any] = spack.config.CONFIG.get("repos", default={})
 
     if namespace not in all_repos:
         raise SpackError(f"No repository with namespace '{namespace}' found in configuration.")
@@ -543,7 +543,7 @@ def repo_set(args):
         )
 
     # Now get the repos for the specific scope we're modifying
-    scope_repos: Dict[str, Any] = spack.config.get("repos", default={}, scope=args.scope)
+    scope_repos: Dict[str, Any] = spack.config.CONFIG.get("repos", default={}, scope=args.scope)
 
     updated_entry = scope_repos[namespace] if namespace in scope_repos else {}
 
@@ -554,7 +554,7 @@ def repo_set(args):
         updated_entry["paths"] = args.path
 
     scope_repos[namespace] = updated_entry
-    spack.config.set("repos", scope_repos, args.scope)
+    spack.config.CONFIG.set("repos", scope_repos, args.scope)
 
     tty.msg(f"Updated repo '{namespace}'")
 
@@ -606,7 +606,7 @@ def repo_update(args):
         )
 
     # Get the repos for the specific scope we're modifying
-    scope_repos: Dict[str, Any] = spack.config.get("repos", default={}, scope=args.scope)
+    scope_repos: Dict[str, Any] = spack.config.CONFIG.get("repos", default={}, scope=args.scope)
 
     for name, descriptor in descriptors.items():
         if not isinstance(descriptor, spack.repo.RemoteRepoDescriptor):
@@ -654,7 +654,7 @@ def repo_update(args):
                 tty.msg(f"{name}: Updated successfully.")
 
     if active_flag:
-        spack.config.set("repos", scope_repos, args.scope)
+        spack.config.CONFIG.set("repos", scope_repos, args.scope)
 
 
 def repo_show_version_updates(args):

--- a/lib/spack/spack/cmd/spec.py
+++ b/lib/spack/spack/cmd/spec.py
@@ -225,8 +225,8 @@ def spec(parser, args):
     solver = asp.Solver()
     output = sys.stdout if "asp" in show else None
     setup_only = set(show) == {"asp"}
-    unify = spack.config.get("concretizer:unify")
-    allow_deprecated = spack.config.get("config:deprecated", False)
+    unify = spack.config.CONFIG.get("concretizer:unify")
+    allow_deprecated = spack.config.CONFIG.get("config:deprecated", False)
     if unify == "when_possible":
         for idx, result in enumerate(
             solver.solve_in_rounds(

--- a/lib/spack/spack/cmd/stage.py
+++ b/lib/spack/spack/cmd/stage.py
@@ -67,7 +67,7 @@ def setup_parser(subparser: argparse.ArgumentParser) -> None:
 
 def stage(parser, args):
     if args.no_checksum:
-        spack.config.set("config:checksum", False, scope="command_line")
+        spack.config.CONFIG.set("config:checksum", False, scope="command_line")
 
     exclusion_specs = spack.cmd.parse_specs(args.exclude, concretize=False)
     filter = StageFilter(exclusion_specs, args.skip_installed)

--- a/lib/spack/spack/cmd/test.py
+++ b/lib/spack/spack/cmd/test.py
@@ -167,7 +167,7 @@ def test_run(args):
 
     # set config option for fail-fast
     if args.fail_fast:
-        spack.config.set("config:fail_fast", True, scope="command_line")
+        spack.config.CONFIG.set("config:fail_fast", True, scope="command_line")
 
     explicit = args.explicit or None
     explicit_str = "explicitly " if args.explicit else ""

--- a/lib/spack/spack/cmd/tutorial.py
+++ b/lib/spack/spack/cmd/tutorial.py
@@ -73,7 +73,7 @@ def tutorial(parser, args):
     )
     mirror_config = syaml_dict()
     mirror_config["tutorial"] = tutorial_mirror
-    spack.config.set("mirrors", mirror_config, scope="user")
+    spack.config.CONFIG.set("mirrors", mirror_config, scope="user")
 
     tty.msg("Ensuring that we trust tutorial binaries", f"spack gpg trust {tutorial_key}")
     spack.util.gpg.trust(tutorial_key)

--- a/lib/spack/spack/cmd/undevelop.py
+++ b/lib/spack/spack/cmd/undevelop.py
@@ -61,7 +61,7 @@ def undevelop(parser, args):
         if args.apply_changes:
             env.apply_develop(remove_specs, paths=None)
 
-    updated_all_dev_specs = set(spack.config.get("develop"))
+    updated_all_dev_specs = set(spack.config.CONFIG.get("develop"))
 
     remove_spec_names = {x.name for x in remove_specs}
     not_fully_removed = updated_all_dev_specs & remove_spec_names

--- a/lib/spack/spack/cmd/undevelop.py
+++ b/lib/spack/spack/cmd/undevelop.py
@@ -43,7 +43,7 @@ def _update_config(specs_to_remove):
                 modified = True
         return modified
 
-    spack.config.update_all("develop", change_fn)
+    spack.config.CONFIG.update_all("develop", change_fn)
 
 
 def undevelop(parser, args):

--- a/lib/spack/spack/concretize.py
+++ b/lib/spack/spack/concretize.py
@@ -42,7 +42,7 @@ def _concretize_specs_together(
     """
     from spack.solver.asp import Solver
 
-    allow_deprecated = spack.config.get("config:deprecated", False)
+    allow_deprecated = spack.config.CONFIG.get("config:deprecated", False)
     result = Solver(specs_factory=factory).solve(
         abstract_specs, tests=tests, allow_deprecated=allow_deprecated
     )
@@ -96,7 +96,7 @@ def concretize_together_when_possible(
     }
 
     result_by_user_spec: Dict[Spec, Spec] = {}
-    allow_deprecated = spack.config.get("config:deprecated", False)
+    allow_deprecated = spack.config.CONFIG.get("config:deprecated", False)
     j = 0
     start = time.monotonic()
     for result in Solver(specs_factory=factory).solve_in_rounds(
@@ -253,7 +253,7 @@ def concretize_one(
                 f"Spec {node} has no name; cannot concretize an anonymous spec"
             )
 
-    allow_deprecated = spack.config.get("config:deprecated", False)
+    allow_deprecated = spack.config.CONFIG.get("config:deprecated", False)
     result = Solver(specs_factory=factory).solve(
         [spec], tests=tests, allow_deprecated=allow_deprecated
     )

--- a/lib/spack/spack/config.py
+++ b/lib/spack/spack/config.py
@@ -40,19 +40,7 @@ import tempfile
 import warnings
 from collections import defaultdict
 from itertools import chain
-from typing import (
-    Any,
-    Callable,
-    ContextManager,
-    Dict,
-    Generator,
-    List,
-    Optional,
-    Set,
-    Tuple,
-    Union,
-    cast,
-)
+from typing import Any, Callable, Dict, Generator, List, Optional, Set, Tuple, Union, cast
 
 from spack.vendor import jsonschema
 
@@ -208,7 +196,7 @@ class ConfigScope:
     def transitive_includes(self, _names: Optional[Set[str]] = None) -> Set[str]:
         """Get name of this scope and names of its transitively included scopes."""
         if _names is None:
-            _names = _set()
+            _names = set()
         _names.add(self.name)
         for scope in self.included_scopes:
             _names |= scope.transitive_includes(_names=_names)
@@ -800,16 +788,16 @@ class Configuration:
         if i < 0:
             return scopes  # no overrides
 
-        keep = _set(s.name for s in scopes[i:])
-        keep |= _set(s.name for s in self.scopes.priority_values(ConfigScopePriority.DEFAULTS))
+        keep = set(s.name for s in scopes[i:])
+        keep |= set(s.name for s in self.scopes.priority_values(ConfigScopePriority.DEFAULTS))
 
         if not includes:
             # For all sections except for the include section:
             # non-included scopes are still active, as are scopes included
             # from the overriding scope
             # Transitive scopes from the overriding scope are not included
-            keep |= _set([s.name for s in scopes[i].included_scopes])
-            keep |= _set([s.name for s in scopes if not s.included])
+            keep |= set([s.name for s in scopes[i].included_scopes])
+            keep |= set([s.name for s in scopes if not s.included])
 
         # return scopes to keep, with order preserved
         return [s for s in scopes if s.name in keep]
@@ -894,11 +882,11 @@ class Configuration:
         Accepts a path syntax that allows us to grab nested config map
         entries.  Getting the ``config`` section would look like::
 
-            spack.config.get("config")
+            spack.config.CONFIG.get("config")
 
         and the ``dirty`` section in the ``config`` scope would be::
 
-            spack.config.get("config:dirty")
+            spack.config.CONFIG.get("config:dirty")
 
         We use ``:`` as the separator, like YAML objects.
         """
@@ -1106,23 +1094,6 @@ class Configuration:
         # merge value into existing
         new = spack.schema.merge_yaml(existing, value)
         self.set(path, new, scope)
-
-
-def override(
-    path_or_scope: Union[ConfigScope, str], value: Optional[Any] = None
-) -> ContextManager[Configuration]:
-    """Simple way to override config settings within a context.
-
-    Arguments:
-        path_or_scope (ConfigScope or str): scope or single option to override
-        value (object or None): value for the single option
-
-    Temporarily push a scope on the current configuration, then remove it
-    after the context completes. If a single option is provided, create
-    an internal config scope for it and push/pop that scope.
-
-    """
-    return CONFIG.override(path_or_scope, value)
 
 
 #: Class for the relevance of an optional path conditioned on a limited
@@ -1680,34 +1651,6 @@ CONFIG = cast(Configuration, lang.Singleton(create_incremental))
 spack.platforms.on_host_changed.append(lambda: CONFIG.clear_caches())
 
 
-def add_from_file(filename: str, scope: Optional[str] = None) -> None:
-    """Add updates to a config from a filename"""
-    CONFIG.add_from_file(filename, scope)
-
-
-def add(fullpath: str, scope: Optional[str] = None) -> None:
-    """Add the given configuration to the specified config scope.
-    Add accepts a path. If you want to add from a filename, use add_from_file"""
-    CONFIG.add(fullpath, scope)
-
-
-def get(path: str, default: Any = default_sigil, scope: Optional[str] = None) -> Any:
-    """Module-level wrapper for ``Configuration.get()``."""
-    return CONFIG.get(path, default, scope)
-
-
-_set = set  #: save this before defining set -- maybe config.set was ill-advised :)
-
-
-def set(path: str, value: Any, scope: Optional[str] = None) -> None:
-    """Convenience function for setting single values in config files.
-
-    Accepts the path syntax described in ``get()``.
-    """
-    result = CONFIG.set(path, value, scope)
-    return result
-
-
 def scopes() -> lang.PriorityOrderedMapping[str, ConfigScope]:
     """Convenience function to get list of configuration scopes."""
     return CONFIG.scopes
@@ -1739,7 +1682,7 @@ def existing_scope_names() -> List[str]:
 
 
 def matched_config(cfg_path: str) -> List[Tuple[str, Any]]:
-    return [(scope, get(cfg_path, scope=scope)) for scope in writable_scope_names()]
+    return [(scope, CONFIG.get(cfg_path, scope=scope)) for scope in writable_scope_names()]
 
 
 def change_or_add(

--- a/lib/spack/spack/config.py
+++ b/lib/spack/spack/config.py
@@ -40,7 +40,19 @@ import tempfile
 import warnings
 from collections import defaultdict
 from itertools import chain
-from typing import Any, Callable, Dict, Generator, List, Optional, Set, Tuple, Union, cast
+from typing import (
+    Any,
+    Callable,
+    ContextManager,
+    Dict,
+    Generator,
+    List,
+    Optional,
+    Set,
+    Tuple,
+    Union,
+    cast,
+)
 
 from spack.vendor import jsonschema
 
@@ -986,11 +998,119 @@ class Configuration:
         except (syaml.SpackYAMLError, OSError) as e:
             raise spack.error.ConfigError(f"cannot read '{section}' configuration") from e
 
+    @contextlib.contextmanager
+    def override(
+        self, path_or_scope: Union[ConfigScope, str], value: Optional[Any] = None
+    ) -> Generator["Configuration", None, None]:
+        """Temporarily override a single option or push a scope, then restore.
 
-@contextlib.contextmanager
+        See the module-level ``override`` for the argument semantics.
+        """
+        path: Optional[str]
+        if isinstance(path_or_scope, ConfigScope):
+            overrides, path = path_or_scope, None
+        else:
+            # Ensure the new override gets a unique scope name
+            existing = {s.name for s in self.matching_scopes(rf"^{_OVERRIDES_BASE_NAME}")}
+            num_overrides = len(existing)
+            while f"{_OVERRIDES_BASE_NAME}{num_overrides}" in existing:
+                num_overrides += 1
+            overrides = InternalConfigScope(f"{_OVERRIDES_BASE_NAME}{num_overrides}")
+            path = path_or_scope
+
+        self.push_scope(overrides, priority=None)
+        try:
+            if path is not None:
+                self.set(path, value, scope=overrides.name)
+            yield self
+        finally:
+            scope = self.remove_scope(overrides.name)
+            assert scope is overrides
+
+    def add_from_file(self, filename: str, scope: Optional[str] = None) -> None:
+        """Add updates to a config from a filename"""
+        # Extract internal attributes, if we are dealing with an environment
+        data = read_config_file(filename)
+        if data is None:
+            return
+
+        if spack.schema.env.TOP_LEVEL_KEY in data:
+            data = data[spack.schema.env.TOP_LEVEL_KEY]
+
+        msg = (
+            "unexpected 'None' value when retrieving configuration. "
+            "Please submit a bug-report at https://github.com/spack/spack/issues"
+        )
+        assert data is not None, msg
+
+        # update all sections from config dict
+        # We have to iterate on keys to keep overrides from the file
+        for section in data.keys():
+            if section in SECTION_SCHEMAS.keys():
+                # Special handling for compiler scope difference
+                # Has to be handled after we choose a section
+                if scope is None:
+                    scope = default_modify_scope(section)
+
+                value = data[section]
+                existing = self.get(section, scope=scope)
+                new = spack.schema.merge_yaml(existing, value)
+
+                self.set(section, new, scope)
+
+    def add(self, fullpath: str, scope: Optional[str] = None) -> None:
+        """Add the given configuration to the specified config scope.
+        Add accepts a path. If you want to add from a filename, use add_from_file"""
+        components = process_config_path(fullpath)
+
+        has_existing_value = True
+        path = ""
+        override = False
+        value = components[-1]
+        if not isinstance(value, syaml.syaml_str):
+            value = syaml.load_config(value)
+        for idx, name in enumerate(components[:-1]):
+            # First handle double colons in constructing path
+            colon = "::" if override else ":" if path else ""
+            path += colon + name
+            if getattr(name, "override", False):
+                override = True
+            else:
+                override = False
+
+            # Test whether there is an existing value at this level
+            existing = self.get(path, scope=scope)
+
+            if existing is None:
+                has_existing_value = False
+                # We've nested further than existing config, so we need the
+                # type information for validation to know how to handle bare
+                # values appended to lists.
+                existing = get_default_from_schema(path)
+
+                # construct value from this point down
+                for component in reversed(components[idx + 1 : -1]):
+                    value: Dict[str, str] = {component: value}  # type: ignore[no-redef]
+                break
+
+        if override:
+            path += "::"
+
+        if has_existing_value:
+            existing = self.get(path, scope=scope)
+
+        # append values to lists
+        if isinstance(existing, list) and not isinstance(value, list):
+            value: List[str] = [value]  # type: ignore[no-redef]
+
+        # merge value into existing
+        new = spack.schema.merge_yaml(existing, value)
+        self.set(path, new, scope)
+
+
 def override(
     path_or_scope: Union[ConfigScope, str], value: Optional[Any] = None
-) -> Generator[Configuration, None, None]:
+) -> ContextManager[Configuration]:
     """Simple way to override config settings within a context.
 
     Arguments:
@@ -1002,26 +1122,7 @@ def override(
     an internal config scope for it and push/pop that scope.
 
     """
-    path: Optional[str]
-    if isinstance(path_or_scope, ConfigScope):
-        overrides, path = path_or_scope, None
-    else:
-        # Ensure the new override gets a unique scope name
-        existing = {s.name for s in CONFIG.matching_scopes(rf"^{_OVERRIDES_BASE_NAME}")}
-        num_overrides = len(existing)
-        while f"{_OVERRIDES_BASE_NAME}{num_overrides}" in existing:
-            num_overrides += 1
-        overrides = InternalConfigScope(f"{_OVERRIDES_BASE_NAME}{num_overrides}")
-        path = path_or_scope
-
-    CONFIG.push_scope(overrides, priority=None)
-    try:
-        if path is not None:
-            CONFIG.set(path, value, scope=overrides.name)
-        yield CONFIG
-    finally:
-        scope = CONFIG.remove_scope(overrides.name)
-        assert scope is overrides
+    return CONFIG.override(path_or_scope, value)
 
 
 #: Class for the relevance of an optional path conditioned on a limited
@@ -1581,85 +1682,13 @@ spack.platforms.on_host_changed.append(lambda: CONFIG.clear_caches())
 
 def add_from_file(filename: str, scope: Optional[str] = None) -> None:
     """Add updates to a config from a filename"""
-    # Extract internal attributes, if we are dealing with an environment
-    data = read_config_file(filename)
-    if data is None:
-        return
-
-    if spack.schema.env.TOP_LEVEL_KEY in data:
-        data = data[spack.schema.env.TOP_LEVEL_KEY]
-
-    msg = (
-        "unexpected 'None' value when retrieving configuration. "
-        "Please submit a bug-report at https://github.com/spack/spack/issues"
-    )
-    assert data is not None, msg
-
-    # update all sections from config dict
-    # We have to iterate on keys to keep overrides from the file
-    for section in data.keys():
-        if section in SECTION_SCHEMAS.keys():
-            # Special handling for compiler scope difference
-            # Has to be handled after we choose a section
-            if scope is None:
-                scope = default_modify_scope(section)
-
-            value = data[section]
-            existing = get(section, scope=scope)
-            new = spack.schema.merge_yaml(existing, value)
-
-            # We cannot call config.set directly (set is a type)
-            CONFIG.set(section, new, scope)
+    CONFIG.add_from_file(filename, scope)
 
 
 def add(fullpath: str, scope: Optional[str] = None) -> None:
     """Add the given configuration to the specified config scope.
     Add accepts a path. If you want to add from a filename, use add_from_file"""
-    components = process_config_path(fullpath)
-
-    has_existing_value = True
-    path = ""
-    override = False
-    value = components[-1]
-    if not isinstance(value, syaml.syaml_str):
-        value = syaml.load_config(value)
-    for idx, name in enumerate(components[:-1]):
-        # First handle double colons in constructing path
-        colon = "::" if override else ":" if path else ""
-        path += colon + name
-        if getattr(name, "override", False):
-            override = True
-        else:
-            override = False
-
-        # Test whether there is an existing value at this level
-        existing = get(path, scope=scope)
-
-        if existing is None:
-            has_existing_value = False
-            # We've nested further than existing config, so we need the
-            # type information for validation to know how to handle bare
-            # values appended to lists.
-            existing = get_default_from_schema(path)
-
-            # construct value from this point down
-            for component in reversed(components[idx + 1 : -1]):
-                value: Dict[str, str] = {component: value}  # type: ignore[no-redef]
-            break
-
-    if override:
-        path += "::"
-
-    if has_existing_value:
-        existing = get(path, scope=scope)
-
-    # append values to lists
-    if isinstance(existing, list) and not isinstance(value, list):
-        value: List[str] = [value]  # type: ignore[no-redef]
-
-    # merge value into existing
-    new = spack.schema.merge_yaml(existing, value)
-    CONFIG.set(path, new, scope)
+    CONFIG.add(fullpath, scope)
 
 
 def get(path: str, default: Any = default_sigil, scope: Optional[str] = None) -> Any:

--- a/lib/spack/spack/config.py
+++ b/lib/spack/spack/config.py
@@ -1038,7 +1038,7 @@ class Configuration:
                 # Special handling for compiler scope difference
                 # Has to be handled after we choose a section
                 if scope is None:
-                    scope = default_modify_scope(section)
+                    scope = self.default_modify_scope(section)
 
                 value = data[section]
                 existing = self.get(section, scope=scope)
@@ -1094,6 +1094,82 @@ class Configuration:
         # merge value into existing
         new = spack.schema.merge_yaml(existing, value)
         self.set(path, new, scope)
+
+    def writable_scope_names(self) -> List[str]:
+        """Names of writable scopes, highest priority first."""
+        return [s.name for s in self.scopes.values() if s.writable][::-1]
+
+    def existing_scope_names(self) -> List[str]:
+        """Names of existing scopes, highest priority first."""
+        return [s.name for s in self.scopes.values() if s.exists][::-1]
+
+    def default_modify_scope(self, section: str = "config") -> str:
+        """Return the config scope that commands should modify by default.
+
+        Commands that modify configuration by default modify the *highest*
+        priority scope.
+
+        Arguments:
+            section (bool): Section for which to get the default scope.
+        """
+        return self.highest_precedence_scope().name
+
+    def matched_config(self, cfg_path: str) -> List[Tuple[str, Any]]:
+        return [(scope, self.get(cfg_path, scope=scope)) for scope in self.writable_scope_names()]
+
+    def change_or_add(
+        self, section_name: str, find_fn: Callable[[str], bool], update_fn: Callable[[str], None]
+    ) -> None:
+        """Change or add a subsection of config, with additional logic to
+        select a reasonable scope where the change is applied.
+
+        Search through config scopes starting with the highest priority:
+        the first matching a criteria (determined by ``find_fn``) is updated;
+        if no such config exists, find the first config scope that defines
+        any config for the named section; if no scopes define any related
+        config, then update the highest-priority config scope.
+        """
+        configs_by_section = self.matched_config(section_name)
+        found = False
+        for scope, section in configs_by_section:
+            found = find_fn(section)
+            if found:
+                break
+
+        if found:
+            update_fn(section)
+            self.set(section_name, section, scope=scope)
+            return
+
+        # If no scope meets the criteria specified by ``find_fn``,
+        # then look for a scope that has any content (for the specified
+        # section name)
+        for scope, section in configs_by_section:
+            if section:
+                update_fn(section)
+                found = True
+                break
+
+        if found:
+            self.set(section_name, section, scope=scope)
+            return
+
+        # If no scopes define any config for the named section, then
+        # modify the highest-priority scope.
+        scope, section = configs_by_section[0]
+        update_fn(section)
+        self.set(section_name, section, scope=scope)
+
+    def update_all(self, section_name: str, change_fn: Callable[[str], bool]) -> None:
+        """Change a config section, which may have details duplicated
+        across multiple scopes.
+        """
+        configs_by_section = self.matched_config("develop")
+
+        for scope, section in configs_by_section:
+            modified = change_fn(section)
+            if modified:
+                self.set(section_name, section, scope=scope)
 
 
 #: Class for the relevance of an optional path conditioned on a limited
@@ -1651,11 +1727,6 @@ CONFIG = cast(Configuration, lang.Singleton(create_incremental))
 spack.platforms.on_host_changed.append(lambda: CONFIG.clear_caches())
 
 
-def scopes() -> lang.PriorityOrderedMapping[str, ConfigScope]:
-    """Convenience function to get list of configuration scopes."""
-    return CONFIG.scopes
-
-
 def writable_scopes() -> List[ConfigScope]:
     """Return list of writable scopes. Higher-priority scopes come first in the list."""
     scopes = [x for x in CONFIG.scopes.values() if x.writable]
@@ -1671,74 +1742,6 @@ def existing_scopes() -> List[ConfigScope]:
     scopes = [x for x in CONFIG.scopes.values() if x.exists]
     scopes.reverse()
     return scopes
-
-
-def writable_scope_names() -> List[str]:
-    return [x.name for x in writable_scopes()]
-
-
-def existing_scope_names() -> List[str]:
-    return [x.name for x in existing_scopes()]
-
-
-def matched_config(cfg_path: str) -> List[Tuple[str, Any]]:
-    return [(scope, CONFIG.get(cfg_path, scope=scope)) for scope in writable_scope_names()]
-
-
-def change_or_add(
-    section_name: str, find_fn: Callable[[str], bool], update_fn: Callable[[str], None]
-) -> None:
-    """Change or add a subsection of config, with additional logic to
-    select a reasonable scope where the change is applied.
-
-    Search through config scopes starting with the highest priority:
-    the first matching a criteria (determined by ``find_fn``) is updated;
-    if no such config exists, find the first config scope that defines
-    any config for the named section; if no scopes define any related
-    config, then update the highest-priority config scope.
-    """
-    configs_by_section = matched_config(section_name)
-    found = False
-    for scope, section in configs_by_section:
-        found = find_fn(section)
-        if found:
-            break
-
-    if found:
-        update_fn(section)
-        CONFIG.set(section_name, section, scope=scope)
-        return
-
-    # If no scope meets the criteria specified by ``find_fn``,
-    # then look for a scope that has any content (for the specified
-    # section name)
-    for scope, section in configs_by_section:
-        if section:
-            update_fn(section)
-            found = True
-            break
-
-    if found:
-        CONFIG.set(section_name, section, scope=scope)
-        return
-
-    # If no scopes define any config for the named section, then
-    # modify the highest-priority scope.
-    scope, section = configs_by_section[0]
-    update_fn(section)
-    CONFIG.set(section_name, section, scope=scope)
-
-
-def update_all(section_name: str, change_fn: Callable[[str], bool]) -> None:
-    """Change a config section, which may have details duplicated
-    across multiple scopes.
-    """
-    configs_by_section = matched_config("develop")
-
-    for scope, section in configs_by_section:
-        modified = change_fn(section)
-        if modified:
-            CONFIG.set(section_name, section, scope=scope)
 
 
 def _validate_section_name(section: str) -> None:
@@ -2078,21 +2081,6 @@ def process_config_path(path: str) -> List[str]:
     should not parse it in this case).
     """
     return ConfigPath.process(path)
-
-
-#
-# Settings for commands that modify configuration
-#
-def default_modify_scope(section: str = "config") -> str:
-    """Return the config scope that commands should modify by default.
-
-    Commands that modify configuration by default modify the *highest*
-    priority scope.
-
-    Arguments:
-        section (bool): Section for which to get the default scope.
-    """
-    return CONFIG.highest_precedence_scope().name
 
 
 def _update_in_memory(data: YamlConfigDict, section: str) -> bool:

--- a/lib/spack/spack/detection/common.py
+++ b/lib/spack/spack/detection/common.py
@@ -34,7 +34,7 @@ from spack.util import tty
 
 def _externals_in_packages_yaml() -> Set[spack.spec.Spec]:
     """Returns all the specs mentioned as externals in packages.yaml"""
-    packages_yaml = spack.config.get("packages")
+    packages_yaml = spack.config.CONFIG.get("packages")
     already_defined_specs = set()
     for pkg_name, package_configuration in packages_yaml.items():
         for item in package_configuration.get("externals", []):
@@ -228,9 +228,9 @@ def update_configuration(
         pkg_to_cfg[package_name] = pkg_config
 
     scope = scope or spack.config.default_modify_scope()
-    pkgs_cfg = spack.config.get("packages", scope=scope)
+    pkgs_cfg = spack.config.CONFIG.get("packages", scope=scope)
     pkgs_cfg = spack.schema.merge_yaml(pkgs_cfg, pkg_to_cfg)
-    spack.config.set("packages", pkgs_cfg, scope=scope)
+    spack.config.CONFIG.set("packages", pkgs_cfg, scope=scope)
 
     return all_new_specs
 
@@ -238,7 +238,7 @@ def update_configuration(
 def set_virtuals_nonbuildable(virtuals: Set[str], scope: Optional[str] = None) -> List[str]:
     """Update packages:virtual:buildable:False for the provided virtual packages, if the property
     is not set by the user. Returns the list of virtual packages that have been updated."""
-    packages = spack.config.get("packages")
+    packages = spack.config.CONFIG.get("packages")
     new_config = {}
     for virtual in virtuals:
         # If the user has set the buildable prop do not override it
@@ -247,9 +247,9 @@ def set_virtuals_nonbuildable(virtuals: Set[str], scope: Optional[str] = None) -
         new_config[virtual] = {"buildable": False}
 
     # Update the provided scope
-    spack.config.set(
+    spack.config.CONFIG.set(
         "packages",
-        spack.schema.merge_yaml(spack.config.get("packages", scope=scope), new_config),
+        spack.schema.merge_yaml(spack.config.CONFIG.get("packages", scope=scope), new_config),
         scope=scope,
     )
 
@@ -406,7 +406,7 @@ def find_win32_additional_install_paths() -> List[str]:
     # Add search path for NuGet package manager default install location
     windows_search_ext.append(os.path.join(user, ".nuget", "packages"))
     windows_search_ext.extend(
-        spack.config.get("config:additional_external_search_paths", default=[])
+        spack.config.CONFIG.get("config:additional_external_search_paths", default=[])
     )
     windows_search_ext.extend(spack.util.environment.get_path("PATH"))
     return windows_search_ext

--- a/lib/spack/spack/detection/common.py
+++ b/lib/spack/spack/detection/common.py
@@ -227,7 +227,7 @@ def update_configuration(
             pkg_config["buildable"] = False
         pkg_to_cfg[package_name] = pkg_config
 
-    scope = scope or spack.config.default_modify_scope()
+    scope = scope or spack.config.CONFIG.default_modify_scope()
     pkgs_cfg = spack.config.CONFIG.get("packages", scope=scope)
     pkgs_cfg = spack.schema.merge_yaml(pkgs_cfg, pkg_to_cfg)
     spack.config.CONFIG.set("packages", pkgs_cfg, scope=scope)

--- a/lib/spack/spack/directory_layout.py
+++ b/lib/spack/spack/directory_layout.py
@@ -160,7 +160,7 @@ class DirectoryLayout:
                 else:
                     raise SpecReadError(f"Did not recognize spec file extension: {extension}")
         except Exception as e:
-            if spack.config.get("config:debug"):
+            if spack.config.CONFIG.get("config:debug"):
                 raise
             raise SpecReadError(f"Unable to read file: {path}", f"Cause: {e}")
 

--- a/lib/spack/spack/environment/environment.py
+++ b/lib/spack/spack/environment/environment.py
@@ -104,7 +104,7 @@ MARKER_FILE = ".spack-view"
 def env_root_path() -> str:
     """Override default root path if the user specified it"""
     return spack.config.canonicalize_path(
-        spack.config.get("config:environments_root", default=default_env_path)
+        spack.config.CONFIG.get("config:environments_root", default=default_env_path)
     )
 
 
@@ -154,7 +154,7 @@ spack:
   view: true
   concretizer:
     unify: {}
-""".format("true" if spack.config.get("concretizer:unify") else "false")
+""".format("true" if spack.config.CONFIG.get("concretizer:unify") else "false")
 
 
 sep_re = re.escape(os.sep)
@@ -237,9 +237,9 @@ def activate(env, use_env_repo=False):
         if not isinstance(env, Environment):
             raise TypeError(f"`env` should be of type {Environment.__name__}")
 
-        install_tree_before = spack.config.get("config:install_tree")
-        upstreams_before = spack.config.get("upstreams")
-        repos_before = spack.config.get("repos")
+        install_tree_before = spack.config.CONFIG.get("config:install_tree")
+        upstreams_before = spack.config.CONFIG.get("upstreams")
+        repos_before = spack.config.CONFIG.get("repos")
         # PATH may be a lazy singleton created from config, so materialize it before pushing
         # the env scope, otherwise we'd save (and later restore) the env's repositories.
         repo_before = ensure_unwrapped(spack.repo.PATH)
@@ -248,9 +248,9 @@ def activate(env, use_env_repo=False):
         set_active_environment(env)
         env.manifest.prepare_config_scope()
 
-        install_tree_after = spack.config.get("config:install_tree")
-        upstreams_after = spack.config.get("upstreams")
-        repos_after = spack.config.get("repos")
+        install_tree_after = spack.config.CONFIG.get("config:install_tree")
+        upstreams_after = spack.config.CONFIG.get("upstreams")
+        repos_after = spack.config.CONFIG.get("repos")
 
         # Check if we need to reinitialize spack.store.STORE and spack.repo.REPO
         if install_tree_before != install_tree_after or upstreams_before != upstreams_after:
@@ -461,7 +461,7 @@ def _rewrite_relative_dev_paths_on_relocation(env, init_file_dir, copied_env=Fal
     to store the environment in a different directory, we have to rewrite
     relative paths to absolute ones."""
     with env:
-        dev_specs = spack.config.get("develop", default={}, scope=env.scope_name)
+        dev_specs = spack.config.CONFIG.get("develop", default={}, scope=env.scope_name)
         if not dev_specs:
             return
         for name, entry in dev_specs.items():
@@ -480,7 +480,7 @@ def _rewrite_relative_dev_paths_on_relocation(env, init_file_dir, copied_env=Fal
 
             dev_specs[name]["path"] = expanded_path
 
-        spack.config.set("develop", dev_specs, scope=env.scope_name)
+        spack.config.CONFIG.set("develop", dev_specs, scope=env.scope_name)
 
         env._dev_specs = None
         # If we changed the environment's spack.yaml scope, that will not be reflected
@@ -493,7 +493,7 @@ def _rewrite_relative_repos_paths_on_relocation(env, init_file_dir, copied_env=F
     to store the environment in a different directory, we have to rewrite
     relative repo paths to absolute ones and expand environment variables."""
     with env:
-        repos_specs = spack.config.get("repos", default={}, scope=env.scope_name)
+        repos_specs = spack.config.CONFIG.get("repos", default={}, scope=env.scope_name)
         if not repos_specs:
             return
         for name, entry in list(repos_specs.items()):
@@ -515,7 +515,7 @@ def _rewrite_relative_repos_paths_on_relocation(env, init_file_dir, copied_env=F
 
             repos_specs[name] = expanded_path
 
-        spack.config.set("repos", repos_specs, scope=env.scope_name)
+        spack.config.CONFIG.set("repos", repos_specs, scope=env.scope_name)
 
         env.repos_specs = None
         # If we changed the environment's spack.yaml scope, that will not be reflected
@@ -1274,7 +1274,7 @@ class Environment:
         """Set up user specs and views from the manifest file."""
         self.views = {}
         self._sync_speclists()
-        self._process_view(spack.config.get("view", True))
+        self._process_view(spack.config.CONFIG.get("view", True))
         self._process_included_lockfiles()
 
     def _sync_speclists(self):
@@ -1316,7 +1316,7 @@ class Environment:
     @property
     def dev_specs(self):
         dev_specs = {}
-        dev_config = spack.config.get("develop", {})
+        dev_config = spack.config.CONFIG.get("develop", {})
         for name, entry in dev_config.items():
             local_entry = {"spec": str(entry["spec"])}
             # default path is the spec name
@@ -1723,7 +1723,7 @@ class Environment:
 
         Arguments:
             force: re-concretize ALL specs, even those that were already concretized;
-                defaults to ``spack.config.get("concretizer:force")``
+                defaults to ``spack.config.CONFIG.get("concretizer:force")``
             tests: False to run no tests, True to test all packages, or a list of
                 package names to run tests for some
 
@@ -2711,7 +2711,7 @@ class EnvironmentConcretizer:
         self, *, force: Optional[bool] = None, tests: Union[bool, Sequence[str]] = False
     ) -> List[SpecPair]:
         if force is None:
-            force = spack.config.get("concretizer:force")
+            force = spack.config.CONFIG.get("concretizer:force")
         self._prepare_environment_for_concretization(force=force)
 
         result = []

--- a/lib/spack/spack/environment/shell.py
+++ b/lib/spack/spack/environment/shell.py
@@ -181,7 +181,7 @@ def activate(
     # become PATH variables.
     #
 
-    env_vars_yaml = spack.config.get("env_vars", None)
+    env_vars_yaml = spack.config.CONFIG.get("env_vars", None)
     if env_vars_yaml:
         env_mods.extend(spack.schema.environment.parse(env_vars_yaml))
 
@@ -219,7 +219,7 @@ def deactivate() -> EnvironmentModifications:
         return env_mods
 
     with active.manifest.use_config():
-        env_vars_yaml = spack.config.get("env_vars", None)
+        env_vars_yaml = spack.config.CONFIG.get("env_vars", None)
     if env_vars_yaml:
         env_mods.extend(spack.schema.environment.parse(env_vars_yaml).reversed())
 

--- a/lib/spack/spack/extensions.py
+++ b/lib/spack/spack/extensions.py
@@ -126,7 +126,7 @@ def load_extension(name: str) -> str:
 
 def get_extension_paths():
     """Return the list of canonicalized extension paths from config:extensions."""
-    extension_paths = spack.config.get("config:extensions") or []
+    extension_paths = spack.config.CONFIG.get("config:extensions") or []
     extension_paths.extend(extension_paths_from_entry_points())
     paths = [spack.config.canonicalize_path(p) for p in extension_paths]
     return paths

--- a/lib/spack/spack/fetch_strategy.py
+++ b/lib/spack/spack/fetch_strategy.py
@@ -407,7 +407,7 @@ class URLFetchStrategy(FetchStrategy):
             )
 
     def _fetch_from_url(self, url):
-        fetch_method = spack.config.get("config:url_fetch_method", "urllib")
+        fetch_method = spack.config.CONFIG.get("config:url_fetch_method", "urllib")
         if fetch_method.startswith("curl"):
             return self._fetch_curl(url, config_args=fetch_method.split()[1:])
         else:
@@ -889,7 +889,7 @@ class GitFetchStrategy(VCSFetchStrategy):
 
             # If the user asked for insecure fetching, make that work
             # with git as well.
-            if not spack.config.get("config:verify_ssl"):
+            if not spack.config.CONFIG.get("config:verify_ssl"):
                 self._git.add_default_env("GIT_SSL_NO_VERIFY", "true")
 
         return self._git
@@ -950,7 +950,7 @@ class GitFetchStrategy(VCSFetchStrategy):
         tty.debug(f"Cloning git repository: {self._repo_info()}")
 
         git = self.git
-        debug = spack.config.get("config:debug")
+        debug = spack.config.CONFIG.get("config:debug")
 
         # We don't need to worry about which commit/branch/tag is checked out
         clone_args = ["clone", "--bare"]
@@ -970,7 +970,11 @@ class GitFetchStrategy(VCSFetchStrategy):
         checkout_ref = self.commit or self.tag or self.branch
         fetch_ref = self.tag or self.branch
 
-        kwargs = {"debug": spack.config.get("config:debug"), "git_exe": self.git, "dest": name}
+        kwargs = {
+            "debug": spack.config.CONFIG.get("config:debug"),
+            "git_exe": self.git,
+            "dest": name,
+        }
 
         # TODO(psakievich) The use of the minimal clone need clearer justification via package API
         # or something. There is a trade space of storage minimization vs available git information
@@ -1005,7 +1009,7 @@ class GitFetchStrategy(VCSFetchStrategy):
             with working_dir(dest):
                 for submodule_to_delete in self.submodules_delete:
                     args = ["rm", submodule_to_delete]
-                    if not spack.config.get("config:debug"):
+                    if not spack.config.CONFIG.get("config:debug"):
                         args.insert(1, "--quiet")
                     git(*args)
 
@@ -1027,7 +1031,7 @@ class GitFetchStrategy(VCSFetchStrategy):
 
         with working_dir(dest):
             for args in git_commands:
-                if not spack.config.get("config:debug"):
+                if not spack.config.CONFIG.get("config:debug"):
                     args.insert(1, "--quiet")
                 git(*args)
 
@@ -1036,7 +1040,7 @@ class GitFetchStrategy(VCSFetchStrategy):
         with working_dir(self.stage.source_path):
             co_args = ["checkout", "."]
             clean_args = ["clean", "-f"]
-            if spack.config.get("config:debug"):
+            if spack.config.CONFIG.get("config:debug"):
                 co_args.insert(1, "--quiet")
                 clean_args.insert(1, "--quiet")
 
@@ -1334,7 +1338,7 @@ class HgFetchStrategy(VCSFetchStrategy):
 
         args = ["clone"]
 
-        if not spack.config.get("config:verify_ssl"):
+        if not spack.config.CONFIG.get("config:verify_ssl"):
             args.append("--insecure")
 
         if self.revision:

--- a/lib/spack/spack/hooks/absolutify_elf_sonames.py
+++ b/lib/spack/spack/hooks/absolutify_elf_sonames.py
@@ -130,7 +130,7 @@ def find_and_patch_sonames(prefix, exclude_list, patchelf):
 
 def post_install(spec, explicit=None):
     # Skip if disabled
-    if not spack.config.get("config:shared_linking:bind", False):
+    if not spack.config.CONFIG.get("config:shared_linking:bind", False):
         return
 
     # Skip externals

--- a/lib/spack/spack/hooks/module_file_generation.py
+++ b/lib/spack/spack/hooks/module_file_generation.py
@@ -14,9 +14,9 @@ def _for_each_enabled(
     spec: spack.spec.Spec, method_name: str, explicit: Optional[bool] = None
 ) -> None:
     """Calls a method for each enabled module"""
-    set_names: Set[str] = set(spack.config.get("modules", {}).keys())
+    set_names: Set[str] = set(spack.config.CONFIG.get("modules", {}).keys())
     for name in set_names:
-        enabled = spack.config.get(f"modules:{name}:enable")
+        enabled = spack.config.CONFIG.get(f"modules:{name}:enable")
         if not enabled:
             tty.debug("NO MODULE WRITTEN: list of enabled module files is empty")
             continue

--- a/lib/spack/spack/hooks/resolve_shared_libraries.py
+++ b/lib/spack/spack/hooks/resolve_shared_libraries.py
@@ -13,7 +13,7 @@ from spack.util.filesystem import visit_directory_tree
 
 def post_install(spec, explicit):
     """Check whether shared libraries can be resolved in RPATHs."""
-    policy = spack.config.get("config:shared_linking:missing_library_policy", "ignore")
+    policy = spack.config.CONFIG.get("config:shared_linking:missing_library_policy", "ignore")
 
     # Currently only supported for ELF files.
     if policy == "ignore" or spec.external or spec.platform not in ("linux", "freebsd"):

--- a/lib/spack/spack/install_test.py
+++ b/lib/spack/spack/install_test.py
@@ -99,7 +99,7 @@ def get_test_stage_dir() -> str:
         absolute path to the configured test stage root or, if none, the default test stage path
     """
     return spack.config.canonicalize_path(
-        spack.config.get("config:test_stage", spack.paths.default_test_path)
+        spack.config.CONFIG.get("config:test_stage", spack.paths.default_test_path)
     )
 
 
@@ -361,7 +361,7 @@ class PackageTest:
             method_names: phase-specific callback method names
         """
         verbose = tty.is_verbose()
-        fail_fast = spack.config.get("config:fail_fast", False)
+        fail_fast = spack.config.CONFIG.get("config:fail_fast", False)
 
         with self.test_logger(verbose=verbose, externals=False) as logger:
             # Report running each of the methods in the build log
@@ -525,7 +525,7 @@ def test_part(
             exc = e  # e is deleted after this block
 
             # If we fail fast, raise another error
-            if spack.config.get("config:fail_fast", False):
+            if spack.config.CONFIG.get("config:fail_fast", False):
                 raise TestFailure([(exc, m)])
             else:
                 tester.add_failure(exc, m)

--- a/lib/spack/spack/installer/build.py
+++ b/lib/spack/spack/installer/build.py
@@ -667,7 +667,7 @@ def _install(
         if stop_at is not None and stop_at not in builder.phases:
             raise spack.error.InstallError(f"'{stop_at}' is not a valid phase for {pkg.name}")
 
-        _enable_sandbox(spack.config.get("config:sandbox", {}), spec, stage.path)
+        _enable_sandbox(spack.config.CONFIG.get("config:sandbox", {}), spec, stage.path)
 
         for phase in builder:
             if stop_before is not None and phase.name == stop_before:

--- a/lib/spack/spack/installer/core.py
+++ b/lib/spack/spack/installer/core.py
@@ -270,7 +270,7 @@ class PackageInstaller:
         self.jobs = spack.config.determine_number_of_jobs(parallel=True)
         self.ui.on_jobs_changed(self.jobs, self.jobs)
         if concurrent_packages is None:
-            concurrent_packages_config = spack.config.get("config:concurrent_packages", 0)
+            concurrent_packages_config = spack.config.CONFIG.get("config:concurrent_packages", 0)
             # The value 0 in config means no limit (other than self.jobs)
             if concurrent_packages_config == 0:
                 self.capacity = sys.maxsize

--- a/lib/spack/spack/installer/ui.py
+++ b/lib/spack/spack/installer/ui.py
@@ -228,7 +228,7 @@ class TerminalUI(InstallerUI):
         self.filter_padding = filter_padding
         #: When True, suppress all terminal output (process is in background).
         self.headless = False
-        self.term_title = spack.config.get("config:install_status", True) and self.is_tty
+        self.term_title = spack.config.CONFIG.get("config:install_status", True) and self.is_tty
 
     def on_resize(self) -> None:
         """Refresh cached terminal size and trigger a redraw."""

--- a/lib/spack/spack/installer_dispatch.py
+++ b/lib/spack/spack/installer_dispatch.py
@@ -42,9 +42,9 @@ def create_installer(
     create_reports: bool = False,
 ) -> Union["spack.old_installer.PackageInstaller", "spack.installer.PackageInstaller"]:
     """Create an installer based on the current configuration and feature support."""
-    use_old_installer = spack.config.get("config:installer", "new") == "old"
+    use_old_installer = spack.config.CONFIG.get("config:installer", "new") == "old"
 
-    if spack.config.get("config:sandbox:enable", False):
+    if spack.config.CONFIG.get("config:sandbox:enable", False):
         if use_old_installer:
             raise spack.sandbox.SandboxError(
                 "config:sandbox:enable is only supported with config:installer:new"

--- a/lib/spack/spack/main.py
+++ b/lib/spack/spack/main.py
@@ -359,7 +359,7 @@ class SpackArgumentParser(argparse.ArgumentParser):
 
             # build a list of aliases
             alias_list = []
-            aliases = spack.config.get("config:aliases")
+            aliases = spack.config.CONFIG.get("config:aliases")
             if aliases:
                 alias_list = [k for k, v in aliases.items() if shlex.split(v)[0] == cmd_name]
 
@@ -571,7 +571,7 @@ def setup_main_options(args):
         spack.error.SHOW_BACKTRACE = True
 
     if args.debug:
-        spack.config.set("config:debug", True, scope="command_line")
+        spack.config.CONFIG.set("config:debug", True, scope="command_line")
         spack.util.environment.TRACING_ENABLED = True
 
     if args.timestamp:
@@ -581,7 +581,7 @@ def setup_main_options(args):
     if args.locks is not None:
         if args.locks is False:
             spack.util.lock.check_lock_safety(spack.paths.prefix)
-        spack.config.set("config:locks", args.locks, scope="command_line")
+        spack.config.CONFIG.set("config:locks", args.locks, scope="command_line")
 
     if args.mock:
         import spack.util.spack_yaml as syaml
@@ -595,11 +595,11 @@ def setup_main_options(args):
     # If the user asked for it, don't check ssl certs.
     if args.insecure:
         tty.warn("You asked for --insecure. Will NOT check SSL certificates.")
-        spack.config.set("config:verify_ssl", False, scope="command_line")
+        spack.config.CONFIG.set("config:verify_ssl", False, scope="command_line")
 
     # Use the spack config command to handle parsing the config strings
     for config_var in args.config_vars or []:
-        spack.config.add(fullpath=config_var, scope="command_line")
+        spack.config.CONFIG.add(fullpath=config_var, scope="command_line")
 
     # On Windows10 console handling for ASCI/VT100 sequences is not
     # on by default. Turn on before we try to write to console
@@ -815,7 +815,7 @@ def print_setup_info(*info):
         path = root_path(name, "default")
         module_to_roots[name].append(path)
 
-    other_spack_instances = spack.config.get("upstreams") or {}
+    other_spack_instances = spack.config.CONFIG.get("upstreams") or {}
     for install_properties in other_spack_instances.values():
         upstream_module_roots = install_properties.get("modules", {})
         upstream_module_roots = {
@@ -860,7 +860,7 @@ def resolve_alias(cmd_name: str, cmd: List[str]) -> Tuple[str, List[str]]:
         new command name and arguments.
     """
     all_commands = spack.cmd.all_commands()
-    aliases = spack.config.get("config:aliases")
+    aliases = spack.config.CONFIG.get("config:aliases")
 
     if aliases:
         for key, value in aliases.items():
@@ -1125,7 +1125,7 @@ def main(argv=None):
     if (
         sys.platform == "darwin"
         and multiprocessing.get_start_method(allow_none=True) is None
-        and spack.config.get("config:installer") == "new"
+        and spack.config.CONFIG.get("config:installer") == "new"
     ):
         # Forkserver is significantly faster than spawn. This has to be configured once and early
         # in the process.
@@ -1147,19 +1147,19 @@ def main(argv=None):
         e.die()  # gracefully die on any SpackErrors
 
     except KeyboardInterrupt:
-        if spack.config.get("config:debug") or spack.error.SHOW_BACKTRACE:
+        if spack.config.CONFIG.get("config:debug") or spack.error.SHOW_BACKTRACE:
             raise
         sys.stderr.write("\n")
         tty.error("Keyboard interrupt.")
         return signal.SIGINT.value
 
     except SystemExit as e:
-        if spack.config.get("config:debug") or spack.error.SHOW_BACKTRACE:
+        if spack.config.CONFIG.get("config:debug") or spack.error.SHOW_BACKTRACE:
             traceback.print_exc()
         return e.code
 
     except Exception as e:
-        if spack.config.get("config:debug") or spack.error.SHOW_BACKTRACE:
+        if spack.config.CONFIG.get("config:debug") or spack.error.SHOW_BACKTRACE:
             raise
         tty.error(e)
         return 3

--- a/lib/spack/spack/mirrors/utils.py
+++ b/lib/spack/spack/mirrors/utils.py
@@ -114,7 +114,7 @@ def get_mirror_cache(path, skip_unstable_versions=False):
 
 def add(mirror: Mirror, scope=None):
     """Add a named mirror in the given scope"""
-    mirrors = spack.config.get("mirrors", scope=scope)
+    mirrors = spack.config.CONFIG.get("mirrors", scope=scope)
     if not mirrors:
         mirrors = syaml.syaml_dict()
 
@@ -124,17 +124,17 @@ def add(mirror: Mirror, scope=None):
     items = [(n, u) for n, u in mirrors.items()]
     items.insert(0, (mirror.name, mirror.to_dict()))
     mirrors = syaml.syaml_dict(items)
-    spack.config.set("mirrors", mirrors, scope=scope)
+    spack.config.CONFIG.set("mirrors", mirrors, scope=scope)
 
 
 def remove(name, scope):
     """Remove the named mirror in the given scope"""
-    mirrors = spack.config.get("mirrors", scope=scope)
+    mirrors = spack.config.CONFIG.get("mirrors", scope=scope)
     if not mirrors:
         mirrors = syaml.syaml_dict()
 
     removed = mirrors.pop(name, False)
-    spack.config.set("mirrors", mirrors, scope=scope)
+    spack.config.CONFIG.set("mirrors", mirrors, scope=scope)
     return bool(removed)
 
 
@@ -225,7 +225,7 @@ def create_mirror_from_package_object(
         except Exception as e:
             pkg_obj.stage.destroy()
             if num_retries + 1 == max_retries:
-                if spack.config.get("config:debug"):
+                if spack.config.CONFIG.get("config:debug"):
                     traceback.print_exc()
                 else:
                     tty.warn(

--- a/lib/spack/spack/modules/common.py
+++ b/lib/spack/spack/modules/common.py
@@ -170,7 +170,7 @@ def _store_core_compilers(
     module_set: str, module_system: str, core_compilers: List[spack.spec.Spec]
 ) -> None:
     """Writes a list of core compilers to the modules.yaml configuration file."""
-    default_scope = spack.config.default_modify_scope()
+    default_scope = spack.config.CONFIG.default_modify_scope()
     modules_cfg = spack.config.CONFIG.get(f"modules:{module_set}", {}, scope=default_scope)
     modules_cfg.setdefault(module_system, {})["core_compilers"] = [str(x) for x in core_compilers]
     spack.config.CONFIG.set(f"modules:{module_set}", modules_cfg, scope=default_scope)

--- a/lib/spack/spack/modules/common.py
+++ b/lib/spack/spack/modules/common.py
@@ -171,9 +171,9 @@ def _store_core_compilers(
 ) -> None:
     """Writes a list of core compilers to the modules.yaml configuration file."""
     default_scope = spack.config.default_modify_scope()
-    modules_cfg = spack.config.get(f"modules:{module_set}", {}, scope=default_scope)
+    modules_cfg = spack.config.CONFIG.get(f"modules:{module_set}", {}, scope=default_scope)
     modules_cfg.setdefault(module_system, {})["core_compilers"] = [str(x) for x in core_compilers]
-    spack.config.set(f"modules:{module_set}", modules_cfg, scope=default_scope)
+    spack.config.CONFIG.set(f"modules:{module_set}", modules_cfg, scope=default_scope)
 
 
 def merge_config_rules(configuration: dict, spec: spack.spec.Spec) -> dict:
@@ -212,7 +212,7 @@ def root_path(module_type: str, module_set: str) -> str:
     """
     dir_name = "modules" if module_type == "tcl" else module_type
     fallback = os.path.join(spack.paths.share_path, dir_name)
-    configured = spack.config.get(f"modules:{module_set}:roots", {})
+    configured = spack.config.CONFIG.get(f"modules:{module_set}:roots", {})
     return spack.config.canonicalize_path(configured.get(module_type, fallback))
 
 
@@ -266,7 +266,7 @@ def _read_module_index(str_or_file: IO[str]) -> Dict[str, ModuleIndexEntry]:
 
 
 def read_module_indices() -> List[Dict[str, Dict[str, ModuleIndexEntry]]]:
-    other_spack_instances = spack.config.get("upstreams") or {}
+    other_spack_instances = spack.config.CONFIG.get("upstreams") or {}
 
     module_indices = []
 
@@ -1450,5 +1450,5 @@ def disable_modules() -> Iterator[None]:
     """Disable the generation of modulefiles within the context manager."""
     data: Dict[str, object] = {"modules:": {"default": {"enable": []}}}
     disable_scope = spack.config.InternalConfigScope("disable_modules", data=data)
-    with spack.config.override(disable_scope):
+    with spack.config.CONFIG.override(disable_scope):
         yield

--- a/lib/spack/spack/oci/opener.py
+++ b/lib/spack/spack/oci/opener.py
@@ -28,7 +28,7 @@ def _urlopen():
     opener = create_opener()
 
     def dispatch_open(fullurl, data=None, timeout=None):
-        timeout = timeout or spack.config.get("config:connect_timeout", 10)
+        timeout = timeout or spack.config.CONFIG.get("config:connect_timeout", 10)
         return opener.open(fullurl, data, timeout)
 
     return dispatch_open

--- a/lib/spack/spack/old_installer.py
+++ b/lib/spack/spack/old_installer.py
@@ -155,7 +155,7 @@ class InstallStatus:
             self.pkg_ids.add(pkg_id)
 
     def set_term_title(self, text: str):
-        if not spack.config.get("config:install_status", True):
+        if not spack.config.CONFIG.get("config:install_status", True):
             return
 
         if not sys.stdout.isatty():
@@ -613,7 +613,7 @@ def install_msg(name: str, pid: int, install_status: InstallStatus) -> str:
     pre = f"{pid}: " if tty.show_pid() else ""
     post = (
         " @*{%s}" % install_status.get_progress()
-        if install_status and spack.config.get("config:install_status", True)
+        if install_status and spack.config.CONFIG.get("config:install_status", True)
         else ""
     )
     return pre + colorize("@*{Installing} @*g{%s}%s" % (name, post))
@@ -1524,7 +1524,7 @@ class PackageInstaller:
             explicit = {pkg.spec.dag_hash() for pkg in packages} if explicit else set()
 
         if concurrent_packages is None:
-            concurrent_packages = spack.config.get("config:concurrent_packages", default=1)
+            concurrent_packages = spack.config.CONFIG.get("config:concurrent_packages", default=1)
         # The value 0 means no concurrency in the old installer.
         if concurrent_packages == 0:
             concurrent_packages = 1
@@ -2626,7 +2626,7 @@ class BuildProcessInstaller:
         self.timer = timer.Timer()
 
         # If we are using a padded path, filter the output to compress padded paths
-        padding = spack.config.get("config:install_tree:padded_length", None)
+        padding = spack.config.CONFIG.get("config:install_tree:padded_length", None)
         self.filter_fn = spack.util.path.padding_filter if padding else None
 
         # info/debug information

--- a/lib/spack/spack/package_base.py
+++ b/lib/spack/spack/package_base.py
@@ -857,7 +857,7 @@ class PackageBase(WindowsRPath, PackageViewMixin, metaclass=PackageMeta):
     @classproperty
     def global_license_dir(cls):
         """Returns the directory where license files for all packages are stored."""
-        return spack.config.canonicalize_path(spack.config.get("config:license_dir"))
+        return spack.config.canonicalize_path(spack.config.CONFIG.get("config:license_dir"))
 
     @property
     def global_license_file(self):
@@ -1209,7 +1209,7 @@ class PackageBase(WindowsRPath, PackageViewMixin, metaclass=PackageMeta):
         dev_path_var = self.spec.variants.get("dev_path", None)
         if dev_path_var:
             dev_path = dev_path_var.value
-            link_format = spack.config.get("config:develop_stage_link")
+            link_format = spack.config.CONFIG.get("config:develop_stage_link")
             if not link_format:
                 link_format = "build-{arch}-{hash:7}"
             if link_format == "None":
@@ -1603,7 +1603,7 @@ class PackageBase(WindowsRPath, PackageViewMixin, metaclass=PackageMeta):
             tty.debug("No fetch required for {0}".format(self.name))
             return
 
-        checksum = spack.config.get("config:checksum")
+        checksum = spack.config.CONFIG.get("config:checksum")
         if (
             checksum
             and (self.version not in self.versions)
@@ -1629,7 +1629,7 @@ class PackageBase(WindowsRPath, PackageViewMixin, metaclass=PackageMeta):
                     "Will not fetch %s" % self.spec.format("{name}{@version}"), ck_msg
                 )
 
-        deprecated = spack.config.get("config:deprecated")
+        deprecated = spack.config.CONFIG.get("config:deprecated")
         if not deprecated and self.versions.get(self.version, {}).get("deprecated", False):
             tty.warn(
                 "{0} is deprecated and may be removed in a future Spack release.".format(
@@ -1674,7 +1674,7 @@ class PackageBase(WindowsRPath, PackageViewMixin, metaclass=PackageMeta):
         self.stage.create()
 
         # Fetch/expand any associated code.
-        user_dev_path = spack.config.get(f"develop:{self.name}:path", None)
+        user_dev_path = spack.config.CONFIG.get(f"develop:{self.name}:path", None)
         skip = user_dev_path and os.path.exists(user_dev_path)
         if skip:
             tty.debug("Skipping staging because develop path exists")

--- a/lib/spack/spack/package_prefs.py
+++ b/lib/spack/spack/package_prefs.py
@@ -161,7 +161,7 @@ class PackagePrefs:
 
 def is_spec_buildable(spec):
     """Return true if the spec is configured as buildable"""
-    allpkgs = spack.config.get("packages")
+    allpkgs = spack.config.CONFIG.get("packages")
     all_buildable = allpkgs.get("all", {}).get("buildable", True)
     so_far = all_buildable  # the default "so far"
 
@@ -187,7 +187,7 @@ def get_package_dir_permissions(spec):
     attribute sticky for the directory. Package-specific settings take
     precedent over settings for ``all``"""
     perms = get_package_permissions(spec)
-    if perms & stat.S_IRWXG and spack.config.get("config:allow_sgid", True):
+    if perms & stat.S_IRWXG and spack.config.CONFIG.get("config:allow_sgid", True):
         perms |= stat.S_ISGID
         if spec.concrete and "/afs/" in spec.prefix:
             warnings.warn(
@@ -206,7 +206,7 @@ def get_package_permissions(spec):
     # Get read permissions level
     for name in (spec.name, "all"):
         try:
-            readable = spack.config.get("packages:%s:permissions:read" % name, "")
+            readable = spack.config.CONFIG.get("packages:%s:permissions:read" % name, "")
             if readable:
                 break
         except AttributeError:
@@ -215,7 +215,7 @@ def get_package_permissions(spec):
     # Get write permissions level
     for name in (spec.name, "all"):
         try:
-            writable = spack.config.get("packages:%s:permissions:write" % name, "")
+            writable = spack.config.CONFIG.get("packages:%s:permissions:write" % name, "")
             if writable:
                 break
         except AttributeError:
@@ -253,7 +253,7 @@ def get_package_group(spec):
     Package-specific settings take precedence over settings for ``all``"""
     for name in (spec.name, "all"):
         try:
-            group = spack.config.get("packages:%s:permissions:group" % name, "")
+            group = spack.config.CONFIG.get("packages:%s:permissions:group" % name, "")
             if group:
                 break
         except AttributeError:

--- a/lib/spack/spack/repo.py
+++ b/lib/spack/spack/repo.py
@@ -2127,11 +2127,6 @@ REPOS_FINDER = ReposFinder()
 sys.meta_path.append(REPOS_FINDER)
 
 
-def all_package_names(include_virtuals=False):
-    """Convenience wrapper around ``spack.repo.all_package_names()``."""
-    return PATH.all_package_names(include_virtuals)
-
-
 @contextlib.contextmanager
 def use_repositories(
     *paths_and_repos: Union[str, Repo], override: bool = True

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -594,7 +594,7 @@ class ConcretizationCache:
     VERSION = 1
 
     def __init__(self, root: Union[str, None] = None):
-        root = root or spack.config.get("concretizer:concretization_cache:url", None)
+        root = root or spack.config.CONFIG.get("concretizer:concretization_cache:url", None)
         if root is None:
             root = os.path.join(spack.caches.misc_cache_location(), "concretization")
 
@@ -605,7 +605,7 @@ class ConcretizationCache:
     def cleanup(self):
         """Prunes the concretization cache according to configured entry
         count limits. Cleanup is done in LRU ordering."""
-        entry_limit = spack.config.get("concretizer:concretization_cache:entry_limit", 1000)
+        entry_limit = spack.config.CONFIG.get("concretizer:concretization_cache:entry_limit", 1000)
 
         try:
             entries = list(self.cache_entries())
@@ -1152,7 +1152,7 @@ class PyclingoDriver:
         timer.stop("ordering")
 
         timer.start("cache-check")
-        use_cache = spack.config.get("concretizer:concretization_cache:enable", False)
+        use_cache = spack.config.CONFIG.get("concretizer:concretization_cache:enable", False)
         cache = self._conc_cache if use_cache else None
 
         # load control files to add to the input representation
@@ -1529,7 +1529,7 @@ class SpackSolverSetup:
     def config_compatible_os(self):
         """Facts about compatible os's specified in configs"""
         self.gen.h2("Compatible OS from concretizer config file")
-        os_data = spack.config.get("concretizer:os_compatible", {})
+        os_data = spack.config.CONFIG.get("concretizer:os_compatible", {})
         for recent, reusable in os_data.items():
             for old in reusable:
                 self.gen.fact(fn.os_compatible(recent, old))
@@ -3155,7 +3155,7 @@ class SpackSolverSetup:
         return self.gen
 
     def compiler_mixing(self):
-        should_mix = spack.config.get("concretizer:compiler_mixing", True)
+        should_mix = spack.config.CONFIG.get("concretizer:compiler_mixing", True)
         if should_mix is True:
             return
         # anything besides should_mix: true

--- a/lib/spack/spack/stage.py
+++ b/lib/spack/spack/stage.py
@@ -68,7 +68,9 @@ def compute_stage_name(spec):
     # commit values for git versions when using source mirrors
     if spec.concrete:
         spec_stage_structure += "{name}-{version}-{hash}"
-        stage_name_structure = spack.config.get("config:stage_name", default=spec_stage_structure)
+        stage_name_structure = spack.config.CONFIG.get(
+            "config:stage_name", default=spec_stage_structure
+        )
     else:
         stage_name_structure = spec_stage_structure + "{name}-{version}"
     return spec.format_path(format_string=stage_name_structure)
@@ -194,7 +196,7 @@ def get_stage_root():
     global _stage_root
 
     if _stage_root is None:
-        candidates = spack.config.get("config:build_stage")
+        candidates = spack.config.CONFIG.get("config:build_stage")
         if isinstance(candidates, str):
             candidates = [candidates]
 
@@ -209,7 +211,7 @@ def get_stage_root():
 
 
 def _mirror_roots():
-    mirrors = spack.config.get("mirrors")
+    mirrors = spack.config.CONFIG.get("mirrors")
     return [
         (
             sup.substitute_path_variables(root)
@@ -681,7 +683,7 @@ class Stage(AbstractStage):
                 f"{self.fetcher}. Spack lacks a tree hash to verify the integrity of this "
                 f"archive. Make sure {secure_msg}.",
             )
-        elif spack.config.get("config:checksum"):
+        elif spack.config.CONFIG.get("config:checksum"):
             self.fetcher.check()
 
     def cache_local(self):

--- a/lib/spack/spack/store.py
+++ b/lib/spack/spack/store.py
@@ -46,7 +46,8 @@ def parse_install_tree(config_dict: dict) -> Tuple[str, str, Dict[str, str]]:
     """Parse config settings and return values relevant to the store object.
 
     Arguments:
-        config_dict: dictionary of config values, as returned from ``spack.config.get("config")``
+        config_dict: dictionary of config values, as returned from
+            ``spack.config.CONFIG.get("config")``
 
     Returns:
         triple of the install tree root, the unpadded install tree
@@ -138,7 +139,7 @@ def filter_padding():
     This is needed because Spack's debug output gets extremely long when we use a
     long padded installation path.
     """
-    padding = spack.config.get("config:install_tree:padded_length", None)
+    padding = spack.config.CONFIG.get("config:install_tree:padded_length", None)
     if padding:
         # filter out all padding from the install command output
         with tty.output_filter(spack.util.path.padding_filter):

--- a/lib/spack/spack/test/audit.py
+++ b/lib/spack/spack/test/audit.py
@@ -4,7 +4,6 @@
 import pytest
 
 import spack.audit
-import spack.config
 
 
 @pytest.mark.parametrize(
@@ -115,7 +114,7 @@ _double_compiler_definition = [
         ),
     ],
 )
-def test_config_audits(config_section, data, failing_check, mock_packages):
-    with spack.config.override(config_section, data):
+def test_config_audits(mutable_config, config_section, data, failing_check, mock_packages):
+    with mutable_config.override(config_section, data):
         reports = spack.audit.run_group("configs")
         assert any((check == failing_check) and errors for check, errors in reports)

--- a/lib/spack/spack/test/audit.py
+++ b/lib/spack/spack/test/audit.py
@@ -4,6 +4,7 @@
 import pytest
 
 import spack.audit
+from spack.config import Configuration
 
 
 @pytest.mark.parametrize(
@@ -114,7 +115,9 @@ _double_compiler_definition = [
         ),
     ],
 )
-def test_config_audits(mutable_config, config_section, data, failing_check, mock_packages):
+def test_config_audits(
+    mutable_config: Configuration, config_section, data, failing_check, mock_packages
+):
     with mutable_config.override(config_section, data):
         reports = spack.audit.run_group("configs")
         assert any((check == failing_check) and errors for check, errors in reports)

--- a/lib/spack/spack/test/binary_distribution.py
+++ b/lib/spack/spack/test/binary_distribution.py
@@ -34,6 +34,7 @@ import spack.util.spack_yaml as syaml
 import spack.util.url as url_util
 import spack.util.web as web_util
 from spack.binary_distribution import CannotListKeys, GenerateIndexError
+from spack.config import Configuration
 from spack.database import INDEX_JSON_FILE
 from spack.hooks import sbang
 from spack.old_installer import PackageInstaller
@@ -228,7 +229,9 @@ def test_spec_needs_rebuild(monkeypatch, tmp_path: pathlib.Path):
 
 
 @pytest.mark.usefixtures("install_mockery", "mock_packages", "mock_fetch")
-def test_generate_index_missing(monkeypatch, tmp_path: pathlib.Path, mutable_config):
+def test_generate_index_missing(
+    monkeypatch, tmp_path: pathlib.Path, mutable_config: Configuration
+):
     """Ensure spack buildcache index only reports available packages"""
 
     # Create a temp mirror directory for buildcache usage
@@ -271,7 +274,7 @@ def test_generate_index_missing(monkeypatch, tmp_path: pathlib.Path, mutable_con
 
 
 @pytest.mark.usefixtures("install_mockery", "mock_packages", "mock_fetch")
-def test_use_bin_index(monkeypatch, tmp_path: pathlib.Path, mutable_config):
+def test_use_bin_index(monkeypatch, tmp_path: pathlib.Path, mutable_config: Configuration):
     """Check use of binary cache index: perform an operation that
     instantiates it, and a second operation that reconstructs it.
     """
@@ -303,7 +306,7 @@ def test_use_bin_index(monkeypatch, tmp_path: pathlib.Path, mutable_config):
 
 @pytest.mark.usefixtures("install_mockery", "mock_packages", "mock_fetch")
 def test_use_bin_index_active_env_with_view(
-    monkeypatch, tmp_path: pathlib.Path, mutable_config, mutable_mock_env_path
+    monkeypatch, tmp_path: pathlib.Path, mutable_config: Configuration, mutable_mock_env_path
 ):
     """Check use of binary cache index: perform an operation that
     instantiates it, and a second operation that reconstructs it.
@@ -340,7 +343,7 @@ def test_use_bin_index_active_env_with_view(
 
 @pytest.mark.usefixtures("install_mockery", "mock_packages", "mock_fetch")
 def test_use_bin_index_with_view(
-    monkeypatch, tmp_path: pathlib.Path, mutable_config, mutable_mock_env_path
+    monkeypatch, tmp_path: pathlib.Path, mutable_config: Configuration, mutable_mock_env_path
 ):
     """Check use of binary cache index: perform an operation that
     instantiates it, and a second operation that reconstructs it.

--- a/lib/spack/spack/test/binary_distribution.py
+++ b/lib/spack/spack/test/binary_distribution.py
@@ -21,7 +21,6 @@ import pytest
 
 import spack.binary_distribution
 import spack.concretize
-import spack.config
 import spack.environment as ev
 import spack.main
 import spack.mirrors.mirror
@@ -235,7 +234,7 @@ def test_generate_index_missing(monkeypatch, tmp_path: pathlib.Path, mutable_con
     # Create a temp mirror directory for buildcache usage
     mirror_dir = tmp_path / "mirror_dir"
     mirror_url = url_util.path_to_file_url(str(mirror_dir))
-    spack.config.set("mirrors", {"test": mirror_url})
+    mutable_config.set("mirrors", {"test": mirror_url})
 
     s = spack.concretize.concretize_one("libdwarf")
 
@@ -264,7 +263,7 @@ def test_generate_index_missing(monkeypatch, tmp_path: pathlib.Path, mutable_con
     # Update index
     buildcache_cmd("update-index", str(mirror_dir))
 
-    with spack.config.override("config:binary_index_ttl", 0):
+    with mutable_config.override("config:binary_index_ttl", 0):
         # Check dependency not in buildcache
         cache_list = buildcache_cmd("list", "--allarch")
         assert "libdwarf" in cache_list
@@ -287,7 +286,7 @@ def test_use_bin_index(monkeypatch, tmp_path: pathlib.Path, mutable_config):
     # put it in the mirror
     mirror_dir = tmp_path / "mirror_dir"
     mirror_url = url_util.path_to_file_url(str(mirror_dir))
-    spack.config.set("mirrors", {"test": mirror_url})
+    mutable_config.set("mirrors", {"test": mirror_url})
     s = spack.concretize.concretize_one("libdwarf")
     install_cmd("--fake", "--no-cache", s.name)
     buildcache_cmd("push", "-u", str(mirror_dir), s.name)
@@ -320,7 +319,7 @@ def test_use_bin_index_active_env_with_view(
     # put it in the mirror
     mirror_dir = tmp_path / "mirror_dir"
     mirror_url = url_util.path_to_file_url(str(mirror_dir))
-    spack.config.set("mirrors", {"test": {"url": mirror_url, "view": "test"}})
+    mutable_config.set("mirrors", {"test": {"url": mirror_url, "view": "test"}})
     s = spack.concretize.concretize_one("libdwarf")
 
     # Create an environment and install specs for the view
@@ -357,7 +356,7 @@ def test_use_bin_index_with_view(
     # put it in the mirror
     mirror_dir = tmp_path / "mirror_dir"
     mirror_url = url_util.path_to_file_url(str(mirror_dir))
-    spack.config.set("mirrors", {"test": {"url": mirror_url, "view": "test"}})
+    mutable_config.set("mirrors", {"test": {"url": mirror_url, "view": "test"}})
     s = spack.concretize.concretize_one("libdwarf")
 
     # Create an environment and install specs for the view

--- a/lib/spack/spack/test/bootstrap.py
+++ b/lib/spack/spack/test/bootstrap.py
@@ -84,7 +84,7 @@ def test_install_tree_customization_is_respected(mutable_config, tmp_path: pathl
 )
 def test_store_path_customization(config_value, expected, mutable_config):
     # Set the current configuration to a specific value
-    spack.config.set("bootstrap:root", config_value)
+    spack.config.CONFIG.set("bootstrap:root", config_value)
 
     # Check the store path
     current = spack.bootstrap.config.store_path()
@@ -93,7 +93,7 @@ def test_store_path_customization(config_value, expected, mutable_config):
 
 def test_raising_exception_if_bootstrap_disabled(mutable_config):
     # Disable bootstrapping in config.yaml
-    spack.config.set("bootstrap:enable", False)
+    spack.config.CONFIG.set("bootstrap:enable", False)
 
     # Check the correct exception is raised
     with pytest.raises(RuntimeError, match="bootstrapping is currently disabled"):
@@ -123,15 +123,15 @@ def test_bootstrap_deactivates_environments(active_mock_environment):
 @pytest.mark.regression("25805")
 def test_bootstrap_disables_modulefile_generation(mutable_config):
     # Be sure to enable both lmod and tcl in modules.yaml
-    spack.config.set("modules:default:enable", ["tcl", "lmod"])
+    spack.config.CONFIG.set("modules:default:enable", ["tcl", "lmod"])
 
-    assert "tcl" in spack.config.get("modules:default:enable")
-    assert "lmod" in spack.config.get("modules:default:enable")
+    assert "tcl" in spack.config.CONFIG.get("modules:default:enable")
+    assert "lmod" in spack.config.CONFIG.get("modules:default:enable")
     with spack.bootstrap.ensure_bootstrap_configuration():
-        assert "tcl" not in spack.config.get("modules:default:enable")
-        assert "lmod" not in spack.config.get("modules:default:enable")
-    assert "tcl" in spack.config.get("modules:default:enable")
-    assert "lmod" in spack.config.get("modules:default:enable")
+        assert "tcl" not in spack.config.CONFIG.get("modules:default:enable")
+        assert "lmod" not in spack.config.CONFIG.get("modules:default:enable")
+    assert "tcl" in spack.config.CONFIG.get("modules:default:enable")
+    assert "lmod" in spack.config.CONFIG.get("modules:default:enable")
 
 
 @pytest.mark.regression("25992")
@@ -159,12 +159,12 @@ def test_bootstrap_search_for_compilers_with_environment_active(
 @pytest.mark.regression("26189")
 def test_config_yaml_is_preserved_during_bootstrap(mutable_config):
     expected_dir = "/tmp/test"
-    spack.config.set("config:test_stage", expected_dir, scope="command_line")
+    spack.config.CONFIG.set("config:test_stage", expected_dir, scope="command_line")
 
-    assert spack.config.get("config:test_stage") == expected_dir
+    assert spack.config.CONFIG.get("config:test_stage") == expected_dir
     with spack.bootstrap.ensure_bootstrap_configuration():
-        assert spack.config.get("config:test_stage") == expected_dir
-    assert spack.config.get("config:test_stage") == expected_dir
+        assert spack.config.CONFIG.get("config:test_stage") == expected_dir
+    assert spack.config.CONFIG.get("config:test_stage") == expected_dir
 
 
 @pytest.mark.regression("26548")
@@ -185,7 +185,7 @@ spack:
     )
     with spack.environment.Environment(str(tmp_path)):
         assert active_environment()
-        assert spack.config.get("config:install_tree:root") == str(install_root)
+        assert spack.config.CONFIG.get("config:install_tree:root") == str(install_root)
         # Don't trigger evaluation here
         with spack.bootstrap.ensure_bootstrap_configuration():
             pass
@@ -282,7 +282,7 @@ def test_source_is_disabled(mutable_config):
     assert not spack.bootstrap.core.source_is_enabled(conf)
 
     # Try to explicitly disable the source and verify that the behavior is the same as above
-    spack.config.add("bootstrap:trusted:{0}:{1}".format(conf["name"], False))
+    spack.config.CONFIG.add("bootstrap:trusted:{0}:{1}".format(conf["name"], False))
     assert not spack.bootstrap.core.source_is_enabled(conf)
 
 

--- a/lib/spack/spack/test/build_environment.py
+++ b/lib/spack/spack/test/build_environment.py
@@ -331,7 +331,7 @@ def test_external_config_env(mock_packages, mutable_config, working_env):
             }
         ]
     }
-    spack.config.set("packages:cmake", cmake_config)
+    mutable_config.set("packages:cmake", cmake_config)
 
     cmake_client = spack.concretize.concretize_one("cmake-client")
     spack.build_environment.setup_package(cmake_client.package, False)
@@ -463,7 +463,7 @@ dt-diamond-left:
   buildable: false
 """
     )
-    spack.config.set("packages", cfg_data)
+    mutable_config.set("packages", cfg_data)
     top = spack.concretize.concretize_one("dt-diamond")
 
     def _trust_me_its_a_dir(path):
@@ -512,7 +512,7 @@ def test_setting_dtags_based_on_config(
 ):
     # Pick a random package to be able to set compiler's variables
     s = spack.concretize.concretize_one("cmake")
-    with spack.config.override("config:shared_linking", {"type": config_setting, "bind": False}):
+    with config.override("config:shared_linking", {"type": config_setting, "bind": False}):
         env = spack.build_environment.setup_package(s.package, dirty=False)
         modifications = env.group_by_name()
         assert "SPACK_DTAGS_TO_STRIP" in modifications
@@ -832,7 +832,7 @@ def test_extra_rpaths_is_set(
     SPACK_COMPILER_EXTRA_RPATHS variable for the wrapper.
     """
     cfg_data = syaml.load_config(gcc_config)
-    spack.config.set("packages", cfg_data)
+    mutable_config.set("packages", cfg_data)
     mpich = spack.concretize.concretize_one("mpich %gcc@14")
     spack.build_environment.setup_package(mpich.package, dirty=False)
 

--- a/lib/spack/spack/test/build_environment.py
+++ b/lib/spack/spack/test/build_environment.py
@@ -23,6 +23,7 @@ import spack.util.environment
 import spack.util.module_cmd
 import spack.util.spack_yaml as syaml
 from spack.build_environment import UseMode, _static_to_shared_library, dso_suffix
+from spack.config import Configuration
 from spack.enums import Context
 from spack.old_installer import PackageInstaller
 from spack.util.environment import EnvironmentModifications
@@ -321,7 +322,7 @@ def test_load_external_modules_error(working_env, monkeypatch):
         spack.build_environment.load_external_modules(context)
 
 
-def test_external_config_env(mock_packages, mutable_config, working_env):
+def test_external_config_env(mock_packages, mutable_config: Configuration, working_env):
     cmake_config = {
         "externals": [
             {
@@ -448,7 +449,9 @@ def test_wrapper_variables(
         delattr(dep_pkg, "libs")
 
 
-def test_external_prefixes_last(mutable_config, mock_packages, working_env, monkeypatch):
+def test_external_prefixes_last(
+    mutable_config: Configuration, mock_packages, working_env, monkeypatch
+):
     # Sanity check: under normal circumstances paths associated with
     # dt-diamond-left would appear first. We'll mark it as external in
     # the test to check if the associated paths are placed last.
@@ -508,7 +511,7 @@ def test_parallel_false_is_not_propagating(config, mock_packages):
 )
 @pytest.mark.skipif(sys.platform != "linux", reason="dtags make sense only on linux")
 def test_setting_dtags_based_on_config(
-    config_setting, expected_flag, config, mock_packages, working_env
+    config_setting, expected_flag, config: Configuration, mock_packages, working_env
 ):
     # Pick a random package to be able to set compiler's variables
     s = spack.concretize.concretize_one("cmake")
@@ -826,7 +829,7 @@ gcc:
 )
 @pytest.mark.not_on_windows("Windows doesn't use the compiler-wrapper")
 def test_extra_rpaths_is_set(
-    working_env, mutable_config, mock_packages, gcc_config, expected_rpaths
+    working_env, mutable_config: Configuration, mock_packages, gcc_config, expected_rpaths
 ):
     """Tests that using a compiler with an 'extra_rpaths' section will set the corresponding
     SPACK_COMPILER_EXTRA_RPATHS variable for the wrapper.

--- a/lib/spack/spack/test/cache_fetch.py
+++ b/lib/spack/spack/test/cache_fetch.py
@@ -8,13 +8,14 @@ import pathlib
 import pytest
 
 import spack.util.url as url_util
+from spack.config import Configuration
 from spack.fetch_strategy import CacheURLFetchStrategy, NoCacheError
 from spack.stage import Stage
 from spack.util.filesystem import mkdirp
 
 
 @pytest.mark.parametrize("_fetch_method", ["curl", "urllib"])
-def test_fetch_missing_cache(mutable_config, tmp_path: pathlib.Path, _fetch_method):
+def test_fetch_missing_cache(mutable_config: Configuration, tmp_path: pathlib.Path, _fetch_method):
     """Ensure raise a missing cache file."""
     testpath = str(tmp_path)
     non_existing = os.path.join(testpath, "non-existing")
@@ -27,7 +28,7 @@ def test_fetch_missing_cache(mutable_config, tmp_path: pathlib.Path, _fetch_meth
 
 
 @pytest.mark.parametrize("_fetch_method", ["curl", "urllib"])
-def test_fetch(mutable_config, tmp_path: pathlib.Path, _fetch_method):
+def test_fetch(mutable_config: Configuration, tmp_path: pathlib.Path, _fetch_method):
     """Ensure a fetch after expanding is effectively a no-op."""
     cache_dir = tmp_path / "cache"
     stage_dir = tmp_path / "stage"

--- a/lib/spack/spack/test/cache_fetch.py
+++ b/lib/spack/spack/test/cache_fetch.py
@@ -7,7 +7,6 @@ import pathlib
 
 import pytest
 
-import spack.config
 import spack.util.url as url_util
 from spack.fetch_strategy import CacheURLFetchStrategy, NoCacheError
 from spack.stage import Stage
@@ -15,11 +14,11 @@ from spack.util.filesystem import mkdirp
 
 
 @pytest.mark.parametrize("_fetch_method", ["curl", "urllib"])
-def test_fetch_missing_cache(tmp_path: pathlib.Path, _fetch_method):
+def test_fetch_missing_cache(mutable_config, tmp_path: pathlib.Path, _fetch_method):
     """Ensure raise a missing cache file."""
     testpath = str(tmp_path)
     non_existing = os.path.join(testpath, "non-existing")
-    with spack.config.override("config:url_fetch_method", _fetch_method):
+    with mutable_config.override("config:url_fetch_method", _fetch_method):
         url = url_util.path_to_file_url(non_existing)
         fetcher = CacheURLFetchStrategy(url=url)
         with Stage(fetcher, path=testpath):
@@ -28,7 +27,7 @@ def test_fetch_missing_cache(tmp_path: pathlib.Path, _fetch_method):
 
 
 @pytest.mark.parametrize("_fetch_method", ["curl", "urllib"])
-def test_fetch(tmp_path: pathlib.Path, _fetch_method):
+def test_fetch(mutable_config, tmp_path: pathlib.Path, _fetch_method):
     """Ensure a fetch after expanding is effectively a no-op."""
     cache_dir = tmp_path / "cache"
     stage_dir = tmp_path / "stage"
@@ -37,7 +36,7 @@ def test_fetch(tmp_path: pathlib.Path, _fetch_method):
     cache = cache_dir / "cache.tar.gz"
     cache.touch()
     url = url_util.path_to_file_url(str(cache))
-    with spack.config.override("config:url_fetch_method", _fetch_method):
+    with mutable_config.override("config:url_fetch_method", _fetch_method):
         fetcher = CacheURLFetchStrategy(url=url)
         with Stage(fetcher, path=str(stage_dir)) as stage:
             source_path = stage.source_path

--- a/lib/spack/spack/test/cmd/bootstrap.py
+++ b/lib/spack/spack/test/cmd/bootstrap.py
@@ -10,7 +10,6 @@ import spack.bootstrap
 import spack.bootstrap.core
 import spack.cmd.mirror
 import spack.concretize
-import spack.config
 import spack.environment as ev
 import spack.main
 import spack.spec
@@ -25,10 +24,10 @@ def test_enable_and_disable(mutable_config, scope):
         scope_args = ["--scope={0}".format(scope)]
 
     _bootstrap("enable", *scope_args)
-    assert spack.config.get("bootstrap:enable", scope=scope) is True
+    assert mutable_config.get("bootstrap:enable", scope=scope) is True
 
     _bootstrap("disable", *scope_args)
-    assert spack.config.get("bootstrap:enable", scope=scope) is False
+    assert mutable_config.get("bootstrap:enable", scope=scope) is False
 
 
 @pytest.mark.parametrize("scope", [None, "site", "system", "user"])
@@ -48,7 +47,7 @@ def test_reset_in_file_scopes(mutable_config, scopes):
     bootstrap_yaml_files = []
     for s in scopes:
         _bootstrap("disable", "--scope={0}".format(s))
-        scope_path = spack.config.CONFIG.scopes[s].path
+        scope_path = mutable_config.scopes[s].path
         bootstrap_yaml = os.path.join(scope_path, "bootstrap.yaml")
         assert os.path.exists(bootstrap_yaml)
         bootstrap_yaml_files.append(bootstrap_yaml)
@@ -65,10 +64,10 @@ def test_reset_in_environment(mutable_mock_env_path, mutable_config):
 
     with current_environment:
         _bootstrap("disable")
-        assert spack.config.get("bootstrap:enable") is False
+        assert mutable_config.get("bootstrap:enable") is False
         _bootstrap("reset", "-y")
         # We have no default settings in tests
-        assert spack.config.get("bootstrap:enable") is None
+        assert mutable_config.get("bootstrap:enable") is None
 
     # Check that reset didn't delete the entire file
     spack_yaml = os.path.join(current_environment.path, "spack.yaml")
@@ -78,7 +77,7 @@ def test_reset_in_environment(mutable_mock_env_path, mutable_config):
 def test_reset_in_file_scopes_overwrites_backup_files(mutable_config):
     # Create a bootstrap.yaml with some config
     _bootstrap("disable", "--scope=site")
-    scope_path = spack.config.CONFIG.scopes["site"].path
+    scope_path = mutable_config.scopes["site"].path
     bootstrap_yaml = os.path.join(scope_path, "bootstrap.yaml")
     assert os.path.exists(bootstrap_yaml)
 
@@ -110,11 +109,11 @@ def test_list_sources(config):
 @pytest.mark.parametrize("command,value", [("enable", True), ("disable", False)])
 def test_enable_or_disable_sources(mutable_config, command, value):
     key = "bootstrap:trusted:github-actions"
-    trusted = spack.config.get(key, default=None)
+    trusted = mutable_config.get(key, default=None)
     assert trusted is None
 
     _bootstrap(command, "github-actions")
-    trusted = spack.config.get(key, default=None)
+    trusted = mutable_config.get(key, default=None)
     assert trusted is value
 
 
@@ -131,7 +130,7 @@ def test_enable_or_disable_fails_with_more_than_one_method(mutable_config):
         ],
         "trusted": {},
     }
-    with spack.config.override("bootstrap", wrong_config):
+    with mutable_config.override("bootstrap", wrong_config):
         with pytest.raises(RuntimeError, match="more than one"):
             _bootstrap("enable", "github-actions")
 
@@ -198,7 +197,7 @@ def test_bootstrap_mirror_metadata(mutable_config, linux_os, monkeypatch, tmp_pa
             }
         }
     ]
-    with spack.config.override("compilers", compilers):
+    with mutable_config.override("compilers", compilers):
         _bootstrap("mirror", str(tmp_path))
 
     # Register the mirror

--- a/lib/spack/spack/test/cmd/bootstrap.py
+++ b/lib/spack/spack/test/cmd/bootstrap.py
@@ -13,12 +13,13 @@ import spack.concretize
 import spack.environment as ev
 import spack.main
 import spack.spec
+from spack.config import Configuration
 
 _bootstrap = spack.main.SpackCommand("bootstrap")
 
 
 @pytest.mark.parametrize("scope", [None, "site", "system", "user"])
-def test_enable_and_disable(mutable_config, scope):
+def test_enable_and_disable(mutable_config: Configuration, scope):
     scope_args = []
     if scope:
         scope_args = ["--scope={0}".format(scope)]
@@ -57,7 +58,7 @@ def test_reset_in_file_scopes(mutable_config, scopes):
         assert not os.path.exists(bootstrap_yaml)
 
 
-def test_reset_in_environment(mutable_mock_env_path, mutable_config):
+def test_reset_in_environment(mutable_mock_env_path, mutable_config: Configuration):
     env = spack.main.SpackCommand("env")
     env("create", "bootstrap-test")
     current_environment = ev.read("bootstrap-test")
@@ -107,7 +108,7 @@ def test_list_sources(config):
 
 
 @pytest.mark.parametrize("command,value", [("enable", True), ("disable", False)])
-def test_enable_or_disable_sources(mutable_config, command, value):
+def test_enable_or_disable_sources(mutable_config: Configuration, command, value):
     key = "bootstrap:trusted:github-actions"
     trusted = mutable_config.get(key, default=None)
     assert trusted is None
@@ -122,7 +123,7 @@ def test_enable_or_disable_fails_with_no_method(mutable_config):
         _bootstrap("enable", "foo")
 
 
-def test_enable_or_disable_fails_with_more_than_one_method(mutable_config):
+def test_enable_or_disable_fails_with_more_than_one_method(mutable_config: Configuration):
     wrong_config = {
         "sources": [
             {"name": "github-actions", "metadata": "$spack/share/spack/bootstrap/github-actions"},
@@ -172,7 +173,9 @@ def test_remove_and_add_a_source(mutable_config):
 
 @pytest.mark.maybeslow
 @pytest.mark.not_on_windows("Not supported on Windows (yet)")
-def test_bootstrap_mirror_metadata(mutable_config, linux_os, monkeypatch, tmp_path: pathlib.Path):
+def test_bootstrap_mirror_metadata(
+    mutable_config: Configuration, linux_os, monkeypatch, tmp_path: pathlib.Path
+):
     """Test that `spack bootstrap mirror` creates a folder that can be ingested by
     `spack bootstrap add`. Here we don't download data, since that would be an
     expensive operation for a unit test.

--- a/lib/spack/spack/test/cmd/checksum.py
+++ b/lib/spack/spack/test/cmd/checksum.py
@@ -11,7 +11,6 @@ import spack.cmd.checksum
 import spack.concretize
 import spack.error
 import spack.package_base
-import spack.repo
 import spack.stage
 import spack.util.web
 from spack.main import SpackCommand
@@ -280,7 +279,7 @@ def test_checksum_interactive_unrecognized_command():
 
 
 def test_checksum_versions(mock_packages, can_fetch_versions, monkeypatch):
-    pkg_cls = spack.repo.PATH.get_pkg_class("zlib")
+    pkg_cls = mock_packages.get_pkg_class("zlib")
     versions = [str(v) for v in pkg_cls.versions]
     output = spack_checksum("zlib", *versions)
     assert "Found 3 versions" in output
@@ -304,7 +303,7 @@ def test_checksum_deprecated_version(mock_packages, can_fetch_versions):
 
 
 def test_checksum_url(mock_packages, config):
-    pkg_cls = spack.repo.PATH.get_pkg_class("zlib")
+    pkg_cls = mock_packages.get_pkg_class("zlib")
     with pytest.raises(spack.error.SpecSyntaxError):
         spack_checksum(f"{pkg_cls.url}")
 
@@ -325,7 +324,7 @@ def test_checksum_verification_fails(config, mock_packages, capfd, can_fetch_ver
 def test_checksum_manual_download_fails(mock_packages, monkeypatch):
     """Confirm that checksumming a manually downloadable package fails."""
     name = "zlib"
-    pkg_cls = spack.repo.PATH.get_pkg_class(name)
+    pkg_cls = mock_packages.get_pkg_class(name)
     versions = [str(v) for v in pkg_cls.versions]
     monkeypatch.setattr(spack.package_base.PackageBase, "manual_download", True)
 

--- a/lib/spack/spack/test/cmd/checksum.py
+++ b/lib/spack/spack/test/cmd/checksum.py
@@ -15,6 +15,7 @@ import spack.stage
 import spack.util.web
 from spack.main import SpackCommand
 from spack.package_base import ManualDownloadRequiredError
+from spack.repo import RepoPath
 from spack.stage import interactive_version_filter
 from spack.version import Version
 
@@ -278,7 +279,7 @@ def test_checksum_interactive_unrecognized_command():
     assert interactive_version_filter(v.copy(), input=input) == v
 
 
-def test_checksum_versions(mock_packages, can_fetch_versions, monkeypatch):
+def test_checksum_versions(mock_packages: RepoPath, can_fetch_versions, monkeypatch):
     pkg_cls = mock_packages.get_pkg_class("zlib")
     versions = [str(v) for v in pkg_cls.versions]
     output = spack_checksum("zlib", *versions)
@@ -321,7 +322,7 @@ def test_checksum_verification_fails(config, mock_packages, capfd, can_fetch_ver
     assert "Invalid checksum" in out
 
 
-def test_checksum_manual_download_fails(mock_packages, monkeypatch):
+def test_checksum_manual_download_fails(mock_packages: RepoPath, monkeypatch):
     """Confirm that checksumming a manually downloadable package fails."""
     name = "zlib"
     pkg_cls = mock_packages.get_pkg_class(name)

--- a/lib/spack/spack/test/cmd/ci.py
+++ b/lib/spack/spack/test/cmd/ci.py
@@ -2067,7 +2067,7 @@ def fetch_versions_invalid(monkeypatch):
 @pytest.mark.parametrize("versions", [["2.1.4"], ["2.1.4", "2.1.5"]])
 def test_ci_validate_standard_versions_valid(capfd, mock_packages, fetch_versions_match, versions):
     spec = spack.spec.Spec("diff-test")
-    pkg = spack.repo.PATH.get_pkg_class(spec.name)(spec)
+    pkg = mock_packages.get_pkg_class(spec.name)(spec)
     version_list = [spack.version.Version(v) for v in versions]
 
     assert spack.cmd.ci.validate_standard_versions(pkg, version_list)
@@ -2082,7 +2082,7 @@ def test_ci_validate_standard_versions_invalid(
     capfd, mock_packages, fetch_versions_invalid, versions
 ):
     spec = spack.spec.Spec("diff-test")
-    pkg = spack.repo.PATH.get_pkg_class(spec.name)(spec)
+    pkg = mock_packages.get_pkg_class(spec.name)(spec)
     version_list = [spack.version.Version(v) for v in versions]
 
     assert spack.cmd.ci.validate_standard_versions(pkg, version_list) is False
@@ -2097,7 +2097,7 @@ def test_ci_validate_git_versions_valid(
     capfd, monkeypatch, mock_packages, mock_git_version_info, versions
 ):
     spec = spack.spec.Spec("diff-test")
-    pkg_class = spack.repo.PATH.get_pkg_class(spec.name)
+    pkg_class = mock_packages.get_pkg_class(spec.name)
     pkg = pkg_class(spec)
     version_list = [spack.version.Version(v) for v, _ in versions]
 
@@ -2121,7 +2121,7 @@ def test_ci_validate_git_versions_bad_tag(
     capfd, monkeypatch, mock_packages, mock_git_version_info, versions
 ):
     spec = spack.spec.Spec("diff-test")
-    pkg_class = spack.repo.PATH.get_pkg_class(spec.name)
+    pkg_class = mock_packages.get_pkg_class(spec.name)
     pkg = pkg_class(spec)
     version_list = [spack.version.Version(v) for v, _ in versions]
 
@@ -2145,7 +2145,7 @@ def test_ci_validate_git_versions_invalid(
     capfd, monkeypatch, mock_packages, mock_git_version_info, versions
 ):
     spec = spack.spec.Spec("diff-test")
-    pkg_class = spack.repo.PATH.get_pkg_class(spec.name)
+    pkg_class = mock_packages.get_pkg_class(spec.name)
     pkg = pkg_class(spec)
     version_list = [spack.version.Version(v) for v, _ in versions]
 
@@ -2278,10 +2278,10 @@ def test_ci_verify_versions_standard_duplicates(
 
 def test_ci_verify_versions_manual_package(monkeypatch, mock_packages, mock_git_package_changes):
     repo, _, commits = mock_git_package_changes
-    with spack.repo.use_repositories(repo):
+    with spack.repo.use_repositories(repo) as repos:
         monkeypatch.setattr(spack.repo, "builtin_repo", lambda: repo)
 
-        pkg_class = spack.repo.PATH.get_pkg_class("diff-test")
+        pkg_class = repos.get_pkg_class("diff-test")
         monkeypatch.setattr(pkg_class, "manual_download", True)
 
         out = ci_cmd("verify-versions", commits[-1], commits[-2])

--- a/lib/spack/spack/test/cmd/common/arguments.py
+++ b/lib/spack/spack/test/cmd/common/arguments.py
@@ -11,6 +11,7 @@ import spack.config
 import spack.environment as ev
 import spack.main
 from spack.cmd.common import arguments
+from spack.config import Configuration
 
 
 @pytest.fixture()
@@ -127,7 +128,7 @@ def test_root_and_dep_match_returns_root(mock_packages, mutable_mock_env_path):
         ("--fresh-roots", "dependencies"),
     ],
 )
-def test_concretizer_arguments(mutable_config, mock_packages, arg, conf):
+def test_concretizer_arguments(mutable_config: Configuration, mock_packages, arg, conf):
     """Ensure that ConfigSetAction is doing the right thing."""
     spec = spack.main.SpackCommand("spec")
 

--- a/lib/spack/spack/test/cmd/common/arguments.py
+++ b/lib/spack/spack/test/cmd/common/arguments.py
@@ -131,12 +131,12 @@ def test_concretizer_arguments(mutable_config, mock_packages, arg, conf):
     """Ensure that ConfigSetAction is doing the right thing."""
     spec = spack.main.SpackCommand("spec")
 
-    assert spack.config.get("concretizer:reuse", None, scope="command_line") is None
+    assert mutable_config.get("concretizer:reuse", None, scope="command_line") is None
 
     spec(arg, "zlib")
 
-    assert spack.config.get("concretizer:reuse", None) == conf
-    assert spack.config.get("concretizer:reuse", None, scope="command_line") == conf
+    assert mutable_config.get("concretizer:reuse", None) == conf
+    assert mutable_config.get("concretizer:reuse", None, scope="command_line") == conf
 
 
 def test_use_buildcache_type():

--- a/lib/spack/spack/test/cmd/common/arguments.py
+++ b/lib/spack/spack/test/cmd/common/arguments.py
@@ -28,13 +28,13 @@ def job_parser():
 def test_setting_jobs_flag(job_parser):
     namespace = job_parser.parse_args(["-j", "24"])
     assert namespace.jobs == 24
-    assert spack.config.get("config:build_jobs", scope="command_line") == 24
+    assert spack.config.CONFIG.get("config:build_jobs", scope="command_line") == 24
 
 
 def test_omitted_job_flag(job_parser):
     namespace = job_parser.parse_args([])
     assert namespace.jobs is None
-    assert spack.config.get("config:build_jobs") is None
+    assert spack.config.CONFIG.get("config:build_jobs") is None
 
 
 def test_negative_integers_not_allowed_for_parallel_jobs(job_parser):

--- a/lib/spack/spack/test/cmd/common/arguments.py
+++ b/lib/spack/spack/test/cmd/common/arguments.py
@@ -162,7 +162,7 @@ def test_missing_config_scopes_are_valid_scope_arguments(mock_missing_dir_includ
     a.add_argument(
         "--scope",
         action=arguments.ConfigScope,
-        default=lambda: spack.config.default_modify_scope(),
+        default=lambda: spack.config.CONFIG.default_modify_scope(),
         help="configuration scope to modify",
     )
     namespace = a.parse_args(["--scope", "sub_base"])
@@ -177,7 +177,7 @@ def test_missing_config_scopes_not_valid_read_scope(mock_missing_dir_include_sco
         "--scope",
         action=arguments.ConfigScope,
         type=arguments.config_scope_readable_validator,
-        default=lambda: spack.config.default_modify_scope(),
+        default=lambda: spack.config.CONFIG.default_modify_scope(),
         help="configuration scope to modify",
     )
     with pytest.raises(SystemExit):

--- a/lib/spack/spack/test/cmd/compiler.py
+++ b/lib/spack/spack/test/cmd/compiler.py
@@ -8,7 +8,6 @@ import pytest
 
 import spack.cmd.compiler
 import spack.compilers.config
-import spack.config
 import spack.main
 import spack.util.pattern
 import spack.version
@@ -97,8 +96,8 @@ def test_compiler_remove(mutable_config):
 @pytest.mark.regression("37996")
 def test_removing_compilers_from_multiple_scopes(mutable_config):
     # Duplicate "site" scope into "user" scope
-    site_config = spack.config.get("packages", scope="site")
-    spack.config.set("packages", site_config, scope="user")
+    site_config = mutable_config.get("packages", scope="site")
+    mutable_config.set("packages", site_config, scope="user")
 
     assert any(
         compiler.satisfies("gcc@=9.4.0") for compiler in spack.compilers.config.all_compilers()
@@ -237,15 +236,15 @@ def test_compiler_list_empty(no_packages_yaml, compilers_dir, monkeypatch):
     ],
 )
 def test_compilers_shows_packages_yaml(
-    external, expected, no_packages_yaml, working_env, compilers_dir
+    external, expected, no_packages_yaml, working_env, compilers_dir, mutable_config
 ):
     """Spack should see a single compiler defined from packages.yaml"""
     external["prefix"] = external["prefix"].format(prefix=os.path.dirname(compilers_dir))
     gcc_entry = {"externals": [external]}
 
-    packages = spack.config.get("packages")
+    packages = mutable_config.get("packages")
     packages["gcc"] = gcc_entry
-    spack.config.set("packages", packages)
+    mutable_config.set("packages", packages)
 
     out = compiler("list", fail_on_error=True)
     assert out.count("gcc@7.7.7") == 1

--- a/lib/spack/spack/test/cmd/compiler.py
+++ b/lib/spack/spack/test/cmd/compiler.py
@@ -11,6 +11,7 @@ import spack.compilers.config
 import spack.main
 import spack.util.pattern
 import spack.version
+from spack.config import Configuration
 
 compiler = spack.main.SpackCommand("compiler")
 
@@ -94,7 +95,7 @@ def test_compiler_remove(mutable_config):
 
 
 @pytest.mark.regression("37996")
-def test_removing_compilers_from_multiple_scopes(mutable_config):
+def test_removing_compilers_from_multiple_scopes(mutable_config: Configuration):
     # Duplicate "site" scope into "user" scope
     site_config = mutable_config.get("packages", scope="site")
     mutable_config.set("packages", site_config, scope="user")
@@ -236,7 +237,7 @@ def test_compiler_list_empty(no_packages_yaml, compilers_dir, monkeypatch):
     ],
 )
 def test_compilers_shows_packages_yaml(
-    external, expected, no_packages_yaml, working_env, compilers_dir, mutable_config
+    external, expected, no_packages_yaml, working_env, compilers_dir, mutable_config: Configuration
 ):
     """Spack should see a single compiler defined from packages.yaml"""
     external["prefix"] = external["prefix"].format(prefix=os.path.dirname(compilers_dir))

--- a/lib/spack/spack/test/cmd/config.py
+++ b/lib/spack/spack/test/cmd/config.py
@@ -17,7 +17,6 @@ import spack.database
 import spack.environment as ev
 import spack.main
 import spack.schema.config
-import spack.store
 import spack.util.filesystem as fs
 import spack.util.spack_yaml as syaml
 
@@ -663,6 +662,7 @@ def test_config_update_shared_linking(mutable_config):
 
 def test_config_prefer_upstream(
     tmp_path_factory: pytest.TempPathFactory,
+    temporary_store,
     install_mockery,
     mock_fetch,
     mutable_config,
@@ -682,7 +682,7 @@ def test_config_prefer_upstream(
 
     downstream_db_root = str(tmp_path_factory.mktemp("mock_downstream_db_root"))
     db_for_test = spack.database.Database(downstream_db_root, upstream_dbs=[prepared_db])
-    monkeypatch.setattr(spack.store.STORE, "db", db_for_test)
+    monkeypatch.setattr(temporary_store, "db", db_for_test)
 
     output = config("prefer-upstream")
     scope = spack.config.default_modify_scope("packages")

--- a/lib/spack/spack/test/cmd/config.py
+++ b/lib/spack/spack/test/cmd/config.py
@@ -219,7 +219,7 @@ repos:
 def test_config_edit(mutable_config, working_env):
     """Ensure `spack config edit` edits the right paths."""
 
-    dms = spack.config.CONFIG.default_modify_scope("compilers")
+    dms = mutable_config.default_modify_scope("compilers")
     dms_path = mutable_config.scopes[dms].path
     user_path = mutable_config.scopes["user"].path
 
@@ -685,7 +685,7 @@ def test_config_prefer_upstream(
     monkeypatch.setattr(temporary_store, "db", db_for_test)
 
     output = config("prefer-upstream")
-    scope = spack.config.CONFIG.default_modify_scope("packages")
+    scope = mutable_config.default_modify_scope("packages")
     cfg_file = mutable_config.get_config_filename(scope, "packages")
     packages = syaml.load(open(cfg_file, encoding="utf-8"))["packages"]
 
@@ -774,7 +774,7 @@ def test_config_with_unknown_group_gives_clear_error(cmd_str, tmp_path, mutable_
 @pytest.mark.regression("52152")
 def test_config_edit_creates_scope_dir(mutable_config, working_env, monkeypatch):
     """Tests that `spack config edit` can create the scope directory if it does not exist."""
-    scope_name = spack.config.CONFIG.default_modify_scope("config")
+    scope_name = mutable_config.default_modify_scope("config")
     scope_dir = pathlib.Path(mutable_config.scopes[scope_name].path)
 
     # Remove the scope directory to simulate a "fresh start" with no ~/.spack

--- a/lib/spack/spack/test/cmd/config.py
+++ b/lib/spack/spack/test/cmd/config.py
@@ -27,7 +27,7 @@ pytestmark = pytest.mark.usefixtures("mock_packages")
 
 
 def _create_config(scope=None, data={}, section="packages"):
-    scope = scope or spack.config.default_modify_scope()
+    scope = scope or spack.config.CONFIG.default_modify_scope()
     cfg_file = spack.config.CONFIG.get_config_filename(scope, section)
     with open(cfg_file, "w", encoding="utf-8") as f:
         syaml.dump(data, stream=f)
@@ -219,7 +219,7 @@ repos:
 def test_config_edit(mutable_config, working_env):
     """Ensure `spack config edit` edits the right paths."""
 
-    dms = spack.config.default_modify_scope("compilers")
+    dms = spack.config.CONFIG.default_modify_scope("compilers")
     dms_path = mutable_config.scopes[dms].path
     user_path = mutable_config.scopes["user"].path
 
@@ -685,7 +685,7 @@ def test_config_prefer_upstream(
     monkeypatch.setattr(temporary_store, "db", db_for_test)
 
     output = config("prefer-upstream")
-    scope = spack.config.default_modify_scope("packages")
+    scope = spack.config.CONFIG.default_modify_scope("packages")
     cfg_file = mutable_config.get_config_filename(scope, "packages")
     packages = syaml.load(open(cfg_file, encoding="utf-8"))["packages"]
 
@@ -774,7 +774,7 @@ def test_config_with_unknown_group_gives_clear_error(cmd_str, tmp_path, mutable_
 @pytest.mark.regression("52152")
 def test_config_edit_creates_scope_dir(mutable_config, working_env, monkeypatch):
     """Tests that `spack config edit` can create the scope directory if it does not exist."""
-    scope_name = spack.config.default_modify_scope("config")
+    scope_name = spack.config.CONFIG.default_modify_scope("config")
     scope_dir = pathlib.Path(mutable_config.scopes[scope_name].path)
 
     # Remove the scope directory to simulate a "fresh start" with no ~/.spack

--- a/lib/spack/spack/test/cmd/config.py
+++ b/lib/spack/spack/test/cmd/config.py
@@ -1,7 +1,6 @@
 # Copyright Spack Project Developers. See COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
-import functools
 import json
 import os
 import pathlib
@@ -24,24 +23,6 @@ config = spack.main.SpackCommand("config")
 env = spack.main.SpackCommand("env")
 
 pytestmark = pytest.mark.usefixtures("mock_packages")
-
-
-def _create_config(scope=None, data={}, section="packages"):
-    scope = scope or spack.config.CONFIG.default_modify_scope()
-    cfg_file = spack.config.CONFIG.get_config_filename(scope, section)
-    with open(cfg_file, "w", encoding="utf-8") as f:
-        syaml.dump(data, stream=f)
-    return cfg_file
-
-
-@pytest.fixture()
-def config_yaml_v015(mutable_config):
-    """Create a packages.yaml in the old format"""
-    old_data = {
-        "config": {"install_tree": "/fake/path", "install_path_scheme": "{name}-{version}"}
-    }
-    return functools.partial(_create_config, data=old_data, section="config")
-
 
 scope_path_re = r"\(([^\)]+)\)"
 

--- a/lib/spack/spack/test/cmd/config.py
+++ b/lib/spack/spack/test/cmd/config.py
@@ -18,6 +18,8 @@ import spack.main
 import spack.schema.config
 import spack.util.filesystem as fs
 import spack.util.spack_yaml as syaml
+from spack.config import Configuration
+from spack.store import Store
 
 config = spack.main.SpackCommand("config")
 env = spack.main.SpackCommand("env")
@@ -225,7 +227,7 @@ def test_config_edit_edits_spack_yaml(mutable_mock_env_path):
         assert config("edit", "--print-file").strip() == env.manifest_path
 
 
-def test_config_add_with_scope_adds_to_scope(mutable_config, mutable_mock_env_path):
+def test_config_add_with_scope_adds_to_scope(mutable_config: Configuration, mutable_mock_env_path):
     """Test adding to non-env config scope with an active environment"""
     env = ev.create("test")
     with env:
@@ -626,14 +628,14 @@ def test_config_remove_from_env(mutable_empty_config, mutable_mock_env_path):
     assert "dirty: true" not in output
 
 
-def test_config_update_not_needed(mutable_config):
+def test_config_update_not_needed(mutable_config: Configuration):
     data_before = mutable_config.get("repos")
     config("update", "-y", "repos")
     data_after = mutable_config.get("repos")
     assert data_before == data_after
 
 
-def test_config_update_shared_linking(mutable_config):
+def test_config_update_shared_linking(mutable_config: Configuration):
     # Old syntax: config:shared_linking:rpath/runpath
     # New syntax: config:shared_linking:{type:rpath/runpath,bind:True/False}
     with mutable_config.override("config:shared_linking", "runpath"):
@@ -643,10 +645,10 @@ def test_config_update_shared_linking(mutable_config):
 
 def test_config_prefer_upstream(
     tmp_path_factory: pytest.TempPathFactory,
-    temporary_store,
+    temporary_store: Store,
     install_mockery,
     mock_fetch,
-    mutable_config,
+    mutable_config: Configuration,
     gen_mock_layout,
     monkeypatch,
 ):

--- a/lib/spack/spack/test/cmd/config.py
+++ b/lib/spack/spack/test/cmd/config.py
@@ -220,8 +220,8 @@ def test_config_edit(mutable_config, working_env):
     """Ensure `spack config edit` edits the right paths."""
 
     dms = spack.config.default_modify_scope("compilers")
-    dms_path = spack.config.CONFIG.scopes[dms].path
-    user_path = spack.config.CONFIG.scopes["user"].path
+    dms_path = mutable_config.scopes[dms].path
+    user_path = mutable_config.scopes["user"].path
 
     comp_path = os.path.join(dms_path, "compilers.yaml")
     repos_path = os.path.join(user_path, "repos.yaml")
@@ -249,7 +249,7 @@ def test_config_add_with_scope_adds_to_scope(mutable_config, mutable_mock_env_pa
     env = ev.create("test")
     with env:
         config("--scope=user", "add", "config:install_tree:root:/usr")
-    assert spack.config.get("config:install_tree:root", scope="user") == "/usr"
+    assert mutable_config.get("config:install_tree:root", scope="user") == "/usr"
 
 
 def test_config_edit_fails_correctly_with_no_env(mutable_mock_env_path):
@@ -646,18 +646,18 @@ def test_config_remove_from_env(mutable_empty_config, mutable_mock_env_path):
 
 
 def test_config_update_not_needed(mutable_config):
-    data_before = spack.config.get("repos")
+    data_before = mutable_config.get("repos")
     config("update", "-y", "repos")
-    data_after = spack.config.get("repos")
+    data_after = mutable_config.get("repos")
     assert data_before == data_after
 
 
 def test_config_update_shared_linking(mutable_config):
     # Old syntax: config:shared_linking:rpath/runpath
     # New syntax: config:shared_linking:{type:rpath/runpath,bind:True/False}
-    with spack.config.override("config:shared_linking", "runpath"):
-        assert spack.config.get("config:shared_linking:type") == "runpath"
-        assert not spack.config.get("config:shared_linking:bind")
+    with mutable_config.override("config:shared_linking", "runpath"):
+        assert mutable_config.get("config:shared_linking:type") == "runpath"
+        assert not mutable_config.get("config:shared_linking:bind")
 
 
 def test_config_prefer_upstream(
@@ -686,7 +686,7 @@ def test_config_prefer_upstream(
 
     output = config("prefer-upstream")
     scope = spack.config.default_modify_scope("packages")
-    cfg_file = spack.config.CONFIG.get_config_filename(scope, "packages")
+    cfg_file = mutable_config.get_config_filename(scope, "packages")
     packages = syaml.load(open(cfg_file, encoding="utf-8"))["packages"]
 
     # Make sure only the non-default variants are set.

--- a/lib/spack/spack/test/cmd/dependencies.py
+++ b/lib/spack/spack/test/cmd/dependencies.py
@@ -6,7 +6,6 @@ import re
 
 import pytest
 
-import spack.store
 from spack.main import SpackCommand
 from spack.util.tty.color import color_when
 
@@ -55,7 +54,7 @@ def test_direct_installed_dependencies(mock_packages, database):
     with color_when(False):
         out = dependencies("--installed", "mpileaks^mpich")
 
-    root = spack.store.STORE.db.query_one("mpileaks ^mpich")
+    root = database.query_one("mpileaks ^mpich")
 
     lines = [line for line in out.strip().split("\n") if line and not line.startswith("--")]
     hashes = {re.split(r"\s+", line)[0] for line in lines}
@@ -69,7 +68,7 @@ def test_transitive_installed_dependencies(mock_packages, database):
     with color_when(False):
         out = dependencies("--installed", "--transitive", "mpileaks^zmpi")
 
-    root = spack.store.STORE.db.query_one("mpileaks ^zmpi")
+    root = database.query_one("mpileaks ^zmpi")
 
     lines = [line for line in out.strip().split("\n") if line and not line.startswith("--")]
     hashes = {re.split(r"\s+", line)[0] for line in lines}

--- a/lib/spack/spack/test/cmd/dependents.py
+++ b/lib/spack/spack/test/cmd/dependents.py
@@ -6,7 +6,6 @@ import re
 
 import pytest
 
-import spack.store
 from spack.main import SpackCommand
 from spack.util.tty.color import color_when
 
@@ -55,11 +54,9 @@ def test_immediate_installed_dependents(mock_packages, database):
     lines = [li for li in out.strip().split("\n") if not li.startswith("--")]
     hashes = set([re.split(r"\s+", li)[0] for li in lines if li])
 
-    expected = set(
-        [spack.store.STORE.db.query_one(s).dag_hash(7) for s in ["dyninst", "libdwarf"]]
-    )
+    expected = set([database.query_one(s).dag_hash(7) for s in ["dyninst", "libdwarf"]])
 
-    libelf = spack.store.STORE.db.query_one("libelf")
+    libelf = database.query_one("libelf")
     expected = set([d.dag_hash(7) for d in libelf.dependents()])
 
     assert expected == hashes
@@ -74,10 +71,7 @@ def test_transitive_installed_dependents(mock_packages, database):
     hashes = set([re.split(r"\s+", li)[0] for li in lines])
 
     expected = set(
-        [
-            spack.store.STORE.db.query_one(s).dag_hash(7)
-            for s in ["zmpi", "callpath^zmpi", "mpileaks^zmpi"]
-        ]
+        [database.query_one(s).dag_hash(7) for s in ["zmpi", "callpath^zmpi", "mpileaks^zmpi"]]
     )
 
     assert expected == hashes

--- a/lib/spack/spack/test/cmd/deprecate.py
+++ b/lib/spack/spack/test/cmd/deprecate.py
@@ -10,6 +10,7 @@ import spack.concretize
 import spack.spec
 from spack.enums import InstallRecordStatus
 from spack.main import SpackCommand
+from spack.store import Store
 
 install = SpackCommand("install")
 uninstall = SpackCommand("uninstall")
@@ -20,7 +21,9 @@ find = SpackCommand("find")
 pytestmark = pytest.mark.usefixtures("mutable_mock_env_path")
 
 
-def test_deprecate(mock_packages, mock_archive, mock_fetch, temporary_store, install_mockery):
+def test_deprecate(
+    mock_packages, mock_archive, mock_fetch, temporary_store: Store, install_mockery
+):
     install("--fake", "libelf@0.8.13")
     install("--fake", "libelf@0.8.10")
 
@@ -50,7 +53,7 @@ def test_deprecate_fails_no_such_package(mock_packages, mock_archive, mock_fetch
 
 
 def test_deprecate_install(
-    mock_packages, mock_archive, mock_fetch, temporary_store, install_mockery, monkeypatch
+    mock_packages, mock_archive, mock_fetch, temporary_store: Store, install_mockery, monkeypatch
 ):
     """Tests that the -i option allows us to deprecate in favor of a spec
     that is not yet installed.
@@ -92,7 +95,7 @@ def test_deprecate_deps(mock_packages, mock_archive, mock_fetch, temporary_store
 
 
 def test_uninstall_deprecated(
-    mock_packages, mock_archive, mock_fetch, temporary_store, install_mockery
+    mock_packages, mock_archive, mock_fetch, temporary_store: Store, install_mockery
 ):
     """Tests that we can still uninstall deprecated packages."""
     install("--fake", "libelf@0.8.13")
@@ -111,7 +114,7 @@ def test_uninstall_deprecated(
 
 
 def test_deprecate_already_deprecated(
-    mock_packages, mock_archive, mock_fetch, temporary_store, install_mockery
+    mock_packages, mock_archive, mock_fetch, temporary_store: Store, install_mockery
 ):
     """Tests that we can re-deprecate a spec to change its deprecator."""
     install("--fake", "libelf@0.8.13")
@@ -137,7 +140,7 @@ def test_deprecate_already_deprecated(
 
 
 def test_deprecate_deprecator(
-    mock_packages, mock_archive, mock_fetch, temporary_store, install_mockery
+    mock_packages, mock_archive, mock_fetch, temporary_store: Store, install_mockery
 ):
     """Tests that when a deprecator spec is deprecated, its deprecatee specs
     are updated to point to the new deprecator."""

--- a/lib/spack/spack/test/cmd/deprecate.py
+++ b/lib/spack/spack/test/cmd/deprecate.py
@@ -8,7 +8,6 @@ import pytest
 
 import spack.concretize
 import spack.spec
-import spack.store
 from spack.enums import InstallRecordStatus
 from spack.main import SpackCommand
 
@@ -21,19 +20,19 @@ find = SpackCommand("find")
 pytestmark = pytest.mark.usefixtures("mutable_mock_env_path")
 
 
-def test_deprecate(mock_packages, mock_archive, mock_fetch, install_mockery):
+def test_deprecate(mock_packages, mock_archive, mock_fetch, temporary_store, install_mockery):
     install("--fake", "libelf@0.8.13")
     install("--fake", "libelf@0.8.10")
 
-    all_installed = spack.store.STORE.db.query("libelf")
+    all_installed = temporary_store.db.query("libelf")
     assert len(all_installed) == 2
 
     deprecate("-y", "libelf@0.8.10", "libelf@0.8.13")
 
-    non_deprecated = spack.store.STORE.db.query("libelf")
-    all_available = spack.store.STORE.db.query("libelf", installed=InstallRecordStatus.ANY)
+    non_deprecated = temporary_store.db.query("libelf")
+    all_available = temporary_store.db.query("libelf", installed=InstallRecordStatus.ANY)
     assert all_available == all_installed
-    assert non_deprecated == spack.store.STORE.db.query("libelf@0.8.13")
+    assert non_deprecated == temporary_store.db.query("libelf@0.8.13")
 
 
 def test_deprecate_fails_no_such_package(mock_packages, mock_archive, mock_fetch, install_mockery):
@@ -50,24 +49,26 @@ def test_deprecate_fails_no_such_package(mock_packages, mock_archive, mock_fetch
     assert "Spec 'libelf@0.8.13' matches no installed packages" in output
 
 
-def test_deprecate_install(mock_packages, mock_archive, mock_fetch, install_mockery, monkeypatch):
+def test_deprecate_install(
+    mock_packages, mock_archive, mock_fetch, temporary_store, install_mockery, monkeypatch
+):
     """Tests that the -i option allows us to deprecate in favor of a spec
     that is not yet installed.
     """
     install("--fake", "libelf@0.8.10")
-    to_deprecate = spack.store.STORE.db.query("libelf")
+    to_deprecate = temporary_store.db.query("libelf")
     assert len(to_deprecate) == 1
 
     deprecate("-y", "-i", "libelf@0.8.10", "libelf@0.8.13")
 
-    non_deprecated = spack.store.STORE.db.query("libelf")
-    deprecated = spack.store.STORE.db.query("libelf", installed=InstallRecordStatus.DEPRECATED)
+    non_deprecated = temporary_store.db.query("libelf")
+    deprecated = temporary_store.db.query("libelf", installed=InstallRecordStatus.DEPRECATED)
     assert deprecated == to_deprecate
     assert len(non_deprecated) == 1
     assert non_deprecated[0].satisfies("libelf@0.8.13")
 
 
-def test_deprecate_deps(mock_packages, mock_archive, mock_fetch, install_mockery):
+def test_deprecate_deps(mock_packages, mock_archive, mock_fetch, temporary_store, install_mockery):
     """Test that the deprecate command deprecates all dependencies properly."""
     install("--fake", "libdwarf@20130729 ^libelf@0.8.13")
     install("--fake", "libdwarf@20130207 ^libelf@0.8.10")
@@ -75,13 +76,13 @@ def test_deprecate_deps(mock_packages, mock_archive, mock_fetch, install_mockery
     new_spec = spack.concretize.concretize_one("libdwarf@20130729^libelf@0.8.13")
     old_spec = spack.concretize.concretize_one("libdwarf@20130207^libelf@0.8.10")
 
-    all_installed = spack.store.STORE.db.query()
+    all_installed = temporary_store.db.query()
 
     deprecate("-y", "-d", "libdwarf@20130207", "libdwarf@20130729")
 
-    non_deprecated = spack.store.STORE.db.query()
-    all_available = spack.store.STORE.db.query(installed=InstallRecordStatus.ANY)
-    deprecated = spack.store.STORE.db.query(installed=InstallRecordStatus.DEPRECATED)
+    non_deprecated = temporary_store.db.query()
+    all_available = temporary_store.db.query(installed=InstallRecordStatus.ANY)
+    deprecated = temporary_store.db.query(installed=InstallRecordStatus.DEPRECATED)
 
     assert all_available == all_installed
     assert sorted(all_available) == sorted(deprecated + non_deprecated)
@@ -90,24 +91,28 @@ def test_deprecate_deps(mock_packages, mock_archive, mock_fetch, install_mockery
     assert sorted(deprecated) == sorted([old_spec, old_spec["libelf"]])
 
 
-def test_uninstall_deprecated(mock_packages, mock_archive, mock_fetch, install_mockery):
+def test_uninstall_deprecated(
+    mock_packages, mock_archive, mock_fetch, temporary_store, install_mockery
+):
     """Tests that we can still uninstall deprecated packages."""
     install("--fake", "libelf@0.8.13")
     install("--fake", "libelf@0.8.10")
 
     deprecate("-y", "libelf@0.8.10", "libelf@0.8.13")
 
-    non_deprecated = spack.store.STORE.db.query()
+    non_deprecated = temporary_store.db.query()
 
     uninstall("-y", "libelf@0.8.10")
 
-    assert spack.store.STORE.db.query() == spack.store.STORE.db.query(
+    assert temporary_store.db.query() == temporary_store.db.query(
         installed=InstallRecordStatus.ANY
     )
-    assert spack.store.STORE.db.query() == non_deprecated
+    assert temporary_store.db.query() == non_deprecated
 
 
-def test_deprecate_already_deprecated(mock_packages, mock_archive, mock_fetch, install_mockery):
+def test_deprecate_already_deprecated(
+    mock_packages, mock_archive, mock_fetch, temporary_store, install_mockery
+):
     """Tests that we can re-deprecate a spec to change its deprecator."""
     install("--fake", "libelf@0.8.13")
     install("--fake", "libelf@0.8.12")
@@ -117,21 +122,23 @@ def test_deprecate_already_deprecated(mock_packages, mock_archive, mock_fetch, i
 
     deprecate("-y", "libelf@0.8.10", "libelf@0.8.12")
 
-    deprecator = spack.store.STORE.db.deprecator(deprecated_spec)
+    deprecator = temporary_store.db.deprecator(deprecated_spec)
     assert deprecator == spack.concretize.concretize_one("libelf@0.8.12")
 
     deprecate("-y", "libelf@0.8.10", "libelf@0.8.13")
 
-    non_deprecated = spack.store.STORE.db.query("libelf")
-    all_available = spack.store.STORE.db.query("libelf", installed=InstallRecordStatus.ANY)
+    non_deprecated = temporary_store.db.query("libelf")
+    all_available = temporary_store.db.query("libelf", installed=InstallRecordStatus.ANY)
     assert len(non_deprecated) == 2
     assert len(all_available) == 3
 
-    deprecator = spack.store.STORE.db.deprecator(deprecated_spec)
+    deprecator = temporary_store.db.deprecator(deprecated_spec)
     assert deprecator == spack.concretize.concretize_one("libelf@0.8.13")
 
 
-def test_deprecate_deprecator(mock_packages, mock_archive, mock_fetch, install_mockery):
+def test_deprecate_deprecator(
+    mock_packages, mock_archive, mock_fetch, temporary_store, install_mockery
+):
     """Tests that when a deprecator spec is deprecated, its deprecatee specs
     are updated to point to the new deprecator."""
     install("--fake", "libelf@0.8.13")
@@ -144,19 +151,19 @@ def test_deprecate_deprecator(mock_packages, mock_archive, mock_fetch, install_m
 
     deprecate("-y", "libelf@0.8.10", "libelf@0.8.12")
 
-    deprecator = spack.store.STORE.db.deprecator(first_deprecated_spec)
+    deprecator = temporary_store.db.deprecator(first_deprecated_spec)
     assert deprecator == second_deprecated_spec
 
     deprecate("-y", "libelf@0.8.12", "libelf@0.8.13")
 
-    non_deprecated = spack.store.STORE.db.query("libelf")
-    all_available = spack.store.STORE.db.query("libelf", installed=InstallRecordStatus.ANY)
+    non_deprecated = temporary_store.db.query("libelf")
+    all_available = temporary_store.db.query("libelf", installed=InstallRecordStatus.ANY)
     assert len(non_deprecated) == 1
     assert len(all_available) == 3
 
-    first_deprecator = spack.store.STORE.db.deprecator(first_deprecated_spec)
+    first_deprecator = temporary_store.db.deprecator(first_deprecated_spec)
     assert first_deprecator == final_deprecator
-    second_deprecator = spack.store.STORE.db.deprecator(second_deprecated_spec)
+    second_deprecator = temporary_store.db.deprecator(second_deprecated_spec)
     assert second_deprecator == final_deprecator
 
 

--- a/lib/spack/spack/test/cmd/dev_build.py
+++ b/lib/spack/spack/test/cmd/dev_build.py
@@ -304,7 +304,7 @@ spack:
 
 
 def test_dev_build_multiple(
-    tmp_path: pathlib.Path, install_mockery, mutable_mock_env_path, mock_fetch
+    tmp_path: pathlib.Path, install_mockery, mutable_mock_env_path, mock_fetch, mock_packages
 ):
     """Test spack install with multiple developer builds
 
@@ -319,7 +319,7 @@ def test_dev_build_multiple(
     leaf_dir = tmp_path / "leaf"
     leaf_dir.mkdir()
     leaf_spec = spack.spec.Spec("dev-build-test-install@=1.0.0")  # non-existing version
-    leaf_pkg_cls = spack.repo.PATH.get_pkg_class(leaf_spec.name)
+    leaf_pkg_cls = mock_packages.get_pkg_class(leaf_spec.name)
     with fs.working_dir(str(leaf_dir)):
         with open(leaf_pkg_cls.filename, "w", encoding="utf-8") as f:  # type: ignore
             f.write(leaf_pkg_cls.original_string)  # type: ignore
@@ -329,7 +329,7 @@ def test_dev_build_multiple(
     root_dir = tmp_path / "root"
     root_dir.mkdir()
     root_spec = spack.spec.Spec("dev-build-test-dependent@0.0.0")
-    root_pkg_cls = spack.repo.PATH.get_pkg_class(root_spec.name)
+    root_pkg_cls = mock_packages.get_pkg_class(root_spec.name)
     with fs.working_dir(str(root_dir)):
         with open(root_pkg_cls.filename, "w", encoding="utf-8") as f:  # type: ignore
             f.write(root_pkg_cls.original_string)  # type: ignore
@@ -373,7 +373,7 @@ spack:
 
 
 def test_dev_build_env_dependency(
-    tmp_path: pathlib.Path, install_mockery, mock_fetch, mutable_mock_env_path
+    tmp_path: pathlib.Path, install_mockery, mock_fetch, mutable_mock_env_path, mock_packages
 ):
     """
     Test non-root specs in an environment are properly marked for dev builds.
@@ -385,7 +385,7 @@ def test_dev_build_env_dependency(
     dep_spec = spack.spec.Spec("dev-build-test-install")
 
     with fs.working_dir(str(build_dir)):
-        dep_pkg_cls = spack.repo.PATH.get_pkg_class(dep_spec.name)
+        dep_pkg_cls = mock_packages.get_pkg_class(dep_spec.name)
         with open(dep_pkg_cls.filename, "w", encoding="utf-8") as f:  # type: ignore
             f.write(dep_pkg_cls.original_string)  # type: ignore
 

--- a/lib/spack/spack/test/cmd/dev_build.py
+++ b/lib/spack/spack/test/cmd/dev_build.py
@@ -15,6 +15,8 @@ import spack.repo
 import spack.spec
 import spack.util.filesystem as fs
 from spack.main import SpackCommand
+from spack.repo import RepoPath
+from spack.store import Store
 
 dev_build = SpackCommand("dev-build")
 install = SpackCommand("install")
@@ -63,7 +65,7 @@ def test_dev_build_before(tmp_path: pathlib.Path, install_mockery, installer_var
 
 @pytest.mark.parametrize("last_phase", ["edit", "install"])
 def test_dev_build_until(
-    tmp_path: pathlib.Path, temporary_store, install_mockery, last_phase, installer_variant
+    tmp_path: pathlib.Path, temporary_store: Store, install_mockery, last_phase, installer_variant
 ):
     spec = spack.concretize.concretize_one(
         spack.spec.Spec(f"dev-build-test-install@0.0.0 dev_path={tmp_path}")
@@ -304,7 +306,11 @@ spack:
 
 
 def test_dev_build_multiple(
-    tmp_path: pathlib.Path, install_mockery, mutable_mock_env_path, mock_fetch, mock_packages
+    tmp_path: pathlib.Path,
+    install_mockery,
+    mutable_mock_env_path,
+    mock_fetch,
+    mock_packages: RepoPath,
 ):
     """Test spack install with multiple developer builds
 
@@ -373,7 +379,11 @@ spack:
 
 
 def test_dev_build_env_dependency(
-    tmp_path: pathlib.Path, install_mockery, mock_fetch, mutable_mock_env_path, mock_packages
+    tmp_path: pathlib.Path,
+    install_mockery,
+    mock_fetch,
+    mutable_mock_env_path,
+    mock_packages: RepoPath,
 ):
     """
     Test non-root specs in an environment are properly marked for dev builds.

--- a/lib/spack/spack/test/cmd/dev_build.py
+++ b/lib/spack/spack/test/cmd/dev_build.py
@@ -13,7 +13,6 @@ import spack.error
 import spack.main
 import spack.repo
 import spack.spec
-import spack.store
 import spack.util.filesystem as fs
 from spack.main import SpackCommand
 
@@ -63,7 +62,9 @@ def test_dev_build_before(tmp_path: pathlib.Path, install_mockery, installer_var
 
 
 @pytest.mark.parametrize("last_phase", ["edit", "install"])
-def test_dev_build_until(tmp_path: pathlib.Path, install_mockery, last_phase, installer_variant):
+def test_dev_build_until(
+    tmp_path: pathlib.Path, temporary_store, install_mockery, last_phase, installer_variant
+):
     spec = spack.concretize.concretize_one(
         spack.spec.Spec(f"dev-build-test-install@0.0.0 dev_path={tmp_path}")
     )
@@ -79,7 +80,7 @@ def test_dev_build_until(tmp_path: pathlib.Path, install_mockery, last_phase, in
             assert f.read() == spec.package.replacement_string  # type: ignore
 
     assert not os.path.exists(spec.prefix)
-    assert not spack.store.STORE.db.query(spec, installed=True)
+    assert not temporary_store.db.query(spec, installed=True)
 
 
 def test_dev_build_before_until(tmp_path: pathlib.Path, install_mockery, installer_variant):

--- a/lib/spack/spack/test/cmd/develop.py
+++ b/lib/spack/spack/test/cmd/develop.py
@@ -15,6 +15,7 @@ import spack.spec
 import spack.stage
 import spack.util.filesystem as fs
 import spack.util.git
+from spack.config import Configuration
 from spack.error import SpackError
 from spack.fetch_strategy import URLFetchStrategy
 from spack.main import SpackCommand
@@ -167,7 +168,7 @@ class TestDevelop:
             with pytest.raises(ev.SpackEnvironmentDevelopError, match="conflicts with concrete"):
                 develop("mpich@1.1")
 
-    def test_develop_applies_changes_path(self, monkeypatch, mutable_config):
+    def test_develop_applies_changes_path(self, monkeypatch, mutable_config: Configuration):
         env("create", "test")
         with ev.read("test") as e:
             e.add("mpich@1.0")

--- a/lib/spack/spack/test/cmd/develop.py
+++ b/lib/spack/spack/test/cmd/develop.py
@@ -36,7 +36,7 @@ class TestDevelop:
         assert dev_specs_entry["spec"] == str(spec)
 
         # check yaml representation
-        dev_config = spack.config.get("develop", {})
+        dev_config = spack.config.CONFIG.get("develop", {})
         assert spec.name in dev_config
         yaml_entry = dev_config[spec.name]
         assert yaml_entry["spec"] == str(spec)
@@ -48,7 +48,7 @@ class TestDevelop:
 
         if build_dir is not None:
             scope = env.scope_name
-            assert build_dir == spack.config.get(
+            assert build_dir == spack.config.CONFIG.get(
                 "packages:{}:package_attributes:build_directory".format(spec.name), scope
             )
 

--- a/lib/spack/spack/test/cmd/develop.py
+++ b/lib/spack/spack/test/cmd/develop.py
@@ -167,7 +167,7 @@ class TestDevelop:
             with pytest.raises(ev.SpackEnvironmentDevelopError, match="conflicts with concrete"):
                 develop("mpich@1.1")
 
-    def test_develop_applies_changes_path(self, monkeypatch):
+    def test_develop_applies_changes_path(self, monkeypatch, mutable_config):
         env("create", "test")
         with ev.read("test") as e:
             e.add("mpich@1.0")
@@ -186,7 +186,7 @@ class TestDevelop:
                 # Check modifications actually worked
                 spec = next(e.roots())
                 assert spec.satisfies(f"dev_path={path}")
-                assert spack.config.get("develop:mpich:path") == path
+                assert mutable_config.get("develop:mpich:path") == path
 
     def test_develop_no_modify(self, monkeypatch):
         env("create", "test")

--- a/lib/spack/spack/test/cmd/env.py
+++ b/lib/spack/spack/test/cmd/env.py
@@ -34,12 +34,14 @@ import spack.util.spack_json as sjson
 import spack.util.spack_yaml
 from spack.active_environment import active_environment
 from spack.cmd.env import _env_create
-from spack.config import substitute_path_variables
+from spack.config import Configuration, substitute_path_variables
 from spack.environment import depfile
 from spack.main import SpackCommand, SpackCommandError
 from spack.old_installer import PackageInstaller
+from spack.repo import RepoPath
 from spack.spec import Spec
 from spack.stage import stage_prefix
+from spack.store import Store
 from spack.test.conftest import RepoBuilder
 from spack.traverse import traverse_nodes
 from spack.util import tty
@@ -511,7 +513,7 @@ def test_env_specs_partition(install_mockery, mock_fetch):
     assert roots_to_install[0].name == "mpileaks"
 
 
-def test_env_install_all(temporary_store, install_mockery, mock_fetch):
+def test_env_install_all(temporary_store: Store, install_mockery, mock_fetch):
     e = ev.create("test")
     e.add("cmake-client")
     e.concretize()
@@ -540,7 +542,12 @@ def test_env_install_single_spec(install_mockery, mock_fetch, installer_variant)
 @pytest.mark.parametrize("unify", [True, False, "when_possible"])
 @pytest.mark.parametrize("reuse", [True, False])
 def test_env_install_include_concrete_env(
-    unify, reuse, temporary_store, install_mockery, mock_fetch, mutable_config
+    unify,
+    reuse,
+    temporary_store: Store,
+    install_mockery,
+    mock_fetch,
+    mutable_config: Configuration,
 ):
     test1, test2, combined = setup_combined_multiple_env()
 
@@ -579,7 +586,7 @@ def test_env_install_include_concrete_env(
 
 
 def test_env_roots_marked_explicit(
-    temporary_store, install_mockery, mock_fetch, installer_variant
+    temporary_store: Store, install_mockery, mock_fetch, installer_variant
 ):
     install = SpackCommand("install")
     install("--fake", "dependent-install")
@@ -602,7 +609,7 @@ def test_env_roots_marked_explicit(
 
 
 def test_env_modifications_error_on_activate(
-    install_mockery, mock_fetch, monkeypatch, capfd, mock_packages
+    install_mockery, mock_fetch, monkeypatch, capfd, mock_packages: RepoPath
 ):
     env("create", "test")
     install = SpackCommand("install")
@@ -657,7 +664,7 @@ def test_env_definition_symlink(install_mockery, mock_fetch, tmp_path: pathlib.P
 
 
 def test_env_install_two_specs_same_dep(
-    temporary_store, install_mockery, mock_fetch, tmp_path: pathlib.Path, monkeypatch
+    temporary_store: Store, install_mockery, mock_fetch, tmp_path: pathlib.Path, monkeypatch
 ):
     """Test installation of two packages that share a dependency with no
     connection and the second specifying the dependency as a 'build'
@@ -1039,7 +1046,7 @@ spack:
 
 
 @pytest.mark.parametrize("use_name", (True, False))
-def test_init_from_env(use_name, environment_from_manifest, mutable_config):
+def test_init_from_env(use_name, environment_from_manifest, mutable_config: Configuration):
     """Test that an environment can be instantiated from an environment dir"""
     e1 = environment_from_manifest(
         """
@@ -1145,7 +1152,7 @@ spack:
 
 
 def test_env_view_external_prefix(
-    tmp_path: pathlib.Path, mutable_database, mock_packages, mutable_config
+    tmp_path: pathlib.Path, mutable_database, mock_packages, mutable_config: Configuration
 ):
     fake_prefix = tmp_path / "a-prefix"
     fake_bin = fake_prefix / "bin"
@@ -1858,7 +1865,7 @@ def test_roots_display_with_variants():
     assert "boost+shared" in out
 
 
-def test_uninstall_keeps_in_env(mock_stage, mock_fetch, temporary_store, install_mockery):
+def test_uninstall_keeps_in_env(mock_stage, mock_fetch, temporary_store: Store, install_mockery):
     # 'spack uninstall' without --remove should not change the environment
     # spack.yaml file, just uninstall specs
     env("create", "test")
@@ -3756,7 +3763,9 @@ def test_virtual_spec_concretize_together(mutable_config):
         (True, (ev.EnvironmentConcretizer, "concretize")),
     ],
 )
-def test_concretize_transactional(unify, method_to_fail, monkeypatch, mutable_config):
+def test_concretize_transactional(
+    unify, method_to_fail, monkeypatch, mutable_config: Configuration
+):
     mutable_config.set("concretizer:unify", unify)
     e = ev.create("test")
 
@@ -3992,7 +4001,9 @@ def test_environment_view_target_already_exists(
     assert os.path.isfile(os.path.join(orphan_dir, "orphan_file"))
 
 
-def test_environment_query_spec_by_hash(mock_stage, mock_fetch, temporary_store, install_mockery):
+def test_environment_query_spec_by_hash(
+    mock_stage, mock_fetch, temporary_store: Store, install_mockery
+):
     env("create", "test")
     with ev.read("test"):
         add("libdwarf")

--- a/lib/spack/spack/test/cmd/env.py
+++ b/lib/spack/spack/test/cmd/env.py
@@ -601,7 +601,9 @@ def test_env_roots_marked_explicit(
     assert len(explicit) == 2
 
 
-def test_env_modifications_error_on_activate(install_mockery, mock_fetch, monkeypatch, capfd):
+def test_env_modifications_error_on_activate(
+    install_mockery, mock_fetch, monkeypatch, capfd, mock_packages
+):
     env("create", "test")
     install = SpackCommand("install")
 
@@ -612,7 +614,7 @@ def test_env_modifications_error_on_activate(install_mockery, mock_fetch, monkey
     def setup_error(pkg, env):
         raise RuntimeError("cmake-client had issues!")
 
-    pkg = spack.repo.PATH.get_pkg_class("cmake-client")
+    pkg = mock_packages.get_pkg_class("cmake-client")
     monkeypatch.setattr(pkg, "setup_run_environment", setup_error)
 
     ev.shell.activate(e)

--- a/lib/spack/spack/test/cmd/env.py
+++ b/lib/spack/spack/test/cmd/env.py
@@ -511,13 +511,13 @@ def test_env_specs_partition(install_mockery, mock_fetch):
     assert roots_to_install[0].name == "mpileaks"
 
 
-def test_env_install_all(install_mockery, mock_fetch):
+def test_env_install_all(temporary_store, install_mockery, mock_fetch):
     e = ev.create("test")
     e.add("cmake-client")
     e.concretize()
     e.install_all(fake=True)
     spec = next(x for x in e.all_specs_generator() if x.name == "cmake-client")
-    assert spack.store.STORE.db.installed(spec)
+    assert temporary_store.db.installed(spec)
 
 
 def test_env_install_single_spec(install_mockery, mock_fetch, installer_variant):
@@ -540,7 +540,7 @@ def test_env_install_single_spec(install_mockery, mock_fetch, installer_variant)
 @pytest.mark.parametrize("unify", [True, False, "when_possible"])
 @pytest.mark.parametrize("reuse", [True, False])
 def test_env_install_include_concrete_env(
-    unify, reuse, install_mockery, mock_fetch, mutable_config
+    unify, reuse, temporary_store, install_mockery, mock_fetch, mutable_config
 ):
     test1, test2, combined = setup_combined_multiple_env()
 
@@ -559,7 +559,7 @@ def test_env_install_include_concrete_env(
     test2_user_spec_hashes = [x.hash for x in test2.concretized_roots]
 
     for spec in combined.all_specs():
-        assert spack.store.STORE.db.installed(spec)
+        assert temporary_store.db.installed(spec)
 
     assert test1_user_spec_hashes == [
         x.hash for x in combined.included_concretized_roots[test1.path]
@@ -578,13 +578,15 @@ def test_env_install_include_concrete_env(
         assert mpileaks["libelf"].dag_hash() in test2_user_spec_hashes
 
 
-def test_env_roots_marked_explicit(install_mockery, mock_fetch, installer_variant):
+def test_env_roots_marked_explicit(
+    temporary_store, install_mockery, mock_fetch, installer_variant
+):
     install = SpackCommand("install")
     install("--fake", "dependent-install")
 
     # Check one explicit, one implicit install
-    dependent = spack.store.STORE.db.query(explicit=True)
-    dependency = spack.store.STORE.db.query(explicit=False)
+    dependent = temporary_store.db.query(explicit=True)
+    dependency = temporary_store.db.query(explicit=False)
     assert len(dependent) == 1
     assert len(dependency) == 1
 
@@ -595,7 +597,7 @@ def test_env_roots_marked_explicit(install_mockery, mock_fetch, installer_varian
         e.concretize()
         e.install_all()
 
-    explicit = spack.store.STORE.db.query(explicit=True)
+    explicit = temporary_store.db.query(explicit=True)
     assert len(explicit) == 2
 
 
@@ -653,7 +655,7 @@ def test_env_definition_symlink(install_mockery, mock_fetch, tmp_path: pathlib.P
 
 
 def test_env_install_two_specs_same_dep(
-    install_mockery, mock_fetch, tmp_path: pathlib.Path, monkeypatch
+    temporary_store, install_mockery, mock_fetch, tmp_path: pathlib.Path, monkeypatch
 ):
     """Test installation of two packages that share a dependency with no
     connection and the second specifying the dependency as a 'build'
@@ -682,10 +684,10 @@ spack:
     assert "depb: Successfully installed" in out
     assert "pkg-a: Successfully installed" in out
 
-    depb = spack.store.STORE.db.query_one("depb", installed=True)
+    depb = temporary_store.db.query_one("depb", installed=True)
     assert depb, "Expected depb to be installed"
 
-    a = spack.store.STORE.db.query_one("pkg-a", installed=True)
+    a = temporary_store.db.query_one("pkg-a", installed=True)
     assert a, "Expected pkg-a to be installed"
 
 
@@ -1852,7 +1854,7 @@ def test_roots_display_with_variants():
     assert "boost+shared" in out
 
 
-def test_uninstall_keeps_in_env(mock_stage, mock_fetch, install_mockery):
+def test_uninstall_keeps_in_env(mock_stage, mock_fetch, temporary_store, install_mockery):
     # 'spack uninstall' without --remove should not change the environment
     # spack.yaml file, just uninstall specs
     env("create", "test")
@@ -1874,7 +1876,7 @@ def test_uninstall_keeps_in_env(mock_stage, mock_fetch, install_mockery):
     assert {x.hash for x in test.concretized_roots} == user_spec_hashes_before
     assert test.user_specs.specs == user_specs_before.specs
     assert mpileaks_hash in test.specs_by_hash
-    assert not spack.store.STORE.db.installed(test.specs_by_hash[mpileaks_hash])
+    assert not temporary_store.db.installed(test.specs_by_hash[mpileaks_hash])
 
 
 def test_uninstall_removes_from_env(mock_stage, mock_fetch, install_mockery):
@@ -3986,7 +3988,7 @@ def test_environment_view_target_already_exists(
     assert os.path.isfile(os.path.join(orphan_dir, "orphan_file"))
 
 
-def test_environment_query_spec_by_hash(mock_stage, mock_fetch, install_mockery):
+def test_environment_query_spec_by_hash(mock_stage, mock_fetch, temporary_store, install_mockery):
     env("create", "test")
     with ev.read("test"):
         add("libdwarf")
@@ -3995,8 +3997,8 @@ def test_environment_query_spec_by_hash(mock_stage, mock_fetch, install_mockery)
         spec = e.matching_spec("libelf")
         install("--fake", f"/{spec.dag_hash()}")
     with ev.read("test") as e:
-        assert not spack.store.STORE.db.installed(e.matching_spec("libdwarf"))
-        assert spack.store.STORE.db.installed(e.matching_spec("libelf"))
+        assert not temporary_store.db.installed(e.matching_spec("libdwarf"))
+        assert temporary_store.db.installed(e.matching_spec("libelf"))
 
 
 @pytest.mark.parametrize("lockfile", ["v1", "v2", "v3"])

--- a/lib/spack/spack/test/cmd/env.py
+++ b/lib/spack/spack/test/cmd/env.py
@@ -1037,7 +1037,7 @@ spack:
 
 
 @pytest.mark.parametrize("use_name", (True, False))
-def test_init_from_env(use_name, environment_from_manifest):
+def test_init_from_env(use_name, environment_from_manifest, mutable_config):
     """Test that an environment can be instantiated from an environment dir"""
     e1 = environment_from_manifest(
         """
@@ -1056,7 +1056,7 @@ spack:
             "libelf": {"spec": "libelf", "path": "./libelf"},
             "mpileaks": {"spec": "mpileaks", "path": "../mpileaks"},
         }
-        spack.config.set("develop", dev_config)
+        mutable_config.set("develop", dev_config)
         fs.touch(os.path.join(e1.path, "libelf"))
 
     e1.concretize()
@@ -1142,7 +1142,9 @@ spack:
         _ = _env_create("test2", init_file=str(e1_manifest))
 
 
-def test_env_view_external_prefix(tmp_path: pathlib.Path, mutable_database, mock_packages):
+def test_env_view_external_prefix(
+    tmp_path: pathlib.Path, mutable_database, mock_packages, mutable_config
+):
     fake_prefix = tmp_path / "a-prefix"
     fake_bin = fake_prefix / "bin"
     fake_bin.mkdir(parents=True, exist_ok=False)
@@ -1172,7 +1174,7 @@ packages:
     external_config_dict = spack.util.spack_yaml.load_config(external_config)
 
     test_scope = spack.config.InternalConfigScope("env-external-test", data=external_config_dict)
-    with spack.config.override(test_scope):
+    with mutable_config.override(test_scope):
         e = ev.create("test", manifest_file)
         e.concretize()
         # Note: normally installing specs in a test environment requires doing
@@ -1515,7 +1517,7 @@ def test_env_with_included_config_file_url(
     env = ev.Environment(str(tmp_path))
     ev.activate(env)
 
-    cfg = spack.config.get("packages")
+    cfg = mutable_empty_config.get("packages")
     assert cfg["mpileaks"]["version"] == ["2.2"]
 
 
@@ -3753,7 +3755,7 @@ def test_virtual_spec_concretize_together(mutable_config):
     ],
 )
 def test_concretize_transactional(unify, method_to_fail, monkeypatch, mutable_config):
-    spack.config.set("concretizer:unify", unify)
+    mutable_config.set("concretizer:unify", unify)
     e = ev.create("test")
 
     e.add("mpi")
@@ -4460,12 +4462,12 @@ spack:
 """
         )
 
-    with spack.config.override("config:url_fetch_method", "curl"):
+    with mutable_empty_config.override("config:url_fetch_method", "curl"):
         env = ev.Environment(str(tmp_path))
         ev.activate(env)
 
         # Make sure a setting from test/data/config/packages.yaml is present
-        cfg = spack.config.get("packages")
+        cfg = mutable_empty_config.get("packages")
         assert "mpich" in cfg["all"]["providers"]["mpi"]
 
 

--- a/lib/spack/spack/test/cmd/external.py
+++ b/lib/spack/spack/test/cmd/external.py
@@ -8,7 +8,6 @@ import sys
 import pytest
 
 import spack.cmd.external
-import spack.config
 import spack.cray_manifest
 import spack.detection
 import spack.detection.path

--- a/lib/spack/spack/test/cmd/external.py
+++ b/lib/spack/spack/test/cmd/external.py
@@ -11,7 +11,6 @@ import spack.cmd.external
 import spack.cray_manifest
 import spack.detection
 import spack.detection.path
-import spack.repo
 from spack.main import SpackCommand
 from spack.spec import Spec
 from spack.util.filesystem import getuid, touch
@@ -68,7 +67,7 @@ external = SpackCommand("external")
 # causing intermittent (spurious) CI failures on all PRs
 @pytest.mark.not_on_windows("Test fails intermittently on Windows")
 def test_find_external_cmd_not_buildable(
-    mutable_config, working_env, mock_executable, monkeypatch
+    mutable_config, working_env, mock_executable, monkeypatch, mock_packages
 ):
     """When the user invokes 'spack external find --not-buildable', the config
     for any package where Spack finds an external version should be marked as
@@ -80,7 +79,7 @@ def test_find_external_cmd_not_buildable(
     def _determine_version(cls, exe):
         return version
 
-    cmake_cls = spack.repo.PATH.get_pkg_class("cmake")
+    cmake_cls = mock_packages.get_pkg_class("cmake")
     monkeypatch.setattr(cmake_cls, "determine_version", _determine_version)
 
     cmake_path = mock_executable("cmake", output=f"echo cmake version {version}")
@@ -246,7 +245,7 @@ def test_list_detectable_packages(mutable_config):
     assert external.returncode == 0
 
 
-def test_overriding_prefix(mock_executable, mutable_config, monkeypatch):
+def test_overriding_prefix(mock_executable, mutable_config, monkeypatch, mock_packages):
     gcc_exe = mock_executable("gcc", output="echo 4.2.1")
     search_dir = gcc_exe.parent
 
@@ -254,12 +253,12 @@ def test_overriding_prefix(mock_executable, mutable_config, monkeypatch):
     def _determine_variants(cls, exes, version_str):
         return "languages=c", {"prefix": "/opt/gcc/bin", "compilers": {"c": exes[0]}}
 
-    gcc_cls = spack.repo.PATH.get_pkg_class("gcc")
+    gcc_cls = mock_packages.get_pkg_class("gcc")
     monkeypatch.setattr(gcc_cls, "determine_variants", _determine_variants)
 
     finder = spack.detection.path.ExecutablesFinder()
     detected_specs = finder.find(
-        pkg_name="gcc", initial_guess=[str(search_dir)], repository=spack.repo.PATH
+        pkg_name="gcc", initial_guess=[str(search_dir)], repository=mock_packages
     )
 
     assert len(detected_specs) == 1
@@ -288,14 +287,16 @@ def test_new_entries_are_reported_correctly(mock_executable, mutable_config, mon
 
 @pytest.mark.parametrize("command_args", [("-t", "build-tools"), ("-t", "build-tools", "cmake")])
 @pytest.mark.not_on_windows("the test uses bash scripts")
-def test_use_tags_for_detection(command_args, mock_executable, mutable_config, monkeypatch):
+def test_use_tags_for_detection(
+    command_args, mock_executable, mutable_config, monkeypatch, mock_packages
+):
     versions = {"cmake": "3.19.1", "openssl": "2.8.3"}
 
     @classmethod
     def _determine_version(cls, exe):
         return versions[os.path.basename(exe)]
 
-    cmake_cls = spack.repo.PATH.get_pkg_class("cmake")
+    cmake_cls = mock_packages.get_pkg_class("cmake")
     monkeypatch.setattr(cmake_cls, "determine_version", _determine_version)
 
     # Prepare an environment to detect a fake cmake
@@ -317,7 +318,7 @@ def test_use_tags_for_detection(command_args, mock_executable, mutable_config, m
 @pytest.mark.regression("38733")
 @pytest.mark.not_on_windows("the test uses bash scripts")
 def test_failures_in_scanning_do_not_result_in_an_error(
-    mock_executable, monkeypatch, mutable_config
+    mock_executable, monkeypatch, mutable_config, mock_packages
 ):
     """Tests that scanning paths with wrong permissions, won't cause `external find` to error."""
     cmake_exe1 = mock_executable(
@@ -336,7 +337,7 @@ def test_failures_in_scanning_do_not_result_in_an_error(
             return "3.23.3"
         assert False, f"Unexpected exe path {exe}"
 
-    cmake_cls = spack.repo.PATH.get_pkg_class("cmake")
+    cmake_cls = mock_packages.get_pkg_class("cmake")
     monkeypatch.setattr(cmake_cls, "determine_version", _determine_version)
     monkeypatch.setenv("PATH", f"{cmake_exe1.parent}{os.pathsep}{cmake_exe2.parent}")
 
@@ -354,7 +355,7 @@ def test_failures_in_scanning_do_not_result_in_an_error(
     assert "3.23.3" in output
 
 
-def test_detect_virtuals(mock_executable, mutable_config, monkeypatch):
+def test_detect_virtuals(mock_executable, mutable_config, monkeypatch, mock_packages):
     """Test whether external find --not-buildable sets virtuals as non-buildable (unless user
     config sets them to buildable)"""
     version = "4.0.2"
@@ -363,7 +364,7 @@ def test_detect_virtuals(mock_executable, mutable_config, monkeypatch):
     def _determine_version(cls, exe):
         return version
 
-    cmake_cls = spack.repo.PATH.get_pkg_class("mpich")
+    cmake_cls = mock_packages.get_pkg_class("mpich")
     monkeypatch.setattr(cmake_cls, "determine_version", _determine_version)
 
     mpich = mock_executable("mpichversion", output=f"echo MPICH Version:    {version}")

--- a/lib/spack/spack/test/cmd/external.py
+++ b/lib/spack/spack/test/cmd/external.py
@@ -44,7 +44,7 @@ def test_find_external_update_config(mutable_config):
     ]
     pkg_to_entries = {"cmake": entries}
 
-    scope = spack.config.CONFIG.default_modify_scope("packages")
+    scope = mutable_config.default_modify_scope("packages")
     spack.detection.update_configuration(pkg_to_entries, scope=scope, buildable=True)
 
     pkgs_cfg = mutable_config.get("packages")
@@ -231,7 +231,7 @@ def test_find_external_merge(mutable_config):
         Spec.from_detection("find-externals1@1.2", external_path="/x/y2"),
     ]
     pkg_to_entries = {"find-externals1": entries}
-    scope = spack.config.CONFIG.default_modify_scope("packages")
+    scope = mutable_config.default_modify_scope("packages")
     spack.detection.update_configuration(pkg_to_entries, scope=scope, buildable=True)
 
     pkgs_cfg = mutable_config.get("packages")

--- a/lib/spack/spack/test/cmd/external.py
+++ b/lib/spack/spack/test/cmd/external.py
@@ -44,7 +44,7 @@ def test_find_external_update_config(mutable_config):
     ]
     pkg_to_entries = {"cmake": entries}
 
-    scope = spack.config.default_modify_scope("packages")
+    scope = spack.config.CONFIG.default_modify_scope("packages")
     spack.detection.update_configuration(pkg_to_entries, scope=scope, buildable=True)
 
     pkgs_cfg = mutable_config.get("packages")
@@ -231,7 +231,7 @@ def test_find_external_merge(mutable_config):
         Spec.from_detection("find-externals1@1.2", external_path="/x/y2"),
     ]
     pkg_to_entries = {"find-externals1": entries}
-    scope = spack.config.default_modify_scope("packages")
+    scope = spack.config.CONFIG.default_modify_scope("packages")
     spack.detection.update_configuration(pkg_to_entries, scope=scope, buildable=True)
 
     pkgs_cfg = mutable_config.get("packages")

--- a/lib/spack/spack/test/cmd/external.py
+++ b/lib/spack/spack/test/cmd/external.py
@@ -47,7 +47,7 @@ def test_find_external_update_config(mutable_config):
     scope = spack.config.default_modify_scope("packages")
     spack.detection.update_configuration(pkg_to_entries, scope=scope, buildable=True)
 
-    pkgs_cfg = spack.config.get("packages")
+    pkgs_cfg = mutable_config.get("packages")
     cmake_cfg = pkgs_cfg["cmake"]
     cmake_externals = cmake_cfg["externals"]
 
@@ -87,7 +87,7 @@ def test_find_external_cmd_not_buildable(
     cmake_path = mock_executable("cmake", output=f"echo cmake version {version}")
     os.environ["PATH"] = str(cmake_path.parent)
     external("find", "--not-buildable", "cmake")
-    pkgs_cfg = spack.config.get("packages")
+    pkgs_cfg = mutable_config.get("packages")
     assert "cmake" in pkgs_cfg
     assert not pkgs_cfg["cmake"]["buildable"]
 
@@ -234,7 +234,7 @@ def test_find_external_merge(mutable_config):
     scope = spack.config.default_modify_scope("packages")
     spack.detection.update_configuration(pkg_to_entries, scope=scope, buildable=True)
 
-    pkgs_cfg = spack.config.get("packages")
+    pkgs_cfg = mutable_config.get("packages")
     pkg_cfg = pkgs_cfg["find-externals1"]
     pkg_externals = pkg_cfg["externals"]
 

--- a/lib/spack/spack/test/cmd/external.py
+++ b/lib/spack/spack/test/cmd/external.py
@@ -11,6 +11,7 @@ import spack.cmd.external
 import spack.cray_manifest
 import spack.detection
 import spack.detection.path
+from spack.config import Configuration
 from spack.main import SpackCommand
 from spack.spec import Spec
 from spack.util.filesystem import getuid, touch
@@ -35,7 +36,7 @@ def define_plat_exe(exe):
     return exe
 
 
-def test_find_external_update_config(mutable_config):
+def test_find_external_update_config(mutable_config: Configuration):
     entries = [
         Spec.from_detection("cmake@1.foo", external_path="/x/y1"),
         Spec.from_detection("cmake@3.17.2", external_path="/x/y2"),
@@ -214,7 +215,7 @@ def test_find_external_manifest_failure(mutable_config, tmp_path: pathlib.Path, 
     assert "Skipping manifest and continuing" in output
 
 
-def test_find_external_merge(mutable_config):
+def test_find_external_merge(mutable_config: Configuration):
     """Checks that 'spack find external' doesn't overwrite an existing spec in packages.yaml."""
     pkgs_cfg_init = {
         "find-externals1": {

--- a/lib/spack/spack/test/cmd/find.py
+++ b/lib/spack/spack/test/cmd/find.py
@@ -18,7 +18,6 @@ import spack.package_base
 import spack.paths
 import spack.repo
 import spack.spec
-import spack.store
 import spack.user_environment as uenv
 from spack.enums import InstallRecordStatus
 from spack.main import SpackCommand
@@ -435,7 +434,7 @@ def test_find_loaded(database, working_env):
     assert output == ""
 
     os.environ[uenv.spack_loaded_hashes_var] = os.pathsep.join(
-        [x.dag_hash() for x in spack.store.STORE.db.query()]
+        [x.dag_hash() for x in database.query()]
     )
     output = find("--loaded")
     expected = find()

--- a/lib/spack/spack/test/cmd/find.py
+++ b/lib/spack/spack/test/cmd/find.py
@@ -19,6 +19,7 @@ import spack.paths
 import spack.repo
 import spack.spec
 import spack.user_environment as uenv
+from spack.database import Database
 from spack.enums import InstallRecordStatus
 from spack.main import SpackCommand
 from spack.test.utilities import SpackCommandArgs
@@ -429,7 +430,7 @@ spack:
     assert "libelf" in output
 
 
-def test_find_loaded(database, working_env):
+def test_find_loaded(database: Database, working_env):
     output = find("--loaded", "--group")
     assert output == ""
 

--- a/lib/spack/spack/test/cmd/gc.py
+++ b/lib/spack/spack/test/cmd/gc.py
@@ -11,7 +11,6 @@ import spack.deptypes as dt
 import spack.environment as ev
 import spack.main
 import spack.spec
-import spack.store
 import spack.traverse
 from spack.old_installer import PackageInstaller
 
@@ -114,7 +113,7 @@ def test_gc_except_any_environments(mutable_database, mutable_mock_env_path):
 
     # All runtime specs in this env should still be installed.
     assert all(
-        spack.store.STORE.db.installed(s)
+        mutable_database.installed(s)
         for s in spack.traverse.traverse_nodes(e.concrete_roots(), deptype=dt.LINK | dt.RUN)
     )
 

--- a/lib/spack/spack/test/cmd/gc.py
+++ b/lib/spack/spack/test/cmd/gc.py
@@ -12,6 +12,7 @@ import spack.environment as ev
 import spack.main
 import spack.spec
 import spack.traverse
+from spack.database import Database
 from spack.old_installer import PackageInstaller
 
 gc = spack.main.SpackCommand("gc")
@@ -92,7 +93,7 @@ def test_gc_with_build_dependency_in_environment(mutable_database, mutable_mock_
 
 
 @pytest.mark.db
-def test_gc_except_any_environments(mutable_database, mutable_mock_env_path):
+def test_gc_except_any_environments(mutable_database: Database, mutable_mock_env_path):
     """Tests whether the garbage collector can remove all specs except those still needed in some
     environment (needed in the sense of roots + link/run deps)."""
     assert mutable_database.query_local("zmpi")

--- a/lib/spack/spack/test/cmd/init_py_functions.py
+++ b/lib/spack/spack/test/cmd/init_py_functions.py
@@ -8,7 +8,6 @@ import pytest
 import spack.config
 import spack.environment as ev
 import spack.error
-import spack.store
 from spack.cmd import (
     CommandNameError,
     PythonNameError,
@@ -69,7 +68,7 @@ def test_special_cases_concretization_parse_specs(
 
     spack.config.set("concretizer:unify", unify)
 
-    args = [f"/{spack.store.STORE.db.query(s)[0].dag_hash()}" for s in spec_strs]
+    args = [f"/{mutable_database.query(s)[0].dag_hash()}" for s in spec_strs]
     if len(args) > 1:
         # We convert the last one to a specfile input
         filename = tmp_path / "spec.json"
@@ -121,7 +120,7 @@ def test_special_cases_concretization_matching_specs_from_env(
     ev.create("test")
     env = ev.read("test")
 
-    args = [f"/{spack.store.STORE.db.query(s)[0].dag_hash()}" for s in spec_strs]
+    args = [f"/{mutable_database.query(s)[0].dag_hash()}" for s in spec_strs]
     if len(args) > 1:
         # We convert the last one to a specfile input
         filename = tmp_path / "spec.json"

--- a/lib/spack/spack/test/cmd/init_py_functions.py
+++ b/lib/spack/spack/test/cmd/init_py_functions.py
@@ -17,6 +17,8 @@ from spack.cmd import (
     require_cmd_name,
     require_python_name,
 )
+from spack.config import Configuration
+from spack.database import Database
 from spack.solver import asp
 
 
@@ -55,7 +57,13 @@ def test_require_cmd_name():
     ],
 )
 def test_special_cases_concretization_parse_specs(
-    unify, spec_strs, error, monkeypatch, mutable_config, mutable_database, tmp_path: pathlib.Path
+    unify,
+    spec_strs,
+    error,
+    monkeypatch,
+    mutable_config: Configuration,
+    mutable_database: Database,
+    tmp_path: pathlib.Path,
 ):
     """Test that special cases in parse_specs(concretize=True) bypass solver"""
 
@@ -101,8 +109,8 @@ def test_special_cases_concretization_matching_specs_from_env(
     spec_strs,
     error,
     monkeypatch,
-    mutable_config,
-    mutable_database,
+    mutable_config: Configuration,
+    mutable_database: Database,
     tmp_path: pathlib.Path,
     mutable_mock_env_path,
 ):

--- a/lib/spack/spack/test/cmd/init_py_functions.py
+++ b/lib/spack/spack/test/cmd/init_py_functions.py
@@ -5,7 +5,6 @@ import pathlib
 
 import pytest
 
-import spack.config
 import spack.environment as ev
 import spack.error
 from spack.cmd import (
@@ -66,7 +65,7 @@ def test_special_cases_concretization_parse_specs(
 
     monkeypatch.setattr(asp.SpackSolverSetup, "setup", _fail)
 
-    spack.config.set("concretizer:unify", unify)
+    mutable_config.set("concretizer:unify", unify)
 
     args = [f"/{mutable_database.query(s)[0].dag_hash()}" for s in spec_strs]
     if len(args) > 1:
@@ -115,7 +114,7 @@ def test_special_cases_concretization_matching_specs_from_env(
 
     monkeypatch.setattr(asp.SpackSolverSetup, "setup", _fail)
 
-    spack.config.set("concretizer:unify", unify)
+    mutable_config.set("concretizer:unify", unify)
 
     ev.create("test")
     env = ev.read("test")

--- a/lib/spack/spack/test/cmd/install.py
+++ b/lib/spack/spack/test/cmd/install.py
@@ -131,7 +131,7 @@ def test_install_package_already_installed(
 @pytest.mark.parametrize(
     "arguments,expected",
     [
-        ([], spack.config.get("config:dirty")),  # default from config file
+        ([], spack.config.CONFIG.get("config:dirty")),  # default from config file
         (["--clean"], False),
         (["--dirty"], True),
     ],

--- a/lib/spack/spack/test/cmd/install.py
+++ b/lib/spack/spack/test/cmd/install.py
@@ -27,10 +27,12 @@ import spack.old_installer
 import spack.package_base
 import spack.reporters.cdash
 import spack.util.filesystem as fs
+from spack.config import Configuration
 from spack.error import SpackError, SpecSyntaxError
 from spack.main import SpackCommand
 from spack.old_installer import PackageInstaller
 from spack.spec import Spec
+from spack.store import Store
 from spack.util import tty
 
 install = SpackCommand("install")
@@ -229,7 +231,12 @@ def test_show_log_on_error(mock_packages, mock_archive, mock_fetch, install_mock
 
 
 def test_install_overwrite(
-    mock_packages, mock_archive, mock_fetch, temporary_store, install_mockery, installer_variant
+    mock_packages,
+    mock_archive,
+    mock_fetch,
+    temporary_store: Store,
+    install_mockery,
+    installer_variant,
 ):
     """Tests installing a spec, and then re-installing it in the same prefix."""
     spec = spack.concretize.concretize_one("pkg-c")
@@ -299,7 +306,12 @@ def test_install_commit(mock_git_version_info, install_mockery, mock_packages, m
 
 
 def test_install_overwrite_multiple(
-    mock_packages, mock_archive, mock_fetch, temporary_store, install_mockery, installer_variant
+    mock_packages,
+    mock_archive,
+    mock_fetch,
+    temporary_store: Store,
+    install_mockery,
+    installer_variant,
 ):
     # Try to install a spec and then to reinstall it.
     libdwarf = spack.concretize.concretize_one("libdwarf")
@@ -520,7 +532,12 @@ def test_install_mix_cli_and_files(spec_format, clispecs, filespecs, tmp_path: p
 
 
 def test_extra_files_are_archived(
-    mock_packages, mock_archive, mock_fetch, temporary_store, install_mockery, installer_variant
+    mock_packages,
+    mock_archive,
+    mock_fetch,
+    temporary_store: Store,
+    install_mockery,
+    installer_variant,
 ):
     s = spack.concretize.concretize_one("archive-files")
 
@@ -701,7 +718,7 @@ def test_build_warning_output(mock_fetch, install_mockery):
 
 
 @pytest.mark.disable_clean_stage_check  # new installer keeps a log for build cache installs
-def test_cache_only_fails(mock_fetch, temporary_store, install_mockery, installer_variant):
+def test_cache_only_fails(mock_fetch, temporary_store: Store, install_mockery, installer_variant):
     # libelf from cache fails to install, which automatically removes the
     # the libdwarf build task
     out = install("--cache-only", "libdwarf", fail_on_error=False)
@@ -801,7 +818,7 @@ def test_install_no_add_in_env(
     tmp_path: pathlib.Path,
     mutable_mock_env_path,
     mock_fetch,
-    temporary_store,
+    temporary_store: Store,
     install_mockery,
     installer_variant,
 ):
@@ -1129,7 +1146,7 @@ def test_install_use_buildcache(
 @pytest.mark.not_on_windows("Windows logger I/O operation on closed file when install fails")
 @pytest.mark.regression("34006")
 @pytest.mark.disable_clean_stage_check
-def test_padded_install_runtests_root(install_mockery, mock_fetch, mutable_config):
+def test_padded_install_runtests_root(install_mockery, mock_fetch, mutable_config: Configuration):
     mutable_config.set("config:install_tree:padded_length", 255)
     output = install(
         "--verbose", "--test=root", "--no-cache", "test-build-callbacks", fail_on_error=False
@@ -1150,7 +1167,7 @@ def test_report_filename_for_cdash(install_mockery, mock_fetch):
     assert filename != "https://blahblah/submit.php?project=debugging"
 
 
-def test_setting_concurrent_packages_flag(mutable_config):
+def test_setting_concurrent_packages_flag(mutable_config: Configuration):
     """Ensure that the number of concurrent packages is properly set from the command-line flag"""
     install = SpackCommand("install")
     install("--concurrent-packages", "8", fail_on_error=False)
@@ -1165,7 +1182,7 @@ def test_invalid_concurrent_packages_flag(mutable_config):
 
 
 @pytest.mark.skipif(sys.platform == "win32", reason="Feature disabled on windows due to locking")
-def test_concurrent_packages_set_in_config(mutable_config, mock_packages):
+def test_concurrent_packages_set_in_config(mutable_config: Configuration, mock_packages):
     """Ensure that the number of concurrent packages is properly set from adding to config"""
     mutable_config.set("config:concurrent_packages", 3)
     spec = spack.concretize.concretize_one("pkg-a")

--- a/lib/spack/spack/test/cmd/install.py
+++ b/lib/spack/spack/test/cmd/install.py
@@ -26,7 +26,6 @@ import spack.hooks.sbom_generate
 import spack.old_installer
 import spack.package_base
 import spack.reporters.cdash
-import spack.store
 import spack.util.filesystem as fs
 from spack.error import SpackError, SpecSyntaxError
 from spack.main import SpackCommand
@@ -230,7 +229,7 @@ def test_show_log_on_error(mock_packages, mock_archive, mock_fetch, install_mock
 
 
 def test_install_overwrite(
-    mock_packages, mock_archive, mock_fetch, install_mockery, installer_variant
+    mock_packages, mock_archive, mock_fetch, temporary_store, install_mockery, installer_variant
 ):
     """Tests installing a spec, and then re-installing it in the same prefix."""
     spec = spack.concretize.concretize_one("pkg-c")
@@ -238,9 +237,7 @@ def test_install_overwrite(
 
     # Ignore manifest, install times, and sbom
     manifest = os.path.join(
-        spec.prefix,
-        spack.store.STORE.layout.metadata_dir,
-        spack.store.STORE.layout.manifest_file_name,
+        spec.prefix, temporary_store.layout.metadata_dir, temporary_store.layout.manifest_file_name
     )
     ignores = [
         manifest,
@@ -302,7 +299,7 @@ def test_install_commit(mock_git_version_info, install_mockery, mock_packages, m
 
 
 def test_install_overwrite_multiple(
-    mock_packages, mock_archive, mock_fetch, install_mockery, installer_variant
+    mock_packages, mock_archive, mock_fetch, temporary_store, install_mockery, installer_variant
 ):
     # Try to install a spec and then to reinstall it.
     libdwarf = spack.concretize.concretize_one("libdwarf")
@@ -314,8 +311,8 @@ def test_install_overwrite_multiple(
     # Ignore manifest, install times, and sbom
     ld_manifest = os.path.join(
         libdwarf.prefix,
-        spack.store.STORE.layout.metadata_dir,
-        spack.store.STORE.layout.manifest_file_name,
+        temporary_store.layout.metadata_dir,
+        temporary_store.layout.manifest_file_name,
     )
 
     ld_ignores = [
@@ -329,8 +326,8 @@ def test_install_overwrite_multiple(
 
     cm_manifest = os.path.join(
         cmake.prefix,
-        spack.store.STORE.layout.metadata_dir,
-        spack.store.STORE.layout.manifest_file_name,
+        temporary_store.layout.metadata_dir,
+        temporary_store.layout.manifest_file_name,
     )
 
     cm_ignores = [
@@ -523,13 +520,13 @@ def test_install_mix_cli_and_files(spec_format, clispecs, filespecs, tmp_path: p
 
 
 def test_extra_files_are_archived(
-    mock_packages, mock_archive, mock_fetch, install_mockery, installer_variant
+    mock_packages, mock_archive, mock_fetch, temporary_store, install_mockery, installer_variant
 ):
     s = spack.concretize.concretize_one("archive-files")
 
     install("archive-files")
 
-    archive_dir = os.path.join(spack.store.STORE.layout.metadata_path(s), "archived-files")
+    archive_dir = os.path.join(temporary_store.layout.metadata_path(s), "archived-files")
     config_log = os.path.join(archive_dir, mock_archive.expanded_archive_basedir, "config.log")
     assert os.path.exists(config_log)
 
@@ -704,13 +701,13 @@ def test_build_warning_output(mock_fetch, install_mockery):
 
 
 @pytest.mark.disable_clean_stage_check  # new installer keeps a log for build cache installs
-def test_cache_only_fails(mock_fetch, install_mockery, installer_variant):
+def test_cache_only_fails(mock_fetch, temporary_store, install_mockery, installer_variant):
     # libelf from cache fails to install, which automatically removes the
     # the libdwarf build task
     out = install("--cache-only", "libdwarf", fail_on_error=False)
     assert isinstance(install.error, spack.error.InstallError)
-    assert not spack.store.STORE.db.query_local("libdwarf")
-    assert not spack.store.STORE.db.query_local("libelf")
+    assert not temporary_store.db.query_local("libdwarf")
+    assert not temporary_store.db.query_local("libelf")
 
     if installer_variant == "old":
         assert "Failed to install gcc-runtime" in out
@@ -719,8 +716,7 @@ def test_cache_only_fails(mock_fetch, install_mockery, installer_variant):
 
         # Check that failure prefix locks are still cached
         failed_packages = [
-            pkg_name
-            for dag_hash, pkg_name in spack.store.STORE.failure_tracker.locker.locks.keys()
+            pkg_name for dag_hash, pkg_name in temporary_store.failure_tracker.locker.locks.keys()
         ]
         assert "libelf" in failed_packages
         assert "libdwarf" in failed_packages
@@ -802,7 +798,12 @@ def test_install_only_dependencies_of_all_in_env(
 
 # Unit tests should not be affected by the user's managed environments
 def test_install_no_add_in_env(
-    tmp_path: pathlib.Path, mutable_mock_env_path, mock_fetch, install_mockery, installer_variant
+    tmp_path: pathlib.Path,
+    mutable_mock_env_path,
+    mock_fetch,
+    temporary_store,
+    install_mockery,
+    installer_variant,
 ):
     # To test behavior of --add option, we create the following environment:
     #
@@ -860,11 +861,7 @@ def test_install_no_add_in_env(
         inst_out = install("--fake", "pkg-a")
         assert (
             len(
-                [
-                    x
-                    for x in e.all_specs()
-                    if spack.store.STORE.db.installed(x) and x.name == "pkg-a"
-                ]
+                [x for x in e.all_specs() if temporary_store.db.installed(x) and x.name == "pkg-a"]
             )
             == 2
         )

--- a/lib/spack/spack/test/cmd/install.py
+++ b/lib/spack/spack/test/cmd/install.py
@@ -1129,8 +1129,8 @@ def test_install_use_buildcache(
 @pytest.mark.not_on_windows("Windows logger I/O operation on closed file when install fails")
 @pytest.mark.regression("34006")
 @pytest.mark.disable_clean_stage_check
-def test_padded_install_runtests_root(install_mockery, mock_fetch):
-    spack.config.set("config:install_tree:padded_length", 255)
+def test_padded_install_runtests_root(install_mockery, mock_fetch, mutable_config):
+    mutable_config.set("config:install_tree:padded_length", 255)
     output = install(
         "--verbose", "--test=root", "--no-cache", "test-build-callbacks", fail_on_error=False
     )
@@ -1154,7 +1154,7 @@ def test_setting_concurrent_packages_flag(mutable_config):
     """Ensure that the number of concurrent packages is properly set from the command-line flag"""
     install = SpackCommand("install")
     install("--concurrent-packages", "8", fail_on_error=False)
-    assert spack.config.get("config:concurrent_packages", scope="command_line") == 8
+    assert mutable_config.get("config:concurrent_packages", scope="command_line") == 8
 
 
 def test_invalid_concurrent_packages_flag(mutable_config):
@@ -1167,7 +1167,7 @@ def test_invalid_concurrent_packages_flag(mutable_config):
 @pytest.mark.skipif(sys.platform == "win32", reason="Feature disabled on windows due to locking")
 def test_concurrent_packages_set_in_config(mutable_config, mock_packages):
     """Ensure that the number of concurrent packages is properly set from adding to config"""
-    spack.config.set("config:concurrent_packages", 3)
+    mutable_config.set("config:concurrent_packages", 3)
     spec = spack.concretize.concretize_one("pkg-a")
     installer = spack.old_installer.PackageInstaller([spec.package])
     assert installer.concurrent_packages == 3

--- a/lib/spack/spack/test/cmd/list.py
+++ b/lib/spack/spack/test/cmd/list.py
@@ -11,6 +11,7 @@ import spack.cmd.list
 import spack.paths
 import spack.repo
 from spack.main import SpackCommand
+from spack.repo import RepoPath
 from spack.test.conftest import RepoBuilder
 
 pytestmark = [pytest.mark.usefixtures("mock_packages")]
@@ -164,7 +165,7 @@ def test_list_tags():
     assert "mpich2" in output
 
 
-def test_list_count(mock_packages):
+def test_list_count(mock_packages: RepoPath):
     output = list("--count")
     assert int(output.strip()) == len(mock_packages.all_package_names())
 

--- a/lib/spack/spack/test/cmd/list.py
+++ b/lib/spack/spack/test/cmd/list.py
@@ -164,13 +164,13 @@ def test_list_tags():
     assert "mpich2" in output
 
 
-def test_list_count():
+def test_list_count(mock_packages):
     output = list("--count")
-    assert int(output.strip()) == len(spack.repo.PATH.all_package_names())
+    assert int(output.strip()) == len(mock_packages.all_package_names())
 
     output = list("--count", "py-")
     assert int(output.strip()) == len(
-        [name for name in spack.repo.PATH.all_package_names() if "py-" in name]
+        [name for name in mock_packages.all_package_names() if "py-" in name]
     )
 
 

--- a/lib/spack/spack/test/cmd/list.py
+++ b/lib/spack/spack/test/cmd/list.py
@@ -166,11 +166,11 @@ def test_list_tags():
 
 def test_list_count():
     output = list("--count")
-    assert int(output.strip()) == len(spack.repo.all_package_names())
+    assert int(output.strip()) == len(spack.repo.PATH.all_package_names())
 
     output = list("--count", "py-")
     assert int(output.strip()) == len(
-        [name for name in spack.repo.all_package_names() if "py-" in name]
+        [name for name in spack.repo.PATH.all_package_names() if "py-" in name]
     )
 
 

--- a/lib/spack/spack/test/cmd/logs.py
+++ b/lib/spack/spack/test/cmd/logs.py
@@ -17,6 +17,7 @@ import spack.error
 import spack.main
 import spack.spec
 from spack.main import SpackCommand
+from spack.store import Store
 
 logs = SpackCommand("logs")
 install = SpackCommand("install")
@@ -48,7 +49,7 @@ def _rewind_collect_and_decode(rw_stream):
 
 
 def test_logs_cmd_errors(
-    temporary_store, install_mockery, mock_fetch, mock_archive, mock_packages
+    temporary_store: Store, install_mockery, mock_fetch, mock_archive, mock_packages
 ):
     spec = spack.concretize.concretize_one("pkg-c")
     assert not temporary_store.db.installed(spec)
@@ -72,7 +73,9 @@ def _write_string_to_path(string, path):
         f.write(string.encode("utf-8"))
 
 
-def test_dump_logs(temporary_store, install_mockery, mock_fetch, mock_archive, mock_packages):
+def test_dump_logs(
+    temporary_store: Store, install_mockery, mock_fetch, mock_archive, mock_packages
+):
     """Test that ``spack log`` can find (and print) the logs for partial
     builds and completed installs.
 

--- a/lib/spack/spack/test/cmd/logs.py
+++ b/lib/spack/spack/test/cmd/logs.py
@@ -16,7 +16,6 @@ import spack.concretize
 import spack.error
 import spack.main
 import spack.spec
-import spack.store
 from spack.main import SpackCommand
 
 logs = SpackCommand("logs")
@@ -48,9 +47,11 @@ def _rewind_collect_and_decode(rw_stream):
     return rw_stream.read().decode("utf-8")
 
 
-def test_logs_cmd_errors(install_mockery, mock_fetch, mock_archive, mock_packages):
+def test_logs_cmd_errors(
+    temporary_store, install_mockery, mock_fetch, mock_archive, mock_packages
+):
     spec = spack.concretize.concretize_one("pkg-c")
-    assert not spack.store.STORE.db.installed(spec)
+    assert not temporary_store.db.installed(spec)
 
     with pytest.raises(spack.error.SpackError, match="is not installed or staged"):
         logs("pkg-c")
@@ -71,7 +72,7 @@ def _write_string_to_path(string, path):
         f.write(string.encode("utf-8"))
 
 
-def test_dump_logs(install_mockery, mock_fetch, mock_archive, mock_packages):
+def test_dump_logs(temporary_store, install_mockery, mock_fetch, mock_archive, mock_packages):
     """Test that ``spack log`` can find (and print) the logs for partial
     builds and completed installs.
 
@@ -83,7 +84,7 @@ def test_dump_logs(install_mockery, mock_fetch, mock_archive, mock_packages):
 
     # Sanity check, make sure this test is checking what we want: to
     # start with
-    assert not spack.store.STORE.db.installed(concrete_spec)
+    assert not temporary_store.db.installed(concrete_spec)
 
     stage_log_content = "test_log stage output\nanother line"
     installed_log_content = "test_log install output\nhere to test multiple lines"

--- a/lib/spack/spack/test/cmd/maintainers.py
+++ b/lib/spack/spack/test/cmd/maintainers.py
@@ -7,6 +7,7 @@ import re
 import pytest
 
 import spack.main
+from spack.repo import RepoPath
 
 pytestmark = [pytest.mark.usefixtures("mock_packages")]
 
@@ -33,7 +34,7 @@ def test_maintained():
     assert out == MAINTAINED_PACKAGES
 
 
-def test_unmaintained(mock_packages):
+def test_unmaintained(mock_packages: RepoPath):
     out = split(maintainers("--unmaintained"))
     assert out == sorted(set(mock_packages.all_package_names()) - set(MAINTAINED_PACKAGES))
 

--- a/lib/spack/spack/test/cmd/maintainers.py
+++ b/lib/spack/spack/test/cmd/maintainers.py
@@ -7,7 +7,6 @@ import re
 import pytest
 
 import spack.main
-import spack.repo
 
 pytestmark = [pytest.mark.usefixtures("mock_packages")]
 
@@ -34,9 +33,9 @@ def test_maintained():
     assert out == MAINTAINED_PACKAGES
 
 
-def test_unmaintained():
+def test_unmaintained(mock_packages):
     out = split(maintainers("--unmaintained"))
-    assert out == sorted(set(spack.repo.PATH.all_package_names()) - set(MAINTAINED_PACKAGES))
+    assert out == sorted(set(mock_packages.all_package_names()) - set(MAINTAINED_PACKAGES))
 
 
 def test_all():

--- a/lib/spack/spack/test/cmd/maintainers.py
+++ b/lib/spack/spack/test/cmd/maintainers.py
@@ -36,7 +36,7 @@ def test_maintained():
 
 def test_unmaintained():
     out = split(maintainers("--unmaintained"))
-    assert out == sorted(set(spack.repo.all_package_names()) - set(MAINTAINED_PACKAGES))
+    assert out == sorted(set(spack.repo.PATH.all_package_names()) - set(MAINTAINED_PACKAGES))
 
 
 def test_all():

--- a/lib/spack/spack/test/cmd/mark.py
+++ b/lib/spack/spack/test/cmd/mark.py
@@ -4,7 +4,6 @@
 
 import pytest
 
-import spack.store
 from spack.main import SpackCommand, SpackCommandError
 
 gc = SpackCommand("gc")
@@ -29,42 +28,42 @@ def test_mark_spec_required(mutable_database):
 
 
 @pytest.mark.db
-def test_mark_all_explicit(mutable_database):
+def test_mark_all_explicit(mutable_database_store):
     mark("-e", "-a")
     gc("-y")
-    all_specs = spack.store.STORE.layout.all_specs()
+    all_specs = mutable_database_store.layout.all_specs()
     assert len(all_specs) == 17
 
 
 @pytest.mark.db
-def test_mark_all_implicit(mutable_database):
+def test_mark_all_implicit(mutable_database_store):
     mark("-i", "-a")
     gc("-y")
-    all_specs = spack.store.STORE.layout.all_specs()
+    all_specs = mutable_database_store.layout.all_specs()
     assert len(all_specs) == 0
 
 
 @pytest.mark.db
-def test_mark_one_explicit(mutable_database):
+def test_mark_one_explicit(mutable_database_store):
     mark("-e", "libelf")
     uninstall("-y", "-a", "mpileaks")
     gc("-y")
-    all_specs = spack.store.STORE.layout.all_specs()
+    all_specs = mutable_database_store.layout.all_specs()
     assert len(all_specs) == 4
 
 
 @pytest.mark.db
-def test_mark_one_implicit(mutable_database):
+def test_mark_one_implicit(mutable_database_store):
     mark("-i", "externaltest")
     gc("-y")
-    all_specs = spack.store.STORE.layout.all_specs()
+    all_specs = mutable_database_store.layout.all_specs()
     assert len(all_specs) == 15
 
 
 @pytest.mark.db
-def test_mark_all_implicit_then_explicit(mutable_database):
+def test_mark_all_implicit_then_explicit(mutable_database_store):
     mark("-i", "-a")
     mark("-e", "-a")
     gc("-y")
-    all_specs = spack.store.STORE.layout.all_specs()
+    all_specs = mutable_database_store.layout.all_specs()
     assert len(all_specs) == 17

--- a/lib/spack/spack/test/cmd/mark.py
+++ b/lib/spack/spack/test/cmd/mark.py
@@ -5,6 +5,7 @@
 import pytest
 
 from spack.main import SpackCommand, SpackCommandError
+from spack.store import Store
 
 gc = SpackCommand("gc")
 mark = SpackCommand("mark")
@@ -28,7 +29,7 @@ def test_mark_spec_required(mutable_database):
 
 
 @pytest.mark.db
-def test_mark_all_explicit(mutable_database_store):
+def test_mark_all_explicit(mutable_database_store: Store):
     mark("-e", "-a")
     gc("-y")
     all_specs = mutable_database_store.layout.all_specs()
@@ -36,7 +37,7 @@ def test_mark_all_explicit(mutable_database_store):
 
 
 @pytest.mark.db
-def test_mark_all_implicit(mutable_database_store):
+def test_mark_all_implicit(mutable_database_store: Store):
     mark("-i", "-a")
     gc("-y")
     all_specs = mutable_database_store.layout.all_specs()
@@ -44,7 +45,7 @@ def test_mark_all_implicit(mutable_database_store):
 
 
 @pytest.mark.db
-def test_mark_one_explicit(mutable_database_store):
+def test_mark_one_explicit(mutable_database_store: Store):
     mark("-e", "libelf")
     uninstall("-y", "-a", "mpileaks")
     gc("-y")
@@ -53,7 +54,7 @@ def test_mark_one_explicit(mutable_database_store):
 
 
 @pytest.mark.db
-def test_mark_one_implicit(mutable_database_store):
+def test_mark_one_implicit(mutable_database_store: Store):
     mark("-i", "externaltest")
     gc("-y")
     all_specs = mutable_database_store.layout.all_specs()
@@ -61,7 +62,7 @@ def test_mark_one_implicit(mutable_database_store):
 
 
 @pytest.mark.db
-def test_mark_all_implicit_then_explicit(mutable_database_store):
+def test_mark_all_implicit_then_explicit(mutable_database_store: Store):
     mark("-i", "-a")
     mark("-e", "-a")
     gc("-y")

--- a/lib/spack/spack/test/cmd/mirror.py
+++ b/lib/spack/spack/test/cmd/mirror.py
@@ -17,6 +17,7 @@ import spack.spec
 import spack.util.git
 import spack.util.url as url_util
 import spack.version
+from spack.config import Configuration
 from spack.main import SpackCommand, SpackCommandError
 from spack.mirrors.utils import MirrorStatsForAllSpecs, MirrorStatsForOneSpec
 
@@ -43,7 +44,11 @@ def test_regression_8083(tmp_path: pathlib.Path, mock_packages, mock_fetch, conf
 # Unit tests should not be affected by the user's managed environments
 @pytest.mark.regression("12345")
 def test_mirror_from_env(
-    mutable_mock_env_path, tmp_path: pathlib.Path, mock_packages, mock_fetch, mutable_config
+    mutable_mock_env_path,
+    tmp_path: pathlib.Path,
+    mock_packages,
+    mock_fetch,
+    mutable_config: Configuration,
 ):
     mirror_dir = str(tmp_path / "mirror")
     env_name = "test"
@@ -65,7 +70,12 @@ def test_mirror_from_env(
 
 
 def test_mirror_cli_parallel_args(
-    tmp_path, mock_packages, mock_fetch, mutable_mock_env_path, monkeypatch, mutable_config
+    tmp_path,
+    mock_packages,
+    mock_fetch,
+    mutable_mock_env_path,
+    monkeypatch,
+    mutable_config: Configuration,
 ):
     """Test the CLI parallel args"""
     mirror_dir = str(tmp_path / "mirror")
@@ -89,7 +99,7 @@ def test_mirror_cli_parallel_args(
 
 
 def test_mirror_from_env_parallel(
-    tmp_path, mock_packages, mock_fetch, mutable_mock_env_path, mutable_config
+    tmp_path, mock_packages, mock_fetch, mutable_mock_env_path, mutable_config: Configuration
 ):
     """Directly test create_mirror_for_all_specs with parallel option"""
     mirror_dir = str(tmp_path / "mirror")
@@ -169,7 +179,11 @@ def test_mirror_stats_merge():
 
 # Test for command line-specified spec in concretized environment
 def test_mirror_spec_from_env(
-    mutable_mock_env_path, tmp_path: pathlib.Path, mock_packages, mock_fetch, mutable_config
+    mutable_mock_env_path,
+    tmp_path: pathlib.Path,
+    mock_packages,
+    mock_fetch,
+    mutable_config: Configuration,
 ):
     mirror_dir = str(tmp_path / "mirror-B")
     env_name = "test"
@@ -594,7 +608,7 @@ class TestMirrorCreate:
         assert all(s.concrete for s in specs)
 
 
-def test_mirror_type(mutable_config):
+def test_mirror_type(mutable_config: Configuration):
     """Test the mirror set command"""
     mirror("add", "example", "--type", "binary", "http://example.com")
     assert mutable_config.get("mirrors:example") == {
@@ -624,7 +638,7 @@ def test_mirror_type(mutable_config):
     }
 
 
-def test_mirror_set_2(mutable_config):
+def test_mirror_set_2(mutable_config: Configuration):
     """Test the mirror set command"""
     mirror("add", "example", "http://example.com")
     mirror(
@@ -648,7 +662,7 @@ def test_mirror_set_2(mutable_config):
     }
 
 
-def test_mirror_add_set_signed(mutable_config):
+def test_mirror_add_set_signed(mutable_config: Configuration):
     mirror("add", "--signed", "example", "http://example.com")
     assert mutable_config.get("mirrors:example") == {"url": "http://example.com", "signed": True}
     mirror("set", "--unsigned", "example")
@@ -657,7 +671,7 @@ def test_mirror_add_set_signed(mutable_config):
     assert mutable_config.get("mirrors:example") == {"url": "http://example.com", "signed": True}
 
 
-def test_mirror_add_set_autopush(mutable_config):
+def test_mirror_add_set_autopush(mutable_config: Configuration):
     # Add mirror without autopush
     mirror("add", "example", "http://example.com")
     assert mutable_config.get("mirrors:example") == "http://example.com"

--- a/lib/spack/spack/test/cmd/mirror.py
+++ b/lib/spack/spack/test/cmd/mirror.py
@@ -10,7 +10,6 @@ import pytest
 import spack.binary_distribution
 import spack.cmd.mirror
 import spack.concretize
-import spack.config
 import spack.environment as ev
 import spack.mirrors.utils
 import spack.package_base
@@ -43,7 +42,9 @@ def test_regression_8083(tmp_path: pathlib.Path, mock_packages, mock_fetch, conf
 
 # Unit tests should not be affected by the user's managed environments
 @pytest.mark.regression("12345")
-def test_mirror_from_env(mutable_mock_env_path, tmp_path: pathlib.Path, mock_packages, mock_fetch):
+def test_mirror_from_env(
+    mutable_mock_env_path, tmp_path: pathlib.Path, mock_packages, mock_fetch, mutable_config
+):
     mirror_dir = str(tmp_path / "mirror")
     env_name = "test"
 
@@ -52,7 +53,7 @@ def test_mirror_from_env(mutable_mock_env_path, tmp_path: pathlib.Path, mock_pac
         add("trivial-install-test-package")
         add("git-test")
         concretize()
-        with spack.config.override("config:checksum", False):
+        with mutable_config.override("config:checksum", False):
             mirror("create", "-d", mirror_dir, "--all")
 
     e = ev.read(env_name)
@@ -64,7 +65,7 @@ def test_mirror_from_env(mutable_mock_env_path, tmp_path: pathlib.Path, mock_pac
 
 
 def test_mirror_cli_parallel_args(
-    tmp_path, mock_packages, mock_fetch, mutable_mock_env_path, monkeypatch
+    tmp_path, mock_packages, mock_fetch, mutable_mock_env_path, monkeypatch, mutable_config
 ):
     """Test the CLI parallel args"""
     mirror_dir = str(tmp_path / "mirror")
@@ -83,11 +84,13 @@ def test_mirror_cli_parallel_args(
         add("trivial-install-test-package")
         add("git-test")
         concretize()
-        with spack.config.override("config:checksum", False):
+        with mutable_config.override("config:checksum", False):
             mirror("create", "-d", mirror_dir, "--all", "-j", "2")
 
 
-def test_mirror_from_env_parallel(tmp_path, mock_packages, mock_fetch, mutable_mock_env_path):
+def test_mirror_from_env_parallel(
+    tmp_path, mock_packages, mock_fetch, mutable_mock_env_path, mutable_config
+):
     """Directly test create_mirror_for_all_specs with parallel option"""
     mirror_dir = str(tmp_path / "mirror")
     env_name = "test-parallel"
@@ -101,7 +104,7 @@ def test_mirror_from_env_parallel(tmp_path, mock_packages, mock_fetch, mutable_m
     e = ev.read(env_name)
     specs = list(e.specs_by_hash.values())
 
-    with spack.config.override("config:checksum", False):
+    with mutable_config.override("config:checksum", False):
         mirror_stats = spack.cmd.mirror.create_mirror_for_all_specs(
             specs, mirror_dir, False, workers=2
         )
@@ -166,7 +169,7 @@ def test_mirror_stats_merge():
 
 # Test for command line-specified spec in concretized environment
 def test_mirror_spec_from_env(
-    mutable_mock_env_path, tmp_path: pathlib.Path, mock_packages, mock_fetch
+    mutable_mock_env_path, tmp_path: pathlib.Path, mock_packages, mock_fetch, mutable_config
 ):
     mirror_dir = str(tmp_path / "mirror-B")
     env_name = "test"
@@ -175,7 +178,7 @@ def test_mirror_spec_from_env(
     with ev.read(env_name):
         add("simple-standalone-test@0.9")
         concretize()
-        with spack.config.override("config:checksum", False):
+        with mutable_config.override("config:checksum", False):
             mirror("create", "-d", mirror_dir, "simple-standalone-test")
 
     e = ev.read(env_name)
@@ -594,27 +597,27 @@ class TestMirrorCreate:
 def test_mirror_type(mutable_config):
     """Test the mirror set command"""
     mirror("add", "example", "--type", "binary", "http://example.com")
-    assert spack.config.get("mirrors:example") == {
+    assert mutable_config.get("mirrors:example") == {
         "url": "http://example.com",
         "source": False,
         "binary": True,
     }
 
     mirror("set", "example", "--type", "source")
-    assert spack.config.get("mirrors:example") == {
+    assert mutable_config.get("mirrors:example") == {
         "url": "http://example.com",
         "source": True,
         "binary": False,
     }
 
     mirror("set", "example", "--type", "binary")
-    assert spack.config.get("mirrors:example") == {
+    assert mutable_config.get("mirrors:example") == {
         "url": "http://example.com",
         "source": False,
         "binary": True,
     }
     mirror("set", "example", "--type", "binary", "--type", "source")
-    assert spack.config.get("mirrors:example") == {
+    assert mutable_config.get("mirrors:example") == {
         "url": "http://example.com",
         "source": True,
         "binary": True,
@@ -636,7 +639,7 @@ def test_mirror_set_2(mutable_config):
         "password",
     )
 
-    assert spack.config.get("mirrors:example") == {
+    assert mutable_config.get("mirrors:example") == {
         "url": "http://example.com",
         "push": {
             "url": "http://example2.com",
@@ -647,34 +650,43 @@ def test_mirror_set_2(mutable_config):
 
 def test_mirror_add_set_signed(mutable_config):
     mirror("add", "--signed", "example", "http://example.com")
-    assert spack.config.get("mirrors:example") == {"url": "http://example.com", "signed": True}
+    assert mutable_config.get("mirrors:example") == {"url": "http://example.com", "signed": True}
     mirror("set", "--unsigned", "example")
-    assert spack.config.get("mirrors:example") == {"url": "http://example.com", "signed": False}
+    assert mutable_config.get("mirrors:example") == {"url": "http://example.com", "signed": False}
     mirror("set", "--signed", "example")
-    assert spack.config.get("mirrors:example") == {"url": "http://example.com", "signed": True}
+    assert mutable_config.get("mirrors:example") == {"url": "http://example.com", "signed": True}
 
 
 def test_mirror_add_set_autopush(mutable_config):
     # Add mirror without autopush
     mirror("add", "example", "http://example.com")
-    assert spack.config.get("mirrors:example") == "http://example.com"
+    assert mutable_config.get("mirrors:example") == "http://example.com"
     mirror("set", "--no-autopush", "example")
-    assert spack.config.get("mirrors:example") == {"url": "http://example.com", "autopush": False}
+    assert mutable_config.get("mirrors:example") == {
+        "url": "http://example.com",
+        "autopush": False,
+    }
     mirror("set", "--autopush", "example")
-    assert spack.config.get("mirrors:example") == {"url": "http://example.com", "autopush": True}
+    assert mutable_config.get("mirrors:example") == {"url": "http://example.com", "autopush": True}
     mirror("set", "--no-autopush", "example")
-    assert spack.config.get("mirrors:example") == {"url": "http://example.com", "autopush": False}
+    assert mutable_config.get("mirrors:example") == {
+        "url": "http://example.com",
+        "autopush": False,
+    }
     mirror("remove", "example")
 
     # Add mirror with autopush
     mirror("add", "--autopush", "example", "http://example.com")
-    assert spack.config.get("mirrors:example") == {"url": "http://example.com", "autopush": True}
+    assert mutable_config.get("mirrors:example") == {"url": "http://example.com", "autopush": True}
     mirror("set", "--autopush", "example")
-    assert spack.config.get("mirrors:example") == {"url": "http://example.com", "autopush": True}
+    assert mutable_config.get("mirrors:example") == {"url": "http://example.com", "autopush": True}
     mirror("set", "--no-autopush", "example")
-    assert spack.config.get("mirrors:example") == {"url": "http://example.com", "autopush": False}
+    assert mutable_config.get("mirrors:example") == {
+        "url": "http://example.com",
+        "autopush": False,
+    }
     mirror("set", "--autopush", "example")
-    assert spack.config.get("mirrors:example") == {"url": "http://example.com", "autopush": True}
+    assert mutable_config.get("mirrors:example") == {"url": "http://example.com", "autopush": True}
     mirror("remove", "example")
 
 

--- a/lib/spack/spack/test/cmd/module.py
+++ b/lib/spack/spack/test/cmd/module.py
@@ -180,7 +180,7 @@ def test_setdefault_command(mutable_database, mutable_config):
             "lmod": {"core_compilers": ["clang@3.3"], "hierarchy": ["mpi"]},
         }
     }
-    spack.config.set("modules", data)
+    mutable_config.set("modules", data)
     # Install two different versions of pkg-a
     other_spec, preferred = "pkg-a@1.0", "pkg-a@2.0"
 

--- a/lib/spack/spack/test/cmd/module.py
+++ b/lib/spack/spack/test/cmd/module.py
@@ -14,6 +14,7 @@ import spack.modules
 import spack.modules.lmod
 import spack.repo
 import spack.store
+from spack.config import Configuration
 from spack.old_installer import PackageInstaller
 
 module = spack.main.SpackCommand("module")
@@ -173,7 +174,7 @@ writer_cls = spack.modules.lmod.LmodModulefileWriter
 
 
 @pytest.mark.db
-def test_setdefault_command(mutable_database, mutable_config):
+def test_setdefault_command(mutable_database, mutable_config: Configuration):
     data = {
         "default": {
             "enable": ["lmod"],

--- a/lib/spack/spack/test/cmd/pkg.py
+++ b/lib/spack/spack/test/cmd/pkg.py
@@ -241,7 +241,7 @@ def test_pkg_source_requires_one_arg(mock_packages):
 def test_pkg_source(mock_packages):
     fake_source = pkg("source", "fake")
 
-    fake_file = spack.repo.PATH.filename_for_package_name("fake")
+    fake_file = mock_packages.filename_for_package_name("fake")
     with open(fake_file, encoding="utf-8") as f:
         contents = f.read()
         assert fake_source == contents
@@ -348,7 +348,7 @@ def test_pkg_grep(mock_packages):
     # only splice-* mock packages have the string "splice" in them
     pkg("grep", "-l", "splice")
     assert pkg.output.strip() == "\n".join(
-        spack.repo.PATH.get_pkg_class(name).module.__file__
+        mock_packages.get_pkg_class(name).module.__file__
         for name in [
             "depends-on-manyvariants",
             "manyvariants",

--- a/lib/spack/spack/test/cmd/pkg.py
+++ b/lib/spack/spack/test/cmd/pkg.py
@@ -14,6 +14,7 @@ import spack.paths
 import spack.repo
 import spack.util.executable
 import spack.util.file_cache
+from spack.repo import RepoPath
 from spack.util.filesystem import mkdirp, working_dir
 
 pkg = spack.main.SpackCommand("pkg")
@@ -238,7 +239,7 @@ def test_pkg_source_requires_one_arg(mock_packages):
         pkg("source", "--canonical", "a", "b")
 
 
-def test_pkg_source(mock_packages):
+def test_pkg_source(mock_packages: RepoPath):
     fake_source = pkg("source", "fake")
 
     fake_file = mock_packages.filename_for_package_name("fake")
@@ -344,7 +345,7 @@ def test_group_arguments(
 
 
 @pytest.mark.skipif(not spack.cmd.pkg.get_grep(), reason="grep is not installed")
-def test_pkg_grep(mock_packages):
+def test_pkg_grep(mock_packages: RepoPath):
     # only splice-* mock packages have the string "splice" in them
     pkg("grep", "-l", "splice")
     assert pkg.output.strip() == "\n".join(

--- a/lib/spack/spack/test/cmd/reindex.py
+++ b/lib/spack/spack/test/cmd/reindex.py
@@ -14,12 +14,12 @@ deprecate = SpackCommand("deprecate")
 reindex = SpackCommand("reindex")
 
 
-def test_reindex_basic(mock_packages, mock_archive, mock_fetch, install_mockery):
+def test_reindex_basic(mock_packages, mock_archive, mock_fetch, temporary_store, install_mockery):
     install("--fake", "libelf@0.8.13")
     install("--fake", "libelf@0.8.12")
-    all_installed = spack.store.STORE.db.query()
+    all_installed = temporary_store.db.query()
     reindex()
-    assert spack.store.STORE.db.query() == all_installed
+    assert temporary_store.db.query() == all_installed
 
 
 def _clear_db(tmp_path: pathlib.Path):
@@ -33,25 +33,35 @@ def _clear_db(tmp_path: pathlib.Path):
 
 
 def test_reindex_db_deleted(
-    mock_packages, mock_archive, mock_fetch, install_mockery, tmp_path: pathlib.Path
+    mock_packages,
+    mock_archive,
+    mock_fetch,
+    temporary_store,
+    install_mockery,
+    tmp_path: pathlib.Path,
 ):
     install("--fake", "libelf@0.8.13")
     install("--fake", "libelf@0.8.12")
-    all_installed = spack.store.STORE.db.query()
+    all_installed = temporary_store.db.query()
     _clear_db(tmp_path)
     reindex()
-    assert spack.store.STORE.db.query() == all_installed
+    assert temporary_store.db.query() == all_installed
 
 
 def test_reindex_with_deprecated_packages(
-    mock_packages, mock_archive, mock_fetch, install_mockery, tmp_path: pathlib.Path
+    mock_packages,
+    mock_archive,
+    mock_fetch,
+    temporary_store,
+    install_mockery,
+    tmp_path: pathlib.Path,
 ):
     install("--fake", "libelf@0.8.13")
     install("--fake", "libelf@0.8.12")
 
     deprecate("-y", "libelf@0.8.12", "libelf@0.8.13")
 
-    db = spack.store.STORE.db
+    db = temporary_store.db
 
     all_installed = db.query(installed=InstallRecordStatus.ANY)
     non_deprecated = db.query(installed=True)

--- a/lib/spack/spack/test/cmd/reindex.py
+++ b/lib/spack/spack/test/cmd/reindex.py
@@ -7,13 +7,16 @@ import shutil
 from spack.database import Database
 from spack.enums import InstallRecordStatus
 from spack.main import SpackCommand
+from spack.store import Store
 
 install = SpackCommand("install")
 deprecate = SpackCommand("deprecate")
 reindex = SpackCommand("reindex")
 
 
-def test_reindex_basic(mock_packages, mock_archive, mock_fetch, temporary_store, install_mockery):
+def test_reindex_basic(
+    mock_packages, mock_archive, mock_fetch, temporary_store: Store, install_mockery
+):
     install("--fake", "libelf@0.8.13")
     install("--fake", "libelf@0.8.12")
     all_installed = temporary_store.db.query()
@@ -35,7 +38,7 @@ def test_reindex_db_deleted(
     mock_packages,
     mock_archive,
     mock_fetch,
-    temporary_store,
+    temporary_store: Store,
     install_mockery,
     tmp_path: pathlib.Path,
 ):
@@ -51,7 +54,7 @@ def test_reindex_with_deprecated_packages(
     mock_packages,
     mock_archive,
     mock_fetch,
-    temporary_store,
+    temporary_store: Store,
     install_mockery,
     tmp_path: pathlib.Path,
 ):

--- a/lib/spack/spack/test/cmd/reindex.py
+++ b/lib/spack/spack/test/cmd/reindex.py
@@ -4,7 +4,6 @@
 import pathlib
 import shutil
 
-import spack.store
 from spack.database import Database
 from spack.enums import InstallRecordStatus
 from spack.main import SpackCommand
@@ -22,14 +21,14 @@ def test_reindex_basic(mock_packages, mock_archive, mock_fetch, temporary_store,
     assert temporary_store.db.query() == all_installed
 
 
-def _clear_db(tmp_path: pathlib.Path):
+def _clear_db(store, tmp_path: pathlib.Path):
     empty_db = Database(str(tmp_path))
     with empty_db.write_transaction():
         pass
-    shutil.rmtree(spack.store.STORE.db.database_directory)
-    shutil.copytree(empty_db.database_directory, spack.store.STORE.db.database_directory)
+    shutil.rmtree(store.db.database_directory)
+    shutil.copytree(empty_db.database_directory, store.db.database_directory)
     # force a re-read of the database
-    assert len(spack.store.STORE.db.query()) == 0
+    assert len(store.db.query()) == 0
 
 
 def test_reindex_db_deleted(
@@ -43,7 +42,7 @@ def test_reindex_db_deleted(
     install("--fake", "libelf@0.8.13")
     install("--fake", "libelf@0.8.12")
     all_installed = temporary_store.db.query()
-    _clear_db(tmp_path)
+    _clear_db(temporary_store, tmp_path)
     reindex()
     assert temporary_store.db.query() == all_installed
 
@@ -66,7 +65,7 @@ def test_reindex_with_deprecated_packages(
     all_installed = db.query(installed=InstallRecordStatus.ANY)
     non_deprecated = db.query(installed=True)
 
-    _clear_db(tmp_path)
+    _clear_db(temporary_store, tmp_path)
 
     reindex()
 

--- a/lib/spack/spack/test/cmd/repo.py
+++ b/lib/spack/spack/test/cmd/repo.py
@@ -82,7 +82,7 @@ def test_repo_remove_by_scope(mutable_config, tmp_path: pathlib.Path):
 
 
 def test_env_repo_path_vars_substitution(
-    tmp_path: pathlib.Path, install_mockery, mutable_mock_env_path, monkeypatch
+    tmp_path: pathlib.Path, install_mockery, mutable_mock_env_path, monkeypatch, mutable_config
 ):
     """Test Spack correctly substitutes repo paths with environment variables when creating an
     environment from a manifest file."""
@@ -108,7 +108,7 @@ spack:
         # check that repo path was correctly substituted with the environment variable
         current_dir = os.getcwd()
         with ev.read("test") as newenv:
-            repos_specs = spack.config.get("repos", default={}, scope=newenv.scope_name)
+            repos_specs = mutable_config.get("repos", default={}, scope=newenv.scope_name)
             assert current_dir in repos_specs.values()
 
 
@@ -705,19 +705,19 @@ def test_repo_set_git_config(mutable_config):
     # Set up initial git repository config in defaults scope
     git_url = "https://github.com/example/test-repo.git"
     initial_config = {"repos": {"test-repo": {"git": git_url}}}
-    spack.config.set("repos", initial_config["repos"], scope="site")
+    mutable_config.set("repos", initial_config["repos"], scope="site")
 
     # Test setting destination and paths
     repo("set", "--scope=user", "--destination", "/custom/path", "test-repo")
     repo("set", "--scope=user", "--path", "subdir1", "--path", "subdir2", "test-repo")
 
     # Check that the user config has the updated entry
-    user_repos = spack.config.get("repos", scope="user")
+    user_repos = mutable_config.get("repos", scope="user")
     assert user_repos["test-repo"]["paths"] == ["subdir1", "subdir2"]
     assert user_repos["test-repo"]["destination"] == "/custom/path"
 
     # Check that site scope is unchanged
-    site_repos = spack.config.get("repos", scope="site")
+    site_repos = mutable_config.get("repos", scope="site")
     assert "destination" not in site_repos["test-repo"]
 
 
@@ -727,7 +727,7 @@ def test_repo_set_nonexistent_repo(mutable_config):
 
 
 def test_repo_set_does_not_work_on_local_path(mutable_config):
-    spack.config.set("repos", {"local-repo": "/local/path"}, scope="site")
+    mutable_config.set("repos", {"local-repo": "/local/path"}, scope="site")
     with pytest.raises(SpackError, match="is not a git repository"):
         repo("set", "--destination", "/some/path", "local-repo")
 
@@ -908,14 +908,14 @@ def test_repo_update_successful_flags(monkeypatch, mutable_config, repo_name, fl
     monkeypatch.setattr(spack.repo, "parse_config_descriptor", mock_parse_config_descriptor)
     monkeypatch.setattr(spack.repo, "RemoteRepoDescriptor", MockDescriptor)
 
-    repos_config = spack.config.get("repos")
+    repos_config = mutable_config.get("repos")
     repos_config[repo_name] = {"git": "https://github.com/example/repo.git"}
-    spack.config.set("repos", repos_config)
+    mutable_config.set("repos", repos_config)
 
     repo("update", repo_name, *flags)
 
     # check that the branch,tag,commit was updated in the configuration
-    repos_config = spack.config.get("repos")
+    repos_config = mutable_config.get("repos")
 
     if "--branch" in flags:
         assert repos_config[repo_name]["branch"] == "develop"

--- a/lib/spack/spack/test/cmd/repo.py
+++ b/lib/spack/spack/test/cmd/repo.py
@@ -15,6 +15,7 @@ import spack.environment as ev
 import spack.main
 import spack.repo
 import spack.repo_migrate
+from spack.config import Configuration
 from spack.error import SpackError
 from spack.util.executable import Executable
 from spack.util.filesystem import working_dir
@@ -82,7 +83,11 @@ def test_repo_remove_by_scope(mutable_config, tmp_path: pathlib.Path):
 
 
 def test_env_repo_path_vars_substitution(
-    tmp_path: pathlib.Path, install_mockery, mutable_mock_env_path, monkeypatch, mutable_config
+    tmp_path: pathlib.Path,
+    install_mockery,
+    mutable_mock_env_path,
+    monkeypatch,
+    mutable_config: Configuration,
 ):
     """Test Spack correctly substitutes repo paths with environment variables when creating an
     environment from a manifest file."""
@@ -700,7 +705,7 @@ def test_add_repo_git_url_detection_edge_cases(monkeypatch, test_url, expected_t
         assert isinstance(entry, str)
 
 
-def test_repo_set_git_config(mutable_config):
+def test_repo_set_git_config(mutable_config: Configuration):
     """Test that 'spack repo set' properly modifies git repository configurations."""
     # Set up initial git repository config in defaults scope
     git_url = "https://github.com/example/test-repo.git"
@@ -726,7 +731,7 @@ def test_repo_set_nonexistent_repo(mutable_config):
         repo("set", "--destination", "/some/path", "nonexistent")
 
 
-def test_repo_set_does_not_work_on_local_path(mutable_config):
+def test_repo_set_does_not_work_on_local_path(mutable_config: Configuration):
     mutable_config.set("repos", {"local-repo": "/local/path"}, scope="site")
     with pytest.raises(SpackError, match="is not a git repository"):
         repo("set", "--destination", "/some/path", "local-repo")
@@ -899,7 +904,9 @@ def test_repo_list_json_output(mutable_config: spack.config.Configuration, tmp_p
         ("new_repo", ["--commit", "abc123"]),
     ],
 )
-def test_repo_update_successful_flags(monkeypatch, mutable_config, repo_name, flags):
+def test_repo_update_successful_flags(
+    monkeypatch, mutable_config: Configuration, repo_name, flags
+):
     """Test repo update with flags."""
 
     def mock_parse_config_descriptor(name, entry, lock):

--- a/lib/spack/spack/test/cmd/spec.py
+++ b/lib/spack/spack/test/cmd/spec.py
@@ -11,7 +11,9 @@ import spack.concretize
 import spack.environment as ev
 import spack.error
 import spack.spec
+from spack.config import Configuration
 from spack.main import SpackCommand, SpackCommandError
+from spack.store import Store
 
 buildcache = SpackCommand("buildcache")
 install = SpackCommand("install")
@@ -210,7 +212,13 @@ def test_spec_version_assigned_git_ref_as_version(name, version, error):
     ],
 )
 def test_spec_unification_from_cli(
-    install_mockery, mutable_config, mutable_database, unify, spec_hash_args, match, error
+    install_mockery,
+    mutable_config: Configuration,
+    mutable_database,
+    unify,
+    spec_hash_args,
+    match,
+    error,
 ):
     """Ensure specs grouped together on the CLI are concretized together when unify:true."""
     mutable_config.set("concretizer:unify", unify)
@@ -231,7 +239,9 @@ def test_spec_unification_from_cli(
         assert match in output
 
 
-def test_buildcache_status_fn_marks_absent_spec(temporary_store, install_mockery, mock_packages):
+def test_buildcache_status_fn_marks_absent_spec(
+    temporary_store: Store, install_mockery, mock_packages
+):
     """Tests the basic semantics of build_cache_status_fn."""
     s = spack.concretize.concretize_one("mpileaks")
     assert temporary_store.db.install_status(s) == spack.spec.InstallStatus.absent

--- a/lib/spack/spack/test/cmd/spec.py
+++ b/lib/spack/spack/test/cmd/spec.py
@@ -12,7 +12,6 @@ import spack.config
 import spack.environment as ev
 import spack.error
 import spack.spec
-import spack.store
 from spack.main import SpackCommand, SpackCommandError
 
 buildcache = SpackCommand("buildcache")
@@ -53,7 +52,7 @@ def test_spec_concretizer_args(mutable_database):
     uninstall("-y", "mpileaks^mpich2")
 
     # get the hash of mpileaks^zmpi
-    mpileaks_zmpi = spack.store.STORE.db.query_one("mpileaks^zmpi")
+    mpileaks_zmpi = mutable_database.query_one("mpileaks^zmpi")
     h = mpileaks_zmpi.dag_hash()[:7]
 
     output = spec("--fresh", "-l", "mpileaks")
@@ -217,7 +216,7 @@ def test_spec_unification_from_cli(
     """Ensure specs grouped together on the CLI are concretized together when unify:true."""
     spack.config.set("concretizer:unify", unify)
 
-    db = spack.store.STORE.db
+    db = mutable_database
     spec_lookup = {
         "mpileaks_mpich": db.query_one("mpileaks ^mpich").dag_hash(),
         "mpileaks_zmpi": db.query_one("mpileaks ^zmpi").dag_hash(),
@@ -233,10 +232,10 @@ def test_spec_unification_from_cli(
         assert match in output
 
 
-def test_buildcache_status_fn_marks_absent_spec(install_mockery, mock_packages):
+def test_buildcache_status_fn_marks_absent_spec(temporary_store, install_mockery, mock_packages):
     """Tests the basic semantics of build_cache_status_fn."""
     s = spack.concretize.concretize_one("mpileaks")
-    assert spack.store.STORE.db.install_status(s) == spack.spec.InstallStatus.absent
+    assert temporary_store.db.install_status(s) == spack.spec.InstallStatus.absent
 
     status_fn = spack.cmd.buildcache_status_fn({s.dag_hash()})
     assert status_fn(s) == spack.spec.InstallStatus.buildcache
@@ -247,8 +246,8 @@ def test_buildcache_status_fn_marks_absent_spec(install_mockery, mock_packages):
 
 def test_buildcache_status_fn_installed_not_overridden(mutable_database):
     """Tests that an installed spec stays installed even if its hash is in the cache."""
-    s = spack.store.STORE.db.query_one("mpileaks^mpich")
-    assert spack.store.STORE.db.install_status(s) == spack.spec.InstallStatus.installed
+    s = mutable_database.query_one("mpileaks^mpich")
+    assert mutable_database.install_status(s) == spack.spec.InstallStatus.installed
 
     status_fn = spack.cmd.buildcache_status_fn({s.dag_hash()})
     assert status_fn(s) == spack.spec.InstallStatus.installed

--- a/lib/spack/spack/test/cmd/spec.py
+++ b/lib/spack/spack/test/cmd/spec.py
@@ -8,7 +8,6 @@ import pytest
 
 import spack.cmd
 import spack.concretize
-import spack.config
 import spack.environment as ev
 import spack.error
 import spack.spec
@@ -214,7 +213,7 @@ def test_spec_unification_from_cli(
     install_mockery, mutable_config, mutable_database, unify, spec_hash_args, match, error
 ):
     """Ensure specs grouped together on the CLI are concretized together when unify:true."""
-    spack.config.set("concretizer:unify", unify)
+    mutable_config.set("concretizer:unify", unify)
 
     db = mutable_database
     spec_lookup = {

--- a/lib/spack/spack/test/cmd/stage.py
+++ b/lib/spack/spack/test/cmd/stage.py
@@ -12,6 +12,7 @@ import spack.package_base
 import spack.store
 import spack.traverse
 from spack.cmd.stage import StageFilter
+from spack.config import Configuration
 from spack.main import SpackCommand, SpackCommandError
 from spack.spec import Spec
 from spack.version import Version
@@ -125,7 +126,7 @@ def test_stage_full_env(mutable_mock_env_path, monkeypatch):
 
 
 @pytest.mark.disable_clean_stage_check
-def test_concretizer_arguments(mock_packages, mock_fetch, mutable_config):
+def test_concretizer_arguments(mock_packages, mock_fetch, mutable_config: Configuration):
     """Make sure stage also has --reuse and --fresh flags."""
     stage("--reuse", "trivial-install-test-package")
     assert mutable_config.get("concretizer:reuse", None) is True

--- a/lib/spack/spack/test/cmd/stage.py
+++ b/lib/spack/spack/test/cmd/stage.py
@@ -6,7 +6,6 @@ import pathlib
 
 import pytest
 
-import spack.config
 import spack.database
 import spack.environment as ev
 import spack.package_base
@@ -126,13 +125,13 @@ def test_stage_full_env(mutable_mock_env_path, monkeypatch):
 
 
 @pytest.mark.disable_clean_stage_check
-def test_concretizer_arguments(mock_packages, mock_fetch):
+def test_concretizer_arguments(mock_packages, mock_fetch, mutable_config):
     """Make sure stage also has --reuse and --fresh flags."""
     stage("--reuse", "trivial-install-test-package")
-    assert spack.config.get("concretizer:reuse", None) is True
+    assert mutable_config.get("concretizer:reuse", None) is True
 
     stage("--fresh", "trivial-install-test-package")
-    assert spack.config.get("concretizer:reuse", None) is False
+    assert mutable_config.get("concretizer:reuse", None) is False
 
 
 @pytest.mark.maybeslow

--- a/lib/spack/spack/test/cmd/style.py
+++ b/lib/spack/spack/test/cmd/style.py
@@ -16,6 +16,7 @@ import spack.main
 import spack.paths
 import spack.repo
 from spack.cmd.style import _run_import_check, changed_files
+from spack.repo import RepoPath
 from spack.util.executable import which
 from spack.util.filesystem import FileFilter, working_dir
 
@@ -119,7 +120,7 @@ def test_changed_no_base(git, tmp_path: pathlib.Path, capfd):
         assert "This repository does not have a 'foobar'" in err
 
 
-def test_changed_files_all_files(mock_packages):
+def test_changed_files_all_files(mock_packages: RepoPath):
     # it's hard to guarantee "all files", so do some sanity checks.
     files = {
         os.path.join(spack.paths.prefix, os.path.normpath(path))

--- a/lib/spack/spack/test/cmd/style.py
+++ b/lib/spack/spack/test/cmd/style.py
@@ -130,7 +130,7 @@ def test_changed_files_all_files(mock_packages):
     assert len(files) > 500
 
     # a builtin package
-    zlib = spack.repo.PATH.get_pkg_class("zlib")
+    zlib = mock_packages.get_pkg_class("zlib")
     zlib_file = zlib.module.__file__
     if zlib_file.endswith("pyc"):
         zlib_file = zlib_file[:-1]

--- a/lib/spack/spack/test/cmd/test.py
+++ b/lib/spack/spack/test/cmd/test.py
@@ -35,7 +35,7 @@ def test_test_package_not_installed(
 @pytest.mark.parametrize(
     "arguments,expected",
     [
-        (["run"], spack.config.get("config:dirty")),  # default from config file
+        (["run"], spack.config.CONFIG.get("config:dirty")),  # default from config file
         (["run", "--clean"], False),
         (["run", "--dirty"], True),
     ],

--- a/lib/spack/spack/test/cmd/uninstall.py
+++ b/lib/spack/spack/test/cmd/uninstall.py
@@ -112,44 +112,45 @@ def test_force_uninstall_spec_with_ref_count_not_zero(
 
 
 @pytest.mark.db
-def test_force_uninstall_and_reinstall_by_hash(mutable_database):
+def test_force_uninstall_and_reinstall_by_hash(mutable_database_store):
     """Test forced uninstall and reinstall of old specs."""
+    db = mutable_database_store.db
     # this is the spec to be removed
-    callpath_spec = mutable_database.query_one("callpath ^mpich")
+    callpath_spec = db.query_one("callpath ^mpich")
     dag_hash = callpath_spec.dag_hash()
 
     # ensure can look up by hash and that it's a dependent of mpileaks
     def validate_callpath_spec(installed):
         assert installed is True or installed is False
 
-        specs = spack.store.STORE.db.get_by_hash(dag_hash, installed=installed)
+        specs = db.get_by_hash(dag_hash, installed=installed)
         assert len(specs) == 1 and specs[0] == callpath_spec
 
-        specs = spack.store.STORE.db.get_by_hash(dag_hash[:7], installed=installed)
+        specs = db.get_by_hash(dag_hash[:7], installed=installed)
         assert len(specs) == 1 and specs[0] == callpath_spec
 
-        specs = spack.store.STORE.db.get_by_hash(dag_hash, installed=InstallRecordStatus.ANY)
+        specs = db.get_by_hash(dag_hash, installed=InstallRecordStatus.ANY)
         assert len(specs) == 1 and specs[0] == callpath_spec
 
-        specs = spack.store.STORE.db.get_by_hash(dag_hash[:7], installed=InstallRecordStatus.ANY)
+        specs = db.get_by_hash(dag_hash[:7], installed=InstallRecordStatus.ANY)
         assert len(specs) == 1 and specs[0] == callpath_spec
 
-        specs = spack.store.STORE.db.get_by_hash(dag_hash, installed=not installed)
+        specs = db.get_by_hash(dag_hash, installed=not installed)
         assert specs is None
 
-        specs = spack.store.STORE.db.get_by_hash(dag_hash[:7], installed=not installed)
+        specs = db.get_by_hash(dag_hash[:7], installed=not installed)
         assert specs is None
 
-        mpileaks_spec = spack.store.STORE.db.query_one("mpileaks ^mpich")
+        mpileaks_spec = db.query_one("mpileaks ^mpich")
         assert callpath_spec in mpileaks_spec
 
-        spec = spack.store.STORE.db.query_one("callpath ^mpich", installed=installed)
+        spec = db.query_one("callpath ^mpich", installed=installed)
         assert spec == callpath_spec
 
-        spec = spack.store.STORE.db.query_one("callpath ^mpich", installed=InstallRecordStatus.ANY)
+        spec = db.query_one("callpath ^mpich", installed=InstallRecordStatus.ANY)
         assert spec == callpath_spec
 
-        spec = spack.store.STORE.db.query_one("callpath ^mpich", installed=not installed)
+        spec = db.query_one("callpath ^mpich", installed=not installed)
         assert spec is None
 
     validate_callpath_spec(True)
@@ -162,7 +163,7 @@ def test_force_uninstall_and_reinstall_by_hash(mutable_database):
 
     # BUT, make sure that the removed callpath spec is not in queries
     def db_specs():
-        all_specs = spack.store.STORE.layout.all_specs()
+        all_specs = mutable_database_store.layout.all_specs()
         return (
             all_specs,
             [s for s in all_specs if s.satisfies("mpileaks")],

--- a/lib/spack/spack/test/cmd/uninstall.py
+++ b/lib/spack/spack/test/cmd/uninstall.py
@@ -47,7 +47,7 @@ def test_correct_installed_dependents(mutable_database):
     # Test whether we return the right dependents.
 
     # Take callpath from the database
-    callpath = spack.store.STORE.db.query_local("callpath")[0]
+    callpath = mutable_database.query_local("callpath")[0]
 
     # Ensure it still has dependents and dependencies
     dependents = callpath.dependents(deptype=("run", "link"))
@@ -115,7 +115,7 @@ def test_force_uninstall_spec_with_ref_count_not_zero(
 def test_force_uninstall_and_reinstall_by_hash(mutable_database):
     """Test forced uninstall and reinstall of old specs."""
     # this is the spec to be removed
-    callpath_spec = spack.store.STORE.db.query_one("callpath ^mpich")
+    callpath_spec = mutable_database.query_one("callpath ^mpich")
     dag_hash = callpath_spec.dag_hash()
 
     # ensure can look up by hash and that it's a dependent of mpileaks

--- a/lib/spack/spack/test/cmd/uninstall.py
+++ b/lib/spack/spack/test/cmd/uninstall.py
@@ -75,12 +75,12 @@ def test_correct_installed_dependents(mutable_database):
 
 
 @pytest.mark.db
-def test_recursive_uninstall(mutable_database):
+def test_recursive_uninstall(mutable_database_store):
     """Test recursive uninstall."""
     uninstall("-y", "-a", "--dependents", "callpath")
 
     # query specs with multiple configurations
-    all_specs = spack.store.STORE.layout.all_specs()
+    all_specs = mutable_database_store.layout.all_specs()
     mpileaks_specs = [s for s in all_specs if s.satisfies("mpileaks")]
     callpath_specs = [s for s in all_specs if s.satisfies("callpath")]
     mpi_specs = [s for s in all_specs if s.satisfies("mpi")]
@@ -94,20 +94,20 @@ def test_recursive_uninstall(mutable_database):
 @pytest.mark.regression("3690")
 @pytest.mark.parametrize("constraint,expected_number_of_specs", [("dyninst", 10), ("libelf", 8)])
 def test_uninstall_spec_with_multiple_roots(
-    constraint, expected_number_of_specs, mutable_database
+    constraint, expected_number_of_specs, mutable_database_store
 ):
     uninstall("-y", "-a", "--dependents", constraint)
-    all_specs = spack.store.STORE.layout.all_specs()
+    all_specs = mutable_database_store.layout.all_specs()
     assert len(all_specs) == expected_number_of_specs
 
 
 @pytest.mark.db
 @pytest.mark.parametrize("constraint,expected_number_of_specs", [("dyninst", 16), ("libelf", 16)])
 def test_force_uninstall_spec_with_ref_count_not_zero(
-    constraint, expected_number_of_specs, mutable_database
+    constraint, expected_number_of_specs, mutable_database_store
 ):
     uninstall("-f", "-y", constraint)
-    all_specs = spack.store.STORE.layout.all_specs()
+    all_specs = mutable_database_store.layout.all_specs()
     assert len(all_specs) == expected_number_of_specs
 
 

--- a/lib/spack/spack/test/cmd/uninstall.py
+++ b/lib/spack/spack/test/cmd/uninstall.py
@@ -8,8 +8,10 @@ import pytest
 import spack.cmd.uninstall
 import spack.environment
 import spack.store
+from spack.database import Database
 from spack.enums import InstallRecordStatus
 from spack.main import SpackCommand, SpackCommandError
+from spack.store import Store
 from spack.util import tty
 
 uninstall = SpackCommand("uninstall")
@@ -43,7 +45,7 @@ def test_installed_dependents(mutable_database):
 
 
 @pytest.mark.db
-def test_correct_installed_dependents(mutable_database):
+def test_correct_installed_dependents(mutable_database: Database):
     # Test whether we return the right dependents.
 
     # Take callpath from the database
@@ -75,7 +77,7 @@ def test_correct_installed_dependents(mutable_database):
 
 
 @pytest.mark.db
-def test_recursive_uninstall(mutable_database_store):
+def test_recursive_uninstall(mutable_database_store: Store):
     """Test recursive uninstall."""
     uninstall("-y", "-a", "--dependents", "callpath")
 
@@ -94,7 +96,7 @@ def test_recursive_uninstall(mutable_database_store):
 @pytest.mark.regression("3690")
 @pytest.mark.parametrize("constraint,expected_number_of_specs", [("dyninst", 10), ("libelf", 8)])
 def test_uninstall_spec_with_multiple_roots(
-    constraint, expected_number_of_specs, mutable_database_store
+    constraint, expected_number_of_specs, mutable_database_store: Store
 ):
     uninstall("-y", "-a", "--dependents", constraint)
     all_specs = mutable_database_store.layout.all_specs()
@@ -104,7 +106,7 @@ def test_uninstall_spec_with_multiple_roots(
 @pytest.mark.db
 @pytest.mark.parametrize("constraint,expected_number_of_specs", [("dyninst", 16), ("libelf", 16)])
 def test_force_uninstall_spec_with_ref_count_not_zero(
-    constraint, expected_number_of_specs, mutable_database_store
+    constraint, expected_number_of_specs, mutable_database_store: Store
 ):
     uninstall("-f", "-y", constraint)
     all_specs = mutable_database_store.layout.all_specs()

--- a/lib/spack/spack/test/cmd/url.py
+++ b/lib/spack/spack/test/cmd/url.py
@@ -7,6 +7,7 @@ import pytest
 
 from spack.cmd.url import name_parsed_correctly, url_summary, version_parsed_correctly
 from spack.main import SpackCommand
+from spack.repo import RepoPath
 from spack.url import UndetectableVersionError
 
 url = SpackCommand("url")
@@ -114,7 +115,7 @@ def test_url_summary(mock_packages):
     assert out_correct_versions == correct_versions
 
 
-def test_url_stats(mock_packages):
+def test_url_stats(mock_packages: RepoPath):
     output = url("stats")
     npkgs = "%d packages" % len(mock_packages.all_package_names())
     assert npkgs in output

--- a/lib/spack/spack/test/cmd/url.py
+++ b/lib/spack/spack/test/cmd/url.py
@@ -5,7 +5,6 @@ import re
 
 import pytest
 
-import spack.repo
 from spack.cmd.url import name_parsed_correctly, url_summary, version_parsed_correctly
 from spack.main import SpackCommand
 from spack.url import UndetectableVersionError
@@ -117,7 +116,7 @@ def test_url_summary(mock_packages):
 
 def test_url_stats(mock_packages):
     output = url("stats")
-    npkgs = "%d packages" % len(spack.repo.all_package_names())
+    npkgs = "%d packages" % len(mock_packages.all_package_names())
     assert npkgs in output
     assert "url" in output
     assert "git" in output
@@ -126,7 +125,7 @@ def test_url_stats(mock_packages):
     assert "resources" in output
 
     output = url("stats", "--show-issues")
-    npkgs = "%d packages" % len(spack.repo.all_package_names())
+    npkgs = "%d packages" % len(mock_packages.all_package_names())
     assert npkgs in output
     assert "url" in output
     assert "git" in output

--- a/lib/spack/spack/test/cmd_extensions.py
+++ b/lib/spack/spack/test/cmd_extensions.py
@@ -10,7 +10,6 @@ import sys
 import pytest
 
 import spack.cmd
-import spack.config
 import spack.extensions
 import spack.main
 
@@ -58,7 +57,7 @@ def extension_creator(tmp_path: pathlib.Path, config):
         root = tmp_path / ("spack-" + extension_name)
         root.mkdir()
         extension = Extension(extension_name, root)
-        with spack.config.CONFIG.override("config:extensions", [str(extension.root)]):
+        with config.override("config:extensions", [str(extension.root)]):
             yield extension
 
     list_of_modules = list(sys.modules.keys())

--- a/lib/spack/spack/test/cmd_extensions.py
+++ b/lib/spack/spack/test/cmd_extensions.py
@@ -238,7 +238,7 @@ def test_extension_naming(tmp_path: pathlib.Path, extension_path, expected_excep
     import spack.util.filesystem as fs
 
     with fs.working_dir(str(tmp_path)):
-        with spack.config.override("config:extensions", [extension_path]):
+        with config.override("config:extensions", [extension_path]):
             with pytest.raises(expected_exception):
                 spack.cmd.get_module("no-such-command")
 
@@ -267,7 +267,7 @@ def test_get_command_paths(config):
         path = os.path.abspath(path)
         expected_cmd_paths.append(path)
 
-    with spack.config.override("config:extensions", ext_paths):
+    with config.override("config:extensions", ext_paths):
         assert spack.extensions.get_command_paths() == expected_cmd_paths
 
 
@@ -280,7 +280,7 @@ def test_variable_in_extension_path(config, working_env):
     expected_ext_paths = [
         os.path.join(os.environ[home_env], os.environ["_MY_VAR"], "spack-extension-1")
     ]
-    with spack.config.override("config:extensions", ext_paths):
+    with config.override("config:extensions", ext_paths):
         assert spack.extensions.get_extension_paths() == expected_ext_paths
 
 

--- a/lib/spack/spack/test/cmd_extensions.py
+++ b/lib/spack/spack/test/cmd_extensions.py
@@ -58,7 +58,7 @@ def extension_creator(tmp_path: pathlib.Path, config):
         root = tmp_path / ("spack-" + extension_name)
         root.mkdir()
         extension = Extension(extension_name, root)
-        with spack.config.override("config:extensions", [str(extension.root)]):
+        with spack.config.CONFIG.override("config:extensions", [str(extension.root)]):
             yield extension
 
     list_of_modules = list(sys.modules.keys())

--- a/lib/spack/spack/test/cmd_extensions.py
+++ b/lib/spack/spack/test/cmd_extensions.py
@@ -12,6 +12,7 @@ import pytest
 import spack.cmd
 import spack.extensions
 import spack.main
+from spack.config import Configuration
 
 
 class Extension:
@@ -49,7 +50,7 @@ class Extension:
 
 
 @pytest.fixture(scope="function")
-def extension_creator(tmp_path: pathlib.Path, config):
+def extension_creator(tmp_path: pathlib.Path, config: Configuration):
     """Create a basic extension command directory structure"""
 
     @contextlib.contextmanager
@@ -227,7 +228,9 @@ def test_missing_command():
     ],
     ids=["no_stem", "vacuous", "leading_hyphen", "basic_good", "trailing_slash", "hyphenated"],
 )
-def test_extension_naming(tmp_path: pathlib.Path, extension_path, expected_exception, config):
+def test_extension_naming(
+    tmp_path: pathlib.Path, extension_path, expected_exception, config: Configuration
+):
     """Ensure that we are correctly validating configured extension paths
     for conformity with the rules: the basename should match
     ``spack-<name>``; <name> may have embedded hyphens but not begin with one.
@@ -254,7 +257,7 @@ def test_missing_command_function(extension_creator, capfd):
         assert "must define function 'bad_cmd'." in capture[1]
 
 
-def test_get_command_paths(config):
+def test_get_command_paths(config: Configuration):
     """Exercise the construction of extension command search paths."""
     extensions = ("extension-1", "extension-2")
     ext_paths = []
@@ -270,7 +273,7 @@ def test_get_command_paths(config):
         assert spack.extensions.get_command_paths() == expected_cmd_paths
 
 
-def test_variable_in_extension_path(config, working_env):
+def test_variable_in_extension_path(config: Configuration, working_env):
     """Test variables in extension paths."""
     os.environ["_MY_VAR"] = os.path.join("my", "var")
     ext_paths = [os.path.join("~", "${_MY_VAR}", "spack-extension-1")]

--- a/lib/spack/spack/test/concretization/compiler_runtimes.py
+++ b/lib/spack/spack/test/concretization/compiler_runtimes.py
@@ -15,6 +15,7 @@ import spack.paths
 import spack.repo
 import spack.solver.asp
 import spack.spec
+from spack.config import Configuration
 from spack.environment.environment import ViewDescriptor
 from spack.externals_config import create_external_parser, external_config_with_implicit_externals
 from spack.solver.reuse import spec_filter_from_packages_yaml
@@ -59,7 +60,9 @@ def test_correct_gcc_runtime_is_injected_as_dependency(runtime_repo):
 
 
 @pytest.mark.regression("41972")
-def test_external_nodes_do_not_have_runtimes(runtime_repo, mutable_config, tmp_path: pathlib.Path):
+def test_external_nodes_do_not_have_runtimes(
+    runtime_repo, mutable_config: Configuration, tmp_path: pathlib.Path
+):
     """Tests that external nodes don't have runtime dependencies."""
 
     packages_yaml = {"pkg-b": {"externals": [{"spec": "pkg-b@1.0", "prefix": f"{str(tmp_path)}"}]}}

--- a/lib/spack/spack/test/concretization/compiler_runtimes.py
+++ b/lib/spack/spack/test/concretization/compiler_runtimes.py
@@ -10,7 +10,6 @@ import pytest
 import spack.vendor.archspec.cpu
 
 import spack.concretize
-import spack.config
 import spack.database
 import spack.paths
 import spack.repo
@@ -64,7 +63,7 @@ def test_external_nodes_do_not_have_runtimes(runtime_repo, mutable_config, tmp_p
     """Tests that external nodes don't have runtime dependencies."""
 
     packages_yaml = {"pkg-b": {"externals": [{"spec": "pkg-b@1.0", "prefix": f"{str(tmp_path)}"}]}}
-    spack.config.set("packages", packages_yaml)
+    mutable_config.set("packages", packages_yaml)
 
     s = spack.concretize.concretize_one("pkg-a%gcc@10.2.1")
 

--- a/lib/spack/spack/test/concretization/core.py
+++ b/lib/spack/spack/test/concretization/core.py
@@ -177,7 +177,7 @@ def current_host(request, monkeypatch):
     else:
         target = spack.vendor.archspec.cpu.TARGETS["sapphirerapids"]
         monkeypatch.setattr(spack.vendor.archspec.cpu, "host", lambda: target)
-        with spack.config.override("packages:all", {"target": [cpu]}):
+        with spack.config.CONFIG.override("packages:all", {"target": [cpu]}):
             yield target
 
 

--- a/lib/spack/spack/test/concretization/core.py
+++ b/lib/spack/spack/test/concretization/core.py
@@ -38,7 +38,6 @@ import spack.solver.input_analysis
 import spack.solver.reuse
 import spack.spec
 import spack.spec_filter
-import spack.store
 import spack.traverse
 import spack.util.file_cache
 import spack.util.hash
@@ -1769,7 +1768,7 @@ spack:
         # the answer set produced by clingo.
         with spack.config.override("concretizer:reuse", True):
             s = spack.concretize.concretize_one(spec_str)
-        assert spack.store.STORE.db.installed(s) is expect_installed
+        assert mutable_database.installed(s) is expect_installed
         assert s.satisfies(spec_str)
 
     @pytest.mark.regression("26721,19736")
@@ -2405,7 +2404,7 @@ spack:
         # If we concretize with --reuse it is not, since "mpich~debug" was already installed
         with spack.config.override("concretizer:reuse", True):
             s = spack.concretize.concretize_one("mpich")
-            assert spack.store.STORE.db.installed(s)
+            assert mutable_database.installed(s)
             assert s.satisfies("~debug"), s
 
     @pytest.mark.regression("32471")
@@ -2600,7 +2599,7 @@ packages:
         """Tests that when we reuse a spec, virtual on edges are reconstructed correctly"""
         with spack.config.override("concretizer:reuse", True):
             spec = spack.concretize.concretize_one(spec_str)
-            assert spack.store.STORE.db.installed(spec)
+            assert mutable_database.installed(spec)
             mpi_edges = spec.edges_to_dependencies(mpi_name)
             assert len(mpi_edges) == 1
             assert "mpi" in mpi_edges[0].virtuals

--- a/lib/spack/spack/test/concretization/core.py
+++ b/lib/spack/spack/test/concretization/core.py
@@ -493,17 +493,17 @@ class TestConcretize:
             assert x.satisfies("%clang") is not expected_gcc
             assert x.satisfies("%gcc") is expected_gcc
 
-    def test_disable_mixing_prevents_mixing(self):
-        with spack.config.override("concretizer", {"compiler_mixing": False}):
+    def test_disable_mixing_prevents_mixing(self, mutable_config):
+        with mutable_config.override("concretizer", {"compiler_mixing": False}):
             with pytest.raises(spack.error.UnsatisfiableSpecError):
                 spack.concretize.concretize_one("dt-diamond%clang ^dt-diamond-bottom%gcc")
 
-    def test_disable_mixing_is_per_language(self):
-        with spack.config.override("concretizer", {"compiler_mixing": False}):
+    def test_disable_mixing_is_per_language(self, mutable_config):
+        with mutable_config.override("concretizer", {"compiler_mixing": False}):
             spack.concretize.concretize_one("openblas %c=llvm %fortran=gcc")
 
-    def test_disable_mixing_override_by_package(self):
-        with spack.config.override("concretizer", {"compiler_mixing": ["dt-diamond-bottom"]}):
+    def test_disable_mixing_override_by_package(self, mutable_config):
+        with mutable_config.override("concretizer", {"compiler_mixing": ["dt-diamond-bottom"]}):
             root = spack.concretize.concretize_one("dt-diamond%clang ^dt-diamond-bottom%gcc")
             assert root.satisfies("%clang")
             assert root["dt-diamond-bottom"].satisfies("%gcc")
@@ -512,7 +512,7 @@ class TestConcretize:
             with pytest.raises(spack.error.UnsatisfiableSpecError):
                 spack.concretize.concretize_one("dt-diamond%clang ^dt-diamond-left%gcc")
 
-    def test_disable_mixing_reuse(self, fake_db_install):
+    def test_disable_mixing_reuse(self, fake_db_install, mutable_config):
         # Install a spec
         left = spack.concretize.concretize_one("dt-diamond-left %gcc")
         fake_db_install(left)
@@ -523,14 +523,14 @@ class TestConcretize:
         spack.concretize.concretize_one(f"dt-diamond%clang ^/{lefthash}")
 
         # Now try to use it with compiler mixing disabled
-        with spack.config.override("concretizer", {"compiler_mixing": False}):
+        with mutable_config.override("concretizer", {"compiler_mixing": False}):
             with pytest.raises(spack.error.UnsatisfiableSpecError):
                 spack.concretize.concretize_one(f"dt-diamond%clang ^/{lefthash}")
 
             # Should be able to reuse if the compilers match
             spack.concretize.concretize_one(f"dt-diamond%gcc ^/{lefthash}")
 
-    def test_disable_mixing_reuse_and_built(self, fake_db_install):
+    def test_disable_mixing_reuse_and_built(self, fake_db_install, mutable_config):
         r"""In this case we have
 
         x
@@ -553,17 +553,17 @@ class TestConcretize:
 
         spack.concretize.concretize_one(f"mixing-parent%clang ^cmake%gcc ^/{dep1hash}")
 
-        with spack.config.override("concretizer", {"compiler_mixing": False}):
+        with mutable_config.override("concretizer", {"compiler_mixing": False}):
             with pytest.raises(spack.error.UnsatisfiableSpecError, match="mixing is disabled"):
                 spack.concretize.concretize_one(f"mixing-parent%clang ^cmake%gcc ^/{dep1hash}")
 
-    def test_disable_mixing_allow_compiler_link(self):
+    def test_disable_mixing_allow_compiler_link(self, mutable_config):
         """Check if we can use a compiler when mixing is disabled, and
         still depend on a separate compiler package (in the latter case
         not using it as a compiler but rather for some utility it
         provides).
         """
-        with spack.config.override("concretizer", {"compiler_mixing": False}):
+        with mutable_config.override("concretizer", {"compiler_mixing": False}):
             x = spack.concretize.concretize_one("llvm-client%gcc")
             assert x.satisfies("%cxx=gcc")
             assert x.satisfies("%c=gcc")
@@ -625,7 +625,7 @@ spack:
                 continue
             assert x.satisfies("%clang")
 
-    def test_architecture_deep_inheritance(self, mock_targets, compiler_factory):
+    def test_architecture_deep_inheritance(self, mock_targets, compiler_factory, mutable_config):
         """Make sure that indirect dependencies receive architecture
         information from the root even when partial architecture information
         is provided by an intermediate dependency.
@@ -633,7 +633,7 @@ spack:
         cnl_compiler = compiler_factory(
             spec="gcc@4.5.0 os=CNL languages:=c,c++,fortran target=nocona"
         )
-        with spack.config.override("packages", {"gcc": {"externals": [cnl_compiler]}}):
+        with mutable_config.override("packages", {"gcc": {"externals": [cnl_compiler]}}):
             spec_str = "mpileaks os=CNL target=nocona %gcc@4.5.0 ^dyninst os=CNL ^callpath os=CNL"
             spec = spack.concretize.concretize_one(spec_str)
             for s in spec.traverse(root=False, deptype=("link", "run")):
@@ -1013,12 +1013,12 @@ spack:
             s = spack.concretize.concretize_one(s)
 
     @pytest.mark.parametrize("spec_str", ["unsat-provider@1.0+foo"])
-    def test_no_conflict_in_external_specs(self, spec_str):
+    def test_no_conflict_in_external_specs(self, spec_str, mutable_config):
         # Modify the configuration to have the spec with conflict
         # registered as an external
         ext = Spec(spec_str)
         data = {"externals": [{"spec": spec_str, "prefix": "/fake/path"}]}
-        spack.config.set("packages::{0}".format(ext.name), data)
+        mutable_config.set("packages::{0}".format(ext.name), data)
         ext = spack.concretize.concretize_one(ext)  # failure raises exception
 
     def test_regression_issue_4492(self):
@@ -1227,7 +1227,7 @@ spack:
         mutable_config.set(
             "concretizer:os_compatible", {"debian6": ["redhat6"], "redhat6": ["debian6"]}
         )
-        with spack.config.override("packages", {"gcc": {"externals": [gcc11_with_flags]}}):
+        with mutable_config.override("packages", {"gcc": {"externals": [gcc11_with_flags]}}):
             s = spack.concretize.concretize_one(spec_str)
             assert s.satisfies(expected_str)
 
@@ -1349,13 +1349,13 @@ spack:
             assert s.satisfies(constraint)
 
     @pytest.mark.regression("5651")
-    def test_package_with_constraint_not_met_by_external(self):
+    def test_package_with_constraint_not_met_by_external(self, mutable_config):
         """Check that if we have an external package A at version X.Y in
         packages.yaml, but our spec doesn't allow X.Y as a version, then
         a new version of A is built that meets the requirements.
         """
         packages_yaml = {"libelf": {"externals": [{"spec": "libelf@0.8.13", "prefix": "/usr"}]}}
-        spack.config.set("packages", packages_yaml)
+        mutable_config.set("packages", packages_yaml)
 
         # quantum-espresso+veritas requires libelf@:0.8.12
         s = spack.concretize.concretize_one("quantum-espresso+veritas")
@@ -1510,7 +1510,14 @@ spack:
     )
     @pytest.mark.parametrize("mock_db", [True, False])
     def test_reuse_does_not_overwrite_dev_specs(
-        self, dev_first, spec, mock_db, tmp_path: pathlib.Path, temporary_store, monkeypatch
+        self,
+        dev_first,
+        spec,
+        mock_db,
+        tmp_path: pathlib.Path,
+        temporary_store,
+        monkeypatch,
+        mutable_config,
     ):
         """Test that reuse does not mix dev specs with non-dev specs.
 
@@ -1540,7 +1547,7 @@ spack:
             monkeypatch.setattr(spack.binary_distribution, "update_cache_and_get_specs", mock_fn)
 
         # concretize and ensure we did not reuse
-        with spack.config.override("concretizer:reuse", True):
+        with mutable_config.override("concretizer:reuse", True):
             second_spec = spack.concretize.concretize_one(second_spec)
         assert first_spec.dag_hash() != second_spec.dag_hash()
 
@@ -1554,10 +1561,10 @@ spack:
         ],
     )
     def test_reuse_installed_packages_when_package_def_changes(
-        self, context, mutable_database, repo_with_changing_recipe
+        self, context, mutable_database, repo_with_changing_recipe, mutable_config
     ):
         # test applies only with reuse turned off in concretizer
-        spack.config.set("concretizer:reuse", False)
+        mutable_config.set("concretizer:reuse", False)
 
         # Install a spec
         root = spack.concretize.concretize_one("root")
@@ -1585,8 +1592,10 @@ spack:
         assert root.dag_hash() != new_root_without_reuse.dag_hash()
 
     @pytest.mark.regression("43663")
-    def test_no_reuse_when_variant_condition_does_not_hold(self, mutable_database, mock_packages):
-        spack.config.set("concretizer:reuse", True)
+    def test_no_reuse_when_variant_condition_does_not_hold(
+        self, mutable_database, mock_packages, mutable_config
+    ):
+        mutable_config.set("concretizer:reuse", True)
 
         # Install a spec for which the `version_based` variant condition does not hold
         old = spack.concretize.concretize_one("conditional-variant-pkg @1")
@@ -1600,7 +1609,7 @@ spack:
         assert new2.satisfies("@2 +two_whens +version_based")
 
     def test_reuse_with_flags(self, mutable_database, mutable_config):
-        spack.config.set("concretizer:reuse", True)
+        mutable_config.set("concretizer:reuse", True)
         spec = spack.concretize.concretize_one("pkg-a cflags=-g cxxflags=-g")
         PackageInstaller([spec.package], fake=True, explicit=True).install()
         testspec = spack.concretize.concretize_one("pkg-a cflags=-g")
@@ -1639,14 +1648,14 @@ spack:
         assert set(expected_values) == set(s.variants[variant_name].value)
 
     @pytest.mark.regression("22533")
-    def test_mv_variants_disjoint_sets_from_packages_yaml(self):
+    def test_mv_variants_disjoint_sets_from_packages_yaml(self, mutable_config):
         external_mvapich2 = {
             "mvapich2": {
                 "buildable": False,
                 "externals": [{"spec": "mvapich2@2.3.1 file_systems=nfs,ufs", "prefix": "/usr"}],
             }
         }
-        spack.config.set("packages", external_mvapich2)
+        mutable_config.set("packages", external_mvapich2)
 
         s = spack.concretize.concretize_one("mvapich2")
         assert set(s.variants["file_systems"].value) == set(["ufs", "nfs"])
@@ -1699,8 +1708,8 @@ spack:
             ("deprecated-versions@=1.1.0", "deprecated-versions@1.1.0"),
         ],
     )
-    def test_deprecated_versions_not_selected(self, spec_str, expected):
-        with spack.config.override("config:deprecated", True):
+    def test_deprecated_versions_not_selected(self, spec_str, expected, mutable_config):
+        with mutable_config.override("config:deprecated", True):
             s = spack.concretize.concretize_one(spec_str)
             s.satisfies(expected)
 
@@ -1760,13 +1769,13 @@ spack:
         [("mpich", True), ("mpich+debug", False), ("mpich~debug", True)],
     )
     def test_concrete_specs_are_not_modified_on_reuse(
-        self, mutable_database, spec_str, expect_installed
+        self, mutable_database, spec_str, expect_installed, mutable_config
     ):
         # Test the internal consistency of solve + DAG reconstruction
         # when reused specs are added to the mix. This prevents things
         # like additional constraints being added to concrete specs in
         # the answer set produced by clingo.
-        with spack.config.override("concretizer:reuse", True):
+        with mutable_config.override("concretizer:reuse", True):
             s = spack.concretize.concretize_one(spec_str)
         assert mutable_database.installed(s) is expect_installed
         assert s.satisfies(spec_str)
@@ -1795,10 +1804,10 @@ spack:
             # FIXME (externals as concrete) ("sticky-variant@1.0", False),
         ],
     )
-    def test_sticky_variant_in_external(self, spec, allow_gcc):
+    def test_sticky_variant_in_external(self, spec, allow_gcc, mutable_config):
         # setup external for sticky-variant+allow-gcc
         config = {"externals": [{"spec": spec, "prefix": "/fake/path"}], "buildable": False}
-        spack.config.set("packages:sticky-variant", config)
+        mutable_config.set("packages:sticky-variant", config)
 
         maybe = spack.util.lang.nullcontext if allow_gcc else pytest.raises
         with maybe(spack.error.SpackError):
@@ -1844,17 +1853,17 @@ spack:
         s = spack.concretize.concretize_one("conditional-values-in-variant@1.60.0")
         assert "cxxstd" in s.variants
 
-    def test_target_granularity(self):
+    def test_target_granularity(self, mutable_config):
         # The test architecture uses core2 as the default target. Check that when
         # we configure Spack for "generic" granularity we concretize for x86_64
         default_target = spack.platforms.test.Test.default
         generic_target = spack.vendor.archspec.cpu.TARGETS[default_target].generic.name
         s = Spec("python")
         assert spack.concretize.concretize_one(s).satisfies("target=%s" % default_target)
-        with spack.config.override("concretizer:targets", {"granularity": "generic"}):
+        with mutable_config.override("concretizer:targets", {"granularity": "generic"}):
             assert spack.concretize.concretize_one(s).satisfies("target=%s" % generic_target)
 
-    def test_host_compatible_concretization(self):
+    def test_host_compatible_concretization(self, mutable_config):
         # Check that after setting "host_compatible" to false we cannot concretize.
         # Here we use "k10" to set a target non-compatible with the current host
         # to avoid a lot of boilerplate when mocking the test platform. The issue
@@ -1862,19 +1871,21 @@ spack:
         # compiler supporting e.g. icelake etc.
         s = Spec("python target=k10")
         assert spack.concretize.concretize_one(s)
-        with spack.config.override("concretizer:targets", {"host_compatible": True}):
+        with mutable_config.override("concretizer:targets", {"host_compatible": True}):
             with pytest.raises(spack.error.SpackError):
                 spack.concretize.concretize_one(s)
 
-    def test_add_microarchitectures_on_explicit_request(self):
+    def test_add_microarchitectures_on_explicit_request(self, mutable_config):
         # Check that if we consider only "generic" targets, we can still solve for
         # specific microarchitectures on explicit requests
-        with spack.config.override("concretizer:targets", {"granularity": "generic"}):
+        with mutable_config.override("concretizer:targets", {"granularity": "generic"}):
             s = spack.concretize.concretize_one("python target=k10")
         assert s.satisfies("target=k10")
 
     @pytest.mark.regression("29201")
-    def test_delete_version_and_reuse(self, mutable_database, repo_with_changing_recipe):
+    def test_delete_version_and_reuse(
+        self, mutable_database, repo_with_changing_recipe, mutable_config
+    ):
         """Test that we can reuse installed specs with versions not
         declared in package.py
         """
@@ -1882,14 +1893,14 @@ spack:
         PackageInstaller([root.package], fake=True, explicit=True).install()
         repo_with_changing_recipe.change({"delete_version": True})
 
-        with spack.config.override("concretizer:reuse", True):
+        with mutable_config.override("concretizer:reuse", True):
             new_root = spack.concretize.concretize_one("root")
 
         assert root.dag_hash() == new_root.dag_hash()
 
     @pytest.mark.regression("29201")
     def test_installed_version_is_selected_only_for_reuse(
-        self, mutable_database, repo_with_changing_recipe
+        self, mutable_database, repo_with_changing_recipe, mutable_config
     ):
         """Test that a version coming from an installed spec is a possible
         version only for reuse
@@ -1900,27 +1911,27 @@ spack:
         PackageInstaller([dependency.package], fake=True, explicit=True).install()
         repo_with_changing_recipe.change({"delete_version": True})
 
-        with spack.config.override("concretizer:reuse", True):
+        with mutable_config.override("concretizer:reuse", True):
             new_root = spack.concretize.concretize_one("root")
 
         assert not new_root["changing"].satisfies("@1.0")
 
     @pytest.mark.regression("28259")
     def test_reuse_with_unknown_namespace_dont_raise(
-        self, temporary_store, mock_custom_repository
+        self, temporary_store, mock_custom_repository, mutable_config
     ):
         with spack.repo.use_repositories(mock_custom_repository, override=False):
             s = spack.concretize.concretize_one("pkg-c")
             assert s.namespace != "builtin_mock"
             PackageInstaller([s.package], fake=True, explicit=True).install()
 
-        with spack.config.override("concretizer:reuse", True):
+        with mutable_config.override("concretizer:reuse", True):
             s = spack.concretize.concretize_one("pkg-c")
         assert s.namespace == "builtin_mock"
 
     @pytest.mark.regression("45538")
     def test_reuse_from_other_namespace_no_raise(
-        self, temporary_store, monkeypatch, repo_builder: RepoBuilder
+        self, temporary_store, monkeypatch, repo_builder: RepoBuilder, mutable_config
     ):
         repo_builder.add_package("zlib")
 
@@ -1928,14 +1939,14 @@ spack:
         PackageInstaller([builtin.package], fake=True, explicit=True).install()
 
         with spack.repo.use_repositories(repo_builder.root, override=False):
-            with spack.config.override("concretizer:reuse", True):
+            with mutable_config.override("concretizer:reuse", True):
                 zlib = spack.concretize.concretize_one(f"{repo_builder.namespace}.zlib")
 
         assert zlib.namespace == repo_builder.namespace
 
     @pytest.mark.regression("28259")
     def test_reuse_with_unknown_package_dont_raise(
-        self, temporary_store, monkeypatch, repo_builder: RepoBuilder
+        self, temporary_store, monkeypatch, repo_builder: RepoBuilder, mutable_config
     ):
         repo_builder.add_package("pkg-c")
         with spack.repo.use_repositories(repo_builder.root, override=False):
@@ -1946,7 +1957,7 @@ spack:
         repo_builder.remove("pkg-c")
         with spack.repo.use_repositories(repo_builder.root, override=False) as repos:
             repos.repos[0]._pkg_checker.invalidate()
-            with spack.config.override("concretizer:reuse", True):
+            with mutable_config.override("concretizer:reuse", True):
                 s = spack.concretize.concretize_one("pkg-c")
             assert s.namespace == "builtin_mock"
 
@@ -2034,14 +2045,14 @@ spack:
         with pytest.raises(spack.solver.asp.OutputDoesNotSatisfyInputError):
             list(solver.solve_in_rounds(specs))
 
-    def test_coconcretize_reuse_and_virtuals(self):
+    def test_coconcretize_reuse_and_virtuals(self, mutable_config):
         reusable_specs = []
         for s in ["mpileaks ^mpich", "zmpi"]:
             reusable_specs.extend(spack.concretize.concretize_one(s).traverse(root=True))
 
         root_specs = [Spec("mpileaks"), Spec("zmpi")]
 
-        with spack.config.override("concretizer:reuse", True):
+        with mutable_config.override("concretizer:reuse", True):
             solver = spack.solver.asp.Solver()
             setup = spack.solver.asp.SpackSolverSetup()
             result, _, _ = solver.driver.solve(setup, root_specs, reuse=reusable_specs)
@@ -2050,14 +2061,14 @@ spack:
             assert "zmpi" in spec
 
     @pytest.mark.regression("30864")
-    def test_misleading_error_message_on_version(self, mutable_database):
+    def test_misleading_error_message_on_version(self, mutable_database, mutable_config):
         # For this bug to be triggered we need a reusable dependency
         # that is not optimal in terms of optimization scores.
         # We pick an old version of "b"
         reusable_specs = [spack.concretize.concretize_one("non-existing-conditional-dep@1.0")]
         root_spec = Spec("non-existing-conditional-dep@2.0")
 
-        with spack.config.override("concretizer:reuse", True):
+        with mutable_config.override("concretizer:reuse", True):
             solver = spack.solver.asp.Solver()
             setup = spack.solver.asp.SpackSolverSetup()
             with pytest.raises(spack.solver.asp.UnsatisfiableSpecError, match="Cannot satisfy"):
@@ -2079,7 +2090,7 @@ spack:
             include=[],
             exclude=[],
         ).selected_specs()
-        with spack.config.override("concretizer:reuse", True):
+        with mutable_config.override("concretizer:reuse", True):
             solver = spack.solver.asp.Solver()
             setup = spack.solver.asp.SpackSolverSetup()
             result, _, _ = solver.driver.solve(
@@ -2284,7 +2295,7 @@ spack:
 
         assert all(x in asp_problem for x in expected)
 
-    def test_reuse_succeeds_with_config_compatible_os(self):
+    def test_reuse_succeeds_with_config_compatible_os(self, mutable_config):
         root_spec = Spec("pkg-b")
         s = spack.concretize.concretize_one(root_spec)
         other_os = s.copy()
@@ -2295,7 +2306,7 @@ spack:
         reusable_specs = [other_os]
         overrides = {"concretizer": {"reuse": True, "os_compatible": {s.os: [mock_os]}}}
         custom_scope = spack.config.InternalConfigScope("concretize_override", overrides)
-        with spack.config.override(custom_scope):
+        with mutable_config.override(custom_scope):
             solver = spack.solver.asp.Solver()
             setup = spack.solver.asp.SpackSolverSetup()
             result, _, _ = solver.driver.solve(setup, [root_spec], reuse=reusable_specs)
@@ -2325,7 +2336,7 @@ spack:
 
     @pytest.mark.regression("31484")
     def test_installed_externals_are_reused(
-        self, mutable_database, repo_with_changing_recipe, tmp_path: pathlib.Path
+        self, mutable_database, repo_with_changing_recipe, tmp_path: pathlib.Path, mutable_config
     ):
         """Tests that external specs that are in the DB can be reused, if they result in a
         better optimization score.
@@ -2336,7 +2347,7 @@ spack:
                 "externals": [{"spec": "changing@1.0", "prefix": str(tmp_path)}],
             }
         }
-        spack.config.set("packages", external_conf)
+        mutable_config.set("packages", external_conf)
 
         # Install the external spec
         middle_pkg = spack.concretize.concretize_one("middle")
@@ -2348,18 +2359,18 @@ spack:
         repo_with_changing_recipe.change({"delete_variant": True})
 
         # Try to concretize the external without reuse and confirm the hash changed
-        with spack.config.override("concretizer:reuse", False):
+        with mutable_config.override("concretizer:reuse", False):
             root_no_reuse = spack.concretize.concretize_one("root")
         assert root_no_reuse["changing"].dag_hash() != changing_external.dag_hash()
 
         # ... while with reuse we have the same hash
-        with spack.config.override("concretizer:reuse", True):
+        with mutable_config.override("concretizer:reuse", True):
             root_with_reuse = spack.concretize.concretize_one("root")
         assert root_with_reuse["changing"].dag_hash() == changing_external.dag_hash()
 
     @pytest.mark.regression("31484")
     def test_user_can_select_externals_with_require(
-        self, mutable_database, tmp_path: pathlib.Path
+        self, mutable_database, tmp_path: pathlib.Path, mutable_config
     ):
         """Test that users have means to select an external even in presence of reusable specs."""
         external_conf: Dict[str, Any] = {
@@ -2368,27 +2379,29 @@ spack:
                 "externals": [{"spec": "multi-provider-mpi@2.0.0", "prefix": str(tmp_path)}]
             },
         }
-        spack.config.set("packages", external_conf)
+        mutable_config.set("packages", external_conf)
 
         # mpich and others are installed, so check that
         # fresh use the external, reuse does not
-        with spack.config.override("concretizer:reuse", False):
+        with mutable_config.override("concretizer:reuse", False):
             mpi_spec = spack.concretize.concretize_one("mpi")
             assert mpi_spec.name == "multi-provider-mpi"
 
-        with spack.config.override("concretizer:reuse", True):
+        with mutable_config.override("concretizer:reuse", True):
             mpi_spec = spack.concretize.concretize_one("mpi")
             assert mpi_spec.name != "multi-provider-mpi"
 
         external_conf["mpi"]["require"] = "multi-provider-mpi"
-        spack.config.set("packages", external_conf)
+        mutable_config.set("packages", external_conf)
 
-        with spack.config.override("concretizer:reuse", True):
+        with mutable_config.override("concretizer:reuse", True):
             mpi_spec = spack.concretize.concretize_one("mpi")
             assert mpi_spec.name == "multi-provider-mpi"
 
     @pytest.mark.regression("31484")
-    def test_installed_specs_disregard_conflicts(self, mutable_database, monkeypatch):
+    def test_installed_specs_disregard_conflicts(
+        self, mutable_database, monkeypatch, mutable_config
+    ):
         """Test that installed specs do not trigger conflicts. This covers for the rare case
         where a conflict is added on a package after a spec matching the conflict was installed.
         """
@@ -2397,12 +2410,12 @@ spack:
         monkeypatch.setitem(pkg_cls.conflicts, Spec(), [(Spec("~debug"), None)])
 
         # If we concretize with --fresh the conflict is taken into account
-        with spack.config.override("concretizer:reuse", False):
+        with mutable_config.override("concretizer:reuse", False):
             s = spack.concretize.concretize_one("mpich")
             assert s.satisfies("+debug")
 
         # If we concretize with --reuse it is not, since "mpich~debug" was already installed
-        with spack.config.override("concretizer:reuse", True):
+        with mutable_config.override("concretizer:reuse", True):
             s = spack.concretize.concretize_one("mpich")
             assert mutable_database.installed(s)
             assert s.satisfies("~debug"), s
@@ -2417,7 +2430,7 @@ spack:
         external_conf = {"all": {"require": f"target={required_target}"}}
         mutable_config.set("packages", external_conf)
 
-        with spack.config.override("concretizer:reuse", False):
+        with mutable_config.override("concretizer:reuse", False):
             spec = spack.concretize.concretize_one("mpich")
 
         for s in spec.traverse(deptype=("link", "run")):
@@ -2551,7 +2564,7 @@ packages:
             "replacement": f"/{mpich_spec.dag_hash()}",
             "transitive": transitive,
         }
-        spack.config.CONFIG.set("concretizer", {"splice": {"explicit": [splice_info]}})
+        mutable_config.set("concretizer", {"splice": {"explicit": [splice_info]}})
 
         spec = spack.concretize.concretize_one("hdf5 ^zmpi")
 
@@ -2566,26 +2579,26 @@ packages:
         assert "hdf5 ^zmpi" in captured.err
         assert str(spec) in captured.err
 
-    def test_explicit_splice_fails_nonexistent(mutable_config, mock_packages, mock_store):
+    def test_explicit_splice_fails_nonexistent(self, mutable_config, mock_packages, mock_store):
         splice_info = {"target": "mpi", "replacement": "mpich/doesnotexist"}
-        spack.config.CONFIG.set("concretizer", {"splice": {"explicit": [splice_info]}})
+        mutable_config.set("concretizer", {"splice": {"explicit": [splice_info]}})
 
         with pytest.raises(spack.spec.InvalidHashError):
             _ = spack.concretize.concretize_one("hdf5^zmpi")
 
-    def test_explicit_splice_fails_no_hash(mutable_config, mock_packages, mock_store):
+    def test_explicit_splice_fails_no_hash(self, mutable_config, mock_packages, mock_store):
         splice_info = {"target": "mpi", "replacement": "mpich"}
-        spack.config.CONFIG.set("concretizer", {"splice": {"explicit": [splice_info]}})
+        mutable_config.set("concretizer", {"splice": {"explicit": [splice_info]}})
 
         with pytest.raises(spack.solver.asp.InvalidSpliceError, match="must be specified by hash"):
             _ = spack.concretize.concretize_one("hdf5^zmpi")
 
     def test_explicit_splice_non_match_nonexistent_succeeds(
-        mutable_config, mock_packages, mock_store
+        self, mutable_config, mock_packages, mock_store
     ):
         """When we have a nonexistent splice configured but are not using it, don't fail."""
         splice_info = {"target": "will_not_match", "replacement": "nonexistent/doesnotexist"}
-        spack.config.CONFIG.set("concretizer", {"splice": {"explicit": [splice_info]}})
+        mutable_config.set("concretizer", {"splice": {"explicit": [splice_info]}})
         spec = spack.concretize.concretize_one("zlib")
         # the main test is that it does not raise
         assert not spec.spliced
@@ -2595,9 +2608,11 @@ packages:
         "spec_str,mpi_name",
         [("mpileaks", "mpich"), ("mpileaks ^mpich2", "mpich2"), ("mpileaks ^zmpi", "zmpi")],
     )
-    def test_virtuals_are_reconstructed_on_reuse(self, spec_str, mpi_name, mutable_database):
+    def test_virtuals_are_reconstructed_on_reuse(
+        self, spec_str, mpi_name, mutable_database, mutable_config
+    ):
         """Tests that when we reuse a spec, virtual on edges are reconstructed correctly"""
-        with spack.config.override("concretizer:reuse", True):
+        with mutable_config.override("concretizer:reuse", True):
             spec = spack.concretize.concretize_one(spec_str)
             assert mutable_database.installed(spec)
             mpi_edges = spec.edges_to_dependencies(mpi_name)
@@ -2613,7 +2628,7 @@ packages:
 
     @pytest.mark.regression("39570")
     @pytest.mark.db
-    def test_reuse_python_from_cli_and_extension_from_db(self, mutable_database):
+    def test_reuse_python_from_cli_and_extension_from_db(self, mutable_database, mutable_config):
         """Tests that reusing python with and explicit request on the command line, when the spec
         also reuses a python extension from the DB, doesn't fail.
         """
@@ -2621,10 +2636,10 @@ packages:
         python_hash = s["python"].dag_hash()
         PackageInstaller([s.package], fake=True, explicit=True).install()
 
-        with spack.config.override("concretizer:reuse", True):
+        with mutable_config.override("concretizer:reuse", True):
             with_reuse = spack.concretize.concretize_one(f"py-extension2 ^/{python_hash}")
 
-        with spack.config.override("concretizer:reuse", False):
+        with mutable_config.override("concretizer:reuse", False):
             without_reuse = spack.concretize.concretize_one("py-extension2")
 
         assert with_reuse.dag_hash() == without_reuse.dag_hash()
@@ -2678,7 +2693,7 @@ packages:
         assert root.satisfies("%gcc@9.4.0")
 
     @pytest.mark.regression("43406")
-    def test_externals_with_platform_explicitly_set(self, tmp_path: pathlib.Path):
+    def test_externals_with_platform_explicitly_set(self, tmp_path: pathlib.Path, mutable_config):
         """Tests that users can specify platform=xxx in an external spec"""
         external_conf = {
             "mpich": {
@@ -2686,7 +2701,7 @@ packages:
                 "externals": [{"spec": "mpich@=2.0.0 platform=test", "prefix": str(tmp_path)}],
             }
         }
-        spack.config.set("packages", external_conf)
+        mutable_config.set("packages", external_conf)
         s = spack.concretize.concretize_one("mpich")
         assert s.external
 
@@ -2705,7 +2720,7 @@ packages:
         assert s["dttop"].dag_hash() == build_dep.dag_hash()
 
     @pytest.mark.regression("44040")
-    def test_exclude_specs_from_reuse(self, monkeypatch):
+    def test_exclude_specs_from_reuse(self, monkeypatch, mutable_config):
         r"""Tests that we can exclude a spec from reuse when concretizing, and that the spec
         is not added back to the solve as a dependency of another reusable spec.
 
@@ -2743,7 +2758,7 @@ packages:
         monkeypatch.setattr(spack.solver.reuse, "_specs_from_mirror", lambda: [reused])
 
         # Exclude dyninst from reuse, so we expect that the old version is not taken into account
-        with spack.config.override(
+        with mutable_config.override(
             "concretizer:reuse",
             {"from": [{"type": "buildcache", "exclude": ["dyninst"]}, {"type": "external"}]},
         ):
@@ -2781,7 +2796,7 @@ packages:
         request_str = "deprecated-client"
 
         # When using the external the version is selected even if deprecated
-        with spack.config.override(
+        with mutable_config.override(
             "concretizer:reuse", {"from": [{"type": "external", "include": included_externals}]}
         ):
             result = spack.concretize.concretize_one(request_str)
@@ -2789,7 +2804,7 @@ packages:
         assert result["deprecated-versions"].satisfies("@1.1.0")
 
         # When excluding it, we pick the non-deprecated version
-        with spack.config.override(
+        with mutable_config.override(
             "concretizer:reuse",
             {"from": [{"type": "external", "exclude": ["deprecated-versions"]}]},
         ):
@@ -2811,7 +2826,7 @@ packages:
         assert external_spec.external
 
         root_specs = [Spec("sombrero")]
-        with spack.config.override("concretizer:reuse", True):
+        with mutable_config.override("concretizer:reuse", True):
             solver = spack.solver.asp.Solver()
             setup = spack.solver.asp.SpackSolverSetup()
             result, _, _ = solver.driver.solve(setup, root_specs, reuse=[external_spec])
@@ -2910,7 +2925,7 @@ class TestConcretizeSeparately:
     """Collects test on separate concretization"""
 
     @pytest.mark.parametrize("strategy", ["minimal", "full"])
-    def test_two_gmake(self, strategy):
+    def test_two_gmake(self, strategy, mutable_config):
         """Tests that we can concretize a spec with nodes using the same build
         dependency pinned at different versions.
 
@@ -2922,7 +2937,7 @@ class TestConcretizeSeparately:
         o gmake@4.1
 
         """
-        spack.config.CONFIG.set("concretizer:duplicates:strategy", strategy)
+        mutable_config.set("concretizer:duplicates:strategy", strategy)
         s = spack.concretize.concretize_one("hdf5")
 
         # Check that hdf5 depends on gmake@=4.1
@@ -2934,7 +2949,7 @@ class TestConcretizeSeparately:
         assert len(pinned_gmake) == 1 and pinned_gmake[0].satisfies("@=3.0")
 
     @pytest.mark.parametrize("strategy", ["minimal", "full"])
-    def test_two_setuptools(self, strategy):
+    def test_two_setuptools(self, strategy, mutable_config):
         """Tests that we can concretize separate build dependencies, when we are dealing
         with extensions.
 
@@ -2954,7 +2969,7 @@ class TestConcretizeSeparately:
         o gmake@4.1
 
         """
-        spack.config.CONFIG.set("concretizer:duplicates:strategy", strategy)
+        mutable_config.set("concretizer:duplicates:strategy", strategy)
         s = spack.concretize.concretize_one("py-shapely")
         # Requirements on py-shapely
         setuptools = s["py-shapely"].dependencies(name="py-setuptools", deptype="build")
@@ -2983,7 +2998,7 @@ class TestConcretizeSeparately:
         assert s["cycle-b"].satisfies("+cycle")
 
     @pytest.mark.parametrize("strategy", ["minimal", "full"])
-    def test_pure_build_virtual_dependency(self, strategy):
+    def test_pure_build_virtual_dependency(self, strategy, mutable_config):
         """Tests that we can concretize a pure build virtual dependency, and ensures that
         pure build virtual dependencies are accounted in the list of possible virtual
         dependencies.
@@ -2992,7 +3007,7 @@ class TestConcretizeSeparately:
         | [type=build, virtual=pkgconfig]
         pkg-config@1.0
         """
-        spack.config.CONFIG.set("concretizer:duplicates:strategy", strategy)
+        mutable_config.set("concretizer:duplicates:strategy", strategy)
 
         s = spack.concretize.concretize_one("virtual-build")
         assert s["pkgconfig"].name == "pkg-config"
@@ -3034,13 +3049,13 @@ class TestConcretizeSeparately:
         assert len(edges) == 1
         assert edges[0].spec.satisfies("@=60")
 
-    def test_build_environment_is_unified(self):
+    def test_build_environment_is_unified(self, mutable_config):
         """A pure build dep that is marked build-tool can creates its own unification set. This
         test ensures that its sibling build dependencies are unified with it, together with their
         runtime dependencies. It ensures the same package cannot appear multiple times in a single
         build environment, for example when it's both a direct build dep, as well as pulled in as
         a transitive runtime dep of a sibling build dep."""
-        spack.config.CONFIG.set("concretizer:duplicates", {"max_dupes": {"unify-build-deps-c": 2}})
+        mutable_config.set("concretizer:duplicates", {"max_dupes": {"unify-build-deps-c": 2}})
 
         # Fails because unify-build-deps-c version @1 and @2 are needed in the build environment
         with pytest.raises(spack.solver.asp.UnsatisfiableSpecError):
@@ -3050,7 +3065,7 @@ class TestConcretizeSeparately:
         spack.concretize.concretize_one("unify-build-deps-a@2.0")
 
         # Lastly, a sanity check that max_dupes is a requirement for this to work.
-        spack.config.CONFIG.set("concretizer:duplicates", {"max_dupes": {"unify-build-deps-c": 1}})
+        mutable_config.set("concretizer:duplicates", {"max_dupes": {"unify-build-deps-c": 1}})
         with pytest.raises(spack.solver.asp.UnsatisfiableSpecError):
             spack.concretize.concretize_one("unify-build-deps-a@2.0")
 
@@ -3416,13 +3431,13 @@ def test_spec_filters(specs, include, exclude, expected):
 
 
 @pytest.mark.regression("38484")
-def test_git_ref_version_can_be_reused(install_mockery):
+def test_git_ref_version_can_be_reused(install_mockery, mutable_config):
     first_spec = spack.concretize.concretize_one(
         spack.spec.Spec("git-ref-package@git.2.1.5=2.1.5~opt")
     )
     PackageInstaller([first_spec.package], fake=True, explicit=True).install()
 
-    with spack.config.override("concretizer:reuse", True):
+    with mutable_config.override("concretizer:reuse", True):
         # reproducer of the issue is that spack will solve when there is a change to the base spec
         second_spec = spack.concretize.concretize_one(
             spack.spec.Spec("git-ref-package@git.2.1.5=2.1.5+opt")
@@ -3437,7 +3452,9 @@ def test_git_ref_version_can_be_reused(install_mockery):
 
 
 @pytest.mark.parametrize("standard_version", ["2.0.0", "2.1.5", "2.1.6"])
-def test_reuse_prefers_standard_over_git_versions(standard_version, install_mockery):
+def test_reuse_prefers_standard_over_git_versions(
+    standard_version, install_mockery, mutable_config
+):
     """
     order matters in this test. typically reuse would pick the highest versioned installed match
     but we want to prefer the standard version over git ref based versions
@@ -3451,7 +3468,7 @@ def test_reuse_prefers_standard_over_git_versions(standard_version, install_mock
     git_spec = spack.concretize.concretize_one("git-ref-package@git.2.1.5=2.1.5")
     PackageInstaller([git_spec.package], fake=True, explicit=True).install()
 
-    with spack.config.override("concretizer:reuse", True):
+    with mutable_config.override("concretizer:reuse", True):
         test_spec = spack.concretize.concretize_one("git-ref-package@2")
         assert git_spec.dag_hash() != test_spec.dag_hash()
         assert standard_spec.dag_hash() == test_spec.dag_hash()
@@ -3459,7 +3476,7 @@ def test_reuse_prefers_standard_over_git_versions(standard_version, install_mock
 
 @pytest.mark.parametrize("unify", [True, "when_possible", False])
 def test_spec_unification(unify, mutable_config, mock_packages):
-    spack.config.set("concretizer:unify", unify)
+    mutable_config.set("concretizer:unify", unify)
     a = "pkg-a"
     a_restricted = "pkg-a^pkg-b foo=baz"
     b = "pkg-b foo=none"
@@ -3539,14 +3556,14 @@ def test_relationship_git_versions_and_commit_variant(version_str):
 
 
 @pytest.mark.usefixtures("install_mockery")
-def test_abstract_commit_spec_reuse():
+def test_abstract_commit_spec_reuse(mutable_config):
     commit = "abcd" * 10
     spec_str_1 = f"git-ref-package@develop commit={commit}"
     spec_str_2 = f"git-ref-package commit={commit}"
     spec1 = spack.concretize.concretize_one(spec_str_1)
     PackageInstaller([spec1.package], fake=True, explicit=True).install()
 
-    with spack.config.override("concretizer:reuse", True):
+    with mutable_config.override("concretizer:reuse", True):
         spec2 = spack.concretize.concretize_one(spec_str_2)
         assert spec2.dag_hash() == spec1.dag_hash()
 
@@ -3556,7 +3573,7 @@ def test_abstract_commit_spec_reuse():
     "installed_commit, incoming_commit, reusable",
     [("a" * 40, "b" * 40, False), (None, "b" * 40, False), ("a" * 40, None, True)],
 )
-def test_commit_variant_can_be_reused(installed_commit, incoming_commit, reusable):
+def test_commit_variant_can_be_reused(installed_commit, incoming_commit, reusable, mutable_config):
     # install a non-default variant to test if reuse picks it
     if installed_commit:
         spec_str_1 = f"git-ref-package@develop commit={installed_commit} ~opt"
@@ -3571,7 +3588,7 @@ def test_commit_variant_can_be_reused(installed_commit, incoming_commit, reusabl
     spec1 = spack.concretize.concretize_one(spack.spec.Spec(spec_str_1))
     PackageInstaller([spec1.package], fake=True, explicit=True).install()
 
-    with spack.config.override("concretizer:reuse", True):
+    with mutable_config.override("concretizer:reuse", True):
         spec2 = spack.spec.Spec(spec_str_2)
         spec2 = spack.concretize.concretize_one(spec2)
         assert (spec1.dag_hash() == spec2.dag_hash()) == reusable
@@ -3765,12 +3782,12 @@ def test_specifying_compilers_with_virtuals_syntax(config, mock_packages):
 
 @pytest.mark.regression("49847")
 @pytest.mark.xfail(sys.platform == "win32", reason="issues with install mockery")
-def test_reuse_when_input_specifies_build_dep(install_mockery):
+def test_reuse_when_input_specifies_build_dep(install_mockery, mutable_config):
     """Test that we can reuse a spec when specifying build dependencies in the input"""
     pkgb_old = spack.concretize.concretize_one(spack.spec.Spec("pkg-b@0.9 %gcc@9"))
     PackageInstaller([pkgb_old.package], fake=True, explicit=True).install()
 
-    with spack.config.override("concretizer:reuse", True):
+    with mutable_config.override("concretizer:reuse", True):
         result = spack.concretize.concretize_one("pkg-b %gcc")
         assert pkgb_old.dag_hash() == result.dag_hash()
 
@@ -3789,7 +3806,7 @@ def test_reuse_when_requiring_build_dep(install_mockery, mutable_config):
     pkgb_old = spack.concretize.concretize_one(spack.spec.Spec("pkg-b@0.9"))
     PackageInstaller([pkgb_old.package], fake=True, explicit=True).install()
 
-    with spack.config.override("concretizer:reuse", True):
+    with mutable_config.override("concretizer:reuse", True):
         result = spack.concretize.concretize_one("pkg-b")
         assert pkgb_old.dag_hash() == result.dag_hash(), result.tree()
 
@@ -3878,12 +3895,12 @@ def test_installed_compiler_and_better_external(install_mockery, mutable_config)
     pkg_b = spack.concretize.concretize_one(spack.spec.Spec("pkg-b %clang"))
     PackageInstaller([pkg_b.package], fake=True, explicit=True).install()
 
-    with spack.config.override("concretizer:reuse", False):
+    with mutable_config.override("concretizer:reuse", False):
         pkg_a = spack.concretize.concretize_one("pkg-a")
         assert pkg_a["c"].satisfies("gcc@10"), pkg_a.tree()
         assert pkg_a["pkg-b"]["c"].satisfies("gcc@10")
 
-    with spack.config.override("concretizer:reuse", False):
+    with mutable_config.override("concretizer:reuse", False):
         mpileaks = spack.concretize.concretize_one("mpileaks")
         assert mpileaks.satisfies("%gcc@10")
 
@@ -4110,7 +4127,7 @@ def test_spec_parts_on_reused_compilers(
         spack.concretize.concretize_one(f"mpileaks %llvm@20 {unsat_request}")
 
     # ...but we can with the original constraint
-    with spack.config.override("concretizer:reuse", True):
+    with mutable_config.override("concretizer:reuse", True):
         s = spack.concretize.concretize_one(f"mpileaks %llvm@20 {sat_request}")
 
     assert s.dag_hash() == installed_spec.dag_hash()
@@ -4121,7 +4138,7 @@ def test_use_compiler_by_hash(mock_packages, mutable_database, mutable_config):
     installed_spec = spack.concretize.concretize_one("gcc@14.0")
     PackageInstaller([installed_spec.package], fake=True, explicit=True).install()
 
-    with spack.config.override("concretizer:reuse", True):
+    with mutable_config.override("concretizer:reuse", True):
         s = spack.concretize.concretize_one(f"mpileaks %gcc/{installed_spec.dag_hash()}")
 
     assert s["c"].dag_hash() == installed_spec.dag_hash()
@@ -4443,7 +4460,7 @@ packages:
 
     root_specs = [Spec("openblas %fortran=gcc")]
 
-    with spack.config.override("concretizer:reuse", True):
+    with mutable_config.override("concretizer:reuse", True):
         solver = spack.solver.asp.Solver()
         setup = spack.solver.asp.SpackSolverSetup()
         result, _, _ = solver.driver.solve(setup, root_specs, reuse=reusable_specs)
@@ -4589,7 +4606,7 @@ def test_concretization_cache_roundtrip(
     """Tests whether we can write the results of a clingo solve to the cache
     and load the same spec request from the cache to produce identical specs"""
 
-    assert spack.config.get("concretizer:concretization_cache:enable")
+    assert mutable_config.get("concretizer:concretization_cache:enable")
 
     # when reusing, install the requested dependency and enable reuse for the solve
     if reused_dep:
@@ -4695,7 +4712,7 @@ def test_concretization_cache_count_cleanup(use_concretization_cache, mutable_co
     conc_cache_dir = use_concretization_cache / f"v{spack.solver.asp.ConcretizationCache.VERSION}"
     conc_cache_dir.mkdir(parents=True)
 
-    spack.config.set("concretizer:concretization_cache:entry_limit", 1000)
+    mutable_config.set("concretizer:concretization_cache:entry_limit", 1000)
 
     def names():
         return {
@@ -5095,7 +5112,7 @@ def test_concrete_specs_skip_prechecks(config, mock_packages):
     with pytest.raises(spack.solver.asp.DeprecatedVersionError):
         spack.solver.asp.SpackSolverSetup().setup(specs)
 
-    with spack.config.override("config:deprecated", True):
+    with config.override("config:deprecated", True):
         concrete_spec = spack.concretize.concretize_one(specs[1])
 
     # Try again with the same version but a concrete spec
@@ -5196,7 +5213,7 @@ def test_virtual_gets_multiple_dupes(mock_packages, config):
     """
     specs = [spack.spec.Spec("pkg-with-c-link-dep")]
     possible_graph = spack.solver.input_analysis.NoStaticAnalysis(
-        configuration=spack.config.CONFIG, repo=mock_packages
+        configuration=config, repo=mock_packages
     )
     counter = spack.solver.input_analysis.MinimalDuplicatesCounter(
         specs, tests=False, possible_graph=possible_graph

--- a/lib/spack/spack/test/concretization/core.py
+++ b/lib/spack/spack/test/concretization/core.py
@@ -44,12 +44,16 @@ import spack.util.hash
 import spack.util.lang
 import spack.util.spack_yaml as syaml
 import spack.variant as vt
+from spack.config import Configuration
+from spack.database import Database
 from spack.externals import ExternalDependencyError
 from spack.externals_config import create_external_parser, external_config_with_implicit_externals
 from spack.old_installer import PackageInstaller
+from spack.repo import RepoPath
 from spack.solver.asp import Result
 from spack.solver.reuse import spec_filter_from_packages_yaml
 from spack.spec import Spec
+from spack.store import Store
 from spack.test.conftest import RepoBuilder
 from spack.version import Version, VersionList, ver
 
@@ -383,7 +387,7 @@ class TestConcretize:
         concrete = check_concretize("mpileaks   ^mpich2@1.3.1:1.4")
         assert concrete["mpich2"].satisfies("mpich2@1.3.1:1.4")
 
-    def test_concretize_with_provides_when(self, mock_packages):
+    def test_concretize_with_provides_when(self, mock_packages: RepoPath):
         """Make sure insufficient versions of MPI are not in providers list when
         we ask for some advanced version.
         """
@@ -394,7 +398,7 @@ class TestConcretize:
         assert not any(s.intersects("mpich@:1") for s in repo.providers_for("mpi@3"))
         assert not any(s.intersects("mpich2") for s in repo.providers_for("mpi@3"))
 
-    def test_provides_handles_multiple_providers_of_same_version(self, mock_packages):
+    def test_provides_handles_multiple_providers_of_same_version(self, mock_packages: RepoPath):
         """ """
         providers = mock_packages.providers_for("mpi@3.0")
 
@@ -493,16 +497,16 @@ class TestConcretize:
             assert x.satisfies("%clang") is not expected_gcc
             assert x.satisfies("%gcc") is expected_gcc
 
-    def test_disable_mixing_prevents_mixing(self, mutable_config):
+    def test_disable_mixing_prevents_mixing(self, mutable_config: Configuration):
         with mutable_config.override("concretizer", {"compiler_mixing": False}):
             with pytest.raises(spack.error.UnsatisfiableSpecError):
                 spack.concretize.concretize_one("dt-diamond%clang ^dt-diamond-bottom%gcc")
 
-    def test_disable_mixing_is_per_language(self, mutable_config):
+    def test_disable_mixing_is_per_language(self, mutable_config: Configuration):
         with mutable_config.override("concretizer", {"compiler_mixing": False}):
             spack.concretize.concretize_one("openblas %c=llvm %fortran=gcc")
 
-    def test_disable_mixing_override_by_package(self, mutable_config):
+    def test_disable_mixing_override_by_package(self, mutable_config: Configuration):
         with mutable_config.override("concretizer", {"compiler_mixing": ["dt-diamond-bottom"]}):
             root = spack.concretize.concretize_one("dt-diamond%clang ^dt-diamond-bottom%gcc")
             assert root.satisfies("%clang")
@@ -512,7 +516,7 @@ class TestConcretize:
             with pytest.raises(spack.error.UnsatisfiableSpecError):
                 spack.concretize.concretize_one("dt-diamond%clang ^dt-diamond-left%gcc")
 
-    def test_disable_mixing_reuse(self, fake_db_install, mutable_config):
+    def test_disable_mixing_reuse(self, fake_db_install, mutable_config: Configuration):
         # Install a spec
         left = spack.concretize.concretize_one("dt-diamond-left %gcc")
         fake_db_install(left)
@@ -530,7 +534,7 @@ class TestConcretize:
             # Should be able to reuse if the compilers match
             spack.concretize.concretize_one(f"dt-diamond%gcc ^/{lefthash}")
 
-    def test_disable_mixing_reuse_and_built(self, fake_db_install, mutable_config):
+    def test_disable_mixing_reuse_and_built(self, fake_db_install, mutable_config: Configuration):
         r"""In this case we have
 
         x
@@ -557,7 +561,7 @@ class TestConcretize:
             with pytest.raises(spack.error.UnsatisfiableSpecError, match="mixing is disabled"):
                 spack.concretize.concretize_one(f"mixing-parent%clang ^cmake%gcc ^/{dep1hash}")
 
-    def test_disable_mixing_allow_compiler_link(self, mutable_config):
+    def test_disable_mixing_allow_compiler_link(self, mutable_config: Configuration):
         """Check if we can use a compiler when mixing is disabled, and
         still depend on a separate compiler package (in the latter case
         not using it as a compiler but rather for some utility it
@@ -625,7 +629,9 @@ spack:
                 continue
             assert x.satisfies("%clang")
 
-    def test_architecture_deep_inheritance(self, mock_targets, compiler_factory, mutable_config):
+    def test_architecture_deep_inheritance(
+        self, mock_targets, compiler_factory, mutable_config: Configuration
+    ):
         """Make sure that indirect dependencies receive architecture
         information from the root even when partial architecture information
         is provided by an intermediate dependency.
@@ -1013,7 +1019,7 @@ spack:
             s = spack.concretize.concretize_one(s)
 
     @pytest.mark.parametrize("spec_str", ["unsat-provider@1.0+foo"])
-    def test_no_conflict_in_external_specs(self, spec_str, mutable_config):
+    def test_no_conflict_in_external_specs(self, spec_str, mutable_config: Configuration):
         # Modify the configuration to have the spec with conflict
         # registered as an external
         ext = Spec(spec_str)
@@ -1222,7 +1228,7 @@ spack:
         ],
     )
     def test_compiler_conflicts_in_package_py(
-        self, spec_str, expected_str, gcc11_with_flags, mutable_config
+        self, spec_str, expected_str, gcc11_with_flags, mutable_config: Configuration
     ):
         mutable_config.set(
             "concretizer:os_compatible", {"debian6": ["redhat6"], "redhat6": ["debian6"]}
@@ -1349,7 +1355,7 @@ spack:
             assert s.satisfies(constraint)
 
     @pytest.mark.regression("5651")
-    def test_package_with_constraint_not_met_by_external(self, mutable_config):
+    def test_package_with_constraint_not_met_by_external(self, mutable_config: Configuration):
         """Check that if we have an external package A at version X.Y in
         packages.yaml, but our spec doesn't allow X.Y as a version, then
         a new version of A is built that meets the requirements.
@@ -1515,9 +1521,9 @@ spack:
         spec,
         mock_db,
         tmp_path: pathlib.Path,
-        temporary_store,
+        temporary_store: Store,
         monkeypatch,
-        mutable_config,
+        mutable_config: Configuration,
     ):
         """Test that reuse does not mix dev specs with non-dev specs.
 
@@ -1561,7 +1567,7 @@ spack:
         ],
     )
     def test_reuse_installed_packages_when_package_def_changes(
-        self, context, mutable_database, repo_with_changing_recipe, mutable_config
+        self, context, mutable_database, repo_with_changing_recipe, mutable_config: Configuration
     ):
         # test applies only with reuse turned off in concretizer
         mutable_config.set("concretizer:reuse", False)
@@ -1593,7 +1599,7 @@ spack:
 
     @pytest.mark.regression("43663")
     def test_no_reuse_when_variant_condition_does_not_hold(
-        self, mutable_database, mock_packages, mutable_config
+        self, mutable_database, mock_packages, mutable_config: Configuration
     ):
         mutable_config.set("concretizer:reuse", True)
 
@@ -1608,7 +1614,7 @@ spack:
         new2 = spack.concretize.concretize_one("conditional-variant-pkg +two_whens")
         assert new2.satisfies("@2 +two_whens +version_based")
 
-    def test_reuse_with_flags(self, mutable_database, mutable_config):
+    def test_reuse_with_flags(self, mutable_database, mutable_config: Configuration):
         mutable_config.set("concretizer:reuse", True)
         spec = spack.concretize.concretize_one("pkg-a cflags=-g cxxflags=-g")
         PackageInstaller([spec.package], fake=True, explicit=True).install()
@@ -1648,7 +1654,7 @@ spack:
         assert set(expected_values) == set(s.variants[variant_name].value)
 
     @pytest.mark.regression("22533")
-    def test_mv_variants_disjoint_sets_from_packages_yaml(self, mutable_config):
+    def test_mv_variants_disjoint_sets_from_packages_yaml(self, mutable_config: Configuration):
         external_mvapich2 = {
             "mvapich2": {
                 "buildable": False,
@@ -1708,7 +1714,9 @@ spack:
             ("deprecated-versions@=1.1.0", "deprecated-versions@1.1.0"),
         ],
     )
-    def test_deprecated_versions_not_selected(self, spec_str, expected, mutable_config):
+    def test_deprecated_versions_not_selected(
+        self, spec_str, expected, mutable_config: Configuration
+    ):
         with mutable_config.override("config:deprecated", True):
             s = spack.concretize.concretize_one(spec_str)
             s.satisfies(expected)
@@ -1752,7 +1760,7 @@ spack:
         assert s["java"].satisfies("virtual-with-versions@1.8.0")
 
     @pytest.mark.regression("26866")
-    def test_non_default_provider_of_multiple_virtuals(self, mock_packages):
+    def test_non_default_provider_of_multiple_virtuals(self, mock_packages: RepoPath):
         s = spack.concretize.concretize_one("many-virtual-consumer ^low-priority-provider")
         assert s["mpi"].name == "low-priority-provider"
         assert s["lapack"].name == "low-priority-provider"
@@ -1769,7 +1777,7 @@ spack:
         [("mpich", True), ("mpich+debug", False), ("mpich~debug", True)],
     )
     def test_concrete_specs_are_not_modified_on_reuse(
-        self, mutable_database, spec_str, expect_installed, mutable_config
+        self, mutable_database: Database, spec_str, expect_installed, mutable_config: Configuration
     ):
         # Test the internal consistency of solve + DAG reconstruction
         # when reused specs are added to the mix. This prevents things
@@ -1804,7 +1812,7 @@ spack:
             # FIXME (externals as concrete) ("sticky-variant@1.0", False),
         ],
     )
-    def test_sticky_variant_in_external(self, spec, allow_gcc, mutable_config):
+    def test_sticky_variant_in_external(self, spec, allow_gcc, mutable_config: Configuration):
         # setup external for sticky-variant+allow-gcc
         config = {"externals": [{"spec": spec, "prefix": "/fake/path"}], "buildable": False}
         mutable_config.set("packages:sticky-variant", config)
@@ -1853,7 +1861,7 @@ spack:
         s = spack.concretize.concretize_one("conditional-values-in-variant@1.60.0")
         assert "cxxstd" in s.variants
 
-    def test_target_granularity(self, mutable_config):
+    def test_target_granularity(self, mutable_config: Configuration):
         # The test architecture uses core2 as the default target. Check that when
         # we configure Spack for "generic" granularity we concretize for x86_64
         default_target = spack.platforms.test.Test.default
@@ -1863,7 +1871,7 @@ spack:
         with mutable_config.override("concretizer:targets", {"granularity": "generic"}):
             assert spack.concretize.concretize_one(s).satisfies("target=%s" % generic_target)
 
-    def test_host_compatible_concretization(self, mutable_config):
+    def test_host_compatible_concretization(self, mutable_config: Configuration):
         # Check that after setting "host_compatible" to false we cannot concretize.
         # Here we use "k10" to set a target non-compatible with the current host
         # to avoid a lot of boilerplate when mocking the test platform. The issue
@@ -1875,7 +1883,7 @@ spack:
             with pytest.raises(spack.error.SpackError):
                 spack.concretize.concretize_one(s)
 
-    def test_add_microarchitectures_on_explicit_request(self, mutable_config):
+    def test_add_microarchitectures_on_explicit_request(self, mutable_config: Configuration):
         # Check that if we consider only "generic" targets, we can still solve for
         # specific microarchitectures on explicit requests
         with mutable_config.override("concretizer:targets", {"granularity": "generic"}):
@@ -1884,7 +1892,7 @@ spack:
 
     @pytest.mark.regression("29201")
     def test_delete_version_and_reuse(
-        self, mutable_database, repo_with_changing_recipe, mutable_config
+        self, mutable_database, repo_with_changing_recipe, mutable_config: Configuration
     ):
         """Test that we can reuse installed specs with versions not
         declared in package.py
@@ -1900,7 +1908,7 @@ spack:
 
     @pytest.mark.regression("29201")
     def test_installed_version_is_selected_only_for_reuse(
-        self, mutable_database, repo_with_changing_recipe, mutable_config
+        self, mutable_database, repo_with_changing_recipe, mutable_config: Configuration
     ):
         """Test that a version coming from an installed spec is a possible
         version only for reuse
@@ -1918,7 +1926,7 @@ spack:
 
     @pytest.mark.regression("28259")
     def test_reuse_with_unknown_namespace_dont_raise(
-        self, temporary_store, mock_custom_repository, mutable_config
+        self, temporary_store, mock_custom_repository, mutable_config: Configuration
     ):
         with spack.repo.use_repositories(mock_custom_repository, override=False):
             s = spack.concretize.concretize_one("pkg-c")
@@ -1931,7 +1939,11 @@ spack:
 
     @pytest.mark.regression("45538")
     def test_reuse_from_other_namespace_no_raise(
-        self, temporary_store, monkeypatch, repo_builder: RepoBuilder, mutable_config
+        self,
+        temporary_store,
+        monkeypatch,
+        repo_builder: RepoBuilder,
+        mutable_config: Configuration,
     ):
         repo_builder.add_package("zlib")
 
@@ -1946,7 +1958,11 @@ spack:
 
     @pytest.mark.regression("28259")
     def test_reuse_with_unknown_package_dont_raise(
-        self, temporary_store, monkeypatch, repo_builder: RepoBuilder, mutable_config
+        self,
+        temporary_store,
+        monkeypatch,
+        repo_builder: RepoBuilder,
+        mutable_config: Configuration,
     ):
         repo_builder.add_package("pkg-c")
         with spack.repo.use_repositories(repo_builder.root, override=False):
@@ -2061,7 +2077,9 @@ spack:
             assert "zmpi" in spec
 
     @pytest.mark.regression("30864")
-    def test_misleading_error_message_on_version(self, mutable_database, mutable_config):
+    def test_misleading_error_message_on_version(
+        self, mutable_database, mutable_config: Configuration
+    ):
         # For this bug to be triggered we need a reusable dependency
         # that is not optimal in terms of optimization scores.
         # We pick an old version of "b"
@@ -2075,7 +2093,7 @@ spack:
                 solver.driver.solve(setup, [root_spec], reuse=reusable_specs)
 
     @pytest.mark.regression("31148")
-    def test_version_weight_and_provenance(self, mutable_config):
+    def test_version_weight_and_provenance(self, mutable_config: Configuration):
         """Test package preferences during concretization."""
         reusable_specs = [
             spack.concretize.concretize_one(spec_str) for spec_str in ("pkg-b@0.9", "pkg-b@1.0")
@@ -2295,7 +2313,7 @@ spack:
 
         assert all(x in asp_problem for x in expected)
 
-    def test_reuse_succeeds_with_config_compatible_os(self, mutable_config):
+    def test_reuse_succeeds_with_config_compatible_os(self, mutable_config: Configuration):
         root_spec = Spec("pkg-b")
         s = spack.concretize.concretize_one(root_spec)
         other_os = s.copy()
@@ -2336,7 +2354,11 @@ spack:
 
     @pytest.mark.regression("31484")
     def test_installed_externals_are_reused(
-        self, mutable_database, repo_with_changing_recipe, tmp_path: pathlib.Path, mutable_config
+        self,
+        mutable_database,
+        repo_with_changing_recipe,
+        tmp_path: pathlib.Path,
+        mutable_config: Configuration,
     ):
         """Tests that external specs that are in the DB can be reused, if they result in a
         better optimization score.
@@ -2370,7 +2392,7 @@ spack:
 
     @pytest.mark.regression("31484")
     def test_user_can_select_externals_with_require(
-        self, mutable_database, tmp_path: pathlib.Path, mutable_config
+        self, mutable_database, tmp_path: pathlib.Path, mutable_config: Configuration
     ):
         """Test that users have means to select an external even in presence of reusable specs."""
         external_conf: Dict[str, Any] = {
@@ -2400,7 +2422,11 @@ spack:
 
     @pytest.mark.regression("31484")
     def test_installed_specs_disregard_conflicts(
-        self, mutable_database, monkeypatch, mutable_config, mock_packages
+        self,
+        mutable_database: Database,
+        monkeypatch,
+        mutable_config: Configuration,
+        mock_packages: RepoPath,
     ):
         """Test that installed specs do not trigger conflicts. This covers for the rare case
         where a conflict is added on a package after a spec matching the conflict was installed.
@@ -2421,7 +2447,7 @@ spack:
             assert s.satisfies("~debug"), s
 
     @pytest.mark.regression("32471")
-    def test_require_targets_are_allowed(self, mutable_config, mutable_database):
+    def test_require_targets_are_allowed(self, mutable_config: Configuration, mutable_database):
         """Test that users can set target constraints under the require attribute."""
         # Configuration to be added to packages.yaml
         required_target = spack.vendor.archspec.cpu.TARGETS[
@@ -2556,7 +2582,12 @@ packages:
 
     @pytest.mark.parametrize("transitive", [True, False])
     def test_explicit_splices(
-        self, mutable_config, database_mutable_config, mock_packages, transitive, capfd
+        self,
+        mutable_config: Configuration,
+        database_mutable_config: Database,
+        mock_packages,
+        transitive,
+        capfd,
     ):
         mpich_spec = database_mutable_config.query("mpich")[0]
         splice_info = {
@@ -2579,14 +2610,18 @@ packages:
         assert "hdf5 ^zmpi" in captured.err
         assert str(spec) in captured.err
 
-    def test_explicit_splice_fails_nonexistent(self, mutable_config, mock_packages, mock_store):
+    def test_explicit_splice_fails_nonexistent(
+        self, mutable_config: Configuration, mock_packages, mock_store
+    ):
         splice_info = {"target": "mpi", "replacement": "mpich/doesnotexist"}
         mutable_config.set("concretizer", {"splice": {"explicit": [splice_info]}})
 
         with pytest.raises(spack.spec.InvalidHashError):
             _ = spack.concretize.concretize_one("hdf5^zmpi")
 
-    def test_explicit_splice_fails_no_hash(self, mutable_config, mock_packages, mock_store):
+    def test_explicit_splice_fails_no_hash(
+        self, mutable_config: Configuration, mock_packages, mock_store
+    ):
         splice_info = {"target": "mpi", "replacement": "mpich"}
         mutable_config.set("concretizer", {"splice": {"explicit": [splice_info]}})
 
@@ -2594,7 +2629,7 @@ packages:
             _ = spack.concretize.concretize_one("hdf5^zmpi")
 
     def test_explicit_splice_non_match_nonexistent_succeeds(
-        self, mutable_config, mock_packages, mock_store
+        self, mutable_config: Configuration, mock_packages, mock_store
     ):
         """When we have a nonexistent splice configured but are not using it, don't fail."""
         splice_info = {"target": "will_not_match", "replacement": "nonexistent/doesnotexist"}
@@ -2609,7 +2644,7 @@ packages:
         [("mpileaks", "mpich"), ("mpileaks ^mpich2", "mpich2"), ("mpileaks ^zmpi", "zmpi")],
     )
     def test_virtuals_are_reconstructed_on_reuse(
-        self, spec_str, mpi_name, mutable_database, mutable_config
+        self, spec_str, mpi_name, mutable_database: Database, mutable_config: Configuration
     ):
         """Tests that when we reuse a spec, virtual on edges are reconstructed correctly"""
         with mutable_config.override("concretizer:reuse", True):
@@ -2628,7 +2663,9 @@ packages:
 
     @pytest.mark.regression("39570")
     @pytest.mark.db
-    def test_reuse_python_from_cli_and_extension_from_db(self, mutable_database, mutable_config):
+    def test_reuse_python_from_cli_and_extension_from_db(
+        self, mutable_database, mutable_config: Configuration
+    ):
         """Tests that reusing python with and explicit request on the command line, when the spec
         also reuses a python extension from the DB, doesn't fail.
         """
@@ -2693,7 +2730,9 @@ packages:
         assert root.satisfies("%gcc@9.4.0")
 
     @pytest.mark.regression("43406")
-    def test_externals_with_platform_explicitly_set(self, tmp_path: pathlib.Path, mutable_config):
+    def test_externals_with_platform_explicitly_set(
+        self, tmp_path: pathlib.Path, mutable_config: Configuration
+    ):
         """Tests that users can specify platform=xxx in an external spec"""
         external_conf = {
             "mpich": {
@@ -2720,7 +2759,7 @@ packages:
         assert s["dttop"].dag_hash() == build_dep.dag_hash()
 
     @pytest.mark.regression("44040")
-    def test_exclude_specs_from_reuse(self, monkeypatch, mutable_config):
+    def test_exclude_specs_from_reuse(self, monkeypatch, mutable_config: Configuration):
         r"""Tests that we can exclude a spec from reuse when concretizing, and that the spec
         is not added back to the solve as a dependency of another reusable spec.
 
@@ -2782,7 +2821,7 @@ packages:
         ],
     )
     def test_include_specs_from_externals_and_libcs(
-        self, included_externals, mutable_config, tmp_path: pathlib.Path
+        self, included_externals, mutable_config: Configuration, tmp_path: pathlib.Path
     ):
         """Tests that when we include specs from externals, we always include libcs."""
         mutable_config.set(
@@ -2813,7 +2852,7 @@ packages:
         assert result["deprecated-versions"].satisfies("@1.0.0")
 
     @pytest.mark.regression("44085")
-    def test_can_reuse_concrete_externals_for_dependents(self, mutable_config):
+    def test_can_reuse_concrete_externals_for_dependents(self, mutable_config: Configuration):
         """Test that external specs that are in the DB can be reused. This means they are
         preferred to concretizing another external from packages.yaml
         """
@@ -2925,7 +2964,7 @@ class TestConcretizeSeparately:
     """Collects test on separate concretization"""
 
     @pytest.mark.parametrize("strategy", ["minimal", "full"])
-    def test_two_gmake(self, strategy, mutable_config):
+    def test_two_gmake(self, strategy, mutable_config: Configuration):
         """Tests that we can concretize a spec with nodes using the same build
         dependency pinned at different versions.
 
@@ -2949,7 +2988,7 @@ class TestConcretizeSeparately:
         assert len(pinned_gmake) == 1 and pinned_gmake[0].satisfies("@=3.0")
 
     @pytest.mark.parametrize("strategy", ["minimal", "full"])
-    def test_two_setuptools(self, strategy, mutable_config):
+    def test_two_setuptools(self, strategy, mutable_config: Configuration):
         """Tests that we can concretize separate build dependencies, when we are dealing
         with extensions.
 
@@ -2998,7 +3037,7 @@ class TestConcretizeSeparately:
         assert s["cycle-b"].satisfies("+cycle")
 
     @pytest.mark.parametrize("strategy", ["minimal", "full"])
-    def test_pure_build_virtual_dependency(self, strategy, mutable_config):
+    def test_pure_build_virtual_dependency(self, strategy, mutable_config: Configuration):
         """Tests that we can concretize a pure build virtual dependency, and ensures that
         pure build virtual dependencies are accounted in the list of possible virtual
         dependencies.
@@ -3049,7 +3088,7 @@ class TestConcretizeSeparately:
         assert len(edges) == 1
         assert edges[0].spec.satisfies("@=60")
 
-    def test_build_environment_is_unified(self, mutable_config):
+    def test_build_environment_is_unified(self, mutable_config: Configuration):
         """A pure build dep that is marked build-tool can creates its own unification set. This
         test ensures that its sibling build dependencies are unified with it, together with their
         runtime dependencies. It ensures the same package cannot appear multiple times in a single
@@ -3431,7 +3470,7 @@ def test_spec_filters(specs, include, exclude, expected):
 
 
 @pytest.mark.regression("38484")
-def test_git_ref_version_can_be_reused(install_mockery, mutable_config):
+def test_git_ref_version_can_be_reused(install_mockery, mutable_config: Configuration):
     first_spec = spack.concretize.concretize_one(
         spack.spec.Spec("git-ref-package@git.2.1.5=2.1.5~opt")
     )
@@ -3453,7 +3492,7 @@ def test_git_ref_version_can_be_reused(install_mockery, mutable_config):
 
 @pytest.mark.parametrize("standard_version", ["2.0.0", "2.1.5", "2.1.6"])
 def test_reuse_prefers_standard_over_git_versions(
-    standard_version, install_mockery, mutable_config
+    standard_version, install_mockery, mutable_config: Configuration
 ):
     """
     order matters in this test. typically reuse would pick the highest versioned installed match
@@ -3475,7 +3514,7 @@ def test_reuse_prefers_standard_over_git_versions(
 
 
 @pytest.mark.parametrize("unify", [True, "when_possible", False])
-def test_spec_unification(unify, mutable_config, mock_packages):
+def test_spec_unification(unify, mutable_config: Configuration, mock_packages):
     mutable_config.set("concretizer:unify", unify)
     a = "pkg-a"
     a_restricted = "pkg-a^pkg-b foo=baz"
@@ -3556,7 +3595,7 @@ def test_relationship_git_versions_and_commit_variant(version_str):
 
 
 @pytest.mark.usefixtures("install_mockery")
-def test_abstract_commit_spec_reuse(mutable_config):
+def test_abstract_commit_spec_reuse(mutable_config: Configuration):
     commit = "abcd" * 10
     spec_str_1 = f"git-ref-package@develop commit={commit}"
     spec_str_2 = f"git-ref-package commit={commit}"
@@ -3573,7 +3612,9 @@ def test_abstract_commit_spec_reuse(mutable_config):
     "installed_commit, incoming_commit, reusable",
     [("a" * 40, "b" * 40, False), (None, "b" * 40, False), ("a" * 40, None, True)],
 )
-def test_commit_variant_can_be_reused(installed_commit, incoming_commit, reusable, mutable_config):
+def test_commit_variant_can_be_reused(
+    installed_commit, incoming_commit, reusable, mutable_config: Configuration
+):
     # install a non-default variant to test if reuse picks it
     if installed_commit:
         spec_str_1 = f"git-ref-package@develop commit={installed_commit} ~opt"
@@ -3782,7 +3823,7 @@ def test_specifying_compilers_with_virtuals_syntax(config, mock_packages):
 
 @pytest.mark.regression("49847")
 @pytest.mark.xfail(sys.platform == "win32", reason="issues with install mockery")
-def test_reuse_when_input_specifies_build_dep(install_mockery, mutable_config):
+def test_reuse_when_input_specifies_build_dep(install_mockery, mutable_config: Configuration):
     """Test that we can reuse a spec when specifying build dependencies in the input"""
     pkgb_old = spack.concretize.concretize_one(spack.spec.Spec("pkg-b@0.9 %gcc@9"))
     PackageInstaller([pkgb_old.package], fake=True, explicit=True).install()
@@ -3800,7 +3841,7 @@ def test_reuse_when_input_specifies_build_dep(install_mockery, mutable_config):
 
 
 @pytest.mark.regression("49847")
-def test_reuse_when_requiring_build_dep(install_mockery, mutable_config):
+def test_reuse_when_requiring_build_dep(install_mockery, mutable_config: Configuration):
     """Test that we can reuse a spec when specifying build dependencies in requirements"""
     mutable_config.set("packages:all:require", "%gcc")
     pkgb_old = spack.concretize.concretize_one(spack.spec.Spec("pkg-b@0.9"))
@@ -3887,7 +3928,7 @@ packages:
 
 
 @pytest.mark.regression("50161")
-def test_installed_compiler_and_better_external(install_mockery, mutable_config):
+def test_installed_compiler_and_better_external(install_mockery, mutable_config: Configuration):
     """Tests that we always prefer a higher-priority external compiler, when we have a
     lower-priority compiler installed, and we try to concretize a spec without specifying
     the compiler dependency.
@@ -4092,7 +4133,11 @@ def test_spec_parts_on_fresh_compilers(
     ],
 )
 def test_spec_parts_on_reused_compilers(
-    constraint_in_yaml, unsat_request, sat_request, mutable_config, tmp_path: pathlib.Path
+    constraint_in_yaml,
+    unsat_request,
+    sat_request,
+    mutable_config: Configuration,
+    tmp_path: pathlib.Path,
 ):
     """Tests that requests of the form <package>%<compiler> <requests> are considered for reused
     specs, even though build dependency are not part of the ASP problem.
@@ -4133,7 +4178,7 @@ def test_spec_parts_on_reused_compilers(
     assert s.dag_hash() == installed_spec.dag_hash()
 
 
-def test_use_compiler_by_hash(mock_packages, mutable_database, mutable_config):
+def test_use_compiler_by_hash(mock_packages, mutable_database, mutable_config: Configuration):
     """Tests that we can reuse an installed compiler specifying its hash"""
     installed_spec = spack.concretize.concretize_one("gcc@14.0")
     PackageInstaller([installed_spec.package], fake=True, explicit=True).install()
@@ -4426,7 +4471,7 @@ def test_commit_variant_enters_the_hash(mutable_config, mock_packages, monkeypat
 
 
 @pytest.mark.regression("51180")
-def test_reuse_with_mixed_compilers(mutable_config, mock_packages):
+def test_reuse_with_mixed_compilers(mutable_config: Configuration, mock_packages):
     """Tests that potentially reusing a spec with a mixed compiler set, will not interfere
     with a request on one of the languages for the same package.
     """
@@ -4601,7 +4646,13 @@ def test_concretization_cache_store_skips_spliced_results(mock_packages, use_con
     ],
 )
 def test_concretization_cache_roundtrip(
-    spec, reused_dep, mock_packages, use_concretization_cache, monkeypatch, mutable_config, request
+    spec,
+    reused_dep,
+    mock_packages,
+    use_concretization_cache,
+    monkeypatch,
+    mutable_config: Configuration,
+    request,
 ):
     """Tests whether we can write the results of a clingo solve to the cache
     and load the same spec request from the cache to produce identical specs"""
@@ -4706,7 +4757,9 @@ def test_concretization_cache_reapplies_patches_on_hit(
     assert initial_sha256s <= new_sha256s
 
 
-def test_concretization_cache_count_cleanup(use_concretization_cache, mutable_config):
+def test_concretization_cache_count_cleanup(
+    use_concretization_cache, mutable_config: Configuration
+):
     """Tests to ensure we are cleaning the cache when we should be respective to the
     number of entries allowed in the cache"""
     conc_cache_dir = use_concretization_cache / f"v{spack.solver.asp.ConcretizationCache.VERSION}"
@@ -5104,7 +5157,7 @@ packages:
     assert mpileaks.satisfies("%c=gcc@12")
 
 
-def test_concrete_specs_skip_prechecks(config, mock_packages):
+def test_concrete_specs_skip_prechecks(config: Configuration, mock_packages):
     """Test that concrete specs are not checked for unknown versions and dependencies."""
 
     specs = [spack.spec.Spec("zlib"), spack.spec.Spec("deprecated-versions@=1.1.0")]
@@ -5207,7 +5260,7 @@ def test_default_values_used_if_subset_required_by_dependent(config, mock_packag
     assert a.satisfies("%multivalue-variant-multi-defaults myvariant=bar,baz")
 
 
-def test_virtual_gets_multiple_dupes(mock_packages, config):
+def test_virtual_gets_multiple_dupes(mock_packages: RepoPath, config: Configuration):
     """Tests that virtual packages always get multiple dupes, according to what we have in
     the configuration files.
     """

--- a/lib/spack/spack/test/concretization/core.py
+++ b/lib/spack/spack/test/concretization/core.py
@@ -383,20 +383,20 @@ class TestConcretize:
         concrete = check_concretize("mpileaks   ^mpich2@1.3.1:1.4")
         assert concrete["mpich2"].satisfies("mpich2@1.3.1:1.4")
 
-    def test_concretize_with_provides_when(self):
+    def test_concretize_with_provides_when(self, mock_packages):
         """Make sure insufficient versions of MPI are not in providers list when
         we ask for some advanced version.
         """
-        repo = spack.repo.PATH
+        repo = mock_packages
         assert not any(s.intersects("mpich2@:1.0") for s in repo.providers_for("mpi@2.1"))
         assert not any(s.intersects("mpich2@:1.1") for s in repo.providers_for("mpi@2.2"))
         assert not any(s.intersects("mpich@:1") for s in repo.providers_for("mpi@2"))
         assert not any(s.intersects("mpich@:1") for s in repo.providers_for("mpi@3"))
         assert not any(s.intersects("mpich2") for s in repo.providers_for("mpi@3"))
 
-    def test_provides_handles_multiple_providers_of_same_version(self):
+    def test_provides_handles_multiple_providers_of_same_version(self, mock_packages):
         """ """
-        providers = spack.repo.PATH.providers_for("mpi@3.0")
+        providers = mock_packages.providers_for("mpi@3.0")
 
         # Note that providers are repo-specific, so we don't misinterpret
         # providers, but vdeps are not namespace-specific, so we can
@@ -1752,13 +1752,13 @@ spack:
         assert s["java"].satisfies("virtual-with-versions@1.8.0")
 
     @pytest.mark.regression("26866")
-    def test_non_default_provider_of_multiple_virtuals(self):
+    def test_non_default_provider_of_multiple_virtuals(self, mock_packages):
         s = spack.concretize.concretize_one("many-virtual-consumer ^low-priority-provider")
         assert s["mpi"].name == "low-priority-provider"
         assert s["lapack"].name == "low-priority-provider"
 
         for virtual_pkg in ("mpi", "lapack"):
-            for pkg in spack.repo.PATH.providers_for(virtual_pkg):
+            for pkg in mock_packages.providers_for(virtual_pkg):
                 if pkg.name == "low-priority-provider":
                     continue
                 assert pkg not in s
@@ -2400,13 +2400,13 @@ spack:
 
     @pytest.mark.regression("31484")
     def test_installed_specs_disregard_conflicts(
-        self, mutable_database, monkeypatch, mutable_config
+        self, mutable_database, monkeypatch, mutable_config, mock_packages
     ):
         """Test that installed specs do not trigger conflicts. This covers for the rare case
         where a conflict is added on a package after a spec matching the conflict was installed.
         """
         # Add a conflict to "mpich" that match an already installed "mpich~debug"
-        pkg_cls = spack.repo.PATH.get_pkg_class("mpich")
+        pkg_cls = mock_packages.get_pkg_class("mpich")
         monkeypatch.setitem(pkg_cls.conflicts, Spec(), [(Spec("~debug"), None)])
 
         # If we concretize with --fresh the conflict is taken into account

--- a/lib/spack/spack/test/concretization/core.py
+++ b/lib/spack/spack/test/concretization/core.py
@@ -5196,7 +5196,7 @@ def test_virtual_gets_multiple_dupes(mock_packages, config):
     """
     specs = [spack.spec.Spec("pkg-with-c-link-dep")]
     possible_graph = spack.solver.input_analysis.NoStaticAnalysis(
-        configuration=spack.config.CONFIG, repo=spack.repo.PATH
+        configuration=spack.config.CONFIG, repo=mock_packages
     )
     counter = spack.solver.input_analysis.MinimalDuplicatesCounter(
         specs, tests=False, possible_graph=possible_graph

--- a/lib/spack/spack/test/concretization/errors.py
+++ b/lib/spack/spack/test/concretization/errors.py
@@ -17,7 +17,6 @@ from typing import List
 import pytest
 
 import spack.concretize
-import spack.config
 import spack.error
 import spack.main
 import spack.solver.asp
@@ -60,7 +59,7 @@ external_config = {
 )
 def test_error_messages(error_messages, config_set, spec, mock_packages, mutable_config):
     for path, conf in config_set.items():
-        spack.config.set(path, conf)
+        mutable_config.set(path, conf)
 
     with pytest.raises(spack.solver.asp.UnsatisfiableSpecError) as e:
         _ = spack.concretize.concretize_one(spec)
@@ -76,7 +75,7 @@ def test_deprecated_version_error(spec, mock_packages, mutable_config):
     with pytest.raises(spack.solver.asp.DeprecatedVersionError, match="deprecated-versions@1.1.0"):
         _ = spack.concretize.concretize_one(spec)
 
-    spack.config.set("config:deprecated", True)
+    mutable_config.set("config:deprecated", True)
     spack.concretize.concretize_one(spec)
 
 
@@ -263,7 +262,7 @@ def test_config_driven_errors(
     identify the package and the config value to fix.
     """
     for path, conf in packages_config.items():
-        spack.config.set(path, conf)
+        mutable_config.set(path, conf)
 
     with pytest.raises(spack.error.SpackError) as exc_info:
         spack.concretize.concretize_one(input_spec)

--- a/lib/spack/spack/test/concretization/errors.py
+++ b/lib/spack/spack/test/concretization/errors.py
@@ -21,6 +21,7 @@ import spack.error
 import spack.main
 import spack.solver.asp
 import spack.spec
+from spack.config import Configuration
 
 version_error_messages = [
     "Cannot satisfy",
@@ -57,7 +58,9 @@ external_config = {
         (variant_error_messages, {}, "quantum-espresso+invino^fftw~mpi"),
     ],
 )
-def test_error_messages(error_messages, config_set, spec, mock_packages, mutable_config):
+def test_error_messages(
+    error_messages, config_set, spec, mock_packages, mutable_config: Configuration
+):
     for path, conf in config_set.items():
         mutable_config.set(path, conf)
 
@@ -71,7 +74,7 @@ def test_error_messages(error_messages, config_set, spec, mock_packages, mutable
 @pytest.mark.parametrize(
     "spec", ["deprecated-versions@1.1.0", "deprecated-client ^deprecated-versions@1.1.0"]
 )
-def test_deprecated_version_error(spec, mock_packages, mutable_config):
+def test_deprecated_version_error(spec, mock_packages, mutable_config: Configuration):
     with pytest.raises(spack.solver.asp.DeprecatedVersionError, match="deprecated-versions@1.1.0"):
         _ = spack.concretize.concretize_one(spec)
 
@@ -256,7 +259,11 @@ def test_input_spec_driven_errors(
     ],
 )
 def test_config_driven_errors(
-    packages_config, input_spec: str, expected_parts: List[str], mock_packages, mutable_config
+    packages_config,
+    input_spec: str,
+    expected_parts: List[str],
+    mock_packages,
+    mutable_config: Configuration,
 ) -> None:
     """Tests errors caused by user configuration, e,g, a setting in packages.yaml. The message must
     identify the package and the config value to fix.

--- a/lib/spack/spack/test/concretization/flag_mixing.py
+++ b/lib/spack/spack/test/concretization/flag_mixing.py
@@ -53,7 +53,7 @@ def test_repo(mutable_config, monkeypatch, mock_stage):
 
 def update_concretize_scope(conf_str, section):
     conf = syaml.load_config(conf_str)
-    spack.config.set(section, conf[section], scope="concretize")
+    spack.config.CONFIG.set(section, conf[section], scope="concretize")
 
 
 def test_mix_spec_and_requirements(concretize_scope, test_repo):

--- a/lib/spack/spack/test/concretization/preferences.py
+++ b/lib/spack/spack/test/concretization/preferences.py
@@ -183,7 +183,7 @@ class TestConcretizePreferences:
             spec = concretize("mpileaks")
             assert spec.package.fetcher.url == expected
 
-    def test_config_set_pkg_property_new(self):
+    def test_config_set_pkg_property_new(self, mutable_config):
         """Test that you can set arbitrary attributes on the Package class"""
         conf = syaml.load_config(
             """\
@@ -201,7 +201,7 @@ mpileaks:
     - 2
 """
         )
-        spack.config.set("packages", conf, scope="concretize")
+        mutable_config.set("packages", conf, scope="concretize")
         with spack.repo.use_repositories(spack.paths.mock_packages_path):
             spec = concretize("mpileaks")
             assert spec.package.v1 == 1
@@ -261,7 +261,7 @@ mpileaks:
         spec = spack.concretize.concretize_one("develop-test2")
         assert spec.version == Version("0.2.15.develop")
 
-    def test_external_mpi(self):
+    def test_external_mpi(self, mutable_config):
         # make sure this doesn't give us an external first.
         spec = spack.concretize.concretize_one("mpi")
         assert not spec.external and spec.package.provides("mpi")
@@ -279,13 +279,13 @@ mpich:
       prefix: /dummy/path
 """
         )
-        spack.config.set("packages", conf, scope="concretize")
+        mutable_config.set("packages", conf, scope="concretize")
 
         # ensure that once config is in place, external is used
         spec = spack.concretize.concretize_one("mpi")
         assert spec["mpich"].external_path == os.path.sep + os.path.join("dummy", "path")
 
-    def test_external_module(self, monkeypatch):
+    def test_external_module(self, monkeypatch, mutable_config):
         """Test that packages can find externals specified by module
 
         The specific code for parsing the module is tested elsewhere.
@@ -313,55 +313,55 @@ mpi:
       modules: [dummy]
 """
         )
-        spack.config.set("packages", conf, scope="concretize")
+        mutable_config.set("packages", conf, scope="concretize")
 
         # ensure that once config is in place, external is used
         spec = spack.concretize.concretize_one("mpi")
         assert spec["mpich"].external_path == os.path.sep + os.path.join("dummy", "path")
 
-    def test_buildable_false(self):
+    def test_buildable_false(self, mutable_config):
         conf = syaml.load_config(
             """\
 libelf:
   buildable: false
 """
         )
-        spack.config.set("packages", conf, scope="concretize")
+        mutable_config.set("packages", conf, scope="concretize")
         spec = Spec("libelf")
         assert not spack.package_prefs.is_spec_buildable(spec)
 
         spec = Spec("mpich")
         assert spack.package_prefs.is_spec_buildable(spec)
 
-    def test_buildable_false_virtual(self):
+    def test_buildable_false_virtual(self, mutable_config):
         conf = syaml.load_config(
             """\
 mpi:
   buildable: false
 """
         )
-        spack.config.set("packages", conf, scope="concretize")
+        mutable_config.set("packages", conf, scope="concretize")
         spec = Spec("libelf")
         assert spack.package_prefs.is_spec_buildable(spec)
 
         spec = Spec("mpich")
         assert not spack.package_prefs.is_spec_buildable(spec)
 
-    def test_buildable_false_all(self):
+    def test_buildable_false_all(self, mutable_config):
         conf = syaml.load_config(
             """\
 all:
   buildable: false
 """
         )
-        spack.config.set("packages", conf, scope="concretize")
+        mutable_config.set("packages", conf, scope="concretize")
         spec = Spec("libelf")
         assert not spack.package_prefs.is_spec_buildable(spec)
 
         spec = Spec("mpich")
         assert not spack.package_prefs.is_spec_buildable(spec)
 
-    def test_buildable_false_all_true_package(self):
+    def test_buildable_false_all_true_package(self, mutable_config):
         conf = syaml.load_config(
             """\
 all:
@@ -370,14 +370,14 @@ libelf:
   buildable: true
 """
         )
-        spack.config.set("packages", conf, scope="concretize")
+        mutable_config.set("packages", conf, scope="concretize")
         spec = Spec("libelf")
         assert spack.package_prefs.is_spec_buildable(spec)
 
         spec = Spec("mpich")
         assert not spack.package_prefs.is_spec_buildable(spec)
 
-    def test_buildable_false_all_true_virtual(self):
+    def test_buildable_false_all_true_virtual(self, mutable_config):
         conf = syaml.load_config(
             """\
 all:
@@ -386,14 +386,14 @@ mpi:
   buildable: true
 """
         )
-        spack.config.set("packages", conf, scope="concretize")
+        mutable_config.set("packages", conf, scope="concretize")
         spec = Spec("libelf")
         assert not spack.package_prefs.is_spec_buildable(spec)
 
         spec = Spec("mpich")
         assert spack.package_prefs.is_spec_buildable(spec)
 
-    def test_buildable_false_virtual_true_pacakge(self):
+    def test_buildable_false_virtual_true_pacakge(self, mutable_config):
         conf = syaml.load_config(
             """\
 mpi:
@@ -402,7 +402,7 @@ mpich:
   buildable: true
 """
         )
-        spack.config.set("packages", conf, scope="concretize")
+        mutable_config.set("packages", conf, scope="concretize")
 
         spec = Spec("zmpi")
         assert not spack.package_prefs.is_spec_buildable(spec)
@@ -480,7 +480,7 @@ mpich:
         assert "version-test-dependency-preferred" not in s
 
     @pytest.mark.regression("26598")
-    def test_multivalued_variants_are_lower_priority_than_providers(self):
+    def test_multivalued_variants_are_lower_priority_than_providers(self, mutable_config):
         """Test that the rule to maximize the number of values for multivalued
         variants is considered at lower priority than selecting the default
         provider for virtual dependencies.
@@ -489,28 +489,28 @@ mpich:
         specified mpich as the default mpi provider, just because openmpi supports
         more fabrics by default.
         """
-        with spack.config.override(
+        with mutable_config.override(
             "packages:all", {"providers": {"somevirtual": ["some-virtual-preferred"]}}
         ):
             s = spack.concretize.concretize_one("somevirtual")
             assert s.name == "some-virtual-preferred"
 
     @pytest.mark.regression("26721,19736")
-    def test_sticky_variant_accounts_for_packages_yaml(self):
-        with spack.config.override("packages:sticky-variant", {"variants": "+allow-gcc"}):
+    def test_sticky_variant_accounts_for_packages_yaml(self, mutable_config):
+        with mutable_config.override("packages:sticky-variant", {"variants": "+allow-gcc"}):
             s = spack.concretize.concretize_one("sticky-variant %gcc")
             assert s.satisfies("%gcc") and s.satisfies("+allow-gcc")
 
     @pytest.mark.regression("41134")
-    def test_default_preference_variant_different_type_does_not_error(self):
+    def test_default_preference_variant_different_type_does_not_error(self, mutable_config):
         """Tests that a different type for an existing variant in the 'all:' section of
         packages.yaml doesn't fail with an error.
         """
-        with spack.config.override("packages:all", {"variants": "+foo"}):
+        with mutable_config.override("packages:all", {"variants": "+foo"}):
             s = spack.concretize.concretize_one("pkg-a")
             assert s.satisfies("foo=bar")
 
-    def test_version_preference_cannot_generate_buildable_versions(self):
+    def test_version_preference_cannot_generate_buildable_versions(self, mutable_config):
         """Tests that a version preference not mentioned in package.py cannot be used in
         a built spec.
         """
@@ -526,7 +526,7 @@ mpich:
     """
         )
 
-        with spack.config.override("packages", mpileaks_external):
+        with mutable_config.override("packages", mpileaks_external):
             # Asking for mpileaks+debug results in the external being chosen
             mpileaks = spack.concretize.concretize_one("mpileaks+debug")
             assert mpileaks.external and mpileaks.satisfies("@0.9 +debug")

--- a/lib/spack/spack/test/concretization/preferences.py
+++ b/lib/spack/spack/test/concretization/preferences.py
@@ -41,7 +41,7 @@ callpath:
     write: world
 """
     )
-    spack.config.set("packages", conf, scope="concretize")
+    spack.config.CONFIG.set("packages", conf, scope="concretize")
 
     yield
 
@@ -53,7 +53,7 @@ def concretize(abstract_spec):
 def update_packages(pkgname, section, value):
     """Update config and reread package list"""
     conf = {pkgname: {section: value}}
-    spack.config.set("packages", conf, scope="concretize")
+    spack.config.CONFIG.set("packages", conf, scope="concretize")
 
 
 def assert_variant_values(spec, **variants):

--- a/lib/spack/spack/test/concretization/preferences.py
+++ b/lib/spack/spack/test/concretization/preferences.py
@@ -14,6 +14,7 @@ import spack.paths
 import spack.repo
 import spack.util.module_cmd
 import spack.util.spack_yaml as syaml
+from spack.config import Configuration
 from spack.error import ConfigError
 from spack.spec import Spec
 from spack.version import Version
@@ -183,7 +184,7 @@ class TestConcretizePreferences:
             spec = concretize("mpileaks")
             assert spec.package.fetcher.url == expected
 
-    def test_config_set_pkg_property_new(self, mutable_config):
+    def test_config_set_pkg_property_new(self, mutable_config: Configuration):
         """Test that you can set arbitrary attributes on the Package class"""
         conf = syaml.load_config(
             """\
@@ -261,7 +262,7 @@ mpileaks:
         spec = spack.concretize.concretize_one("develop-test2")
         assert spec.version == Version("0.2.15.develop")
 
-    def test_external_mpi(self, mutable_config):
+    def test_external_mpi(self, mutable_config: Configuration):
         # make sure this doesn't give us an external first.
         spec = spack.concretize.concretize_one("mpi")
         assert not spec.external and spec.package.provides("mpi")
@@ -285,7 +286,7 @@ mpich:
         spec = spack.concretize.concretize_one("mpi")
         assert spec["mpich"].external_path == os.path.sep + os.path.join("dummy", "path")
 
-    def test_external_module(self, monkeypatch, mutable_config):
+    def test_external_module(self, monkeypatch, mutable_config: Configuration):
         """Test that packages can find externals specified by module
 
         The specific code for parsing the module is tested elsewhere.
@@ -319,7 +320,7 @@ mpi:
         spec = spack.concretize.concretize_one("mpi")
         assert spec["mpich"].external_path == os.path.sep + os.path.join("dummy", "path")
 
-    def test_buildable_false(self, mutable_config):
+    def test_buildable_false(self, mutable_config: Configuration):
         conf = syaml.load_config(
             """\
 libelf:
@@ -333,7 +334,7 @@ libelf:
         spec = Spec("mpich")
         assert spack.package_prefs.is_spec_buildable(spec)
 
-    def test_buildable_false_virtual(self, mutable_config):
+    def test_buildable_false_virtual(self, mutable_config: Configuration):
         conf = syaml.load_config(
             """\
 mpi:
@@ -347,7 +348,7 @@ mpi:
         spec = Spec("mpich")
         assert not spack.package_prefs.is_spec_buildable(spec)
 
-    def test_buildable_false_all(self, mutable_config):
+    def test_buildable_false_all(self, mutable_config: Configuration):
         conf = syaml.load_config(
             """\
 all:
@@ -361,7 +362,7 @@ all:
         spec = Spec("mpich")
         assert not spack.package_prefs.is_spec_buildable(spec)
 
-    def test_buildable_false_all_true_package(self, mutable_config):
+    def test_buildable_false_all_true_package(self, mutable_config: Configuration):
         conf = syaml.load_config(
             """\
 all:
@@ -377,7 +378,7 @@ libelf:
         spec = Spec("mpich")
         assert not spack.package_prefs.is_spec_buildable(spec)
 
-    def test_buildable_false_all_true_virtual(self, mutable_config):
+    def test_buildable_false_all_true_virtual(self, mutable_config: Configuration):
         conf = syaml.load_config(
             """\
 all:
@@ -393,7 +394,7 @@ mpi:
         spec = Spec("mpich")
         assert spack.package_prefs.is_spec_buildable(spec)
 
-    def test_buildable_false_virtual_true_pacakge(self, mutable_config):
+    def test_buildable_false_virtual_true_pacakge(self, mutable_config: Configuration):
         conf = syaml.load_config(
             """\
 mpi:
@@ -480,7 +481,9 @@ mpich:
         assert "version-test-dependency-preferred" not in s
 
     @pytest.mark.regression("26598")
-    def test_multivalued_variants_are_lower_priority_than_providers(self, mutable_config):
+    def test_multivalued_variants_are_lower_priority_than_providers(
+        self, mutable_config: Configuration
+    ):
         """Test that the rule to maximize the number of values for multivalued
         variants is considered at lower priority than selecting the default
         provider for virtual dependencies.
@@ -496,13 +499,15 @@ mpich:
             assert s.name == "some-virtual-preferred"
 
     @pytest.mark.regression("26721,19736")
-    def test_sticky_variant_accounts_for_packages_yaml(self, mutable_config):
+    def test_sticky_variant_accounts_for_packages_yaml(self, mutable_config: Configuration):
         with mutable_config.override("packages:sticky-variant", {"variants": "+allow-gcc"}):
             s = spack.concretize.concretize_one("sticky-variant %gcc")
             assert s.satisfies("%gcc") and s.satisfies("+allow-gcc")
 
     @pytest.mark.regression("41134")
-    def test_default_preference_variant_different_type_does_not_error(self, mutable_config):
+    def test_default_preference_variant_different_type_does_not_error(
+        self, mutable_config: Configuration
+    ):
         """Tests that a different type for an existing variant in the 'all:' section of
         packages.yaml doesn't fail with an error.
         """
@@ -510,7 +515,9 @@ mpich:
             s = spack.concretize.concretize_one("pkg-a")
             assert s.satisfies("foo=bar")
 
-    def test_version_preference_cannot_generate_buildable_versions(self, mutable_config):
+    def test_version_preference_cannot_generate_buildable_versions(
+        self, mutable_config: Configuration
+    ):
         """Tests that a version preference not mentioned in package.py cannot be used in
         a built spec.
         """

--- a/lib/spack/spack/test/concretization/requirements.py
+++ b/lib/spack/spack/test/concretization/requirements.py
@@ -18,6 +18,7 @@ import spack.spec
 import spack.store
 import spack.util.spack_yaml as syaml
 import spack.version
+from spack.config import Configuration
 from spack.externals_config import create_external_parser, external_config_with_implicit_externals
 from spack.old_installer import PackageInstaller
 from spack.solver.asp import InternalConcretizerError, UnsatisfiableSpecError
@@ -454,7 +455,7 @@ packages:
 
 
 def test_reuse_oneof(
-    concretize_scope, test_repo, tmp_path: pathlib.Path, mock_fetch, mutable_config
+    concretize_scope, test_repo, tmp_path: pathlib.Path, mock_fetch, mutable_config: Configuration
 ):
     conf_str = """\
 packages:
@@ -480,7 +481,12 @@ packages:
     [(True, ["@=2.3", "%gcc"], []), (False, ["%gcc"], ["@=2.3"])],
 )
 def test_requirements_and_deprecated_versions(
-    allow_deprecated, expected, not_expected, concretize_scope, test_repo, mutable_config
+    allow_deprecated,
+    expected,
+    not_expected,
+    concretize_scope,
+    test_repo,
+    mutable_config: Configuration,
 ):
     """Tests the expected behavior of requirements and deprecated versions.
 
@@ -1158,7 +1164,7 @@ def test_forward_multi_valued_variant_using_requires(
 
 
 def test_strong_preferences_higher_priority_than_reuse(
-    concretize_scope, mock_packages, mutable_config
+    concretize_scope, mock_packages, mutable_config: Configuration
 ):
     """Tests that strong preferences have a higher priority than reusing specs."""
     reused_spec = spack.concretize.concretize_one("adios2~bzip2")
@@ -1308,7 +1314,7 @@ packages:
 def test_requirements_on_compilers_and_reuse(
     concretize_scope,
     mock_packages,
-    mutable_config,
+    mutable_config: Configuration,
     packages_yaml,
     expected_reuse,
     expected_contraints,
@@ -1355,7 +1361,7 @@ def test_requirements_on_compilers_and_reuse(
     ],
 )
 def test_requirements_conditional_deps(
-    abstract, req_is_noop, mutable_config, mock_packages, config_two_gccs
+    abstract, req_is_noop, mutable_config: Configuration, mock_packages, config_two_gccs
 ):
     required_spec = (
         "%[when='^c' virtuals=c]gcc@10.3.1 "
@@ -1486,7 +1492,7 @@ def test_language_preferences_and_reuse(
     current_preference,
     constraint_kind,
     concretize_scope,
-    mutable_config,
+    mutable_config: Configuration,
     mock_packages,
 ):
     """Tests that language preferences are respected when reusing specs."""

--- a/lib/spack/spack/test/concretization/requirements.py
+++ b/lib/spack/spack/test/concretization/requirements.py
@@ -453,7 +453,9 @@ packages:
     assert s2.satisfies("@2.5")
 
 
-def test_reuse_oneof(concretize_scope, test_repo, tmp_path: pathlib.Path, mock_fetch):
+def test_reuse_oneof(
+    concretize_scope, test_repo, tmp_path: pathlib.Path, mock_fetch, mutable_config
+):
     conf_str = """\
 packages:
   y:
@@ -468,7 +470,7 @@ packages:
 
         update_packages_config(conf_str)
 
-        with spack.config.override("concretizer:reuse", True):
+        with mutable_config.override("concretizer:reuse", True):
             s2 = spack.concretize.concretize_one("y")
             assert not s2.satisfies("@2.5~shared")
 
@@ -478,7 +480,7 @@ packages:
     [(True, ["@=2.3", "%gcc"], []), (False, ["%gcc"], ["@=2.3"])],
 )
 def test_requirements_and_deprecated_versions(
-    allow_deprecated, expected, not_expected, concretize_scope, test_repo
+    allow_deprecated, expected, not_expected, concretize_scope, test_repo, mutable_config
 ):
     """Tests the expected behavior of requirements and deprecated versions.
 
@@ -497,7 +499,7 @@ packages:
 """
     update_packages_config(conf_str)
 
-    with spack.config.override("config:deprecated", allow_deprecated):
+    with mutable_config.override("config:deprecated", allow_deprecated):
         s1 = spack.concretize.concretize_one("y")
         for constrain in expected:
             assert s1.satisfies(constrain)
@@ -1155,14 +1157,16 @@ def test_forward_multi_valued_variant_using_requires(
         assert not s.satisfies(constraint)
 
 
-def test_strong_preferences_higher_priority_than_reuse(concretize_scope, mock_packages):
+def test_strong_preferences_higher_priority_than_reuse(
+    concretize_scope, mock_packages, mutable_config
+):
     """Tests that strong preferences have a higher priority than reusing specs."""
     reused_spec = spack.concretize.concretize_one("adios2~bzip2")
     reuse_nodes = list(reused_spec.traverse())
     root_specs = [Spec("ascent+adios2")]
 
     # Check that without further configuration adios2 is reused
-    with spack.config.override("concretizer:reuse", True):
+    with mutable_config.override("concretizer:reuse", True):
         solver = spack.solver.asp.Solver()
         setup = spack.solver.asp.SpackSolverSetup()
         result, _, _ = solver.driver.solve(setup, root_specs, reuse=reuse_nodes)
@@ -1178,7 +1182,7 @@ def test_strong_preferences_higher_priority_than_reuse(concretize_scope, mock_pa
         - "+bzip2"
 """
     )
-    with spack.config.override("concretizer:reuse", True):
+    with mutable_config.override("concretizer:reuse", True):
         solver = spack.solver.asp.Solver()
         setup = spack.solver.asp.SpackSolverSetup()
         result, _, _ = solver.driver.solve(setup, root_specs, reuse=reuse_nodes)
@@ -1188,7 +1192,7 @@ def test_strong_preferences_higher_priority_than_reuse(concretize_scope, mock_pa
     assert ascent["adios2"].satisfies("+bzip2")
 
     # A preference is still preference, so we can override from input
-    with spack.config.override("concretizer:reuse", True):
+    with mutable_config.override("concretizer:reuse", True):
         solver = spack.solver.asp.Solver()
         setup = spack.solver.asp.SpackSolverSetup()
         result, _, _ = solver.driver.solve(
@@ -1327,7 +1331,7 @@ def test_requirements_on_compilers_and_reuse(
         exclude=[],
     ).selected_specs()
 
-    with spack.config.override("concretizer:reuse", True):
+    with mutable_config.override("concretizer:reuse", True):
         solver = spack.solver.asp.Solver()
         setup = spack.solver.asp.SpackSolverSetup()
         result, _, _ = solver.driver.solve(setup, root_specs, reuse=reused_nodes + external_specs)
@@ -1362,7 +1366,7 @@ def test_requirements_conditional_deps(
     abstract = spack.spec.Spec(abstract)
 
     no_requirements = spack.concretize.concretize_one(abstract)
-    spack.config.CONFIG.set(f"packages:{abstract.name}", {"require": required_spec})
+    mutable_config.set(f"packages:{abstract.name}", {"require": required_spec})
     requirements = spack.concretize.concretize_one(abstract)
 
     assert requirements.satisfies(required_spec)
@@ -1518,7 +1522,7 @@ packages:
     ).selected_specs()
 
     # Ask for just "mpileaks" and check the spec is reused
-    with spack.config.override("concretizer:reuse", True):
+    with mutable_config.override("concretizer:reuse", True):
         solver = spack.solver.asp.Solver()
         setup = spack.solver.asp.SpackSolverSetup()
         result, _, _ = solver.driver.solve(
@@ -1547,7 +1551,7 @@ packages:
           cxx: /path1/bin/clang++
 """
     update_packages_config(packages_yaml)
-    with spack.config.override("concretizer:reuse", True):
+    with mutable_config.override("concretizer:reuse", True):
         solver = spack.solver.asp.Solver()
         setup = spack.solver.asp.SpackSolverSetup()
         result, _, _ = solver.driver.solve(

--- a/lib/spack/spack/test/concretization/requirements.py
+++ b/lib/spack/spack/test/concretization/requirements.py
@@ -29,7 +29,7 @@ from spack.util.url import path_to_file_url
 
 def update_packages_config(conf_str):
     conf = syaml.load_config(conf_str)
-    spack.config.set("packages", conf["packages"], scope="concretize")
+    spack.config.CONFIG.set("packages", conf["packages"], scope="concretize")
 
 
 @pytest.fixture

--- a/lib/spack/spack/test/concretization/splicing.py
+++ b/lib/spack/spack/test/concretization/splicing.py
@@ -35,7 +35,7 @@ def install_specs(mutable_database, mock_packages, mutable_config, install_mocke
 
 
 def _enable_splicing():
-    spack.config.set("concretizer:splice", {"automatic": True})
+    spack.config.CONFIG.set("concretizer:splice", {"automatic": True})
 
 
 @pytest.mark.parametrize("spec_str", ["splice-z", "splice-h@1"])

--- a/lib/spack/spack/test/config.py
+++ b/lib/spack/spack/test/config.py
@@ -21,7 +21,6 @@ import spack.error
 import spack.package_base
 import spack.paths
 import spack.platforms
-import spack.repo
 import spack.schema.compilers
 import spack.schema.config
 import spack.schema.env
@@ -1184,13 +1183,13 @@ def test_license_dir_config(mutable_config, mock_packages, tmp_path):
     expected_dir = spack.paths.default_license_dir
     assert spack.config.get("config:license_dir") == expected_dir
     assert spack.package_base.PackageBase.global_license_dir == expected_dir
-    assert spack.repo.PATH.get_pkg_class("pkg-a").global_license_dir == expected_dir
+    assert mock_packages.get_pkg_class("pkg-a").global_license_dir == expected_dir
 
     abs_path = str(tmp_path / "foo" / "bar" / "baz")
     spack.config.set("config:license_dir", abs_path)
     assert spack.config.get("config:license_dir") == abs_path
     assert spack.package_base.PackageBase.global_license_dir == abs_path
-    assert spack.repo.PATH.get_pkg_class("pkg-a").global_license_dir == abs_path
+    assert mock_packages.get_pkg_class("pkg-a").global_license_dir == abs_path
 
 
 @pytest.mark.regression("22547")

--- a/lib/spack/spack/test/config.py
+++ b/lib/spack/spack/test/config.py
@@ -82,7 +82,7 @@ spack:
 
 def check_compiler_config(comps, *compiler_names):
     """Check that named compilers in comps match Spack's config."""
-    config = spack.config.get("compilers")
+    config = spack.config.CONFIG.get("compilers")
     compiler_list = ["cc", "cxx", "f77", "fc"]
     flag_list = ["cflags", "cxxflags", "fflags", "cppflags", "ldflags", "ldlibs"]
     param_list = ["modules", "paths", "spec", "operating_system"]

--- a/lib/spack/spack/test/config.py
+++ b/lib/spack/spack/test/config.py
@@ -207,8 +207,8 @@ def compiler_specs():
 
 def test_write_key_in_memory(mock_low_high_config, compiler_specs):
     # Write b_comps "on top of" a_comps.
-    spack.config.set("compilers", a_comps["compilers"], scope="low")
-    spack.config.set("compilers", b_comps["compilers"], scope="high")
+    mock_low_high_config.set("compilers", a_comps["compilers"], scope="low")
+    mock_low_high_config.set("compilers", b_comps["compilers"], scope="high")
 
     # Make sure the config looks how we expect.
     check_compiler_config(a_comps["compilers"], *compiler_specs.a)
@@ -217,11 +217,11 @@ def test_write_key_in_memory(mock_low_high_config, compiler_specs):
 
 def test_write_key_to_disk(mock_low_high_config, compiler_specs):
     # Write b_comps "on top of" a_comps.
-    spack.config.set("compilers", a_comps["compilers"], scope="low")
-    spack.config.set("compilers", b_comps["compilers"], scope="high")
+    mock_low_high_config.set("compilers", a_comps["compilers"], scope="low")
+    mock_low_high_config.set("compilers", b_comps["compilers"], scope="high")
 
     # Clear caches so we're forced to read from disk.
-    spack.config.CONFIG.clear_caches()
+    mock_low_high_config.clear_caches()
 
     # Same check again, to ensure consistency.
     check_compiler_config(a_comps["compilers"], *compiler_specs.a)
@@ -230,11 +230,11 @@ def test_write_key_to_disk(mock_low_high_config, compiler_specs):
 
 def test_write_to_same_priority_file(mock_low_high_config, compiler_specs):
     # Write b_comps in the same file as a_comps.
-    spack.config.set("compilers", a_comps["compilers"], scope="low")
-    spack.config.set("compilers", b_comps["compilers"], scope="low")
+    mock_low_high_config.set("compilers", a_comps["compilers"], scope="low")
+    mock_low_high_config.set("compilers", b_comps["compilers"], scope="low")
 
     # Clear caches so we're forced to read from disk.
-    spack.config.CONFIG.clear_caches()
+    mock_low_high_config.clear_caches()
 
     # Same check again, to ensure consistency.
     check_compiler_config(a_comps["compilers"], *compiler_specs.a)
@@ -253,14 +253,14 @@ repos_high = {"repos": {"high": "/some/other/path"}}
 def test_add_config_path(mutable_config):
     # Try setting a new install tree root
     path = "config:install_tree:root:/path/to/config.yaml"
-    spack.config.add(path)
-    set_value = spack.config.get("config")["install_tree"]["root"]
+    mutable_config.add(path)
+    set_value = mutable_config.get("config")["install_tree"]["root"]
     assert set_value == "/path/to/config.yaml"
 
     # Now a package:all setting
     path = "packages:all:target:[x86_64]"
-    spack.config.add(path)
-    targets = spack.config.get("packages")["all"]["target"]
+    mutable_config.add(path)
+    targets = mutable_config.get("packages")["all"]["target"]
     assert "x86_64" in targets
 
     # Try quotes to escape brackets
@@ -268,16 +268,18 @@ def test_add_config_path(mutable_config):
         "config:install_tree:projections:cmake:"
         "'{architecture}/{compiler.name}-{compiler.version}/{name}-{version}-{hash}'"
     )
-    spack.config.add(path)
-    set_value = spack.config.get("config")["install_tree"]["projections"]["cmake"]
+    mutable_config.add(path)
+    set_value = mutable_config.get("config")["install_tree"]["projections"]["cmake"]
     assert set_value == "{architecture}/{compiler.name}-{compiler.version}/{name}-{version}-{hash}"
 
     path = 'modules:default:tcl:all:environment:set:"{name}_ROOT":"{prefix}"'
-    spack.config.add(path)
-    set_value = spack.config.get("modules")["default"]["tcl"]["all"]["environment"]["set"]
+    mutable_config.add(path)
+    set_value = mutable_config.get("modules")["default"]["tcl"]["all"]["environment"]["set"]
     assert r"{name}_ROOT" in set_value
     assert set_value[r"{name}_ROOT"] == r"{prefix}"
-    assert spack.config.get('modules:default:tcl:all:environment:set:"{name}_ROOT"') == r"{prefix}"
+    assert (
+        mutable_config.get('modules:default:tcl:all:environment:set:"{name}_ROOT"') == r"{prefix}"
+    )
 
     # NOTE:
     # The config path: "config:install_tree:root:<path>" is unique in that it can accept multiple
@@ -287,21 +289,21 @@ def test_add_config_path(mutable_config):
 
     # try quotes to escape colons
     path = "config:build_stage:'C:\\path\\to\\config.yaml'"
-    spack.config.add(path)
-    set_value = spack.config.get("config")["build_stage"]
+    mutable_config.add(path)
+    set_value = mutable_config.get("config")["build_stage"]
     assert "C:\\path\\to\\config.yaml" in set_value
 
 
 @pytest.mark.regression("17543,23259")
 def test_add_config_path_with_enumerated_type(mutable_config):
-    spack.config.add("config:flags:keep_werror:all")
-    assert spack.config.get("config")["flags"]["keep_werror"] == "all"
+    mutable_config.add("config:flags:keep_werror:all")
+    assert mutable_config.get("config")["flags"]["keep_werror"] == "all"
 
-    spack.config.add("config:flags:keep_werror:specific")
-    assert spack.config.get("config")["flags"]["keep_werror"] == "specific"
+    mutable_config.add("config:flags:keep_werror:specific")
+    assert mutable_config.get("config")["flags"]["keep_werror"] == "specific"
 
     with pytest.raises(spack.error.ConfigError):
-        spack.config.add("config:flags:keep_werror:foo")
+        mutable_config.add("config:flags:keep_werror:foo")
 
 
 def test_add_config_filename(mock_low_high_config, tmp_path: pathlib.Path):
@@ -310,19 +312,19 @@ def test_add_config_filename(mock_low_high_config, tmp_path: pathlib.Path):
     with config_yaml.open("w") as f:
         syaml.dump_config(config_low, f)
 
-    spack.config.add_from_file(str(config_yaml), scope="low")
-    assert "build_stage" in spack.config.get("config")
-    build_stages = spack.config.get("config")["build_stage"]
+    mock_low_high_config.add_from_file(str(config_yaml), scope="low")
+    assert "build_stage" in mock_low_high_config.get("config")
+    build_stages = mock_low_high_config.get("config")["build_stage"]
     for stage in config_low["config"]["build_stage"]:
         assert stage in build_stages
 
 
 # repos
 def test_write_list_in_memory(mock_low_high_config):
-    spack.config.set("repos", repos_low["repos"], scope="low")
-    spack.config.set("repos", repos_high["repos"], scope="high")
+    mock_low_high_config.set("repos", repos_low["repos"], scope="low")
+    mock_low_high_config.set("repos", repos_high["repos"], scope="high")
 
-    config = spack.config.get("repos")
+    config = mock_low_high_config.get("repos")
     assert config == {**repos_high["repos"], **repos_low["repos"]}
 
 
@@ -374,7 +376,7 @@ def test_substitute_config_variables(mock_low_high_config, monkeypatch, tmp_path
 
     # Fake an active environment and $env is replaced properly
     fake_env_path = str(tmp_path / "quux" / "quuux")
-    monkeypatch.setattr(spack.config.CONFIG, "env_path", fake_env_path)
+    monkeypatch.setattr(mock_low_high_config, "env_path", fake_env_path)
     assert spack.config.canonicalize_path("$env/foo/bar/baz") == os.path.join(
         fake_env_path, os.path.join("foo", "bar", "baz")
     )
@@ -385,11 +387,11 @@ def test_substitute_config_variables(mock_low_high_config, monkeypatch, tmp_path
     )
 
     # relative paths with source information are relative to the file
-    spack.config.set(
+    mock_low_high_config.set(
         "modules:default", {"roots": {"lmod": os.path.join("foo", "bar", "baz")}}, scope="low"
     )
-    spack.config.CONFIG.clear_caches()
-    path = spack.config.get("modules:default:roots:lmod")
+    mock_low_high_config.clear_caches()
+    path = mock_low_high_config.get("modules:default:roots:lmod")
     assert spack.config.canonicalize_path(path) == os.path.normpath(
         os.path.join(mock_low_high_config.scopes["low"].path, os.path.join("foo", "bar", "baz"))
     )
@@ -421,17 +423,17 @@ packages_merge_high = {
 def test_config_set_beyond_existing(mutable_config):
     # no raised error is the primary test for this regression
     # Needs to be for a repo that does not already exist for valid test
-    spack.config.CONFIG.set("repos:nonexistent", "foo")
-    assert spack.config.CONFIG.get("repos:nonexistent") == "foo"
+    mutable_config.set("repos:nonexistent", "foo")
+    assert mutable_config.get("repos:nonexistent") == "foo"
 
 
 @pytest.mark.regression("52423")
 def test_config_section_defaults(mutable_config):
-    view_default = spack.config.CONFIG.get("view")
+    view_default = mutable_config.get("view")
     assert view_default == spack.config.get_default_from_schema("view")
     assert view_default is True
 
-    view_with_default = spack.config.get("view", default="my default")
+    view_with_default = mutable_config.get("view", default="my default")
     assert view_with_default == "my default"
 
 
@@ -445,7 +447,7 @@ def test_merge_with_defaults(mock_low_high_config, write_config_file):
     """
     write_config_file("packages", packages_merge_low, "low")
     write_config_file("packages", packages_merge_high, "high")
-    cfg = spack.config.get("packages")
+    cfg = mock_low_high_config.get("packages")
 
     assert cfg["foo"]["version"] == ["a"]
     assert cfg["bar"]["version"] == ["b"]
@@ -532,9 +534,9 @@ def test_parse_install_tree(config_settings_fn, expected_fn, mutable_config, tmp
 
 
 def test_change_or_add(mutable_config, mock_packages):
-    spack.config.add("packages:a:version:['1.0']", scope="user")
+    mutable_config.add("packages:a:version:['1.0']", scope="user")
 
-    spack.config.add("packages:b:version:['1.1']", scope="system")
+    mutable_config.add("packages:b:version:['1.1']", scope="system")
 
     class ChangeTest:
         def __init__(self, pkg_name, new_version):
@@ -604,19 +606,19 @@ def test_parse_install_tree_padded(config_settings, expected, mutable_config):
 
 def test_read_config(mock_low_high_config, write_config_file):
     write_config_file("config", config_low, "low")
-    assert spack.config.get("config") == config_low["config"]
+    assert mock_low_high_config.get("config") == config_low["config"]
 
 
 def test_read_config_override_all(mock_low_high_config, write_config_file):
     write_config_file("config", config_low, "low")
     write_config_file("config", config_override_all, "high")
-    assert spack.config.get("config") == {"install_tree": {"root": "override_all"}}
+    assert mock_low_high_config.get("config") == {"install_tree": {"root": "override_all"}}
 
 
 def test_read_config_override_key(mock_low_high_config, write_config_file):
     write_config_file("config", config_low, "low")
     write_config_file("config", config_override_key, "high")
-    assert spack.config.get("config") == {
+    assert mock_low_high_config.get("config") == {
         "install_tree": {"root": "override_key"},
         "build_stage": ["path1", "path2", "path3"],
     }
@@ -625,7 +627,7 @@ def test_read_config_override_key(mock_low_high_config, write_config_file):
 def test_read_config_merge_list(mock_low_high_config, write_config_file):
     write_config_file("config", config_low, "low")
     write_config_file("config", config_merge_list, "high")
-    assert spack.config.get("config") == {
+    assert mock_low_high_config.get("config") == {
         "install_tree": {"root": "install_tree_path"},
         "build_stage": ["patha", "pathb", "path1", "path2", "path3"],
     }
@@ -634,7 +636,7 @@ def test_read_config_merge_list(mock_low_high_config, write_config_file):
 def test_read_config_override_list(mock_low_high_config, write_config_file):
     write_config_file("config", config_low, "low")
     write_config_file("config", config_override_list, "high")
-    assert spack.config.get("config") == {
+    assert mock_low_high_config.get("config") == {
         "install_tree": {"root": "install_tree_path"},
         "build_stage": config_override_list["config"]["build_stage:"],
     }
@@ -769,7 +771,7 @@ def test_keys_are_ordered(configuration_dir):
 def test_config_format_error(mutable_config):
     """This is raised when we try to write a bad configuration."""
     with pytest.raises(spack.config.ConfigFormatError):
-        spack.config.set("compilers", {"bad": "data"}, scope="site")
+        mutable_config.set("compilers", {"bad": "data"}, scope="site")
 
 
 def get_config_error(filename, schema, yaml_string):
@@ -841,37 +843,37 @@ mirrors:
 def test_bad_config_section(mock_low_high_config):
     """Test that getting or setting a bad section gives an error."""
     with pytest.raises(spack.config.ConfigSectionError):
-        spack.config.set("foobar", "foobar")
+        mock_low_high_config.set("foobar", "foobar")
 
     with pytest.raises(spack.config.ConfigSectionError):
-        spack.config.get("foobar")
+        mock_low_high_config.get("foobar")
 
 
-def test_nested_override():
+def test_nested_override(mutable_config):
     """Ensure proper scope naming of nested overrides."""
     base_name = spack.config._OVERRIDES_BASE_NAME
 
     def _check_scopes(num_expected, debug_values):
         scope_names = [
-            s.name for s in spack.config.CONFIG.scopes.values() if s.name.startswith(base_name)
+            s.name for s in mutable_config.scopes.values() if s.name.startswith(base_name)
         ]
 
         for i in range(num_expected):
             name = "{0}{1}".format(base_name, i)
             assert name in scope_names
 
-            data = spack.config.CONFIG.get_config("config", name)
+            data = mutable_config.get_config("config", name)
             assert data["debug"] == debug_values[i]
 
     # Check results from single and nested override
-    with spack.config.override("config:debug", True):
-        with spack.config.override("config:debug", False):
+    with mutable_config.override("config:debug", True):
+        with mutable_config.override("config:debug", False):
             _check_scopes(2, [True, False])
 
         _check_scopes(1, [True])
 
 
-def test_alternate_override(monkeypatch):
+def test_alternate_override(monkeypatch, mutable_config):
     """Ensure proper scope naming of override when conflict present."""
     base_name = spack.config._OVERRIDES_BASE_NAME
 
@@ -879,17 +881,17 @@ def test_alternate_override(monkeypatch):
         return [spack.config.InternalConfigScope("{0}1".format(base_name))]
 
     # Check that the alternate naming works
-    monkeypatch.setattr(spack.config.CONFIG, "matching_scopes", _matching_scopes)
+    monkeypatch.setattr(mutable_config, "matching_scopes", _matching_scopes)
 
-    with spack.config.override("config:debug", False):
+    with mutable_config.override("config:debug", False):
         name = "{0}2".format(base_name)
 
         scope_names = [
-            s.name for s in spack.config.CONFIG.scopes.values() if s.name.startswith(base_name)
+            s.name for s in mutable_config.scopes.values() if s.name.startswith(base_name)
         ]
         assert name in scope_names
 
-        data = spack.config.CONFIG.get_config("config", name)
+        data = mutable_config.get_config("config", name)
         assert data["debug"] is False
 
 
@@ -918,16 +920,16 @@ def test_single_file_scope(config, env_yaml):
         "env", env_yaml, spack.schema.env.schema, yaml_path=["spack"]
     )
 
-    with spack.config.override(scope):
+    with config.override(scope):
         # from the single-file config
-        assert spack.config.get("config:verify_ssl") is False
-        assert spack.config.get("config:dirty") is False
+        assert config.get("config:verify_ssl") is False
+        assert config.get("config:dirty") is False
 
         # from the lower config scopes
-        assert spack.config.get("config:checksum") is True
-        assert spack.config.get("config:checksum") is True
-        assert spack.config.get("packages:externalmodule:buildable") is False
-        assert spack.config.get("repos") == {
+        assert config.get("config:checksum") is True
+        assert config.get("config:checksum") is True
+        assert config.get("packages:externalmodule:buildable") is False
+        assert config.get("repos") == {
             "z": "/x/y/z",
             "builtin_mock": "$spack/var/spack/test_repos/spack_repo/builtin_mock",
         }
@@ -958,15 +960,15 @@ spack:
         "env", env_yaml, spack.schema.env.schema, yaml_path=["spack"]
     )
 
-    with spack.config.override(scope):
+    with config.override(scope):
         # from the single-file config
-        assert spack.config.get("config:verify_ssl") is False
-        assert spack.config.get("packages:all:target") == ["x86_64"]
+        assert config.get("config:verify_ssl") is False
+        assert config.get("packages:all:target") == ["x86_64"]
 
         # from the lower config scopes
-        assert spack.config.get("config:checksum") is True
-        assert not spack.config.get("packages:externalmodule")
-        assert spack.config.get("repos") == {
+        assert config.get("config:checksum") is True
+        assert not config.get("packages:externalmodule")
+        assert config.get("repos") == {
             "z": "/x/y/z",
             "builtin_mock": "$spack/var/spack/test_repos/spack_repo/builtin_mock",
         }
@@ -1131,7 +1133,7 @@ def test_internal_config_list_override(mock_low_high_config, write_config_file):
 def test_set_section_override(mock_low_high_config, write_config_file):
     write_config_file("config", config_merge_list, "low")
     wanted_list = config_override_list["config"]["build_stage:"]
-    with spack.config.override("config::build_stage", wanted_list):
+    with mock_low_high_config.override("config::build_stage", wanted_list):
         assert mock_low_high_config.get("config:build_stage") == wanted_list
     assert config_merge_list["config"]["build_stage"] == mock_low_high_config.get(
         "config:build_stage"
@@ -1141,7 +1143,7 @@ def test_set_section_override(mock_low_high_config, write_config_file):
 def test_set_list_override(mock_low_high_config, write_config_file):
     write_config_file("config", config_merge_list, "low")
     wanted_list = config_override_list["config"]["build_stage:"]
-    with spack.config.override("config:build_stage:", wanted_list):
+    with mock_low_high_config.override("config:build_stage:", wanted_list):
         assert wanted_list == mock_low_high_config.get("config:build_stage")
     assert config_merge_list["config"]["build_stage"] == mock_low_high_config.get(
         "config:build_stage"
@@ -1151,43 +1153,43 @@ def test_set_list_override(mock_low_high_config, write_config_file):
 def test_set_dict_override(mock_low_high_config, write_config_file):
     write_config_file("config", config_merge_dict, "low")
     wanted_dict = config_override_dict["config"]["aliases:"]
-    with spack.config.override("config:aliases:", wanted_dict):
+    with mock_low_high_config.override("config:aliases:", wanted_dict):
         assert wanted_dict == mock_low_high_config.get("config:aliases")
     assert config_merge_dict["config"]["aliases"] == mock_low_high_config.get("config:aliases")
 
 
 def test_set_bad_path(config):
     with pytest.raises(ValueError):
-        with spack.config.override(":bad:path", ""):
+        with config.override(":bad:path", ""):
             pass
 
 
 def test_bad_path_double_override(config):
     with pytest.raises(syaml.SpackYAMLError, match="Meaningless second override"):
-        with spack.config.override("bad::double:override::directive", ""):
+        with config.override("bad::double:override::directive", ""):
             pass
 
 
 def test_override_error_does_not_leak_scope(config):
     """A failed override must not leave its internal scope behind."""
-    before = [s.name for s in spack.config.CONFIG.matching_scopes(r"^overrides-")]
+    before = [s.name for s in config.matching_scopes(r"^overrides-")]
     with pytest.raises(ValueError):
-        with spack.config.override(":bad:path", ""):
+        with config.override(":bad:path", ""):
             pass
-    after = [s.name for s in spack.config.CONFIG.matching_scopes(r"^overrides-")]
+    after = [s.name for s in config.matching_scopes(r"^overrides-")]
     assert after == before
 
 
 def test_license_dir_config(mutable_config, mock_packages, tmp_path):
     """Ensure license directory is customizable"""
     expected_dir = spack.paths.default_license_dir
-    assert spack.config.get("config:license_dir") == expected_dir
+    assert mutable_config.get("config:license_dir") == expected_dir
     assert spack.package_base.PackageBase.global_license_dir == expected_dir
     assert mock_packages.get_pkg_class("pkg-a").global_license_dir == expected_dir
 
     abs_path = str(tmp_path / "foo" / "bar" / "baz")
-    spack.config.set("config:license_dir", abs_path)
-    assert spack.config.get("config:license_dir") == abs_path
+    mutable_config.set("config:license_dir", abs_path)
+    assert mutable_config.get("config:license_dir") == abs_path
     assert spack.package_base.PackageBase.global_license_dir == abs_path
     assert mock_packages.get_pkg_class("pkg-a").global_license_dir == abs_path
 
@@ -1251,7 +1253,7 @@ def test_user_config_path_is_default_when_env_var_is_empty(working_env):
 def test_default_install_tree(monkeypatch, default_config):
     s = spack.spec.Spec("nonexistent@x.y.z arch=foo-bar-baz")
     monkeypatch.setattr(s, "dag_hash", lambda length: "abc123")
-    _, _, projections = spack.store.parse_install_tree(spack.config.get("config"))
+    _, _, projections = spack.store.parse_install_tree(default_config.get("config"))
     assert s.format(projections["all"]) == "foo-baz/nonexistent-x.y.z-abc123"
 
 
@@ -1582,38 +1584,38 @@ def test_config_path_dsl(path, it_should_work, expected_parsed):
 
 
 @pytest.mark.regression("48254")
-def test_env_activation_preserves_command_line_scope(mutable_mock_env_path):
+def test_env_activation_preserves_command_line_scope(mutable_mock_env_path, mutable_config):
     """Check that the "command_line" scope remains the highest priority scope, when we activate,
     or deactivate, environments.
     """
-    expected_cl_scope = spack.config.CONFIG.highest()
+    expected_cl_scope = mutable_config.highest()
     assert expected_cl_scope.name == "command_line"
 
     # Creating an environment pushes a new scope
     ev.create("test")
     with ev.read("test"):
-        assert spack.config.CONFIG.highest() == expected_cl_scope
+        assert mutable_config.highest() == expected_cl_scope
 
         # No active environment pops the scope
         with ev.no_active_environment():
-            assert spack.config.CONFIG.highest() == expected_cl_scope
-        assert spack.config.CONFIG.highest() == expected_cl_scope
+            assert mutable_config.highest() == expected_cl_scope
+        assert mutable_config.highest() == expected_cl_scope
 
         # Switch the environment to another one
         ev.create("test-2")
         with ev.read("test-2"):
-            assert spack.config.CONFIG.highest() == expected_cl_scope
-        assert spack.config.CONFIG.highest() == expected_cl_scope
+            assert mutable_config.highest() == expected_cl_scope
+        assert mutable_config.highest() == expected_cl_scope
 
-    assert spack.config.CONFIG.highest() == expected_cl_scope
+    assert mutable_config.highest() == expected_cl_scope
 
 
 @pytest.mark.regression("48414")
 @pytest.mark.regression("49188")
-def test_env_activation_preserves_config_scopes(mutable_mock_env_path):
+def test_env_activation_preserves_config_scopes(mutable_mock_env_path, mutable_config):
     """Check that the priority of scopes is respected when merging configuration files."""
     custom_scope = spack.config.InternalConfigScope("custom_scope")
-    spack.config.CONFIG.push_scope(custom_scope, priority=ConfigScopePriority.CUSTOM)
+    mutable_config.push_scope(custom_scope, priority=ConfigScopePriority.CUSTOM)
     expected_scopes_without_env = ["custom_scope", "command_line"]
     expected_scopes_with_first_env = ["env:test", "custom_scope", "command_line"]
     expected_scopes_with_second_env = ["env:test-2", "custom_scope", "command_line"]
@@ -1621,39 +1623,29 @@ def test_env_activation_preserves_config_scopes(mutable_mock_env_path):
     def highest_priority_scopes(config, *, nscopes):
         return list(config.scopes)[-nscopes:]
 
-    assert highest_priority_scopes(spack.config.CONFIG, nscopes=2) == expected_scopes_without_env
+    assert highest_priority_scopes(mutable_config, nscopes=2) == expected_scopes_without_env
     # Creating an environment pushes a new scope
     ev.create("test")
     with ev.read("test"):
-        assert (
-            highest_priority_scopes(spack.config.CONFIG, nscopes=3)
-            == expected_scopes_with_first_env
-        )
+        assert highest_priority_scopes(mutable_config, nscopes=3) == expected_scopes_with_first_env
 
         # No active environment pops the scope
         with ev.no_active_environment():
             assert (
-                highest_priority_scopes(spack.config.CONFIG, nscopes=2)
-                == expected_scopes_without_env
+                highest_priority_scopes(mutable_config, nscopes=2) == expected_scopes_without_env
             )
-        assert (
-            highest_priority_scopes(spack.config.CONFIG, nscopes=3)
-            == expected_scopes_with_first_env
-        )
+        assert highest_priority_scopes(mutable_config, nscopes=3) == expected_scopes_with_first_env
 
         # Switch the environment to another one
         ev.create("test-2")
         with ev.read("test-2"):
             assert (
-                highest_priority_scopes(spack.config.CONFIG, nscopes=3)
+                highest_priority_scopes(mutable_config, nscopes=3)
                 == expected_scopes_with_second_env
             )
-        assert (
-            highest_priority_scopes(spack.config.CONFIG, nscopes=3)
-            == expected_scopes_with_first_env
-        )
+        assert highest_priority_scopes(mutable_config, nscopes=3) == expected_scopes_with_first_env
 
-    assert highest_priority_scopes(spack.config.CONFIG, nscopes=2) == expected_scopes_without_env
+    assert highest_priority_scopes(mutable_config, nscopes=2) == expected_scopes_without_env
 
 
 @pytest.mark.regression("51059")
@@ -2041,19 +2033,21 @@ def test_included_path_git_errs(tmp_path: pathlib.Path, mock_low_high_config, mo
 def test_missing_include_scope_list(mock_missing_dir_include_scopes):
     """Tests that an included scope with a non existent file/directory
     is still listed as a scope under spack.config.CONFIG.scopes"""
-    assert "sub_base" in list(spack.config.CONFIG.scopes), (
+    assert "sub_base" in list(mock_missing_dir_include_scopes.scopes), (
         "Missing Optional Scope Missing from Config Scopes"
     )
 
 
 def test_missing_include_scope_writable_list(mock_missing_dir_include_scopes):
     """Tests that missing include scopes are included in writeable config lists"""
-    assert [x for x in spack.config.CONFIG.writable_scopes if x.name == "sub_base"]
+    assert [x for x in mock_missing_dir_include_scopes.writable_scopes if x.name == "sub_base"]
 
 
 def test_missing_include_scope_not_readable_list(mock_missing_dir_include_scopes):
     """Tests that missing include scopes are not included in existing config lists"""
-    existing_scopes = [x for x in spack.config.CONFIG.existing_scopes if x.name != "sub_base"]
+    existing_scopes = [
+        x for x in mock_missing_dir_include_scopes.existing_scopes if x.name != "sub_base"
+    ]
     assert len(existing_scopes) == 1
     assert existing_scopes[0].name != "sub_base"
 
@@ -2061,24 +2055,24 @@ def test_missing_include_scope_not_readable_list(mock_missing_dir_include_scopes
 def test_missing_include_scope_default_created_as_dir_scope(mock_missing_dir_include_scopes):
     """Tests that an optional include with no existing file/directory and no yaml extension
     is created as a directoryscope object"""
-    missing_inc_scope = spack.config.CONFIG.scopes["sub_base"]
+    missing_inc_scope = mock_missing_dir_include_scopes.scopes["sub_base"]
     assert isinstance(missing_inc_scope, spack.config.DirectoryConfigScope)
 
 
 def test_missing_include_scope_yaml_ext_is_file_scope(mock_missing_file_include_scopes):
     """Tests that an optional include scope with no existing file/directory and a
     yaml extension is created as a file scope"""
-    missing_inc_scope = spack.config.CONFIG.scopes["sub_base"]
+    missing_inc_scope = mock_missing_file_include_scopes.scopes["sub_base"]
     assert isinstance(missing_inc_scope, spack.config.SingleFileScope)
 
 
 def test_missing_include_scope_writeable_not_readable(mock_missing_dir_include_scopes):
     """Tests that an included scope with a non existent file/directory
     can be written to (and created)"""
-    assert spack.config.CONFIG.scopes["sub_base"].writable, (
+    assert mock_missing_dir_include_scopes.scopes["sub_base"].writable, (
         "Missing Optional Scope should be writable"
     )
-    assert not spack.config.CONFIG.scopes["sub_base"].exists, (
+    assert not mock_missing_dir_include_scopes.scopes["sub_base"].exists, (
         "Missing Optional Scope should not exist"
     )
 
@@ -2086,10 +2080,10 @@ def test_missing_include_scope_writeable_not_readable(mock_missing_dir_include_s
 def test_missing_include_scope_empty_read(mock_missing_dir_include_scopes):
     """Tests that an included scope with a non existent file/directory
     returns an empty dict on read and has "exists" set to false"""
-    assert spack.config.CONFIG.get("config", scope="sub_base") == {}, (
+    assert mock_missing_dir_include_scopes.get("config", scope="sub_base") == {}, (
         "Missing optional include scope does not return an empty value."
     )
-    assert not spack.config.CONFIG.scopes["sub_base"].exists, (
+    assert not mock_missing_dir_include_scopes.scopes["sub_base"].exists, (
         "Missing optional include should not be created on read"
     )
 
@@ -2097,10 +2091,10 @@ def test_missing_include_scope_empty_read(mock_missing_dir_include_scopes):
 def test_missing_include_scope_file_empty_read(mock_missing_file_include_scopes):
     """Tests that an include scope with a non existent file returns an empty
     dict and has exists set to false"""
-    assert spack.config.CONFIG.get("config", scope="sub_base") == {}, (
+    assert mock_missing_file_include_scopes.get("config", scope="sub_base") == {}, (
         "Missing optional include scope does not return an empty value."
     )
-    assert not spack.config.CONFIG.scopes["sub_base"].exists, (
+    assert not mock_missing_file_include_scopes.scopes["sub_base"].exists, (
         "Missing optional include should not be created on read"
     )
 
@@ -2109,9 +2103,11 @@ def test_missing_include_scope_write_directory(mock_missing_dir_include_scopes):
     """Tests that an include scope with a non existent directory
     creates said directory and the appropriate section file on write"""
     install_tree = syaml.syaml_dict({"install_tree": {"root": "$spack/tmp/spack"}})
-    spack.config.CONFIG.set("config", install_tree, scope="sub_base")
-    assert os.path.exists(spack.config.CONFIG.scopes["sub_base"].path)
-    install_root = spack.config.CONFIG.get("config:install_tree:root", scope="sub_base")
+    mock_missing_dir_include_scopes.set("config", install_tree, scope="sub_base")
+    assert os.path.exists(mock_missing_dir_include_scopes.scopes["sub_base"].path)
+    install_root = mock_missing_dir_include_scopes.get(
+        "config:install_tree:root", scope="sub_base"
+    )
     assert install_root == "$spack/tmp/spack"
 
 
@@ -2119,9 +2115,11 @@ def test_missing_include_scope_write_file(mock_missing_file_include_scopes):
     """Tests that an include scope with a non existent file creates said file
     with the appropriate section entry"""
     install_tree = syaml.syaml_dict({"install_tree": {"root": "$spack/tmp/spack"}})
-    spack.config.CONFIG.set("config", install_tree, scope="sub_base")
-    assert os.path.exists(spack.config.CONFIG.scopes["sub_base"].path)
-    install_root = spack.config.CONFIG.get("config:install_tree:root", scope="sub_base")
+    mock_missing_file_include_scopes.set("config", install_tree, scope="sub_base")
+    assert os.path.exists(mock_missing_file_include_scopes.scopes["sub_base"].path)
+    install_root = mock_missing_file_include_scopes.get(
+        "config:install_tree:root", scope="sub_base"
+    )
     assert install_root == "$spack/tmp/spack"
 
 
@@ -2153,7 +2151,7 @@ def test_include_bad_parent_scope(tmp_path: pathlib.Path):
 def test_config_invalid_scope(mock_low_high_config):
     err = "Must be one of \\['low', 'high'\\]"  # noqa: W605
     with pytest.raises(ValueError, match=err):
-        spack.config.CONFIG.get_config_filename("noscope", "nosection")
+        mock_low_high_config.get_config_filename("noscope", "nosection")
 
 
 @pytest.mark.not_on_windows("Unix path")
@@ -2183,20 +2181,20 @@ def test_canonicalize_file_relative():
     )
 
 
-def test_env_substitution_follows_activation(mutable_mock_env_path):
+def test_env_substitution_follows_activation(mutable_mock_env_path, mutable_config):
     """Tests that the "$env" substitution resolves to the active environment's path only while an
     environment is active, and is a no-op before and after activation.
     """
     # Before activation "$env" is a no-op
-    assert spack.config.CONFIG.env_path is None
+    assert mutable_config.env_path is None
     assert spack.config.substitute_path_variables("$env/foo/bar") == "$env/foo/bar"
 
     env = ev.create("test")
     with env:
         # During activation "$env" resolves to the environment's path
-        assert spack.config.CONFIG.env_path == env.path
+        assert mutable_config.env_path == env.path
         assert spack.config.substitute_path_variables("$env/foo/bar") == f"{env.path}/foo/bar"
 
     # After deactivation "$env" is a no-op again
-    assert spack.config.CONFIG.env_path is None
+    assert mutable_config.env_path is None
     assert spack.config.substitute_path_variables("$env/foo/bar") == "$env/foo/bar"

--- a/lib/spack/spack/test/config.py
+++ b/lib/spack/spack/test/config.py
@@ -80,13 +80,13 @@ spack:
     return env_yaml
 
 
-def check_compiler_config(configuration, comps, *compiler_names):
+def check_compiler_config(config, comps, *compiler_names):
     """Check that named compilers in comps match Spack's config."""
-    config = configuration.get("compilers")
+    compilers = config.get("compilers")
     compiler_list = ["cc", "cxx", "f77", "fc"]
     flag_list = ["cflags", "cxxflags", "fflags", "cppflags", "ldflags", "ldlibs"]
     param_list = ["modules", "paths", "spec", "operating_system"]
-    for compiler in config:
+    for compiler in compilers:
         conf = compiler["compiler"]
         if conf["spec"] in compiler_names:
             comp = next(

--- a/lib/spack/spack/test/config.py
+++ b/lib/spack/spack/test/config.py
@@ -552,12 +552,12 @@ def test_change_or_add(mutable_config, mock_packages):
             section[self.pkg_name] = pkg_section
 
     change1 = ChangeTest("b", ["1.2"])
-    spack.config.CONFIG.change_or_add("packages", change1.find_fn, change1.change_fn)
+    mutable_config.change_or_add("packages", change1.find_fn, change1.change_fn)
     assert "b" not in mutable_config.get("packages", scope="user")
     assert mutable_config.get("packages")["b"]["version"] == ["1.2"]
 
     change2 = ChangeTest("c", ["1.0"])
-    spack.config.CONFIG.change_or_add("packages", change2.find_fn, change2.change_fn)
+    mutable_config.change_or_add("packages", change2.find_fn, change2.change_fn)
     assert "c" in mutable_config.get("packages", scope="user")
 
 

--- a/lib/spack/spack/test/config.py
+++ b/lib/spack/spack/test/config.py
@@ -552,12 +552,12 @@ def test_change_or_add(mutable_config, mock_packages):
             section[self.pkg_name] = pkg_section
 
     change1 = ChangeTest("b", ["1.2"])
-    spack.config.change_or_add("packages", change1.find_fn, change1.change_fn)
+    spack.config.CONFIG.change_or_add("packages", change1.find_fn, change1.change_fn)
     assert "b" not in mutable_config.get("packages", scope="user")
     assert mutable_config.get("packages")["b"]["version"] == ["1.2"]
 
     change2 = ChangeTest("c", ["1.0"])
-    spack.config.change_or_add("packages", change2.find_fn, change2.change_fn)
+    spack.config.CONFIG.change_or_add("packages", change2.find_fn, change2.change_fn)
     assert "c" in mutable_config.get("packages", scope="user")
 
 

--- a/lib/spack/spack/test/config.py
+++ b/lib/spack/spack/test/config.py
@@ -80,9 +80,9 @@ spack:
     return env_yaml
 
 
-def check_compiler_config(comps, *compiler_names):
+def check_compiler_config(configuration, comps, *compiler_names):
     """Check that named compilers in comps match Spack's config."""
-    config = spack.config.CONFIG.get("compilers")
+    config = configuration.get("compilers")
     compiler_list = ["cc", "cxx", "f77", "fc"]
     flag_list = ["cflags", "cxxflags", "fflags", "cppflags", "ldflags", "ldlibs"]
     param_list = ["modules", "paths", "spec", "operating_system"]
@@ -211,8 +211,8 @@ def test_write_key_in_memory(mock_low_high_config, compiler_specs):
     mock_low_high_config.set("compilers", b_comps["compilers"], scope="high")
 
     # Make sure the config looks how we expect.
-    check_compiler_config(a_comps["compilers"], *compiler_specs.a)
-    check_compiler_config(b_comps["compilers"], *compiler_specs.b)
+    check_compiler_config(mock_low_high_config, a_comps["compilers"], *compiler_specs.a)
+    check_compiler_config(mock_low_high_config, b_comps["compilers"], *compiler_specs.b)
 
 
 def test_write_key_to_disk(mock_low_high_config, compiler_specs):
@@ -224,8 +224,8 @@ def test_write_key_to_disk(mock_low_high_config, compiler_specs):
     mock_low_high_config.clear_caches()
 
     # Same check again, to ensure consistency.
-    check_compiler_config(a_comps["compilers"], *compiler_specs.a)
-    check_compiler_config(b_comps["compilers"], *compiler_specs.b)
+    check_compiler_config(mock_low_high_config, a_comps["compilers"], *compiler_specs.a)
+    check_compiler_config(mock_low_high_config, b_comps["compilers"], *compiler_specs.b)
 
 
 def test_write_to_same_priority_file(mock_low_high_config, compiler_specs):
@@ -237,8 +237,8 @@ def test_write_to_same_priority_file(mock_low_high_config, compiler_specs):
     mock_low_high_config.clear_caches()
 
     # Same check again, to ensure consistency.
-    check_compiler_config(a_comps["compilers"], *compiler_specs.a)
-    check_compiler_config(b_comps["compilers"], *compiler_specs.b)
+    check_compiler_config(mock_low_high_config, a_comps["compilers"], *compiler_specs.a)
+    check_compiler_config(mock_low_high_config, b_comps["compilers"], *compiler_specs.b)
 
 
 #

--- a/lib/spack/spack/test/config.py
+++ b/lib/spack/spack/test/config.py
@@ -34,7 +34,9 @@ import spack.util.filesystem as fs
 import spack.util.git
 import spack.util.path as spack_path
 import spack.util.spack_yaml as syaml
+from spack.config import Configuration
 from spack.enums import ConfigScopePriority
+from spack.repo import RepoPath
 from spack.util.filesystem import getuid, join_path, touch
 from spack.util.spack_yaml import DictWithLineInfo
 
@@ -80,7 +82,7 @@ spack:
     return env_yaml
 
 
-def check_compiler_config(config, comps, *compiler_names):
+def check_compiler_config(config: Configuration, comps, *compiler_names):
     """Check that named compilers in comps match Spack's config."""
     compilers = config.get("compilers")
     compiler_list = ["cc", "cxx", "f77", "fc"]
@@ -250,7 +252,7 @@ repos_high = {"repos": {"high": "/some/other/path"}}
 # Test setting config values via path in filename
 
 
-def test_add_config_path(mutable_config):
+def test_add_config_path(mutable_config: Configuration):
     # Try setting a new install tree root
     path = "config:install_tree:root:/path/to/config.yaml"
     mutable_config.add(path)
@@ -295,7 +297,7 @@ def test_add_config_path(mutable_config):
 
 
 @pytest.mark.regression("17543,23259")
-def test_add_config_path_with_enumerated_type(mutable_config):
+def test_add_config_path_with_enumerated_type(mutable_config: Configuration):
     mutable_config.add("config:flags:keep_werror:all")
     assert mutable_config.get("config")["flags"]["keep_werror"] == "all"
 
@@ -420,7 +422,7 @@ packages_merge_high = {
 
 
 @pytest.mark.regression("52423")
-def test_config_set_beyond_existing(mutable_config):
+def test_config_set_beyond_existing(mutable_config: Configuration):
     # no raised error is the primary test for this regression
     # Needs to be for a repo that does not already exist for valid test
     mutable_config.set("repos:nonexistent", "foo")
@@ -428,7 +430,7 @@ def test_config_set_beyond_existing(mutable_config):
 
 
 @pytest.mark.regression("52423")
-def test_config_section_defaults(mutable_config):
+def test_config_section_defaults(mutable_config: Configuration):
     view_default = mutable_config.get("view")
     assert view_default == spack.config.get_default_from_schema("view")
     assert view_default is True
@@ -533,7 +535,7 @@ def test_parse_install_tree(config_settings_fn, expected_fn, mutable_config, tmp
     assert projections == expected_proj
 
 
-def test_change_or_add(mutable_config, mock_packages):
+def test_change_or_add(mutable_config: Configuration, mock_packages):
     mutable_config.add("packages:a:version:['1.0']", scope="user")
 
     mutable_config.add("packages:b:version:['1.1']", scope="system")
@@ -768,7 +770,7 @@ def test_keys_are_ordered(configuration_dir):
         assert actual == expected
 
 
-def test_config_format_error(mutable_config):
+def test_config_format_error(mutable_config: Configuration):
     """This is raised when we try to write a bad configuration."""
     with pytest.raises(spack.config.ConfigFormatError):
         mutable_config.set("compilers", {"bad": "data"}, scope="site")
@@ -849,7 +851,7 @@ def test_bad_config_section(mock_low_high_config):
         mock_low_high_config.get("foobar")
 
 
-def test_nested_override(mutable_config):
+def test_nested_override(mutable_config: Configuration):
     """Ensure proper scope naming of nested overrides."""
     base_name = spack.config._OVERRIDES_BASE_NAME
 
@@ -873,7 +875,7 @@ def test_nested_override(mutable_config):
         _check_scopes(1, [True])
 
 
-def test_alternate_override(monkeypatch, mutable_config):
+def test_alternate_override(monkeypatch, mutable_config: Configuration):
     """Ensure proper scope naming of override when conflict present."""
     base_name = spack.config._OVERRIDES_BASE_NAME
 
@@ -915,7 +917,7 @@ config:
         scope._write_section("config")
 
 
-def test_single_file_scope(config, env_yaml):
+def test_single_file_scope(config: Configuration, env_yaml):
     scope = spack.config.SingleFileScope(
         "env", env_yaml, spack.schema.env.schema, yaml_path=["spack"]
     )
@@ -935,7 +937,7 @@ def test_single_file_scope(config, env_yaml):
         }
 
 
-def test_single_file_scope_section_override(tmp_path: pathlib.Path, config):
+def test_single_file_scope_section_override(tmp_path: pathlib.Path, config: Configuration):
     """Check that individual config sections can be overridden in an
     environment config. The config here primarily differs in that the
     ``packages`` section is intended to override all other scopes (using the
@@ -1158,19 +1160,19 @@ def test_set_dict_override(mock_low_high_config, write_config_file):
     assert config_merge_dict["config"]["aliases"] == mock_low_high_config.get("config:aliases")
 
 
-def test_set_bad_path(config):
+def test_set_bad_path(config: Configuration):
     with pytest.raises(ValueError):
         with config.override(":bad:path", ""):
             pass
 
 
-def test_bad_path_double_override(config):
+def test_bad_path_double_override(config: Configuration):
     with pytest.raises(syaml.SpackYAMLError, match="Meaningless second override"):
         with config.override("bad::double:override::directive", ""):
             pass
 
 
-def test_override_error_does_not_leak_scope(config):
+def test_override_error_does_not_leak_scope(config: Configuration):
     """A failed override must not leave its internal scope behind."""
     before = [s.name for s in config.matching_scopes(r"^overrides-")]
     with pytest.raises(ValueError):
@@ -1180,7 +1182,7 @@ def test_override_error_does_not_leak_scope(config):
     assert after == before
 
 
-def test_license_dir_config(mutable_config, mock_packages, tmp_path):
+def test_license_dir_config(mutable_config: Configuration, mock_packages: RepoPath, tmp_path):
     """Ensure license directory is customizable"""
     expected_dir = spack.paths.default_license_dir
     assert mutable_config.get("config:license_dir") == expected_dir
@@ -1584,7 +1586,9 @@ def test_config_path_dsl(path, it_should_work, expected_parsed):
 
 
 @pytest.mark.regression("48254")
-def test_env_activation_preserves_command_line_scope(mutable_mock_env_path, mutable_config):
+def test_env_activation_preserves_command_line_scope(
+    mutable_mock_env_path, mutable_config: Configuration
+):
     """Check that the "command_line" scope remains the highest priority scope, when we activate,
     or deactivate, environments.
     """
@@ -1612,7 +1616,9 @@ def test_env_activation_preserves_command_line_scope(mutable_mock_env_path, muta
 
 @pytest.mark.regression("48414")
 @pytest.mark.regression("49188")
-def test_env_activation_preserves_config_scopes(mutable_mock_env_path, mutable_config):
+def test_env_activation_preserves_config_scopes(
+    mutable_mock_env_path, mutable_config: Configuration
+):
     """Check that the priority of scopes is respected when merging configuration files."""
     custom_scope = spack.config.InternalConfigScope("custom_scope")
     mutable_config.push_scope(custom_scope, priority=ConfigScopePriority.CUSTOM)
@@ -2181,7 +2187,7 @@ def test_canonicalize_file_relative():
     )
 
 
-def test_env_substitution_follows_activation(mutable_mock_env_path, mutable_config):
+def test_env_substitution_follows_activation(mutable_mock_env_path, mutable_config: Configuration):
     """Tests that the "$env" substitution resolves to the active environment's path only while an
     environment is active, and is a no-op before and after activation.
     """

--- a/lib/spack/spack/test/conftest.py
+++ b/lib/spack/spack/test/conftest.py
@@ -1258,32 +1258,45 @@ def _mock_store_tarball(mock_store) -> bytes:
 
 
 @pytest.fixture(scope="function")
-def database(mock_store, mock_packages, config):
-    """This activates the mock store, packages, AND config."""
+def database_store(mock_store, mock_packages, config):
+    """This activates the mock store, packages, AND config. Yields the Store."""
     with spack.store.use_store(str(mock_store)) as store:
-        yield store.db
+        yield store
         # Force reading the database again between tests
         store.db.last_seen_verifier = ""
 
 
 @pytest.fixture(scope="function")
-def database_mutable_config(mock_store, mock_packages, mutable_config, monkeypatch):
-    """This activates the mock store, packages, AND config."""
+def database(database_store):
+    """This activates the mock store, packages, AND config. Yields store.db."""
+    return database_store.db
+
+
+@pytest.fixture(scope="function")
+def database_mutable_config_store(mock_store, mock_packages, mutable_config, monkeypatch):
+    """Like database_store, but with a mutable config. Yields the Store."""
     with spack.store.use_store(str(mock_store)) as store:
-        yield store.db
+        yield store
         store.db.last_seen_verifier = ""
 
 
 @pytest.fixture(scope="function")
-def mutable_database(database_mutable_config, _store_dir: Path, _mock_store_tarball: bytes):
-    """Writeable version of the fixture, restored to its initial state
-    after each test.
-    """
+def database_mutable_config(database_mutable_config_store):
+    """This activates the mock store, packages, AND config. Yields store.db."""
+    return database_mutable_config_store.db
+
+
+@pytest.fixture(scope="function")
+def mutable_database_store(
+    database_mutable_config_store, _store_dir: Path, _mock_store_tarball: bytes
+):
+    """Writeable version of database_store, restored to its initial state after each
+    test. Yields the Store."""
     # Make the database writeable, as we are going to modify it
     store_path = _store_dir
     _recursive_chmod(store_path, 0o755)
 
-    yield database_mutable_config
+    yield database_mutable_config_store
 
     # Restore the initial state from the pristine tarball; modes recorded in the tar
     # make the database read-only again.
@@ -1292,6 +1305,14 @@ def mutable_database(database_mutable_config, _store_dir: Path, _mock_store_tarb
     with tarfile.open(fileobj=io.BytesIO(_mock_store_tarball), mode="r") as tar:
         tar.extraction_filter = lambda member, path: member
         tar.extractall(str(store_path))
+
+
+@pytest.fixture(scope="function")
+def mutable_database(mutable_database_store):
+    """Writeable version of the fixture, restored to its initial state
+    after each test. Yields store.db.
+    """
+    return mutable_database_store.db
 
 
 @pytest.fixture()

--- a/lib/spack/spack/test/conftest.py
+++ b/lib/spack/spack/test/conftest.py
@@ -70,10 +70,13 @@ import spack.util.tty.color
 import spack.util.url as url_util
 import spack.util.web
 import spack.version
+from spack.config import Configuration
 from spack.enums import ConfigScopePriority
 from spack.fetch_strategy import URLFetchStrategy
 from spack.main import SpackCommand
 from spack.old_installer import PackageInstaller
+from spack.repo import RepoPath
+from spack.store import Store
 from spack.util import tty
 from spack.util.filesystem import copy, join_path, mkdirp, remove_linked_tree, working_dir
 from spack.util.pattern import Bunch
@@ -460,7 +463,7 @@ def pytest_collection_modifyitems(config, items):
 
 
 @pytest.fixture(scope="function")
-def use_concretization_cache(mock_packages, mutable_config, tmp_path: Path):
+def use_concretization_cache(mock_packages, mutable_config: Configuration, tmp_path: Path):
     """Enables the use of the concretization cache"""
     conc_cache_dir = tmp_path / "concretization"
 
@@ -1094,7 +1097,7 @@ def mock_wsdk_externals(monkeypatch):
 
 
 @pytest.fixture(scope="function")
-def concretize_scope(mutable_config, tmp_path: Path):
+def concretize_scope(mutable_config: Configuration, tmp_path: Path):
     """Adds a scope for concretization preferences"""
     concretize_dir = tmp_path / "concretize"
     concretize_dir.mkdir()
@@ -1258,7 +1261,7 @@ def _mock_store_tarball(mock_store) -> bytes:
 
 
 @pytest.fixture(scope="function")
-def database_store(mock_store, mock_packages, config):
+def database_store(mock_store: Store, mock_packages, config):
     """This activates the mock store, packages, AND config. Yields the Store."""
     with spack.store.use_store(str(mock_store)) as store:
         yield store
@@ -1267,13 +1270,13 @@ def database_store(mock_store, mock_packages, config):
 
 
 @pytest.fixture(scope="function")
-def database(database_store):
+def database(database_store: Store):
     """This activates the mock store, packages, AND config. Yields store.db."""
     return database_store.db
 
 
 @pytest.fixture(scope="function")
-def database_mutable_config_store(mock_store, mock_packages, mutable_config, monkeypatch):
+def database_mutable_config_store(mock_store: Store, mock_packages, mutable_config, monkeypatch):
     """Like database_store, but with a mutable config. Yields the Store."""
     with spack.store.use_store(str(mock_store)) as store:
         yield store
@@ -1281,14 +1284,14 @@ def database_mutable_config_store(mock_store, mock_packages, mutable_config, mon
 
 
 @pytest.fixture(scope="function")
-def database_mutable_config(database_mutable_config_store):
+def database_mutable_config(database_mutable_config_store: Store):
     """This activates the mock store, packages, AND config. Yields store.db."""
     return database_mutable_config_store.db
 
 
 @pytest.fixture(scope="function")
 def mutable_database_store(
-    database_mutable_config_store, _store_dir: Path, _mock_store_tarball: bytes
+    database_mutable_config_store: Store, _store_dir: Path, _mock_store_tarball: bytes
 ):
     """Writeable version of database_store, restored to its initial state after each
     test. Yields the Store."""
@@ -1308,7 +1311,7 @@ def mutable_database_store(
 
 
 @pytest.fixture(scope="function")
-def mutable_database(mutable_database_store):
+def mutable_database(mutable_database_store: Store):
     """Writeable version of the fixture, restored to its initial state
     after each test. Yields store.db.
     """
@@ -1916,7 +1919,7 @@ def mock_git_repository(git, tmp_path_factory: pytest.TempPathFactory):
 
 
 @pytest.fixture(scope="function")
-def mock_git_test_package(mock_git_repository, mutable_mock_repo, monkeypatch):
+def mock_git_test_package(mock_git_repository, mutable_mock_repo: RepoPath, monkeypatch):
     # install a fake git version in the package class
     pkg_class = mutable_mock_repo.get_pkg_class("git-test")
     monkeypatch.delattr(pkg_class, "git")

--- a/lib/spack/spack/test/conftest.py
+++ b/lib/spack/spack/test/conftest.py
@@ -465,7 +465,7 @@ def use_concretization_cache(mock_packages, mutable_config, tmp_path: Path):
     conc_cache_dir = tmp_path / "concretization"
 
     # ensure we have an isolated concretization cache while using fixture
-    with spack.config.override(
+    with spack.config.CONFIG.override(
         "concretizer:concretization_cache", {"enable": True, "url": str(conc_cache_dir)}
     ):
         yield conc_cache_dir
@@ -505,7 +505,7 @@ def onerror(func, path, error_info):
 def mock_stage(tmp_path_factory: pytest.TempPathFactory, monkeypatch, request):
     """Establish the temporary build_stage for the mock archive."""
     # The approach with this autouse fixture is to set the stage root
-    # instead of using spack.config.override() to avoid configuration
+    # instead of using spack.config.CONFIG.override() to avoid configuration
     # conflicts with dozens of tests that rely on other configuration
     # fixtures, such as config.
 
@@ -1098,7 +1098,7 @@ def concretize_scope(mutable_config, tmp_path: Path):
     """Adds a scope for concretization preferences"""
     concretize_dir = tmp_path / "concretize"
     concretize_dir.mkdir()
-    with spack.config.override(
+    with spack.config.CONFIG.override(
         spack.config.DirectoryConfigScope("concretize", str(concretize_dir))
     ):
         yield str(concretize_dir)
@@ -1335,7 +1335,7 @@ def disable_compiler_output_cache(monkeypatch):
 def install_mockery(temporary_store: spack.store.Store, mutable_config, mock_packages):
     """Hooks a fake install directory, DB, and stage directory into Spack."""
     # We use a fake package, so temporarily disable checksumming
-    with spack.config.override("config:checksum", False):
+    with spack.config.CONFIG.override("config:checksum", False):
         yield
 
     # Wipe out any cached prefix failure locks (associated with the session-scoped mock archive)
@@ -1464,7 +1464,7 @@ class ConfigUpdate:
         file = os.path.join(self.root_for_conf, filename + ".yaml")
         with open(file, encoding="utf-8") as f:
             config_settings = syaml.load_config(f)
-        spack.config.set("modules:default", config_settings)
+        spack.config.CONFIG.set("modules:default", config_settings)
 
 
 @pytest.fixture()
@@ -2634,7 +2634,7 @@ def reset_extension_paths():
 @pytest.fixture(params=["old", "new"])
 def installer_variant(request):
     """Parametrize a test over the old and new installer."""
-    with spack.config.override("config:installer", request.param):
+    with spack.config.CONFIG.override("config:installer", request.param):
         yield request.param
 
 

--- a/lib/spack/spack/test/conftest.py
+++ b/lib/spack/spack/test/conftest.py
@@ -1897,7 +1897,7 @@ def mock_git_repository(git, tmp_path_factory: pytest.TempPathFactory):
 @pytest.fixture(scope="function")
 def mock_git_test_package(mock_git_repository, mutable_mock_repo, monkeypatch):
     # install a fake git version in the package class
-    pkg_class = spack.repo.PATH.get_pkg_class("git-test")
+    pkg_class = mutable_mock_repo.get_pkg_class("git-test")
     monkeypatch.delattr(pkg_class, "git")
     monkeypatch.setitem(pkg_class.versions, spack.version.Version("git"), mock_git_repository.url)
     return pkg_class

--- a/lib/spack/spack/test/conftest.py
+++ b/lib/spack/spack/test/conftest.py
@@ -465,7 +465,7 @@ def use_concretization_cache(mock_packages, mutable_config, tmp_path: Path):
     conc_cache_dir = tmp_path / "concretization"
 
     # ensure we have an isolated concretization cache while using fixture
-    with spack.config.CONFIG.override(
+    with mutable_config.override(
         "concretizer:concretization_cache", {"enable": True, "url": str(conc_cache_dir)}
     ):
         yield conc_cache_dir
@@ -1098,7 +1098,7 @@ def concretize_scope(mutable_config, tmp_path: Path):
     """Adds a scope for concretization preferences"""
     concretize_dir = tmp_path / "concretize"
     concretize_dir.mkdir()
-    with spack.config.CONFIG.override(
+    with mutable_config.override(
         spack.config.DirectoryConfigScope("concretize", str(concretize_dir))
     ):
         yield str(concretize_dir)

--- a/lib/spack/spack/test/cray_manifest.py
+++ b/lib/spack/spack/test/cray_manifest.py
@@ -26,6 +26,7 @@ import spack.platforms.test
 import spack.solver.reuse
 import spack.spec
 from spack.cray_manifest import compiler_from_entry, entries_to_specs
+from spack.store import Store
 
 pytestmark = [
     pytest.mark.skipif(
@@ -333,7 +334,9 @@ def test_read_cray_manifest(temporary_store, manifest_file):
     assert concretized_spec["hwloc"].dag_hash() == "hwlocfakehashaaa"
 
 
-def test_read_cray_manifest_add_compiler_failure(temporary_store, manifest_file, monkeypatch):
+def test_read_cray_manifest_add_compiler_failure(
+    temporary_store: Store, manifest_file, monkeypatch
+):
     """Tests the Cray manifest can be read even if some compilers cannot be added."""
 
     def _mock(entry, *, manifest_path):

--- a/lib/spack/spack/test/cray_manifest.py
+++ b/lib/spack/spack/test/cray_manifest.py
@@ -25,7 +25,6 @@ import spack.platforms
 import spack.platforms.test
 import spack.solver.reuse
 import spack.spec
-import spack.store
 from spack.cray_manifest import compiler_from_entry, entries_to_specs
 
 pytestmark = [
@@ -345,7 +344,7 @@ def test_read_cray_manifest_add_compiler_failure(temporary_store, manifest_file,
     monkeypatch.setattr(spack.cray_manifest, "compiler_from_entry", _mock)
 
     spack.cray_manifest.read(str(manifest_file), True)
-    query_specs = spack.store.STORE.db.query("openmpi")
+    query_specs = temporary_store.db.query("openmpi")
     assert any(x.dag_hash() == "openmpifakehasha" for x in query_specs)
 
 

--- a/lib/spack/spack/test/database.py
+++ b/lib/spack/spack/test/database.py
@@ -873,7 +873,7 @@ def test_query_unused_specs(mutable_database):
     trivial_smoke_test = mutable_database.query_one("trivial-smoke-test").dag_hash()
 
     def check_unused(roots, deptype, expected):
-        unused = spack.store.STORE.db.unused_specs(root_hashes=roots, deptype=deptype)
+        unused = mutable_database.unused_specs(root_hashes=roots, deptype=deptype)
         assert {u.name for u in unused} == set(expected)
 
     default_dt = dt.LINK | dt.RUN

--- a/lib/spack/spack/test/database.py
+++ b/lib/spack/spack/test/database.py
@@ -17,8 +17,10 @@ import pytest
 
 import spack.config
 import spack.subprocess_context
+from spack.config import Configuration
 from spack.database import Database
 from spack.directory_layout import DirectoryLayoutError
+from spack.store import Store
 
 try:
     import uuid
@@ -473,7 +475,7 @@ def test_005_db_exists(database):
         spack.vendor.jsonschema.validate(index_object, schema)
 
 
-def test_010_all_install_sanity(database_store):
+def test_010_all_install_sanity(database_store: Store):
     """Ensure that the install layout reflects what we think it does."""
     all_specs = database_store.layout.all_specs()
     assert len(all_specs) == 17
@@ -502,7 +504,7 @@ def test_010_all_install_sanity(database_store):
     assert len([s for s in all_specs if s.satisfies("mpileaks ^zmpi")]) == 1
 
 
-def test_015_write_and_read(mutable_database):
+def test_015_write_and_read(mutable_database: Database):
     # write and read DB
     with mutable_database.write_transaction():
         specs = mutable_database.query()
@@ -532,7 +534,7 @@ def test_016_roundtrip_spliced_spec(mutable_database):
     assert buildspec_record  # buildspec needs to be recorded in db
 
 
-def test_017_write_and_read_without_uuid(mutable_database, monkeypatch):
+def test_017_write_and_read_without_uuid(mutable_database: Database, monkeypatch):
     monkeypatch.setattr(spack.database, "_use_uuid", False)
     # write and read DB
     with mutable_database.write_transaction():
@@ -566,7 +568,7 @@ def test_try_write_transaction(mutable_database, monkeypatch):
         assert not acquired
 
 
-def test_try_write_transaction_does_not_flush_on_exception(mutable_database):
+def test_try_write_transaction_does_not_flush_on_exception(mutable_database: Database):
     """Regression test: an exception inside try_write_transaction must not flush the possibly
     inconsistent in-memory database to disk; the next transaction re-reads it instead."""
     db = mutable_database
@@ -582,7 +584,7 @@ def test_try_write_transaction_does_not_flush_on_exception(mutable_database):
         assert db.query("mpileaks")
 
 
-def test_try_read_transaction(mutable_database, monkeypatch):
+def test_try_read_transaction(mutable_database: Database, monkeypatch):
     db = mutable_database
 
     with db.try_read_transaction() as acquired:
@@ -599,13 +601,13 @@ def test_020_db_sanity(database):
     _check_db_sanity(database)
 
 
-def test_025_reindex(mutable_database_store):
+def test_025_reindex(mutable_database_store: Store):
     """Make sure reindex works and ref counts are valid."""
     mutable_database_store.reindex()
     _check_db_sanity(mutable_database_store.db)
 
 
-def test_026_reindex_after_deprecate(mutable_database_store):
+def test_026_reindex_after_deprecate(mutable_database_store: Store):
     """Make sure reindex works and ref counts are valid after deprecation."""
     db = mutable_database_store.db
     mpich = db.query_one("mpich")
@@ -655,7 +657,7 @@ def test_041_ref_counts_deprecate(mutable_database):
     mutable_database._check_ref_counts()
 
 
-def test_050_basic_query(database):
+def test_050_basic_query(database: Database):
     """Ensure querying database is consistent with what is installed."""
     # query everything
     total_specs = len(database.query())
@@ -753,7 +755,7 @@ def test_090_non_root_ref_counts(mutable_database):
     assert mpich_rec.ref_count == 0
 
 
-def test_100_no_write_with_exception_on_remove(database):
+def test_100_no_write_with_exception_on_remove(database: Database):
     def fail_while_writing():
         with database.write_transaction():
             _mock_remove("mpileaks ^zmpi", database)
@@ -787,7 +789,9 @@ def test_110_no_write_with_exception_on_install(database):
         assert database.query("cmake", installed=InstallRecordStatus.ANY) == []
 
 
-def test_115_reindex_with_packages_not_in_repo(mutable_database_store, repo_builder: RepoBuilder):
+def test_115_reindex_with_packages_not_in_repo(
+    mutable_database_store: Store, repo_builder: RepoBuilder
+):
     # Dont add any package definitions to this repository, the idea is that
     # packages should not have to be defined in the repository once they
     # are installed
@@ -814,7 +818,7 @@ def test_external_entries_in_db(mutable_database):
 
 
 @pytest.mark.regression("8036")
-def test_regression_issue_8036(mutable_database, usr_folder_exists):
+def test_regression_issue_8036(mutable_database: Database, usr_folder_exists):
     # The test ensures that the external package prefix is treated as
     # existing. Even when the package prefix exists, the package should
     # not be considered installed until it is added to the database by
@@ -910,7 +914,7 @@ def test_query_unused_specs(mutable_database):
 
 
 @pytest.mark.regression("10019")
-def test_query_spec_with_conditional_dependency(mutable_database):
+def test_query_spec_with_conditional_dependency(mutable_database: Database):
     # The issue is triggered by having dependencies that are
     # conditional on a Boolean variant
     s = spack.concretize.concretize_one("hdf5~mpi")
@@ -921,14 +925,14 @@ def test_query_spec_with_conditional_dependency(mutable_database):
 
 
 @pytest.mark.regression("10019")
-def test_query_spec_with_non_conditional_virtual_dependency(database):
+def test_query_spec_with_non_conditional_virtual_dependency(database: Database):
     # Ensure the same issue doesn't come up for virtual
     # dependency that are not conditional on variants
     results = database.query_local("mpileaks ^mpich")
     assert len(results) == 1
 
 
-def test_query_virtual_spec(database):
+def test_query_virtual_spec(database: Database):
     """Make sure we can query for virtuals in the DB"""
     results = database.query_local("mpi")
     assert len(results) == 3
@@ -936,7 +940,7 @@ def test_query_virtual_spec(database):
     assert all(name in names for name in ["mpich", "mpich2", "zmpi"])
 
 
-def test_failed_spec_path_error(mutable_database_store):
+def test_failed_spec_path_error(mutable_database_store: Store):
     """Ensure spec not concrete check is covered."""
     s = spack.spec.Spec("pkg-a")
     with pytest.raises(AssertionError, match="concrete spec required"):
@@ -944,7 +948,7 @@ def test_failed_spec_path_error(mutable_database_store):
 
 
 @pytest.mark.db
-def test_clear_failure_keep(mutable_database_store, monkeypatch, capfd):
+def test_clear_failure_keep(mutable_database_store: Store, monkeypatch, capfd):
     """Add test coverage for clear_failure operation when to be retained."""
 
     def _is(self, spec):
@@ -960,7 +964,7 @@ def test_clear_failure_keep(mutable_database_store, monkeypatch, capfd):
 
 
 @pytest.mark.db
-def test_clear_failure_forced(mutable_database_store, monkeypatch, capfd):
+def test_clear_failure_forced(mutable_database_store: Store, monkeypatch, capfd):
     """Add test coverage for clear_failure operation when force."""
 
     def _is(self, spec):
@@ -979,7 +983,7 @@ def test_clear_failure_forced(mutable_database_store, monkeypatch, capfd):
 
 
 @pytest.mark.db
-def test_mark_failed(mutable_database_store, monkeypatch, tmp_path: pathlib.Path, capfd):
+def test_mark_failed(mutable_database_store: Store, monkeypatch, tmp_path: pathlib.Path, capfd):
     """Add coverage to mark_failed."""
 
     def _raise_exc(lock):
@@ -999,7 +1003,7 @@ def test_mark_failed(mutable_database_store, monkeypatch, tmp_path: pathlib.Path
 
 
 @pytest.mark.db
-def test_prefix_failed(mutable_database_store, monkeypatch):
+def test_prefix_failed(mutable_database_store: Store, monkeypatch):
     """Add coverage to failed operation."""
 
     s = spack.concretize.concretize_one("pkg-a")
@@ -1021,7 +1025,7 @@ def test_prefix_failed(mutable_database_store, monkeypatch):
     assert failure_tracker.has_failed(s)
 
 
-def test_prefix_write_lock_error(mutable_database_store, monkeypatch):
+def test_prefix_write_lock_error(mutable_database_store: Store, monkeypatch):
     """Cover the prefix write lock exception."""
 
     def _raise(db, spec):
@@ -1071,7 +1075,7 @@ def test_store_find_accept_string(database):
     assert len(result) == 3
 
 
-def test_reindex_removed_prefix_is_not_installed(mutable_database_store, mock_store, capfd):
+def test_reindex_removed_prefix_is_not_installed(mutable_database_store, mock_store: Store, capfd):
     """When a prefix of a dependency is removed and the database is reindexed,
     the spec should still be added through the dependent, but should be listed as
     not installed."""
@@ -1097,7 +1101,7 @@ def test_reindex_removed_prefix_is_not_installed(mutable_database_store, mock_st
     assert mutable_database.query_one("libelf", installed=False)
 
 
-def test_reindex_when_all_prefixes_are_removed(mutable_database_store, mock_store):
+def test_reindex_when_all_prefixes_are_removed(mutable_database_store: Store, mock_store: Store):
     mutable_database = mutable_database_store.db
     # Remove all non-external installations from the filesystem
     for spec in mutable_database.query_local():
@@ -1182,7 +1186,7 @@ def test_query_installed_when_package_unknown(database, repo_builder: RepoBuilde
                 s.package
 
 
-def test_error_message_when_using_too_new_db(database, monkeypatch):
+def test_error_message_when_using_too_new_db(database: Database, monkeypatch):
     """Sometimes the database format needs to be bumped. When that happens, we have forward
     incompatibilities that need to be reported in a clear way to the user, in case we moved
     back to an older version of Spack. This test ensures that the error message for a too
@@ -1200,7 +1204,7 @@ def test_error_message_when_using_too_new_db(database, monkeypatch):
     [spack.database.NO_LOCK, spack.database.NO_TIMEOUT, spack.database.DEFAULT_LOCK_CFG, None],
 )
 def test_database_construction_doesnt_use_globals(
-    tmp_path: pathlib.Path, config, nullify_globals, lock_cfg
+    tmp_path: pathlib.Path, config: Configuration, nullify_globals, lock_cfg
 ):
     lock_cfg = lock_cfg or spack.database.lock_configuration(config)
     db = Database(str(tmp_path), lock_cfg=lock_cfg)
@@ -1226,7 +1230,7 @@ def test_database_read_works_with_trailing_data(tmp_path: pathlib.Path, config, 
     assert Database(root).query_local() == specs_in_db
 
 
-def test_database_errors_with_just_a_version_key(mutable_database):
+def test_database_errors_with_just_a_version_key(mutable_database: Database):
     next_version = f"{spack.database._DB_VERSION}.next"
     with open(mutable_database._index_path, "w", encoding="utf-8") as f:
         f.write(json.dumps({"database": {"version": next_version}}))

--- a/lib/spack/spack/test/database.py
+++ b/lib/spack/spack/test/database.py
@@ -505,12 +505,12 @@ def test_010_all_install_sanity(database):
 
 def test_015_write_and_read(mutable_database):
     # write and read DB
-    with spack.store.STORE.db.write_transaction():
-        specs = spack.store.STORE.db.query()
-        recs = [spack.store.STORE.db.get_record(s) for s in specs]
+    with mutable_database.write_transaction():
+        specs = mutable_database.query()
+        recs = [mutable_database.get_record(s) for s in specs]
 
     for spec, rec in zip(specs, recs):
-        new_rec = spack.store.STORE.db.get_record(spec)
+        new_rec = mutable_database.get_record(spec)
         assert new_rec.ref_count == rec.ref_count
         assert new_rec.spec == rec.spec
         assert new_rec.path == rec.path
@@ -522,11 +522,11 @@ def test_016_roundtrip_spliced_spec(mutable_database):
     replacement = spack.concretize.concretize_one("splice-h+foo")
     spec = build_spec.splice(replacement)
 
-    spack.store.STORE.db.add(spec)
-    spack.store.STORE.db._state_is_inconsistent = True  # force re-read
+    mutable_database.add(spec)
+    mutable_database._state_is_inconsistent = True  # force re-read
 
-    _, spec_record = spack.store.STORE.db.query_by_spec_hash(spec.dag_hash())
-    _, buildspec_record = spack.store.STORE.db.query_by_spec_hash(spec.build_spec.dag_hash())
+    _, spec_record = mutable_database.query_by_spec_hash(spec.dag_hash())
+    _, buildspec_record = mutable_database.query_by_spec_hash(spec.build_spec.dag_hash())
 
     assert spec_record.spec == spec
     assert spec_record.spec.build_spec == spec.build_spec
@@ -536,12 +536,12 @@ def test_016_roundtrip_spliced_spec(mutable_database):
 def test_017_write_and_read_without_uuid(mutable_database, monkeypatch):
     monkeypatch.setattr(spack.database, "_use_uuid", False)
     # write and read DB
-    with spack.store.STORE.db.write_transaction():
-        specs = spack.store.STORE.db.query()
-        recs = [spack.store.STORE.db.get_record(s) for s in specs]
+    with mutable_database.write_transaction():
+        specs = mutable_database.query()
+        recs = [mutable_database.get_record(s) for s in specs]
 
     for spec, rec in zip(specs, recs):
-        new_rec = spack.store.STORE.db.get_record(spec)
+        new_rec = mutable_database.get_record(spec)
         assert new_rec.ref_count == rec.ref_count
         assert new_rec.spec == rec.spec
         assert new_rec.path == rec.path
@@ -551,7 +551,7 @@ def test_017_write_and_read_without_uuid(mutable_database, monkeypatch):
 def test_try_write_transaction(mutable_database, monkeypatch):
     """try_write_transaction persists changes on success and yields False without doing anything
     when acquiring the lock would block."""
-    db = spack.store.STORE.db
+    db = mutable_database
 
     spec = db.query_one("mpileaks ^zmpi")
     with db.try_write_transaction() as acquired:
@@ -570,7 +570,7 @@ def test_try_write_transaction(mutable_database, monkeypatch):
 def test_try_write_transaction_does_not_flush_on_exception(mutable_database):
     """Regression test: an exception inside try_write_transaction must not flush the possibly
     inconsistent in-memory database to disk; the next transaction re-reads it instead."""
-    db = spack.store.STORE.db
+    db = mutable_database
 
     with pytest.raises(ValueError):
         with db.try_write_transaction() as acquired:
@@ -584,7 +584,7 @@ def test_try_write_transaction_does_not_flush_on_exception(mutable_database):
 
 
 def test_try_read_transaction(mutable_database, monkeypatch):
-    db = spack.store.STORE.db
+    db = mutable_database
 
     with db.try_read_transaction() as acquired:
         assert acquired
@@ -656,7 +656,7 @@ def test_041_ref_counts_deprecate(mutable_database):
 def test_050_basic_query(database):
     """Ensure querying database is consistent with what is installed."""
     # query everything
-    total_specs = len(spack.store.STORE.db.query())
+    total_specs = len(database.query())
     assert total_specs == 20
 
     # query specs with multiple configurations
@@ -818,16 +818,16 @@ def test_regression_issue_8036(mutable_database, usr_folder_exists):
     # not be considered installed until it is added to the database by
     # the installer with install().
     s = spack.concretize.concretize_one("externaltool@0.9")
-    assert not spack.store.STORE.db.installed(s)
+    assert not mutable_database.installed(s)
 
     # Now install the external package and check again the `installed` status
     PackageInstaller([s.package], fake=True, explicit=True).install()
-    assert spack.store.STORE.db.installed(s)
+    assert mutable_database.installed(s)
 
 
 @pytest.mark.regression("11118")
 def test_old_external_entries_prefix(mutable_database: spack.database.Database):
-    with open(spack.store.STORE.db._index_path, "r", encoding="utf-8") as f:
+    with open(mutable_database._index_path, "r", encoding="utf-8") as f:
         db_obj = json.loads(f.read())
 
     spack.vendor.jsonschema.validate(db_obj, schema)
@@ -836,13 +836,13 @@ def test_old_external_entries_prefix(mutable_database: spack.database.Database):
 
     db_obj["database"]["installs"][s.dag_hash()]["path"] = "None"
 
-    with open(spack.store.STORE.db._index_path, "w", encoding="utf-8") as f:
+    with open(mutable_database._index_path, "w", encoding="utf-8") as f:
         f.write(json.dumps(db_obj))
     if _use_uuid:
-        with open(spack.store.STORE.db._verifier_path, "w", encoding="utf-8") as f:
+        with open(mutable_database._verifier_path, "w", encoding="utf-8") as f:
             f.write(str(uuid.uuid4()))
 
-    record = spack.store.STORE.db.get_record(s)
+    record = mutable_database.get_record(s)
     assert record is not None
     assert record.path is None
     assert record.spec._prefix is None
@@ -865,11 +865,11 @@ def test_query_unused_specs(mutable_database):
     PackageInstaller([s.package], fake=True, explicit=True).install()
 
     si = s.dag_hash()
-    ml_mpich = spack.store.STORE.db.query_one("mpileaks ^mpich").dag_hash()
-    ml_mpich2 = spack.store.STORE.db.query_one("mpileaks ^mpich2").dag_hash()
-    ml_zmpi = spack.store.STORE.db.query_one("mpileaks ^zmpi").dag_hash()
-    externaltest = spack.store.STORE.db.query_one("externaltest").dag_hash()
-    trivial_smoke_test = spack.store.STORE.db.query_one("trivial-smoke-test").dag_hash()
+    ml_mpich = mutable_database.query_one("mpileaks ^mpich").dag_hash()
+    ml_mpich2 = mutable_database.query_one("mpileaks ^mpich2").dag_hash()
+    ml_zmpi = mutable_database.query_one("mpileaks ^zmpi").dag_hash()
+    externaltest = mutable_database.query_one("externaltest").dag_hash()
+    trivial_smoke_test = mutable_database.query_one("trivial-smoke-test").dag_hash()
 
     def check_unused(roots, deptype, expected):
         unused = spack.store.STORE.db.unused_specs(root_hashes=roots, deptype=deptype)
@@ -914,7 +914,7 @@ def test_query_spec_with_conditional_dependency(mutable_database):
     s = spack.concretize.concretize_one("hdf5~mpi")
     PackageInstaller([s.package], fake=True, explicit=True).install()
 
-    results = spack.store.STORE.db.query_local("hdf5 ^mpich")
+    results = mutable_database.query_local("hdf5 ^mpich")
     assert not results
 
 
@@ -922,13 +922,13 @@ def test_query_spec_with_conditional_dependency(mutable_database):
 def test_query_spec_with_non_conditional_virtual_dependency(database):
     # Ensure the same issue doesn't come up for virtual
     # dependency that are not conditional on variants
-    results = spack.store.STORE.db.query_local("mpileaks ^mpich")
+    results = database.query_local("mpileaks ^mpich")
     assert len(results) == 1
 
 
 def test_query_virtual_spec(database):
     """Make sure we can query for virtuals in the DB"""
-    results = spack.store.STORE.db.query_local("mpi")
+    results = database.query_local("mpi")
     assert len(results) == 3
     names = [s.name for s in results]
     assert all(name in names for name in ["mpich", "mpich2", "zmpi"])
@@ -1095,7 +1095,7 @@ def test_reindex_removed_prefix_is_not_installed(mutable_database, mock_store, c
 
 def test_reindex_when_all_prefixes_are_removed(mutable_database, mock_store):
     # Remove all non-external installations from the filesystem
-    for spec in spack.store.STORE.db.query_local():
+    for spec in mutable_database.query_local():
         if not spec.external:
             assert spec.prefix.startswith(str(mock_store))
             shutil.rmtree(spec.prefix)

--- a/lib/spack/spack/test/database.py
+++ b/lib/spack/spack/test/database.py
@@ -311,21 +311,21 @@ def usr_folder_exists(monkeypatch):
     monkeypatch.setattr(os.path, "isdir", mock_isdir)
 
 
-def _print_ref_counts():
+def _print_ref_counts(db):
     """Print out all ref counts for the graph used here, for debugging"""
     recs = []
 
     def add_rec(spec):
-        cspecs = spack.store.STORE.db.query(spec, installed=InstallRecordStatus.ANY)
+        cspecs = db.query(spec, installed=InstallRecordStatus.ANY)
 
         if not cspecs:
             recs.append("[ %-7s ] %-20s-" % ("", spec))
         else:
             key = cspecs[0].dag_hash()
-            rec = spack.store.STORE.db.get_record(cspecs[0])
+            rec = db.get_record(cspecs[0])
             recs.append("[ %-7s ] %-20s%d" % (key[:7], spec, rec.ref_count))
 
-    with spack.store.STORE.db.read_transaction():
+    with db.read_transaction():
         add_rec("mpileaks ^mpich")
         add_rec("callpath ^mpich")
         add_rec("mpich")
@@ -346,9 +346,9 @@ def _print_ref_counts():
     colify(recs, cols=3)
 
 
-def _check_merkleiness():
+def _check_merkleiness(db):
     """Ensure the spack database is a valid merkle graph."""
-    all_specs = spack.store.STORE.db.query(installed=InstallRecordStatus.ANY)
+    all_specs = db.query(installed=InstallRecordStatus.ANY)
 
     seen = {}
     for spec in all_specs:
@@ -362,7 +362,7 @@ def _check_merkleiness():
 
 def _check_db_sanity(database):
     """Utility function to check db against install layout."""
-    pkg_in_layout = sorted(spack.store.STORE.layout.all_specs())
+    pkg_in_layout = sorted(database.layout.all_specs())
     actual = sorted(database.query())
 
     externals = sorted([x for x in actual if x.external])
@@ -375,7 +375,7 @@ def _check_db_sanity(database):
     for e, a in zip(pkg_in_layout, non_external_in_db):
         assert e == a
 
-    _check_merkleiness()
+    _check_merkleiness(database)
 
 
 def _check_remove_and_add_package(database: spack.database.Database, spec):
@@ -413,8 +413,8 @@ def _mock_install(spec: str):
     PackageInstaller([s.package], fake=True, explicit=True).install()
 
 
-def _mock_remove(spec):
-    specs = spack.store.STORE.db.query(spec)
+def _mock_remove(spec, db):
+    specs = db.query(spec)
     assert len(specs) == 1
     spec = specs[0]
     spec.package.do_uninstall(spec)
@@ -623,10 +623,12 @@ class ReadModify:
     """
 
     def __call__(self):
+        # Runs in a child process where the global store is legitimately re-established.
+        db = spack.store.STORE.db
         # check that other process can read DB
-        _check_db_sanity(spack.store.STORE.db)
-        with spack.store.STORE.db.write_transaction():
-            _mock_remove("mpileaks ^zmpi")
+        _check_db_sanity(db)
+        with db.write_transaction():
+            _mock_remove("mpileaks ^zmpi", db)
 
 
 def test_030_db_sanity_from_another_process(mutable_database):
@@ -755,7 +757,7 @@ def test_090_non_root_ref_counts(mutable_database):
 def test_100_no_write_with_exception_on_remove(database):
     def fail_while_writing():
         with database.write_transaction():
-            _mock_remove("mpileaks ^zmpi")
+            _mock_remove("mpileaks ^zmpi", database)
             raise Exception()
 
     with database.read_transaction():

--- a/lib/spack/spack/test/database.py
+++ b/lib/spack/spack/test/database.py
@@ -474,9 +474,9 @@ def test_005_db_exists(database):
         spack.vendor.jsonschema.validate(index_object, schema)
 
 
-def test_010_all_install_sanity(database):
+def test_010_all_install_sanity(database_store):
     """Ensure that the install layout reflects what we think it does."""
-    all_specs = spack.store.STORE.layout.all_specs()
+    all_specs = database_store.layout.all_specs()
     assert len(all_specs) == 17
 
     # Query specs with multiple configurations
@@ -600,20 +600,21 @@ def test_020_db_sanity(database):
     _check_db_sanity(database)
 
 
-def test_025_reindex(mutable_database):
+def test_025_reindex(mutable_database_store):
     """Make sure reindex works and ref counts are valid."""
-    spack.store.STORE.reindex()
-    _check_db_sanity(mutable_database)
+    mutable_database_store.reindex()
+    _check_db_sanity(mutable_database_store.db)
 
 
-def test_026_reindex_after_deprecate(mutable_database):
+def test_026_reindex_after_deprecate(mutable_database_store):
     """Make sure reindex works and ref counts are valid after deprecation."""
-    mpich = mutable_database.query_one("mpich")
-    zmpi = mutable_database.query_one("zmpi")
-    mutable_database.deprecate(mpich, zmpi)
+    db = mutable_database_store.db
+    mpich = db.query_one("mpich")
+    zmpi = db.query_one("zmpi")
+    db.deprecate(mpich, zmpi)
 
-    spack.store.STORE.reindex()
-    _check_db_sanity(mutable_database)
+    mutable_database_store.reindex()
+    _check_db_sanity(db)
 
 
 class ReadModify:
@@ -785,13 +786,13 @@ def test_110_no_write_with_exception_on_install(database):
         assert database.query("cmake", installed=InstallRecordStatus.ANY) == []
 
 
-def test_115_reindex_with_packages_not_in_repo(mutable_database, repo_builder: RepoBuilder):
+def test_115_reindex_with_packages_not_in_repo(mutable_database_store, repo_builder: RepoBuilder):
     # Dont add any package definitions to this repository, the idea is that
     # packages should not have to be defined in the repository once they
     # are installed
     with spack.repo.use_repositories(repo_builder.root):
-        spack.store.STORE.reindex()
-        _check_db_sanity(mutable_database)
+        mutable_database_store.reindex()
+        _check_db_sanity(mutable_database_store.db)
 
 
 def test_external_entries_in_db(mutable_database):
@@ -934,15 +935,15 @@ def test_query_virtual_spec(database):
     assert all(name in names for name in ["mpich", "mpich2", "zmpi"])
 
 
-def test_failed_spec_path_error(mutable_database):
+def test_failed_spec_path_error(mutable_database_store):
     """Ensure spec not concrete check is covered."""
     s = spack.spec.Spec("pkg-a")
     with pytest.raises(AssertionError, match="concrete spec required"):
-        spack.store.STORE.failure_tracker.mark(s)
+        mutable_database_store.failure_tracker.mark(s)
 
 
 @pytest.mark.db
-def test_clear_failure_keep(mutable_database, monkeypatch, capfd):
+def test_clear_failure_keep(mutable_database_store, monkeypatch, capfd):
     """Add test coverage for clear_failure operation when to be retained."""
 
     def _is(self, spec):
@@ -952,13 +953,13 @@ def test_clear_failure_keep(mutable_database, monkeypatch, capfd):
     monkeypatch.setattr(spack.database.FailureTracker, "lock_taken", _is)
 
     s = spack.concretize.concretize_one("pkg-a")
-    spack.store.STORE.failure_tracker.clear(s)
+    mutable_database_store.failure_tracker.clear(s)
     out = capfd.readouterr()[0]
     assert "Retaining failure marking" in out
 
 
 @pytest.mark.db
-def test_clear_failure_forced(mutable_database, monkeypatch, capfd):
+def test_clear_failure_forced(mutable_database_store, monkeypatch, capfd):
     """Add test coverage for clear_failure operation when force."""
 
     def _is(self, spec):
@@ -970,14 +971,14 @@ def test_clear_failure_forced(mutable_database, monkeypatch, capfd):
     monkeypatch.setattr(spack.database.FailureTracker, "persistent_mark", _is)
 
     s = spack.concretize.concretize_one("pkg-a")
-    spack.store.STORE.failure_tracker.clear(s, force=True)
+    mutable_database_store.failure_tracker.clear(s, force=True)
     out = capfd.readouterr()[1]
     assert "Removing failure marking despite lock" in out
     assert "Unable to remove failure marking" in out
 
 
 @pytest.mark.db
-def test_mark_failed(mutable_database, monkeypatch, tmp_path: pathlib.Path, capfd):
+def test_mark_failed(mutable_database_store, monkeypatch, tmp_path: pathlib.Path, capfd):
     """Add coverage to mark_failed."""
 
     def _raise_exc(lock):
@@ -989,36 +990,37 @@ def test_mark_failed(mutable_database, monkeypatch, tmp_path: pathlib.Path, capf
         # Ensure attempt to acquire write lock on the mark raises the exception
         monkeypatch.setattr(lk.Lock, "acquire_write", _raise_exc)
 
-        spack.store.STORE.failure_tracker.mark(s)
+        mutable_database_store.failure_tracker.mark(s)
         out = str(capfd.readouterr()[1])
         assert "Unable to mark pkg-a as failed" in out
 
-    spack.store.STORE.failure_tracker.clear_all()
+    mutable_database_store.failure_tracker.clear_all()
 
 
 @pytest.mark.db
-def test_prefix_failed(mutable_database, monkeypatch):
+def test_prefix_failed(mutable_database_store, monkeypatch):
     """Add coverage to failed operation."""
 
     s = spack.concretize.concretize_one("pkg-a")
+    failure_tracker = mutable_database_store.failure_tracker
 
     # Confirm the spec is not already marked as failed
-    assert not spack.store.STORE.failure_tracker.has_failed(s)
+    assert not failure_tracker.has_failed(s)
 
     # Check that a failure entry is sufficient
-    spack.store.STORE.failure_tracker.mark(s)
-    assert spack.store.STORE.failure_tracker.has_failed(s)
+    failure_tracker.mark(s)
+    assert failure_tracker.has_failed(s)
 
     # Remove the entry and check again
-    spack.store.STORE.failure_tracker.clear(s)
-    assert not spack.store.STORE.failure_tracker.has_failed(s)
+    failure_tracker.clear(s)
+    assert not failure_tracker.has_failed(s)
 
     # Now pretend that the prefix failure is locked
     monkeypatch.setattr(spack.database.FailureTracker, "lock_taken", lambda self, spec: True)
-    assert spack.store.STORE.failure_tracker.has_failed(s)
+    assert failure_tracker.has_failed(s)
 
 
-def test_prefix_write_lock_error(mutable_database, monkeypatch):
+def test_prefix_write_lock_error(mutable_database_store, monkeypatch):
     """Cover the prefix write lock exception."""
 
     def _raise(db, spec):
@@ -1030,7 +1032,7 @@ def test_prefix_write_lock_error(mutable_database, monkeypatch):
     monkeypatch.setattr(lk.Lock, "acquire_write", _raise)
 
     with pytest.raises(Exception):
-        with spack.store.STORE.prefix_locker.write_lock(s):
+        with mutable_database_store.prefix_locker.write_lock(s):
             assert False
 
 
@@ -1068,10 +1070,11 @@ def test_store_find_accept_string(database):
     assert len(result) == 3
 
 
-def test_reindex_removed_prefix_is_not_installed(mutable_database, mock_store, capfd):
+def test_reindex_removed_prefix_is_not_installed(mutable_database_store, mock_store, capfd):
     """When a prefix of a dependency is removed and the database is reindexed,
     the spec should still be added through the dependent, but should be listed as
     not installed."""
+    mutable_database = mutable_database_store.db
 
     # Remove libelf from the filesystem
     prefix = mutable_database.query_one("libelf").prefix
@@ -1079,7 +1082,7 @@ def test_reindex_removed_prefix_is_not_installed(mutable_database, mock_store, c
     shutil.rmtree(prefix)
 
     # Reindex should pick up libelf as a dependency of libdwarf
-    spack.store.STORE.reindex()
+    mutable_database_store.reindex()
 
     # Reindexing should warn about libelf not found on the filesystem
     assert re.search(
@@ -1093,7 +1096,8 @@ def test_reindex_removed_prefix_is_not_installed(mutable_database, mock_store, c
     assert mutable_database.query_one("libelf", installed=False)
 
 
-def test_reindex_when_all_prefixes_are_removed(mutable_database, mock_store):
+def test_reindex_when_all_prefixes_are_removed(mutable_database_store, mock_store):
+    mutable_database = mutable_database_store.db
     # Remove all non-external installations from the filesystem
     for spec in mutable_database.query_local():
         if not spec.external:
@@ -1105,7 +1109,7 @@ def test_reindex_when_all_prefixes_are_removed(mutable_database, mock_store):
     assert num > 0
 
     # Reindex uses the current index to repopulate itself
-    spack.store.STORE.reindex()
+    mutable_database_store.reindex()
 
     # Make sure all explicit specs are still there, but are now uninstalled.
     specs = mutable_database.query_local(installed=False, explicit=True)

--- a/lib/spack/spack/test/database.py
+++ b/lib/spack/spack/test/database.py
@@ -17,6 +17,7 @@ import pytest
 
 import spack.config
 import spack.subprocess_context
+from spack.database import Database
 from spack.directory_layout import DirectoryLayoutError
 
 try:
@@ -233,11 +234,11 @@ def test_add_to_upstream_after_downstream(upstream_and_downstream_db, repo_build
 def test_cannot_write_upstream(tmp_path: pathlib.Path, mock_packages, config):
     # Instantiate the database that will be used as the upstream DB and make
     # sure it has an index file
-    with spack.database.Database(str(tmp_path)).write_transaction():
+    with Database(str(tmp_path)).write_transaction():
         pass
 
     # Create it as an upstream
-    db = spack.database.Database(str(tmp_path), is_upstream=True)
+    db = Database(str(tmp_path), is_upstream=True)
 
     with pytest.raises(spack.database.ForbiddenLockError):
         db.add(spack.concretize.concretize_one("pkg-a"))
@@ -258,21 +259,19 @@ def test_recursive_upstream_dbs(
 
     with spack.repo.use_repositories(repo_builder.root):
         spec = spack.concretize.concretize_one("x")
-        db_c = spack.database.Database(roots[2], layout=layouts[2])
+        db_c = Database(roots[2], layout=layouts[2])
         db_c.add(spec["z"])
 
-        db_b = spack.database.Database(roots[1], upstream_dbs=[db_c], layout=layouts[1])
+        db_b = Database(roots[1], upstream_dbs=[db_c], layout=layouts[1])
         db_b.add(spec["y"])
 
-        db_a = spack.database.Database(roots[0], upstream_dbs=[db_b, db_c], layout=layouts[0])
+        db_a = Database(roots[0], upstream_dbs=[db_b, db_c], layout=layouts[0])
         db_a.add(spec["x"])
 
         upstream_dbs_from_scratch = spack.store._construct_upstream_dbs_from_install_roots(
             [roots[1], roots[2]]
         )
-        db_a_from_scratch = spack.database.Database(
-            roots[0], upstream_dbs=upstream_dbs_from_scratch
-        )
+        db_a_from_scratch = Database(roots[0], upstream_dbs=upstream_dbs_from_scratch)
 
         assert db_a_from_scratch.db_for_spec_hash(spec.dag_hash()) == (db_a_from_scratch)
         assert (
@@ -311,7 +310,7 @@ def usr_folder_exists(monkeypatch):
     monkeypatch.setattr(os.path, "isdir", mock_isdir)
 
 
-def _print_ref_counts(db):
+def _print_ref_counts(db: Database):
     """Print out all ref counts for the graph used here, for debugging"""
     recs = []
 
@@ -378,7 +377,7 @@ def _check_db_sanity(database):
     _check_merkleiness(database)
 
 
-def _check_remove_and_add_package(database: spack.database.Database, spec):
+def _check_remove_and_add_package(database: Database, spec):
     """Remove a spec from the DB, then add it and make sure everything's
     still ok once it is added.  This checks that it was
     removed, that it's back when added again, and that ref
@@ -829,7 +828,7 @@ def test_regression_issue_8036(mutable_database, usr_folder_exists):
 
 
 @pytest.mark.regression("11118")
-def test_old_external_entries_prefix(mutable_database: spack.database.Database):
+def test_old_external_entries_prefix(mutable_database: Database):
     with open(mutable_database._index_path, "r", encoding="utf-8") as f:
         db_obj = json.loads(f.read())
 
@@ -1047,7 +1046,7 @@ def test_database_works_with_empty_dir(tmp_path: pathlib.Path):
     (db_dir / spack.database._LOCK_FILE).touch()
     (db_dir / "failures").mkdir()
     tmp_path.chmod(mode=0o555)
-    db = spack.database.Database(str(tmp_path))
+    db = Database(str(tmp_path))
     with db.read_transaction():
         db.query()
     # Check that reading an empty directory didn't create a new index.json
@@ -1193,7 +1192,7 @@ def test_error_message_when_using_too_new_db(database, monkeypatch):
     with pytest.raises(
         spack.database.InvalidDatabaseVersionError, match="you need a newer Spack version"
     ):
-        spack.database.Database(database.root)._read()
+        Database(database.root)._read()
 
 
 @pytest.mark.parametrize(
@@ -1204,7 +1203,7 @@ def test_database_construction_doesnt_use_globals(
     tmp_path: pathlib.Path, config, nullify_globals, lock_cfg
 ):
     lock_cfg = lock_cfg or spack.database.lock_configuration(config)
-    db = spack.database.Database(str(tmp_path), lock_cfg=lock_cfg)
+    db = Database(str(tmp_path), lock_cfg=lock_cfg)
     with db.write_transaction():
         pass  # ensure the DB is written
     assert os.path.exists(db.database_directory)
@@ -1213,7 +1212,7 @@ def test_database_construction_doesnt_use_globals(
 def test_database_read_works_with_trailing_data(tmp_path: pathlib.Path, config, mock_packages):
     # Populate a database
     root = str(tmp_path)
-    db = spack.database.Database(root, layout=None)
+    db = Database(root, layout=None)
     spec = spack.concretize.concretize_one("pkg-a")
     db.add(spec)
     specs_in_db = db.query_local()
@@ -1224,7 +1223,7 @@ def test_database_read_works_with_trailing_data(tmp_path: pathlib.Path, config, 
         f.write(json.dumps({"hello": "world"}))
 
     # Read the database and check that it ignores the trailing data
-    assert spack.database.Database(root).query_local() == specs_in_db
+    assert Database(root).query_local() == specs_in_db
 
 
 def test_database_errors_with_just_a_version_key(mutable_database):
@@ -1233,7 +1232,7 @@ def test_database_errors_with_just_a_version_key(mutable_database):
         f.write(json.dumps({"database": {"version": next_version}}))
 
     with pytest.raises(spack.database.InvalidDatabaseVersionError):
-        spack.database.Database(mutable_database.root).query_local()
+        Database(mutable_database.root).query_local()
 
 
 def test_reindex_with_upstreams(tmp_path: pathlib.Path, monkeypatch, mock_packages, config):
@@ -1332,7 +1331,7 @@ def test_querying_reindexed_database_specfilev5(tmp_path: pathlib.Path):
     index_json.parent.mkdir(parents=True)
     index_json.write_text(json.dumps(data))
 
-    db = spack.database.Database(str(tmp_path))
+    db = Database(str(tmp_path))
 
     specs = db.query("%gcc")
 

--- a/lib/spack/spack/test/detection.py
+++ b/lib/spack/spack/test/detection.py
@@ -6,7 +6,6 @@ import pathlib
 
 import pytest
 
-import spack.config
 import spack.detection
 import spack.detection.common
 import spack.detection.path
@@ -22,7 +21,7 @@ def test_detection_update_config(mutable_config):
     # update config for new package
     spack.detection.common.update_configuration(detected_packages)
     # Check entries in 'packages.yaml'
-    packages_yaml = spack.config.get("packages")
+    packages_yaml = mutable_config.get("packages")
     assert "cmake" in packages_yaml
     assert "externals" in packages_yaml["cmake"]
     externals = packages_yaml["cmake"]["externals"]

--- a/lib/spack/spack/test/detection.py
+++ b/lib/spack/spack/test/detection.py
@@ -9,7 +9,6 @@ import pytest
 import spack.detection
 import spack.detection.common
 import spack.detection.path
-import spack.repo
 import spack.spec
 
 
@@ -57,7 +56,7 @@ def test_dedupe_paths(tmp_path: pathlib.Path):
 
 
 @pytest.mark.usefixtures("mock_packages")
-def test_detect_specs_deduplicates_across_prefixes(tmp_path, monkeypatch):
+def test_detect_specs_deduplicates_across_prefixes(tmp_path, monkeypatch, mock_packages):
     """Tests that the same spec detected at two different prefixes should yield only one result.
 
     Returning both causes duplicate externals in packages.yaml and non-deterministic hashes
@@ -73,7 +72,7 @@ def test_detect_specs_deduplicates_across_prefixes(tmp_path, monkeypatch):
     exe_a.touch()
     exe_b.touch()
 
-    cmake_cls = spack.repo.PATH.get_pkg_class("cmake")
+    cmake_cls = mock_packages.get_pkg_class("cmake")
 
     # Patch determine_spec_details to always return the same spec, regardless of prefix.
     @classmethod
@@ -84,7 +83,7 @@ def test_detect_specs_deduplicates_across_prefixes(tmp_path, monkeypatch):
 
     finder = spack.detection.path.ExecutablesFinder()
     detected = finder.detect_specs(
-        pkg=cmake_cls, paths=[str(exe_a), str(exe_b)], repo_path=spack.repo.PATH
+        pkg=cmake_cls, paths=[str(exe_a), str(exe_b)], repo_path=mock_packages
     )
 
     # Both prefixes produce cmake@3.17.1; only the first should be kept.

--- a/lib/spack/spack/test/detection.py
+++ b/lib/spack/spack/test/detection.py
@@ -8,9 +8,10 @@ import spack.detection
 import spack.detection.common
 import spack.detection.path
 import spack.spec
+from spack.config import Configuration
 
 
-def test_detection_update_config(mutable_config):
+def test_detection_update_config(mutable_config: Configuration):
     # mock detected package
     detected_packages = collections.defaultdict(list)
     detected_packages["cmake"] = [spack.spec.Spec("cmake@3.27.5", external_path="/usr/bin")]

--- a/lib/spack/spack/test/detection.py
+++ b/lib/spack/spack/test/detection.py
@@ -4,8 +4,6 @@
 import collections
 import pathlib
 
-import pytest
-
 import spack.detection
 import spack.detection.common
 import spack.detection.path
@@ -55,7 +53,6 @@ def test_dedupe_paths(tmp_path: pathlib.Path):
     assert spack.detection.path.dedupe_paths([str(y), str(z), str(x)]) == [str(y), str(x)]
 
 
-@pytest.mark.usefixtures("mock_packages")
 def test_detect_specs_deduplicates_across_prefixes(tmp_path, monkeypatch, mock_packages):
     """Tests that the same spec detected at two different prefixes should yield only one result.
 

--- a/lib/spack/spack/test/directives.py
+++ b/lib/spack/spack/test/directives.py
@@ -11,10 +11,11 @@ import spack.spec
 import spack.version
 from spack.directives import _make_when_spec, depends_on, extends, patch
 from spack.directives_meta import DirectiveDictDescriptor, DirectiveMeta
+from spack.repo import RepoPath
 from spack.spec import Spec
 
 
-def test_false_directives_do_not_exist(mock_packages):
+def test_false_directives_do_not_exist(mock_packages: RepoPath):
     """Ensure directives that evaluate to False at import time are added to
     dicts on packages.
     """
@@ -24,7 +25,7 @@ def test_false_directives_do_not_exist(mock_packages):
     assert not cls.patches
 
 
-def test_true_directives_exist(mock_packages):
+def test_true_directives_exist(mock_packages: RepoPath):
     """Ensure directives that evaluate to True at import time are added to
     dicts on packages.
     """
@@ -41,7 +42,7 @@ def test_true_directives_exist(mock_packages):
     assert spack.spec.Spec() in cls.patches
 
 
-def test_constraints_from_context(mock_packages):
+def test_constraints_from_context(mock_packages: RepoPath):
     pkg_cls = mock_packages.get_pkg_class("with-constraint-met")
 
     assert pkg_cls.dependencies
@@ -52,7 +53,7 @@ def test_constraints_from_context(mock_packages):
 
 
 @pytest.mark.regression("26656")
-def test_constraints_from_context_are_merged(mock_packages):
+def test_constraints_from_context_are_merged(mock_packages: RepoPath):
     pkg_cls = mock_packages.get_pkg_class("with-constraint-met")
 
     assert pkg_cls.dependencies
@@ -83,7 +84,7 @@ def test_conditionally_extends_direct_dep(config, mock_packages):
 
 
 @pytest.mark.regression("34368")
-def test_error_on_anonymous_dependency(config, mock_packages):
+def test_error_on_anonymous_dependency(config, mock_packages: RepoPath):
     pkg = mock_packages.get_pkg_class("pkg-a")
     with pytest.raises(spack.directives.DependencyError):
         spack.directives._execute_depends_on(pkg, spack.spec.Spec("@4.5"))
@@ -100,7 +101,7 @@ def test_error_on_anonymous_dependency(config, mock_packages):
         ("maintainers-3", ["user0", "user1", "user2", "user3"]),
     ],
 )
-def test_maintainer_directive(config, mock_packages, package_name, expected_maintainers):
+def test_maintainer_directive(config, mock_packages: RepoPath, package_name, expected_maintainers):
     pkg_cls = mock_packages.get_pkg_class(package_name)
     assert pkg_cls.maintainers == expected_maintainers
 
@@ -108,7 +109,7 @@ def test_maintainer_directive(config, mock_packages, package_name, expected_main
 @pytest.mark.parametrize(
     "package_name,expected_licenses", [("licenses-1", [("MIT", "+foo"), ("Apache-2.0", "~foo")])]
 )
-def test_license_directive(config, mock_packages, package_name, expected_licenses):
+def test_license_directive(config, mock_packages: RepoPath, package_name, expected_licenses):
     pkg_cls = mock_packages.get_pkg_class(package_name)
     for license in expected_licenses:
         assert spack.spec.Spec(license[1]) in pkg_cls.licenses
@@ -172,7 +173,9 @@ def test_version_type_validation():
         ("redistribute-y@2.1+bar", False, False),
     ],
 )
-def test_redistribute_directive(config, mock_packages, spec_str, distribute_src, distribute_bin):
+def test_redistribute_directive(
+    config, mock_packages: RepoPath, spec_str, distribute_src, distribute_bin
+):
     spec = spack.spec.Spec(spec_str)
     assert mock_packages.get_pkg_class(spec.fullname).redistribute_source(spec) == distribute_src
     concretized_spec = spack.concretize.concretize_one(spec)
@@ -201,7 +204,7 @@ def test_redistribute_override_when():
 
 
 @pytest.mark.regression("51248")
-def test_direct_dependencies_from_when_context_are_retained(mock_packages):
+def test_direct_dependencies_from_when_context_are_retained(mock_packages: RepoPath):
     """Tests that direct dependencies from the "when" context manager don't lose the "direct"
     attribute when turned into directives on the package class.
     """

--- a/lib/spack/spack/test/directives.py
+++ b/lib/spack/spack/test/directives.py
@@ -7,7 +7,6 @@ import pytest
 
 import spack.concretize
 import spack.directives
-import spack.repo
 import spack.spec
 import spack.version
 from spack.directives import _make_when_spec, depends_on, extends, patch
@@ -19,7 +18,7 @@ def test_false_directives_do_not_exist(mock_packages):
     """Ensure directives that evaluate to False at import time are added to
     dicts on packages.
     """
-    cls = spack.repo.PATH.get_pkg_class("when-directives-false")
+    cls = mock_packages.get_pkg_class("when-directives-false")
     assert not cls.dependencies
     assert not cls.resources
     assert not cls.patches
@@ -29,7 +28,7 @@ def test_true_directives_exist(mock_packages):
     """Ensure directives that evaluate to True at import time are added to
     dicts on packages.
     """
-    cls = spack.repo.PATH.get_pkg_class("when-directives-true")
+    cls = mock_packages.get_pkg_class("when-directives-true")
 
     assert cls.dependencies
     assert "extendee" in cls.dependencies[spack.spec.Spec()]
@@ -43,7 +42,7 @@ def test_true_directives_exist(mock_packages):
 
 
 def test_constraints_from_context(mock_packages):
-    pkg_cls = spack.repo.PATH.get_pkg_class("with-constraint-met")
+    pkg_cls = mock_packages.get_pkg_class("with-constraint-met")
 
     assert pkg_cls.dependencies
     assert "pkg-b" in pkg_cls.dependencies[spack.spec.Spec("@1.0")]
@@ -54,7 +53,7 @@ def test_constraints_from_context(mock_packages):
 
 @pytest.mark.regression("26656")
 def test_constraints_from_context_are_merged(mock_packages):
-    pkg_cls = spack.repo.PATH.get_pkg_class("with-constraint-met")
+    pkg_cls = mock_packages.get_pkg_class("with-constraint-met")
 
     assert pkg_cls.dependencies
     assert "pkg-c" in pkg_cls.dependencies[spack.spec.Spec("@0.14:15 ^pkg-b@3.8:4.0")]
@@ -85,7 +84,7 @@ def test_conditionally_extends_direct_dep(config, mock_packages):
 
 @pytest.mark.regression("34368")
 def test_error_on_anonymous_dependency(config, mock_packages):
-    pkg = spack.repo.PATH.get_pkg_class("pkg-a")
+    pkg = mock_packages.get_pkg_class("pkg-a")
     with pytest.raises(spack.directives.DependencyError):
         spack.directives._execute_depends_on(pkg, spack.spec.Spec("@4.5"))
 
@@ -102,7 +101,7 @@ def test_error_on_anonymous_dependency(config, mock_packages):
     ],
 )
 def test_maintainer_directive(config, mock_packages, package_name, expected_maintainers):
-    pkg_cls = spack.repo.PATH.get_pkg_class(package_name)
+    pkg_cls = mock_packages.get_pkg_class(package_name)
     assert pkg_cls.maintainers == expected_maintainers
 
 
@@ -110,7 +109,7 @@ def test_maintainer_directive(config, mock_packages, package_name, expected_main
     "package_name,expected_licenses", [("licenses-1", [("MIT", "+foo"), ("Apache-2.0", "~foo")])]
 )
 def test_license_directive(config, mock_packages, package_name, expected_licenses):
-    pkg_cls = spack.repo.PATH.get_pkg_class(package_name)
+    pkg_cls = mock_packages.get_pkg_class(package_name)
     for license in expected_licenses:
         assert spack.spec.Spec(license[1]) in pkg_cls.licenses
         assert license[0] == pkg_cls.licenses[spack.spec.Spec(license[1])]
@@ -175,7 +174,7 @@ def test_version_type_validation():
 )
 def test_redistribute_directive(config, mock_packages, spec_str, distribute_src, distribute_bin):
     spec = spack.spec.Spec(spec_str)
-    assert spack.repo.PATH.get_pkg_class(spec.fullname).redistribute_source(spec) == distribute_src
+    assert mock_packages.get_pkg_class(spec.fullname).redistribute_source(spec) == distribute_src
     concretized_spec = spack.concretize.concretize_one(spec)
     assert concretized_spec.package.redistribute_binary == distribute_bin
 
@@ -206,7 +205,7 @@ def test_direct_dependencies_from_when_context_are_retained(mock_packages):
     """Tests that direct dependencies from the "when" context manager don't lose the "direct"
     attribute when turned into directives on the package class.
     """
-    pkg_cls = spack.repo.PATH.get_pkg_class("with-constraint-met")
+    pkg_cls = mock_packages.get_pkg_class("with-constraint-met")
     # Direct dependency in a "when" single context manager
     assert spack.spec.Spec("%pkg-b") in pkg_cls.dependencies
     # Direct dependency in a "when" nested context manager

--- a/lib/spack/spack/test/directory_layout.py
+++ b/lib/spack/spack/test/directory_layout.py
@@ -83,7 +83,7 @@ def test_read_and_write_spec(temporary_store, config, mock_packages):
     layout.
     """
     layout = temporary_store.layout
-    pkg_names = list(spack.repo.PATH.all_package_names())[:max_packages]
+    pkg_names = list(mock_packages.all_package_names())[:max_packages]
 
     for name in pkg_names:
         if name.startswith("external"):
@@ -195,7 +195,7 @@ def test_handle_unknown_package(temporary_store, config, mock_packages, tmp_path
 def test_find(temporary_store, config, mock_packages):
     """Test that finding specs within an install layout works."""
     layout = temporary_store.layout
-    package_names = list(spack.repo.PATH.all_package_names())[:max_packages]
+    package_names = list(mock_packages.all_package_names())[:max_packages]
 
     # Create install prefixes for all packages in the list
     installed_specs = {}

--- a/lib/spack/spack/test/directory_layout.py
+++ b/lib/spack/spack/test/directory_layout.py
@@ -18,7 +18,9 @@ import spack.paths
 import spack.repo
 import spack.util.file_cache
 from spack.directory_layout import DirectoryLayout, InvalidDirectoryLayoutParametersError
+from spack.repo import RepoPath
 from spack.spec import Spec
+from spack.store import Store
 from spack.util.path import path_to_os_path
 
 # number of packages to test (to reduce test time)
@@ -144,7 +146,9 @@ def test_read_and_write_spec(temporary_store, config, mock_packages):
         assert not os.path.exists(install_dir)
 
 
-def test_handle_unknown_package(temporary_store, config, mock_packages, tmp_path: pathlib.Path):
+def test_handle_unknown_package(
+    temporary_store: Store, config, mock_packages: RepoPath, tmp_path: pathlib.Path
+):
     """This test ensures that spack can at least do *some*
     operations with packages that are installed but that it
     does not know about.  This is actually not such an uncommon
@@ -192,7 +196,7 @@ def test_handle_unknown_package(temporary_store, config, mock_packages, tmp_path
             assert spec.dag_hash() == spec_from_file.dag_hash()
 
 
-def test_find(temporary_store, config, mock_packages):
+def test_find(temporary_store: Store, config, mock_packages: RepoPath):
     """Test that finding specs within an install layout works."""
     layout = temporary_store.layout
     package_names = list(mock_packages.all_package_names())[:max_packages]

--- a/lib/spack/spack/test/directory_layout.py
+++ b/lib/spack/spack/test/directory_layout.py
@@ -161,7 +161,7 @@ def test_handle_unknown_package(temporary_store, config, mock_packages, tmp_path
     mock_db = spack.repo.Repo(spack.paths.mock_packages_path, cache=repo_cache)
 
     not_in_mock = set.difference(
-        set(spack.repo.all_package_names()), set(mock_db.all_package_names())
+        set(mock_packages.all_package_names()), set(mock_db.all_package_names())
     )
     packages = list(not_in_mock)[:max_packages]
 

--- a/lib/spack/spack/test/env.py
+++ b/lib/spack/spack/test/env.py
@@ -11,7 +11,6 @@ import pickle
 
 import pytest
 
-import spack.config
 import spack.environment as ev
 import spack.package_base
 import spack.platforms
@@ -537,7 +536,7 @@ spack:
 
 
 @pytest.mark.parametrize("unify_in_config", [True, False, "when_possible"])
-def test_environment_config_scheme_used(tmp_path: pathlib.Path, unify_in_config):
+def test_environment_config_scheme_used(mutable_config, tmp_path: pathlib.Path, unify_in_config):
     """Tests that "unify" settings in lower configuration scopes is taken into account,
     if absent in spack.yaml.
     """
@@ -550,9 +549,9 @@ spack:
 """
     )
 
-    with spack.config.override("concretizer:unify", unify_in_config):
+    with mutable_config.override("concretizer:unify", unify_in_config):
         with ev.Environment(manifest.parent):
-            assert spack.config.CONFIG.get("concretizer:unify") == unify_in_config
+            assert mutable_config.get("concretizer:unify") == unify_in_config
 
 
 @pytest.mark.parametrize(
@@ -983,7 +982,7 @@ def test_environment_from_name_or_dir(mutable_mock_env_path):
         _ = ev.environment_from_name_or_dir("fake-env")
 
 
-def test_env_include_configs(mutable_mock_env_path):
+def test_env_include_configs(mutable_mock_env_path, mutable_config):
     """check config and package values using new include schema"""
     env_path = mutable_mock_env_path
     env_path.mkdir()
@@ -1024,8 +1023,8 @@ spack:
 
     e = ev.Environment(env_path)
     with e.manifest.use_config():
-        assert not spack.config.get("config:verify_ssl")
-        python_reqs = spack.config.get("packages")["python"]["require"]
+        assert not mutable_config.get("config:verify_ssl")
+        python_reqs = mutable_config.get("packages")["python"]["require"]
         req_specs = {x["spec"] for x in python_reqs}
         assert req_specs == set(["@3.11:"])
 
@@ -1644,7 +1643,7 @@ spack:
     manifest.write_text(spack_yaml)
     with ev.Environment(tmp_path):
         # We rely on this behavior when emitting facts for the solver
-        toolchains = spack.config.CONFIG.get("toolchains", {})
+        toolchains = mutable_config.get("toolchains", {})
         s = spack.spec_parser.parse("mpileaks %gnu ^callpath %gnu", toolchains=toolchains)[0]
         assert id(s["gcc"]) != id(s["callpath"]["gcc"])
 
@@ -2173,9 +2172,11 @@ def test_unified_environment_with_mixed_compilers_and_fortran(tmp_path, config):
 
 
 @pytest.mark.parametrize("enable_locks", [True, False])
-def test_environment_pickle_preserves_lock_state(enable_locks, tmp_path: pathlib.Path):
+def test_environment_pickle_preserves_lock_state(
+    mutable_config, enable_locks, tmp_path: pathlib.Path
+):
     """Tests that an environment round-trips through pickle with its lock-enable state intact."""
-    with spack.config.override("config:locks", enable_locks):
+    with mutable_config.override("config:locks", enable_locks):
         env = ev.create_in_dir(tmp_path)
     original_enabled = env.txlock.enabled
 
@@ -2183,7 +2184,7 @@ def test_environment_pickle_preserves_lock_state(enable_locks, tmp_path: pathlib
 
     # Flip the global config, then unpickle: the rebuilt transaction lock must keep the state
     # that was pickled, not the (now different) global one.
-    with spack.config.override("config:locks", not enable_locks):
+    with mutable_config.override("config:locks", not enable_locks):
         restored = pickle.loads(blob)
 
     assert restored.txlock.enabled == original_enabled

--- a/lib/spack/spack/test/env.py
+++ b/lib/spack/spack/test/env.py
@@ -18,6 +18,7 @@ import spack.solver.asp
 import spack.spec
 import spack.spec_parser
 import spack.util.filesystem as fs
+from spack.config import Configuration
 from spack.enums import ConfigScopePriority
 from spack.environment import SpackEnvironmentConfigError
 from spack.environment.environment import EnvironmentManifestFile
@@ -536,7 +537,9 @@ spack:
 
 
 @pytest.mark.parametrize("unify_in_config", [True, False, "when_possible"])
-def test_environment_config_scheme_used(mutable_config, tmp_path: pathlib.Path, unify_in_config):
+def test_environment_config_scheme_used(
+    mutable_config: Configuration, tmp_path: pathlib.Path, unify_in_config
+):
     """Tests that "unify" settings in lower configuration scopes is taken into account,
     if absent in spack.yaml.
     """
@@ -982,7 +985,7 @@ def test_environment_from_name_or_dir(mutable_mock_env_path):
         _ = ev.environment_from_name_or_dir("fake-env")
 
 
-def test_env_include_configs(mutable_mock_env_path, mutable_config):
+def test_env_include_configs(mutable_mock_env_path, mutable_config: Configuration):
     """check config and package values using new include schema"""
     env_path = mutable_mock_env_path
     env_path.mkdir()
@@ -1621,7 +1624,7 @@ def test_static_analysis_in_environments(spack_yaml, tmp_path, mutable_config):
 
 
 @pytest.mark.regression("51606")
-def test_ids_when_using_toolchain_twice_in_a_spec(tmp_path, mutable_config):
+def test_ids_when_using_toolchain_twice_in_a_spec(tmp_path, mutable_config: Configuration):
     """Tests that using the same toolchain twice in a spec constructs different objects"""
     spack_yaml = """
 spack:
@@ -2173,7 +2176,7 @@ def test_unified_environment_with_mixed_compilers_and_fortran(tmp_path, config):
 
 @pytest.mark.parametrize("enable_locks", [True, False])
 def test_environment_pickle_preserves_lock_state(
-    mutable_config, enable_locks, tmp_path: pathlib.Path
+    mutable_config: Configuration, enable_locks, tmp_path: pathlib.Path
 ):
     """Tests that an environment round-trips through pickle with its lock-enable state intact."""
     with mutable_config.override("config:locks", enable_locks):

--- a/lib/spack/spack/test/environment/mutate.py
+++ b/lib/spack/spack/test/environment/mutate.py
@@ -8,6 +8,7 @@ import pytest
 import spack.concretize
 import spack.environment as ev
 import spack.spec
+from spack.config import Configuration
 from spack.main import SpackCommand
 
 pytestmark = [
@@ -36,7 +37,7 @@ change = SpackCommand("change")
         ),
     ],
 )
-def test_mutate_internals(dep, orig_constraint, mutated_constraint, mutable_config):
+def test_mutate_internals(dep, orig_constraint, mutated_constraint, mutable_config: Configuration):
     """
     Check that Environment.mutate and Spec.mutate work for several different constraint types.
 

--- a/lib/spack/spack/test/environment/mutate.py
+++ b/lib/spack/spack/test/environment/mutate.py
@@ -6,7 +6,6 @@ import platform
 import pytest
 
 import spack.concretize
-import spack.config
 import spack.environment as ev
 import spack.spec
 from spack.main import SpackCommand
@@ -37,7 +36,7 @@ change = SpackCommand("change")
         ),
     ],
 )
-def test_mutate_internals(dep, orig_constraint, mutated_constraint):
+def test_mutate_internals(dep, orig_constraint, mutated_constraint, mutable_config):
     """
     Check that Environment.mutate and Spec.mutate work for several different constraint types.
 
@@ -46,7 +45,7 @@ def test_mutate_internals(dep, orig_constraint, mutated_constraint):
     ev.create("test")
     env = ev.read("test")
 
-    spack.config.set("packages:cmake", {"require": orig_constraint})
+    mutable_config.set("packages:cmake", {"require": orig_constraint})
 
     root_name = "cmake-client" if dep else "cmake"
     env.add(root_name)

--- a/lib/spack/spack/test/error_messages.py
+++ b/lib/spack/spack/test/error_messages.py
@@ -12,7 +12,6 @@ import pytest
 
 import spack.vendor.archspec.cpu
 
-import spack.config
 import spack.error
 import spack.repo
 import spack.util.file_cache
@@ -23,9 +22,9 @@ from spack.main import SpackCommand
 solve = SpackCommand("solve")
 
 
-def update_packages_config(conf_str):
+def update_packages_config(conf_str, config):
     conf = syaml.load_config(conf_str)
-    spack.config.CONFIG.set("packages", conf["packages"], scope="concretize")
+    config.set("packages", conf["packages"], scope="concretize")
 
 
 _pkgx1 = (
@@ -486,7 +485,7 @@ def test_errmsg_requirements_1(concretize_scope, test_repo):
         concretize_one("w4@:2.0 ^w3@2.1")
 
 
-def test_errmsg_requirements_cfg(concretize_scope, test_repo):
+def test_errmsg_requirements_cfg(concretize_scope, test_repo, mutable_config):
     conf_str = """\
 packages:
   w2:
@@ -494,7 +493,7 @@ packages:
     - one_of: ["~v1"]
       when: "@2.0"
 """
-    update_packages_config(conf_str)
+    update_packages_config(conf_str, mutable_config)
 
     important_points = [
         r"~v1 is a requirement for package w2 when @2.0",
@@ -525,7 +524,7 @@ def test_errmsg_requirements_directives(concretize_scope, test_repo):
 
 # Simulates a user error: package is specified as external with a version,
 # but a different version was required in config.
-def test_errmsg_requirements_external_mismatch(concretize_scope, test_repo):
+def test_errmsg_requirements_external_mismatch(concretize_scope, test_repo, mutable_config):
     conf_str = """\
 packages:
   t1:
@@ -536,7 +535,7 @@ packages:
     require:
     - spec: "t1@2.0"
 """
-    update_packages_config(conf_str)
+    update_packages_config(conf_str, mutable_config)
 
     important_points = ["no externals satisfy the request"]
 
@@ -545,9 +544,11 @@ packages:
 
 
 @pytest.mark.parametrize("section", ["prefer", "require"])
-def test_warns_on_compiler_constraint_in_all(concretize_scope, mock_packages, section):
+def test_warns_on_compiler_constraint_in_all(
+    concretize_scope, mock_packages, section, mutable_config
+):
     """Compiler constraints under packages:all: are a footgun and should warn."""
-    update_packages_config(f"packages:\n  all:\n    {section}:\n    - '%c=gcc'\n")
+    update_packages_config(f"packages:\n  all:\n    {section}:\n    - '%c=gcc'\n", mutable_config)
     with pytest.warns(UserWarning, match="packages: all:"):
         concretize_one("gmake")
 
@@ -564,7 +565,7 @@ def test_unknown_concrete_target_in_input_spec(concretize_scope, test_repo):
 
 
 @pytest.mark.regression("52209")
-def test_require_single_unknown_target_errors(concretize_scope, test_repo):
+def test_require_single_unknown_target_errors(concretize_scope, test_repo, mutable_config):
     """Tests that a single-option require with an unknown target raises a clear error."""
     target_str = "target=not-a-real-uarch"
     update_packages_config(
@@ -572,7 +573,8 @@ def test_require_single_unknown_target_errors(concretize_scope, test_repo):
 packages:
   x4:
     require: {target_str}
-"""
+""",
+        mutable_config,
     )
     with pytest.raises(spack.error.SpackError) as exc_info:
         concretize_one("x4")
@@ -580,7 +582,7 @@ packages:
 
 
 @pytest.mark.regression("52209")
-def test_require_all_unknown_targets_errors(concretize_scope, test_repo):
+def test_require_all_unknown_targets_errors(concretize_scope, test_repo, mutable_config):
     """Tests that a group where every option has an unknown target also raises a clear error."""
     update_packages_config(
         """\
@@ -588,7 +590,8 @@ packages:
   x4:
     require:
     - any_of: ["target=not-a-real-uarch", "target=also-fake"]
-"""
+""",
+        mutable_config,
     )
     with pytest.raises(spack.error.SpackError) as exc_info:
         concretize_one("x4")
@@ -602,7 +605,7 @@ packages:
 @pytest.mark.skipif(
     str(spack.vendor.archspec.cpu.host().family) != "x86_64", reason="test assumes x86_64 uarchs"
 )
-def test_require_mixed_unknown_and_valid_target_warns(concretize_scope, test_repo):
+def test_require_mixed_unknown_and_valid_target_warns(concretize_scope, test_repo, mutable_config):
     """Tests that a "require" group with at least one valid option just warns."""
     update_packages_config(
         """\
@@ -610,21 +613,23 @@ packages:
   x4:
     require:
     - one_of: ["target=not-a-real-uarch", "target=x86_64"]
-"""
+""",
+        mutable_config,
     )
     with pytest.warns(UserWarning, match="not-a-real-uarch"):
         concretize_one("x4")
 
 
 @pytest.mark.regression("52209")
-def test_prefer_unknown_target_warns(concretize_scope, test_repo):
+def test_prefer_unknown_target_warns(concretize_scope, test_repo, mutable_config):
     """A preference with an unknown target has the @: fallback, so it only warns."""
     update_packages_config(
         """\
 packages:
   x4:
     prefer: ["target=not-a-real-uarch"]
-"""
+""",
+        mutable_config,
     )
     with pytest.warns(UserWarning, match="not-a-real-uarch"):
         concretize_one("x4")

--- a/lib/spack/spack/test/error_messages.py
+++ b/lib/spack/spack/test/error_messages.py
@@ -17,12 +17,13 @@ import spack.repo
 import spack.util.file_cache
 import spack.util.spack_yaml as syaml
 from spack.concretize import concretize_one
+from spack.config import Configuration
 from spack.main import SpackCommand
 
 solve = SpackCommand("solve")
 
 
-def update_packages_config(conf_str, config):
+def update_packages_config(conf_str, config: Configuration):
     conf = syaml.load_config(conf_str)
     config.set("packages", conf["packages"], scope="concretize")
 
@@ -485,7 +486,7 @@ def test_errmsg_requirements_1(concretize_scope, test_repo):
         concretize_one("w4@:2.0 ^w3@2.1")
 
 
-def test_errmsg_requirements_cfg(concretize_scope, test_repo, mutable_config):
+def test_errmsg_requirements_cfg(concretize_scope, test_repo, mutable_config: Configuration):
     conf_str = """\
 packages:
   w2:
@@ -524,7 +525,9 @@ def test_errmsg_requirements_directives(concretize_scope, test_repo):
 
 # Simulates a user error: package is specified as external with a version,
 # but a different version was required in config.
-def test_errmsg_requirements_external_mismatch(concretize_scope, test_repo, mutable_config):
+def test_errmsg_requirements_external_mismatch(
+    concretize_scope, test_repo, mutable_config: Configuration
+):
     conf_str = """\
 packages:
   t1:
@@ -545,7 +548,7 @@ packages:
 
 @pytest.mark.parametrize("section", ["prefer", "require"])
 def test_warns_on_compiler_constraint_in_all(
-    concretize_scope, mock_packages, section, mutable_config
+    concretize_scope, mock_packages, section, mutable_config: Configuration
 ):
     """Compiler constraints under packages:all: are a footgun and should warn."""
     update_packages_config(f"packages:\n  all:\n    {section}:\n    - '%c=gcc'\n", mutable_config)
@@ -565,7 +568,9 @@ def test_unknown_concrete_target_in_input_spec(concretize_scope, test_repo):
 
 
 @pytest.mark.regression("52209")
-def test_require_single_unknown_target_errors(concretize_scope, test_repo, mutable_config):
+def test_require_single_unknown_target_errors(
+    concretize_scope, test_repo, mutable_config: Configuration
+):
     """Tests that a single-option require with an unknown target raises a clear error."""
     target_str = "target=not-a-real-uarch"
     update_packages_config(
@@ -582,7 +587,9 @@ packages:
 
 
 @pytest.mark.regression("52209")
-def test_require_all_unknown_targets_errors(concretize_scope, test_repo, mutable_config):
+def test_require_all_unknown_targets_errors(
+    concretize_scope, test_repo, mutable_config: Configuration
+):
     """Tests that a group where every option has an unknown target also raises a clear error."""
     update_packages_config(
         """\
@@ -605,7 +612,9 @@ packages:
 @pytest.mark.skipif(
     str(spack.vendor.archspec.cpu.host().family) != "x86_64", reason="test assumes x86_64 uarchs"
 )
-def test_require_mixed_unknown_and_valid_target_warns(concretize_scope, test_repo, mutable_config):
+def test_require_mixed_unknown_and_valid_target_warns(
+    concretize_scope, test_repo, mutable_config: Configuration
+):
     """Tests that a "require" group with at least one valid option just warns."""
     update_packages_config(
         """\
@@ -621,7 +630,7 @@ packages:
 
 
 @pytest.mark.regression("52209")
-def test_prefer_unknown_target_warns(concretize_scope, test_repo, mutable_config):
+def test_prefer_unknown_target_warns(concretize_scope, test_repo, mutable_config: Configuration):
     """A preference with an unknown target has the @: fallback, so it only warns."""
     update_packages_config(
         """\

--- a/lib/spack/spack/test/error_messages.py
+++ b/lib/spack/spack/test/error_messages.py
@@ -25,7 +25,7 @@ solve = SpackCommand("solve")
 
 def update_packages_config(conf_str):
     conf = syaml.load_config(conf_str)
-    spack.config.set("packages", conf["packages"], scope="concretize")
+    spack.config.CONFIG.set("packages", conf["packages"], scope="concretize")
 
 
 _pkgx1 = (

--- a/lib/spack/spack/test/externals.py
+++ b/lib/spack/spack/test/externals.py
@@ -10,6 +10,7 @@ from spack.vendor.archspec.cpu import TARGETS
 import spack.archspec
 import spack.traverse
 from spack.compilers.config import CompilerFactory
+from spack.config import Configuration
 from spack.externals import (
     DuplicateExternalError,
     ExternalDict,
@@ -376,7 +377,7 @@ def test_external_spec_multi_valued_variant_is_not_changed():
 
 
 @pytest.mark.regression("52643")
-def test_external_compiler_with_non_compiler_dependency(mutable_config):
+def test_external_compiler_with_non_compiler_dependency(mutable_config: Configuration):
     packages_config = {
         "compiler-with-deps": {
             "externals": [

--- a/lib/spack/spack/test/externals.py
+++ b/lib/spack/spack/test/externals.py
@@ -20,7 +20,7 @@ from spack.externals import (
     complete_variants_and_architecture,
 )
 
-pytestmark = pytest.mark.usefixtures("config", "mock_packages")
+pytestmark = pytest.mark.usefixtures("mock_packages")
 
 
 @pytest.mark.parametrize(
@@ -59,7 +59,7 @@ pytestmark = pytest.mark.usefixtures("config", "mock_packages")
         ),
     ],
 )
-def test_basic_parsing(externals_dict, expected_length, expected_queries):
+def test_basic_parsing(config, externals_dict, expected_length, expected_queries):
     """Tests parsing external specs, in some basic cases"""
     parser = ExternalSpecsParser(externals_dict)
 
@@ -91,7 +91,7 @@ def test_basic_parsing(externals_dict, expected_length, expected_queries):
     ],
 )
 def test_external_specs_architecture_completion(
-    externals_dict: List[ExternalDict], expected_triplet, monkeypatch
+    config, externals_dict: List[ExternalDict], expected_triplet, monkeypatch
 ):
     """Tests the completion of external specs architectures when using the default behavior"""
     monkeypatch.setattr(spack.archspec, "HOST_TARGET_FAMILY", TARGETS["aarch64"])
@@ -106,7 +106,7 @@ def test_external_specs_architecture_completion(
         assert node.target == expected_target
 
 
-def test_external_specs_parser_with_missing_packages():
+def test_external_specs_parser_with_missing_packages(config):
     """Tests the parsing of external specs when some packages are missing"""
     externals_dict: List[ExternalDict] = [
         {"spec": "gmake@1.0", "prefix": "/path/to/gmake1"},
@@ -125,7 +125,7 @@ def test_external_specs_parser_with_missing_packages():
         ExternalSpecsParser(externals_dict, allow_nonexisting=False)
 
 
-def test_externals_with_duplicate_id():
+def test_externals_with_duplicate_id(config):
     """Tests the parsing of external specs when some specs have the same id"""
     externals_dict: List[ExternalDict] = [
         {"spec": "gmake@1.0", "prefix": "/path/to/gmake1", "id": "gmake"},
@@ -266,7 +266,9 @@ def test_externals_with_duplicate_id():
         ),
     ],
 )
-def test_externals_with_dependencies(externals_dicts: List[ExternalDict], expected, not_expected):
+def test_externals_with_dependencies(
+    config, externals_dicts: List[ExternalDict], expected, not_expected
+):
     """Tests constructing externals with dependencies"""
     parser = ExternalSpecsParser(externals_dicts)
 
@@ -293,7 +295,7 @@ def test_externals_with_dependencies(externals_dicts: List[ExternalDict], expect
     ],
 )
 def test_externals_without_concrete_version(
-    externals_dicts: List[ExternalDict], expected_length, not_expected
+    config, externals_dicts: List[ExternalDict], expected_length, not_expected
 ):
     """Tests parsing externals, when some dicts are malformed and don't have a concrete version"""
     parser = ExternalSpecsParser(externals_dicts)
@@ -322,7 +324,7 @@ def test_externals_without_concrete_version(
     ],
 )
 def test_external_node_completion(
-    externals_dict: List[ExternalDict], completion_fn, expected, not_expected
+    config, externals_dict: List[ExternalDict], completion_fn, expected, not_expected
 ):
     """Tests the completion of external specs with different node completion"""
     parser = ExternalSpecsParser(externals_dict, complete_node=completion_fn)
@@ -345,7 +347,7 @@ def test_external_node_completion(
 
 
 @pytest.mark.regression("52179")
-def test_external_spec_single_valued_variant_type_is_corrected():
+def test_external_spec_single_valued_variant_type_is_corrected(config):
     """Tests that an external spec string including a single-valued variant is parsed correctly."""
     externals_dict = [
         {"spec": "dual-cmake-autotools@1.0 build_system=autotools", "prefix": "/usr/dual"}
@@ -364,7 +366,7 @@ def test_external_spec_single_valued_variant_type_is_corrected():
 
 
 @pytest.mark.regression("52179")
-def test_external_spec_multi_valued_variant_is_not_changed():
+def test_external_spec_multi_valued_variant_is_not_changed(config):
     """Tests that multi-valued variants in external specs are preserved as they are, even if the
     definition in package.py says otherwise.
     """

--- a/lib/spack/spack/test/externals.py
+++ b/lib/spack/spack/test/externals.py
@@ -377,7 +377,7 @@ def test_external_spec_multi_valued_variant_is_not_changed():
 
 
 @pytest.mark.regression("52643")
-def test_external_compiler_with_non_compiler_dependency():
+def test_external_compiler_with_non_compiler_dependency(mutable_config):
     packages_config = {
         "compiler-with-deps": {
             "externals": [
@@ -399,7 +399,7 @@ def test_external_compiler_with_non_compiler_dependency():
             "externals": [{"spec": "binutils-for-test@1", "prefix": "/usr", "id": "bin_id"}]
         },
     }
-    with spack.config.CONFIG.override("packages", packages_config) as cfg:
+    with mutable_config.override("packages", packages_config) as cfg:
         valid_compilers = CompilerFactory.from_packages_yaml(cfg)
         for c in valid_compilers:
             if c.name == "compiler-with-deps":

--- a/lib/spack/spack/test/externals.py
+++ b/lib/spack/spack/test/externals.py
@@ -8,7 +8,6 @@ import pytest
 from spack.vendor.archspec.cpu import TARGETS
 
 import spack.archspec
-import spack.config
 import spack.traverse
 from spack.compilers.config import CompilerFactory
 from spack.externals import (

--- a/lib/spack/spack/test/externals.py
+++ b/lib/spack/spack/test/externals.py
@@ -8,9 +8,9 @@ import pytest
 from spack.vendor.archspec.cpu import TARGETS
 
 import spack.archspec
+import spack.config
 import spack.traverse
 from spack.compilers.config import CompilerFactory
-from spack.config import override
 from spack.externals import (
     DuplicateExternalError,
     ExternalDict,
@@ -399,7 +399,7 @@ def test_external_compiler_with_non_compiler_dependency():
             "externals": [{"spec": "binutils-for-test@1", "prefix": "/usr", "id": "bin_id"}]
         },
     }
-    with override("packages", packages_config) as cfg:
+    with spack.config.CONFIG.override("packages", packages_config) as cfg:
         valid_compilers = CompilerFactory.from_packages_yaml(cfg)
         for c in valid_compilers:
             if c.name == "compiler-with-deps":

--- a/lib/spack/spack/test/git_fetch.py
+++ b/lib/spack/spack/test/git_fetch.py
@@ -15,7 +15,6 @@ import spack.error
 import spack.fetch_strategy
 import spack.package_base
 import spack.platforms
-import spack.repo
 import spack.util.git
 from spack.fetch_strategy import GitFetchStrategy
 from spack.package_base import PackageBase
@@ -103,7 +102,7 @@ def test_fetch(
     t = mock_git_repository.checks[type_of_test]
     h = mock_git_repository.hash
 
-    pkg_class = spack.repo.PATH.get_pkg_class("git-test")
+    pkg_class = mutable_mock_repo.get_pkg_class("git-test")
     # This would fail using the default-no-per-version-git check but that
     # isn't included in this test
     monkeypatch.delattr(pkg_class, "git")
@@ -153,7 +152,7 @@ def test_fetch_pkg_attr_submodule_init(
     """
 
     t = mock_git_repository.checks["default-no-per-version-git"]
-    pkg_class = spack.repo.PATH.get_pkg_class("git-test")
+    pkg_class = mutable_mock_repo.get_pkg_class("git-test")
     # For this test, the version args don't specify 'git' (which is
     # the majority of version specifications)
     monkeypatch.setattr(pkg_class, "git", mock_git_repository.url)
@@ -190,7 +189,7 @@ def test_adhoc_version_submodules(
 ):
     t = mock_git_repository.checks["tag"]
     # Construct the package under test
-    pkg_class = spack.repo.PATH.get_pkg_class("git-test")
+    pkg_class = mutable_mock_repo.get_pkg_class("git-test")
     monkeypatch.setitem(pkg_class.versions, Version("git"), t.args)
     monkeypatch.setattr(pkg_class, "git", mock_git_repository.url, raising=False)
 

--- a/lib/spack/spack/test/git_fetch.py
+++ b/lib/spack/spack/test/git_fetch.py
@@ -10,7 +10,6 @@ import shutil
 import pytest
 
 import spack.concretize
-import spack.config
 import spack.error
 import spack.fetch_strategy
 import spack.package_base
@@ -116,7 +115,7 @@ def test_fetch(
 
     # Enter the stage directory and check some properties
     with s.package.stage:
-        with spack.config.override("config:verify_ssl", secure):
+        with config.override("config:verify_ssl", secure):
             s.package.do_stage()
 
         with working_dir(s.package.stage.source_path):
@@ -216,7 +215,7 @@ def test_debug_fetch(mock_packages, type_of_test, mock_git_repository, config, m
 
     # Fetch then ensure source path exists
     with s.package.stage:
-        with spack.config.override("config:debug", True):
+        with config.override("config:debug", True):
             s.package.do_fetch()
             assert os.path.isdir(s.package.stage.source_path)
 
@@ -283,7 +282,7 @@ def test_get_full_repo(
             git_exe("-C", path, "config", "uploadpack.allowReachableSHA1InWant", "true")
 
     with s.package.stage:
-        with spack.config.override("config:verify_ssl", secure):
+        with config.override("config:verify_ssl", secure):
             s.package.do_stage()
             with working_dir(s.package.stage.source_path):
                 branches = mock_git_repository.git_exe("branch", "-a", output=str).splitlines()

--- a/lib/spack/spack/test/git_fetch.py
+++ b/lib/spack/spack/test/git_fetch.py
@@ -15,8 +15,10 @@ import spack.fetch_strategy
 import spack.package_base
 import spack.platforms
 import spack.util.git
+from spack.config import Configuration
 from spack.fetch_strategy import GitFetchStrategy
 from spack.package_base import PackageBase
+from spack.repo import RepoPath
 from spack.spec import Spec
 from spack.stage import Stage
 from spack.util.filesystem import mkdirp, touch, working_dir
@@ -83,8 +85,8 @@ def test_fetch(
     type_of_test,
     secure,
     mock_git_repository,
-    config,
-    mutable_mock_repo,
+    config: Configuration,
+    mutable_mock_repo: RepoPath,
     git_version,
     monkeypatch,
 ):
@@ -142,7 +144,7 @@ def test_fetch(
 
 @pytest.mark.disable_clean_stage_check
 def test_fetch_pkg_attr_submodule_init(
-    mock_git_repository, config, mutable_mock_repo, monkeypatch, mock_stage
+    mock_git_repository, config, mutable_mock_repo: RepoPath, monkeypatch, mock_stage
 ):
     """In this case the version() args do not contain a 'git' URL, so
     the fetcher must be assembled using the Package-level 'git' attribute.
@@ -181,7 +183,7 @@ def test_fetch_pkg_attr_submodule_init(
 def test_adhoc_version_submodules(
     mock_git_repository,
     config,
-    mutable_mock_repo,
+    mutable_mock_repo: RepoPath,
     monkeypatch,
     mock_stage,
     override_git_repos_cache_path,
@@ -204,7 +206,9 @@ def test_adhoc_version_submodules(
 
 
 @pytest.mark.parametrize("type_of_test", ["branch", "commit"])
-def test_debug_fetch(mock_packages, type_of_test, mock_git_repository, config, monkeypatch):
+def test_debug_fetch(
+    mock_packages, type_of_test, mock_git_repository, config: Configuration, monkeypatch
+):
     """Fetch the repo with debug enabled."""
     # Retrieve the right test parameters
     t = mock_git_repository.checks[type_of_test]
@@ -247,7 +251,7 @@ def test_get_full_repo(
     use_commit,
     git_version,
     mock_git_repository,
-    config,
+    config: Configuration,
     mutable_mock_repo,
     monkeypatch,
 ):

--- a/lib/spack/spack/test/hg_fetch.py
+++ b/lib/spack/spack/test/hg_fetch.py
@@ -8,6 +8,7 @@ import pathlib
 import pytest
 
 import spack.concretize
+from spack.config import Configuration
 from spack.fetch_strategy import HgFetchStrategy
 from spack.stage import Stage
 from spack.util.executable import which
@@ -24,7 +25,9 @@ pytestmark = [
 
 @pytest.mark.parametrize("type_of_test", ["default", "rev0"])
 @pytest.mark.parametrize("secure", [True, False])
-def test_fetch(type_of_test, secure, mock_hg_repository, config, mutable_mock_repo, monkeypatch):
+def test_fetch(
+    type_of_test, secure, mock_hg_repository, config: Configuration, mutable_mock_repo, monkeypatch
+):
     """Tries to:
 
     1. Fetch the repo using a fetch strategy constructed with

--- a/lib/spack/spack/test/hg_fetch.py
+++ b/lib/spack/spack/test/hg_fetch.py
@@ -8,7 +8,6 @@ import pathlib
 import pytest
 
 import spack.concretize
-import spack.config
 from spack.fetch_strategy import HgFetchStrategy
 from spack.stage import Stage
 from spack.util.executable import which
@@ -45,7 +44,7 @@ def test_fetch(type_of_test, secure, mock_hg_repository, config, mutable_mock_re
 
     # Enter the stage directory and check some properties
     with s.package.stage:
-        with spack.config.override("config:verify_ssl", secure):
+        with config.override("config:verify_ssl", secure):
             s.package.do_stage()
 
         with working_dir(s.package.stage.source_path):

--- a/lib/spack/spack/test/install.py
+++ b/lib/spack/spack/test/install.py
@@ -540,7 +540,7 @@ def test_log_install_with_build_files(install_mockery, monkeypatch):
 def test_unconcretized_install(install_mockery, mock_fetch, mock_packages):
     """Test attempts to perform install phases with unconcretized spec."""
     spec = Spec("trivial-install-test-package")
-    pkg_cls = spack.repo.PATH.get_pkg_class(spec.name)
+    pkg_cls = mock_packages.get_pkg_class(spec.name)
 
     with pytest.raises(ValueError, match="must have a concrete spec"):
         PackageInstaller([pkg_cls(spec)], explicit=True).install()

--- a/lib/spack/spack/test/install.py
+++ b/lib/spack/spack/test/install.py
@@ -44,23 +44,23 @@ def find_nothing(*args):
     raise spack.repo.UnknownPackageError("Repo package access is disabled for test")
 
 
-def test_install_and_uninstall(install_mockery, mock_fetch, monkeypatch):
+def test_install_and_uninstall(temporary_store, install_mockery, mock_fetch, monkeypatch):
     spec = spack.concretize.concretize_one("trivial-install-test-package")
 
     PackageInstaller([spec.package], explicit=True).install()
-    assert spack.store.STORE.db.installed(spec)
+    assert temporary_store.db.installed(spec)
 
     spec.package.do_uninstall()
-    assert not spack.store.STORE.db.installed(spec)
+    assert not temporary_store.db.installed(spec)
 
 
 @pytest.mark.regression("11870")
-def test_uninstall_non_existing_package(install_mockery, mock_fetch, monkeypatch):
+def test_uninstall_non_existing_package(temporary_store, install_mockery, mock_fetch, monkeypatch):
     """Ensure that we can uninstall a package that has been deleted from the repo"""
     spec = spack.concretize.concretize_one("trivial-install-test-package")
 
     PackageInstaller([spec.package], explicit=True).install()
-    assert spack.store.STORE.db.installed(spec)
+    assert temporary_store.db.installed(spec)
 
     # Mock deletion of the package
     spec._package = None
@@ -70,7 +70,7 @@ def test_uninstall_non_existing_package(install_mockery, mock_fetch, monkeypatch
 
     # Ensure we can uninstall it
     PackageBase.uninstall_by_spec(spec)
-    assert not spack.store.STORE.db.installed(spec)
+    assert not temporary_store.db.installed(spec)
 
 
 def test_pkg_attributes(install_mockery, mock_fetch, monkeypatch):
@@ -129,7 +129,9 @@ class RemovePrefixChecker:
         self.wrapped_rm_prefix()
 
 
-def test_partial_install_delete_prefix_and_stage(install_mockery, mock_fetch, working_env):
+def test_partial_install_delete_prefix_and_stage(
+    temporary_store, install_mockery, mock_fetch, working_env
+):
     s = spack.concretize.concretize_one("canfail")
     s.package.succeed = False
 
@@ -143,20 +145,20 @@ def test_partial_install_delete_prefix_and_stage(install_mockery, mock_fetch, wo
     s.package.remove_prefix = rm_prefix_checker.remove_prefix
 
     # must clear failure markings for the package before re-installing it
-    spack.store.STORE.failure_tracker.clear(s, True)
+    temporary_store.failure_tracker.clear(s, True)
 
     s.package.succeed = True
     spack.builder._BUILDERS.clear()  # the builder is cached with a copy of the pkg's __dict__.
 
     PackageInstaller([s.package], explicit=True, restage=True).install()
     assert rm_prefix_checker.removed
-    assert spack.store.STORE.db.installed(s.package.spec)
+    assert temporary_store.db.installed(s.package.spec)
 
 
 @pytest.mark.not_on_windows("Fails spuriously on Windows")
 @pytest.mark.disable_clean_stage_check
 def test_failing_overwrite_install_should_keep_previous_installation(
-    mock_fetch, install_mockery, working_env
+    mock_fetch, temporary_store, install_mockery, working_env
 ):
     """
     Make sure that whenever `spack install --overwrite` fails, spack restores
@@ -175,7 +177,7 @@ def test_failing_overwrite_install_should_keep_previous_installation(
     with pytest.raises(Exception):
         PackageInstaller([s.package], explicit=True, **kwargs).install()
 
-    assert spack.store.STORE.db.installed(s.package.spec)
+    assert temporary_store.db.installed(s.package.spec)
     assert os.path.exists(s.prefix)
 
 
@@ -288,7 +290,9 @@ def test_installed_upstream(install_upstream, mock_fetch):
 
 
 @pytest.mark.disable_clean_stage_check
-def test_partial_install_keep_prefix(install_mockery, mock_fetch, monkeypatch, working_env):
+def test_partial_install_keep_prefix(
+    temporary_store, install_mockery, mock_fetch, monkeypatch, working_env
+):
     s = spack.concretize.concretize_one("canfail")
     s.package.succeed = False
 
@@ -299,21 +303,23 @@ def test_partial_install_keep_prefix(install_mockery, mock_fetch, monkeypatch, w
     assert os.path.exists(s.package.prefix)
 
     # must clear failure markings for the package before re-installing it
-    spack.store.STORE.failure_tracker.clear(s, True)
+    temporary_store.failure_tracker.clear(s, True)
 
     s.package.succeed = True
     spack.builder._BUILDERS.clear()  # the builder is cached with a copy of the pkg's __dict__.
     PackageInstaller([s.package], explicit=True, keep_prefix=True).install()
-    assert spack.store.STORE.db.installed(s.package.spec)
+    assert temporary_store.db.installed(s.package.spec)
 
 
-def test_second_install_no_overwrite_first(install_mockery, mock_fetch, monkeypatch):
+def test_second_install_no_overwrite_first(
+    temporary_store, install_mockery, mock_fetch, monkeypatch
+):
     s = spack.concretize.concretize_one("canfail")
     monkeypatch.setattr(spack.package_base.PackageBase, "remove_prefix", mock_remove_prefix)
 
     s.package.succeed = True
     PackageInstaller([s.package], explicit=True).install()
-    assert spack.store.STORE.db.installed(s.package.spec)
+    assert temporary_store.db.installed(s.package.spec)
 
     # If Package.install is called after this point, it will fail
     s.package.succeed = False
@@ -613,7 +619,9 @@ def test_install_from_binary_with_missing_patch_succeeds(
 
 
 @pytest.mark.parametrize("transitive", [True, False])
-def test_install_spliced(install_mockery, mock_fetch, monkeypatch, transitive, installer_variant):
+def test_install_spliced(
+    temporary_store, install_mockery, mock_fetch, monkeypatch, transitive, installer_variant
+):
     """Test installing a spliced spec"""
     spec = spack.concretize.concretize_one("splice-t")
     dep = spack.concretize.concretize_one("splice-h+foo")
@@ -625,13 +633,13 @@ def test_install_spliced(install_mockery, mock_fetch, monkeypatch, transitive, i
     )
     installer.install()
     for node in out.traverse():
-        assert spack.store.STORE.db.installed(node)
-        assert spack.store.STORE.db.installed(node.build_spec)
+        assert temporary_store.db.installed(node)
+        assert temporary_store.db.installed(node.build_spec)
 
 
 @pytest.mark.parametrize("transitive", [True, False])
 def test_install_spliced_build_spec_installed(
-    install_mockery, mock_fetch, transitive, installer_variant
+    temporary_store, install_mockery, mock_fetch, transitive, installer_variant
 ):
     """Test installing a spliced spec with the build spec already installed"""
     spec = spack.concretize.concretize_one("splice-t")
@@ -646,8 +654,8 @@ def test_install_spliced_build_spec_installed(
     )
     installer.install()
     for node in out.traverse():
-        assert spack.store.STORE.db.installed(node)
-        assert spack.store.STORE.db.installed(node.build_spec)
+        assert temporary_store.db.installed(node)
+        assert temporary_store.db.installed(node.build_spec)
 
 
 # Unit tests should not be affected by the user's managed environments
@@ -658,6 +666,7 @@ def test_install_spliced_build_spec_installed(
 )
 def test_install_splice_root_from_binary(
     mutable_mock_env_path,
+    temporary_store,
     install_mockery,
     mock_fetch,
     temporary_mirror,
@@ -691,7 +700,7 @@ def test_install_splice_root_from_binary(
 
     spack.installer_dispatch.create_installer([out.package], unsigned=True).install()
 
-    assert len(spack.store.STORE.db.query()) == len(list(out.traverse()))
+    assert len(temporary_store.db.query()) == len(list(out.traverse()))
 
 
 @pytest.mark.disable_clean_stage_check

--- a/lib/spack/spack/test/install.py
+++ b/lib/spack/spack/test/install.py
@@ -333,7 +333,7 @@ def test_install_prefix_collision_fails(config, mock_fetch, mock_packages, tmp_p
     """
     projections = {"projections": {"all": "one-prefix-per-package-{name}"}}
     with spack.store.use_store(str(tmp_path), extra_data=projections):
-        with spack.config.override("config:checksum", False):
+        with config.override("config:checksum", False):
             pkg_a = spack.concretize.concretize_one("libelf@0.8.13").package
             pkg_b = spack.concretize.concretize_one("libelf@0.8.12").package
             PackageInstaller([pkg_a], explicit=True, fake=True).install()

--- a/lib/spack/spack/test/install.py
+++ b/lib/spack/spack/test/install.py
@@ -26,6 +26,7 @@ import spack.store
 import spack.util.filesystem as fs
 import spack.util.spack_json as sjson
 from spack import binary_distribution
+from spack.config import Configuration
 from spack.error import InstallError
 from spack.main import SpackCommand
 from spack.old_installer import PackageInstaller
@@ -37,14 +38,16 @@ from spack.package_base import (
     _spack_configure_argsfile,
     spack_times_log,
 )
+from spack.repo import RepoPath
 from spack.spec import Spec
+from spack.store import Store
 
 
 def find_nothing(*args):
     raise spack.repo.UnknownPackageError("Repo package access is disabled for test")
 
 
-def test_install_and_uninstall(temporary_store, install_mockery, mock_fetch, monkeypatch):
+def test_install_and_uninstall(temporary_store: Store, install_mockery, mock_fetch, monkeypatch):
     spec = spack.concretize.concretize_one("trivial-install-test-package")
 
     PackageInstaller([spec.package], explicit=True).install()
@@ -55,7 +58,9 @@ def test_install_and_uninstall(temporary_store, install_mockery, mock_fetch, mon
 
 
 @pytest.mark.regression("11870")
-def test_uninstall_non_existing_package(temporary_store, install_mockery, mock_fetch, monkeypatch):
+def test_uninstall_non_existing_package(
+    temporary_store: Store, install_mockery, mock_fetch, monkeypatch
+):
     """Ensure that we can uninstall a package that has been deleted from the repo"""
     spec = spack.concretize.concretize_one("trivial-install-test-package")
 
@@ -130,7 +135,7 @@ class RemovePrefixChecker:
 
 
 def test_partial_install_delete_prefix_and_stage(
-    temporary_store, install_mockery, mock_fetch, working_env
+    temporary_store: Store, install_mockery, mock_fetch, working_env
 ):
     s = spack.concretize.concretize_one("canfail")
     s.package.succeed = False
@@ -291,7 +296,7 @@ def test_installed_upstream(install_upstream, mock_fetch):
 
 @pytest.mark.disable_clean_stage_check
 def test_partial_install_keep_prefix(
-    temporary_store, install_mockery, mock_fetch, monkeypatch, working_env
+    temporary_store: Store, install_mockery, mock_fetch, monkeypatch, working_env
 ):
     s = spack.concretize.concretize_one("canfail")
     s.package.succeed = False
@@ -312,7 +317,7 @@ def test_partial_install_keep_prefix(
 
 
 def test_second_install_no_overwrite_first(
-    temporary_store, install_mockery, mock_fetch, monkeypatch
+    temporary_store: Store, install_mockery, mock_fetch, monkeypatch
 ):
     s = spack.concretize.concretize_one("canfail")
     monkeypatch.setattr(spack.package_base.PackageBase, "remove_prefix", mock_remove_prefix)
@@ -326,7 +331,9 @@ def test_second_install_no_overwrite_first(
     PackageInstaller([s.package], explicit=True).install()
 
 
-def test_install_prefix_collision_fails(config, mock_fetch, mock_packages, tmp_path: pathlib.Path):
+def test_install_prefix_collision_fails(
+    config: Configuration, mock_fetch, mock_packages, tmp_path: pathlib.Path
+):
     """
     Test that different specs with coinciding install prefixes will fail
     to install.
@@ -537,7 +544,7 @@ def test_log_install_with_build_files(install_mockery, monkeypatch):
     shutil.rmtree(log_dir)
 
 
-def test_unconcretized_install(install_mockery, mock_fetch, mock_packages):
+def test_unconcretized_install(install_mockery, mock_fetch, mock_packages: RepoPath):
     """Test attempts to perform install phases with unconcretized spec."""
     spec = Spec("trivial-install-test-package")
     pkg_cls = mock_packages.get_pkg_class(spec.name)
@@ -620,7 +627,7 @@ def test_install_from_binary_with_missing_patch_succeeds(
 
 @pytest.mark.parametrize("transitive", [True, False])
 def test_install_spliced(
-    temporary_store, install_mockery, mock_fetch, monkeypatch, transitive, installer_variant
+    temporary_store: Store, install_mockery, mock_fetch, monkeypatch, transitive, installer_variant
 ):
     """Test installing a spliced spec"""
     spec = spack.concretize.concretize_one("splice-t")
@@ -639,7 +646,7 @@ def test_install_spliced(
 
 @pytest.mark.parametrize("transitive", [True, False])
 def test_install_spliced_build_spec_installed(
-    temporary_store, install_mockery, mock_fetch, transitive, installer_variant
+    temporary_store: Store, install_mockery, mock_fetch, transitive, installer_variant
 ):
     """Test installing a spliced spec with the build spec already installed"""
     spec = spack.concretize.concretize_one("splice-t")
@@ -666,7 +673,7 @@ def test_install_spliced_build_spec_installed(
 )
 def test_install_splice_root_from_binary(
     mutable_mock_env_path,
-    temporary_store,
+    temporary_store: Store,
     install_mockery,
     mock_fetch,
     temporary_mirror,

--- a/lib/spack/spack/test/installer/core.py
+++ b/lib/spack/spack/test/installer/core.py
@@ -10,9 +10,11 @@ import pytest
 
 import spack.error
 import spack.spec
+from spack.config import Configuration
 from spack.installer.base import ExitCode
 from spack.installer.core import PackageInstaller, read_connection, write_connection
 from spack.installer.ui import ChangeJobs, SetEcho
+from spack.store import Store
 from spack.test.installer.conftest import (
     DrivingUI,
     RecordingUI,
@@ -93,7 +95,7 @@ def test_build_failure_reported_through_event_loop(temporary_store, mock_package
 
 
 def test_cache_miss_falls_back_to_source_build(
-    temporary_store, mock_packages, mutable_config, tmp_path
+    temporary_store: Store, mock_packages, mutable_config: Configuration, tmp_path
 ):
     """With a binary mirror configured, the first attempt is cache_only; a cache miss removes the
     build from the UI, reschedules it as source_only, and the second attempt succeeds."""

--- a/lib/spack/spack/test/installer/core.py
+++ b/lib/spack/spack/test/installer/core.py
@@ -8,7 +8,6 @@ import sys
 
 import pytest
 
-import spack.config
 import spack.error
 import spack.spec
 from spack.installer.base import ExitCode
@@ -98,7 +97,9 @@ def test_cache_miss_falls_back_to_source_build(
 ):
     """With a binary mirror configured, the first attempt is cache_only; a cache miss removes the
     build from the UI, reschedules it as source_only, and the second attempt succeeds."""
-    spack.config.set("mirrors", {"local": {"url": (tmp_path / "mirror").as_uri(), "binary": True}})
+    mutable_config.set(
+        "mirrors", {"local": {"url": (tmp_path / "mirror").as_uri(), "binary": True}}
+    )
     spec = _make_concrete("trivial-install-test-package")
     launcher = ScriptedLauncher(
         {spec.name: [Script(exitcode=ExitCode.BUILD_CACHE_MISS), Script(exitcode=0)]}

--- a/lib/spack/spack/test/installer/schedule.py
+++ b/lib/spack/spack/test/installer/schedule.py
@@ -9,7 +9,6 @@ from typing import Dict, List, Optional, Set, Tuple
 
 import pytest
 
-import spack.config
 import spack.deptypes as dt
 import spack.error
 import spack.spec
@@ -1146,7 +1145,9 @@ class TestScheduleBuilds:
 def test_cache_miss_expands_build_deps(temporary_store, mock_packages, mutable_config, tmp_path):
     """A cache miss on a root with unexpanded build deps schedules those deps (growing the UI
     total) and retries the root as source_only."""
-    spack.config.set("mirrors", {"local": {"url": (tmp_path / "mirror").as_uri(), "binary": True}})
+    mutable_config.set(
+        "mirrors", {"local": {"url": (tmp_path / "mirror").as_uri(), "binary": True}}
+    )
     dep = _make_concrete("dependency-install")
     root = _make_concrete("dependent-install", deps=[dep], depflag=dt.BUILD)
     launcher = ScriptedLauncher(

--- a/lib/spack/spack/test/installer/schedule.py
+++ b/lib/spack/spack/test/installer/schedule.py
@@ -14,6 +14,7 @@ import spack.error
 import spack.spec
 import spack.store
 import spack.traverse
+from spack.config import Configuration
 from spack.database import Database
 from spack.installer.base import ExitCode, JobServerBase, NoopJobServer
 from spack.installer.schedule import BuildGraph, ScheduleResult, _node_to_roots, schedule_builds
@@ -1142,7 +1143,9 @@ class TestScheduleBuilds:
             _schedule([colliding.dag_hash()], _FakeBuildGraph([colliding]), temporary_store)
 
 
-def test_cache_miss_expands_build_deps(temporary_store, mock_packages, mutable_config, tmp_path):
+def test_cache_miss_expands_build_deps(
+    temporary_store: Store, mock_packages, mutable_config: Configuration, tmp_path
+):
     """A cache miss on a root with unexpanded build deps schedules those deps (growing the UI
     total) and retries the root as source_only."""
     mutable_config.set(

--- a/lib/spack/spack/test/main.py
+++ b/lib/spack/spack/test/main.py
@@ -243,12 +243,12 @@ packages:
     include_cfg = {"include": include_entries}
     filename = write_config_file("include", include_cfg, "low")
 
-    assert not spack.config.get("config:dirty")
+    assert not mock_low_high_config.get("config:dirty")
 
     spack.main.add_command_line_scopes(mock_low_high_config, [os.path.dirname(filename)])
 
-    assert spack.config.get("config:dirty")
-    python_reqs = spack.config.get("packages")["python"]["require"]
+    assert mock_low_high_config.get("config:dirty")
+    python_reqs = mock_low_high_config.get("packages")["python"]["require"]
     req_specs = {x["spec"] for x in python_reqs}
     assert req_specs == set(["@3.11:", "+ssl", "+tk"])
 
@@ -345,13 +345,13 @@ include:
 
 
 @pytest.mark.regression("52664")
-def test_env_substitution_via_main_entrypoint(mutable_mock_env_path):
+def test_env_substitution_via_main_entrypoint(mutable_mock_env_path, mutable_config):
     """Tests that an environment activated through the CLI entrypoint can substitute ``$env``"""
     env = ev.create("test")
-    assert spack.config.CONFIG.env_path is None
+    assert mutable_config.env_path is None
 
     # Just call a fast command
     spack.main._main(["-e", "test", "config", "scopes"])
 
-    assert spack.config.CONFIG.env_path == env.path
+    assert mutable_config.env_path == env.path
     assert spack.config.substitute_path_variables("$env/foo") == f"{env.path}/foo"

--- a/lib/spack/spack/test/main.py
+++ b/lib/spack/spack/test/main.py
@@ -21,6 +21,7 @@ import spack.util.filesystem as fs
 import spack.util.git
 import spack.util.spack_yaml as syaml
 from spack.active_environment import active_environment
+from spack.config import Configuration
 
 pytestmark = pytest.mark.not_on_windows(
     "Test functionality supported but tests are failing on Win"
@@ -345,7 +346,9 @@ include:
 
 
 @pytest.mark.regression("52664")
-def test_env_substitution_via_main_entrypoint(mutable_mock_env_path, mutable_config):
+def test_env_substitution_via_main_entrypoint(
+    mutable_mock_env_path, mutable_config: Configuration
+):
     """Tests that an environment activated through the CLI entrypoint can substitute ``$env``"""
     env = ev.create("test")
     assert mutable_config.env_path is None

--- a/lib/spack/spack/test/mirror.py
+++ b/lib/spack/spack/test/mirror.py
@@ -20,6 +20,7 @@ import spack.patch
 import spack.stage
 import spack.util.url as url_util
 from spack.cmd.common.arguments import mirror_name_or_url
+from spack.config import Configuration
 from spack.spec import Spec
 from spack.util.executable import which
 from spack.util.filesystem import resolve_link_target_relative_to_the_link, working_dir
@@ -61,7 +62,7 @@ def set_up_package(name, repository, url_attr, monkeypatch):
     monkeypatch.setitem(s.package.versions[v], url_attr, repository.url)
 
 
-def check_mirror(mutable_config):
+def check_mirror(mutable_config: Configuration):
     with spack.stage.Stage("spack-mirror-test") as stage:
         mirror_root = os.path.join(stage.path, "test-mirror")
         # register mirror with spack config
@@ -110,22 +111,22 @@ def check_mirror(mutable_config):
                         assert all(left in exclude for left in dcmp.left_only)
 
 
-def test_url_mirror(mock_archive, monkeypatch, mutable_config):
+def test_url_mirror(mock_archive, monkeypatch, mutable_config: Configuration):
     set_up_package("trivial-install-test-package", mock_archive, "url", monkeypatch)
     check_mirror(mutable_config)
 
 
-def test_git_mirror(git, mock_git_repository, monkeypatch, mutable_config):
+def test_git_mirror(git, mock_git_repository, monkeypatch, mutable_config: Configuration):
     set_up_package("git-test", mock_git_repository, "git", monkeypatch)
     check_mirror(mutable_config)
 
 
-def test_svn_mirror(mock_svn_repository, monkeypatch, mutable_config):
+def test_svn_mirror(mock_svn_repository, monkeypatch, mutable_config: Configuration):
     set_up_package("svn-test", mock_svn_repository, "svn", monkeypatch)
     check_mirror(mutable_config)
 
 
-def test_hg_mirror(mock_hg_repository, monkeypatch, mutable_config):
+def test_hg_mirror(mock_hg_repository, monkeypatch, mutable_config: Configuration):
     set_up_package("hg-test", mock_hg_repository, "hg", monkeypatch)
     check_mirror(mutable_config)
 
@@ -136,7 +137,7 @@ def test_all_mirror(
     mock_hg_repository,
     mock_archive,
     monkeypatch,
-    mutable_config,
+    mutable_config: Configuration,
 ):
     set_up_package("git-test", mock_git_repository, "git", monkeypatch)
     set_up_package("svn-test", mock_svn_repository, "svn", monkeypatch)
@@ -175,7 +176,7 @@ def test_mirror_archive_paths_no_version(mock_packages, mock_archive):
     spack.mirrors.layout.default_mirror_layout(fetcher, "per-package-ref", spec)
 
 
-def test_mirror_with_url_patches(mock_packages, monkeypatch, mutable_config):
+def test_mirror_with_url_patches(mock_packages, monkeypatch, mutable_config: Configuration):
     spec = spack.concretize.concretize_one("patch-several-dependencies")
     files_cached_in_mirror = set()
 

--- a/lib/spack/spack/test/mirror.py
+++ b/lib/spack/spack/test/mirror.py
@@ -171,7 +171,7 @@ def test_mirror_archive_paths_no_version(mock_packages, mock_archive):
     spack.mirrors.layout.default_mirror_layout(fetcher, "per-package-ref", spec)
 
 
-def test_mirror_with_url_patches(mock_packages, monkeypatch):
+def test_mirror_with_url_patches(mock_packages, monkeypatch, mutable_config):
     spec = spack.concretize.concretize_one("patch-several-dependencies")
     files_cached_in_mirror = set()
 
@@ -205,7 +205,7 @@ def test_mirror_with_url_patches(mock_packages, monkeypatch):
             spack.mirrors.layout.DefaultLayout, "make_alias", successful_make_alias
         )
 
-        with spack.config.override("config:checksum", False):
+        with mutable_config.override("config:checksum", False):
             spack.cmd.mirror.create(mirror_root, list(spec.traverse()))
 
         assert {

--- a/lib/spack/spack/test/mirror.py
+++ b/lib/spack/spack/test/mirror.py
@@ -67,8 +67,8 @@ def check_mirror():
         mirror_root = os.path.join(stage.path, "test-mirror")
         # register mirror with spack config
         mirrors = {"spack-mirror-test": url_util.path_to_file_url(mirror_root)}
-        with spack.config.override("mirrors", mirrors):
-            with spack.config.override("config:checksum", False):
+        with spack.config.CONFIG.override("mirrors", mirrors):
+            with spack.config.CONFIG.override("config:checksum", False):
                 specs = [spack.concretize.concretize_one(x) for x in repos]
                 spack.cmd.mirror.create(mirror_root, specs)
 
@@ -89,7 +89,7 @@ def check_mirror():
                 spec = spack.concretize.concretize_one(name)
                 pkg = spec.package
 
-                with spack.config.override("config:checksum", False):
+                with spack.config.CONFIG.override("config:checksum", False):
                     with pkg.stage:
                         pkg.do_stage(mirror_only=True)
 

--- a/lib/spack/spack/test/mirror.py
+++ b/lib/spack/spack/test/mirror.py
@@ -12,7 +12,6 @@ import pytest
 import spack.caches
 import spack.cmd.mirror
 import spack.concretize
-import spack.config
 import spack.fetch_strategy
 import spack.mirrors.layout
 import spack.mirrors.mirror
@@ -62,13 +61,13 @@ def set_up_package(name, repository, url_attr, monkeypatch):
     monkeypatch.setitem(s.package.versions[v], url_attr, repository.url)
 
 
-def check_mirror():
+def check_mirror(mutable_config):
     with spack.stage.Stage("spack-mirror-test") as stage:
         mirror_root = os.path.join(stage.path, "test-mirror")
         # register mirror with spack config
         mirrors = {"spack-mirror-test": url_util.path_to_file_url(mirror_root)}
-        with spack.config.CONFIG.override("mirrors", mirrors):
-            with spack.config.CONFIG.override("config:checksum", False):
+        with mutable_config.override("mirrors", mirrors):
+            with mutable_config.override("config:checksum", False):
                 specs = [spack.concretize.concretize_one(x) for x in repos]
                 spack.cmd.mirror.create(mirror_root, specs)
 
@@ -89,7 +88,7 @@ def check_mirror():
                 spec = spack.concretize.concretize_one(name)
                 pkg = spec.package
 
-                with spack.config.CONFIG.override("config:checksum", False):
+                with mutable_config.override("config:checksum", False):
                     with pkg.stage:
                         pkg.do_stage(mirror_only=True)
 
@@ -111,34 +110,39 @@ def check_mirror():
                         assert all(left in exclude for left in dcmp.left_only)
 
 
-def test_url_mirror(mock_archive, monkeypatch):
+def test_url_mirror(mock_archive, monkeypatch, mutable_config):
     set_up_package("trivial-install-test-package", mock_archive, "url", monkeypatch)
-    check_mirror()
+    check_mirror(mutable_config)
 
 
-def test_git_mirror(git, mock_git_repository, monkeypatch):
+def test_git_mirror(git, mock_git_repository, monkeypatch, mutable_config):
     set_up_package("git-test", mock_git_repository, "git", monkeypatch)
-    check_mirror()
+    check_mirror(mutable_config)
 
 
-def test_svn_mirror(mock_svn_repository, monkeypatch):
+def test_svn_mirror(mock_svn_repository, monkeypatch, mutable_config):
     set_up_package("svn-test", mock_svn_repository, "svn", monkeypatch)
-    check_mirror()
+    check_mirror(mutable_config)
 
 
-def test_hg_mirror(mock_hg_repository, monkeypatch):
+def test_hg_mirror(mock_hg_repository, monkeypatch, mutable_config):
     set_up_package("hg-test", mock_hg_repository, "hg", monkeypatch)
-    check_mirror()
+    check_mirror(mutable_config)
 
 
 def test_all_mirror(
-    mock_git_repository, mock_svn_repository, mock_hg_repository, mock_archive, monkeypatch
+    mock_git_repository,
+    mock_svn_repository,
+    mock_hg_repository,
+    mock_archive,
+    monkeypatch,
+    mutable_config,
 ):
     set_up_package("git-test", mock_git_repository, "git", monkeypatch)
     set_up_package("svn-test", mock_svn_repository, "svn", monkeypatch)
     set_up_package("hg-test", mock_hg_repository, "hg", monkeypatch)
     set_up_package("trivial-install-test-package", mock_archive, "url", monkeypatch)
-    check_mirror()
+    check_mirror(mutable_config)
 
 
 @pytest.mark.parametrize(

--- a/lib/spack/spack/test/modules/common.py
+++ b/lib/spack/spack/test/modules/common.py
@@ -17,6 +17,7 @@ import spack.package_base
 import spack.package_prefs
 import spack.repo
 import spack.store
+from spack.config import Configuration
 from spack.modules.common import UpstreamModuleIndex
 from spack.old_installer import PackageInstaller
 from spack.util.filesystem import readlink
@@ -198,7 +199,7 @@ def test_load_installed_package_not_in_repo(install_mockery, mock_fetch, monkeyp
 
 
 @pytest.mark.regression("37649")
-def test_check_module_set_name(mutable_config):
+def test_check_module_set_name(mutable_config: Configuration):
     """Tests that modules set name are validated correctly and an error is reported if the
     name we require does not exist or is reserved by the configuration."""
     # Minimal modules.yaml config.

--- a/lib/spack/spack/test/modules/common.py
+++ b/lib/spack/spack/test/modules/common.py
@@ -9,7 +9,6 @@ import pytest
 
 import spack.cmd.modules
 import spack.concretize
-import spack.config
 import spack.error
 import spack.modules
 import spack.modules.common
@@ -203,7 +202,7 @@ def test_check_module_set_name(mutable_config):
     """Tests that modules set name are validated correctly and an error is reported if the
     name we require does not exist or is reserved by the configuration."""
     # Minimal modules.yaml config.
-    spack.config.set(
+    mutable_config.set(
         "modules",
         {
             "prefix_inspections": {"./bin": ["PATH"]},

--- a/lib/spack/spack/test/modules/lmod.py
+++ b/lib/spack/spack/test/modules/lmod.py
@@ -406,7 +406,7 @@ class TestLmod:
         def no_op_set(*args, **kwargs):
             pass
 
-        monkeypatch.setattr(spack.config, "set", no_op_set)
+        monkeypatch.setattr(spack.config.Configuration, "set", no_op_set)
 
         # Assert we have core compilers now
         writer, _ = factory(mpileaks_spec_string)

--- a/lib/spack/spack/test/modules/lmod.py
+++ b/lib/spack/spack/test/modules/lmod.py
@@ -17,6 +17,7 @@ import spack.modules.error
 import spack.modules.lmod
 import spack.spec
 import spack.util.environment
+from spack.config import Configuration
 
 mpich_spec_string = "mpich@3.0.4"
 mpileaks_spec_string = "mpileaks"
@@ -135,7 +136,7 @@ class TestLmod:
             assert repetitions == 1
 
     def test_compilers_provided_different_name(
-        self, factory, module_configuration, compiler_factory, mutable_config
+        self, factory, module_configuration, compiler_factory, mutable_config: Configuration
     ):
         with mutable_config.override(
             "packages", {"llvm": {"externals": [compiler_factory(spec="llvm@3.3 +clang")]}}

--- a/lib/spack/spack/test/modules/lmod.py
+++ b/lib/spack/spack/test/modules/lmod.py
@@ -135,9 +135,9 @@ class TestLmod:
             assert repetitions == 1
 
     def test_compilers_provided_different_name(
-        self, factory, module_configuration, compiler_factory
+        self, factory, module_configuration, compiler_factory, mutable_config
     ):
-        with spack.config.override(
+        with mutable_config.override(
             "packages", {"llvm": {"externals": [compiler_factory(spec="llvm@3.3 +clang")]}}
         ):
             module_configuration("complex_hierarchy")

--- a/lib/spack/spack/test/modules/tcl.py
+++ b/lib/spack/spack/test/modules/tcl.py
@@ -15,6 +15,7 @@ import spack.modules.error
 import spack.modules.tcl
 import spack.spec
 import spack.util.environment
+from spack.config import Configuration
 
 mpich_spec_string = "mpich@3.0.4"
 mpileaks_spec_string = "mpileaks"
@@ -678,7 +679,7 @@ class TestTcl:
             assert repetitions == 1
 
     def test_compilers_provided_different_name(
-        self, factory, module_configuration, compiler_factory, mutable_config
+        self, factory, module_configuration, compiler_factory, mutable_config: Configuration
     ):
         with mutable_config.override(
             "packages", {"llvm": {"externals": [compiler_factory(spec="llvm@3.3 +clang")]}}

--- a/lib/spack/spack/test/modules/tcl.py
+++ b/lib/spack/spack/test/modules/tcl.py
@@ -756,7 +756,7 @@ class TestTcl:
         def no_op_set(*args, **kwargs):
             pass
 
-        monkeypatch.setattr(spack.config, "set", no_op_set)
+        monkeypatch.setattr(spack.config.Configuration, "set", no_op_set)
 
         # Assert we have core compilers now
         writer, _ = factory(mpileaks_spec_string)

--- a/lib/spack/spack/test/modules/tcl.py
+++ b/lib/spack/spack/test/modules/tcl.py
@@ -678,9 +678,9 @@ class TestTcl:
             assert repetitions == 1
 
     def test_compilers_provided_different_name(
-        self, factory, module_configuration, compiler_factory
+        self, factory, module_configuration, compiler_factory, mutable_config
     ):
-        with spack.config.override(
+        with mutable_config.override(
             "packages", {"llvm": {"externals": [compiler_factory(spec="llvm@3.3 +clang")]}}
         ):
             module_configuration("complex_hierarchy")

--- a/lib/spack/spack/test/oci/integration_test.py
+++ b/lib/spack/spack/test/oci/integration_test.py
@@ -23,6 +23,7 @@ import spack.error
 import spack.oci.opener
 import spack.spec
 import spack.traverse
+from spack.database import Database
 from spack.main import SpackCommand
 from spack.oci.image import Digest, ImageReference, default_config, default_manifest
 from spack.oci.oci import blob_exists, get_manifest_and_config, upload_blob, upload_manifest
@@ -43,7 +44,7 @@ def oci_servers(*servers: DummyServer):
     spack.oci.opener.urlopen = old_opener
 
 
-def test_buildcache_push_command(mutable_database):
+def test_buildcache_push_command(mutable_database: Database):
     with oci_servers(InMemoryOCIRegistry("example.com")):
         mirror("add", "oci-test", "oci://example.com/image")
 

--- a/lib/spack/spack/test/oci/integration_test.py
+++ b/lib/spack/spack/test/oci/integration_test.py
@@ -22,7 +22,6 @@ import spack.environment as ev
 import spack.error
 import spack.oci.opener
 import spack.spec
-import spack.store
 import spack.traverse
 from spack.main import SpackCommand
 from spack.oci.image import Digest, ImageReference, default_config, default_manifest
@@ -61,7 +60,7 @@ def test_buildcache_push_command(mutable_database):
         buildcache("install", "--unsigned", "mpileaks^mpich")
 
         # Now it should be installed again
-        assert spack.store.STORE.db.installed(spec)
+        assert mutable_database.installed(spec)
 
         # And let's check that the bin/mpileaks executable is there
         assert os.path.exists(os.path.join(spec.prefix, "bin", "mpileaks"))

--- a/lib/spack/spack/test/old_installer.py
+++ b/lib/spack/spack/test/old_installer.py
@@ -26,6 +26,7 @@ import spack.report
 import spack.spec
 import spack.util.filesystem as fs
 import spack.util.lock as lk
+from spack.store import Store
 from spack.test.conftest import RepoBuilder
 from spack.util import tty
 
@@ -440,7 +441,7 @@ def test_dump_packages_deps_ok(install_mockery, tmp_path: pathlib.Path, mock_pac
 
 
 def test_dump_packages_deps_errs(
-    temporary_store, install_mockery, tmp_path: pathlib.Path, monkeypatch, capfd
+    temporary_store: Store, install_mockery, tmp_path: pathlib.Path, monkeypatch, capfd
 ):
     """Test error paths for dump_packages with dependencies."""
     orig_bpp = temporary_store.layout.build_packages_path
@@ -581,7 +582,7 @@ def test_combine_phase_logs_does_not_care_about_encoding(tmp_path: pathlib.Path)
         assert f.read() == data * 2
 
 
-def test_check_deps_status_install_failure(temporary_store, install_mockery):
+def test_check_deps_status_install_failure(temporary_store: Store, install_mockery):
     """Tests that checking the dependency status on a request to install
     'a' fails, if we mark the dependency as failed.
     """
@@ -810,7 +811,7 @@ def test_cleanup_all_tasks(install_mockery, monkeypatch):
     assert len(installer.build_tasks) == 1
 
 
-def test_setup_install_dir_grp(temporary_store, install_mockery, monkeypatch, capfd):
+def test_setup_install_dir_grp(temporary_store: Store, install_mockery, monkeypatch, capfd):
     """Test _setup_install_dir's group change."""
     mock_group = "mockgroup"
     mock_chgrp_msg = "Changing group for {0} to {1}"
@@ -1180,7 +1181,9 @@ def fail(*args, **kwargs):
     assert False
 
 
-def test_overwrite_install_backup_success(monkeypatch, temporary_store, config, mock_packages):
+def test_overwrite_install_backup_success(
+    monkeypatch, temporary_store: Store, config, mock_packages
+):
     """
     When doing an overwrite install that fails, Spack should restore the backup
     of the original prefix, and leave the original spec marked installed.
@@ -1264,7 +1267,7 @@ def test_term_status_line():
 
 
 @pytest.mark.parametrize("explicit", [True, False])
-def test_single_external_implicit_install(temporary_store, install_mockery, explicit):
+def test_single_external_implicit_install(temporary_store: Store, install_mockery, explicit):
     pkg = "trivial-install-test-package"
     s = spack.concretize.concretize_one(pkg)
     s.external_path = "/usr"
@@ -1273,7 +1276,9 @@ def test_single_external_implicit_install(temporary_store, install_mockery, expl
     assert temporary_store.db.get_record(pkg).explicit == explicit
 
 
-def test_overwrite_install_does_install_build_deps(temporary_store, install_mockery, mock_fetch):
+def test_overwrite_install_does_install_build_deps(
+    temporary_store: Store, install_mockery, mock_fetch
+):
     """When overwrite installing something from sources, build deps should be installed."""
     s = spack.concretize.concretize_one("dtrun3")
     create_installer([s]).install()

--- a/lib/spack/spack/test/old_installer.py
+++ b/lib/spack/spack/test/old_installer.py
@@ -24,7 +24,6 @@ import spack.package_prefs as prefs
 import spack.repo
 import spack.report
 import spack.spec
-import spack.store
 import spack.util.filesystem as fs
 import spack.util.lock as lk
 from spack.test.conftest import RepoBuilder
@@ -440,9 +439,11 @@ def test_dump_packages_deps_ok(install_mockery, tmp_path: pathlib.Path, mock_pac
     assert os.path.isfile(dest_pkg)
 
 
-def test_dump_packages_deps_errs(install_mockery, tmp_path: pathlib.Path, monkeypatch, capfd):
+def test_dump_packages_deps_errs(
+    temporary_store, install_mockery, tmp_path: pathlib.Path, monkeypatch, capfd
+):
     """Test error paths for dump_packages with dependencies."""
-    orig_bpp = spack.store.STORE.layout.build_packages_path
+    orig_bpp = temporary_store.layout.build_packages_path
     orig_dirname = spack.repo.Repo.dirname_for_package_name
     repo_err_msg = "Mock dirname_for_package_name"
 
@@ -461,7 +462,7 @@ def test_dump_packages_deps_errs(install_mockery, tmp_path: pathlib.Path, monkey
 
     # Now mock the creation of the required directory structure to cover
     # the try-except block
-    monkeypatch.setattr(spack.store.STORE.layout, "build_packages_path", bpp_path)
+    monkeypatch.setattr(temporary_store.layout, "build_packages_path", bpp_path)
 
     spec = spack.concretize.concretize_one("simple-inheritance")
     path = str(tmp_path)
@@ -580,13 +581,13 @@ def test_combine_phase_logs_does_not_care_about_encoding(tmp_path: pathlib.Path)
         assert f.read() == data * 2
 
 
-def test_check_deps_status_install_failure(install_mockery):
+def test_check_deps_status_install_failure(temporary_store, install_mockery):
     """Tests that checking the dependency status on a request to install
     'a' fails, if we mark the dependency as failed.
     """
     s = spack.concretize.concretize_one("pkg-a")
     for dep in s.traverse(root=False):
-        spack.store.STORE.failure_tracker.mark(dep)
+        temporary_store.failure_tracker.mark(dep)
 
     installer = create_installer(["pkg-a"], {})
     request = installer.build_requests[0]
@@ -809,7 +810,7 @@ def test_cleanup_all_tasks(install_mockery, monkeypatch):
     assert len(installer.build_tasks) == 1
 
 
-def test_setup_install_dir_grp(install_mockery, monkeypatch, capfd):
+def test_setup_install_dir_grp(temporary_store, install_mockery, monkeypatch, capfd):
     """Test _setup_install_dir's group change."""
     mock_group = "mockgroup"
     mock_chgrp_msg = "Changing group for {0} to {1}"
@@ -829,7 +830,7 @@ def test_setup_install_dir_grp(install_mockery, monkeypatch, capfd):
     spec = build_task.request.pkg.spec
 
     fs.touchp(spec.prefix)
-    metadatadir = spack.store.STORE.layout.metadata_path(spec)
+    metadatadir = temporary_store.layout.metadata_path(spec)
     # Regex matching with Windows style paths typically fails
     # so we skip the match check here
     if sys.platform == "win32":
@@ -1199,7 +1200,7 @@ def test_overwrite_install_backup_success(monkeypatch, temporary_store, config, 
     monkeypatch.setattr(inst, "build_process", wipe_prefix)
 
     # Make sure the package is not marked uninstalled
-    monkeypatch.setattr(spack.store.STORE.db, "remove", fail)
+    monkeypatch.setattr(temporary_store.db, "remove", fail)
     # Make sure that the installer does an overwrite install
     monkeypatch.setattr(task, "_install_action", inst.InstallAction.OVERWRITE)
 
@@ -1263,16 +1264,16 @@ def test_term_status_line():
 
 
 @pytest.mark.parametrize("explicit", [True, False])
-def test_single_external_implicit_install(install_mockery, explicit):
+def test_single_external_implicit_install(temporary_store, install_mockery, explicit):
     pkg = "trivial-install-test-package"
     s = spack.concretize.concretize_one(pkg)
     s.external_path = "/usr"
     args = {"explicit": [s.dag_hash()] if explicit else []}
     create_installer([s], args).install()
-    assert spack.store.STORE.db.get_record(pkg).explicit == explicit
+    assert temporary_store.db.get_record(pkg).explicit == explicit
 
 
-def test_overwrite_install_does_install_build_deps(install_mockery, mock_fetch):
+def test_overwrite_install_does_install_build_deps(temporary_store, install_mockery, mock_fetch):
     """When overwrite installing something from sources, build deps should be installed."""
     s = spack.concretize.concretize_one("dtrun3")
     create_installer([s]).install()
@@ -1289,7 +1290,7 @@ def test_overwrite_install_does_install_build_deps(install_mockery, mock_fetch):
     create_installer([s], {"overwrite": [s.dag_hash()]}).install()
 
     # Verify that the build dep was also installed.
-    assert spack.store.STORE.db.installed(build_dep)
+    assert temporary_store.db.installed(build_dep)
 
 
 @pytest.mark.parametrize("run_tests", [True, False])

--- a/lib/spack/spack/test/old_installer.py
+++ b/lib/spack/spack/test/old_installer.py
@@ -1329,12 +1329,12 @@ def test_print_install_test_log_failures(
     assert "See test results at" in out
 
 
-def test_build_request_errors(install_mockery):
+def test_build_request_errors(install_mockery, mock_packages):
     with pytest.raises(ValueError, match="must be a package"):
         inst.BuildRequest("abc", {})
 
     spec = spack.spec.Spec("trivial-install-test-package")
-    pkg_cls = spack.repo.PATH.get_pkg_class(spec.name)
+    pkg_cls = mock_packages.get_pkg_class(spec.name)
     with pytest.raises(ValueError, match="must have a concrete spec"):
         inst.BuildRequest(pkg_cls(spec), {})
 
@@ -1398,10 +1398,10 @@ def test_build_request_deptypes(
     assert actual_dependency_deptypes == dependencies_deptypes
 
 
-def test_build_task_errors(install_mockery):
+def test_build_task_errors(install_mockery, mock_packages):
     """Check expected errors when instantiating a BuildTask."""
     spec = spack.spec.Spec("trivial-install-test-package")
-    pkg_cls = spack.repo.PATH.get_pkg_class(spec.name)
+    pkg_cls = mock_packages.get_pkg_class(spec.name)
 
     # The value of the request argument is expected to not be checked.
     for pkg in [None, "abc"]:

--- a/lib/spack/spack/test/package_class.py
+++ b/lib/spack/spack/test/package_class.py
@@ -20,7 +20,6 @@ import spack.deptypes as dt
 import spack.error
 import spack.install_test
 import spack.package_base
-import spack.repo
 import spack.spec
 import spack.store
 import spack.subprocess_context
@@ -393,7 +392,7 @@ def test_git_provenance_cant_resolve_commit(mock_packages, monkeypatch, config, 
     # patch the base class for dependencies, and the concrete class, whose own ``git``
     # attribute (a real github URL) shadows the base class one
     monkeypatch.setattr(spack.package_base.PackageBase, "git", repo_path, raising=False)
-    monkeypatch.setattr(spack.repo.PATH.get_pkg_class("git-ref-package"), "git", repo_path)
+    monkeypatch.setattr(mock_packages.get_pkg_class("git-ref-package"), "git", repo_path)
     monkeypatch.setattr(spack.package_base.PackageBase, "do_fetch", lambda *args, **kwargs: None)
     spec = spack.concretize.concretize_one("git-ref-package@develop")
     captured = capfd.readouterr()

--- a/lib/spack/spack/test/package_class.py
+++ b/lib/spack/spack/test/package_class.py
@@ -26,6 +26,7 @@ import spack.subprocess_context
 import spack.util.filesystem as fs
 from spack.error import InstallError
 from spack.package_base import PackageBase
+from spack.repo import RepoPath
 from spack.solver.input_analysis import NoStaticAnalysis, StaticAnalysis
 from spack.version import Version
 
@@ -386,7 +387,9 @@ def test_git_provenance_find_commit_ls_remote(
 
 @pytest.mark.require_provenance
 @pytest.mark.disable_clean_stage_check
-def test_git_provenance_cant_resolve_commit(mock_packages, monkeypatch, config, capfd, tmp_path):
+def test_git_provenance_cant_resolve_commit(
+    mock_packages: RepoPath, monkeypatch, config, capfd, tmp_path
+):
     """Fail all attempts to resolve git commits"""
     repo_path = str(tmp_path / "non_existent")
     # patch the base class for dependencies, and the concrete class, whose own ``git``

--- a/lib/spack/spack/test/packages.py
+++ b/lib/spack/spack/test/packages.py
@@ -17,6 +17,7 @@ import spack.package
 import spack.package_base
 import spack.repo
 from spack.paths import mock_packages_path
+from spack.repo import RepoPath
 from spack.spec import Spec
 from spack.util.naming import pkg_name_to_class_name
 from spack.version import VersionChecksumError
@@ -38,10 +39,10 @@ def pkg_factory(name):
 
 @pytest.mark.usefixtures("config", "mock_packages")
 class TestPackage:
-    def test_load_package(self, mock_packages):
+    def test_load_package(self, mock_packages: RepoPath):
         mock_packages.get_pkg_class("mpich")
 
-    def test_package_name(self, mock_packages):
+    def test_package_name(self, mock_packages: RepoPath):
         pkg_cls = mock_packages.get_pkg_class("mpich")
         assert pkg_cls.name == "mpich"
 
@@ -83,7 +84,7 @@ class TestPackage:
         del sys.modules["spack.pkg.testing_repo"]
         del sys.modules["spack.pkg.testing_repo.mpich"]
 
-    def test_inheritance_of_directives(self, mock_packages):
+    def test_inheritance_of_directives(self, mock_packages: RepoPath):
         pkg_cls = mock_packages.get_pkg_class("simple-inheritance")
 
         # Check dictionaries that should have been filled by directives
@@ -128,7 +129,7 @@ def test_urls_for_versions(mock_packages, config):
         assert url == "http://www.doesnotexist.org/url_override-0.8.1.tar.gz"
 
 
-def test_url_for_version_with_no_urls(mock_packages, config):
+def test_url_for_version_with_no_urls(mock_packages: RepoPath, config):
     spec = Spec("git-test")
     pkg_cls = mock_packages.get_pkg_class(spec.name)
     with pytest.raises(spack.error.NoURLError):
@@ -319,7 +320,7 @@ def test_fetch_options(version_str, digest_end, extra_options):
     assert fetcher.extra_options == extra_options
 
 
-def test_package_deprecated_version(mock_packages, mock_fetch, mock_stage):
+def test_package_deprecated_version(mock_packages: RepoPath, mock_fetch, mock_stage):
     spec = Spec("deprecated-versions")
     pkg_cls = mock_packages.get_pkg_class(spec.name)
 
@@ -327,7 +328,9 @@ def test_package_deprecated_version(mock_packages, mock_fetch, mock_stage):
     assert not spack.package_base.deprecated_version(pkg_cls, "1.0.0")
 
 
-def test_package_can_have_sparse_checkout_properties(mock_packages, mock_fetch, mock_stage):
+def test_package_can_have_sparse_checkout_properties(
+    mock_packages: RepoPath, mock_fetch, mock_stage
+):
     spec = Spec("git-sparsepaths-pkg")
     pkg_cls = mock_packages.get_pkg_class(spec.name)
     assert hasattr(pkg_cls, "git_sparse_paths")
@@ -339,7 +342,7 @@ def test_package_can_have_sparse_checkout_properties(mock_packages, mock_fetch, 
 
 
 def test_package_can_have_sparse_checkout_properties_with_commit_version(
-    mock_packages, mock_fetch, mock_stage
+    mock_packages: RepoPath, mock_fetch, mock_stage
 ):
     spec = Spec("git-sparsepaths-pkg commit=abcdefg")
     pkg_cls = mock_packages.get_pkg_class(spec.name)
@@ -352,7 +355,7 @@ def test_package_can_have_sparse_checkout_properties_with_commit_version(
 
 
 def test_package_can_have_sparse_checkout_properties_with_gitversion(
-    mock_packages, mock_fetch, mock_stage
+    mock_packages: RepoPath, mock_fetch, mock_stage
 ):
     spec = Spec("git-sparsepaths-pkg")
     pkg_cls = mock_packages.get_pkg_class(spec.name)
@@ -366,7 +369,7 @@ def test_package_can_have_sparse_checkout_properties_with_gitversion(
 
 
 def test_package_version_can_have_sparse_checkout_properties(
-    mock_packages, mock_fetch, mock_stage
+    mock_packages: RepoPath, mock_fetch, mock_stage
 ):
     spec = Spec("git-sparsepaths-version")
     pkg_cls = mock_packages.get_pkg_class(spec.name)

--- a/lib/spack/spack/test/packages.py
+++ b/lib/spack/spack/test/packages.py
@@ -38,11 +38,11 @@ def pkg_factory(name):
 
 @pytest.mark.usefixtures("config", "mock_packages")
 class TestPackage:
-    def test_load_package(self):
-        spack.repo.PATH.get_pkg_class("mpich")
+    def test_load_package(self, mock_packages):
+        mock_packages.get_pkg_class("mpich")
 
-    def test_package_name(self):
-        pkg_cls = spack.repo.PATH.get_pkg_class("mpich")
+    def test_package_name(self, mock_packages):
+        pkg_cls = mock_packages.get_pkg_class("mpich")
         assert pkg_cls.name == "mpich"
 
     def test_package_filename(self):
@@ -83,8 +83,8 @@ class TestPackage:
         del sys.modules["spack.pkg.testing_repo"]
         del sys.modules["spack.pkg.testing_repo.mpich"]
 
-    def test_inheritance_of_directives(self):
-        pkg_cls = spack.repo.PATH.get_pkg_class("simple-inheritance")
+    def test_inheritance_of_directives(self, mock_packages):
+        pkg_cls = mock_packages.get_pkg_class("simple-inheritance")
 
         # Check dictionaries that should have been filled by directives
         dependencies = pkg_cls.dependencies_by_name()

--- a/lib/spack/spack/test/packages.py
+++ b/lib/spack/spack/test/packages.py
@@ -130,7 +130,7 @@ def test_urls_for_versions(mock_packages, config):
 
 def test_url_for_version_with_no_urls(mock_packages, config):
     spec = Spec("git-test")
-    pkg_cls = spack.repo.PATH.get_pkg_class(spec.name)
+    pkg_cls = mock_packages.get_pkg_class(spec.name)
     with pytest.raises(spack.error.NoURLError):
         pkg_cls(spec).url_for_version("1.0")
 
@@ -321,7 +321,7 @@ def test_fetch_options(version_str, digest_end, extra_options):
 
 def test_package_deprecated_version(mock_packages, mock_fetch, mock_stage):
     spec = Spec("deprecated-versions")
-    pkg_cls = spack.repo.PATH.get_pkg_class(spec.name)
+    pkg_cls = mock_packages.get_pkg_class(spec.name)
 
     assert spack.package_base.deprecated_version(pkg_cls, "1.1.0")
     assert not spack.package_base.deprecated_version(pkg_cls, "1.0.0")
@@ -329,7 +329,7 @@ def test_package_deprecated_version(mock_packages, mock_fetch, mock_stage):
 
 def test_package_can_have_sparse_checkout_properties(mock_packages, mock_fetch, mock_stage):
     spec = Spec("git-sparsepaths-pkg")
-    pkg_cls = spack.repo.PATH.get_pkg_class(spec.name)
+    pkg_cls = mock_packages.get_pkg_class(spec.name)
     assert hasattr(pkg_cls, "git_sparse_paths")
 
     fetcher = spack.fetch_strategy.for_package_version(pkg_cls(spec), "1.0")
@@ -342,7 +342,7 @@ def test_package_can_have_sparse_checkout_properties_with_commit_version(
     mock_packages, mock_fetch, mock_stage
 ):
     spec = Spec("git-sparsepaths-pkg commit=abcdefg")
-    pkg_cls = spack.repo.PATH.get_pkg_class(spec.name)
+    pkg_cls = mock_packages.get_pkg_class(spec.name)
     assert hasattr(pkg_cls, "git_sparse_paths")
 
     fetcher = spack.fetch_strategy.for_package_version(pkg_cls(spec), "1.0")
@@ -355,7 +355,7 @@ def test_package_can_have_sparse_checkout_properties_with_gitversion(
     mock_packages, mock_fetch, mock_stage
 ):
     spec = Spec("git-sparsepaths-pkg")
-    pkg_cls = spack.repo.PATH.get_pkg_class(spec.name)
+    pkg_cls = mock_packages.get_pkg_class(spec.name)
     assert hasattr(pkg_cls, "git_sparse_paths")
 
     version = "git.foo=1.0"
@@ -369,7 +369,7 @@ def test_package_version_can_have_sparse_checkout_properties(
     mock_packages, mock_fetch, mock_stage
 ):
     spec = Spec("git-sparsepaths-version")
-    pkg_cls = spack.repo.PATH.get_pkg_class(spec.name)
+    pkg_cls = mock_packages.get_pkg_class(spec.name)
 
     fetcher = spack.fetch_strategy.for_package_version(pkg_cls(spec), version="1.0")
     assert isinstance(fetcher, spack.fetch_strategy.GitFetchStrategy)

--- a/lib/spack/spack/test/packaging.py
+++ b/lib/spack/spack/test/packaging.py
@@ -26,6 +26,7 @@ import spack.stage
 import spack.util.gpg
 import spack.util.url as url_util
 from spack.cmd import buildcache
+from spack.config import Configuration
 from spack.fetch_strategy import URLFetchStrategy
 from spack.old_installer import PackageInstaller
 from spack.paths import mock_gpg_keys_path
@@ -37,7 +38,9 @@ pytestmark = pytest.mark.not_on_windows("does not run on windows")
 
 
 @pytest.mark.usefixtures("install_mockery", "mock_gnupghome")
-def test_buildcache(mock_archive, tmp_path: pathlib.Path, monkeypatch, mutable_config):
+def test_buildcache(
+    mock_archive, tmp_path: pathlib.Path, monkeypatch, mutable_config: Configuration
+):
     # Install a test package
     spec = spack.concretize.concretize_one("trivial-install-test-package")
     monkeypatch.setattr(spec.package, "fetcher", URLFetchStrategy(url=mock_archive.url))

--- a/lib/spack/spack/test/packaging.py
+++ b/lib/spack/spack/test/packaging.py
@@ -19,7 +19,6 @@ import pytest
 import spack.binary_distribution
 import spack.cmd.mirror
 import spack.concretize
-import spack.config
 import spack.error
 import spack.fetch_strategy
 import spack.package_base
@@ -59,7 +58,7 @@ def test_buildcache(mock_archive, tmp_path: pathlib.Path, monkeypatch, mutable_c
 
     # register mirror with spack config
     mirrors = {"spack-mirror-test": url_util.path_to_file_url(mirror_path)}
-    spack.config.set("mirrors", mirrors)
+    mutable_config.set("mirrors", mirrors)
 
     with spack.stage.Stage(mirrors["spack-mirror-test"], name="build_cache", keep=True):
         parser = argparse.ArgumentParser()

--- a/lib/spack/spack/test/patch.py
+++ b/lib/spack/spack/test/patch.py
@@ -177,10 +177,10 @@ def test_patch_in_spec(mock_packages, config):
 def test_stale_patch_cache_falls_back_to_fresh(mock_packages, config):
     """spec.patches returns correct patches even when the stale in-memory cache is wrong."""
     spec = spack.concretize.concretize_one("patch@=1.0")
-    pkg_cls = spack.repo.PATH.get_pkg_class("patch")
+    pkg_cls = mock_packages.get_pkg_class("patch")
 
     # Inject a stale PatchCache: foo_sha256 points to a non-existent patch file
-    stale_cache = spack.patch.PatchCache(repository=spack.repo.PATH)
+    stale_cache = spack.patch.PatchCache(repository=mock_packages)
     stale_cache.index = {
         foo_sha256: {
             pkg_cls.fullname: {
@@ -192,8 +192,8 @@ def test_stale_patch_cache_falls_back_to_fresh(mock_packages, config):
             }
         }
     }
-    spack.repo.PATH._patch_index = stale_cache
-    spack.repo.PATH._index_is_fresh = False
+    mock_packages._patch_index = stale_cache
+    mock_packages._index_is_fresh = False
 
     patches = spec.patches
 
@@ -248,7 +248,7 @@ def test_nested_directives(mock_packages):
     """Ensure pkg data structures are set up properly by nested directives."""
     # this ensures that the patch() directive results were removed
     # properly from the DirectiveMeta._directives_to_be_executed list
-    package = spack.repo.PATH.get_pkg_class("patch-several-dependencies")
+    package = mock_packages.get_pkg_class("patch-several-dependencies")
     assert len(package.patches) == 0
 
     # this ensures that results of dependency patches were properly added
@@ -563,8 +563,8 @@ def test_patch_lookup_for_shadowed_package(mock_packages, config, repo_builder):
     package in a higher-precedence repo doesn't shadow the patch owner."""
     repo_builder.add_package("patch")
 
-    with spack.repo.use_repositories(repo_builder.root, override=False):
-        assert spack.repo.PATH.repo_for_pkg("patch").namespace == repo_builder.namespace
+    with spack.repo.use_repositories(repo_builder.root, override=False) as repos:
+        assert repos.repo_for_pkg("patch").namespace == repo_builder.namespace
 
         spec = spack.concretize.concretize_one("builtin_mock.patch@=1.0")
         default = spack.concretize.concretize_one("patch")

--- a/lib/spack/spack/test/patch.py
+++ b/lib/spack/spack/test/patch.py
@@ -21,6 +21,7 @@ import spack.repo
 import spack.spec
 import spack.stage
 import spack.util.url as url_util
+from spack.repo import RepoPath
 from spack.spec import Spec
 from spack.stage import Stage
 from spack.util.executable import Executable
@@ -174,7 +175,7 @@ def test_patch_in_spec(mock_packages, config):
     )
 
 
-def test_stale_patch_cache_falls_back_to_fresh(mock_packages, config):
+def test_stale_patch_cache_falls_back_to_fresh(mock_packages: RepoPath, config):
     """spec.patches returns correct patches even when the stale in-memory cache is wrong."""
     spec = spack.concretize.concretize_one("patch@=1.0")
     pkg_cls = mock_packages.get_pkg_class("patch")
@@ -244,7 +245,7 @@ def test_patch_order(mock_packages, config):
     assert expected_order == tuple(patch_order)
 
 
-def test_nested_directives(mock_packages):
+def test_nested_directives(mock_packages: RepoPath):
     """Ensure pkg data structures are set up properly by nested directives."""
     # this ensures that the patch() directive results were removed
     # properly from the DirectiveMeta._directives_to_be_executed list

--- a/lib/spack/spack/test/provider_index.py
+++ b/lib/spack/spack/test/provider_index.py
@@ -20,13 +20,12 @@ Tests assume that mock packages provide this::
 
 import io
 
-import spack.repo
 from spack.provider_index import ProviderIndex
 from spack.spec import Spec
 
 
 def test_provider_index_round_trip(mock_packages):
-    p = ProviderIndex(specs=spack.repo.all_package_names(), repository=mock_packages)
+    p = ProviderIndex(specs=mock_packages.all_package_names(), repository=mock_packages)
 
     ostream = io.StringIO()
     p.to_json(ostream)
@@ -38,7 +37,7 @@ def test_provider_index_round_trip(mock_packages):
 
 
 def test_providers_for_simple(mock_packages):
-    p = ProviderIndex(specs=spack.repo.all_package_names(), repository=mock_packages)
+    p = ProviderIndex(specs=mock_packages.all_package_names(), repository=mock_packages)
 
     blas_providers = p.providers_for("blas")
     assert Spec("netlib-blas") in blas_providers
@@ -51,7 +50,7 @@ def test_providers_for_simple(mock_packages):
 
 
 def test_mpi_providers(mock_packages):
-    p = ProviderIndex(specs=spack.repo.all_package_names(), repository=mock_packages)
+    p = ProviderIndex(specs=mock_packages.all_package_names(), repository=mock_packages)
 
     mpi_2_providers = p.providers_for("mpi@2")
     assert Spec("mpich2") in mpi_2_providers
@@ -64,13 +63,13 @@ def test_mpi_providers(mock_packages):
 
 
 def test_equal(mock_packages):
-    p = ProviderIndex(specs=spack.repo.all_package_names(), repository=mock_packages)
-    q = ProviderIndex(specs=spack.repo.all_package_names(), repository=mock_packages)
+    p = ProviderIndex(specs=mock_packages.all_package_names(), repository=mock_packages)
+    q = ProviderIndex(specs=mock_packages.all_package_names(), repository=mock_packages)
     assert p == q
 
 
 def test_copy(mock_packages):
-    p = ProviderIndex(specs=spack.repo.all_package_names(), repository=mock_packages)
+    p = ProviderIndex(specs=mock_packages.all_package_names(), repository=mock_packages)
     q = p.copy()
     assert p == q
 

--- a/lib/spack/spack/test/provider_index.py
+++ b/lib/spack/spack/test/provider_index.py
@@ -26,19 +26,19 @@ from spack.spec import Spec
 
 
 def test_provider_index_round_trip(mock_packages):
-    p = ProviderIndex(specs=spack.repo.all_package_names(), repository=spack.repo.PATH)
+    p = ProviderIndex(specs=spack.repo.all_package_names(), repository=mock_packages)
 
     ostream = io.StringIO()
     p.to_json(ostream)
 
     istream = io.StringIO(ostream.getvalue())
-    q = ProviderIndex.from_json(istream, repository=spack.repo.PATH)
+    q = ProviderIndex.from_json(istream, repository=mock_packages)
 
     assert p == q
 
 
 def test_providers_for_simple(mock_packages):
-    p = ProviderIndex(specs=spack.repo.all_package_names(), repository=spack.repo.PATH)
+    p = ProviderIndex(specs=spack.repo.all_package_names(), repository=mock_packages)
 
     blas_providers = p.providers_for("blas")
     assert Spec("netlib-blas") in blas_providers
@@ -51,7 +51,7 @@ def test_providers_for_simple(mock_packages):
 
 
 def test_mpi_providers(mock_packages):
-    p = ProviderIndex(specs=spack.repo.all_package_names(), repository=spack.repo.PATH)
+    p = ProviderIndex(specs=spack.repo.all_package_names(), repository=mock_packages)
 
     mpi_2_providers = p.providers_for("mpi@2")
     assert Spec("mpich2") in mpi_2_providers
@@ -64,20 +64,20 @@ def test_mpi_providers(mock_packages):
 
 
 def test_equal(mock_packages):
-    p = ProviderIndex(specs=spack.repo.all_package_names(), repository=spack.repo.PATH)
-    q = ProviderIndex(specs=spack.repo.all_package_names(), repository=spack.repo.PATH)
+    p = ProviderIndex(specs=spack.repo.all_package_names(), repository=mock_packages)
+    q = ProviderIndex(specs=spack.repo.all_package_names(), repository=mock_packages)
     assert p == q
 
 
 def test_copy(mock_packages):
-    p = ProviderIndex(specs=spack.repo.all_package_names(), repository=spack.repo.PATH)
+    p = ProviderIndex(specs=spack.repo.all_package_names(), repository=mock_packages)
     q = p.copy()
     assert p == q
 
 
 def test_remove_providers(mock_packages):
     """Test removing providers from the index."""
-    p = ProviderIndex(specs=["mpich"], repository=spack.repo.PATH)
+    p = ProviderIndex(specs=["mpich"], repository=mock_packages)
     # Check that mpich is a provider for mpi
     providers = p.providers_for("mpi")
     assert any(spec.name == "mpich" for spec in providers)

--- a/lib/spack/spack/test/repo.py
+++ b/lib/spack/spack/test/repo.py
@@ -6,7 +6,6 @@ import pathlib
 
 import pytest
 
-import spack.config
 import spack.environment
 import spack.package_base
 import spack.paths
@@ -126,7 +125,7 @@ def test_use_repositories_with_unmaterialized_path(tmp_path: pathlib.Path, confi
     (tmp_path / "repo.yaml").write_text("repo:\n  namespace: myrepo\n")
 
     monkeypatch.setattr(
-        spack.repo, "PATH", Singleton(lambda: spack.repo.create_and_enable(spack.config.CONFIG))
+        spack.repo, "PATH", Singleton(lambda: spack.repo.create_and_enable(config))
     )
 
     with spack.repo.use_repositories(str(tmp_path)) as repo:
@@ -149,7 +148,7 @@ spack:
     )
 
     monkeypatch.setattr(
-        spack.repo, "PATH", Singleton(lambda: spack.repo.create_and_enable(spack.config.CONFIG))
+        spack.repo, "PATH", Singleton(lambda: spack.repo.create_and_enable(config))
     )
 
     env = spack.environment.Environment(tmp_path)

--- a/lib/spack/spack/test/repo.py
+++ b/lib/spack/spack/test/repo.py
@@ -100,8 +100,8 @@ def test_repo_invisibles(mutable_mock_repo, extra_repo):
 
 @pytest.mark.regression("24552")
 def test_all_package_names_is_cached_correctly(mock_packages):
-    assert "mpi" in spack.repo.all_package_names(include_virtuals=True)
-    assert "mpi" not in spack.repo.all_package_names(include_virtuals=False)
+    assert "mpi" in mock_packages.all_package_names(include_virtuals=True)
+    assert "mpi" not in mock_packages.all_package_names(include_virtuals=False)
 
 
 @pytest.mark.regression("29203")

--- a/lib/spack/spack/test/repo.py
+++ b/lib/spack/spack/test/repo.py
@@ -76,9 +76,9 @@ def test_repo_unknown_pkg(mutable_mock_repo):
 def test_repo_last_mtime(mock_packages):
     mtime_with_package_py = [
         (os.path.getmtime(p.module.__file__), p.module.__file__)
-        for p in spack.repo.PATH.all_package_classes()
+        for p in mock_packages.all_package_classes()
     ]
-    repo_mtime = spack.repo.PATH.last_mtime()
+    repo_mtime = mock_packages.last_mtime()
     max_mtime, max_file = max(mtime_with_package_py)
     if max_mtime > repo_mtime:
         modified_after = "\n    ".join(
@@ -639,7 +639,7 @@ def test_repo_update(tmp_path: pathlib.Path):
 
 
 def test_mock_builtin_repo(mock_packages):
-    assert spack.repo.builtin_repo() is spack.repo.PATH.get_repo("builtin_mock")
+    assert spack.repo.builtin_repo() is mock_packages.get_repo("builtin_mock")
 
 
 def test_parse_config_descriptor_git_1(tmp_path: pathlib.Path):

--- a/lib/spack/spack/test/repo.py
+++ b/lib/spack/spack/test/repo.py
@@ -16,6 +16,8 @@ import spack.util.executable
 import spack.util.file_cache
 import spack.util.lock
 import spack.util.naming
+from spack.config import Configuration
+from spack.repo import RepoPath
 from spack.test.conftest import RepoBuilder
 from spack.util.lang import Singleton
 from spack.util.naming import valid_module_name
@@ -73,7 +75,7 @@ def test_repo_unknown_pkg(mutable_mock_repo):
         mutable_mock_repo.get_pkg_class("builtin_mock.nonexistentpackage")
 
 
-def test_repo_last_mtime(mock_packages):
+def test_repo_last_mtime(mock_packages: RepoPath):
     mtime_with_package_py = [
         (os.path.getmtime(p.module.__file__), p.module.__file__)
         for p in mock_packages.all_package_classes()
@@ -99,7 +101,7 @@ def test_repo_invisibles(mutable_mock_repo, extra_repo):
 
 
 @pytest.mark.regression("24552")
-def test_all_package_names_is_cached_correctly(mock_packages):
+def test_all_package_names_is_cached_correctly(mock_packages: RepoPath):
     assert "mpi" in mock_packages.all_package_names(include_virtuals=True)
     assert "mpi" not in mock_packages.all_package_names(include_virtuals=False)
 
@@ -116,7 +118,9 @@ def test_use_repositories_doesnt_change_class(mock_packages):
     assert id(zlib_cls_inner) == id(zlib_cls_outer)
 
 
-def test_use_repositories_with_unmaterialized_path(tmp_path: pathlib.Path, config, monkeypatch):
+def test_use_repositories_with_unmaterialized_path(
+    tmp_path: pathlib.Path, config: Configuration, monkeypatch
+):
     """Tests that use_repositories restores the repositories from config even when the global
     PATH singleton is materialized for the first time inside the context manager. Materializing
     it after pushing the new repos scope onto the config would "save" the new repositories and
@@ -134,7 +138,9 @@ def test_use_repositories_with_unmaterialized_path(tmp_path: pathlib.Path, confi
     assert [r.root for r in spack.repo.PATH.repos] == [spack.paths.mock_packages_path]
 
 
-def test_env_activate_with_unmaterialized_path(tmp_path: pathlib.Path, config, monkeypatch):
+def test_env_activate_with_unmaterialized_path(
+    tmp_path: pathlib.Path, config: Configuration, monkeypatch
+):
     """Tests that env deactivation restores the repositories from config even when activation
     is the first to touch the global PATH singleton. Materializing it after pushing the env
     config scope would "save" the env's repositories and "restore" them on deactivation."""
@@ -638,7 +644,7 @@ def test_repo_update(tmp_path: pathlib.Path):
     }
 
 
-def test_mock_builtin_repo(mock_packages):
+def test_mock_builtin_repo(mock_packages: RepoPath):
     assert spack.repo.builtin_repo() is mock_packages.get_repo("builtin_mock")
 
 

--- a/lib/spack/spack/test/rewiring.py
+++ b/lib/spack/spack/test/rewiring.py
@@ -12,6 +12,7 @@ import spack.concretize
 import spack.deptypes as dt
 import spack.rewiring
 from spack.old_installer import PackageInstaller
+from spack.store import Store
 from spack.test.relocate import text_in_bin
 
 if sys.platform == "darwin":
@@ -32,7 +33,7 @@ def check_spliced_spec_prefixes(spliced_spec):
 
 @pytest.mark.requires_executables(*required_executables)
 @pytest.mark.parametrize("transitive", [True, False])
-def test_rewire_db(mock_fetch, temporary_store, install_mockery, transitive):
+def test_rewire_db(mock_fetch, temporary_store: Store, install_mockery, transitive):
     """Tests basic rewiring without binary executables."""
     spec = spack.concretize.concretize_one("splice-t^splice-h~foo")
     dep = spack.concretize.concretize_one("splice-h+foo")
@@ -56,7 +57,7 @@ def test_rewire_db(mock_fetch, temporary_store, install_mockery, transitive):
 
 @pytest.mark.requires_executables(*required_executables)
 @pytest.mark.parametrize("transitive", [True, False])
-def test_rewire_bin(mock_fetch, temporary_store, install_mockery, transitive):
+def test_rewire_bin(mock_fetch, temporary_store: Store, install_mockery, transitive):
     """Tests basic rewiring with binary executables."""
     spec = spack.concretize.concretize_one("quux")
     dep = spack.concretize.concretize_one("garply cflags=-g")
@@ -84,7 +85,7 @@ def test_rewire_bin(mock_fetch, temporary_store, install_mockery, transitive):
 
 
 @pytest.mark.requires_executables(*required_executables)
-def test_rewire_writes_new_metadata(mock_fetch, temporary_store, install_mockery):
+def test_rewire_writes_new_metadata(mock_fetch, temporary_store: Store, install_mockery):
     """Tests that new metadata was written during a rewire.
     Accuracy of metadata is left to other tests."""
     spec = spack.concretize.concretize_one("quux")
@@ -127,7 +128,7 @@ def test_rewire_writes_new_metadata(mock_fetch, temporary_store, install_mockery
 
 @pytest.mark.requires_executables(*required_executables)
 @pytest.mark.parametrize("transitive", [True, False])
-def test_uninstall_rewired_spec(mock_fetch, temporary_store, install_mockery, transitive):
+def test_uninstall_rewired_spec(mock_fetch, temporary_store: Store, install_mockery, transitive):
     """Test that rewired packages can be uninstalled as normal."""
     spec = spack.concretize.concretize_one("quux")
     dep = spack.concretize.concretize_one("garply cflags=-g")

--- a/lib/spack/spack/test/rewiring.py
+++ b/lib/spack/spack/test/rewiring.py
@@ -11,7 +11,6 @@ import pytest
 import spack.concretize
 import spack.deptypes as dt
 import spack.rewiring
-import spack.store
 from spack.old_installer import PackageInstaller
 from spack.test.relocate import text_in_bin
 
@@ -33,7 +32,7 @@ def check_spliced_spec_prefixes(spliced_spec):
 
 @pytest.mark.requires_executables(*required_executables)
 @pytest.mark.parametrize("transitive", [True, False])
-def test_rewire_db(mock_fetch, install_mockery, transitive):
+def test_rewire_db(mock_fetch, temporary_store, install_mockery, transitive):
     """Tests basic rewiring without binary executables."""
     spec = spack.concretize.concretize_one("splice-t^splice-h~foo")
     dep = spack.concretize.concretize_one("splice-h+foo")
@@ -47,7 +46,7 @@ def test_rewire_db(mock_fetch, install_mockery, transitive):
     assert os.path.exists(spliced_spec.prefix)
 
     # test that it made it into the database
-    rec = spack.store.STORE.db.get_record(spliced_spec)
+    rec = temporary_store.db.get_record(spliced_spec)
     installed_in_db = rec.installed if rec else False
     assert installed_in_db
 
@@ -57,7 +56,7 @@ def test_rewire_db(mock_fetch, install_mockery, transitive):
 
 @pytest.mark.requires_executables(*required_executables)
 @pytest.mark.parametrize("transitive", [True, False])
-def test_rewire_bin(mock_fetch, install_mockery, transitive):
+def test_rewire_bin(mock_fetch, temporary_store, install_mockery, transitive):
     """Tests basic rewiring with binary executables."""
     spec = spack.concretize.concretize_one("quux")
     dep = spack.concretize.concretize_one("garply cflags=-g")
@@ -72,7 +71,7 @@ def test_rewire_bin(mock_fetch, install_mockery, transitive):
     assert os.path.exists(spliced_spec.prefix)
 
     # test that it made it into the database
-    rec = spack.store.STORE.db.get_record(spliced_spec)
+    rec = temporary_store.db.get_record(spliced_spec)
     installed_in_db = rec.installed if rec else False
     assert installed_in_db
 
@@ -85,7 +84,7 @@ def test_rewire_bin(mock_fetch, install_mockery, transitive):
 
 
 @pytest.mark.requires_executables(*required_executables)
-def test_rewire_writes_new_metadata(mock_fetch, install_mockery):
+def test_rewire_writes_new_metadata(mock_fetch, temporary_store, install_mockery):
     """Tests that new metadata was written during a rewire.
     Accuracy of metadata is left to other tests."""
     spec = spack.concretize.concretize_one("quux")
@@ -96,11 +95,11 @@ def test_rewire_writes_new_metadata(mock_fetch, install_mockery):
 
     # test install manifests
     for node in spliced_spec.traverse(root=True):
-        spack.store.STORE.layout.ensure_installed(node)
+        temporary_store.layout.ensure_installed(node)
         manifest_file_path = os.path.join(
             node.prefix,
-            spack.store.STORE.layout.metadata_dir,
-            spack.store.STORE.layout.manifest_file_name,
+            temporary_store.layout.metadata_dir,
+            temporary_store.layout.manifest_file_name,
         )
         assert os.path.exists(manifest_file_path)
         orig_node = spec[node.name]
@@ -108,21 +107,19 @@ def test_rewire_writes_new_metadata(mock_fetch, install_mockery):
             continue
         orig_manifest_file_path = os.path.join(
             orig_node.prefix,
-            spack.store.STORE.layout.metadata_dir,
-            spack.store.STORE.layout.manifest_file_name,
+            temporary_store.layout.metadata_dir,
+            temporary_store.layout.manifest_file_name,
         )
         assert os.path.exists(orig_manifest_file_path)
         assert not filecmp.cmp(orig_manifest_file_path, manifest_file_path, shallow=False)
         specfile_path = os.path.join(
-            node.prefix,
-            spack.store.STORE.layout.metadata_dir,
-            spack.store.STORE.layout.spec_file_name,
+            node.prefix, temporary_store.layout.metadata_dir, temporary_store.layout.spec_file_name
         )
         assert os.path.exists(specfile_path)
         orig_specfile_path = os.path.join(
             orig_node.prefix,
-            spack.store.STORE.layout.metadata_dir,
-            spack.store.STORE.layout.spec_file_name,
+            temporary_store.layout.metadata_dir,
+            temporary_store.layout.spec_file_name,
         )
         assert os.path.exists(orig_specfile_path)
         assert not filecmp.cmp(orig_specfile_path, specfile_path, shallow=False)
@@ -130,7 +127,7 @@ def test_rewire_writes_new_metadata(mock_fetch, install_mockery):
 
 @pytest.mark.requires_executables(*required_executables)
 @pytest.mark.parametrize("transitive", [True, False])
-def test_uninstall_rewired_spec(mock_fetch, install_mockery, transitive):
+def test_uninstall_rewired_spec(mock_fetch, temporary_store, install_mockery, transitive):
     """Test that rewired packages can be uninstalled as normal."""
     spec = spack.concretize.concretize_one("quux")
     dep = spack.concretize.concretize_one("garply cflags=-g")
@@ -138,7 +135,7 @@ def test_uninstall_rewired_spec(mock_fetch, install_mockery, transitive):
     spliced_spec = spec.splice(dep, transitive=transitive)
     spack.rewiring.rewire(spliced_spec)
     spliced_spec.package.do_uninstall()
-    assert len(spack.store.STORE.db.query(spliced_spec)) == 0
+    assert len(temporary_store.db.query(spliced_spec)) == 0
     assert not os.path.exists(spliced_spec.prefix)
 
 

--- a/lib/spack/spack/test/sbang.py
+++ b/lib/spack/spack/test/sbang.py
@@ -57,8 +57,8 @@ last_line = "last!\n"
 
 
 @pytest.fixture  # type: ignore[no-redef]
-def sbang_line():
-    yield "#!/bin/sh %s/bin/sbang\n" % spack.store.STORE.layout.root
+def sbang_line(temporary_store: spack.store.Store):
+    yield "#!/bin/sh %s/bin/sbang\n" % temporary_store.layout.root
 
 
 class ScriptDirectory:
@@ -303,10 +303,10 @@ all:
     yield
 
 
-def check_sbang_installation(group=False):
+def check_sbang_installation(store: spack.store.Store, group=False):
     sbang_path = sbang.sbang_install_path()
     sbang_bin_dir = os.path.dirname(sbang_path)
-    assert sbang_path.startswith(spack.store.STORE.unpadded_root)
+    assert sbang_path.startswith(store.unpadded_root)
 
     assert os.path.exists(sbang_path)
     assert fs.is_exe(sbang_path)
@@ -326,35 +326,35 @@ def check_sbang_installation(group=False):
         assert mode == 0o755, "Unexpected {0}".format(oct(mode))
 
 
-def run_test_install_sbang(group):
+def run_test_install_sbang(store: spack.store.Store, group):
     sbang_path = sbang.sbang_install_path()
     sbang_bin_dir = os.path.dirname(sbang_path)
 
-    assert sbang_path.startswith(spack.store.STORE.unpadded_root)
+    assert sbang_path.startswith(store.unpadded_root)
     assert not os.path.exists(sbang_bin_dir)
 
-    spack.store.STORE.install_sbang()
-    check_sbang_installation(group)
+    store.install_sbang()
+    check_sbang_installation(store, group)
 
     # put an invalid file in for sbang
     fs.mkdirp(sbang_bin_dir)
     with open(sbang_path, "w", encoding="utf-8") as f:
         f.write("foo")
 
-    spack.store.STORE.install_sbang()
-    check_sbang_installation(group)
+    store.install_sbang()
+    check_sbang_installation(store, group)
 
     # install again and make sure sbang is still fine
-    spack.store.STORE.install_sbang()
-    check_sbang_installation(group)
+    store.install_sbang()
+    check_sbang_installation(store, group)
 
 
-def test_install_group_sbang(install_mockery, configure_group_perms):
-    run_test_install_sbang(True)
+def test_install_group_sbang(temporary_store, install_mockery, configure_group_perms):
+    run_test_install_sbang(temporary_store, True)
 
 
-def test_install_user_sbang(install_mockery, configure_user_perms):
-    run_test_install_sbang(False)
+def test_install_user_sbang(temporary_store, install_mockery, configure_user_perms):
+    run_test_install_sbang(temporary_store, False)
 
 
 def test_install_sbang_too_long(tmp_path: pathlib.Path):

--- a/lib/spack/spack/test/sbang.py
+++ b/lib/spack/spack/test/sbang.py
@@ -283,7 +283,7 @@ all:
     group: {0}
 """.format(group_name)
     )
-    spack.config.set("packages", conf, scope="user")
+    spack.config.CONFIG.set("packages", conf, scope="user")
 
     yield
 
@@ -298,7 +298,7 @@ all:
     write: user
 """
     )
-    spack.config.set("packages", conf, scope="user")
+    spack.config.CONFIG.set("packages", conf, scope="user")
 
     yield
 

--- a/lib/spack/spack/test/sbang.py
+++ b/lib/spack/spack/test/sbang.py
@@ -21,6 +21,7 @@ import spack.store
 import spack.util.filesystem as fs
 import spack.util.spack_yaml as syaml
 from spack.hooks import sbang
+from spack.store import Store
 from spack.util.executable import which
 
 if sys.platform != "win32":
@@ -349,11 +350,11 @@ def run_test_install_sbang(store: spack.store.Store, group):
     check_sbang_installation(store, group)
 
 
-def test_install_group_sbang(temporary_store, install_mockery, configure_group_perms):
+def test_install_group_sbang(temporary_store: Store, install_mockery, configure_group_perms):
     run_test_install_sbang(temporary_store, True)
 
 
-def test_install_user_sbang(temporary_store, install_mockery, configure_user_perms):
+def test_install_user_sbang(temporary_store: Store, install_mockery, configure_user_perms):
     run_test_install_sbang(temporary_store, False)
 
 

--- a/lib/spack/spack/test/stage.py
+++ b/lib/spack/spack/test/stage.py
@@ -189,7 +189,7 @@ def get_stage_path(stage, stage_name):
 def tmp_build_stage_dir(tmp_path: pathlib.Path, clear_stage_root):
     """Use a temporary test directory for the stage root."""
     test_path = str(tmp_path / "stage")
-    with spack.config.override("config:build_stage", test_path):
+    with spack.config.CONFIG.override("config:build_stage", test_path):
         yield tmp_path, spack.stage.get_stage_root()
 
     shutil.rmtree(test_path)

--- a/lib/spack/spack/test/stage.py
+++ b/lib/spack/spack/test/stage.py
@@ -492,9 +492,9 @@ class TestStage:
         check_destroy(stage, None)
 
     @pytest.mark.parametrize("debug", [False, True])
-    def test_fetch(self, mock_stage_archive, debug):
+    def test_fetch(self, mutable_config, mock_stage_archive, debug):
         archive = mock_stage_archive()
-        with spack.config.override("config:debug", debug):
+        with mutable_config.override("config:debug", debug):
             with Stage(archive.url, name=self.stage_name) as stage:
                 stage.fetch()
                 check_setup(stage, self.stage_name, archive)
@@ -754,9 +754,9 @@ class TestStage:
 
     @pytest.mark.not_on_windows("Windows file permission erroring is not yet supported")
     @pytest.mark.skipif(getuid() == 0, reason="user is root")
-    def test_get_stage_root_bad_path(self, clear_stage_root):
+    def test_get_stage_root_bad_path(self, mutable_config, clear_stage_root):
         """Ensure an invalid stage path root raises a StageError."""
-        with spack.config.override("config:build_stage", "/no/such/path"):
+        with mutable_config.override("config:build_stage", "/no/such/path"):
             with pytest.raises(spack.stage.StageError, match="No accessible stage paths in"):
                 spack.stage.get_stage_root()
 
@@ -771,11 +771,13 @@ class TestStage:
             ("stage-spack", False),
         ],
     )
-    def test_stage_purge(self, tmp_path: pathlib.Path, clear_stage_root, path, purged):
+    def test_stage_purge(
+        self, mutable_config, tmp_path: pathlib.Path, clear_stage_root, path, purged
+    ):
         """Test purging of stage directories."""
         stage_config_path = str(tmp_path / "stage")
 
-        with spack.config.override("config:build_stage", stage_config_path):
+        with mutable_config.override("config:build_stage", stage_config_path):
             stage_root = spack.stage.get_stage_root()
 
             test_dir = pathlib.Path(stage_root) / path

--- a/lib/spack/spack/test/stage.py
+++ b/lib/spack/spack/test/stage.py
@@ -21,7 +21,7 @@ import spack.fetch_strategy
 import spack.stage
 import spack.util.executable
 import spack.util.url as url_util
-from spack.config import canonicalize_path
+from spack.config import Configuration, canonicalize_path
 from spack.resource import Resource
 from spack.stage import DevelopStage, ResourceStage, Stage, StageComposite
 from spack.util.filesystem import getuid, mkdirp, partition_path, readlink, touch, working_dir
@@ -492,7 +492,7 @@ class TestStage:
         check_destroy(stage, None)
 
     @pytest.mark.parametrize("debug", [False, True])
-    def test_fetch(self, mutable_config, mock_stage_archive, debug):
+    def test_fetch(self, mutable_config: Configuration, mock_stage_archive, debug):
         archive = mock_stage_archive()
         with mutable_config.override("config:debug", debug):
             with Stage(archive.url, name=self.stage_name) as stage:
@@ -754,7 +754,7 @@ class TestStage:
 
     @pytest.mark.not_on_windows("Windows file permission erroring is not yet supported")
     @pytest.mark.skipif(getuid() == 0, reason="user is root")
-    def test_get_stage_root_bad_path(self, mutable_config, clear_stage_root):
+    def test_get_stage_root_bad_path(self, mutable_config: Configuration, clear_stage_root):
         """Ensure an invalid stage path root raises a StageError."""
         with mutable_config.override("config:build_stage", "/no/such/path"):
             with pytest.raises(spack.stage.StageError, match="No accessible stage paths in"):
@@ -772,7 +772,7 @@ class TestStage:
         ],
     )
     def test_stage_purge(
-        self, mutable_config, tmp_path: pathlib.Path, clear_stage_root, path, purged
+        self, mutable_config: Configuration, tmp_path: pathlib.Path, clear_stage_root, path, purged
     ):
         """Test purging of stage directories."""
         stage_config_path = str(tmp_path / "stage")

--- a/lib/spack/spack/test/svn_fetch.py
+++ b/lib/spack/spack/test/svn_fetch.py
@@ -8,6 +8,7 @@ import pathlib
 import pytest
 
 import spack.concretize
+from spack.config import Configuration
 from spack.fetch_strategy import SvnFetchStrategy
 from spack.stage import Stage
 from spack.util.executable import which
@@ -24,7 +25,14 @@ pytestmark = [
 
 @pytest.mark.parametrize("type_of_test", ["default", "rev0"])
 @pytest.mark.parametrize("secure", [True, False])
-def test_fetch(type_of_test, secure, mock_svn_repository, config, mutable_mock_repo, monkeypatch):
+def test_fetch(
+    type_of_test,
+    secure,
+    mock_svn_repository,
+    config: Configuration,
+    mutable_mock_repo,
+    monkeypatch,
+):
     """Tries to:
 
     1. Fetch the repo using a fetch strategy constructed with

--- a/lib/spack/spack/test/svn_fetch.py
+++ b/lib/spack/spack/test/svn_fetch.py
@@ -8,7 +8,6 @@ import pathlib
 import pytest
 
 import spack.concretize
-import spack.config
 from spack.fetch_strategy import SvnFetchStrategy
 from spack.stage import Stage
 from spack.util.executable import which
@@ -45,7 +44,7 @@ def test_fetch(type_of_test, secure, mock_svn_repository, config, mutable_mock_r
 
     # Enter the stage directory and check some properties
     with s.package.stage:
-        with spack.config.override("config:verify_ssl", secure):
+        with config.override("config:verify_ssl", secure):
             s.package.do_stage()
 
         with working_dir(s.package.stage.source_path):

--- a/lib/spack/spack/test/tag.py
+++ b/lib/spack/spack/test/tag.py
@@ -10,6 +10,7 @@ import pytest
 import spack.cmd.tags
 import spack.tag
 from spack.main import SpackCommand
+from spack.repo import RepoPath
 
 install = SpackCommand("install")
 
@@ -88,7 +89,7 @@ def test_tag_get_installed_packages(mock_packages, mock_archive, mock_fetch, ins
         assert skip or all_pkgs["tag3"] == []
 
 
-def test_tag_index_round_trip(mock_packages):
+def test_tag_index_round_trip(mock_packages: RepoPath):
     # Assumes at least two packages -- mpich and mpich2 -- have tags
     mock_index = mock_packages.tag_index
     assert mock_index.tags

--- a/lib/spack/spack/test/tag.py
+++ b/lib/spack/spack/test/tag.py
@@ -8,7 +8,6 @@ import io
 import pytest
 
 import spack.cmd.tags
-import spack.repo
 import spack.tag
 from spack.main import SpackCommand
 
@@ -147,6 +146,6 @@ def test_tag_no_tags(mock_packages):
 def test_tag_update_package(mock_packages):
     mock_index = mock_packages.tag_index
     index = spack.tag.TagIndex()
-    index.update_packages(set(spack.repo.all_package_names()), repo=mock_packages)
+    index.update_packages(set(mock_packages.all_package_names()), repo=mock_packages)
 
     ensure_tags_results_equal(mock_index.tags, index.tags)

--- a/lib/spack/spack/test/tag.py
+++ b/lib/spack/spack/test/tag.py
@@ -91,7 +91,7 @@ def test_tag_get_installed_packages(mock_packages, mock_archive, mock_fetch, ins
 
 def test_tag_index_round_trip(mock_packages):
     # Assumes at least two packages -- mpich and mpich2 -- have tags
-    mock_index = spack.repo.PATH.tag_index
+    mock_index = mock_packages.tag_index
     assert mock_index.tags
 
     ostream = io.StringIO()

--- a/lib/spack/spack/test/tengine.py
+++ b/lib/spack/spack/test/tengine.py
@@ -5,7 +5,6 @@
 
 import pytest
 
-import spack.config
 from spack import tengine
 from spack.config import canonicalize_path
 
@@ -66,10 +65,10 @@ class TestContext:
 
 @pytest.mark.usefixtures("config")
 class TestTengineEnvironment:
-    def test_template_retrieval(self):
+    def test_template_retrieval(self, config):
         """Tests the template retrieval mechanism hooked into config files"""
         # Check the directories are correct
-        template_dirs = spack.config.get("config:template_dirs")
+        template_dirs = config.get("config:template_dirs")
         template_dirs = tuple([canonicalize_path(x) for x in template_dirs])
         assert len(template_dirs) == 3
 

--- a/lib/spack/spack/test/tengine.py
+++ b/lib/spack/spack/test/tengine.py
@@ -6,7 +6,7 @@
 import pytest
 
 from spack import tengine
-from spack.config import canonicalize_path
+from spack.config import Configuration, canonicalize_path
 
 
 class TestContext:
@@ -65,7 +65,7 @@ class TestContext:
 
 @pytest.mark.usefixtures("config")
 class TestTengineEnvironment:
-    def test_template_retrieval(self, config):
+    def test_template_retrieval(self, config: Configuration):
         """Tests the template retrieval mechanism hooked into config files"""
         # Check the directories are correct
         template_dirs = config.get("config:template_dirs")

--- a/lib/spack/spack/test/test_suite.py
+++ b/lib/spack/spack/test/test_suite.py
@@ -9,7 +9,6 @@ import sys
 import pytest
 
 import spack.concretize
-import spack.config
 import spack.database
 import spack.install_test
 import spack.spec
@@ -339,7 +338,7 @@ def test_test_part_skip(install_mockery, mock_fetch, mock_test_stage):
 
 
 def test_test_part_missing_exe_fail_fast(
-    tmp_path: pathlib.Path, install_mockery, mock_fetch, mock_test_stage
+    tmp_path: pathlib.Path, install_mockery, mock_fetch, mock_test_stage, mutable_config
 ):
     """Confirm test_part with fail fast enabled raises exception."""
     s = spack.concretize.concretize_one("trivial-smoke-test")
@@ -348,7 +347,7 @@ def test_test_part_missing_exe_fail_fast(
     touch(pkg.tester.test_log_file)
 
     name = "test_fail_fast"
-    with spack.config.override("config:fail_fast", True):
+    with mutable_config.override("config:fail_fast", True):
         with pytest.raises(spack.install_test.TestFailure, match="object is not callable"):
             with spack.install_test.test_part(pkg, name, "fail fast"):
                 missing = which("no-possible-program")

--- a/lib/spack/spack/test/test_suite.py
+++ b/lib/spack/spack/test/test_suite.py
@@ -13,6 +13,7 @@ import spack.database
 import spack.install_test
 import spack.spec
 import spack.util.executable
+from spack.config import Configuration
 from spack.install_test import TestStatus
 from spack.util.executable import which
 from spack.util.filesystem import touch
@@ -338,7 +339,11 @@ def test_test_part_skip(install_mockery, mock_fetch, mock_test_stage):
 
 
 def test_test_part_missing_exe_fail_fast(
-    tmp_path: pathlib.Path, install_mockery, mock_fetch, mock_test_stage, mutable_config
+    tmp_path: pathlib.Path,
+    install_mockery,
+    mock_fetch,
+    mock_test_stage,
+    mutable_config: Configuration,
 ):
     """Confirm test_part with fail fast enabled raises exception."""
     s = spack.concretize.concretize_one("trivial-smoke-test")

--- a/lib/spack/spack/test/url_fetch.py
+++ b/lib/spack/spack/test/url_fetch.py
@@ -17,6 +17,7 @@ import spack.fetch_strategy as fs
 import spack.url
 import spack.util.web as web_util
 import spack.version
+from spack.config import Configuration
 from spack.stage import Stage
 from spack.util import crypto, tty
 from spack.util.executable import which
@@ -94,7 +95,7 @@ def test_urlfetchstrategy_bad_url(tmp_path: pathlib.Path, mutable_config, method
         assert isinstance(exception.reason, FileNotFoundError)
 
 
-def test_fetch_options(mutable_config, tmp_path: pathlib.Path, mock_archive):
+def test_fetch_options(mutable_config: Configuration, tmp_path: pathlib.Path, mock_archive):
     with mutable_config.override("config:url_fetch_method", "curl"):
         fetcher = fs.URLFetchStrategy(
             url=mock_archive.url, fetch_options={"cookie": "True", "timeout": 10}
@@ -108,7 +109,9 @@ def test_fetch_options(mutable_config, tmp_path: pathlib.Path, mock_archive):
             assert filecmp.cmp(archive_file, mock_archive.archive_file)
 
 
-def test_fetch_curl_options(mutable_config, tmp_path: pathlib.Path, mock_archive, monkeypatch):
+def test_fetch_curl_options(
+    mutable_config: Configuration, tmp_path: pathlib.Path, mock_archive, monkeypatch
+):
     with mutable_config.override("config:url_fetch_method", "curl -k -q"):
         fetcher = fs.URLFetchStrategy(
             url=mock_archive.url, fetch_options={"cookie": "True", "timeout": 10}
@@ -129,7 +132,9 @@ def test_fetch_curl_options(mutable_config, tmp_path: pathlib.Path, mock_archive
 
 
 @pytest.mark.parametrize("_fetch_method", ["curl", "urllib"])
-def test_archive_file_errors(tmp_path: pathlib.Path, mutable_config, mock_archive, _fetch_method):
+def test_archive_file_errors(
+    tmp_path: pathlib.Path, mutable_config: Configuration, mock_archive, _fetch_method
+):
     """Ensure FetchStrategy commands may only be used as intended"""
     with mutable_config.override("config:url_fetch_method", _fetch_method):
         fetcher = fs.URLFetchStrategy(url=mock_archive.url)
@@ -158,7 +163,13 @@ if sys.platform != "win32":
 @pytest.mark.parametrize("_fetch_method", ["curl", "urllib"])
 @pytest.mark.parametrize("mock_archive", files, indirect=True)
 def test_fetch(
-    mock_archive, secure, _fetch_method, checksum_type, config, mutable_mock_repo, monkeypatch
+    mock_archive,
+    secure,
+    _fetch_method,
+    checksum_type,
+    config: Configuration,
+    mutable_mock_repo,
+    monkeypatch,
 ):
     """Fetch an archive and make sure we can checksum it."""
     algo = crypto.hash_fun_for_algo(checksum_type)()
@@ -205,7 +216,7 @@ def test_fetch(
     ],
 )
 @pytest.mark.parametrize("_fetch_method", ["curl", "urllib"])
-def test_from_list_url(mock_packages, config, spec, url, digest, _fetch_method):
+def test_from_list_url(mock_packages, config: Configuration, spec, url, digest, _fetch_method):
     """
     Test URLs in the url-list-test package, which means they should
     have checksums in the package.
@@ -233,7 +244,7 @@ def test_from_list_url(mock_packages, config, spec, url, digest, _fetch_method):
     ],
 )
 def test_new_version_from_list_url(
-    mock_packages, config, _fetch_method, requested_version, tarball, digest
+    mock_packages, config: Configuration, _fetch_method, requested_version, tarball, digest
 ):
     """Test non-specific URLs from the url-list-test package."""
     with config.override("config:url_fetch_method", _fetch_method):
@@ -270,7 +281,7 @@ def test_unknown_hash(checksum_type):
 
 @pytest.mark.skipif(which("curl") is None, reason="Urllib does not have built-in status bar")
 def test_url_with_status_bar(
-    mutable_config, tmp_path: pathlib.Path, mock_archive, monkeypatch, capfd
+    mutable_config: Configuration, tmp_path: pathlib.Path, mock_archive, monkeypatch, capfd
 ):
     """Ensure fetch with status bar option succeeds."""
 
@@ -323,7 +334,9 @@ def test_url_extra_fetch(tmp_path: pathlib.Path, mutable_config, mock_archive, _
     ],
 )
 @pytest.mark.parametrize("_fetch_method", ["curl", "urllib"])
-def test_candidate_urls(mutable_config, pkg_factory, url, urls, version, expected, _fetch_method):
+def test_candidate_urls(
+    mutable_config: Configuration, pkg_factory, url, urls, version, expected, _fetch_method
+):
     """Tests that candidate urls include mirrors and that they go through
     pattern matching and substitution for versions.
     """

--- a/lib/spack/spack/test/url_fetch.py
+++ b/lib/spack/spack/test/url_fetch.py
@@ -12,7 +12,6 @@ import urllib.error
 import pytest
 
 import spack.concretize
-import spack.config
 import spack.error
 import spack.fetch_strategy as fs
 import spack.url
@@ -95,8 +94,8 @@ def test_urlfetchstrategy_bad_url(tmp_path: pathlib.Path, mutable_config, method
         assert isinstance(exception.reason, FileNotFoundError)
 
 
-def test_fetch_options(tmp_path: pathlib.Path, mock_archive):
-    with spack.config.override("config:url_fetch_method", "curl"):
+def test_fetch_options(mutable_config, tmp_path: pathlib.Path, mock_archive):
+    with mutable_config.override("config:url_fetch_method", "curl"):
         fetcher = fs.URLFetchStrategy(
             url=mock_archive.url, fetch_options={"cookie": "True", "timeout": 10}
         )
@@ -109,8 +108,8 @@ def test_fetch_options(tmp_path: pathlib.Path, mock_archive):
             assert filecmp.cmp(archive_file, mock_archive.archive_file)
 
 
-def test_fetch_curl_options(tmp_path: pathlib.Path, mock_archive, monkeypatch):
-    with spack.config.override("config:url_fetch_method", "curl -k -q"):
+def test_fetch_curl_options(mutable_config, tmp_path: pathlib.Path, mock_archive, monkeypatch):
+    with mutable_config.override("config:url_fetch_method", "curl -k -q"):
         fetcher = fs.URLFetchStrategy(
             url=mock_archive.url, fetch_options={"cookie": "True", "timeout": 10}
         )
@@ -132,7 +131,7 @@ def test_fetch_curl_options(tmp_path: pathlib.Path, mock_archive, monkeypatch):
 @pytest.mark.parametrize("_fetch_method", ["curl", "urllib"])
 def test_archive_file_errors(tmp_path: pathlib.Path, mutable_config, mock_archive, _fetch_method):
     """Ensure FetchStrategy commands may only be used as intended"""
-    with spack.config.override("config:url_fetch_method", _fetch_method):
+    with mutable_config.override("config:url_fetch_method", _fetch_method):
         fetcher = fs.URLFetchStrategy(url=mock_archive.url)
         with Stage(fetcher, path=str(tmp_path)) as stage:
             assert fetcher.archive_file is None
@@ -180,8 +179,8 @@ def test_fetch(
 
     # Enter the stage directory and check some properties
     with s.package.stage:
-        with spack.config.override("config:verify_ssl", secure):
-            with spack.config.override("config:url_fetch_method", _fetch_method):
+        with config.override("config:verify_ssl", secure):
+            with config.override("config:url_fetch_method", _fetch_method):
                 s.package.do_stage()
         with working_dir(s.package.stage.source_path):
             assert os.path.exists("configure")
@@ -211,7 +210,7 @@ def test_from_list_url(mock_packages, config, spec, url, digest, _fetch_method):
     Test URLs in the url-list-test package, which means they should
     have checksums in the package.
     """
-    with spack.config.override("config:url_fetch_method", _fetch_method):
+    with config.override("config:url_fetch_method", _fetch_method):
         s = spack.concretize.concretize_one(spec)
         fetch_strategy = fs.from_list_url(s.package)
         assert isinstance(fetch_strategy, fs.URLFetchStrategy)
@@ -237,7 +236,7 @@ def test_new_version_from_list_url(
     mock_packages, config, _fetch_method, requested_version, tarball, digest
 ):
     """Test non-specific URLs from the url-list-test package."""
-    with spack.config.override("config:url_fetch_method", _fetch_method):
+    with config.override("config:url_fetch_method", _fetch_method):
         s = spack.concretize.concretize_one(f"url-list-test @{requested_version}")
         fetch_strategy = fs.from_list_url(s.package)
 
@@ -270,7 +269,9 @@ def test_unknown_hash(checksum_type):
 
 
 @pytest.mark.skipif(which("curl") is None, reason="Urllib does not have built-in status bar")
-def test_url_with_status_bar(tmp_path: pathlib.Path, mock_archive, monkeypatch, capfd):
+def test_url_with_status_bar(
+    mutable_config, tmp_path: pathlib.Path, mock_archive, monkeypatch, capfd
+):
     """Ensure fetch with status bar option succeeds."""
 
     def is_true():
@@ -280,7 +281,7 @@ def test_url_with_status_bar(tmp_path: pathlib.Path, mock_archive, monkeypatch, 
 
     monkeypatch.setattr(sys.stdout, "isatty", is_true)
     monkeypatch.setattr(tty, "msg_enabled", is_true)
-    with spack.config.override("config:url_fetch_method", "curl"):
+    with mutable_config.override("config:url_fetch_method", "curl"):
         fetcher = fs.URLFetchStrategy(url=mock_archive.url)
         with Stage(fetcher, path=testpath) as stage:
             assert fetcher.archive_file is None
@@ -322,11 +323,11 @@ def test_url_extra_fetch(tmp_path: pathlib.Path, mutable_config, mock_archive, _
     ],
 )
 @pytest.mark.parametrize("_fetch_method", ["curl", "urllib"])
-def test_candidate_urls(pkg_factory, url, urls, version, expected, _fetch_method):
+def test_candidate_urls(mutable_config, pkg_factory, url, urls, version, expected, _fetch_method):
     """Tests that candidate urls include mirrors and that they go through
     pattern matching and substitution for versions.
     """
-    with spack.config.override("config:url_fetch_method", _fetch_method):
+    with mutable_config.override("config:url_fetch_method", _fetch_method):
         pkg = pkg_factory(url, urls)
         f = fs._from_merged_attrs(fs.URLFetchStrategy, pkg, version)
         assert f.candidate_urls == expected

--- a/lib/spack/spack/test/util/package_hash.py
+++ b/lib/spack/spack/test/util/package_hash.py
@@ -10,7 +10,6 @@ import pytest
 import spack.concretize
 import spack.directives_meta
 import spack.paths
-import spack.repo
 import spack.util.package_hash as ph
 from spack.spec import Spec
 from spack.util.unparse import unparse
@@ -18,25 +17,25 @@ from spack.util.unparse import unparse
 datadir = os.path.join(spack.paths.test_path, "data", "unparse")
 
 
-def compare_sans_name(eq, spec1, spec2):
+def compare_sans_name(repo, eq, spec1, spec2):
     content1 = ph.canonical_source(spec1)
-    content1 = content1.replace(spack.repo.PATH.get_pkg_class(spec1.name).__name__, "TestPackage")
+    content1 = content1.replace(repo.get_pkg_class(spec1.name).__name__, "TestPackage")
     content2 = ph.canonical_source(spec2)
-    content2 = content2.replace(spack.repo.PATH.get_pkg_class(spec2.name).__name__, "TestPackage")
+    content2 = content2.replace(repo.get_pkg_class(spec2.name).__name__, "TestPackage")
     if eq:
         assert content1 == content2
     else:
         assert content1 != content2
 
 
-def compare_hash_sans_name(eq, spec1, spec2):
+def compare_hash_sans_name(repo, eq, spec1, spec2):
     content1 = ph.canonical_source(spec1)
-    pkg_cls1 = spack.repo.PATH.get_pkg_class(spec1.name)
+    pkg_cls1 = repo.get_pkg_class(spec1.name)
     content1 = content1.replace(pkg_cls1.__name__, "TestPackage")
     hash1 = pkg_cls1(spec1).content_hash(content=content1)
 
     content2 = ph.canonical_source(spec2)
-    pkg_cls2 = spack.repo.PATH.get_pkg_class(spec2.name)
+    pkg_cls2 = repo.get_pkg_class(spec2.name)
     content2 = content2.replace(pkg_cls2.__name__, "TestPackage")
     hash2 = pkg_cls2(spec2).content_hash(content=content2)
 
@@ -56,11 +55,11 @@ def test_different_variants(mock_packages, config):
 def test_all_same_but_name(mock_packages, config):
     spec1 = Spec("hash-test1@=1.2")
     spec2 = Spec("hash-test2@=1.2")
-    compare_sans_name(True, spec1, spec2)
+    compare_sans_name(mock_packages, True, spec1, spec2)
 
     spec1 = Spec("hash-test1@=1.2 +varianty")
     spec2 = Spec("hash-test2@=1.2 +varianty")
-    compare_sans_name(True, spec1, spec2)
+    compare_sans_name(mock_packages, True, spec1, spec2)
 
 
 def test_all_same_but_archive_hash(mock_packages, config):
@@ -69,31 +68,31 @@ def test_all_same_but_archive_hash(mock_packages, config):
     """
     spec1 = Spec("hash-test1@=1.3")
     spec2 = Spec("hash-test2@=1.3")
-    compare_sans_name(True, spec1, spec2)
+    compare_sans_name(mock_packages, True, spec1, spec2)
 
 
 def test_all_same_but_patch_contents(mock_packages, config):
     spec1 = Spec("hash-test1@=1.1")
     spec2 = Spec("hash-test2@=1.1")
-    compare_sans_name(True, spec1, spec2)
+    compare_sans_name(mock_packages, True, spec1, spec2)
 
 
 def test_all_same_but_patches_to_apply(mock_packages, config):
     spec1 = Spec("hash-test1@=1.4")
     spec2 = Spec("hash-test2@=1.4")
-    compare_sans_name(True, spec1, spec2)
+    compare_sans_name(mock_packages, True, spec1, spec2)
 
 
 def test_all_same_but_install(mock_packages, config):
     spec1 = Spec("hash-test1@=1.5")
     spec2 = Spec("hash-test2@=1.5")
-    compare_sans_name(False, spec1, spec2)
+    compare_sans_name(mock_packages, False, spec1, spec2)
 
 
 def test_content_hash_all_same_but_patch_contents(mock_packages, config):
     spec1 = spack.concretize.concretize_one("hash-test1@1.1")
     spec2 = spack.concretize.concretize_one("hash-test2@1.1")
-    compare_hash_sans_name(False, spec1, spec2)
+    compare_hash_sans_name(mock_packages, False, spec1, spec2)
 
 
 def test_content_hash_not_concretized(mock_packages, config):
@@ -101,25 +100,25 @@ def test_content_hash_not_concretized(mock_packages, config):
     # these are different due to the package hash
     spec1 = Spec("hash-test1@=1.1")
     spec2 = Spec("hash-test2@=1.3")
-    compare_hash_sans_name(False, spec1, spec2)
+    compare_hash_sans_name(mock_packages, False, spec1, spec2)
 
     # at v1.1 these are actually the same package when @when's are removed
     # and the name isn't considered
     spec1 = Spec("hash-test1@=1.1")
     spec2 = Spec("hash-test2@=1.1")
-    compare_hash_sans_name(True, spec1, spec2)
+    compare_hash_sans_name(mock_packages, True, spec1, spec2)
 
     # these end up being different b/c we can't eliminate much of the package.py
     # without a version.
     spec1 = Spec("hash-test1")
     spec2 = Spec("hash-test2")
-    compare_hash_sans_name(False, spec1, spec2)
+    compare_hash_sans_name(mock_packages, False, spec1, spec2)
 
 
 def test_content_hash_different_variants(mock_packages, config):
     spec1 = spack.concretize.concretize_one("hash-test1@1.2 +variantx")
     spec2 = spack.concretize.concretize_one("hash-test2@1.2 ~variantx")
-    compare_hash_sans_name(True, spec1, spec2)
+    compare_hash_sans_name(mock_packages, True, spec1, spec2)
 
 
 def test_content_hash_cannot_get_details_from_ast(mock_packages, config):
@@ -134,13 +133,13 @@ def test_content_hash_cannot_get_details_from_ast(mock_packages, config):
     """
     spec3 = spack.concretize.concretize_one("hash-test1@1.7")
     spec4 = spack.concretize.concretize_one("hash-test3@1.7")
-    compare_hash_sans_name(False, spec3, spec4)
+    compare_hash_sans_name(mock_packages, False, spec3, spec4)
 
 
 def test_content_hash_all_same_but_archive_hash(mock_packages, config):
     spec1 = spack.concretize.concretize_one("hash-test1@1.3")
     spec2 = spack.concretize.concretize_one("hash-test2@1.3")
-    compare_hash_sans_name(False, spec1, spec2)
+    compare_hash_sans_name(mock_packages, False, spec1, spec2)
 
 
 def test_content_hash_parse_dynamic_function_call(mock_packages, config):

--- a/lib/spack/spack/test/util/package_hash.py
+++ b/lib/spack/spack/test/util/package_hash.py
@@ -11,6 +11,7 @@ import spack.concretize
 import spack.directives_meta
 import spack.paths
 import spack.util.package_hash as ph
+from spack.repo import RepoPath
 from spack.spec import Spec
 from spack.util.unparse import unparse
 
@@ -52,7 +53,7 @@ def test_different_variants(mock_packages, config):
     assert ph.package_hash(spec1) == ph.package_hash(spec2)
 
 
-def test_all_same_but_name(mock_packages, config):
+def test_all_same_but_name(mock_packages: RepoPath, config):
     spec1 = Spec("hash-test1@=1.2")
     spec2 = Spec("hash-test2@=1.2")
     compare_sans_name(mock_packages, True, spec1, spec2)
@@ -62,7 +63,7 @@ def test_all_same_but_name(mock_packages, config):
     compare_sans_name(mock_packages, True, spec1, spec2)
 
 
-def test_all_same_but_archive_hash(mock_packages, config):
+def test_all_same_but_archive_hash(mock_packages: RepoPath, config):
     """
     Archive hash is not intended to be reflected in Package hash.
     """
@@ -71,31 +72,31 @@ def test_all_same_but_archive_hash(mock_packages, config):
     compare_sans_name(mock_packages, True, spec1, spec2)
 
 
-def test_all_same_but_patch_contents(mock_packages, config):
+def test_all_same_but_patch_contents(mock_packages: RepoPath, config):
     spec1 = Spec("hash-test1@=1.1")
     spec2 = Spec("hash-test2@=1.1")
     compare_sans_name(mock_packages, True, spec1, spec2)
 
 
-def test_all_same_but_patches_to_apply(mock_packages, config):
+def test_all_same_but_patches_to_apply(mock_packages: RepoPath, config):
     spec1 = Spec("hash-test1@=1.4")
     spec2 = Spec("hash-test2@=1.4")
     compare_sans_name(mock_packages, True, spec1, spec2)
 
 
-def test_all_same_but_install(mock_packages, config):
+def test_all_same_but_install(mock_packages: RepoPath, config):
     spec1 = Spec("hash-test1@=1.5")
     spec2 = Spec("hash-test2@=1.5")
     compare_sans_name(mock_packages, False, spec1, spec2)
 
 
-def test_content_hash_all_same_but_patch_contents(mock_packages, config):
+def test_content_hash_all_same_but_patch_contents(mock_packages: RepoPath, config):
     spec1 = spack.concretize.concretize_one("hash-test1@1.1")
     spec2 = spack.concretize.concretize_one("hash-test2@1.1")
     compare_hash_sans_name(mock_packages, False, spec1, spec2)
 
 
-def test_content_hash_not_concretized(mock_packages, config):
+def test_content_hash_not_concretized(mock_packages: RepoPath, config):
     """Check that Package.content_hash() works on abstract specs."""
     # these are different due to the package hash
     spec1 = Spec("hash-test1@=1.1")
@@ -115,13 +116,13 @@ def test_content_hash_not_concretized(mock_packages, config):
     compare_hash_sans_name(mock_packages, False, spec1, spec2)
 
 
-def test_content_hash_different_variants(mock_packages, config):
+def test_content_hash_different_variants(mock_packages: RepoPath, config):
     spec1 = spack.concretize.concretize_one("hash-test1@1.2 +variantx")
     spec2 = spack.concretize.concretize_one("hash-test2@1.2 ~variantx")
     compare_hash_sans_name(mock_packages, True, spec1, spec2)
 
 
-def test_content_hash_cannot_get_details_from_ast(mock_packages, config):
+def test_content_hash_cannot_get_details_from_ast(mock_packages: RepoPath, config):
     """Packages hash-test1 and hash-test3 would be considered the same
     except that hash-test3 conditionally executes a phase based on
     a "when" directive that Spack cannot evaluate by examining the
@@ -136,7 +137,7 @@ def test_content_hash_cannot_get_details_from_ast(mock_packages, config):
     compare_hash_sans_name(mock_packages, False, spec3, spec4)
 
 
-def test_content_hash_all_same_but_archive_hash(mock_packages, config):
+def test_content_hash_all_same_but_archive_hash(mock_packages: RepoPath, config):
     spec1 = spack.concretize.concretize_one("hash-test1@1.3")
     spec2 = spack.concretize.concretize_one("hash-test2@1.3")
     compare_hash_sans_name(mock_packages, False, spec1, spec2)

--- a/lib/spack/spack/test/util/path.py
+++ b/lib/spack/spack/test/util/path.py
@@ -89,7 +89,7 @@ def test_output_filtering(capfd, install_mockery, mutable_config):
     padding_string = "[padded-to-%d-chars]" % len(long_path)
 
     # test filtering when padding is enabled
-    with spack.config.override("config:install_tree", {"padded_length": 256}):
+    with mutable_config.override("config:install_tree", {"padded_length": 256}):
         # tty.msg with filtering on the first argument
         with spack.store.filter_padding():
             tty.msg("here is a long path: %s/with/a/suffix" % long_path)

--- a/lib/spack/spack/test/util/path.py
+++ b/lib/spack/spack/test/util/path.py
@@ -145,5 +145,5 @@ def test_path_debug_padded_filter(debug, monkeypatch):
     )
 
     monkeypatch.setattr(tty, "_debug", debug)
-    with spack.config.override("config:install_tree", {"padded_length": 128}):
+    with spack.config.CONFIG.override("config:install_tree", {"padded_length": 128}):
         assert expected == sup.debug_padded_filter(string)

--- a/lib/spack/spack/test/util/path.py
+++ b/lib/spack/spack/test/util/path.py
@@ -10,6 +10,7 @@ import pytest
 import spack.config
 import spack.store
 import spack.util.path as sup
+from spack.config import Configuration
 from spack.util import tty
 
 #: Some lines with lots of placeholders
@@ -83,7 +84,7 @@ class TestPathPadding:
 
 
 @pytest.mark.not_on_windows("Padding functionality unsupported on Windows")
-def test_output_filtering(capfd, install_mockery, mutable_config):
+def test_output_filtering(capfd, install_mockery, mutable_config: Configuration):
     """Test filtering padding out of tty messages."""
     long_path = "/" + "/".join([sup.SPACK_PATH_PADDING_CHARS] * 200)
     padding_string = "[padded-to-%d-chars]" % len(long_path)

--- a/lib/spack/spack/test/util/remote_file_cache.py
+++ b/lib/spack/spack/test/util/remote_file_cache.py
@@ -7,7 +7,6 @@ import sys
 
 import pytest
 
-import spack.config
 import spack.util.remote_file_cache as rfc_util
 from spack.util import tty
 from spack.util.filesystem import join_path
@@ -91,11 +90,11 @@ def test_rfc_remote_local_path(
     dest_dir = join_path(str(tmp_path), "cache")
 
     if err is not None:
-        with spack.config.override("config:url_fetch_method", "curl"):
+        with mutable_empty_config.override("config:url_fetch_method", "curl"):
             with pytest.raises(err, match=msg):
                 rfc_util.local_path(url, sha256, dest_dir)
     else:
-        with spack.config.override("config:url_fetch_method", "curl"):
+        with mutable_empty_config.override("config:url_fetch_method", "curl"):
             path = rfc_util.local_path(url, sha256, dest_dir)
             assert os.path.exists(path)
             # Ensure correct file is "fetched"

--- a/lib/spack/spack/test/util/spack_yaml.py
+++ b/lib/spack/spack/test/util/spack_yaml.py
@@ -4,6 +4,7 @@
 
 import re
 
+from spack.config import Configuration
 from spack.main import SpackCommand
 
 config_cmd = SpackCommand("config")
@@ -51,7 +52,7 @@ def test_config_blame(config):
     check_blame("dirty", config_file, 15)
 
 
-def test_config_blame_with_override(config):
+def test_config_blame_with_override(config: Configuration):
     """check blame for an element from an override scope"""
     config_file = config.get_config_filename("site", "config")
 

--- a/lib/spack/spack/test/util/spack_yaml.py
+++ b/lib/spack/spack/test/util/spack_yaml.py
@@ -4,7 +4,6 @@
 
 import re
 
-import spack.config
 from spack.main import SpackCommand
 
 config_cmd = SpackCommand("config")
@@ -56,7 +55,7 @@ def test_config_blame_with_override(config):
     """check blame for an element from an override scope"""
     config_file = config.get_config_filename("site", "config")
 
-    with spack.config.override("config:install_tree", {"root": "foobar"}):
+    with config.override("config:install_tree", {"root": "foobar"}):
         check_blame("install_tree", "overrides")
 
         check_blame("source_cache", config_file, 11)

--- a/lib/spack/spack/test/variant.py
+++ b/lib/spack/spack/test/variant.py
@@ -9,6 +9,7 @@ import spack.concretize
 import spack.error
 import spack.spec
 import spack.variant
+from spack.repo import RepoPath
 from spack.spec import Spec, VariantMap
 from spack.variant import (
     BoolValuedVariant,
@@ -600,7 +601,7 @@ def test_wild_card_valued_variants_equivalent_to_str():
     assert str_output.value == wild_output.value
 
 
-def test_variant_definitions(mock_packages):
+def test_variant_definitions(mock_packages: RepoPath):
     pkg = mock_packages.get_pkg_class("variant-values")
 
     # two variant names
@@ -651,7 +652,7 @@ def test_variant_definitions(mock_packages):
         ("variant-values-override", "baz", "@4.0", [0]),
     ],
 )
-def test_prevalidate_variant_value(mock_packages, pkg_name, value, spec, def_ids):
+def test_prevalidate_variant_value(mock_packages: RepoPath, pkg_name, value, spec, def_ids):
     pkg = mock_packages.get_pkg_class(pkg_name)
 
     all_defs = [vdef for _, vdef in pkg.variant_definitions("v")]
@@ -681,7 +682,7 @@ def test_prevalidate_variant_value(mock_packages, pkg_name, value, spec, def_ids
         ("variant-values-override", "foo", "@4.0"),
     ],
 )
-def test_strict_invalid_variant_values(mock_packages, pkg_name, value, spec):
+def test_strict_invalid_variant_values(mock_packages: RepoPath, pkg_name, value, spec):
     pkg = mock_packages.get_pkg_class(pkg_name)
 
     with pytest.raises(spack.variant.InvalidVariantValueError):
@@ -702,7 +703,7 @@ def test_strict_invalid_variant_values(mock_packages, pkg_name, value, spec):
     ],
 )
 def test_concretize_variant_default_with_multiple_defs(
-    mock_packages, config, pkg_name, spec, satisfies, def_id
+    mock_packages: RepoPath, config, pkg_name, spec, satisfies, def_id
 ):
     pkg = mock_packages.get_pkg_class(pkg_name)
     pkg_defs = [vdef for _, vdef in pkg.variant_definitions("v")]

--- a/lib/spack/spack/test/variant.py
+++ b/lib/spack/spack/test/variant.py
@@ -7,7 +7,6 @@ import pytest
 
 import spack.concretize
 import spack.error
-import spack.repo
 import spack.spec
 import spack.variant
 from spack.spec import Spec, VariantMap
@@ -602,7 +601,7 @@ def test_wild_card_valued_variants_equivalent_to_str():
 
 
 def test_variant_definitions(mock_packages):
-    pkg = spack.repo.PATH.get_pkg_class("variant-values")
+    pkg = mock_packages.get_pkg_class("variant-values")
 
     # two variant names
     assert len(pkg.variant_names()) == 2
@@ -653,7 +652,7 @@ def test_variant_definitions(mock_packages):
     ],
 )
 def test_prevalidate_variant_value(mock_packages, pkg_name, value, spec, def_ids):
-    pkg = spack.repo.PATH.get_pkg_class(pkg_name)
+    pkg = mock_packages.get_pkg_class(pkg_name)
 
     all_defs = [vdef for _, vdef in pkg.variant_definitions("v")]
 
@@ -683,7 +682,7 @@ def test_prevalidate_variant_value(mock_packages, pkg_name, value, spec, def_ids
     ],
 )
 def test_strict_invalid_variant_values(mock_packages, pkg_name, value, spec):
-    pkg = spack.repo.PATH.get_pkg_class(pkg_name)
+    pkg = mock_packages.get_pkg_class(pkg_name)
 
     with pytest.raises(spack.variant.InvalidVariantValueError):
         spack.variant.prevalidate_variant_value(
@@ -705,7 +704,7 @@ def test_strict_invalid_variant_values(mock_packages, pkg_name, value, spec):
 def test_concretize_variant_default_with_multiple_defs(
     mock_packages, config, pkg_name, spec, satisfies, def_id
 ):
-    pkg = spack.repo.PATH.get_pkg_class(pkg_name)
+    pkg = mock_packages.get_pkg_class(pkg_name)
     pkg_defs = [vdef for _, vdef in pkg.variant_definitions("v")]
 
     spec = spack.concretize.concretize_one(f"{pkg_name}{spec}")

--- a/lib/spack/spack/test/web.py
+++ b/lib/spack/spack/test/web.py
@@ -394,7 +394,7 @@ def ssl_scrubbed_env(mutable_config, monkeypatch):
     monkeypatch.delenv("SSL_CERT_FILE", raising=False)
     monkeypatch.delenv("SSL_CERT_DIR", raising=False)
     monkeypatch.delenv("CURL_CA_BUNDLE", raising=False)
-    spack.config.set("config:verify_ssl", True)
+    spack.config.CONFIG.set("config:verify_ssl", True)
 
 
 @pytest.mark.parametrize(

--- a/lib/spack/spack/test/web.py
+++ b/lib/spack/spack/test/web.py
@@ -19,6 +19,7 @@ import spack.url
 import spack.util.s3
 import spack.util.url as url_util
 import spack.util.web
+from spack.config import Configuration
 from spack.util import tty
 from spack.util.filesystem import working_dir
 from spack.version import Version
@@ -388,7 +389,7 @@ def test_detailed_http_error_pickle(tmp_path: pathlib.Path):
 
 
 @pytest.fixture()
-def ssl_scrubbed_env(mutable_config, monkeypatch):
+def ssl_scrubbed_env(mutable_config: Configuration, monkeypatch):
     """clear out environment variables that could give false positives for SSL Cert tests"""
     monkeypatch.delenv("SSL_CERT_FILE", raising=False)
     monkeypatch.delenv("SSL_CERT_DIR", raising=False)
@@ -412,7 +413,12 @@ def ssl_scrubbed_env(mutable_config, monkeypatch):
     ],
 )
 def test_ssl_urllib(
-    cert_path, cert_creator, tmp_path: pathlib.Path, ssl_scrubbed_env, mutable_config, monkeypatch
+    cert_path,
+    cert_creator,
+    tmp_path: pathlib.Path,
+    ssl_scrubbed_env,
+    mutable_config: Configuration,
+    monkeypatch,
 ):
     """
     create a proposed cert type and then verify that they exist inside ssl's checks
@@ -442,7 +448,11 @@ def test_ssl_urllib(
 
 @pytest.mark.parametrize("cert_exists", [True, False], ids=["exists", "missing"])
 def test_ssl_curl_cert_file(
-    cert_exists, tmp_path: pathlib.Path, ssl_scrubbed_env, mutable_config, monkeypatch
+    cert_exists,
+    tmp_path: pathlib.Path,
+    ssl_scrubbed_env,
+    mutable_config: Configuration,
+    monkeypatch,
 ):
     """
     Assure that if a valid cert file is specified curl executes

--- a/lib/spack/spack/test/web.py
+++ b/lib/spack/spack/test/web.py
@@ -13,7 +13,6 @@ from typing import Any, Dict, List, Tuple
 
 import pytest
 
-import spack.config
 import spack.mirrors.mirror
 import spack.paths
 import spack.url
@@ -394,7 +393,7 @@ def ssl_scrubbed_env(mutable_config, monkeypatch):
     monkeypatch.delenv("SSL_CERT_FILE", raising=False)
     monkeypatch.delenv("SSL_CERT_DIR", raising=False)
     monkeypatch.delenv("CURL_CA_BUNDLE", raising=False)
-    spack.config.CONFIG.set("config:verify_ssl", True)
+    mutable_config.set("config:verify_ssl", True)
 
 
 @pytest.mark.parametrize(

--- a/lib/spack/spack/test/web.py
+++ b/lib/spack/spack/test/web.py
@@ -418,7 +418,7 @@ def test_ssl_urllib(
     """
     create a proposed cert type and then verify that they exist inside ssl's checks
     """
-    spack.config.set("config:url_fetch_method", "urllib")
+    mutable_config.set("config:url_fetch_method", "urllib")
 
     def mock_verify_locations(self, cafile, capath, cadata):
         """overwrite ssl's verification to simply check for valid file/path"""
@@ -433,9 +433,9 @@ def test_ssl_urllib(
     with working_dir(str(tmp_path)):
         mock_cert = cert_path(str(tmp_path))
         cert_creator(mock_cert)
-        spack.config.set("config:ssl_certs", mock_cert)
+        mutable_config.set("config:ssl_certs", mock_cert)
 
-        assert mock_cert == spack.config.get("config:ssl_certs", None)
+        assert mock_cert == mutable_config.get("config:ssl_certs", None)
 
         ssl_context = spack.util.web.ssl_create_default_context()
         assert ssl_context.verify_mode == ssl.CERT_REQUIRED
@@ -449,10 +449,10 @@ def test_ssl_curl_cert_file(
     Assure that if a valid cert file is specified curl executes
     with CURL_CA_BUNDLE in the env
     """
-    spack.config.set("config:url_fetch_method", "curl")
+    mutable_config.set("config:url_fetch_method", "curl")
     with working_dir(str(tmp_path)):
         mock_cert = str(tmp_path / "mock_cert.crt")
-        spack.config.set("config:ssl_certs", mock_cert)
+        mutable_config.set("config:ssl_certs", mock_cert)
         if cert_exists:
             open(mock_cert, "w", encoding="utf-8").close()
             assert os.path.isfile(mock_cert)

--- a/lib/spack/spack/url_buildcache.py
+++ b/lib/spack/spack/url_buildcache.py
@@ -1359,7 +1359,7 @@ def try_verify(specfile_path):
     Returns:
         ``True`` if the signature could be verified, ``False`` otherwise.
     """
-    suppress = config.get("config:suppress_gpg_warnings", False)
+    suppress = config.CONFIG.get("config:suppress_gpg_warnings", False)
 
     try:
         spack.util.gpg.verify(specfile_path, suppress_warnings=suppress)

--- a/lib/spack/spack/user_environment.py
+++ b/lib/spack/spack/user_environment.py
@@ -27,7 +27,7 @@ def prefix_inspections(platform: str) -> dict:
         A dictionary mapping subdirectory names to lists of environment variables to modify with
         that directory if it exists.
     """
-    inspections = spack.config.get("modules:prefix_inspections")
+    inspections = spack.config.CONFIG.get("modules:prefix_inspections")
     if isinstance(inspections, dict):
         return inspections
 

--- a/lib/spack/spack/util/s3.py
+++ b/lib/spack/spack/util/s3.py
@@ -89,7 +89,7 @@ def get_mirror_s3_connection_info(mirror, method):
     from spack.mirrors.mirror import Mirror
 
     s3_connection = {}
-    s3_client_args = {"use_ssl": spack.config.get("config:verify_ssl")}
+    s3_client_args = {"use_ssl": spack.config.CONFIG.get("config:verify_ssl")}
 
     # access token
     if isinstance(mirror, Mirror):

--- a/lib/spack/spack/util/web.py
+++ b/lib/spack/spack/util/web.py
@@ -207,7 +207,7 @@ class SpackHTTPSHandler(HTTPSHandler):
 
 def custom_ssl_certs() -> Optional[Tuple[bool, str]]:
     """Returns a tuple (is_file, path) if custom SSL certifates are configured and valid."""
-    ssl_certs = spack.config.get("config:ssl_certs")
+    ssl_certs = spack.config.CONFIG.get("config:ssl_certs")
     if not ssl_certs:
         return None
     path = spack.config.substitute_path_variables(ssl_certs)
@@ -274,8 +274,8 @@ def _urlopen():
 
     # And dynamically dispatch based on the config:verify_ssl.
     def dispatch_open(fullurl, data=None, timeout=None):
-        opener = with_ssl if spack.config.get("config:verify_ssl", True) else without_ssl
-        timeout = timeout or spack.config.get("config:connect_timeout", 10)
+        opener = with_ssl if spack.config.CONFIG.get("config:verify_ssl", True) else without_ssl
+        timeout = timeout or spack.config.CONFIG.get("config:connect_timeout", 10)
         return opener.open(fullurl, data, timeout)
 
     return dispatch_open
@@ -500,7 +500,7 @@ def base_curl_fetch_args(url, timeout=0):
         "-L",  # resolve 3xx redirects
         url,
     ]
-    if not spack.config.get("config:verify_ssl"):
+    if not spack.config.CONFIG.get("config:verify_ssl"):
         curl_args.append("-k")
 
     if sys.stdout.isatty() and tty.msg_enabled():
@@ -508,7 +508,7 @@ def base_curl_fetch_args(url, timeout=0):
     else:
         curl_args.append("-sS")  # show errors if fail
 
-    connect_timeout = spack.config.get("config:connect_timeout", 10)
+    connect_timeout = spack.config.CONFIG.get("config:connect_timeout", 10)
     if timeout:
         connect_timeout = max(int(connect_timeout), int(timeout))
     if connect_timeout > 0:
@@ -585,7 +585,7 @@ def fetch_url_text(url, curl: Optional[Executable] = None, dest_dir="."):
     filename = os.path.basename(url)
     path = os.path.join(dest_dir, filename)
 
-    fetch_method = spack.config.get("config:url_fetch_method")
+    fetch_method = spack.config.CONFIG.get("config:url_fetch_method")
     tty.debug("Using '{0}' to fetch {1} into {2}".format(fetch_method, url, path))
     if fetch_method and fetch_method.startswith("curl"):
         curl_exe = curl or require_curl()
@@ -618,7 +618,7 @@ def fetch_url_text(url, curl: Optional[Executable] = None, dest_dir="."):
 def _url_exists_urllib_impl(url):
     with urlopen(
         Request(url, method="HEAD", headers={"User-Agent": SPACK_USER_AGENT}),
-        timeout=spack.config.get("config:connect_timeout", 10),
+        timeout=spack.config.CONFIG.get("config:connect_timeout", 10),
     ) as _:
         pass
 
@@ -644,7 +644,7 @@ def url_exists(url, curl=None):
     url_result = urllib.parse.urlparse(url)
 
     # Use curl if configured to do so
-    fetch_method = spack.config.get("config:url_fetch_method", "urllib")
+    fetch_method = spack.config.CONFIG.get("config:url_fetch_method", "urllib")
     use_curl = fetch_method.startswith("curl") and url_result.scheme not in ("gs", "s3")
     if use_curl:
         curl_exe = curl or require_curl()
@@ -652,7 +652,7 @@ def url_exists(url, curl=None):
         # Telling curl to fetch the first byte (-r 0-0) is supposed to be
         # portable.
         curl_args = fetch_method.split()[1:] + ["--stderr", "-", "-s", "-f", "-r", "0-0", url]
-        if not spack.config.get("config:verify_ssl"):
+        if not spack.config.CONFIG.get("config:verify_ssl"):
             curl_args.append("-k")
         _ = curl_exe(*curl_args, fail_on_error=False, output=os.devnull)
         return curl_exe.returncode == 0


### PR DESCRIPTION
Reduce and make explicit the use of the `spack.config.CONFIG`, `spack.store.STORE` and `spack.repo.PATH` globals.

There are two related things in this PR:

- In tests, use the `config` / `mutable_config`, `temporary_store` and `mock_packages` fixtures instead of reaching for the globals directly, so tests don't depend directly on global state.

- In core, the `spack.config` module exposed a set of thin wrapper functions (`get`, `set`, `override`, `add`, `add_from_file`, `scopes`, `default_modify_scope`, `change_or_add`, `update_all`, ...) that operated on the `CONFIG` global. These are now methods on the `Configuration` object and are called through `spack.config.CONFIG`, so every use of the config global is explicit at the call site. In the same spirit, the `spack.repo.all_package_names` convenience wrapper is removed in favor of naming `spack.repo.PATH` explicitly at its call sites.

The idea is that core is now explicit about where it uses the `CONFIG` global, so we can see where we still need dependency injection. Once core passes these objects around properly, the call sites that use `spack.config.CONFIG` can take a configuration argument instead of relying on the global being set. The same reasoning applies to `spack.store.STORE` and `spack.repo.PATH`. Tests can then be refactored to pass the instance.
