### PR TITLE
spec.py: remove finalize branch in _constrain

### DIFF
--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -3104,9 +3104,6 @@ class Spec:
         if deps:
             changed |= self._constrain_dependencies(other, resolve_virtuals=resolve_virtuals)
 
-        if other.concrete and not self.concrete and other.satisfies(self):
-            self._finalize_concretization()
-
         return changed
 
     def _constrain_dependencies(self, other: "Spec", resolve_virtuals: bool = True) -> bool:


### PR DESCRIPTION
Extracted from a larger refactor PR so that PR just moves code
around.

Delete

```python
if other.concrete and not self.concrete and other.satisfies(self):
    self._finalize_concretization()
```

from `Spec._constrain`. This is fine because at the start of
`Spec._constrain` there is already

```python
if other.concrete and other._satisfies(self, resolve_virtuals=resolve_virtuals):
    self._dup(other)
    return True
```

and the case of `resolve_virtuals=False` only applies when calling
`_constrain_symbolically`, which is private API, and has only a single
call site where the right-hand side is guaranteed to be abstract.

So, `Spec("mpi").constrain(concrete_mpich)` continues to work.