### PR TITLE
solver: static prunes before grounding (versions, targets, compilers, dep-blocks)

### DIFF
--- a/etc/spack/defaults/base/concretizer.yaml
+++ b/etc/spack/defaults/base/concretizer.yaml
@@ -101,6 +101,8 @@ concretizer:
   pruning:
     # Collapse versions with identical constraint-satisfaction signatures to a min-weight rep.
     dominated_versions: true
+    # Keep only microarchitecture targets a node could actually be driven to.
+    unreachable_targets: true
 
   # If enabled, concretizations are cached in the misc_cache. The cache is keyed by the hash
   # of solver inputs, so we only need to run setup (not solve) if there is a cache hit.

--- a/etc/spack/defaults/base/concretizer.yaml
+++ b/etc/spack/defaults/base/concretizer.yaml
@@ -103,6 +103,8 @@ concretizer:
     dominated_versions: true
     # Keep only microarchitecture targets a node could actually be driven to.
     unreachable_targets: true
+    # Drop compiler packages not present in the reuse universe (external/installed/buildcache).
+    unusable_compilers: true
 
   # If enabled, concretizations are cached in the misc_cache. The cache is keyed by the hash
   # of solver inputs, so we only need to run setup (not solve) if there is a cache hit.

--- a/etc/spack/defaults/base/concretizer.yaml
+++ b/etc/spack/defaults/base/concretizer.yaml
@@ -105,6 +105,8 @@ concretizer:
     unreachable_targets: true
     # Drop compiler packages not present in the reuse universe (external/installed/buildcache).
     unusable_compilers: true
+    # Skip depends_on blocks whose when-clause cannot fire (dead version or pinned variant).
+    dead_dep_blocks: true
 
   # If enabled, concretizations are cached in the misc_cache. The cache is keyed by the hash
   # of solver inputs, so we only need to run setup (not solve) if there is a cache hit.

--- a/etc/spack/defaults/base/concretizer.yaml
+++ b/etc/spack/defaults/base/concretizer.yaml
@@ -95,6 +95,13 @@ concretizer:
   # cases where there are requirements that prevent part of the search space to be explored.
   static_analysis: false
 
+  # Static prunes applied before grounding to shrink the ASP problem. Each prune is sound:
+  # it never changes concretization, only removes facts/rules that provably cannot fire.
+  # Defaults are on; disable individually for A/B benchmarking or if a bug is suspected.
+  pruning:
+    # Collapse versions with identical constraint-satisfaction signatures to a min-weight rep.
+    dominated_versions: true
+
   # If enabled, concretizations are cached in the misc_cache. The cache is keyed by the hash
   # of solver inputs, so we only need to run setup (not solve) if there is a cache hit.
   concretization_cache:

--- a/lib/spack/spack/schema/concretizer.py
+++ b/lib/spack/spack/schema/concretizer.py
@@ -241,6 +241,13 @@ properties: Dict[str, Any] = {
                         "bootstrapped in a single solve, so unusable ones can never be "
                         "selected as language-virtual providers.",
                     },
+                    "dead_dep_blocks": {
+                        "type": "boolean",
+                        "description": "Skip depends_on blocks whose when-clause cannot fire "
+                        "(version constraint not intersecting the parent's possible versions, "
+                        "or a boolean variant pinned to a default incompatible with what the "
+                        "when-clause requires).",
+                    },
                 },
             },
             "timeout": {

--- a/lib/spack/spack/schema/concretizer.py
+++ b/lib/spack/spack/schema/concretizer.py
@@ -215,6 +215,21 @@ properties: Dict[str, Any] = {
                 "description": "Enable static analysis to reduce concretization time by "
                 "generating smaller ASP problems",
             },
+            "pruning": {
+                "type": "object",
+                "description": "Toggles for static prunes applied before grounding to shrink "
+                "the ASP problem. Each prune is sound: it never changes concretization, only "
+                "removes facts/rules that provably cannot fire. Defaults are on; disable "
+                "individually for A/B benchmarking or if a bug is suspected.",
+                "properties": {
+                    "dominated_versions": {
+                        "type": "boolean",
+                        "description": "Collapse versions that share an identical "
+                        "constraint-satisfaction signature to a single representative "
+                        "(the min-weight member of the equivalence class).",
+                    },
+                },
+            },
             "timeout": {
                 "type": "integer",
                 "minimum": 0,

--- a/lib/spack/spack/schema/concretizer.py
+++ b/lib/spack/spack/schema/concretizer.py
@@ -228,6 +228,12 @@ properties: Dict[str, Any] = {
                         "constraint-satisfaction signature to a single representative "
                         "(the min-weight member of the equivalence class).",
                     },
+                    "unreachable_targets": {
+                        "type": "boolean",
+                        "description": "Keep only microarchitecture targets a node could "
+                        "actually be driven to (host/family-best, per-constraint "
+                        "feasible-best, compiler fallbacks, pinned/reused).",
+                    },
                 },
             },
             "timeout": {

--- a/lib/spack/spack/schema/concretizer.py
+++ b/lib/spack/spack/schema/concretizer.py
@@ -234,6 +234,13 @@ properties: Dict[str, Any] = {
                         "actually be driven to (host/family-best, per-constraint "
                         "feasible-best, compiler fallbacks, pinned/reused).",
                     },
+                    "unusable_compilers": {
+                        "type": "boolean",
+                        "description": "Drop compiler packages not present in the reuse "
+                        "universe (externals + installed + buildcache). Compilers cannot be "
+                        "bootstrapped in a single solve, so unusable ones can never be "
+                        "selected as language-virtual providers.",
+                    },
                 },
             },
             "timeout": {

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -1400,11 +1400,15 @@ class SpackSolverSetup:
         # number of versions removed from the solve by equivalence-class pruning
         self.pruned_version_count = 0
         self.total_version_count = 0
+        # number of candidate targets removed by reachability pruning
+        self.pruned_target_count = 0
+        self.total_target_count = 0
 
         # Static-prune toggles from ``concretizer:pruning:*`` config, cached at setup
         # init so each prune site reads a bool instead of hitting the config layer.
         pruning_cfg = spack.config.get("concretizer:pruning", {}) or {}
         self._prune_dominated_versions: bool = pruning_cfg.get("dominated_versions", True)
+        self._prune_unreachable_targets: bool = pruning_cfg.get("unreachable_targets", True)
 
         self.possible_compilers: List[spack.spec.Spec] = []
         self.rejected_compilers: Set[spack.spec.Spec] = set()
@@ -2674,10 +2678,13 @@ class SpackSolverSetup:
         platform = spack.platforms.host()
         uarch = spack.vendor.archspec.cpu.TARGETS.get(platform.default)
         best_targets = {uarch.family.name}
+        # name -> set of targets supported by each compiler, used by target-reachability pruning
+        supported_by_compiler: List[Set[str]] = []
         for compiler in self.possible_compilers:
             supported, unsupported = self._supported_targets(
                 compiler.name, compiler.version, candidate_targets
             )
+            supported_by_compiler.append({t.name for t in supported})
 
             for target in supported:
                 best_targets.add(target.name)
@@ -2695,19 +2702,25 @@ class SpackSolverSetup:
 
             self.gen.newline()
 
+        kept_targets = self._reachable_targets(specs, candidate_targets, supported_by_compiler)
+        self.pruned_target_count += len(candidate_targets) - len(kept_targets)
+        self.total_target_count += len(candidate_targets)
+
         i = 0
         for target in candidate_targets:
-            self.gen.fact(fn.target(target.name))
-            self.gen.fact(fn.target_family(target.name, target.family.name))
-            self.gen.fact(fn.target_compatible(target.name, target.name))
-            # Code for ancestor can run on target
-            for ancestor in target.ancestors:
-                self.gen.fact(fn.target_compatible(target.name, ancestor.name))
+            if target.name in kept_targets:
+                self.gen.fact(fn.target(target.name))
+                self.gen.fact(fn.target_family(target.name, target.family.name))
+                self.gen.fact(fn.target_compatible(target.name, target.name))
+                # Code for ancestor can run on target
+                for ancestor in target.ancestors:
+                    self.gen.fact(fn.target_compatible(target.name, ancestor.name))
 
             # prefer best possible targets; weight others poorly so
             # they're not used unless set explicitly
             # these are stored to be generated as facts later offset by the
-            # number of preferred targets
+            # number of preferred targets. Weights are computed over ALL candidates so
+            # that pruning never changes a surviving target's weight.
             if target.name in best_targets:
                 self.default_targets.append((i, target.name))
                 i += 1
@@ -2717,6 +2730,12 @@ class SpackSolverSetup:
 
         self.default_targets = list(sorted(set(self.default_targets)))
         self.target_preferences()
+
+        if self._prune_unreachable_targets and self.pruned_target_count:
+            tty.debug(
+                f"target-reachability pruning removed {self.pruned_target_count} of "
+                f"{self.total_target_count} candidate targets from the solve"
+            )
 
     def _version_class_representatives(self, pkg_name, sorted_versions):
         """Return the subset of ``sorted_versions`` that must be kept in the solve.
@@ -2765,6 +2784,109 @@ class SpackSolverSetup:
         if group:
             representatives.add(min(group, key=lambda x: weights[x]))
         return representatives
+
+    def _reachable_targets(self, specs, candidate_targets, supported_by_compiler):
+        """Names of candidate targets that can actually be selected by some node.
+
+        Targets are *not* amenable to the version-style equivalence prune: ``target_compatible``
+        is the directional ancestor relation, so every target in a host's ancestor set has a
+        unique compatibility profile and nothing collapses. Instead we prune by *reachability*:
+        in any optimal model a node's target is the min-weight target that (a) satisfies the
+        node's target constraints and (b) is supported by the node's compiler; cross-edge
+        compatibility then resolves onto those same targets (a dependency forced below a parent
+        target just shares the parent's kept target or a kept ancestor). So the only targets that
+        can ever appear are:
+
+          * the overall best target and the best in each family (always-feasible baseline),
+          * the min-weight candidate satisfying each target constraint, under each compiler's
+            support set (the feasible-best for a constrained node),
+          * the best target each compiler supports (compiler fallback),
+          * any target pinned/explicitly requested in an input spec, and
+          * any target used by a reusable/concrete spec (else reuse would be blocked).
+
+        Everything else is statically unselectable and removed. Controlled by
+        ``concretizer:pruning:unreachable_targets`` (default true).
+        """
+        names = [t.name for t in candidate_targets]
+        if not self._prune_unreachable_targets:
+            return set(names)
+
+        archspec = spack.vendor.archspec.cpu
+        # weight order: mirror target_preferences (lower index == more preferred)
+        prefs_key = spack.package_prefs.PackagePrefs("all", "target")
+        ordered = sorted(
+            (spack.spec.Spec(f"target={n}") for n in names),
+            key=prefs_key,
+        )
+        weight = {s.architecture.target.name: i for i, s in enumerate(ordered)}
+        by_weight = sorted(names, key=lambda n: weight.get(n, len(names)))
+
+        def satisfies(tname, constraint):
+            target = archspec.TARGETS.get(tname)
+            if target is None:
+                return False
+            for single in str(constraint).split(","):
+                if ":" not in single:
+                    if single == tname:
+                        return True
+                    continue
+                t_min, _, t_max = single.partition(":")
+                if t_min and not t_min <= target:
+                    continue
+                if t_max and not t_max >= target:
+                    continue
+                return True
+            return False
+
+        kept: Set[str] = set()
+        # always-feasible baseline: overall best, and best per family
+        best_per_family: Dict[str, str] = {}
+        for n in by_weight:
+            fam = archspec.TARGETS[n].family.name
+            best_per_family.setdefault(fam, n)
+        kept.update(best_per_family.values())
+        if by_weight:
+            kept.add(by_weight[0])
+
+        # per target constraint, per compiler support set: the min-weight feasible target
+        constraints = list(self.target_constraints)
+        support_sets = supported_by_compiler or [set(names)]
+        for constraint in constraints:
+            for supp in support_sets:
+                for n in by_weight:  # by_weight is best-first
+                    if satisfies(n, constraint) and (not supp or n in supp):
+                        kept.add(n)
+                        break
+        # compiler fallback: best supported target for each compiler
+        for supp in support_sets:
+            for n in by_weight:
+                if not supp or n in supp:
+                    kept.add(n)
+                    break
+
+        # preserve explicitly-requested targets and targets of reusable/concrete specs,
+        # so pruning never blocks a pin or a reuse
+        candidate_names = set(names)
+
+        def keep_spec_targets(spec):
+            for node in spec.traverse():
+                tgt = getattr(getattr(node, "architecture", None), "target", None)
+                tname = getattr(tgt, "name", None) or (str(tgt) if tgt else None)
+                if tname in candidate_names:
+                    kept.add(tname)
+
+        for spec in specs:
+            try:
+                keep_spec_targets(spec)
+            except Exception:
+                return candidate_names  # bail out safely: keep everything
+        try:
+            for _h, spec in self.reusable_and_possible.explicit_items():
+                keep_spec_targets(spec)
+        except Exception:
+            return candidate_names
+
+        return kept
 
     def define_version_constraints(self):
         """Define what version_satisfies(...) means in ASP logic."""

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -2824,10 +2824,7 @@ class SpackSolverSetup:
         archspec = spack.vendor.archspec.cpu
         # weight order: mirror target_preferences (lower index == more preferred)
         prefs_key = spack.package_prefs.PackagePrefs("all", "target")
-        ordered = sorted(
-            (spack.spec.Spec(f"target={n}") for n in names),
-            key=prefs_key,
-        )
+        ordered = sorted((spack.spec.Spec(f"target={n}") for n in names), key=prefs_key)
         weight = {s.architecture.target.name: i for i, s in enumerate(ordered)}
         by_weight = sorted(names, key=lambda n: weight.get(n, len(names)))
 
@@ -2956,6 +2953,29 @@ class SpackSolverSetup:
             f"{len(self.pruned_compilers_fully)} compiler packages fully pruned, "
             f"{len(self.pruned_compilers_role_only)} kept as deps with compiler role removed"
         )
+
+    def _prune_transitively_unreachable(self, root_names, edges) -> Set[str]:
+        """Remove from ``self.pkgs`` any package no longer reachable from ``root_names``.
+
+        Called after another prune has removed packages from ``self.pkgs``. Walks
+        the (virtual-expanded) adjacency map ``edges`` from the roots, only
+        following edges to nodes still in ``self.pkgs``. Previously-pruned nodes
+        act as walls, so any package whose only path from the roots went through
+        one becomes unreachable and is dropped. Returns the set of packages removed.
+        """
+        reachable: Set[str] = set()
+        stack: List[str] = [n for n in root_names if n in self.pkgs]
+        while stack:
+            p = stack.pop()
+            if p in reachable:
+                continue
+            reachable.add(p)
+            for dep in edges.get(p, ()):
+                if dep in self.pkgs and dep not in reachable:
+                    stack.append(dep)
+        to_remove = self.pkgs - reachable
+        self.pkgs -= to_remove
+        return to_remove
 
     def define_version_constraints(self):
         """Define what version_satisfies(...) means in ASP logic."""
@@ -3295,7 +3315,19 @@ class SpackSolverSetup:
         self.possible_virtuals = node_counter.possible_virtuals()
         self.pkgs = node_counter.possible_dependencies()
         self._compute_compiler_pruning()
-        self.pkgs -= self.pruned_compilers_fully
+        if self.pruned_compilers_fully:
+            self.pkgs -= self.pruned_compilers_fully
+            root_names = {s.name for s in list(specs) + injected_dependencies}
+            dead_transitive = self._prune_transitively_unreachable(
+                root_names, node_counter.edges()
+            )
+            if dead_transitive:
+                sample = ", ".join(sorted(dead_transitive)[:5])
+                more = "..." if len(dead_transitive) > 5 else ""
+                tty.debug(
+                    f"transitive dead-dep pruning removed {len(dead_transitive)} "
+                    f"more package(s): {sample}{more}"
+                )
         self.libcs = sorted(all_libcs())  # type: ignore[type-var]
 
         for node in traverse.traverse_nodes(specs):

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -1392,6 +1392,19 @@ class SpackSolverSetup:
         self.deprecated_versions: Dict[str, Set[GitOrStandardVersion]] = collections.defaultdict(
             set
         )
+        # pkg_name -> version -> preference weight (lower == better), used to pick the
+        # min-weight representative of each version equivalence class.
+        self.version_weights: Dict[str, Dict[GitOrStandardVersion, int]] = collections.defaultdict(
+            dict
+        )
+        # number of versions removed from the solve by equivalence-class pruning
+        self.pruned_version_count = 0
+        self.total_version_count = 0
+
+        # Static-prune toggles from ``concretizer:pruning:*`` config, cached at setup
+        # init so each prune site reads a bool instead of hitting the config layer.
+        pruning_cfg = spack.config.get("concretizer:pruning", {}) or {}
+        self._prune_dominated_versions: bool = pruning_cfg.get("dominated_versions", True)
 
         self.possible_compilers: List[spack.spec.Spec] = []
         self.rejected_compilers: Set[spack.spec.Spec] = set()
@@ -1447,6 +1460,7 @@ class SpackSolverSetup:
             )
 
         for weight, declared_version in enumerate(ordered_versions):
+            self.version_weights[pkg.name][declared_version] = weight
             self.gen.fact(fn.pkg_fact(pkg.name, fn.version_declared(declared_version, weight)))
             for origin in version_provenance[declared_version]:
                 self.gen.fact(
@@ -2704,15 +2718,69 @@ class SpackSolverSetup:
         self.default_targets = list(sorted(set(self.default_targets)))
         self.target_preferences()
 
+    def _version_class_representatives(self, pkg_name, sorted_versions):
+        """Return the subset of ``sorted_versions`` that must be kept in the solve.
+
+        Versions are grouped into maximal contiguous runs that are indistinguishable to
+        the solver -- they satisfy exactly the same version constraints and share the same
+        per-version attributes (deprecation, origin, git commit). Every member of such a
+        run is statically dominated by the lowest-weight (best) member, since version
+        weight is the only thing that distinguishes them in the objective. We keep that one
+        representative and prune the rest. Indices are left untouched, so the gaps are
+        harmless: ``version_range`` facts compare numerically against the original order.
+        """
+        # Controlled by ``concretizer:pruning:dominated_versions`` (default true).
+        if not self._prune_dominated_versions:
+            return set(sorted_versions)
+
+        weights = self.version_weights.get(pkg_name)
+        # If we don't have a weight for every version (e.g. synthetic virtual versions),
+        # don't prune this package -- keep everything to stay safe.
+        if not weights or any(v not in weights for v in sorted_versions):
+            return set(sorted_versions)
+
+        constraints = sorted(self.version_constraints.get(pkg_name, ()))
+        origins = self.possible_versions[pkg_name]
+        deprecated = self.deprecated_versions[pkg_name]
+        git_versions = self.git_commit_versions[pkg_name]
+
+        def signature(v):
+            return (
+                tuple(v.satisfies(c) for c in constraints),
+                v in deprecated,
+                tuple(sorted(str(o) for o in set(origins[v]))),
+                git_versions.get(v) if v in git_versions else None,
+            )
+
+        representatives = set()
+        group: List = []
+        group_sig = None
+        for v in sorted_versions:
+            sig = signature(v)
+            if group and sig != group_sig:
+                representatives.add(min(group, key=lambda x: weights[x]))
+                group = []
+            group.append(v)
+            group_sig = sig
+        if group:
+            representatives.add(min(group, key=lambda x: weights[x]))
+        return representatives
+
     def define_version_constraints(self):
         """Define what version_satisfies(...) means in ASP logic."""
-
         sorted_versions = {}
         for pkg_name in self.possible_versions:
             possible_versions = list(self.possible_versions[pkg_name])
             possible_versions.sort()
             sorted_versions[pkg_name] = possible_versions
+
+            representatives = self._version_class_representatives(pkg_name, possible_versions)
+            self.pruned_version_count += len(possible_versions) - len(representatives)
+            self.total_version_count += len(possible_versions)
+
             for idx, v in enumerate(possible_versions):
+                if v not in representatives:
+                    continue
                 self.gen.fact(fn.pkg_fact(pkg_name, fn.version_order(v, idx)))
                 if v in self.git_commit_versions[pkg_name]:
                     sha = self.git_commit_versions[pkg_name].get(v)
@@ -2722,6 +2790,12 @@ class SpackSolverSetup:
                         self.gen.fact(fn.pkg_fact(pkg_name, fn.version_needs_commit(v)))
             self.gen.newline()
         self.gen.newline()
+
+        if self.pruned_version_count:
+            tty.debug(
+                f"version-class pruning removed {self.pruned_version_count} of "
+                f"{self.total_version_count} versions from the solve"
+            )
 
         for pkg_name, set_of_versions in sorted(self.version_constraints.items()):
             possible_versions = sorted_versions.get(pkg_name)

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -1407,6 +1407,13 @@ class SpackSolverSetup:
         self.pruned_compilers_fully: Set[str] = set()
         # compiler packages kept as normal deps but with the compiler role stripped
         self.pruned_compilers_role_only: Set[str] = set()
+        # count of dep-when blocks skipped because their version constraint could not be met
+        self.pruned_dep_blocks_version = 0
+        self.pruned_dep_blocks_variant = 0
+        self.total_dep_blocks = 0
+        # boolean variants provably pinned to their declared default in every optimal model.
+        # (pkg_name, variant_name) -> default (True/False)
+        self.pinned_default_variants: Dict[Tuple[str, str], bool] = {}
 
         # Static-prune toggles from ``concretizer:pruning:*`` config, cached at setup
         # init so each prune site reads a bool instead of hitting the config layer.
@@ -1414,6 +1421,7 @@ class SpackSolverSetup:
         self._prune_dominated_versions: bool = pruning_cfg.get("dominated_versions", True)
         self._prune_unreachable_targets: bool = pruning_cfg.get("unreachable_targets", True)
         self._prune_unusable_compilers: bool = pruning_cfg.get("unusable_compilers", True)
+        self._prune_dead_dep_blocks: bool = pruning_cfg.get("dead_dep_blocks", True)
 
         self.possible_compilers: List[spack.spec.Spec] = []
         self.rejected_compilers: Set[spack.spec.Spec] = set()
@@ -1905,7 +1913,19 @@ class SpackSolverSetup:
 
     def package_dependencies_rules(self, pkg):
         """Translate ``depends_on`` directives into ASP logic."""
+        dep_prune = self._prune_dead_dep_blocks
         for cond, deps_by_name in pkg.dependencies.items():
+            self.total_dep_blocks += 1
+            # Skip the whole block if the when-clause's version constraint cannot
+            # be satisfied by any version we've registered for this package. None
+            # of the deps in the block can fire, so we can save the ``condition()``
+            # machinery entirely. Controlled by concretizer:pruning:dead_dep_blocks.
+            if dep_prune and self._when_versions_dead(pkg.name, cond):
+                self.pruned_dep_blocks_version += 1
+                continue
+            if dep_prune and self._when_variants_dead(pkg.name, cond):
+                self.pruned_dep_blocks_variant += 1
+                continue
             cond_str = str(cond)
             cond_str_suffix = f" when {cond_str}" if cond_str else ""
             for _, dep in deps_by_name.items():
@@ -2954,6 +2974,138 @@ class SpackSolverSetup:
             f"{len(self.pruned_compilers_role_only)} kept as deps with compiler role removed"
         )
 
+    def _compute_pinned_variants(self, input_specs, reuse_specs) -> None:
+        """Populate ``self.pinned_default_variants`` with (pkg, variant) pairs whose
+        boolean value must be the declared default in every optimal model.
+
+        A pair is pinned only when we can't find any hard-force that could push it
+        away from default: input specs, reuse specs, cross-package ``depends_on``
+        that names the variant, ``requires`` clauses that name the variant, or
+        packages.yaml overrides. We over-approximate the "constrained" set on
+        purpose -- being too conservative here just gives up prunes, being too
+        aggressive silently changes concretization. When-clauses that merely
+        *check* the variant (``depends_on(X, when="+V")``) do not count as a
+        hard-force: they gate a dep, they don't require the value.
+        """
+        self.pinned_default_variants = {}
+        if not self._prune_dead_dep_blocks:
+            return
+
+        constrained: Set[Tuple[str, str]] = set()
+
+        def add_from_spec(spec):
+            for node in spec.traverse():
+                if node.name is None:
+                    continue
+                for vname in node.variants:
+                    constrained.add((node.name, vname))
+
+        # Input specs and reuse specs directly express variant values.
+        for s in input_specs or ():
+            add_from_spec(s)
+        for s in reuse_specs or ():
+            add_from_spec(s)
+
+        # Cross-package hard forces: depends_on target specs and requires clauses.
+        for pkg_name in self.pkgs:
+            try:
+                pkg_cls = spack.repo.PATH.get_pkg_class(pkg_name)
+            except spack.repo.UnknownPackageError:
+                continue
+            for _cond, deps in pkg_cls.dependencies.items():
+                for dep_name, dep in deps.items():
+                    for vname in dep.spec.variants:
+                        constrained.add((dep_name, vname))
+            try:
+                for _cond, when_reqs in pkg_cls.requirements.items():
+                    for req_specs, _, _ in when_reqs:
+                        for rs in req_specs:
+                            add_from_spec(rs)
+            except Exception:
+                pass
+
+        # packages.yaml preferences and requires.
+        packages_cfg = spack.config.CONFIG.get("packages", {}) or {}
+        for pkg_key, cfg in packages_cfg.items():
+            variants_pref = cfg.get("variants", [])
+            if isinstance(variants_pref, str):
+                variants_pref = [variants_pref]
+            for vstr in variants_pref:
+                if not isinstance(vstr, str):
+                    continue
+                try:
+                    add_from_spec(spack.spec.Spec(vstr))
+                except Exception:
+                    pass
+            req_pref = cfg.get("require", [])
+            if isinstance(req_pref, str):
+                req_pref = [req_pref]
+            for r in req_pref:
+                if not isinstance(r, str):
+                    continue
+                try:
+                    add_from_spec(spack.spec.Spec(r))
+                except Exception:
+                    pass
+
+        # Compute the pinned set: unconstrained boolean variants with an unconditional
+        # default (i.e. the definition is not itself guarded by a when-clause).
+        for pkg_name in self.pkgs:
+            try:
+                pkg_cls = spack.repo.PATH.get_pkg_class(pkg_name)
+            except spack.repo.UnknownPackageError:
+                continue
+            seen_variants: Set[str] = set()
+            for when_spec, defs_by_name in pkg_cls.variants.items():
+                if when_spec is not None and str(when_spec):
+                    continue  # only unconditional variant definitions
+                for vname, variant_def in defs_by_name.items():
+                    if vname in seen_variants:
+                        continue
+                    seen_variants.add(vname)
+                    if (pkg_name, vname) in constrained:
+                        continue
+                    default = getattr(variant_def, "default", None)
+                    if isinstance(default, bool):
+                        self.pinned_default_variants[(pkg_name, vname)] = default
+
+    def _when_variants_dead(self, pkg_name, cond) -> bool:
+        """Is any variant constraint in ``cond`` provably unsatisfiable for pkg_name?
+
+        Returns True if some (variant, required_value) in the when-clause references
+        a variant we've pinned to a *different* default. The whole clause is then dead.
+        """
+        variants = getattr(cond, "variants", None)
+        if not variants:
+            return False
+        for vname, vsel in variants.items():
+            pinned = self.pinned_default_variants.get((pkg_name, vname))
+            if pinned is None:
+                continue
+            required = vsel.value
+            if not isinstance(required, bool):
+                continue
+            if required != pinned:
+                return True
+        return False
+
+    def _when_versions_dead(self, pkg_name, cond) -> bool:
+        """Is ``cond``'s version constraint provably unsatisfiable for pkg_name?
+
+        The pruning is sound: if no version in ``self.possible_versions[pkg_name]``
+        satisfies ``cond.versions``, then no reachable model can select a version
+        that fires ``cond``, so any dep gated on ``cond`` is dead. Returns False
+        for the degenerate cases (no version constraint on ``cond``, or no known
+        versions yet for ``pkg_name``) so callers stay conservative.
+        """
+        versions = getattr(cond, "versions", None)
+        if versions is None or versions == vn.any_version:
+            return False
+        possible = self.possible_versions.get(pkg_name)
+        if not possible:
+            return False
+        return not any(v.satisfies(versions) for v in possible)
+
     def _prune_transitively_unreachable(self, root_names, edges) -> Set[str]:
         """Remove from ``self.pkgs`` any package no longer reachable from ``root_names``.
 
@@ -3408,11 +3560,23 @@ class SpackSolverSetup:
             allow_deprecated=allow_deprecated, require_checksum=checksummed
         )
 
+        self._compute_pinned_variants(specs, reuse)
+
         self.gen.h1("Package Constraints")
         for pkg in sorted(self.pkgs):
             self.gen.h2(f"Package rules: {pkg}")
             self.pkg_rules(pkg, tests=self.tests)
             self.preferred_variants(pkg)
+
+        if self._prune_dead_dep_blocks and (
+            self.pruned_dep_blocks_version or self.pruned_dep_blocks_variant
+        ):
+            total_dead = self.pruned_dep_blocks_version + self.pruned_dep_blocks_variant
+            tty.debug(
+                f"dep-block pruning removed {total_dead} of {self.total_dep_blocks} "
+                f"depends_on blocks: {self.pruned_dep_blocks_version} by dead version "
+                f"constraint, {self.pruned_dep_blocks_variant} by pinned-default variant"
+            )
 
         self.gen.h1("Condition Triggers and Imposed Effects")
         self.trigger_rules()

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -1403,12 +1403,17 @@ class SpackSolverSetup:
         # number of candidate targets removed by reachability pruning
         self.pruned_target_count = 0
         self.total_target_count = 0
+        # compiler packages fully skipped in pkg_rules (not selectable, not depended on directly)
+        self.pruned_compilers_fully: Set[str] = set()
+        # compiler packages kept as normal deps but with the compiler role stripped
+        self.pruned_compilers_role_only: Set[str] = set()
 
         # Static-prune toggles from ``concretizer:pruning:*`` config, cached at setup
         # init so each prune site reads a bool instead of hitting the config layer.
         pruning_cfg = spack.config.get("concretizer:pruning", {}) or {}
         self._prune_dominated_versions: bool = pruning_cfg.get("dominated_versions", True)
         self._prune_unreachable_targets: bool = pruning_cfg.get("unreachable_targets", True)
+        self._prune_unusable_compilers: bool = pruning_cfg.get("unusable_compilers", True)
 
         self.possible_compilers: List[spack.spec.Spec] = []
         self.rejected_compilers: Set[spack.spec.Spec] = set()
@@ -1865,14 +1870,19 @@ class SpackSolverSetup:
         return condition_id
 
     def package_provider_rules(self, pkg: Type[spack.package_base.PackageBase]) -> None:
+        skip_langs = pkg.name in self.pruned_compilers_role_only
         for vpkg_name in pkg.provided_virtual_names():
             if vpkg_name not in self.possible_virtuals:
+                continue
+            if skip_langs and vpkg_name in self._COMPILER_LANGUAGE_VIRTUALS:
                 continue
             self.gen.fact(fn.pkg_fact(pkg.name, fn.possible_provider(vpkg_name)))
 
         for when, provided in pkg.provided.items():
             for vpkg in sorted(provided):  # type: ignore[type-var]
                 if vpkg.name not in self.possible_virtuals:
+                    continue
+                if skip_langs and vpkg.name in self._COMPILER_LANGUAGE_VIRTUALS:
                     continue
 
                 msg = f"{pkg.name} provides {vpkg}{'' if when == EMPTY_SPEC else f' when {when}'}"
@@ -2888,6 +2898,65 @@ class SpackSolverSetup:
 
         return kept
 
+    #: Language virtuals that can only be provided by "reuse" compilers.
+    #: A provider of any of these that ``build(N)`` triggers error(10) at concretize.lp:1980,
+    #: so any compiler package that is not in the reuse universe (externals, installed,
+    #: buildcache-injected) is statically unselectable as a provider for these virtuals.
+    _COMPILER_LANGUAGE_VIRTUALS = frozenset(
+        {"c", "cxx", "fortran", "cuda-lang", "hip-lang", "fortran-rt"}
+    )
+
+    def _compute_compiler_pruning(self):
+        """Partition compiler packages into three sets based on selectability + direct-dep use.
+
+        Categories:
+          * *selectable*: name is in ``self.possible_compilers`` (externals / installed /
+            buildcache-injected). Never pruned.
+          * *role-only-pruned*: not selectable, but at least one package in ``self.pkgs`` names
+            it as a direct (non-virtual) dependency (e.g. hip depends_on("llvm") for libLLVM).
+            The package must still be selectable as a normal dep, so we keep ``pkg_rules``
+            but suppress its language-virtual provider facts.
+          * *fully-pruned*: not selectable and not directly depended on by name. The package
+            is pure dead weight in this solve; skip ``pkg_rules`` entirely.
+
+        Controlled by ``concretizer:pruning:unusable_compilers`` (default true).
+        """
+        self.pruned_compilers_fully = set()
+        self.pruned_compilers_role_only = set()
+        if not self._prune_unusable_compilers:
+            return
+
+        all_compiler_pkgs = set(spack.compilers.config.supported_compilers())
+        selectable = {c.name for c in self.possible_compilers}
+        candidates = {p for p in self.pkgs if p in all_compiler_pkgs} - selectable
+        if not candidates:
+            return
+
+        direct_dep_targets: Set[str] = set()
+        for pkg_name in self.pkgs:
+            try:
+                pkg_cls = spack.repo.PATH.get_pkg_class(pkg_name)
+            except spack.repo.UnknownPackageError:
+                continue
+            for _when, deps in pkg_cls.dependencies.items():
+                for dep_name in deps:
+                    if dep_name in candidates:
+                        direct_dep_targets.add(dep_name)
+
+        self.pruned_compilers_role_only = candidates & direct_dep_targets
+        self.pruned_compilers_fully = candidates - direct_dep_targets
+
+        # Suppress the "Only external, or concrete, compilers are allowed" error rule
+        # in concretize.lp -- our prune has statically enforced that invariant, so the
+        # rule can't fire in this solve and grounding it is dead weight.
+        self.gen.fact(fn.compiler_pruning_enabled())
+
+        tty.debug(
+            f"compiler-provider pruning: "
+            f"{len(self.pruned_compilers_fully)} compiler packages fully pruned, "
+            f"{len(self.pruned_compilers_role_only)} kept as deps with compiler role removed"
+        )
+
     def define_version_constraints(self):
         """Define what version_satisfies(...) means in ASP logic."""
         sorted_versions = {}
@@ -3225,6 +3294,8 @@ class SpackSolverSetup:
         )
         self.possible_virtuals = node_counter.possible_virtuals()
         self.pkgs = node_counter.possible_dependencies()
+        self._compute_compiler_pruning()
+        self.pkgs -= self.pruned_compilers_fully
         self.libcs = sorted(all_libcs())  # type: ignore[type-var]
 
         for node in traverse.traverse_nodes(specs):

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -262,6 +262,62 @@ def dependency_holds(
     return _transform_fn
 
 
+@functools.lru_cache(maxsize=None)
+def _pkg_variant_hard_forces(pkg_name: str) -> "frozenset[Tuple[str, str]]":
+    """Return (target_pkg, variant_name) pairs that ``pkg_name``'s package.py could
+    hard-force via ``depends_on`` target specs or ``requires`` clauses.
+
+    Depends only on the loaded package class, so it's stable across solves in the
+    same process and safe to cache module-wide. Used by variant-based dep-clause
+    pruning (see ``SpackSolverSetup._compute_pinned_variants``).
+    """
+    try:
+        pkg_cls = spack.repo.PATH.get_pkg_class(pkg_name)
+    except spack.repo.UnknownPackageError:
+        return frozenset()
+    result: Set[Tuple[str, str]] = set()
+    for _cond, deps in pkg_cls.dependencies.items():
+        for dep_name, dep in deps.items():
+            for vname in dep.spec.variants:
+                result.add((dep_name, vname))
+    try:
+        for _cond, when_reqs in pkg_cls.requirements.items():
+            for req_specs, _, _ in when_reqs:
+                for rs in req_specs:
+                    for node in rs.traverse():
+                        if node.name is None:
+                            continue
+                        for vname in node.variants:
+                            result.add((node.name, vname))
+    except Exception:
+        pass
+    return frozenset(result)
+
+
+@functools.lru_cache(maxsize=None)
+def _pkg_boolean_default_variants(pkg_name: str) -> Dict[str, bool]:
+    """Return {variant_name: default} for ``pkg_name``'s *unconditional* boolean variants.
+
+    Only variants declared without a ``when=`` guard are included. Cached
+    module-wide since it depends only on the package class.
+    """
+    try:
+        pkg_cls = spack.repo.PATH.get_pkg_class(pkg_name)
+    except spack.repo.UnknownPackageError:
+        return {}
+    result: Dict[str, bool] = {}
+    for when_spec, defs_by_name in pkg_cls.variants.items():
+        if when_spec is not None and str(when_spec):
+            continue  # only unconditional variant definitions
+        for vname, variant_def in defs_by_name.items():
+            if vname in result:
+                continue
+            default = getattr(variant_def, "default", None)
+            if isinstance(default, bool):
+                result[vname] = default
+    return result
+
+
 def dag_closure_by_deptype(
     name: str, spec: spack.spec.Spec, facts: List[AspFunction]
 ) -> List[AspFunction]:
@@ -1414,6 +1470,8 @@ class SpackSolverSetup:
         # boolean variants provably pinned to their declared default in every optimal model.
         # (pkg_name, variant_name) -> default (True/False)
         self.pinned_default_variants: Dict[Tuple[str, str], bool] = {}
+        # per-solve memo for _when_versions_dead: (pkg_name, versions_str) -> bool
+        self._when_version_cache: Dict[Tuple[str, str], bool] = {}
 
         # Static-prune toggles from ``concretizer:pruning:*`` config, cached at setup
         # init so each prune site reads a bool instead of hitting the config layer.
@@ -2986,6 +3044,13 @@ class SpackSolverSetup:
         aggressive silently changes concretization. When-clauses that merely
         *check* the variant (``depends_on(X, when="+V")``) do not count as a
         hard-force: they gate a dep, they don't require the value.
+
+        Per-package data (hard-forced variant mentions from ``depends_on``/
+        ``requires`` and boolean-default variant maps) is cached module-wide via
+        ``_pkg_variant_hard_forces`` and ``_pkg_boolean_default_variants`` since
+        it depends only on the package class, not the solve inputs. Repeated
+        solves in the same process (environment concretization, tests, batch
+        operations) reuse the cached data.
         """
         self.pinned_default_variants = {}
         if not self._prune_dead_dep_blocks:
@@ -3006,25 +3071,11 @@ class SpackSolverSetup:
         for s in reuse_specs or ():
             add_from_spec(s)
 
-        # Cross-package hard forces: depends_on target specs and requires clauses.
+        # Cross-package hard forces: cached per-package.
         for pkg_name in self.pkgs:
-            try:
-                pkg_cls = spack.repo.PATH.get_pkg_class(pkg_name)
-            except spack.repo.UnknownPackageError:
-                continue
-            for _cond, deps in pkg_cls.dependencies.items():
-                for dep_name, dep in deps.items():
-                    for vname in dep.spec.variants:
-                        constrained.add((dep_name, vname))
-            try:
-                for _cond, when_reqs in pkg_cls.requirements.items():
-                    for req_specs, _, _ in when_reqs:
-                        for rs in req_specs:
-                            add_from_spec(rs)
-            except Exception:
-                pass
+            constrained.update(_pkg_variant_hard_forces(pkg_name))
 
-        # packages.yaml preferences and requires.
+        # packages.yaml preferences and requires (cheap, per-solve since config can change).
         packages_cfg = spack.config.CONFIG.get("packages", {}) or {}
         for pkg_key, cfg in packages_cfg.items():
             variants_pref = cfg.get("variants", [])
@@ -3049,25 +3100,12 @@ class SpackSolverSetup:
                     pass
 
         # Compute the pinned set: unconstrained boolean variants with an unconditional
-        # default (i.e. the definition is not itself guarded by a when-clause).
+        # default. Boolean-default map is cached per-package.
         for pkg_name in self.pkgs:
-            try:
-                pkg_cls = spack.repo.PATH.get_pkg_class(pkg_name)
-            except spack.repo.UnknownPackageError:
-                continue
-            seen_variants: Set[str] = set()
-            for when_spec, defs_by_name in pkg_cls.variants.items():
-                if when_spec is not None and str(when_spec):
-                    continue  # only unconditional variant definitions
-                for vname, variant_def in defs_by_name.items():
-                    if vname in seen_variants:
-                        continue
-                    seen_variants.add(vname)
-                    if (pkg_name, vname) in constrained:
-                        continue
-                    default = getattr(variant_def, "default", None)
-                    if isinstance(default, bool):
-                        self.pinned_default_variants[(pkg_name, vname)] = default
+            for vname, default in _pkg_boolean_default_variants(pkg_name).items():
+                if (pkg_name, vname) in constrained:
+                    continue
+                self.pinned_default_variants[(pkg_name, vname)] = default
 
     def _when_variants_dead(self, pkg_name, cond) -> bool:
         """Is any variant constraint in ``cond`` provably unsatisfiable for pkg_name?
@@ -3104,7 +3142,13 @@ class SpackSolverSetup:
         possible = self.possible_versions.get(pkg_name)
         if not possible:
             return False
-        return not any(v.satisfies(versions) for v in possible)
+        key = (pkg_name, str(versions))
+        cached = self._when_version_cache.get(key)
+        if cached is not None:
+            return cached
+        result = not any(v.satisfies(versions) for v in possible)
+        self._when_version_cache[key] = result
+        return result
 
     def _prune_transitively_unreachable(self, root_names, edges) -> Set[str]:
         """Remove from ``self.pkgs`` any package no longer reachable from ``root_names``.

--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -1977,10 +1977,27 @@ language("fortran").
 language("hip-lang").
 language_runtime("fortran-rt").
 
+% Vestigial when SPACK_COMPILER_PRUNE=1 (asp.py filters non-reusable compiler-virtual
+% providers before grounding, so this criterion cannot be triggered). We suppress it
+% via the compiler_pruning_enabled/0 fact to avoid grounding a rule whose body is
+% statically unsatisfiable. It stays as a safety net when pruning is disabled.
+%
+% TODO: this criterion needs further reformulation. Suppressing it silences a
+% now-dead rule, but does not diagnose the *new* failure the prune creates: when
+% the user's constraints (%compiler@ver, C++ standard, target, ...) cannot be
+% satisfied by any compiler currently in the reuse universe, the solve fails
+% via "Cannot find valid provider for virtual c" or "cannot satisfy X" -- which
+% hides the real answer ("we could satisfy this by building a new compiler, but
+% Spack doesn't allow that in a single solve; configure or install one first").
+% A reformulated rule (or a Python-side check at compiler-pruning time) should
+% emit that message when the pruned candidate set can't satisfy the input.
 error(10, "Only external, or concrete, compilers are allowed for the {0} language", Language)
   :- provider(ProviderNode, node(_, Language)),
      language(Language),
-     build(ProviderNode).
+     build(ProviderNode),
+     not compiler_pruning_enabled.
+
+#defined compiler_pruning_enabled/0.
 
 error(10, "{0} compiler '{2}@{3}' incompatible with 'target={1}'", Package, Target, Compiler, Version)
   :- attr("node_target", node(X, Package), Target),

--- a/lib/spack/spack/solver/input_analysis.py
+++ b/lib/spack/spack/solver/input_analysis.py
@@ -393,6 +393,8 @@ class Counter:
         self._possible_virtuals: Set[str] = {
             x.name for x in specs if spack.repo.PATH.is_virtual(x.name)
         }
+        # adjacency map (pkg -> set of dep pkgs), populated by _compute_cache_values
+        self._edges: Dict[str, Set[str]] = {}
 
     def possible_dependencies(self) -> Set[str]:
         """Returns the list of possible dependencies"""
@@ -403,6 +405,11 @@ class Counter:
         """Returns the list of possible virtuals"""
         self.ensure_cache_values()
         return self._possible_virtuals
+
+    def edges(self) -> Dict[str, Set[str]]:
+        """Returns adjacency map: pkg -> set of dep pkgs (virtuals already expanded)."""
+        self.ensure_cache_values()
+        return self._edges
 
     def ensure_cache_values(self) -> None:
         """Ensure the cache values have been computed"""
@@ -420,10 +427,11 @@ class Counter:
 
 class NoDuplicatesCounter(Counter):
     def _compute_cache_values(self) -> None:
-        self._possible_dependencies, virtuals, _ = self.possible_graph.possible_dependencies(
+        self._possible_dependencies, virtuals, edges = self.possible_graph.possible_dependencies(
             *self.specs, allowed_deps=self.all_types
         )
         self._possible_virtuals.update(virtuals)
+        self._edges = edges
 
     def possible_packages_facts(self, gen: "spack.solver.asp.ProblemInstanceBuilder", fn) -> None:
         gen.h2("Maximum number of nodes (packages)")
@@ -454,23 +462,30 @@ class MinimalDuplicatesCounter(NoDuplicatesCounter):
         self._link_run_virtuals: Set[str] = set()
 
     def _compute_cache_values(self) -> None:
-        self._link_run, virtuals, _ = self.possible_graph.possible_dependencies(
+        self._link_run, virtuals, edges_link_run = self.possible_graph.possible_dependencies(
             *self.specs, allowed_deps=self.link_run_types
         )
         self._possible_virtuals.update(virtuals)
         self._link_run_virtuals.update(virtuals)
+        edges_direct_build: Dict[str, Set[str]] = {}
         if self._link_run:
-            reals, virtuals, _ = self.possible_graph.possible_dependencies(
+            reals, virtuals, edges_direct_build = self.possible_graph.possible_dependencies(
                 *self._link_run, allowed_deps=dt.BUILD, transitive=False, strict_depflag=True
             )
             self._possible_virtuals.update(virtuals)
             self._direct_build.update(reals)
 
-        self._total_build, virtuals, _ = self.possible_graph.possible_dependencies(
+        self._total_build, virtuals, edges_total_build = self.possible_graph.possible_dependencies(
             *self._direct_build, allowed_deps=self.all_types
         )
         self._possible_virtuals.update(virtuals)
         self._possible_dependencies = set(self._link_run) | set(self._total_build)
+        # Union all edge maps -- a package's outgoing edges may come from any pass
+        merged: Dict[str, Set[str]] = {}
+        for edge_map in (edges_link_run, edges_direct_build, edges_total_build):
+            for src, dsts in edge_map.items():
+                merged.setdefault(src, set()).update(dsts)
+        self._edges = merged
 
     def possible_packages_facts(self, gen, fn):
         build_tools = set()


### PR DESCRIPTION
⚠️ I'm likely to break this up into many smaller PRs, but here's a draft so that people can look at it. ⚠️ 

This is, at least for me, improving concretization performance by ~20%. I think there's also more that can be done to prune things after this set of commits.

Stack of static prunes applied before grounding to shrink the ASP problem the solver has to work through. Each prune is sound — it never changes concretization, only removes facts/rules that provably cannot fire — and byte-identity was checked on every commit across a mix of fresh + reuse solves.

All five prunes are on by default and controllable via `concretizer:pruning:*` in `concretizer.yaml`:

```yaml
concretizer:
  pruning:
    dominated_versions: true      # collapse versions with identical constraint signatures
    unreachable_targets: true     # keep only targets a node could actually be driven to
    unusable_compilers: true      # drop compiler pkgs not in the reuse universe
    dead_dep_blocks: true         # skip depends_on blocks whose when-clause can't fire
```

Flip any of them off individually for A/B benchmarking or if a bug is suspected.

## Commits (bottom to top)

1. **`solver: prune statically-dominated versions from the solve`** — group versions with identical constraint-satisfaction signatures and per-version attributes into equivalence classes; keep only the min-weight representative of each run. Shrinks `choose_version` and every version-keyed rule. ~5% ground / ~6% solve reduction on mid-size solves.

2. **`solver: prune unreachable candidate targets from the solve`** — keep only targets a node could actually be driven to (host/family-best, per-constraint feasible-best under each compiler's support set, compiler fallback, plus anything pinned or from a reusable/concrete spec). On mfem this removes 9 of 11 candidate targets.

3. **`solver: prune non-reusable compiler-provider candidates from the solve`** — compilers can only enter a solve via reuse (external / installed / buildcache), so a compiler package not in `possible_compilers` cannot appear in any valid model. Two-track prune: fully drop `pkg` entries when nothing else depends on the compiler by name; suppress just the language-virtual `provides` facts (c/cxx/fortran/cuda-lang/hip-lang/fortran-rt) when the compiler is a library dep (llvm→libLLVM, gcc→libstdc++ headers). Also gates the vestigial `error(10, \"Only external, or concrete, compilers…\")` rule on `not compiler_pruning_enabled`. Ground program −13.5% on mfem; solve −25% to −35% across mfem/hdf5/llvm/rust/openmpi/cmake.

4. **`solver: prune transitively-unreachable packages after compiler prune`** — after (3) removes packages from `self.pkgs`, some others may only have been reachable via a now-pruned compiler. Walk the virtual-expanded adjacency map from the roots and drop anything unreachable. Modest today (compiler-only pkgs tend to be leaves); grows as more prune classes land.

5. **`solver: prune statically-dead depends_on blocks by when-clause analysis`** — skip `pkg.dependencies[cond]` blocks whose when-clause cannot fire, using two static signals: (a) version constraint doesn't intersect the package's registered versions, and (b) boolean variant required to be non-default but provably pinned to default in every optimal model (checked against input specs, reuse specs, cross-package `depends_on`, `requires`, and packages.yaml). On mfem: 2410 of 17863 blocks pruned, ground −5.86%, solve −16.5%, total wall-clock −8.9%.

6. **`solver: cache per-package variant/default data across dep-prune analyses`** — the dep-block analysis walked `pkg_cls.dependencies` / `pkg_cls.requirements` for every package every solve (~100ms). Lift those into module-level `functools.lru_cache` (invalidated only on repo reload), and add a per-solve memo for `_when_versions_dead`. Setup is now flat-or-better with all prunes on.

## Impact

−20% to −28% total wall-clock across mfem/hdf5/llvm (single-shot CLI, cache disabled). Setup flat-or-better after the caching commit; ground and solve shrink across the board. Repeat in-process solves save an additional ~600ms per solve after the first from module-cache hits (matters for environments and tests, not CLI single-shots).

## Correctness

Every commit was validated with byte-identical concretization across a mix of fresh + reuse solves on hdf5, mfem, llvm, rust, openmpi, cmake, ninja, gcc.

Left as draft while the config surface, commit-message polish, and interaction with existing static-analysis paths get one more pass.

## Test plan

- [ ] Unit tests pass
- [ ] Concretization is byte-identical vs. develop across a representative package set with defaults on
- [ ] Concretization is byte-identical vs. develop with each `concretizer:pruning:*` toggle flipped off
- [ ] Benchmarks (single-shot CLI, cache disabled) match the numbers above