### PR TITLE
Spec.mutate: allow mutating namespace

### DIFF
--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -4870,9 +4870,6 @@ class Spec:
         if mutator.name and mutator.name != self.name:
             raise SpecMutationError(f"Cannot mutate spec name: spec {self} mutator {mutator}")
 
-        if mutator.namespace and mutator.namespace != self.namespace:
-            raise SpecMutationError(f"Cannot mutate spec namespace: spec {self} mutator {mutator}")
-
         if len(mutator.dependencies()) > 0:
             raise SpecMutationError(f"Cannot mutate dependencies: spec {self} mutator {mutator}")
 
@@ -4888,6 +4885,10 @@ class Spec:
             raise SpecMutationError(f"Cannot mutate abstract_hash: spec {self} mutator {mutator}")
 
         changed = False
+
+        if mutator.namespace and mutator.namespace != self.namespace:
+            self.namespace = mutator.namespace
+            changed = True
 
         if mutator.versions != vn.VersionList(":") and self.versions != mutator.versions:
             self.versions = mutator.versions

--- a/lib/spack/spack/test/environment/mutate.py
+++ b/lib/spack/spack/test/environment/mutate.py
@@ -7,6 +7,7 @@ import pytest
 
 import spack.concretize
 import spack.environment as ev
+import spack.repo
 import spack.spec
 from spack.config import Configuration
 from spack.main import SpackCommand
@@ -122,6 +123,36 @@ def test_mutate_internals_multiple_mutations():
 
     new_hash = next(env.roots()).dag_hash()
     assert new_hash != orig_hash
+
+
+def test_mutate_namespace(repo_builder):
+    """
+    Check that Environment.mutate and Spec.mutate can change the namespace of a Spec.
+    """
+    repo_builder.add_package("cmake")
+
+    ev.create("test")
+    env = ev.read("test")
+
+    env.add("cmake-client")
+    env.concretize()
+
+    root_spec = next(env.roots()).copy()
+    cmake_spec = root_spec["cmake"]
+    assert cmake_spec.namespace == "builtin_mock"
+    orig_hash = root_spec.dag_hash()
+
+    selector = spack.spec.Spec("cmake")
+    mutator = spack.spec.Spec(f"{repo_builder.namespace}.cmake")
+
+    with spack.repo.use_repositories(repo_builder.root, override=False):
+        env.mutate(selectors=[selector], mutators=[mutator])
+        cmake_spec.mutate(mutator)
+
+    for spec in env.all_specs_generator():
+        if spec.name == "cmake":
+            assert spec.namespace == repo_builder.namespace
+    assert cmake_spec.namespace == repo_builder.namespace
 
 
 @pytest.mark.parametrize("constraint", ["foo", "foo.bar", "foo%cmake@1.0", "foo@1.1:", "foo/abc"])

--- a/lib/spack/spack/test/environment/mutate.py
+++ b/lib/spack/spack/test/environment/mutate.py
@@ -140,7 +140,6 @@ def test_mutate_namespace(repo_builder):
     root_spec = next(env.roots()).copy()
     cmake_spec = root_spec["cmake"]
     assert cmake_spec.namespace == "builtin_mock"
-    orig_hash = root_spec.dag_hash()
 
     selector = spack.spec.Spec("cmake")
     mutator = spack.spec.Spec(f"{repo_builder.namespace}.cmake")


### PR DESCRIPTION
Previously, `spack change --concrete foo namespace=bar` would fail.

Includes regression test.

@white238 @scheibelp @balos1 @LinaMuryanto as discussed earlier