### PR TITLE
core: fix a couple slots issues

### DIFF
--- a/lib/spack/spack/database.py
+++ b/lib/spack/spack/database.py
@@ -197,6 +197,18 @@ class InstallRecord:
         installation_time (datetime.datetime or None): time of the installation
     """
 
+    __slots__ = (
+        "spec",
+        "path",
+        "installed",
+        "ref_count",
+        "explicit",
+        "installation_time",
+        "deprecated_for",
+        "in_buildcache",
+        "origin",
+    )
+
     def __init__(
         self,
         spec: "spack.spec.Spec",

--- a/lib/spack/spack/mirrors/utils.py
+++ b/lib/spack/spack/mirrors/utils.py
@@ -77,9 +77,6 @@ def get_matching_versions(specs, num_versions=1):
                 s = spack.spec.Spec(pkg.name)
                 s.versions = spack.version.VersionList([v])
                 s.variants = spec.variants.copy()
-                # This is needed to avoid hanging references during the
-                # concretization phase
-                s.variants.spec = s
                 matching_spec.append(s)
                 pkg_versions -= 1
 

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -935,6 +935,8 @@ def _shared_subset_pair_iterate(container1, container2):
 
 
 class FlagMap(lang.HashableMap[str, List[CompilerFlag]]):
+    __slots__ = ()
+
     def satisfies(self, other):
         return all(f in self and set(self[f]) >= set(other[f]) for f in other)
 
@@ -1436,6 +1438,8 @@ def tree(
 
 
 class SpecAnnotations:
+    __slots__ = ("original_spec_format", "compiler_node_attribute")
+
     def __init__(self) -> None:
         self.original_spec_format = SPECFILE_FORMAT_VERSION
         self.compiler_node_attribute: Optional["Spec"] = None
@@ -3598,7 +3602,6 @@ class Spec:
         self.versions = other.versions.copy()
         self.architecture = other.architecture.copy() if other.architecture else None
         self.compiler_flags = other.compiler_flags.copy()
-        self.compiler_flags.spec = self
         self.variants = other.variants.copy()
         self._build_spec = other._build_spec
 
@@ -3614,7 +3617,6 @@ class Spec:
             if patches:
                 self.variants[k]._patches_in_order_of_appearance = patches
 
-        self.variants.spec = self
         self.external_path = other.external_path
         self.external_modules = other.external_modules
         self.extra_attributes = other.extra_attributes
@@ -5037,6 +5039,8 @@ class Spec:
 class VariantMap(lang.HashableMap[str, vt.VariantValue]):
     """Map containing variant instances. New values can be added only
     if the key is not already present."""
+
+    __slots__ = ()
 
     def __setitem__(self, name, vspec):
         # Raise a TypeError if vspec is not of the right type

--- a/lib/spack/spack/variant.py
+++ b/lib/spack/spack/variant.py
@@ -287,7 +287,15 @@ class VariantValue:
     type: VariantType
     _values: ValueType
 
-    slots = ("name", "propagate", "concrete", "type", "_values")
+    # _patches_in_order_of_appearance is attached to the "patches" variant after concretization
+    __slots__ = (
+        "name",
+        "propagate",
+        "concrete",
+        "type",
+        "_values",
+        "_patches_in_order_of_appearance",
+    )
 
     def __init__(
         self,
@@ -507,6 +515,8 @@ def BoolValuedVariant(name: str, value: bool, propagate: bool = False) -> Varian
 
 class VariantValueRemoval(VariantValue):
     """Indicator class for Spec.mutate to remove a variant"""
+
+    __slots__ = ()
 
     def __init__(self, name):
         super().__init__(VariantType.INDICATOR, name, (None,))

--- a/lib/spack/spack/version/version_types.py
+++ b/lib/spack/spack/version/version_types.py
@@ -940,6 +940,8 @@ class ClosedOpenRange(VersionType):
 class VersionList(VersionType):
     """Sorted, non-redundant list of Version and ClosedOpenRange elements."""
 
+    __slots__ = ("versions",)
+
     versions: List[VersionType]
 
     def __init__(self, vlist: Optional[Union[str, VersionType, Iterable]] = None):


### PR DESCRIPTION
* Our slots check didn't catch the missing slots in `VariantMap` etc.
* `slots` was used in one place instead of `__slots__`
* There were still leftover `self.compiler_flags.spec = self` object cycles
  that I had eliminated in the past to reduce GC pressure; using slots makes
  the assignment an error
