### PR TITLE
Windows: handle cross drive relative paths

### DIFF
--- a/lib/spack/spack/cmd/style.py
+++ b/lib/spack/spack/cmd/style.py
@@ -209,7 +209,10 @@ def cwd_relative(path: Path, root: Union[Path, str], initial_working_dir: Path) 
         return Path(os.path.relpath(abs_path, initial_working_dir))
     except ValueError:
         if not same_drive(abs_path, initial_working_dir):
-            tty.debug(f"Cannot make relative path across drives ({abs_path!r} vs {initial_working_dir!r}); using absolute path")
+            tty.debug(
+                f"Cannot make relative path across drives ({abs_path!r}"
+                " vs {initial_working_dir!r}); using absolute path"
+            )
             return abs_path
         raise
 
@@ -538,7 +541,10 @@ def style(parser, args):
             return Path(os.path.relpath(abs_path, args.root))
         except ValueError:
             if not same_drive(abs_path, args.root):
-                tty.debug(f"Cannot make relative path across drives ({abs_path!r} vs {args.root!r}); using absolute path")
+                tty.debug(
+                    f"Cannot make relative path across drives ({abs_path!r} vs {args.root!r});"
+                    " using absolute path"
+                )
                 return Path(abs_path)
             raise
 

--- a/lib/spack/spack/cmd/style.py
+++ b/lib/spack/spack/cmd/style.py
@@ -20,6 +20,7 @@ from spack.cmd.common.spec_strings import (
 from spack.util import tty
 from spack.util.executable import Executable, which
 from spack.util.filesystem import working_dir
+from spack.util.path import same_drive
 from spack.util.tty import color
 
 description = "runs source code style checks on spack"
@@ -203,7 +204,14 @@ def cwd_relative(path: Path, root: Union[Path, str], initial_working_dir: Path) 
     """Translate prefix-relative path to current working directory-relative."""
     if path.is_absolute():
         return path
-    return Path(os.path.relpath((root / path), initial_working_dir))
+    abs_path = (Path(root) / path).resolve()
+    try:
+        return Path(os.path.relpath(abs_path, initial_working_dir))
+    except ValueError:
+        if not same_drive(abs_path, initial_working_dir):
+            tty.debug(f"Cannot make relative path across drives ({abs_path!r} vs {initial_working_dir!r}); using absolute path")
+            return abs_path
+        raise
 
 
 def rewrite_and_print_output(
@@ -525,7 +533,14 @@ def style(parser, args):
         tty.die("This does not look like a valid spack root.", "No such file: '%s'" % spack_script)
 
     def prefix_relative(path: Union[Path, str]) -> Path:
-        return Path(os.path.relpath(os.path.abspath(os.path.realpath(path)), args.root))
+        abs_path = os.path.abspath(os.path.realpath(path))
+        try:
+            return Path(os.path.relpath(abs_path, args.root))
+        except ValueError:
+            if not same_drive(abs_path, args.root):
+                tty.debug(f"Cannot make relative path across drives ({abs_path!r} vs {args.root!r}); using absolute path")
+                return Path(abs_path)
+            raise
 
     file_list = [prefix_relative(file) for file in args.files]
 

--- a/lib/spack/spack/test/cmd/style.py
+++ b/lib/spack/spack/test/cmd/style.py
@@ -25,10 +25,6 @@ style_data = os.path.join(spack.paths.test_path, "data", "style")
 
 style = spack.main.SpackCommand("style")
 
-pytestmark = pytest.mark.skipif(
-    sys.platform == "win32", reason="CI uses cross drive paths that raise errors with relpath"
-)
-
 RUFF = which("ruff")
 MYPY = which("mypy")
 
@@ -42,23 +38,23 @@ def has_develop_branch(git):
 
 
 @pytest.fixture(scope="function")
-def ruff_package(tmp_path: pathlib.Path):
+def ruff_package():
     """Style only checks files that have been modified. This fixture makes a small
     change to the ``ruff`` mock package, yields the filename, then undoes the
     change on cleanup.
     """
     repo = spack.repo.from_path(spack.paths.mock_packages_path)
     filename = repo.filename_for_package_name("ruff")
-    rel_path = os.path.dirname(os.path.relpath(filename, spack.paths.prefix))
-    tmp = tmp_path / rel_path / "ruff-ci-package.py"
-    tmp.parent.mkdir(parents=True, exist_ok=True)
-    tmp.touch()
-    tmp = str(tmp)
+    # Place the copy next to the original so it shares the same drive on Windows,
+    # avoiding cross-drive relpath failures when comparing against spack.paths.prefix.
+    tmp = os.path.join(os.path.dirname(filename), "ruff-ci-package.py")
 
     shutil.copy(filename, tmp)
     package = FileFilter(tmp)
     package.filter("state = 'unmodified'", "state = 'modified'", string=True)
     yield tmp
+    if os.path.exists(tmp):
+        os.remove(tmp)
 
 
 @pytest.fixture
@@ -79,6 +75,8 @@ def ruff_package_with_errors(scope="function"):
         "from spack.package import *", "from spack.package import *\nimport os", string=True
     )
     yield tmp
+    if os.path.exists(tmp):
+        os.remove(tmp)
 
 
 def test_changed_files_from_git_rev_base(git, tmp_path: pathlib.Path):
@@ -240,12 +238,13 @@ def test_external_root(external_style_root):
 
 
 @pytest.mark.skipif(not RUFF, reason="ruff is not installed.")
-def test_style(ruff_package, tmp_path: pathlib.Path):
+def test_style(ruff_package):
     root_relative = os.path.relpath(ruff_package, spack.paths.prefix)
 
-    # use a working directory to test cwd-relative paths, as tests run in
-    # the spack prefix by default
-    with working_dir(str(tmp_path)):
+    # Use the spack prefix parent as a working directory to test cwd-relative path output.
+    # Must stay on the same drive as ruff_package to avoid cross-drive relpath errors on Windows.
+    parent_dir = str(pathlib.Path(spack.paths.prefix).parent)
+    with working_dir(parent_dir):
         relative = os.path.relpath(ruff_package)
 
         # one specific arg

--- a/lib/spack/spack/util/link_tree.py
+++ b/lib/spack/spack/util/link_tree.py
@@ -12,6 +12,7 @@ from typing import Callable, Dict, List, Optional, Sequence, Tuple, Union
 
 import spack.util.filesystem as fs
 from spack.util import tty
+from spack.util.path import same_drive
 
 __all__ = ["LinkTree"]
 
@@ -562,8 +563,15 @@ class LinkTree:
             elif relative:
                 abs_src = os.path.abspath(src)
                 dst_dir = os.path.dirname(os.path.abspath(dst))
-                rel = os.path.relpath(abs_src, dst_dir)
-                link(rel, dst)
+                try:
+                    rel = os.path.relpath(abs_src, dst_dir)
+                    link(rel, dst)
+                except ValueError:
+                    if not same_drive(abs_src, dst_dir):
+                        tty.debug(f"Cannot make relative symlink across drives ({abs_src!r} vs {dst_dir!r}); using absolute path")
+                        link(abs_src, dst)
+                    else:
+                        raise
             else:
                 link(src, dst)
 

--- a/lib/spack/spack/util/link_tree.py
+++ b/lib/spack/spack/util/link_tree.py
@@ -568,7 +568,10 @@ class LinkTree:
                     link(rel, dst)
                 except ValueError:
                     if not same_drive(abs_src, dst_dir):
-                        tty.debug(f"Cannot make relative symlink across drives ({abs_src!r} vs {dst_dir!r}); using absolute path")
+                        tty.debug(
+                            f"Cannot make relative symlink across drives ({abs_src!r}"
+                            " vs {dst_dir!r}); using absolute path"
+                        )
                         link(abs_src, dst)
                     else:
                         raise

--- a/lib/spack/spack/util/path.py
+++ b/lib/spack/spack/util/path.py
@@ -123,6 +123,20 @@ else:
     system_path_filter = _noop_decorator
 
 
+def same_drive(
+    path_a: Union[str, "os.PathLike[str]"], path_b: Union[str, "os.PathLike[str]"]
+) -> bool:
+    """Return True if both paths share the same Windows drive letter.
+
+    On non-Windows systems ``os.path.splitdrive`` always returns an empty drive
+    component, so this function returns True for any two paths (they are trivially
+    on the same "drive").  Comparison is case-insensitive.
+    """
+    return os.path.splitdrive(os.fspath(path_a))[0].upper() == os.path.splitdrive(
+        os.fspath(path_b)
+    )[0].upper()
+
+
 def sanitize_win_longpath(path: str) -> str:
     """Strip Windows extended path prefix from strings
     Returns sanitized string.

--- a/lib/spack/spack/util/path.py
+++ b/lib/spack/spack/util/path.py
@@ -132,9 +132,10 @@ def same_drive(
     component, so this function returns True for any two paths (they are trivially
     on the same "drive").  Comparison is case-insensitive.
     """
-    return os.path.splitdrive(os.fspath(path_a))[0].upper() == os.path.splitdrive(
-        os.fspath(path_b)
-    )[0].upper()
+    return (
+        os.path.splitdrive(os.fspath(path_a))[0].upper()
+        == os.path.splitdrive(os.fspath(path_b))[0].upper()
+    )
 
 
 def sanitize_win_longpath(path: str) -> str:


### PR DESCRIPTION
Spack attempts to call `relpath` on a few paths that can find themselves on different drives (see pytest's tmp_path in GHA), which produces an error on Windows (paths cannot be relative to a path on a different drive). This PR adds guards to catch that scenario, confirm the paths are on differing drives, reports to debug this has occured, and returns the absolute path, similar to how relpath would behave on linux accross mounts/networks.