### PR TITLE
external: make find --all environment-aware

### DIFF
--- a/lib/spack/spack/cmd/external.py
+++ b/lib/spack/spack/cmd/external.py
@@ -17,6 +17,7 @@ import spack.package_base
 import spack.repo
 import spack.spec
 from spack import cray_manifest
+from spack.active_environment import active_environment
 from spack.cmd.common import arguments
 from spack.util import tty
 from spack.util.tty import colify
@@ -51,14 +52,18 @@ def setup_parser(subparser: argparse.ArgumentParser) -> None:
         help="configuration scope to modify",
     )
     find_parser.add_argument(
-        "--all", action="store_true", help="search for all packages that Spack knows about"
+        "--all",
+        action="store_true",
+        help="search for all packages (if in a concretized environment, search for packages "
+        "in the environment's concretization; otherwise search for all detectable packages)",
     )
     arguments.add_common_arguments(find_parser, ["tags", "jobs"])
     find_parser.add_argument("packages", nargs=argparse.REMAINDER)
     find_parser.epilog = (
         'The search is by default on packages tagged with the "build-tools" or '
-        '"core-packages" tags. Use the --all option to search for every possible '
-        "package Spack knows how to find."
+        '"core-packages" tags. Use the --all option to search for all relevant packages. '
+        "When a concretized environment is active, --all searches for packages in the "
+        "environment's concretization; otherwise it searches for all detectable packages."
     )
 
     sp.add_parser("list", aliases=["ls"], help="list detectable packages, by repository and name")
@@ -118,6 +123,34 @@ def external_find(args):
 
     # Outside the Cray manifest, the search is done by tag for performance reasons,
     # since tags are cached.
+
+    # When --all is used with a concretized environment, limit search to packages
+    # in the environment (similar to spack mirror create behavior)
+    env = active_environment()
+    if args.all and env:
+        concrete_specs = env.all_specs()
+        if concrete_specs:
+            args.packages = list({spec.name for spec in concrete_specs})
+            tty.debug(f"Searching for packages from environment: {', '.join(args.packages)}")
+
+            # Exclude environment view paths to avoid detecting Spack-installed
+            # packages as externals
+            if not args.path:
+                from spack.util import environment as env_util
+                from spack.util.filesystem import path_contains_subdirectory
+
+                view_roots = [os.path.realpath(view.root) for view in env.views.values()]
+
+                def under_view(path_dir):
+                    real_path = os.path.realpath(path_dir)
+                    if any(path_contains_subdirectory(real_path, root) for root in view_roots):
+                        tty.debug(f"Excluding view path from search: {path_dir}")
+                        return True
+                    return False
+
+                filtered_paths = [p for p in env_util.get_path("PATH") if not under_view(p)]
+                if filtered_paths:
+                    args.path = filtered_paths
 
     # If the user specified both --all and --tag, then --all has precedence
     if args.all or args.packages:

--- a/lib/spack/spack/test/cmd/external.py
+++ b/lib/spack/spack/test/cmd/external.py
@@ -11,6 +11,7 @@ import spack.cmd.external
 import spack.cray_manifest
 import spack.detection
 import spack.detection.path
+from spack.active_environment import active_environment
 from spack.config import Configuration
 from spack.main import SpackCommand
 from spack.spec import Spec
@@ -389,3 +390,124 @@ def test_detect_virtuals(mock_executable, mutable_config, monkeypatch, mock_pack
 
     # Check that the mpi:buildable entry was not overwritten
     assert mutable_config.get("packages:mpi:buildable") is True
+
+
+def _setup_external_find_test(mock_executable, monkeypatch, mock_packages):
+    """Helper to set up mock executables for external find tests."""
+    versions = {"gcc": "9.3.0", "cmake": "3.19.1"}
+
+    @classmethod
+    def _determine_version_gcc(cls, exe):
+        return versions["gcc"]
+
+    @classmethod
+    def _determine_version_cmake(cls, exe):
+        return versions["cmake"]
+
+    gcc_cls = mock_packages.get_pkg_class("gcc")
+    cmake_cls = mock_packages.get_pkg_class("cmake")
+    monkeypatch.setattr(gcc_cls, "determine_version", _determine_version_gcc)
+    monkeypatch.setattr(cmake_cls, "determine_version", _determine_version_cmake)
+
+    gcc_exe = mock_executable("gcc", output=f"echo {versions['gcc']}")
+    cmake_exe = mock_executable("cmake", output=f"echo cmake version {versions['cmake']}")
+
+    path = f"{gcc_exe.parent}{os.pathsep}{cmake_exe.parent}"
+    monkeypatch.setenv("PATH", path)
+
+
+def test_find_external_all_in_concretized_env(
+    mock_executable, mutable_config, monkeypatch, mock_packages, mutable_mock_env_path
+):
+    """Test that 'spack external find --all' in a concretized environment only searches for
+    packages in the environment's concretization."""
+    import spack.environment as ev
+
+    _setup_external_find_test(mock_executable, monkeypatch, mock_packages)
+
+    env = ev.create("test")
+    env.add("gcc")
+    env.concretize()
+
+    with env:
+        assert active_environment() is env
+        external("find", "--all")
+
+        pkgs_cfg = mutable_config.get("packages")
+        assert "gcc" in pkgs_cfg
+        assert "cmake" not in pkgs_cfg
+
+
+def test_find_external_all_in_unconcretized_env(
+    mock_executable, mutable_config, monkeypatch, mock_packages, mutable_mock_env_path
+):
+    """Test that 'spack external find --all' in an unconcretized environment searches for
+    all detectable packages (fallback behavior)."""
+    import spack.environment as ev
+
+    _setup_external_find_test(mock_executable, monkeypatch, mock_packages)
+
+    env = ev.create("test")
+    env.add("gcc")
+
+    with env:
+        assert active_environment() is env
+        assert not env.all_specs()
+        external("find", "--all")
+
+        pkgs_cfg = mutable_config.get("packages")
+        assert "gcc" in pkgs_cfg
+        assert "cmake" in pkgs_cfg
+
+
+def test_find_external_all_excludes_view_paths(
+    mock_executable, mutable_config, monkeypatch, mock_packages, mutable_mock_env_path, tmp_path
+):
+    """Test that 'spack external find --all' in a concretized environment excludes
+    environment view paths from the search."""
+    import spack.environment as ev
+    from spack.environment.environment import ViewDescriptor
+
+    versions = {"view": "3.18.0", "external": "3.19.1"}
+
+    @classmethod
+    def _determine_version(cls, exe):
+        if "view" in exe:
+            return versions["view"]
+        else:
+            return versions["external"]
+
+    cmake_cls = mock_packages.get_pkg_class("cmake")
+    monkeypatch.setattr(cmake_cls, "determine_version", _determine_version)
+
+    view_dir = tmp_path / "view" / "bin"
+    view_dir.mkdir(parents=True)
+    external_dir = tmp_path / "external" / "bin"
+    external_dir.mkdir(parents=True)
+
+    cmake_in_view = mock_executable(
+        "cmake", output=f"echo cmake version {versions['view']}", subdir=("view", "bin")
+    )
+    cmake_external = mock_executable(
+        "cmake", output=f"echo cmake version {versions['external']}", subdir=("external", "bin")
+    )
+
+    path = f"{cmake_in_view.parent}{os.pathsep}{cmake_external.parent}"
+    monkeypatch.setenv("PATH", path)
+
+    env = ev.create("test")
+    env.add("cmake")
+    env.concretize()
+
+    env.views = {"default": ViewDescriptor(env.path, str(tmp_path / "view"))}
+
+    with env:
+        assert active_environment() is env
+        external("find", "--all")
+
+        pkgs_cfg = mutable_config.get("packages")
+        assert "cmake" in pkgs_cfg
+        cmake_externals = pkgs_cfg["cmake"]["externals"]
+        assert len(cmake_externals) == 1
+        assert versions["external"] in cmake_externals[0]["spec"]
+        assert versions["view"] not in str(cmake_externals)

--- a/share/spack/spack-completion.fish
+++ b/share/spack/spack-completion.fish
@@ -1832,7 +1832,7 @@ complete -c spack -n '__fish_spack_using_command external find' -s p -l path -r 
 complete -c spack -n '__fish_spack_using_command external find' -l scope -r -f -a '_builtin defaults:base defaults system site user spack command_line'
 complete -c spack -n '__fish_spack_using_command external find' -l scope -r -d 'configuration scope to modify'
 complete -c spack -n '__fish_spack_using_command external find' -l all -f -a all
-complete -c spack -n '__fish_spack_using_command external find' -l all -d 'search for all packages that Spack knows about'
+complete -c spack -n '__fish_spack_using_command external find' -l all -d 'search for all packages (if in a concretized environment, search for packages in the environment'"'"'s concretization; otherwise search for all detectable packages)'
 complete -c spack -n '__fish_spack_using_command external find' -s t -l tag -r -f -a tags
 complete -c spack -n '__fish_spack_using_command external find' -s t -l tag -r -d 'filter a package query by tag (multiple use allowed)'
 complete -c spack -n '__fish_spack_using_command external find' -s j -l jobs -r -f -a jobs


### PR DESCRIPTION
Make `spack external find --all` environment-aware, matching the behavior  of `spack mirror create --all`. When used with a concretized environment, --all searches only for packages in the environment's concretization instead of all detectable packages. If the environment is not concretized, it falls back to searching all detectable packages.

This provides a more focused and efficient way to find externals for environment packages without detecting irrelevant system packages.

The implementation also filters environment view paths from the search to avoid incorrectly detecting Spack-installed packages as externals.