### PR TITLE
tests: preload spack.test.conftest in the forkserver

### DIFF
--- a/lib/spack/spack/test/conftest.py
+++ b/lib/spack/spack/test/conftest.py
@@ -442,7 +442,10 @@ def pytest_configure(config):
     # improve performance on macOS
     if sys.platform == "darwin" and multiprocessing.get_start_method(allow_none=True) is None:
         multiprocessing.set_start_method("forkserver")
-    multiprocessing.set_forkserver_preload(["spack.main", "spack.package", "spack.installer"])
+    # forkserver build subprocesses re-import this conftest, so preload it too
+    multiprocessing.set_forkserver_preload(
+        ["spack.main", "spack.package", "spack.installer", "spack.test.conftest"]
+    )
 
 
 def pytest_addoption(parser):


### PR DESCRIPTION
On Python 3.14 and macOS we use forkserver with a couple modules preloaded to improve startup time. This adds `spack.test.conftest` which should improve test runtime significantly as it pulls in more of spack core with it. In tests it's relevant cause we pass monkeypatches down to the install subproces, so more modules are needed than at runtime.