### PR TITLE
tests: use a smaller package DAG in install run-tests tests

### DIFF
--- a/lib/spack/spack/test/cmd/install.py
+++ b/lib/spack/spack/test/cmd/install.py
@@ -78,8 +78,8 @@ def _check_runtests_none(pkg):
     assert not pkg.run_tests
 
 
-def _check_runtests_dttop(pkg):
-    assert pkg.run_tests == (pkg.name == "dttop")
+def _check_runtests_root(pkg):
+    assert pkg.run_tests == (pkg.name == "dependent-install")
 
 
 def _check_runtests_all(pkg):
@@ -89,19 +89,19 @@ def _check_runtests_all(pkg):
 @pytest.mark.disable_clean_stage_check
 def test_install_runtests_notests(monkeypatch, mock_packages, mock_fetch, install_mockery):
     monkeypatch.setattr(spack.package_base.PackageBase, "_unit_test_check", _check_runtests_none)
-    install("-v", "dttop")
+    install("-v", "dependent-install")
 
 
 @pytest.mark.disable_clean_stage_check
 def test_install_runtests_root(monkeypatch, mock_packages, mock_fetch, install_mockery):
-    monkeypatch.setattr(spack.package_base.PackageBase, "_unit_test_check", _check_runtests_dttop)
-    install("--test=root", "dttop")
+    monkeypatch.setattr(spack.package_base.PackageBase, "_unit_test_check", _check_runtests_root)
+    install("--test=root", "dependent-install")
 
 
 @pytest.mark.disable_clean_stage_check
 def test_install_runtests_all(monkeypatch, mock_packages, mock_fetch, install_mockery):
     monkeypatch.setattr(spack.package_base.PackageBase, "_unit_test_check", _check_runtests_all)
-    install("--test=all", "pkg-a")
+    install("--test=all", "dependent-install")
 
 
 def test_install_package_already_installed(


### PR DESCRIPTION
These tests were rather slow because they spin up many sub-processes. All that's needed is a root and a non-root.