### PR TITLE
gha: swap os<->python-version in unit-tests

### DIFF
--- a/.github/workflows/unit_tests.yaml
+++ b/.github/workflows/unit_tests.yaml
@@ -31,7 +31,7 @@ jobs:
         # Python 3.7 needs ubuntu-22.04, newer runner images no longer ship it.
         include: >-
           ${{ github.ref == 'refs/heads/develop'
-          && fromJSON('[{"python-version": "3.7", "os": "ubuntu-22.04"}]')
+          && fromJSON('[{"os": "ubuntu-22.04", "python-version": "3.7"}]')
           || fromJSON('[]') }}
 
     steps:


### PR DESCRIPTION
nothing functional, just that the job is rendered `ubuntu (3.7,
ubuntu-22.04)` instead of `(ubuntu-22.04, 3.7)` like the others.
