### PR TITLE
spec.py: remove Spec.package_hash

### DIFF
--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -2285,17 +2285,6 @@ class Spec:
 
         return hash_string[:length]
 
-    def package_hash(self):
-        """Compute the hash of the contents of the package for this node"""
-        # Concrete specs with the old DAG hash did not have the package hash, so we do
-        # not know what the package looked like at concretization time
-        if self.concrete and not self._package_hash:
-            raise ValueError(
-                "Cannot call package_hash() on concrete specs with the old dag_hash()"
-            )
-
-        return self._cached_hash(ht.package_hash)
-
     def dag_hash(self, length=None):
         """This is Spack's default hash, used to identify installations.
 
@@ -2420,11 +2409,9 @@ class Spec:
             and hasattr(self, "_package_hash")
             and self._package_hash
         ):
-            # We use the attribute here instead of `self.package_hash()` because this
-            # should *always* be assignhed at concretization time. We don't want to try
-            # to compute a package hash for concrete spec where a) the package might not
-            # exist, or b) the `dag_hash` didn't include the package hash when the spec
-            # was concretized.
+            # The package hash is assigned at concretization time, and only read here. We don't
+            # want to compute one for a concrete spec, where a) the package might not exist, or
+            # b) the `dag_hash` didn't include the package hash when the spec was concretized.
             package_hash = self._package_hash
 
             # Full hashes are in bytes

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -2409,9 +2409,9 @@ class Spec:
             and hasattr(self, "_package_hash")
             and self._package_hash
         ):
-            # The package hash is assigned at concretization time, and only read here. We don't
-            # want to compute one for a concrete spec, where a) the package might not exist, or
-            # b) the `dag_hash` didn't include the package hash when the spec was concretized.
+            # The package hash is assigned at concretization time. We don't want to compute one for
+            # a concrete spec, where a) the package might not exist, or b) the `dag_hash` didn't
+            # include the package hash when the spec was concretized.
             package_hash = self._package_hash
 
             # Full hashes are in bytes

--- a/lib/spack/spack/test/spec_semantics.py
+++ b/lib/spack/spack/test/spec_semantics.py
@@ -1821,6 +1821,7 @@ def test_call_dag_hash_on_old_dag_hash_spec(mock_packages, config):
 
     for spec in a.traverse():
         assert dag_hashes[spec.name] == spec.dag_hash()
+        assert "package_hash" not in spec.to_node_dict()
 
 
 def test_spec_trim(mock_packages, config):

--- a/lib/spack/spack/test/spec_semantics.py
+++ b/lib/spack/spack/test/spec_semantics.py
@@ -1822,9 +1822,6 @@ def test_call_dag_hash_on_old_dag_hash_spec(mock_packages, config):
     for spec in a.traverse():
         assert dag_hashes[spec.name] == spec.dag_hash()
 
-        with pytest.raises(ValueError, match="Cannot call package_hash()"):
-            spec.package_hash()
-
 
 def test_spec_trim(mock_packages, config):
     top = spack.concretize.concretize_one("dt-diamond")


### PR DESCRIPTION
Nothing calls `Spec.package_hash()`, and it is a bug that it was exposed as a
method as part of the package API.

Oddly enough you can call this function on abstract specs, and it will compute
the package hash only to discard it immediately, because `Spec._package_hash`
is only saved for concrete specs.

With the method gone, the remaining caller of the package hash descriptor in the
Spec class is `_finalize_concretization`. My goal is to get rid of this and make it
assigned by the solver, which knows the associated repo it concretized with; the
package hash should not be computed lazily relative to whatever the current global
repo happens to be enabled.