### PR TITLE
spec.py: a star means any value, and an edge merges its propagation policy

### DIFF
--- a/lib/spack/spack/database.py
+++ b/lib/spack/spack/database.py
@@ -805,27 +805,28 @@ class Database:
             spec_node_dict = spec_node_dict[spec.name]
         if "dependencies" in spec_node_dict:
             yaml_deps = spec_node_dict["dependencies"]
-            for dname, dhash, dtypes, _, virtuals, direct in spec_reader.read_specfile_dep_specs(
-                yaml_deps
-            ):
+            for dep in spec_reader.read_specfile_dep_specs(yaml_deps):
                 # It is important that we always check upstream installations in the same order,
                 # and that we always check the local installation first: if a downstream Spack
                 # installs a package then dependents in that installation could be using it. If a
                 # hash is installed locally and upstream, there isn't enough information to
                 # determine which one a local package depends on, so the convention ensures that
                 # this isn't an issue.
-                _, record = self.query_by_spec_hash(dhash, data=data)
+                _, record = self.query_by_spec_hash(dep.hash, data=data)
                 child = record.spec if record else None
 
                 if not child:
                     tty.warn(
                         f"Missing dependency not in database: "
-                        f"{spec.cformat('{name}{/hash:7}')} needs {dname}-{dhash[:7]}"
+                        f"{spec.cformat('{name}{/hash:7}')} needs {dep.name}-{dep.hash[:7]}"
                     )
                     continue
 
                 spec._add_dependency(
-                    child, depflag=dt.canonicalize(dtypes), virtuals=virtuals, direct=direct
+                    child,
+                    depflag=dt.canonicalize(dep.deptypes),
+                    virtuals=dep.virtuals,
+                    direct=dep.direct,
                 )
 
     def _read_from_file(self, filename: pathlib.Path, *, reindex: bool = False) -> None:

--- a/lib/spack/spack/enums.py
+++ b/lib/spack/spack/enums.py
@@ -27,7 +27,7 @@ class ConfigScopePriority(enum.IntEnum):
     ENVIRONMENT_SPEC_GROUPS = 5
 
 
-class PropagationPolicy(enum.Enum):
+class PropagationPolicy(enum.IntEnum):
     """Enum to specify the behavior of a propagated dependency"""
 
     NONE = enum.auto()

--- a/lib/spack/spack/environment/environment.py
+++ b/lib/spack/spack/environment/environment.py
@@ -2462,14 +2462,12 @@ class Environment:
         # and add them to the spec, including build specs
         for lockfile_key, node_dict in json_specs_by_hash.items():
             name, data = reader.name_and_data(node_dict)
-            for _, dep_hash, deptypes, _, virtuals, direct in reader.dependencies_from_node_dict(
-                data
-            ):
+            for dep in reader.dependencies_from_node_dict(data):
                 specs_by_hash[lockfile_key]._add_dependency(
-                    specs_by_hash[dep_hash],
-                    depflag=dt.canonicalize(deptypes),
-                    virtuals=virtuals,
-                    direct=direct,
+                    specs_by_hash[dep.hash],
+                    depflag=dt.canonicalize(dep.deptypes),
+                    virtuals=dep.virtuals,
+                    direct=dep.direct,
                 )
 
             if "build_spec" in node_dict:

--- a/lib/spack/spack/schema/spec.py
+++ b/lib/spack/spack/schema/spec.py
@@ -121,6 +121,16 @@ dependencies_v4_plus = {
                         "type": "boolean",
                         "description": "Whether the dependency is direct (only on abstract specs)",
                     },
+                    "when": {
+                        "type": "string",
+                        "description": "Condition under which the dependency holds, as a spec "
+                        "string (only on abstract specs)",
+                    },
+                    "propagation": {
+                        "type": "string",
+                        "description": "Propagation policy of a direct dependency (only on "
+                        "abstract specs)",
+                    },
                 },
             },
         },
@@ -188,6 +198,24 @@ spec_node = {
             "dependencies)",
         },
         "namespace": {"type": "string", "description": "Package repository namespace"},
+        "abstract_hash": {
+            "type": "string",
+            "description": "Hash prefix of the concrete spec this refers to (for abstract specs)",
+        },
+        "compiler_flags": {
+            "type": "object",
+            "description": "Compiler flags with their propagation (for abstract specs). "
+            "Supersedes the flags under parameters",
+            "additionalProperties": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "additionalProperties": False,
+                    "required": ["value"],
+                    "properties": {"value": {"type": "string"}, "propagate": {"type": "boolean"}},
+                },
+            },
+        },
         "parameters": {
             "type": "object",
             "additionalProperties": True,

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -851,6 +851,11 @@ class DependencySpec:
         if not self.direct and other.direct:
             changed = True
             self.direct = True
+        # A propagated edge constrains the whole DAG, so it is the narrower of the two policies.
+        # It is also always direct, which the assignment above has already taken care of.
+        if self.propagation == PropagationPolicy.NONE and other.propagation != self.propagation:
+            changed = True
+            self.propagation = other.propagation
         return changed
 
     def _cmp_iter(self):

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -68,6 +68,7 @@ from typing import (
     Iterable,
     List,
     Match,
+    NamedTuple,
     Optional,
     Sequence,
     Set,
@@ -907,6 +908,20 @@ class CompilerFlag(str):
         obj.source = kwargs.pop("source", None)
         return obj
 
+    def to_dict(self) -> Dict[str, Any]:
+        """Value and propagation of this flag, unlike ``FlagMap.yaml_entry``, which is its value
+        only. ``flag_group`` and ``source`` are not included: they are bookkeeping for a single
+        solve, and nothing reads them back. Attributes that have their default value are
+        omitted."""
+        d: Dict[str, Any] = {"value": str(self)}
+        if self.propagate:
+            d["propagate"] = True
+        return d
+
+    @staticmethod
+    def from_dict(d: Dict[str, Any]) -> "CompilerFlag":
+        return CompilerFlag(d["value"], propagate=d.get("propagate", False))
+
 
 _valid_compiler_flags = ["cflags", "cxxflags", "fflags", "ldflags", "ldlibs", "cppflags"]
 
@@ -972,6 +987,21 @@ class FlagMap(lang.HashableMap[str, List[CompilerFlag]]):
         # intersection specify different behaviors for flag propagation?
 
         return changed
+
+    def to_dict(self) -> Dict[str, List[Dict[str, Any]]]:
+        """Values and propagation of the flags, unlike ``yaml_entry``, which drops everything but
+        their values."""
+        return {
+            flag_type: [flag.to_dict() for flag in flags]
+            for flag_type, flags in sorted(self.items())
+        }
+
+    @staticmethod
+    def from_dict(d: Dict[str, List[Dict[str, Any]]]) -> "FlagMap":
+        result = FlagMap()
+        for flag_type, flags in d.items():
+            result[flag_type] = [CompilerFlag.from_dict(flag) for flag in flags]
+        return result
 
     @staticmethod
     def valid_compiler_flags():
@@ -2399,6 +2429,15 @@ class Spec:
             )
             d["abstract"] = sorted(v.name for v in self.variants.values() if not v.concrete)
 
+        if not self._concrete:
+            # State that only abstract specs have, or that "parameters" and "propagate" above are
+            # too coarse to express. Concrete node dicts are left alone: they feed the DAG hash.
+            if self.abstract_hash:
+                d["abstract_hash"] = self.abstract_hash
+
+            if self.compiler_flags:
+                d["compiler_flags"] = self.compiler_flags.to_dict()
+
         if self.external:
             d["external"] = {
                 "path": self.external_path,
@@ -2448,6 +2487,11 @@ class Spec:
                     }
                     if dspec.direct:
                         dep_attrs["parameters"]["direct"] = True
+                    if not self._concrete:
+                        if dspec.when != EMPTY_SPEC:
+                            dep_attrs["parameters"]["when"] = str(dspec.when)
+                        if dspec.propagation != PropagationPolicy.NONE:
+                            dep_attrs["parameters"]["propagation"] = dspec.propagation.name
                     dependencies.append(dep_attrs)
 
             d["dependencies"] = dependencies
@@ -5268,7 +5312,18 @@ def reconstruct_virtuals_on_edges(spec: Spec) -> None:
             edge.update_virtuals(virtuals_to_add)
 
 
-DepSpecComponents = Tuple[str, str, List[str], str, Tuple[str, ...], bool]
+class DepSpecComponents(NamedTuple):
+    """A dependency edge as it is stored in a spec file. The fields ``direct``, ``when``, and
+    ``propagation`` only occur on edges of abstract specs, and only from specfile v5 on."""
+
+    name: str
+    hash: str
+    deptypes: List[str]
+    hash_type: str
+    virtuals: Tuple[str, ...]
+    direct: bool
+    when: str = ""
+    propagation: str = PropagationPolicy.NONE.name
 
 
 _SPECFILE_READERS: Dict[int, Type["SpecfileReaderBase"]] = {}
@@ -5316,6 +5371,7 @@ class SpecfileReaderBase(abc.ABC):
         # old anonymous spec files had name=None, we use name="" now
         spec.name = name if isinstance(name, str) else ""
         spec.namespace = node.get("namespace", None)
+        spec.abstract_hash = node.get("abstract_hash", None)
 
         if "version" in node or "versions" in node:
             spec.versions = vn.VersionList.from_dict(node)
@@ -5324,11 +5380,17 @@ class SpecfileReaderBase(abc.ABC):
         if "arch" in node:
             spec.architecture = ArchSpec.from_dict(node)
 
+        # "compiler_flags" supersedes the flags under "parameters": it records propagation per
+        # flag, where "propagate" only records propagation per flag type.
+        spec.compiler_flags = FlagMap.from_dict(node.get("compiler_flags", {}))
+
         propagated_names = node.get("propagate", [])
         abstract_variants = set(node.get("abstract", ()))
         for name, values in node.get("parameters", {}).items():
             propagate = name in propagated_names
             if name in _valid_compiler_flags:
+                if name in spec.compiler_flags:
+                    continue
                 spec.compiler_flags[name] = []
                 for val in values:
                     spec.compiler_flags.add_flag(name, val, propagate)
@@ -5404,10 +5466,10 @@ class SpecfileReaderBase(abc.ABC):
         hash_type = None
         any_deps = False
         for node in nodes:
-            for _, _, _, dhash_type, _, _ in cls.dependencies_from_node_dict(node):
+            for dep in cls.dependencies_from_node_dict(node):
                 any_deps = True
-                if dhash_type:
-                    hash_type = dhash_type
+                if dep.hash_type:
+                    hash_type = dep.hash_type
                     break
 
         if not any_deps:  # If we never see a dependency...
@@ -5440,14 +5502,19 @@ def wire_spec_nodes(
     for node in nodes:
         node_spec = specs_by_hash[node[hash_type]]
 
-        for dname, dhash, dtype, _, virtuals, direct in reader.dependencies_from_node_dict(node):
-            dep_spec = specs_by_hash.get(dhash)
+        for dep in reader.dependencies_from_node_dict(node):
+            dep_spec = specs_by_hash.get(dep.hash)
             if dep_spec is None:
                 raise MissingSpecHashError(
-                    f"node '{node['name']}' references missing dep hash {dname}/{dhash}"
+                    f"node '{node['name']}' references missing dep hash {dep.name}/{dep.hash}"
                 )
             node_spec._add_dependency(
-                dep_spec, depflag=dt.canonicalize(dtype), virtuals=virtuals, direct=direct
+                dep_spec,
+                depflag=dt.canonicalize(dep.deptypes),
+                virtuals=dep.virtuals,
+                direct=dep.direct,
+                when=Spec(dep.when) if dep.when else None,
+                propagation=PropagationPolicy[dep.propagation],
             )
 
         if "build_spec" in node.keys():
@@ -5493,9 +5560,12 @@ class SpecfileV1(SpecfileReaderBase):
         for node in nodes:
             # get dependency dict from the node.
             name, data = cls.name_and_data(node)
-            for dname, _, dtypes, _, virtuals, direct in cls.dependencies_from_node_dict(data):
+            for dep in cls.dependencies_from_node_dict(data):
                 deps[name]._add_dependency(
-                    deps[dname], depflag=dt.canonicalize(dtypes), virtuals=virtuals, direct=direct
+                    deps[dep.name],
+                    depflag=dt.canonicalize(dep.deptypes),
+                    virtuals=dep.virtuals,
+                    direct=dep.direct,
                 )
 
         reconstruct_virtuals_on_edges(result)
@@ -5527,7 +5597,6 @@ class SpecfileV1(SpecfileReaderBase):
                     if h.name in elt:
                         dep_hash, deptypes = elt[h.name], elt["type"]
                         hash_type = h.name
-                        virtuals: Tuple[str, ...] = ()
                         break
                 else:  # We never determined a hash type...
                     raise spack.error.SpecError("Couldn't parse dependency spec.")
@@ -5535,7 +5604,14 @@ class SpecfileV1(SpecfileReaderBase):
                 raise spack.error.SpecError("Couldn't parse dependency types in spec.")
 
             dspec_list.append(
-                (dep_name, dep_hash, list(deptypes), hash_type, tuple(virtuals), True)
+                DepSpecComponents(
+                    name=dep_name,
+                    hash=dep_hash,
+                    deptypes=list(deptypes),
+                    hash_type=hash_type,
+                    virtuals=(),
+                    direct=True,
+                )
             )
 
         return dspec_list
@@ -5576,31 +5652,29 @@ class SpecfileV2(SpecfileReaderBase):
             raise spack.error.SpecError("Spec dictionary contains malformed dependencies")
 
         result = []
-        for dep in deps:
-            elt = dep
-            dep_name = dep["name"]
+        for elt in deps:
             if isinstance(elt, dict):
                 # new format: elements of dependency spec are keyed.
                 for h in ht.HASHES:
                     if h.name in elt:
-                        dep_hash, deptypes, hash_type, virtuals, direct = (
-                            cls.extract_info_from_dep(elt, h)
-                        )
+                        result.append(cls.extract_info_from_dep(elt, h))
                         break
                 else:  # We never determined a hash type...
                     raise spack.error.SpecError("Couldn't parse dependency spec.")
             else:
                 raise spack.error.SpecError("Couldn't parse dependency types in spec.")
-            result.append((dep_name, dep_hash, list(deptypes), hash_type, tuple(virtuals), direct))
         return result
 
     @classmethod
-    def extract_info_from_dep(cls, elt, hash):
-        dep_hash, deptypes = elt[hash.name], elt["type"]
-        hash_type = hash.name
-        virtuals = []
-        direct = True
-        return dep_hash, deptypes, hash_type, virtuals, direct
+    def extract_info_from_dep(cls, elt, hash) -> DepSpecComponents:
+        return DepSpecComponents(
+            name=elt["name"],
+            hash=elt[hash.name],
+            deptypes=list(elt["type"]),
+            hash_type=hash.name,
+            virtuals=(),
+            direct=True,
+        )
 
     @classmethod
     def extract_build_spec_info_from_node_dict(cls, node, hash_type=ht.dag_hash.name):
@@ -5618,13 +5692,15 @@ class SpecfileV4(SpecfileV2):
     SPEC_VERSION = 4
 
     @classmethod
-    def extract_info_from_dep(cls, elt, hash):
-        dep_hash = elt[hash.name]
-        deptypes = elt["parameters"]["deptypes"]
-        hash_type = hash.name
-        virtuals = elt["parameters"]["virtuals"]
-        direct = True
-        return dep_hash, deptypes, hash_type, virtuals, direct
+    def extract_info_from_dep(cls, elt, hash) -> DepSpecComponents:
+        return DepSpecComponents(
+            name=elt["name"],
+            hash=elt[hash.name],
+            deptypes=list(elt["parameters"]["deptypes"]),
+            hash_type=hash.name,
+            virtuals=tuple(elt["parameters"]["virtuals"]),
+            direct=True,
+        )
 
     @classmethod
     def load(cls, data) -> Spec:
@@ -5633,6 +5709,10 @@ class SpecfileV4(SpecfileV2):
 
 @register_reader
 class SpecfileV5(SpecfileV4):
+    """abstract_hash, compiler_flags, when and propagation are optional node/dependency keys,
+    used only for abstract specs. Not enforcing them is what avoids a version bump: an older
+    reader ignores an unknown key, and a spec file without one stays valid."""
+
     SPEC_VERSION = 5
 
     @classmethod
@@ -5640,13 +5720,18 @@ class SpecfileV5(SpecfileV4):
         raise RuntimeError("The 'compiler' option is unexpected in specfiles at v5 or greater")
 
     @classmethod
-    def extract_info_from_dep(cls, elt, hash):
-        dep_hash = elt[hash.name]
-        deptypes = elt["parameters"]["deptypes"]
-        hash_type = hash.name
-        virtuals = elt["parameters"]["virtuals"]
-        direct = elt["parameters"].get("direct", False)
-        return dep_hash, deptypes, hash_type, virtuals, direct
+    def extract_info_from_dep(cls, elt, hash) -> DepSpecComponents:
+        parameters = elt["parameters"]
+        return DepSpecComponents(
+            name=elt["name"],
+            hash=elt[hash.name],
+            deptypes=list(parameters["deptypes"]),
+            hash_type=hash.name,
+            virtuals=tuple(parameters["virtuals"]),
+            direct=parameters.get("direct", False),
+            when=parameters.get("when", ""),
+            propagation=parameters.get("propagation", PropagationPolicy.NONE.name),
+        )
 
 
 #: Alias to the latest version of specfiles

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -933,29 +933,6 @@ class CompilerFlag(str):
 _valid_compiler_flags = ["cflags", "cxxflags", "fflags", "ldflags", "ldlibs", "cppflags"]
 
 
-def _shared_subset_pair_iterate(container1, container2):
-    """
-    [0, a, c, d, f]
-    [a, d, e, f]
-
-    yields [(a, a), (d, d), (f, f)]
-
-    no repeated elements
-    """
-    a_idx, b_idx = 0, 0
-    max_a, max_b = len(container1), len(container2)
-    while a_idx < max_a and b_idx < max_b:
-        if container1[a_idx] == container2[b_idx]:
-            yield (container1[a_idx], container2[b_idx])
-            a_idx += 1
-            b_idx += 1
-        else:
-            while container1[a_idx] < container2[b_idx]:
-                a_idx += 1
-            while container1[a_idx] > container2[b_idx]:
-                b_idx += 1
-
-
 class FlagMap(lang.HashableMap[str, List[CompilerFlag]]):
     __slots__ = ()
 
@@ -985,22 +962,18 @@ class FlagMap(lang.HashableMap[str, List[CompilerFlag]]):
                 ]
                 changed = True
 
-            # Next, if any flags in other propagate, we force them to propagate in our case.
-            # CompilerFlag objects can be shared with other specs, so they are replaced rather
-            # than modified in place.
-            shared = sorted(set(other[flag_type]) - extra_other)
-            demoted = {
-                id(y)
-                for x, y in _shared_subset_pair_iterate(shared, sorted(self[flag_type]))
-                if y.propagate is True and x.propagate is False
-            }
-            if demoted:
+            # A flag that propagates is the narrower of the two, so a value that propagates on
+            # either side propagates in the result. CompilerFlag objects can be shared with other
+            # specs, so they are replaced rather than modified in place.
+            propagating = {str(f) for f in other[flag_type] if f.propagate}
+            promoted = [not f.propagate and str(f) in propagating for f in self[flag_type]]
+            if any(promoted):
                 changed = True
                 self[flag_type] = [
-                    CompilerFlag(f, propagate=False, flag_group=f.flag_group, source=f.source)
-                    if id(f) in demoted
+                    CompilerFlag(f, propagate=True, flag_group=f.flag_group, source=f.source)
+                    if promote
                     else f
-                    for f in self[flag_type]
+                    for f, promote in zip(self[flag_type], promoted)
                 ]
 
         # TODO: what happens if flag groups with a partial (but not complete)

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -5508,14 +5508,24 @@ def wire_spec_nodes(
                 raise MissingSpecHashError(
                     f"node '{node['name']}' references missing dep hash {dep.name}/{dep.hash}"
                 )
-            node_spec._add_dependency(
+            # Register the edge directly instead of going through _add_dependency: each entry
+            # here is already a fully resolved, distinct edge from a concrete DAG, so there is
+            # nothing to merge. Two entries can reference the same dep hash (a build-only edge
+            # and a link-only edge to the same node, say), which would make dep_spec the same
+            # object both times - _add_dependency's identity-based merge detection exists for
+            # incrementally building up one edge's deptypes call by call, and would wrongly fold
+            # this into one edge instead of registering a second, parallel one.
+            edge = DependencySpec(
+                node_spec,
                 dep_spec,
                 depflag=dt.canonicalize(dep.deptypes),
                 virtuals=dep.virtuals,
                 direct=dep.direct,
-                when=Spec(dep.when) if dep.when else None,
+                when=Spec(dep.when) if dep.when else EMPTY_SPEC,
                 propagation=PropagationPolicy[dep.propagation],
             )
+            _add_edge_to_map(node_spec._dependencies, edge.spec.name, edge)
+            _add_edge_to_map(edge.spec._dependents, edge.parent.name, edge)
 
         if "build_spec" in node.keys():
             bname, bhash, _ = reader.extract_build_spec_info_from_node_dict(

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -231,6 +231,22 @@ def _make_microarchitecture(name: str) -> spack.vendor.archspec.cpu.Microarchite
     )
 
 
+def _attr_satisfies(lhs: Optional[str], rhs: Optional[str]) -> bool:
+    """Whether a platform or operating system on the lhs satisfies the one on the rhs. A star
+    requires a value without naming one, so any value on the lhs satisfies it."""
+    if not rhs:
+        return True
+    return bool(lhs) if rhs == "*" else lhs == rhs
+
+
+def _attr_intersects(lhs: Optional[str], rhs: Optional[str]) -> bool:
+    """Whether a platform or operating system on either side can be made equal to the other. An
+    unset value is still open to any value, and a star is satisfied by any of them."""
+    if not lhs or not rhs:
+        return True
+    return lhs == "*" or rhs == "*" or lhs == rhs
+
+
 @lang.lazy_lexicographic_ordering
 class ArchSpec:
     """Aggregate the target platform, the operating system and the target microarchitecture."""
@@ -406,16 +422,8 @@ class ArchSpec:
         """
         other = self._autospec(other)
 
-        # Check platform and os
         for attribute in ("platform", "os"):
-            other_attribute = getattr(other, attribute)
-            self_attribute = getattr(self, attribute)
-
-            # platform=* or os=*
-            if self_attribute and other_attribute == "*":
-                return True
-
-            if other_attribute and self_attribute != other_attribute:
+            if not _attr_satisfies(getattr(self, attribute), getattr(other, attribute)):
                 return False
 
         return self._target_satisfies(other, strict=True)
@@ -432,11 +440,8 @@ class ArchSpec:
         """
         other = self._autospec(other)
 
-        # Check platform and os
         for attribute in ("platform", "os"):
-            other_attribute = getattr(other, attribute)
-            self_attribute = getattr(self, attribute)
-            if other_attribute and self_attribute and self_attribute != other_attribute:
+            if not _attr_intersects(getattr(self, attribute), getattr(other, attribute)):
                 return False
 
         return self._target_satisfies(other, strict=False)
@@ -458,6 +463,10 @@ class ArchSpec:
         if other.target == ArchSpec.ANY_TARGET:
             return True
 
+        # target=* on the lhs overlaps any target, but is too broad to satisfy a specific one
+        if not strict and self.target == ArchSpec.ANY_TARGET:
+            return True
+
         return bool(self._target_intersection(other))
 
     def _target_constrain(self, other: "ArchSpec") -> bool:
@@ -466,6 +475,18 @@ class ArchSpec:
         # the two has no target, which would turn into an empty target below.
         if other.target is None:
             return False
+
+        # target=* constrains a target to be set without naming one, so any target already
+        # satisfies it and a side without one becomes the star. It is also concrete by the
+        # definition below, which would otherwise make it override a real target.
+        if other.target == ArchSpec.ANY_TARGET:
+            if self.target is not None:
+                return False
+            self.target = other.target
+            return True
+        if self.target == ArchSpec.ANY_TARGET:
+            self.target = other.target
+            return True
 
         if not other._target_satisfies(self, strict=False):
             raise UnsatisfiableArchitectureSpecError(self, other)
@@ -592,7 +613,9 @@ class ArchSpec:
         constrained = False
         for attr in ("platform", "os"):
             svalue, ovalue = getattr(self, attr), getattr(other, attr)
-            if svalue is None and ovalue is not None:
+            # a star constrains the value to be set, so it is kept when there is none yet and
+            # is replaced by a real value from the other side
+            if ovalue is not None and (svalue is None or (svalue == "*" and ovalue != "*")):
                 setattr(self, attr, ovalue)
                 constrained = True
 

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -3170,9 +3170,10 @@ class Spec:
         changed = False
 
         if other.abstract_hash and (
-            not self.abstract_hash or other.abstract_hash.startswith(self.abstract_hash)
+            not self.abstract_hash or len(other.abstract_hash) > len(self.abstract_hash)
         ):
             self.abstract_hash = other.abstract_hash
+            changed = True
 
         if not self.name and other.name:
             self.name = other.name

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -1083,15 +1083,12 @@ class FlagMap(lang.HashableMap[str, List[CompilerFlag]]):
 
         result = ""
         for flag_type, flags in sorted_items:
-            normal = [f for f in flags if not f.propagate]
-            if normal:
-                value = spack.spec_parser.quote_if_needed(" ".join(normal))
-                result += f" {flag_type}={value}"
-
-            propagated = [f for f in flags if f.propagate]
-            if propagated:
-                value = spack.spec_parser.quote_if_needed(" ".join(propagated))
-                result += f" {flag_type}=={value}"
+            # The order of the flags of one type is significant, so they are printed in the order
+            # they are stored, in runs of flags that agree on whether they propagate.
+            for propagate, group in itertools.groupby(flags, key=lambda flag: flag.propagate):
+                sigil = "==" if propagate else "="
+                value = spack.spec_parser.quote_if_needed(" ".join(group))
+                result += f" {flag_type}{sigil}{value}"
 
         # TODO: somehow add this space only if something follows in Spec.format()
         if sorted_items:

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -879,7 +879,9 @@ class DependencySpec:
             keywords.append(f"when={self.when}")
 
         if self.propagation != PropagationPolicy.NONE:
-            keywords.append(f"propagation={self.propagation}")
+            # IntEnum's default formatting renders as its int value, not its name, so the name
+            # is spelled out explicitly here.
+            keywords.append(f"propagation=PropagationPolicy.{self.propagation.name}")
 
         keywords_str = ", ".join(keywords)
         return f"DependencySpec({self.parent.format()!r}, {self.spec.format()!r}, {keywords_str})"

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -3116,11 +3116,15 @@ class Spec:
             self._dup(other)
             return True
 
-        if other.abstract_hash:
-            if not self.abstract_hash or other.abstract_hash.startswith(self.abstract_hash):
-                self.abstract_hash = other.abstract_hash
-            elif not self.abstract_hash.startswith(other.abstract_hash):
-                raise InvalidHashError(self, other.abstract_hash)
+        # Every dimension is validated before any of them is merged, so that a conflict in one
+        # dimension does not leave the others already applied to self.
+        if (
+            self.abstract_hash
+            and other.abstract_hash
+            and not other.abstract_hash.startswith(self.abstract_hash)
+            and not self.abstract_hash.startswith(other.abstract_hash)
+        ):
+            raise InvalidHashError(self, other.abstract_hash)
 
         if not (self.name == other.name or (not self.name) or (not other.name)):
             raise UnsatisfiableSpecNameError(self.name, other.name)
@@ -3139,6 +3143,11 @@ class Spec:
             if not self.variants[v].intersects(other.variants[v]):
                 raise vt.UnsatisfiableVariantSpecError(self.variants[v], other.variants[v])
 
+        if other._concrete:
+            for v in self.variants:
+                if v not in other.variants:
+                    raise vt.UnsatisfiableVariantSpecError(self.variants[v], "<absent>")
+
         sarch, oarch = self.architecture, other.architecture
         if (
             sarch is not None
@@ -3147,7 +3156,23 @@ class Spec:
         ):
             raise UnsatisfiableArchitectureSpecError(sarch, oarch)
 
+        if deps and other._dependencies:
+            # TODO: might want more detail than this, e.g. specific deps
+            # in violation. if this becomes a priority get rid of this
+            # check and be more specific about what's wrong.
+            if not other._intersects_dependencies(self, resolve_virtuals=resolve_virtuals):
+                raise UnsatisfiableDependencySpecError(other, self)
+
+            for d in other.traverse(root=False):
+                if not d.name:
+                    raise UnconstrainableDependencySpecError(other)
+
         changed = False
+
+        if other.abstract_hash and (
+            not self.abstract_hash or other.abstract_hash.startswith(self.abstract_hash)
+        ):
+            self.abstract_hash = other.abstract_hash
 
         if not self.name and other.name:
             self.name = other.name
@@ -3171,24 +3196,18 @@ class Spec:
             changed = True
 
         if deps:
-            changed |= self._constrain_dependencies(other, resolve_virtuals=resolve_virtuals)
+            changed |= self._constrain_dependencies(other)
 
         return changed
 
-    def _constrain_dependencies(self, other: "Spec", resolve_virtuals: bool = True) -> bool:
-        """Apply constraints of other spec's dependencies to this spec."""
+    def _constrain_dependencies(self, other: "Spec") -> bool:
+        """Apply constraints of other spec's dependencies to this spec.
+
+        Precondition: ``_constrain`` has checked that the two intersect and that every
+        dependency of other is named."""
         if not other._dependencies:
             return False
 
-        # TODO: might want more detail than this, e.g. specific deps
-        # in violation. if this becomes a priority get rid of this
-        # check and be more specific about what's wrong.
-        if not other._intersects_dependencies(self, resolve_virtuals=resolve_virtuals):
-            raise UnsatisfiableDependencySpecError(other, self)
-
-        for d in other.traverse(root=False):
-            if not d.name:
-                raise UnconstrainableDependencySpecError(other)
         changed = False
         for other_edge in other.edges_to_dependencies():
             # Find the first edge in self that matches other_edge by name and when clause.

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -973,22 +973,35 @@ class FlagMap(lang.HashableMap[str, List[CompilerFlag]]):
         changed = False
         for flag_type in other:
             if flag_type not in self:
-                self[flag_type] = other[flag_type]
+                # copy the list, so that self and other do not share it
+                self[flag_type] = list(other[flag_type])
                 changed = True
-            else:
-                extra_other = set(other[flag_type]) - set(self[flag_type])
-                if extra_other:
-                    self[flag_type] = list(self[flag_type]) + [
-                        x for x in other[flag_type] if x in extra_other
-                    ]
-                    changed = True
+                continue
 
-                # Next, if any flags in other propagate, we force them to propagate in our case
-                shared = list(sorted(set(other[flag_type]) - extra_other))
-                for x, y in _shared_subset_pair_iterate(shared, sorted(self[flag_type])):
-                    if y.propagate is True and x.propagate is False:
-                        changed = True
-                        y.propagate = False
+            extra_other = set(other[flag_type]) - set(self[flag_type])
+            if extra_other:
+                self[flag_type] = list(self[flag_type]) + [
+                    x for x in other[flag_type] if x in extra_other
+                ]
+                changed = True
+
+            # Next, if any flags in other propagate, we force them to propagate in our case.
+            # CompilerFlag objects can be shared with other specs, so they are replaced rather
+            # than modified in place.
+            shared = sorted(set(other[flag_type]) - extra_other)
+            demoted = {
+                id(y)
+                for x, y in _shared_subset_pair_iterate(shared, sorted(self[flag_type]))
+                if y.propagate is True and x.propagate is False
+            }
+            if demoted:
+                changed = True
+                self[flag_type] = [
+                    CompilerFlag(f, propagate=False, flag_group=f.flag_group, source=f.source)
+                    if id(f) in demoted
+                    else f
+                    for f in self[flag_type]
+                ]
 
         # TODO: what happens if flag groups with a partial (but not complete)
         # intersection specify different behaviors for flag propagation?
@@ -3153,7 +3166,8 @@ class Spec:
         if sarch is not None and oarch is not None:
             changed |= self.architecture.constrain(other.architecture)
         elif oarch is not None:
-            self.architecture = oarch
+            # copy, so that a later constrain on self does not write through into other
+            self.architecture = oarch.copy()
             changed = True
 
         if deps:

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -461,11 +461,18 @@ class ArchSpec:
         return bool(self._target_intersection(other))
 
     def _target_constrain(self, other: "ArchSpec") -> bool:
-        if self.target is None and other.target is None:
+        # An unconstrained target on either side means the other side is the intersection.
+        # _target_intersection cannot express that: it returns an empty list whenever one of
+        # the two has no target, which would turn into an empty target below.
+        if other.target is None:
             return False
 
         if not other._target_satisfies(self, strict=False):
             raise UnsatisfiableArchitectureSpecError(self, other)
+
+        if self.target is None:
+            self.target = other.target
+            return True
 
         if self.target_concrete:
             return False

--- a/lib/spack/spack/test/architecture.py
+++ b/lib/spack/spack/test/architecture.py
@@ -8,6 +8,7 @@ import pytest
 import spack.vendor.archspec.cpu
 
 import spack.concretize
+import spack.error
 import spack.operating_systems
 import spack.platforms
 from spack.spec import ArchSpec, Spec
@@ -107,6 +108,27 @@ def test_satisfy_strict_constraint_when_not_concrete(architecture_tuple, constra
     architecture = ArchSpec(architecture_tuple)
     constraint = ArchSpec(constraint_tuple)
     assert not architecture.satisfies(constraint)
+
+
+@pytest.mark.xfail(
+    reason="_target_intersection returns an empty list when the lhs has no target, and "
+    "_target_constrain turns that into an empty target",
+    strict=True,
+)
+def test_constrain_range_target_onto_missing_target():
+    """A target range from the rhs is adopted as is when the lhs has no target."""
+    architecture = ArchSpec((None, "debian6", None))
+    assert architecture.constrain(ArchSpec((None, None, "x86_64:"))) is True
+    assert architecture.target == ArchSpec((None, None, "x86_64:")).target
+
+
+def test_constrain_is_atomic_when_targets_are_disjoint():
+    """platform and os are applied before the target, so the up-front intersection check is what
+    keeps a failed constrain from leaving them behind."""
+    architecture = ArchSpec(("linux", None, "haswell"))
+    with pytest.raises(spack.error.UnsatisfiableSpecError):
+        architecture.constrain(ArchSpec((None, "ubuntu18.04", "ppc64le")))
+    assert architecture == ArchSpec(("linux", None, "haswell"))
 
 
 @pytest.mark.parametrize(

--- a/lib/spack/spack/test/architecture.py
+++ b/lib/spack/spack/test/architecture.py
@@ -110,16 +110,19 @@ def test_satisfy_strict_constraint_when_not_concrete(architecture_tuple, constra
     assert not architecture.satisfies(constraint)
 
 
-@pytest.mark.xfail(
-    reason="_target_intersection returns an empty list when the lhs has no target, and "
-    "_target_constrain turns that into an empty target",
-    strict=True,
+@pytest.mark.parametrize(
+    "lhs_tuple,rhs_tuple,expected_target",
+    [
+        ((None, "debian6", None), (None, None, "x86_64:"), "x86_64:"),
+        ((None, None, "x86_64:"), (None, "debian6", None), "x86_64:"),
+        ((None, "debian6", None), (None, None, "haswell"), "haswell"),
+    ],
 )
-def test_constrain_range_target_onto_missing_target():
-    """A target range from the rhs is adopted as is when the lhs has no target."""
-    architecture = ArchSpec((None, "debian6", None))
-    assert architecture.constrain(ArchSpec((None, None, "x86_64:"))) is True
-    assert architecture.target == ArchSpec((None, None, "x86_64:")).target
+def test_constrain_target_when_only_one_side_has_one(lhs_tuple, rhs_tuple, expected_target):
+    """The side that has a target wins, ranges included."""
+    architecture = ArchSpec(lhs_tuple)
+    architecture.constrain(ArchSpec(rhs_tuple))
+    assert architecture.target == ArchSpec((None, None, expected_target)).target
 
 
 def test_constrain_is_atomic_when_targets_are_disjoint():

--- a/lib/spack/spack/test/architecture.py
+++ b/lib/spack/spack/test/architecture.py
@@ -135,6 +135,50 @@ def test_constrain_is_atomic_when_targets_are_disjoint():
 
 
 @pytest.mark.parametrize(
+    "architecture_tuple,constraint_tuple",
+    [
+        (("linux", "ubuntu18.04", "x86_64"), ("*", None, None)),
+        (("linux", "ubuntu18.04", "x86_64"), (None, "*", None)),
+        (("linux", "ubuntu18.04", "x86_64"), (None, None, "*")),
+        (("linux", "ubuntu18.04", "x86_64"), ("*", "*", "*")),
+        (("linux", None, None), ("*", None, None)),
+    ],
+)
+def test_star_is_satisfied_and_intersected_and_does_not_constrain(
+    architecture_tuple, constraint_tuple
+):
+    """A star requires the attribute to be set, so a spec that sets it satisfies the star, the
+    two overlap in both directions, and merging changes nothing."""
+    architecture = ArchSpec(architecture_tuple)
+    constraint = ArchSpec(constraint_tuple)
+
+    assert architecture.satisfies(constraint)
+    assert architecture.intersects(constraint)
+    assert constraint.intersects(architecture)
+
+    merged = architecture.copy()
+    assert merged.constrain(constraint) is False
+    assert merged == architecture
+
+
+def test_star_does_not_short_circuit_the_other_attributes():
+    """A star on one attribute used to return from satisfies straight away, leaving the
+    remaining attributes unchecked."""
+    architecture = ArchSpec(("linux", "ubuntu18.04", "x86_64"))
+    assert not architecture.satisfies(ArchSpec(("*", "rhel6", None)))
+    assert not architecture.satisfies(ArchSpec(("*", None, "aarch64")))
+    assert not architecture.intersects(ArchSpec(("*", "rhel6", None)))
+
+
+def test_star_target_is_replaced_by_a_real_target_when_constrained():
+    """target=* names no target, so the other side is the intersection. It is concrete by the
+    definition in ArchSpec, which would otherwise make it override a real target."""
+    architecture = ArchSpec((None, None, "*"))
+    assert architecture.constrain(ArchSpec((None, None, "x86_64"))) is True
+    assert str(architecture.target) == "x86_64"
+
+
+@pytest.mark.parametrize(
     "root_target_range,dep_target_range,result",
     [
         ("x86_64:nocona", "x86_64:core2", "nocona"),  # pref not in intersection

--- a/lib/spack/spack/test/spec_semantics.py
+++ b/lib/spack/spack/test/spec_semantics.py
@@ -2395,6 +2395,18 @@ def test_flag_propagation_is_invisible_to_satisfies(mock_packages):
     assert merged.compiler_flags["cflags"][0].propagate
 
 
+def test_edge_propagation_is_merged(mock_packages):
+    """A propagated edge constrains the whole DAG, so it is the narrower of the two policies and
+    the meet takes it from whichever operand has it."""
+    lhs, rhs = Spec("pkg-a ^pkg-b"), Spec("pkg-a %%pkg-b")
+    forward = lhs.copy()
+    forward.constrain(rhs)
+    backward = rhs.copy()
+    backward.constrain(lhs)
+    assert forward.to_dict() == backward.to_dict()
+    assert forward.edges_to_dependencies()[0].propagation == PropagationPolicy.PREFERENCE
+
+
 def test_flag_order_survives_formatting(mock_packages):
     """Compiler flags are printed in the order they are stored, in runs of flags that agree on
     whether they propagate, so a propagating flag followed by a plain one comes back in that

--- a/lib/spack/spack/test/spec_semantics.py
+++ b/lib/spack/spack/test/spec_semantics.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+import itertools
 import pathlib
 
 import pytest
@@ -2439,6 +2440,188 @@ def test_constrain_symbolically(constraints, expected):
     for c in reversed(constraints):
         reverse_order._constrain_symbolically(c)
     assert reverse_order == Spec(expected)
+
+
+#: Abstract specs covering every dimension ``constrain`` merges, and pairs that conflict within
+#: each dimension. The properties below are checked over the product of this list with itself.
+CONSTRAIN_CORPUS = [
+    # names and namespaces
+    "",
+    "pkg-a",
+    "pkg-b",
+    "builtin_mock.pkg-a",
+    # versions
+    "pkg-a@1:3",
+    "pkg-a@2",
+    "@:1",
+    # variants, including propagation and concrete multi-valued
+    "pkg-a+foo",
+    "pkg-a~foo",
+    "pkg-a++foo",
+    "pkg-a foo=bar",
+    "pkg-a foo=baz",
+    "pkg-a foo=bar,baz",
+    "pkg-a foo:=bar",
+    # compiler flags. The propagating entries are what reaches the propagate reset in
+    # FlagMap.constrain.
+    "pkg-a cflags=-O2",
+    "pkg-a cflags=-g",
+    "pkg-a cflags==-O2",
+    "pkg-a cflags=-g cflags==-O2",
+    # architecture
+    "pkg-a target=haswell",
+    "pkg-a target=x86_64:",
+    "pkg-a target=:icelake",
+    "pkg-a os=debian6",
+    # abstract hashes
+    "pkg-a/abcdef",
+    "pkg-a/abc",
+    # dependency edges
+    "^pkg-b",
+    "^pkg-b@1",
+    "^pkg-b@2",
+    "pkg-a ^pkg-b@1 ^pkg-c",
+    "%pkg-b",
+    "%%pkg-b",
+    "%[deptypes=build] pkg-b",
+    "%[deptypes=link] pkg-b",
+    "pkg-a ^[when='+foo'] pkg-b@1",
+    "pkg-a ^[when='+bar'] pkg-b@2",
+    # virtuals
+    "pkg-a ^[virtuals=mpi] mpich",
+    "mpi",
+]
+
+
+def _constrain_corpus_pairs():
+    for lhs_str, rhs_str in itertools.product(CONSTRAIN_CORPUS, repeat=2):
+        yield lhs_str, rhs_str, Spec(lhs_str), Spec(rhs_str)
+
+
+def _try_constrain(lhs, rhs):
+    """Return ``(changed, error)``, exactly one of which is None."""
+    try:
+        return lhs.constrain(rhs), None
+    except SpecError as e:
+        return None, e
+
+
+class TestConstrainMutationSafety:
+    """``Spec.constrain`` intersects the left-hand side with the right-hand side in place. It
+    must apply the whole intersection or nothing at all, and it must never write to the
+    right-hand side, now or through an object the two ends up sharing.
+
+    These properties are checked over the product of ``CONSTRAIN_CORPUS`` rather than over
+    hand-written cases, so a dimension added later is covered as soon as it appears in the
+    corpus, and a refactor that reintroduces partial mutation in any dimension is caught.
+
+    Specs are snapshotted with ``to_dict()``, which round-trips abstract specs and so compares
+    their state directly. ``Spec.__eq__`` is semantic equality instead: it leaves the propagation
+    policy of an edge out of the comparison, so ``pkg-a %pkg-b`` and ``pkg-a %%pkg-b`` are equal,
+    as they are also mutually satisfying.
+    """
+
+    @pytest.mark.xfail(
+        reason="_constrain assigns abstract_hash and merges node attributes before validating "
+        "the remaining dimensions",
+        strict=True,
+    )
+    def test_lhs_is_unchanged_when_constrain_raises(self, mock_packages):
+        for lhs_str, rhs_str, lhs, rhs in _constrain_corpus_pairs():
+            before = lhs.to_dict()
+            _, error = _try_constrain(lhs, rhs)
+            if error is None:
+                continue
+            assert lhs.to_dict() == before, f"'{lhs_str}' mutated by failed constrain '{rhs_str}'"
+
+    def test_rhs_is_never_mutated(self, mock_packages):
+        for lhs_str, rhs_str, lhs, rhs in _constrain_corpus_pairs():
+            before = rhs.to_dict()
+            _try_constrain(lhs, rhs)
+            assert rhs.to_dict() == before, f"'{lhs_str}'.constrain('{rhs_str}') mutated the rhs"
+
+    @pytest.mark.xfail(
+        reason="FlagMap.constrain shares the flag list, and _constrain shares the ArchSpec, "
+        "so a later constrain on the lhs writes through into the rhs",
+        strict=True,
+    )
+    def test_rhs_is_not_corrupted_by_later_constraints(self, mock_packages):
+        """A successful constrain must not leave the two specs sharing a mutable object, which
+        a later constrain on the lhs would then write through into the rhs."""
+        for lhs_str, rhs_str, lhs, rhs in _constrain_corpus_pairs():
+            if _try_constrain(lhs, rhs)[1] is not None:
+                continue
+            before = rhs.to_dict()
+            for extra_str in CONSTRAIN_CORPUS:
+                _try_constrain(lhs, Spec(extra_str))
+                assert rhs.to_dict() == before, (
+                    f"'{lhs_str}'.constrain('{rhs_str}') shares state with the rhs: "
+                    f"constraining with '{extra_str}' afterwards changed it"
+                )
+
+    @pytest.mark.xfail(
+        reason="extending abstract_hash mutates the lhs without feeding the changed flag",
+        strict=True,
+    )
+    def test_returned_changed_flag_is_honest(self, mock_packages):
+        """Callers use the return value to decide whether to redo work, so it has to report
+        exactly whether the lhs changed."""
+        for lhs_str, rhs_str, lhs, rhs in _constrain_corpus_pairs():
+            before = lhs.to_dict()
+            changed, error = _try_constrain(lhs, rhs)
+            if error is not None:
+                continue
+            assert changed is (lhs.to_dict() != before), (
+                f"'{lhs_str}'.constrain('{rhs_str}') returned {changed}"
+            )
+
+    def test_intersects_agrees_with_constrain(self, mock_packages):
+        """``intersects`` is the question ``constrain`` answers by raising or not. The product
+        covers both orders, so this also pins the commutativity of ``intersects``."""
+        for lhs_str, rhs_str, lhs, rhs in _constrain_corpus_pairs():
+            intersects = lhs.intersects(rhs)
+            _, error = _try_constrain(lhs, rhs)
+            assert intersects is (error is None), (
+                f"'{lhs_str}'.intersects('{rhs_str}') is {intersects}, but constrain "
+                f"{'raised ' + type(error).__name__ if error else 'succeeded'}"
+            )
+
+    @pytest.mark.xfail(
+        reason="ArchSpec._target_constrain empties the target when the lhs has none and the "
+        "rhs has a range, so constraining again raises",
+        strict=True,
+    )
+    def test_constrain_is_idempotent(self, mock_packages):
+        for lhs_str, rhs_str, lhs, rhs in _constrain_corpus_pairs():
+            if _try_constrain(lhs, rhs)[1] is not None:
+                continue
+            before = lhs.to_dict()
+            assert lhs.constrain(rhs) is False, f"'{lhs_str}'.constrain('{rhs_str}') twice"
+            assert lhs.to_dict() == before
+
+    @pytest.mark.xfail(
+        reason="ArchSpec._target_constrain empties the target when the lhs has none and the "
+        "rhs has a range, dropping the constraint instead of applying it",
+        strict=True,
+    )
+    def test_constrained_lhs_satisfies_rhs(self, mock_packages):
+        """Guards against making constrain atomic by making it do nothing."""
+        for lhs_str, rhs_str, lhs, rhs in _constrain_corpus_pairs():
+            if _try_constrain(lhs, rhs)[1] is not None:
+                continue
+            assert lhs.satisfies(rhs), f"'{lhs_str}'.constrain('{rhs_str}') gave '{lhs}'"
+
+    @pytest.mark.xfail(
+        reason="ArchSpec._target_constrain empties the target when only one side has one",
+        strict=True,
+    )
+    def test_constrain_never_weakens_the_lhs(self, mock_packages):
+        """The result is the intersection of both operands, so together with the property above
+        this pins that constrain narrows and never drops a constraint."""
+        for lhs_str, rhs_str, lhs, rhs in _constrain_corpus_pairs():
+            if _try_constrain(lhs, rhs)[1] is not None:
+                continue
+            assert lhs.satisfies(Spec(lhs_str)), f"'{lhs_str}'.constrain('{rhs_str}') gave '{lhs}'"
 
 
 @pytest.mark.parametrize(

--- a/lib/spack/spack/test/spec_semantics.py
+++ b/lib/spack/spack/test/spec_semantics.py
@@ -449,8 +449,9 @@ class TestSpecSemantics:
         """Test that Specs specified only by their hashes can constrain each other."""
         mpich_dag_hash = "/" + database.query_one("mpich").dag_hash()
         spec = Spec(mpich_dag_hash[:7])
-        assert spec.constrain(Spec(mpich_dag_hash)) is False
+        assert spec.constrain(Spec(mpich_dag_hash)) is True
         assert spec.abstract_hash == mpich_dag_hash[1:]
+        assert spec.constrain(Spec(mpich_dag_hash[:7])) is False
 
     def test_mismatched_constrain_spec_by_hash(self, database):
         """Test that Specs specified only by their incompatible hashes fail appropriately."""
@@ -2549,10 +2550,6 @@ class TestConstrainMutationSafety:
                     f"constraining with '{extra_str}' afterwards changed it"
                 )
 
-    @pytest.mark.xfail(
-        reason="extending abstract_hash mutates the lhs without feeding the changed flag",
-        strict=True,
-    )
     def test_returned_changed_flag_is_honest(self, mock_packages):
         """Callers use the return value to decide whether to redo work, so it has to report
         exactly whether the lhs changed."""

--- a/lib/spack/spack/test/spec_semantics.py
+++ b/lib/spack/spack/test/spec_semantics.py
@@ -390,10 +390,10 @@ class TestSpecSemantics:
             (
                 'mpich cflags="-O3 -g"',
                 'mpich cflags=="-O3"',
-                'mpich cflags="-O3 -g"',
-                'mpich cflags="-O3 -g"',
-                [],
-                [],
+                'mpich cflags=="-O3" cflags="-g"',
+                'mpich cflags=="-O3" cflags="-g"',
+                [("cflags", "-O3")],
+                [("cflags", "-O3")],
             ),
             (
                 'mpich cflags=="-O3 -g"',
@@ -2375,6 +2375,24 @@ def test_the_default_format_leaves_out_the_namespace(mock_packages):
     assert spec.namespace == "builtin_mock"
     assert round_tripped.namespace is None
     assert round_tripped.satisfies(spec) and spec.satisfies(round_tripped)
+
+
+def test_flag_propagation_is_invisible_to_satisfies(mock_packages):
+    """A propagating flag applies to a package and to the packages it is built against, which is
+    a condition on the whole DAG that concretization discharges into plain flags on every node it
+    reaches, so satisfies follows non-contradiction here the same way it does for a propagating
+    variant. CompilerFlag subclasses str, so == and hash ignore the propagation and that falls
+    out by itself.
+
+    The merge does keep the propagation of either side, though, which is what makes the meet the
+    narrower of the two constraints rather than the plain flag."""
+    propagating, plain = Spec("pkg-a cflags==-O2"), Spec("pkg-a cflags=-O2")
+    assert propagating.satisfies(plain)
+    assert plain.satisfies(propagating)
+
+    merged = plain.copy()
+    merged.constrain(propagating)
+    assert merged.compiler_flags["cflags"][0].propagate
 
 
 def test_flag_order_survives_formatting(mock_packages):

--- a/lib/spack/spack/test/spec_semantics.py
+++ b/lib/spack/spack/test/spec_semantics.py
@@ -325,12 +325,7 @@ class TestSpecSemantics:
             (
                 "libelf patches=ba5e334fe247335f3a116decfb5284100791dc302b5571ff5e664d8f9a6806c2",
                 "libelf patches=ba5e3",  # constrain by a patch sha256 prefix
-                # TODO: the result below is not ideal. Prefix satisfies() works for patches, but
-                # constrain() isn't similarly special-cased to do the same thing
-                (
-                    "libelf patches=ba5e3,"
-                    "ba5e334fe247335f3a116decfb5284100791dc302b5571ff5e664d8f9a6806c2"
-                ),
+                "libelf patches=ba5e334fe247335f3a116decfb5284100791dc302b5571ff5e664d8f9a6806c2",
             ),
             # deptypes on direct deps
             (

--- a/lib/spack/spack/test/spec_semantics.py
+++ b/lib/spack/spack/test/spec_semantics.py
@@ -2395,6 +2395,15 @@ def test_flag_propagation_is_invisible_to_satisfies(mock_packages):
     assert merged.compiler_flags["cflags"][0].propagate
 
 
+def test_parallel_edges_sort_with_differing_propagation(mock_packages):
+    """Parallel edges to one package are sorted to give ``_add_edge_to_map`` a canonical order.
+    ``DependencySpec._cmp_iter`` yields ``propagation``, so two edges that differ only in it must
+    be orderable, which requires ``PropagationPolicy`` to support ``<`` and not just ``==``."""
+    spec = Spec("pkg-a %%pkg-e %[when='+bvv'] pkg-e")
+    spec.to_dict()
+    assert spec.copy() == spec
+
+
 def test_edge_propagation_is_merged(mock_packages):
     """A propagated edge constrains the whole DAG, so it is the narrower of the two policies and
     the meet takes it from whichever operand has it."""

--- a/lib/spack/spack/test/spec_semantics.py
+++ b/lib/spack/spack/test/spec_semantics.py
@@ -2586,11 +2586,6 @@ class TestConstrainMutationSafety:
                 f"{'raised ' + type(error).__name__ if error else 'succeeded'}"
             )
 
-    @pytest.mark.xfail(
-        reason="ArchSpec._target_constrain empties the target when the lhs has none and the "
-        "rhs has a range, so constraining again raises",
-        strict=True,
-    )
     def test_constrain_is_idempotent(self, mock_packages):
         for lhs_str, rhs_str, lhs, rhs in _constrain_corpus_pairs():
             if _try_constrain(lhs, rhs)[1] is not None:
@@ -2599,11 +2594,6 @@ class TestConstrainMutationSafety:
             assert lhs.constrain(rhs) is False, f"'{lhs_str}'.constrain('{rhs_str}') twice"
             assert lhs.to_dict() == before
 
-    @pytest.mark.xfail(
-        reason="ArchSpec._target_constrain empties the target when the lhs has none and the "
-        "rhs has a range, dropping the constraint instead of applying it",
-        strict=True,
-    )
     def test_constrained_lhs_satisfies_rhs(self, mock_packages):
         """Guards against making constrain atomic by making it do nothing."""
         for lhs_str, rhs_str, lhs, rhs in _constrain_corpus_pairs():
@@ -2611,10 +2601,6 @@ class TestConstrainMutationSafety:
                 continue
             assert lhs.satisfies(rhs), f"'{lhs_str}'.constrain('{rhs_str}') gave '{lhs}'"
 
-    @pytest.mark.xfail(
-        reason="ArchSpec._target_constrain empties the target when only one side has one",
-        strict=True,
-    )
     def test_constrain_never_weakens_the_lhs(self, mock_packages):
         """The result is the intersection of both operands, so together with the property above
         this pins that constrain narrows and never drops a constraint."""

--- a/lib/spack/spack/test/spec_semantics.py
+++ b/lib/spack/spack/test/spec_semantics.py
@@ -2540,11 +2540,6 @@ class TestConstrainMutationSafety:
             _try_constrain(lhs, rhs)
             assert rhs.to_dict() == before, f"'{lhs_str}'.constrain('{rhs_str}') mutated the rhs"
 
-    @pytest.mark.xfail(
-        reason="FlagMap.constrain shares the flag list, and _constrain shares the ArchSpec, "
-        "so a later constrain on the lhs writes through into the rhs",
-        strict=True,
-    )
     def test_rhs_is_not_corrupted_by_later_constraints(self, mock_packages):
         """A successful constrain must not leave the two specs sharing a mutable object, which
         a later constrain on the lhs would then write through into the rhs."""

--- a/lib/spack/spack/test/spec_semantics.py
+++ b/lib/spack/spack/test/spec_semantics.py
@@ -2540,6 +2540,14 @@ CONSTRAIN_CORPUS = [
     "%[deptypes=link] pkg-b",
     "pkg-a ^[when='+foo'] pkg-b@1",
     "pkg-a ^[when='+bar'] pkg-b@2",
+    # architecture wildcards, which stand for "this attribute is set"
+    "pkg-a platform=test",
+    "pkg-a platform=*",
+    "pkg-a os=*",
+    "pkg-a target=*",
+    # patches, where an abstract value may be a prefix of a concrete one
+    "pkg-a patches=abcdef",
+    "pkg-a patches:=abcdef1234567890",
     # virtuals
     "pkg-a ^[virtuals=mpi] mpich",
     "mpi",
@@ -2647,6 +2655,51 @@ class TestConstrainMutationSafety:
             if _try_constrain(lhs, rhs)[1] is not None:
                 continue
             assert lhs.satisfies(Spec(lhs_str)), f"'{lhs_str}'.constrain('{rhs_str}') gave '{lhs}'"
+
+    def test_satisfies_implies_intersects(self, mock_packages):
+        """Satisfaction is subset and intersection is non-empty overlap, so a spec that is inside
+        another one also overlaps it. Each dimension implements the two separately, which is why
+        they can diverge, as they did for patch prefixes and architecture wildcards."""
+        for lhs_str, rhs_str, lhs, rhs in _constrain_corpus_pairs():
+            if not lhs.satisfies(rhs):
+                continue
+            assert lhs.intersects(rhs), (
+                f"'{lhs_str}' satisfies '{rhs_str}' but does not intersect it"
+            )
+
+    def test_satisfies_implies_constrain_succeeds(self, mock_packages):
+        """Constrain is only undefined where the two are disjoint, so it cannot reject a
+        constraint the lhs already satisfies."""
+        for lhs_str, rhs_str, lhs, rhs in _constrain_corpus_pairs():
+            if not lhs.satisfies(rhs):
+                continue
+            _, error = _try_constrain(lhs, rhs)
+            assert error is None, (
+                f"'{lhs_str}' satisfies '{rhs_str}' but constrain raised {type(error).__name__}"
+            )
+
+    def test_satisfies_implies_variants_are_unchanged(self, mock_packages):
+        """An lhs that is already inside the rhs has nothing left to intersect in the variant
+        dimension.
+
+        Only variants are asserted. Names, namespaces and edges whose when condition does not
+        apply are read as satisfied when the lhs leaves them unset, so constrain legitimately
+        fills those in without narrowing the set the lhs denotes. Propagated variants follow a
+        non-contradiction rule rather than subset semantics: a spec without such a variant
+        satisfies one that propagates it, and still acquires it when constrained; see
+        test_abstract_specs_with_propagation.
+        """
+        for lhs_str, rhs_str, lhs, rhs in _constrain_corpus_pairs():
+            if not lhs.satisfies(rhs):
+                continue
+            if any(value.propagate for value in rhs.variants.values()):
+                continue
+            before = {name: str(value) for name, value in lhs.variants.items()}
+            _try_constrain(lhs, rhs)
+            after = {name: str(value) for name, value in lhs.variants.items()}
+            assert after == before, (
+                f"'{lhs_str}' satisfies '{rhs_str}' but constrain changed its variants to '{lhs}'"
+            )
 
 
 @pytest.mark.parametrize(

--- a/lib/spack/spack/test/spec_semantics.py
+++ b/lib/spack/spack/test/spec_semantics.py
@@ -2364,6 +2364,45 @@ def test_satisfies_and_subscript_with_compilers(config, mock_packages):
     assert s["pkg-a"].dependencies(name="gmake")[0] == s["pkg-a"]["gmake"]
 
 
+def test_the_default_format_leaves_out_the_namespace(mock_packages):
+    """The default format prints the namespace only for an anonymous spec, since every concrete
+    spec has one and printing it everywhere would be noise, so a named spec that has one loses it
+    when it goes through a string. The two still denote the same set, since an unset namespace on
+    the left is read as no constraint."""
+    spec = Spec("builtin_mock.pkg-a")
+    round_tripped = Spec(str(spec))
+
+    assert spec.namespace == "builtin_mock"
+    assert round_tripped.namespace is None
+    assert round_tripped.satisfies(spec) and spec.satisfies(round_tripped)
+
+
+def test_flag_order_survives_formatting(mock_packages):
+    """Compiler flags are printed in the order they are stored, in runs of flags that agree on
+    whether they propagate, so a propagating flag followed by a plain one comes back in that
+    order. Flag order is significant to the build, so losing it would change the hash."""
+    spec = Spec("pkg-a cflags==-O2").copy()
+    spec.constrain(Spec("pkg-a cflags=-g"))
+    assert [str(flag) for flag in spec.compiler_flags["cflags"]] == ["-O2", "-g"]
+    assert str(spec) == "pkg-a cflags==-O2 cflags=-g"
+
+    round_tripped = Spec(str(spec))
+    assert [str(flag) for flag in round_tripped.compiler_flags["cflags"]] == ["-O2", "-g"]
+    assert round_tripped.dag_hash() == spec.dag_hash()
+
+
+def test_concrete_patches_are_truncated_by_formatting(mock_packages):
+    """Patch checksums are abbreviated to seven characters when printed. A concrete patches value
+    takes exactly the values it lists, so the abbreviation is not a prefix constraint that the
+    full checksum satisfies: the spec that comes back out of a string is disjoint from the one
+    that went in."""
+    spec = Spec("pkg-a patches:=abcdef1234567890")
+    round_tripped = Spec(str(spec))
+
+    assert round_tripped.variants["patches"].value == ("abcdef1",)
+    assert not spec.intersects(round_tripped)
+
+
 @pytest.mark.parametrize(
     "spec_str,spec_fmt,expected",
     [

--- a/lib/spack/spack/test/spec_semantics.py
+++ b/lib/spack/spack/test/spec_semantics.py
@@ -2521,11 +2521,6 @@ class TestConstrainMutationSafety:
     as they are also mutually satisfying.
     """
 
-    @pytest.mark.xfail(
-        reason="_constrain assigns abstract_hash and merges node attributes before validating "
-        "the remaining dimensions",
-        strict=True,
-    )
     def test_lhs_is_unchanged_when_constrain_raises(self, mock_packages):
         for lhs_str, rhs_str, lhs, rhs in _constrain_corpus_pairs():
             before = lhs.to_dict()

--- a/lib/spack/spack/test/spec_yaml.py
+++ b/lib/spack/spack/test/spec_yaml.py
@@ -23,6 +23,7 @@ import spack.vendor.ruamel.yaml
 
 import spack.concretize
 import spack.config
+import spack.deptypes as dt
 import spack.error
 import spack.hash_types as ht
 import spack.paths
@@ -584,6 +585,18 @@ def test_direct_edges_and_round_tripping_to_dict(spec_str, config, mock_packages
             continue
         for dependency_data in node["dependencies"]:
             assert "direct" not in dependency_data["parameters"]
+
+
+def test_parallel_deptype_edges_survive_round_trip(mock_packages):
+    """Two parallel edges to one package, differing only in deptype, hash the same on the child
+    side and so share one object once read back from JSON. That must not fold them into a single
+    edge: to_node_dict already emits one entry per edge, with no uniqueness constraint on
+    dependencies, so a round trip needs to keep both."""
+    original = Spec("pkg-a ^[deptypes=build] pkg-b ^[deptypes=link] pkg-b")
+    reconstructed = Spec.from_dict(original.to_dict())
+    edges = reconstructed.edges_to_dependencies("pkg-b")
+    assert len(edges) == 2
+    assert {e.depflag for e in edges} == {dt.BUILD, dt.LINK}
 
 
 def test_pickle_preserves_identity_and_prefix(config, mock_packages):

--- a/lib/spack/spack/test/spec_yaml.py
+++ b/lib/spack/spack/test/spec_yaml.py
@@ -523,15 +523,38 @@ def test_pickle_roundtrip_for_abstract_specs(spec_str):
 
 
 @pytest.mark.parametrize(
-    "spec_str", ["zlib os=redhat6", "zlib platform=test", "zlib os=debian6 target=x86_64"]
+    "spec_str",
+    [
+        # partial architectures. Regression test: ArchSpec.to_dict crashed with AttributeError
+        # when target was None.
+        "zlib os=redhat6",
+        "zlib platform=test",
+        "zlib os=debian6 target=x86_64",
+        # abstract hash
+        "zlib/abcdef",
+        # conditional edges
+        "zlib ^[when='+mpi'] mpich@1",
+        "zlib ^[when='+mpi'] mpich@1 ^[when='~mpi'] mpich@2",
+        # propagated direct dependencies
+        "zlib %%gcc",
+        # flags that propagate and flags that don't, on the same flag type
+        "zlib cflags=-g cflags==-O2",
+        # several flags given as a single group
+        'zlib cflags="-O2 -g"',
+        # several dimensions at once
+        "zlib ++mpi cflags==-g foo=bar,baz target=x86_64:",
+    ],
 )
-def test_dict_roundtrip_for_abstract_specs_with_partial_arch(spec_str):
-    """Abstract specs with a partial architecture survive to_dict/from_dict.
-    Regression test: ArchSpec.to_dict crashed with AttributeError when target was None."""
+def test_dict_roundtrip_for_abstract_specs(spec_str):
+    """Abstract specs survive to_dict/from_dict.
+
+    This compares the spec objects, their string representation and the dicts themselves, since
+    `Spec.__eq__` is blind to some of what is serialized, and vice versa."""
     s = spack.spec.Spec(spec_str)
     t = spack.spec.Spec.from_dict(s.to_dict())
     assert s == t
     assert str(s) == str(t)
+    assert s.to_dict() == t.to_dict()
 
 
 def test_specfile_alias_is_updated():

--- a/lib/spack/spack/test/variant.py
+++ b/lib/spack/spack/test/variant.py
@@ -879,6 +879,23 @@ def test_patches_variant():
     assert not Spec("patches:=abcdef").satisfies("patches:=abcdefghi")
 
 
+def test_patches_variant_prefix_intersects_and_constrains():
+    """Prefix matching applies to intersection too, so a spec that satisfies a prefix also
+    overlaps it and can be constrained by it."""
+    assert Spec("patches:=abcdef").intersects("patches=ab")
+    assert Spec("patches=ab").intersects("patches:=abcdef")
+    assert not Spec("patches:=abcdef").intersects("patches=xyz")
+    assert not Spec("patches:=abcdef").intersects("patches=abcdefghi")
+
+    s = Spec("patches:=abcdef")
+    assert s.constrain("patches=ab") is False
+    assert s.variants["patches"].values == ("abcdef",)
+
+    s = Spec("patches=ab")
+    assert s.constrain("patches:=abcdef") is True
+    assert s.variants["patches"].values == ("abcdef",)
+
+
 def test_constrain_narrowing():
     s = Spec("foo=*")
     assert s.variants["foo"].type == spack.variant.VariantType.MULTI

--- a/lib/spack/spack/variant.py
+++ b/lib/spack/spack/variant.py
@@ -414,6 +414,29 @@ class VariantValue:
             self.type, self.name, self.values, propagate=self.propagate, concrete=self.concrete
         )
 
+    def _merged_values(self, other: "VariantValue") -> Tuple[Union[str, bool], ...]:
+        """The values of both sides. For patches a value identified by a checksum prefix and the
+        full checksum name the same patch, so only the longer one is kept."""
+        values = (*self.values, *other.values)
+        if self.name != "patches":
+            return values
+        return tuple(
+            v
+            for v in values
+            if not any(
+                w != v and isinstance(w, str) and isinstance(v, str) and w.startswith(v)
+                for w in values
+            )
+        )
+
+    def _contains(self, value: Union[str, bool]) -> bool:
+        """Whether this variant covers a single value of another one. A patch is identified by a
+        prefix of its checksum, so a shorter value is covered by any value starting with it.
+        """
+        if self.name == "patches" and isinstance(value, str):
+            return any(isinstance(w, str) and w.startswith(value) for w in self.values)
+        return value in self.values
+
     def satisfies(self, other: "VariantValue") -> bool:
         """The lhs satisfies the rhs if all possible concretizations of lhs are also
         possible concretizations of rhs."""
@@ -421,16 +444,7 @@ class VariantValue:
             return False
 
         if not other.concrete:
-            # rhs abstract means the lhs must at least contain its values.
-            # special-case patches with rhs abstract: their values may be prefixes of the lhs
-            # values.
-            if self.name == "patches":
-                return all(
-                    isinstance(v, str)
-                    and any(isinstance(w, str) and w.startswith(v) for w in self.values)
-                    for v in other.values
-                )
-            return all(v in self for v in other.values)
+            return all(self._contains(v) for v in other.values)
         if self.concrete:
             # both concrete: they must be equal
             return self.values == other.values
@@ -443,9 +457,9 @@ class VariantValue:
         if self.concrete:
             if other.concrete:
                 return self.values == other.values
-            return all(v in self for v in other.values)
+            return all(self._contains(v) for v in other.values)
         if other.concrete:
-            return all(v in other for v in self.values)
+            return all(other._contains(v) for v in self.values)
         # both abstract: the union is a valid concretization of both
         return True
 
@@ -454,7 +468,7 @@ class VariantValue:
         if not self.intersects(other):
             raise UnsatisfiableVariantSpecError(self, other)
         old_values = self.values
-        self.set(*self.values, *other.values)
+        self.set(*self._merged_values(other))
         changed = old_values != self.values
         if self.propagate and not other.propagate:
             self.propagate = False


### PR DESCRIPTION
Depends on #52796.

The base is `develop`, so the diff shows the PRs it depends on too. This one is about the last
four commits, `09d4442c2f..ae4ea4aa2b`:

- `ced625e138` ArchSpec: let a star mean any value in intersects and constrain too
- `e5351225fe` spec: pin that satisfies implies intersects and a satisfied constraint
- `d4f173dd29` spec: merge the propagation policy of an edge
- `ae4ea4aa2b` spec: make PropagationPolicy orderable

`<key>=*` constrains an attribute to be set without naming a value, and `satisfies` implements that for `platform`, `os` and `target`. `intersects` compares the strings, so a star matches nothing and specs that satisfy a constraint are reported as disjoint, which makes `constrain` reject them:

```python
Spec("pkg-a os=debian6").satisfies("pkg-a os=*")    # True
Spec("pkg-a os=debian6").intersects("pkg-a os=*")   # False, and constrain raised
```

The platform and os checks now go through one pair of helpers used from both sides.

Three more bugs in the same lines:

- The star branch returned from `satisfies` straight away rather than moving on to the next attribute, so a star on the platform left the operating system and the target unchecked: `Spec("pkg-a platform=test os=debian6").satisfies("pkg-a platform=* os=redhat6")` was True.
- A star target is concrete by the definition in `ArchSpec`, being neither a range nor a list, so it overrode an actual target when merged, and made `intersects` inconsistent depending on the order of the operands.
- Merging dropped the constraint: constraining with a star left a result that did not satisfy it. A star is now replaced by an actual value from the other side, and kept when the other side has none.

The second commit adds two properties to the corpus from #52787, plus the entries whose absence let these bugs through. The eight properties already there now run over those entries too, which is what turned up the merge bug.

The third commit fixes an unrelated bug with the same backport reach, which is why it rides along here. Merging two edges took the dependency types, the virtuals and the direct flag from both sides but kept the propagation policy of the left-hand one, so the meet of a plain edge and a propagated one depended on the order of the operands. A propagated edge constrains the whole DAG, which makes it the narrower of the two, so the merge now takes it.

```python
spec = Spec("pkg-a ^pkg-b")
spec.constrain(Spec("pkg-a %%pkg-b"))      # "pkg-a %pkg-b": the propagation was dropped
```

The fourth commit is a follow-on to the third: `DependencySpec._cmp_iter` yields `propagation`, and
parallel edges to one package are sorted by their full comparison tuple to give them a canonical
order, so two edges whose policies differ now have to be orderable, not just comparable for
equality. Plain `Enum` only supports the latter:

```python
Spec("pkg-a %%pkg-e %[when='+bvv'] pkg-e")   # TypeError: '<' not supported between instances of 'PropagationPolicy' and 'PropagationPolicy'
```

Made `PropagationPolicy` an `IntEnum`, matching `VariantType`, which is one for the same reason.

Not backportable to v1.0: `ArchSpec.satisfies` has no wildcard handling there, so the two operations already match, and there is no `PropagationPolicy` on an edge either.

Stacked on #52796.

---

Part of a stack of fixes to `Spec.satisfies` / `intersects` / `constrain`, found by fuzzing their
algebraic identities. Each PR is based on the one above it and groups commits by how far they can
be backported, so a single label applies to the whole PR.

| PR | what | backport |
| --- | --- | --- |
| #52788 | round-trip abstract specs through `to_dict` | v1.0.5, v1.1.2, v1.2.3 |
| #52787 | `constrain` does not mutate on failure and reports what it changed | v1.0.5, v1.1.2, v1.2.3 |
| #52789 | the patch prefix rule applies to `intersects` and `constrain` too | v1.0.5, v1.1.2, v1.2.3 |
| #52796 | compiler flags keep their order and their propagation | v1.0.5, v1.1.2, v1.2.3 |
| #52790 | a star means any value; an edge merges its propagation policy | v1.1.2, v1.2.3 |
| #52797 | `satisfies` for virtual providers, direct edges and anonymous specs | v1.2.3 |
| #52798 | target satisfaction is containment; parallel edges have an order | none |
| #52800 | `satisfies`, `intersects` and `constrain` become stateless | none |
| #52799 | an edge naming a virtual is merged into the edge naming its provider | none |
| #52795 | the property tests | none |

The v1.0.5 and v1.1.2 backports need #51870 on `releases/v1.0` and `releases/v1.1` first: it
rewrote `_constrain_dependencies`, which these fixes build on. `releases/v1.2` already has it.
