### PR TITLE
spack change -c/-C: allow removing variant

### DIFF
--- a/lib/spack/spack/cmd/change.py
+++ b/lib/spack/spack/cmd/change.py
@@ -8,6 +8,7 @@ import warnings
 import spack.cmd
 import spack.environment
 import spack.spec
+import spack.variant
 from spack.cmd.common import arguments
 
 description = "change an existing spec in an environment"
@@ -48,6 +49,15 @@ def setup_parser(subparser: argparse.ArgumentParser) -> None:
         default=False,
         help="change only concrete specs in the environment",
     )
+    subparser.add_argument(
+        "--remove-variant",
+        dest="remove_variants",
+        action="append",
+        default=[],
+        metavar="VARIANT",
+        help="remove a variant from matching concrete specs"
+        " (requires '--concrete' or '--concrete-only', may be used multiple times)",
+    )
     arguments.add_common_arguments(subparser, ["specs"])
 
 
@@ -56,6 +66,10 @@ def change(parser, args):
         warnings.warn("'spack change --all' argument is ignored with '--concrete-only'")
     if args.list_name != "specs" and args.concrete_only:
         warnings.warn("'spack change --list-name' argument is ignored with '--concrete-only'")
+    if args.remove_variants and not (args.concrete or args.concrete_only):
+        raise ValueError(
+            "'spack change --remove-variant' requires '--concrete' or '--concrete-only'"
+        )
 
     env = spack.cmd.require_active_env(args.subparser)
 
@@ -80,9 +94,23 @@ def change(parser, args):
                 raise ValueError(msg) from e
 
         if args.concrete or args.concrete_only:
+            if args.remove_variants and not specs:
+                if not match_spec:
+                    raise ValueError(
+                        "'spack change --remove-variant' without a spec requires '--match-spec'"
+                    )
+                specs = [spack.spec.Spec()]
+
             selectors = []
             mutators = []
             for spec in specs:
+                for variant_name in args.remove_variants:
+                    if variant_name in spec.variants:
+                        raise ValueError(
+                            f"Cannot remove variant '{variant_name}' that is also set"
+                            f" by the change spec '{spec}'"
+                        )
+                    spec.variants[variant_name] = spack.variant.VariantValueRemoval(variant_name)
                 selectors.append(match_spec or spack.spec.Spec(spec.name))
                 mutators.append(spec)
 

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -4870,9 +4870,6 @@ class Spec:
         if mutator.name and mutator.name != self.name:
             raise SpecMutationError(f"Cannot mutate spec name: spec {self} mutator {mutator}")
 
-        if mutator.namespace and mutator.namespace != self.namespace:
-            raise SpecMutationError(f"Cannot mutate spec namespace: spec {self} mutator {mutator}")
-
         if len(mutator.dependencies()) > 0:
             raise SpecMutationError(f"Cannot mutate dependencies: spec {self} mutator {mutator}")
 
@@ -4888,6 +4885,10 @@ class Spec:
             raise SpecMutationError(f"Cannot mutate abstract_hash: spec {self} mutator {mutator}")
 
         changed = False
+
+        if mutator.namespace and mutator.namespace != self.namespace:
+            self.namespace = mutator.namespace
+            changed = True
 
         if mutator.versions != vn.VersionList(":") and self.versions != mutator.versions:
             self.versions = mutator.versions

--- a/lib/spack/spack/test/environment/mutate.py
+++ b/lib/spack/spack/test/environment/mutate.py
@@ -7,6 +7,7 @@ import pytest
 
 import spack.concretize
 import spack.environment as ev
+import spack.repo
 import spack.spec
 from spack.config import Configuration
 from spack.main import SpackCommand
@@ -122,6 +123,36 @@ def test_mutate_internals_multiple_mutations():
 
     new_hash = next(env.roots()).dag_hash()
     assert new_hash != orig_hash
+
+
+def test_mutate_namespace(repo_builder):
+    """
+    Check that Environment.mutate and Spec.mutate can change the namespace of a Spec.
+    """
+    repo_builder.add_package("cmake")
+
+    ev.create("test")
+    env = ev.read("test")
+
+    env.add("cmake-client")
+    env.concretize()
+
+    root_spec = next(env.roots()).copy()
+    cmake_spec = root_spec["cmake"]
+    assert cmake_spec.namespace == "builtin_mock"
+    orig_hash = root_spec.dag_hash()
+
+    selector = spack.spec.Spec("cmake")
+    mutator = spack.spec.Spec(f"{repo_builder.namespace}.cmake")
+
+    with spack.repo.use_repositories(repo_builder.root, override=False):
+        env.mutate(selectors=[selector], mutators=[mutator])
+        cmake_spec.mutate(mutator)
+
+    for spec in env.all_specs_generator():
+        if spec.name == "cmake":
+            assert spec.namespace == repo_builder.namespace
+    assert cmake_spec.namespace == repo_builder.namespace
 
 
 @pytest.mark.parametrize("constraint", ["foo", "foo.bar", "foo%cmake@1.0", "foo@1.1:", "foo/abc"])

--- a/lib/spack/spack/test/environment/mutate.py
+++ b/lib/spack/spack/test/environment/mutate.py
@@ -140,7 +140,6 @@ def test_mutate_namespace(repo_builder):
     root_spec = next(env.roots()).copy()
     cmake_spec = root_spec["cmake"]
     assert cmake_spec.namespace == "builtin_mock"
-    orig_hash = root_spec.dag_hash()
 
     selector = spack.spec.Spec("cmake")
     mutator = spack.spec.Spec(f"{repo_builder.namespace}.cmake")

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -691,7 +691,7 @@ _spack_cd() {
 _spack_change() {
     if $list_options
     then
-        SPACK_COMPREPLY="-h --help -l --list-name --match-spec -a --all -c --concrete -C --concrete-only"
+        SPACK_COMPREPLY="-h --help -l --list-name --match-spec -a --all -c --concrete -C --concrete-only --remove-variant"
     else
         _all_packages
     fi

--- a/share/spack/spack-completion.fish
+++ b/share/spack/spack-completion.fish
@@ -955,7 +955,7 @@ complete -c spack -n '__fish_spack_using_command cd' -l first -f -a find_first
 complete -c spack -n '__fish_spack_using_command cd' -l first -d 'use the first match if multiple packages match the spec'
 
 # spack change
-set -g __fish_spack_optspecs_spack_change h/help l/list-name= match-spec= a/all c/concrete C/concrete-only
+set -g __fish_spack_optspecs_spack_change h/help l/list-name= match-spec= a/all c/concrete C/concrete-only remove-variant=
 complete -c spack -n '__fish_spack_using_command_pos_remainder 0 change' -f -k -a '(__fish_spack_specs)'
 complete -c spack -n '__fish_spack_using_command change' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command change' -s h -l help -d 'show this help message and exit'
@@ -969,6 +969,8 @@ complete -c spack -n '__fish_spack_using_command change' -s c -l concrete -f -a 
 complete -c spack -n '__fish_spack_using_command change' -s c -l concrete -d 'change concrete specs in the environment'
 complete -c spack -n '__fish_spack_using_command change' -s C -l concrete-only -f -a concrete_only
 complete -c spack -n '__fish_spack_using_command change' -s C -l concrete-only -d 'change only concrete specs in the environment'
+complete -c spack -n '__fish_spack_using_command change' -l remove-variant -r -f -a remove_variants
+complete -c spack -n '__fish_spack_using_command change' -l remove-variant -r -d 'remove a variant from matching concrete specs (requires '"'"'--concrete'"'"' or '"'"'--concrete-only'"'"', may be used multiple times)'
 
 # spack checksum
 set -g __fish_spack_optspecs_spack_checksum h/help keep-stage b/batch l/latest p/preferred a/add-to-package verify j/jobs=


### PR DESCRIPTION
Depends on #52769 because otherwise it would conflict when merged.

There is no way to write a change-spec for removing a variant (because the spec syntax does not support negation).

This PR provides a flag to remove a variant from a concrete spec in an environment with the `spack change` command. The internal capability was already present, this is just a CLI interface that constructs the `spack.variant.VariantRemoveValue` object.

@white238 @scheibelp @balos1 @LinaMuryanto 