### PR TITLE
variant: apply the patch prefix rule to intersects and constrain too

### DIFF
--- a/lib/spack/spack/database.py
+++ b/lib/spack/spack/database.py
@@ -805,27 +805,28 @@ class Database:
             spec_node_dict = spec_node_dict[spec.name]
         if "dependencies" in spec_node_dict:
             yaml_deps = spec_node_dict["dependencies"]
-            for dname, dhash, dtypes, _, virtuals, direct in spec_reader.read_specfile_dep_specs(
-                yaml_deps
-            ):
+            for dep in spec_reader.read_specfile_dep_specs(yaml_deps):
                 # It is important that we always check upstream installations in the same order,
                 # and that we always check the local installation first: if a downstream Spack
                 # installs a package then dependents in that installation could be using it. If a
                 # hash is installed locally and upstream, there isn't enough information to
                 # determine which one a local package depends on, so the convention ensures that
                 # this isn't an issue.
-                _, record = self.query_by_spec_hash(dhash, data=data)
+                _, record = self.query_by_spec_hash(dep.hash, data=data)
                 child = record.spec if record else None
 
                 if not child:
                     tty.warn(
                         f"Missing dependency not in database: "
-                        f"{spec.cformat('{name}{/hash:7}')} needs {dname}-{dhash[:7]}"
+                        f"{spec.cformat('{name}{/hash:7}')} needs {dep.name}-{dep.hash[:7]}"
                     )
                     continue
 
                 spec._add_dependency(
-                    child, depflag=dt.canonicalize(dtypes), virtuals=virtuals, direct=direct
+                    child,
+                    depflag=dt.canonicalize(dep.deptypes),
+                    virtuals=dep.virtuals,
+                    direct=dep.direct,
                 )
 
     def _read_from_file(self, filename: pathlib.Path, *, reindex: bool = False) -> None:

--- a/lib/spack/spack/environment/environment.py
+++ b/lib/spack/spack/environment/environment.py
@@ -2462,14 +2462,12 @@ class Environment:
         # and add them to the spec, including build specs
         for lockfile_key, node_dict in json_specs_by_hash.items():
             name, data = reader.name_and_data(node_dict)
-            for _, dep_hash, deptypes, _, virtuals, direct in reader.dependencies_from_node_dict(
-                data
-            ):
+            for dep in reader.dependencies_from_node_dict(data):
                 specs_by_hash[lockfile_key]._add_dependency(
-                    specs_by_hash[dep_hash],
-                    depflag=dt.canonicalize(deptypes),
-                    virtuals=virtuals,
-                    direct=direct,
+                    specs_by_hash[dep.hash],
+                    depflag=dt.canonicalize(dep.deptypes),
+                    virtuals=dep.virtuals,
+                    direct=dep.direct,
                 )
 
             if "build_spec" in node_dict:

--- a/lib/spack/spack/schema/spec.py
+++ b/lib/spack/spack/schema/spec.py
@@ -121,6 +121,16 @@ dependencies_v4_plus = {
                         "type": "boolean",
                         "description": "Whether the dependency is direct (only on abstract specs)",
                     },
+                    "when": {
+                        "type": "string",
+                        "description": "Condition under which the dependency holds, as a spec "
+                        "string (only on abstract specs)",
+                    },
+                    "propagation": {
+                        "type": "string",
+                        "description": "Propagation policy of a direct dependency (only on "
+                        "abstract specs)",
+                    },
                 },
             },
         },
@@ -188,6 +198,24 @@ spec_node = {
             "dependencies)",
         },
         "namespace": {"type": "string", "description": "Package repository namespace"},
+        "abstract_hash": {
+            "type": "string",
+            "description": "Hash prefix of the concrete spec this refers to (for abstract specs)",
+        },
+        "compiler_flags": {
+            "type": "object",
+            "description": "Compiler flags with their propagation (for abstract specs). "
+            "Supersedes the flags under parameters",
+            "additionalProperties": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "additionalProperties": False,
+                    "required": ["value"],
+                    "properties": {"value": {"type": "string"}, "propagate": {"type": "boolean"}},
+                },
+            },
+        },
         "parameters": {
             "type": "object",
             "additionalProperties": True,

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -68,6 +68,7 @@ from typing import (
     Iterable,
     List,
     Match,
+    NamedTuple,
     Optional,
     Sequence,
     Set,
@@ -907,6 +908,20 @@ class CompilerFlag(str):
         obj.source = kwargs.pop("source", None)
         return obj
 
+    def to_dict(self) -> Dict[str, Any]:
+        """Value and propagation of this flag, unlike ``FlagMap.yaml_entry``, which is its value
+        only. ``flag_group`` and ``source`` are not included: they are bookkeeping for a single
+        solve, and nothing reads them back. Attributes that have their default value are
+        omitted."""
+        d: Dict[str, Any] = {"value": str(self)}
+        if self.propagate:
+            d["propagate"] = True
+        return d
+
+    @staticmethod
+    def from_dict(d: Dict[str, Any]) -> "CompilerFlag":
+        return CompilerFlag(d["value"], propagate=d.get("propagate", False))
+
 
 _valid_compiler_flags = ["cflags", "cxxflags", "fflags", "ldflags", "ldlibs", "cppflags"]
 
@@ -972,6 +987,21 @@ class FlagMap(lang.HashableMap[str, List[CompilerFlag]]):
         # intersection specify different behaviors for flag propagation?
 
         return changed
+
+    def to_dict(self) -> Dict[str, List[Dict[str, Any]]]:
+        """Values and propagation of the flags, unlike ``yaml_entry``, which drops everything but
+        their values."""
+        return {
+            flag_type: [flag.to_dict() for flag in flags]
+            for flag_type, flags in sorted(self.items())
+        }
+
+    @staticmethod
+    def from_dict(d: Dict[str, List[Dict[str, Any]]]) -> "FlagMap":
+        result = FlagMap()
+        for flag_type, flags in d.items():
+            result[flag_type] = [CompilerFlag.from_dict(flag) for flag in flags]
+        return result
 
     @staticmethod
     def valid_compiler_flags():
@@ -2399,6 +2429,15 @@ class Spec:
             )
             d["abstract"] = sorted(v.name for v in self.variants.values() if not v.concrete)
 
+        if not self._concrete:
+            # State that only abstract specs have, or that "parameters" and "propagate" above are
+            # too coarse to express. Concrete node dicts are left alone: they feed the DAG hash.
+            if self.abstract_hash:
+                d["abstract_hash"] = self.abstract_hash
+
+            if self.compiler_flags:
+                d["compiler_flags"] = self.compiler_flags.to_dict()
+
         if self.external:
             d["external"] = {
                 "path": self.external_path,
@@ -2448,6 +2487,11 @@ class Spec:
                     }
                     if dspec.direct:
                         dep_attrs["parameters"]["direct"] = True
+                    if not self._concrete:
+                        if dspec.when != EMPTY_SPEC:
+                            dep_attrs["parameters"]["when"] = str(dspec.when)
+                        if dspec.propagation != PropagationPolicy.NONE:
+                            dep_attrs["parameters"]["propagation"] = dspec.propagation.name
                     dependencies.append(dep_attrs)
 
             d["dependencies"] = dependencies
@@ -5268,7 +5312,18 @@ def reconstruct_virtuals_on_edges(spec: Spec) -> None:
             edge.update_virtuals(virtuals_to_add)
 
 
-DepSpecComponents = Tuple[str, str, List[str], str, Tuple[str, ...], bool]
+class DepSpecComponents(NamedTuple):
+    """A dependency edge as it is stored in a spec file. The fields ``direct``, ``when``, and
+    ``propagation`` only occur on edges of abstract specs, and only from specfile v5 on."""
+
+    name: str
+    hash: str
+    deptypes: List[str]
+    hash_type: str
+    virtuals: Tuple[str, ...]
+    direct: bool
+    when: str = ""
+    propagation: str = PropagationPolicy.NONE.name
 
 
 _SPECFILE_READERS: Dict[int, Type["SpecfileReaderBase"]] = {}
@@ -5316,6 +5371,7 @@ class SpecfileReaderBase(abc.ABC):
         # old anonymous spec files had name=None, we use name="" now
         spec.name = name if isinstance(name, str) else ""
         spec.namespace = node.get("namespace", None)
+        spec.abstract_hash = node.get("abstract_hash", None)
 
         if "version" in node or "versions" in node:
             spec.versions = vn.VersionList.from_dict(node)
@@ -5324,11 +5380,17 @@ class SpecfileReaderBase(abc.ABC):
         if "arch" in node:
             spec.architecture = ArchSpec.from_dict(node)
 
+        # "compiler_flags" supersedes the flags under "parameters": it records propagation per
+        # flag, where "propagate" only records propagation per flag type.
+        spec.compiler_flags = FlagMap.from_dict(node.get("compiler_flags", {}))
+
         propagated_names = node.get("propagate", [])
         abstract_variants = set(node.get("abstract", ()))
         for name, values in node.get("parameters", {}).items():
             propagate = name in propagated_names
             if name in _valid_compiler_flags:
+                if name in spec.compiler_flags:
+                    continue
                 spec.compiler_flags[name] = []
                 for val in values:
                     spec.compiler_flags.add_flag(name, val, propagate)
@@ -5404,10 +5466,10 @@ class SpecfileReaderBase(abc.ABC):
         hash_type = None
         any_deps = False
         for node in nodes:
-            for _, _, _, dhash_type, _, _ in cls.dependencies_from_node_dict(node):
+            for dep in cls.dependencies_from_node_dict(node):
                 any_deps = True
-                if dhash_type:
-                    hash_type = dhash_type
+                if dep.hash_type:
+                    hash_type = dep.hash_type
                     break
 
         if not any_deps:  # If we never see a dependency...
@@ -5440,14 +5502,19 @@ def wire_spec_nodes(
     for node in nodes:
         node_spec = specs_by_hash[node[hash_type]]
 
-        for dname, dhash, dtype, _, virtuals, direct in reader.dependencies_from_node_dict(node):
-            dep_spec = specs_by_hash.get(dhash)
+        for dep in reader.dependencies_from_node_dict(node):
+            dep_spec = specs_by_hash.get(dep.hash)
             if dep_spec is None:
                 raise MissingSpecHashError(
-                    f"node '{node['name']}' references missing dep hash {dname}/{dhash}"
+                    f"node '{node['name']}' references missing dep hash {dep.name}/{dep.hash}"
                 )
             node_spec._add_dependency(
-                dep_spec, depflag=dt.canonicalize(dtype), virtuals=virtuals, direct=direct
+                dep_spec,
+                depflag=dt.canonicalize(dep.deptypes),
+                virtuals=dep.virtuals,
+                direct=dep.direct,
+                when=Spec(dep.when) if dep.when else None,
+                propagation=PropagationPolicy[dep.propagation],
             )
 
         if "build_spec" in node.keys():
@@ -5493,9 +5560,12 @@ class SpecfileV1(SpecfileReaderBase):
         for node in nodes:
             # get dependency dict from the node.
             name, data = cls.name_and_data(node)
-            for dname, _, dtypes, _, virtuals, direct in cls.dependencies_from_node_dict(data):
+            for dep in cls.dependencies_from_node_dict(data):
                 deps[name]._add_dependency(
-                    deps[dname], depflag=dt.canonicalize(dtypes), virtuals=virtuals, direct=direct
+                    deps[dep.name],
+                    depflag=dt.canonicalize(dep.deptypes),
+                    virtuals=dep.virtuals,
+                    direct=dep.direct,
                 )
 
         reconstruct_virtuals_on_edges(result)
@@ -5527,7 +5597,6 @@ class SpecfileV1(SpecfileReaderBase):
                     if h.name in elt:
                         dep_hash, deptypes = elt[h.name], elt["type"]
                         hash_type = h.name
-                        virtuals: Tuple[str, ...] = ()
                         break
                 else:  # We never determined a hash type...
                     raise spack.error.SpecError("Couldn't parse dependency spec.")
@@ -5535,7 +5604,14 @@ class SpecfileV1(SpecfileReaderBase):
                 raise spack.error.SpecError("Couldn't parse dependency types in spec.")
 
             dspec_list.append(
-                (dep_name, dep_hash, list(deptypes), hash_type, tuple(virtuals), True)
+                DepSpecComponents(
+                    name=dep_name,
+                    hash=dep_hash,
+                    deptypes=list(deptypes),
+                    hash_type=hash_type,
+                    virtuals=(),
+                    direct=True,
+                )
             )
 
         return dspec_list
@@ -5576,31 +5652,29 @@ class SpecfileV2(SpecfileReaderBase):
             raise spack.error.SpecError("Spec dictionary contains malformed dependencies")
 
         result = []
-        for dep in deps:
-            elt = dep
-            dep_name = dep["name"]
+        for elt in deps:
             if isinstance(elt, dict):
                 # new format: elements of dependency spec are keyed.
                 for h in ht.HASHES:
                     if h.name in elt:
-                        dep_hash, deptypes, hash_type, virtuals, direct = (
-                            cls.extract_info_from_dep(elt, h)
-                        )
+                        result.append(cls.extract_info_from_dep(elt, h))
                         break
                 else:  # We never determined a hash type...
                     raise spack.error.SpecError("Couldn't parse dependency spec.")
             else:
                 raise spack.error.SpecError("Couldn't parse dependency types in spec.")
-            result.append((dep_name, dep_hash, list(deptypes), hash_type, tuple(virtuals), direct))
         return result
 
     @classmethod
-    def extract_info_from_dep(cls, elt, hash):
-        dep_hash, deptypes = elt[hash.name], elt["type"]
-        hash_type = hash.name
-        virtuals = []
-        direct = True
-        return dep_hash, deptypes, hash_type, virtuals, direct
+    def extract_info_from_dep(cls, elt, hash) -> DepSpecComponents:
+        return DepSpecComponents(
+            name=elt["name"],
+            hash=elt[hash.name],
+            deptypes=list(elt["type"]),
+            hash_type=hash.name,
+            virtuals=(),
+            direct=True,
+        )
 
     @classmethod
     def extract_build_spec_info_from_node_dict(cls, node, hash_type=ht.dag_hash.name):
@@ -5618,13 +5692,15 @@ class SpecfileV4(SpecfileV2):
     SPEC_VERSION = 4
 
     @classmethod
-    def extract_info_from_dep(cls, elt, hash):
-        dep_hash = elt[hash.name]
-        deptypes = elt["parameters"]["deptypes"]
-        hash_type = hash.name
-        virtuals = elt["parameters"]["virtuals"]
-        direct = True
-        return dep_hash, deptypes, hash_type, virtuals, direct
+    def extract_info_from_dep(cls, elt, hash) -> DepSpecComponents:
+        return DepSpecComponents(
+            name=elt["name"],
+            hash=elt[hash.name],
+            deptypes=list(elt["parameters"]["deptypes"]),
+            hash_type=hash.name,
+            virtuals=tuple(elt["parameters"]["virtuals"]),
+            direct=True,
+        )
 
     @classmethod
     def load(cls, data) -> Spec:
@@ -5633,6 +5709,10 @@ class SpecfileV4(SpecfileV2):
 
 @register_reader
 class SpecfileV5(SpecfileV4):
+    """abstract_hash, compiler_flags, when and propagation are optional node/dependency keys,
+    used only for abstract specs. Not enforcing them is what avoids a version bump: an older
+    reader ignores an unknown key, and a spec file without one stays valid."""
+
     SPEC_VERSION = 5
 
     @classmethod
@@ -5640,13 +5720,18 @@ class SpecfileV5(SpecfileV4):
         raise RuntimeError("The 'compiler' option is unexpected in specfiles at v5 or greater")
 
     @classmethod
-    def extract_info_from_dep(cls, elt, hash):
-        dep_hash = elt[hash.name]
-        deptypes = elt["parameters"]["deptypes"]
-        hash_type = hash.name
-        virtuals = elt["parameters"]["virtuals"]
-        direct = elt["parameters"].get("direct", False)
-        return dep_hash, deptypes, hash_type, virtuals, direct
+    def extract_info_from_dep(cls, elt, hash) -> DepSpecComponents:
+        parameters = elt["parameters"]
+        return DepSpecComponents(
+            name=elt["name"],
+            hash=elt[hash.name],
+            deptypes=list(parameters["deptypes"]),
+            hash_type=hash.name,
+            virtuals=tuple(parameters["virtuals"]),
+            direct=parameters.get("direct", False),
+            when=parameters.get("when", ""),
+            propagation=parameters.get("propagation", PropagationPolicy.NONE.name),
+        )
 
 
 #: Alias to the latest version of specfiles

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -5508,14 +5508,24 @@ def wire_spec_nodes(
                 raise MissingSpecHashError(
                     f"node '{node['name']}' references missing dep hash {dep.name}/{dep.hash}"
                 )
-            node_spec._add_dependency(
+            # Register the edge directly instead of going through _add_dependency: each entry
+            # here is already a fully resolved, distinct edge from a concrete DAG, so there is
+            # nothing to merge. Two entries can reference the same dep hash (a build-only edge
+            # and a link-only edge to the same node, say), which would make dep_spec the same
+            # object both times - _add_dependency's identity-based merge detection exists for
+            # incrementally building up one edge's deptypes call by call, and would wrongly fold
+            # this into one edge instead of registering a second, parallel one.
+            edge = DependencySpec(
+                node_spec,
                 dep_spec,
                 depflag=dt.canonicalize(dep.deptypes),
                 virtuals=dep.virtuals,
                 direct=dep.direct,
-                when=Spec(dep.when) if dep.when else None,
+                when=Spec(dep.when) if dep.when else EMPTY_SPEC,
                 propagation=PropagationPolicy[dep.propagation],
             )
+            _add_edge_to_map(node_spec._dependencies, edge.spec.name, edge)
+            _add_edge_to_map(edge.spec._dependents, edge.parent.name, edge)
 
         if "build_spec" in node.keys():
             bname, bhash, _ = reader.extract_build_spec_info_from_node_dict(

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -3170,9 +3170,10 @@ class Spec:
         changed = False
 
         if other.abstract_hash and (
-            not self.abstract_hash or other.abstract_hash.startswith(self.abstract_hash)
+            not self.abstract_hash or len(other.abstract_hash) > len(self.abstract_hash)
         ):
             self.abstract_hash = other.abstract_hash
+            changed = True
 
         if not self.name and other.name:
             self.name = other.name

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -3116,11 +3116,15 @@ class Spec:
             self._dup(other)
             return True
 
-        if other.abstract_hash:
-            if not self.abstract_hash or other.abstract_hash.startswith(self.abstract_hash):
-                self.abstract_hash = other.abstract_hash
-            elif not self.abstract_hash.startswith(other.abstract_hash):
-                raise InvalidHashError(self, other.abstract_hash)
+        # Every dimension is validated before any of them is merged, so that a conflict in one
+        # dimension does not leave the others already applied to self.
+        if (
+            self.abstract_hash
+            and other.abstract_hash
+            and not other.abstract_hash.startswith(self.abstract_hash)
+            and not self.abstract_hash.startswith(other.abstract_hash)
+        ):
+            raise InvalidHashError(self, other.abstract_hash)
 
         if not (self.name == other.name or (not self.name) or (not other.name)):
             raise UnsatisfiableSpecNameError(self.name, other.name)
@@ -3139,6 +3143,11 @@ class Spec:
             if not self.variants[v].intersects(other.variants[v]):
                 raise vt.UnsatisfiableVariantSpecError(self.variants[v], other.variants[v])
 
+        if other._concrete:
+            for v in self.variants:
+                if v not in other.variants:
+                    raise vt.UnsatisfiableVariantSpecError(self.variants[v], "<absent>")
+
         sarch, oarch = self.architecture, other.architecture
         if (
             sarch is not None
@@ -3147,7 +3156,23 @@ class Spec:
         ):
             raise UnsatisfiableArchitectureSpecError(sarch, oarch)
 
+        if deps and other._dependencies:
+            # TODO: might want more detail than this, e.g. specific deps
+            # in violation. if this becomes a priority get rid of this
+            # check and be more specific about what's wrong.
+            if not other._intersects_dependencies(self, resolve_virtuals=resolve_virtuals):
+                raise UnsatisfiableDependencySpecError(other, self)
+
+            for d in other.traverse(root=False):
+                if not d.name:
+                    raise UnconstrainableDependencySpecError(other)
+
         changed = False
+
+        if other.abstract_hash and (
+            not self.abstract_hash or other.abstract_hash.startswith(self.abstract_hash)
+        ):
+            self.abstract_hash = other.abstract_hash
 
         if not self.name and other.name:
             self.name = other.name
@@ -3171,24 +3196,18 @@ class Spec:
             changed = True
 
         if deps:
-            changed |= self._constrain_dependencies(other, resolve_virtuals=resolve_virtuals)
+            changed |= self._constrain_dependencies(other)
 
         return changed
 
-    def _constrain_dependencies(self, other: "Spec", resolve_virtuals: bool = True) -> bool:
-        """Apply constraints of other spec's dependencies to this spec."""
+    def _constrain_dependencies(self, other: "Spec") -> bool:
+        """Apply constraints of other spec's dependencies to this spec.
+
+        Precondition: ``_constrain`` has checked that the two intersect and that every
+        dependency of other is named."""
         if not other._dependencies:
             return False
 
-        # TODO: might want more detail than this, e.g. specific deps
-        # in violation. if this becomes a priority get rid of this
-        # check and be more specific about what's wrong.
-        if not other._intersects_dependencies(self, resolve_virtuals=resolve_virtuals):
-            raise UnsatisfiableDependencySpecError(other, self)
-
-        for d in other.traverse(root=False):
-            if not d.name:
-                raise UnconstrainableDependencySpecError(other)
         changed = False
         for other_edge in other.edges_to_dependencies():
             # Find the first edge in self that matches other_edge by name and when clause.

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -973,22 +973,35 @@ class FlagMap(lang.HashableMap[str, List[CompilerFlag]]):
         changed = False
         for flag_type in other:
             if flag_type not in self:
-                self[flag_type] = other[flag_type]
+                # copy the list, so that self and other do not share it
+                self[flag_type] = list(other[flag_type])
                 changed = True
-            else:
-                extra_other = set(other[flag_type]) - set(self[flag_type])
-                if extra_other:
-                    self[flag_type] = list(self[flag_type]) + [
-                        x for x in other[flag_type] if x in extra_other
-                    ]
-                    changed = True
+                continue
 
-                # Next, if any flags in other propagate, we force them to propagate in our case
-                shared = list(sorted(set(other[flag_type]) - extra_other))
-                for x, y in _shared_subset_pair_iterate(shared, sorted(self[flag_type])):
-                    if y.propagate is True and x.propagate is False:
-                        changed = True
-                        y.propagate = False
+            extra_other = set(other[flag_type]) - set(self[flag_type])
+            if extra_other:
+                self[flag_type] = list(self[flag_type]) + [
+                    x for x in other[flag_type] if x in extra_other
+                ]
+                changed = True
+
+            # Next, if any flags in other propagate, we force them to propagate in our case.
+            # CompilerFlag objects can be shared with other specs, so they are replaced rather
+            # than modified in place.
+            shared = sorted(set(other[flag_type]) - extra_other)
+            demoted = {
+                id(y)
+                for x, y in _shared_subset_pair_iterate(shared, sorted(self[flag_type]))
+                if y.propagate is True and x.propagate is False
+            }
+            if demoted:
+                changed = True
+                self[flag_type] = [
+                    CompilerFlag(f, propagate=False, flag_group=f.flag_group, source=f.source)
+                    if id(f) in demoted
+                    else f
+                    for f in self[flag_type]
+                ]
 
         # TODO: what happens if flag groups with a partial (but not complete)
         # intersection specify different behaviors for flag propagation?
@@ -3153,7 +3166,8 @@ class Spec:
         if sarch is not None and oarch is not None:
             changed |= self.architecture.constrain(other.architecture)
         elif oarch is not None:
-            self.architecture = oarch
+            # copy, so that a later constrain on self does not write through into other
+            self.architecture = oarch.copy()
             changed = True
 
         if deps:

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -461,11 +461,18 @@ class ArchSpec:
         return bool(self._target_intersection(other))
 
     def _target_constrain(self, other: "ArchSpec") -> bool:
-        if self.target is None and other.target is None:
+        # An unconstrained target on either side means the other side is the intersection.
+        # _target_intersection cannot express that: it returns an empty list whenever one of
+        # the two has no target, which would turn into an empty target below.
+        if other.target is None:
             return False
 
         if not other._target_satisfies(self, strict=False):
             raise UnsatisfiableArchitectureSpecError(self, other)
+
+        if self.target is None:
+            self.target = other.target
+            return True
 
         if self.target_concrete:
             return False

--- a/lib/spack/spack/test/architecture.py
+++ b/lib/spack/spack/test/architecture.py
@@ -8,6 +8,7 @@ import pytest
 import spack.vendor.archspec.cpu
 
 import spack.concretize
+import spack.error
 import spack.operating_systems
 import spack.platforms
 from spack.spec import ArchSpec, Spec
@@ -107,6 +108,27 @@ def test_satisfy_strict_constraint_when_not_concrete(architecture_tuple, constra
     architecture = ArchSpec(architecture_tuple)
     constraint = ArchSpec(constraint_tuple)
     assert not architecture.satisfies(constraint)
+
+
+@pytest.mark.xfail(
+    reason="_target_intersection returns an empty list when the lhs has no target, and "
+    "_target_constrain turns that into an empty target",
+    strict=True,
+)
+def test_constrain_range_target_onto_missing_target():
+    """A target range from the rhs is adopted as is when the lhs has no target."""
+    architecture = ArchSpec((None, "debian6", None))
+    assert architecture.constrain(ArchSpec((None, None, "x86_64:"))) is True
+    assert architecture.target == ArchSpec((None, None, "x86_64:")).target
+
+
+def test_constrain_is_atomic_when_targets_are_disjoint():
+    """platform and os are applied before the target, so the up-front intersection check is what
+    keeps a failed constrain from leaving them behind."""
+    architecture = ArchSpec(("linux", None, "haswell"))
+    with pytest.raises(spack.error.UnsatisfiableSpecError):
+        architecture.constrain(ArchSpec((None, "ubuntu18.04", "ppc64le")))
+    assert architecture == ArchSpec(("linux", None, "haswell"))
 
 
 @pytest.mark.parametrize(

--- a/lib/spack/spack/test/architecture.py
+++ b/lib/spack/spack/test/architecture.py
@@ -110,16 +110,19 @@ def test_satisfy_strict_constraint_when_not_concrete(architecture_tuple, constra
     assert not architecture.satisfies(constraint)
 
 
-@pytest.mark.xfail(
-    reason="_target_intersection returns an empty list when the lhs has no target, and "
-    "_target_constrain turns that into an empty target",
-    strict=True,
+@pytest.mark.parametrize(
+    "lhs_tuple,rhs_tuple,expected_target",
+    [
+        ((None, "debian6", None), (None, None, "x86_64:"), "x86_64:"),
+        ((None, None, "x86_64:"), (None, "debian6", None), "x86_64:"),
+        ((None, "debian6", None), (None, None, "haswell"), "haswell"),
+    ],
 )
-def test_constrain_range_target_onto_missing_target():
-    """A target range from the rhs is adopted as is when the lhs has no target."""
-    architecture = ArchSpec((None, "debian6", None))
-    assert architecture.constrain(ArchSpec((None, None, "x86_64:"))) is True
-    assert architecture.target == ArchSpec((None, None, "x86_64:")).target
+def test_constrain_target_when_only_one_side_has_one(lhs_tuple, rhs_tuple, expected_target):
+    """The side that has a target wins, ranges included."""
+    architecture = ArchSpec(lhs_tuple)
+    architecture.constrain(ArchSpec(rhs_tuple))
+    assert architecture.target == ArchSpec((None, None, expected_target)).target
 
 
 def test_constrain_is_atomic_when_targets_are_disjoint():

--- a/lib/spack/spack/test/spec_semantics.py
+++ b/lib/spack/spack/test/spec_semantics.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+import itertools
 import pathlib
 
 import pytest
@@ -2439,6 +2440,188 @@ def test_constrain_symbolically(constraints, expected):
     for c in reversed(constraints):
         reverse_order._constrain_symbolically(c)
     assert reverse_order == Spec(expected)
+
+
+#: Abstract specs covering every dimension ``constrain`` merges, and pairs that conflict within
+#: each dimension. The properties below are checked over the product of this list with itself.
+CONSTRAIN_CORPUS = [
+    # names and namespaces
+    "",
+    "pkg-a",
+    "pkg-b",
+    "builtin_mock.pkg-a",
+    # versions
+    "pkg-a@1:3",
+    "pkg-a@2",
+    "@:1",
+    # variants, including propagation and concrete multi-valued
+    "pkg-a+foo",
+    "pkg-a~foo",
+    "pkg-a++foo",
+    "pkg-a foo=bar",
+    "pkg-a foo=baz",
+    "pkg-a foo=bar,baz",
+    "pkg-a foo:=bar",
+    # compiler flags. The propagating entries are what reaches the propagate reset in
+    # FlagMap.constrain.
+    "pkg-a cflags=-O2",
+    "pkg-a cflags=-g",
+    "pkg-a cflags==-O2",
+    "pkg-a cflags=-g cflags==-O2",
+    # architecture
+    "pkg-a target=haswell",
+    "pkg-a target=x86_64:",
+    "pkg-a target=:icelake",
+    "pkg-a os=debian6",
+    # abstract hashes
+    "pkg-a/abcdef",
+    "pkg-a/abc",
+    # dependency edges
+    "^pkg-b",
+    "^pkg-b@1",
+    "^pkg-b@2",
+    "pkg-a ^pkg-b@1 ^pkg-c",
+    "%pkg-b",
+    "%%pkg-b",
+    "%[deptypes=build] pkg-b",
+    "%[deptypes=link] pkg-b",
+    "pkg-a ^[when='+foo'] pkg-b@1",
+    "pkg-a ^[when='+bar'] pkg-b@2",
+    # virtuals
+    "pkg-a ^[virtuals=mpi] mpich",
+    "mpi",
+]
+
+
+def _constrain_corpus_pairs():
+    for lhs_str, rhs_str in itertools.product(CONSTRAIN_CORPUS, repeat=2):
+        yield lhs_str, rhs_str, Spec(lhs_str), Spec(rhs_str)
+
+
+def _try_constrain(lhs, rhs):
+    """Return ``(changed, error)``, exactly one of which is None."""
+    try:
+        return lhs.constrain(rhs), None
+    except SpecError as e:
+        return None, e
+
+
+class TestConstrainMutationSafety:
+    """``Spec.constrain`` intersects the left-hand side with the right-hand side in place. It
+    must apply the whole intersection or nothing at all, and it must never write to the
+    right-hand side, now or through an object the two ends up sharing.
+
+    These properties are checked over the product of ``CONSTRAIN_CORPUS`` rather than over
+    hand-written cases, so a dimension added later is covered as soon as it appears in the
+    corpus, and a refactor that reintroduces partial mutation in any dimension is caught.
+
+    Specs are snapshotted with ``to_dict()``, which round-trips abstract specs and so compares
+    their state directly. ``Spec.__eq__`` is semantic equality instead: it leaves the propagation
+    policy of an edge out of the comparison, so ``pkg-a %pkg-b`` and ``pkg-a %%pkg-b`` are equal,
+    as they are also mutually satisfying.
+    """
+
+    @pytest.mark.xfail(
+        reason="_constrain assigns abstract_hash and merges node attributes before validating "
+        "the remaining dimensions",
+        strict=True,
+    )
+    def test_lhs_is_unchanged_when_constrain_raises(self, mock_packages):
+        for lhs_str, rhs_str, lhs, rhs in _constrain_corpus_pairs():
+            before = lhs.to_dict()
+            _, error = _try_constrain(lhs, rhs)
+            if error is None:
+                continue
+            assert lhs.to_dict() == before, f"'{lhs_str}' mutated by failed constrain '{rhs_str}'"
+
+    def test_rhs_is_never_mutated(self, mock_packages):
+        for lhs_str, rhs_str, lhs, rhs in _constrain_corpus_pairs():
+            before = rhs.to_dict()
+            _try_constrain(lhs, rhs)
+            assert rhs.to_dict() == before, f"'{lhs_str}'.constrain('{rhs_str}') mutated the rhs"
+
+    @pytest.mark.xfail(
+        reason="FlagMap.constrain shares the flag list, and _constrain shares the ArchSpec, "
+        "so a later constrain on the lhs writes through into the rhs",
+        strict=True,
+    )
+    def test_rhs_is_not_corrupted_by_later_constraints(self, mock_packages):
+        """A successful constrain must not leave the two specs sharing a mutable object, which
+        a later constrain on the lhs would then write through into the rhs."""
+        for lhs_str, rhs_str, lhs, rhs in _constrain_corpus_pairs():
+            if _try_constrain(lhs, rhs)[1] is not None:
+                continue
+            before = rhs.to_dict()
+            for extra_str in CONSTRAIN_CORPUS:
+                _try_constrain(lhs, Spec(extra_str))
+                assert rhs.to_dict() == before, (
+                    f"'{lhs_str}'.constrain('{rhs_str}') shares state with the rhs: "
+                    f"constraining with '{extra_str}' afterwards changed it"
+                )
+
+    @pytest.mark.xfail(
+        reason="extending abstract_hash mutates the lhs without feeding the changed flag",
+        strict=True,
+    )
+    def test_returned_changed_flag_is_honest(self, mock_packages):
+        """Callers use the return value to decide whether to redo work, so it has to report
+        exactly whether the lhs changed."""
+        for lhs_str, rhs_str, lhs, rhs in _constrain_corpus_pairs():
+            before = lhs.to_dict()
+            changed, error = _try_constrain(lhs, rhs)
+            if error is not None:
+                continue
+            assert changed is (lhs.to_dict() != before), (
+                f"'{lhs_str}'.constrain('{rhs_str}') returned {changed}"
+            )
+
+    def test_intersects_agrees_with_constrain(self, mock_packages):
+        """``intersects`` is the question ``constrain`` answers by raising or not. The product
+        covers both orders, so this also pins the commutativity of ``intersects``."""
+        for lhs_str, rhs_str, lhs, rhs in _constrain_corpus_pairs():
+            intersects = lhs.intersects(rhs)
+            _, error = _try_constrain(lhs, rhs)
+            assert intersects is (error is None), (
+                f"'{lhs_str}'.intersects('{rhs_str}') is {intersects}, but constrain "
+                f"{'raised ' + type(error).__name__ if error else 'succeeded'}"
+            )
+
+    @pytest.mark.xfail(
+        reason="ArchSpec._target_constrain empties the target when the lhs has none and the "
+        "rhs has a range, so constraining again raises",
+        strict=True,
+    )
+    def test_constrain_is_idempotent(self, mock_packages):
+        for lhs_str, rhs_str, lhs, rhs in _constrain_corpus_pairs():
+            if _try_constrain(lhs, rhs)[1] is not None:
+                continue
+            before = lhs.to_dict()
+            assert lhs.constrain(rhs) is False, f"'{lhs_str}'.constrain('{rhs_str}') twice"
+            assert lhs.to_dict() == before
+
+    @pytest.mark.xfail(
+        reason="ArchSpec._target_constrain empties the target when the lhs has none and the "
+        "rhs has a range, dropping the constraint instead of applying it",
+        strict=True,
+    )
+    def test_constrained_lhs_satisfies_rhs(self, mock_packages):
+        """Guards against making constrain atomic by making it do nothing."""
+        for lhs_str, rhs_str, lhs, rhs in _constrain_corpus_pairs():
+            if _try_constrain(lhs, rhs)[1] is not None:
+                continue
+            assert lhs.satisfies(rhs), f"'{lhs_str}'.constrain('{rhs_str}') gave '{lhs}'"
+
+    @pytest.mark.xfail(
+        reason="ArchSpec._target_constrain empties the target when only one side has one",
+        strict=True,
+    )
+    def test_constrain_never_weakens_the_lhs(self, mock_packages):
+        """The result is the intersection of both operands, so together with the property above
+        this pins that constrain narrows and never drops a constraint."""
+        for lhs_str, rhs_str, lhs, rhs in _constrain_corpus_pairs():
+            if _try_constrain(lhs, rhs)[1] is not None:
+                continue
+            assert lhs.satisfies(Spec(lhs_str)), f"'{lhs_str}'.constrain('{rhs_str}') gave '{lhs}'"
 
 
 @pytest.mark.parametrize(

--- a/lib/spack/spack/test/spec_semantics.py
+++ b/lib/spack/spack/test/spec_semantics.py
@@ -449,8 +449,9 @@ class TestSpecSemantics:
         """Test that Specs specified only by their hashes can constrain each other."""
         mpich_dag_hash = "/" + database.query_one("mpich").dag_hash()
         spec = Spec(mpich_dag_hash[:7])
-        assert spec.constrain(Spec(mpich_dag_hash)) is False
+        assert spec.constrain(Spec(mpich_dag_hash)) is True
         assert spec.abstract_hash == mpich_dag_hash[1:]
+        assert spec.constrain(Spec(mpich_dag_hash[:7])) is False
 
     def test_mismatched_constrain_spec_by_hash(self, database):
         """Test that Specs specified only by their incompatible hashes fail appropriately."""
@@ -2549,10 +2550,6 @@ class TestConstrainMutationSafety:
                     f"constraining with '{extra_str}' afterwards changed it"
                 )
 
-    @pytest.mark.xfail(
-        reason="extending abstract_hash mutates the lhs without feeding the changed flag",
-        strict=True,
-    )
     def test_returned_changed_flag_is_honest(self, mock_packages):
         """Callers use the return value to decide whether to redo work, so it has to report
         exactly whether the lhs changed."""

--- a/lib/spack/spack/test/spec_semantics.py
+++ b/lib/spack/spack/test/spec_semantics.py
@@ -325,12 +325,7 @@ class TestSpecSemantics:
             (
                 "libelf patches=ba5e334fe247335f3a116decfb5284100791dc302b5571ff5e664d8f9a6806c2",
                 "libelf patches=ba5e3",  # constrain by a patch sha256 prefix
-                # TODO: the result below is not ideal. Prefix satisfies() works for patches, but
-                # constrain() isn't similarly special-cased to do the same thing
-                (
-                    "libelf patches=ba5e3,"
-                    "ba5e334fe247335f3a116decfb5284100791dc302b5571ff5e664d8f9a6806c2"
-                ),
+                "libelf patches=ba5e334fe247335f3a116decfb5284100791dc302b5571ff5e664d8f9a6806c2",
             ),
             # deptypes on direct deps
             (

--- a/lib/spack/spack/test/spec_semantics.py
+++ b/lib/spack/spack/test/spec_semantics.py
@@ -2586,11 +2586,6 @@ class TestConstrainMutationSafety:
                 f"{'raised ' + type(error).__name__ if error else 'succeeded'}"
             )
 
-    @pytest.mark.xfail(
-        reason="ArchSpec._target_constrain empties the target when the lhs has none and the "
-        "rhs has a range, so constraining again raises",
-        strict=True,
-    )
     def test_constrain_is_idempotent(self, mock_packages):
         for lhs_str, rhs_str, lhs, rhs in _constrain_corpus_pairs():
             if _try_constrain(lhs, rhs)[1] is not None:
@@ -2599,11 +2594,6 @@ class TestConstrainMutationSafety:
             assert lhs.constrain(rhs) is False, f"'{lhs_str}'.constrain('{rhs_str}') twice"
             assert lhs.to_dict() == before
 
-    @pytest.mark.xfail(
-        reason="ArchSpec._target_constrain empties the target when the lhs has none and the "
-        "rhs has a range, dropping the constraint instead of applying it",
-        strict=True,
-    )
     def test_constrained_lhs_satisfies_rhs(self, mock_packages):
         """Guards against making constrain atomic by making it do nothing."""
         for lhs_str, rhs_str, lhs, rhs in _constrain_corpus_pairs():
@@ -2611,10 +2601,6 @@ class TestConstrainMutationSafety:
                 continue
             assert lhs.satisfies(rhs), f"'{lhs_str}'.constrain('{rhs_str}') gave '{lhs}'"
 
-    @pytest.mark.xfail(
-        reason="ArchSpec._target_constrain empties the target when only one side has one",
-        strict=True,
-    )
     def test_constrain_never_weakens_the_lhs(self, mock_packages):
         """The result is the intersection of both operands, so together with the property above
         this pins that constrain narrows and never drops a constraint."""

--- a/lib/spack/spack/test/spec_semantics.py
+++ b/lib/spack/spack/test/spec_semantics.py
@@ -2540,11 +2540,6 @@ class TestConstrainMutationSafety:
             _try_constrain(lhs, rhs)
             assert rhs.to_dict() == before, f"'{lhs_str}'.constrain('{rhs_str}') mutated the rhs"
 
-    @pytest.mark.xfail(
-        reason="FlagMap.constrain shares the flag list, and _constrain shares the ArchSpec, "
-        "so a later constrain on the lhs writes through into the rhs",
-        strict=True,
-    )
     def test_rhs_is_not_corrupted_by_later_constraints(self, mock_packages):
         """A successful constrain must not leave the two specs sharing a mutable object, which
         a later constrain on the lhs would then write through into the rhs."""

--- a/lib/spack/spack/test/spec_semantics.py
+++ b/lib/spack/spack/test/spec_semantics.py
@@ -2521,11 +2521,6 @@ class TestConstrainMutationSafety:
     as they are also mutually satisfying.
     """
 
-    @pytest.mark.xfail(
-        reason="_constrain assigns abstract_hash and merges node attributes before validating "
-        "the remaining dimensions",
-        strict=True,
-    )
     def test_lhs_is_unchanged_when_constrain_raises(self, mock_packages):
         for lhs_str, rhs_str, lhs, rhs in _constrain_corpus_pairs():
             before = lhs.to_dict()

--- a/lib/spack/spack/test/spec_yaml.py
+++ b/lib/spack/spack/test/spec_yaml.py
@@ -23,6 +23,7 @@ import spack.vendor.ruamel.yaml
 
 import spack.concretize
 import spack.config
+import spack.deptypes as dt
 import spack.error
 import spack.hash_types as ht
 import spack.paths
@@ -584,6 +585,18 @@ def test_direct_edges_and_round_tripping_to_dict(spec_str, config, mock_packages
             continue
         for dependency_data in node["dependencies"]:
             assert "direct" not in dependency_data["parameters"]
+
+
+def test_parallel_deptype_edges_survive_round_trip(mock_packages):
+    """Two parallel edges to one package, differing only in deptype, hash the same on the child
+    side and so share one object once read back from JSON. That must not fold them into a single
+    edge: to_node_dict already emits one entry per edge, with no uniqueness constraint on
+    dependencies, so a round trip needs to keep both."""
+    original = Spec("pkg-a ^[deptypes=build] pkg-b ^[deptypes=link] pkg-b")
+    reconstructed = Spec.from_dict(original.to_dict())
+    edges = reconstructed.edges_to_dependencies("pkg-b")
+    assert len(edges) == 2
+    assert {e.depflag for e in edges} == {dt.BUILD, dt.LINK}
 
 
 def test_pickle_preserves_identity_and_prefix(config, mock_packages):

--- a/lib/spack/spack/test/spec_yaml.py
+++ b/lib/spack/spack/test/spec_yaml.py
@@ -523,15 +523,38 @@ def test_pickle_roundtrip_for_abstract_specs(spec_str):
 
 
 @pytest.mark.parametrize(
-    "spec_str", ["zlib os=redhat6", "zlib platform=test", "zlib os=debian6 target=x86_64"]
+    "spec_str",
+    [
+        # partial architectures. Regression test: ArchSpec.to_dict crashed with AttributeError
+        # when target was None.
+        "zlib os=redhat6",
+        "zlib platform=test",
+        "zlib os=debian6 target=x86_64",
+        # abstract hash
+        "zlib/abcdef",
+        # conditional edges
+        "zlib ^[when='+mpi'] mpich@1",
+        "zlib ^[when='+mpi'] mpich@1 ^[when='~mpi'] mpich@2",
+        # propagated direct dependencies
+        "zlib %%gcc",
+        # flags that propagate and flags that don't, on the same flag type
+        "zlib cflags=-g cflags==-O2",
+        # several flags given as a single group
+        'zlib cflags="-O2 -g"',
+        # several dimensions at once
+        "zlib ++mpi cflags==-g foo=bar,baz target=x86_64:",
+    ],
 )
-def test_dict_roundtrip_for_abstract_specs_with_partial_arch(spec_str):
-    """Abstract specs with a partial architecture survive to_dict/from_dict.
-    Regression test: ArchSpec.to_dict crashed with AttributeError when target was None."""
+def test_dict_roundtrip_for_abstract_specs(spec_str):
+    """Abstract specs survive to_dict/from_dict.
+
+    This compares the spec objects, their string representation and the dicts themselves, since
+    `Spec.__eq__` is blind to some of what is serialized, and vice versa."""
     s = spack.spec.Spec(spec_str)
     t = spack.spec.Spec.from_dict(s.to_dict())
     assert s == t
     assert str(s) == str(t)
+    assert s.to_dict() == t.to_dict()
 
 
 def test_specfile_alias_is_updated():

--- a/lib/spack/spack/test/variant.py
+++ b/lib/spack/spack/test/variant.py
@@ -879,6 +879,23 @@ def test_patches_variant():
     assert not Spec("patches:=abcdef").satisfies("patches:=abcdefghi")
 
 
+def test_patches_variant_prefix_intersects_and_constrains():
+    """Prefix matching applies to intersection too, so a spec that satisfies a prefix also
+    overlaps it and can be constrained by it."""
+    assert Spec("patches:=abcdef").intersects("patches=ab")
+    assert Spec("patches=ab").intersects("patches:=abcdef")
+    assert not Spec("patches:=abcdef").intersects("patches=xyz")
+    assert not Spec("patches:=abcdef").intersects("patches=abcdefghi")
+
+    s = Spec("patches:=abcdef")
+    assert s.constrain("patches=ab") is False
+    assert s.variants["patches"].values == ("abcdef",)
+
+    s = Spec("patches=ab")
+    assert s.constrain("patches:=abcdef") is True
+    assert s.variants["patches"].values == ("abcdef",)
+
+
 def test_constrain_narrowing():
     s = Spec("foo=*")
     assert s.variants["foo"].type == spack.variant.VariantType.MULTI

--- a/lib/spack/spack/variant.py
+++ b/lib/spack/spack/variant.py
@@ -414,6 +414,29 @@ class VariantValue:
             self.type, self.name, self.values, propagate=self.propagate, concrete=self.concrete
         )
 
+    def _merged_values(self, other: "VariantValue") -> Tuple[Union[str, bool], ...]:
+        """The values of both sides. For patches a value identified by a checksum prefix and the
+        full checksum name the same patch, so only the longer one is kept."""
+        values = (*self.values, *other.values)
+        if self.name != "patches":
+            return values
+        return tuple(
+            v
+            for v in values
+            if not any(
+                w != v and isinstance(w, str) and isinstance(v, str) and w.startswith(v)
+                for w in values
+            )
+        )
+
+    def _contains(self, value: Union[str, bool]) -> bool:
+        """Whether this variant covers a single value of another one. A patch is identified by a
+        prefix of its checksum, so a shorter value is covered by any value starting with it.
+        """
+        if self.name == "patches" and isinstance(value, str):
+            return any(isinstance(w, str) and w.startswith(value) for w in self.values)
+        return value in self.values
+
     def satisfies(self, other: "VariantValue") -> bool:
         """The lhs satisfies the rhs if all possible concretizations of lhs are also
         possible concretizations of rhs."""
@@ -421,16 +444,7 @@ class VariantValue:
             return False
 
         if not other.concrete:
-            # rhs abstract means the lhs must at least contain its values.
-            # special-case patches with rhs abstract: their values may be prefixes of the lhs
-            # values.
-            if self.name == "patches":
-                return all(
-                    isinstance(v, str)
-                    and any(isinstance(w, str) and w.startswith(v) for w in self.values)
-                    for v in other.values
-                )
-            return all(v in self for v in other.values)
+            return all(self._contains(v) for v in other.values)
         if self.concrete:
             # both concrete: they must be equal
             return self.values == other.values
@@ -443,9 +457,9 @@ class VariantValue:
         if self.concrete:
             if other.concrete:
                 return self.values == other.values
-            return all(v in self for v in other.values)
+            return all(self._contains(v) for v in other.values)
         if other.concrete:
-            return all(v in other for v in self.values)
+            return all(other._contains(v) for v in self.values)
         # both abstract: the union is a valid concretization of both
         return True
 
@@ -454,7 +468,7 @@ class VariantValue:
         if not self.intersects(other):
             raise UnsatisfiableVariantSpecError(self, other)
         old_values = self.values
-        self.set(*self.values, *other.values)
+        self.set(*self._merged_values(other))
         changed = old_values != self.values
         if self.propagate and not other.propagate:
             self.propagate = False


### PR DESCRIPTION
Depends on #52787.

The base is `develop`, so the diff shows the PRs it depends on too. This one is about the last
commit, `2e449b58a8..040ffb42d6`:

- `040ffb42d6` variant: apply the patch prefix rule to intersects and constrain too

A patch can be named by a prefix of its checksum, and `satisfies` implements that: an abstract `patches` value on the right-hand side may be a prefix of a value on the left. `intersects` compares the values for equality instead, so a spec could satisfy a constraint it did not overlap, and `constrain` rejected it:

```python
Spec("libelf patches:=ba5e334f...").satisfies("libelf patches=ba5e3")   # True
Spec("libelf patches:=ba5e334f...").intersects("libelf patches=ba5e3")  # False, raises
```

Both methods spell the containment test out inline, and the rule was only ever added to one of them. Extract it once and call it from both.

Merging two values that name the same patch now keeps the full checksum instead of listing the prefix beside it, which is what the removed TODO in the constrain test asked for.

Stacked on #52787.

---

Part of a stack of fixes to `Spec.satisfies` / `intersects` / `constrain`, found by fuzzing their
algebraic identities. Each PR is based on the one above it and groups commits by how far they can
be backported, so a single label applies to the whole PR.

| PR | what | backport |
| --- | --- | --- |
| #52788 | round-trip abstract specs through `to_dict` | v1.0.5, v1.1.2, v1.2.3 |
| #52787 | `constrain` does not mutate on failure and reports what it changed | v1.0.5, v1.1.2, v1.2.3 |
| #52789 | the patch prefix rule applies to `intersects` and `constrain` too | v1.0.5, v1.1.2, v1.2.3 |
| #52796 | compiler flags keep their order and their propagation | v1.0.5, v1.1.2, v1.2.3 |
| #52790 | a star means any value; an edge merges its propagation policy | v1.1.2, v1.2.3 |
| #52797 | `satisfies` for virtual providers, direct edges and anonymous specs | v1.2.3 |
| #52798 | target satisfaction is containment; parallel edges have an order | none |
| #52800 | `satisfies`, `intersects` and `constrain` become stateless | none |
| #52799 | an edge naming a virtual is merged into the edge naming its provider | none |
| #52795 | the property tests | none |

The v1.0.5 and v1.1.2 backports need #51870 on `releases/v1.0` and `releases/v1.1` first: it
rewrote `_constrain_dependencies`, which these fixes build on. `releases/v1.2` already has it.
