### PR TITLE
CI: inline install command

### DIFF
--- a/lib/spack/spack/ci/__init__.py
+++ b/lib/spack/spack/ci/__init__.py
@@ -683,7 +683,7 @@ def copy_test_logs_to_artifacts(test_stage, job_test_dir):
     """
     tty.debug(f"test stage: {test_stage}")
     if not os.path.exists(test_stage):
-        tty.error(f"Cannot copy test logs: job test stage ({test_stage}) does not exist")
+        tty.warn(f"Cannot copy test logs: job test stage ({test_stage}) does not exist")
         return
 
     copy_files_to_artifacts(

--- a/lib/spack/spack/ci/__init__.py
+++ b/lib/spack/spack/ci/__init__.py
@@ -61,6 +61,7 @@ spack_gpg = spack.main.SpackCommand("gpg")
 spack_compiler = spack.main.SpackCommand("compiler")
 
 PushResult = namedtuple("PushResult", "success url")
+test_cmd = spack.main.SpackCommand("test")
 
 urlopen = web_util.urlopen  # alias for mocking in tests
 
@@ -1333,7 +1334,6 @@ def run_standalone_tests(
     fail_fast: bool = False,
     log_file: Optional[str] = None,
     job_spec: Optional[spack.spec.Spec] = None,
-    repro_dir: Optional[str] = None,
     timeout: Optional[int] = None,
 ):
     """Run stand-alone tests on the current spec.
@@ -1343,7 +1343,6 @@ def run_standalone_tests(
         fail_fast: terminate tests after the first failure
         log_file: test log file name if NOT CDash reporting
         job_spec: spec that was built
-        repro_dir: reproduction directory
         timeout: maximum time (in seconds) that tests are allowed to run
     """
     if cdash and log_file:
@@ -1355,11 +1354,7 @@ def run_standalone_tests(
         tty.error("Job spec is required to run stand-alone tests")
         return
 
-    if not repro_dir:
-        tty.error("Reproduction directory is required for stand-alone tests")
-        return
-
-    test_args = ["spack", "--color=always", "--backtrace", "--verbose", "test", "run"]
+    test_args = ["run"]
     if fail_fast:
         test_args.append("--fail-fast")
 
@@ -1375,6 +1370,4 @@ def run_standalone_tests(
     test_args.append(job_spec.name)
 
     tty.debug(f"Running {job_spec.name} stand-alone tests")
-    exit_code = process_command("test", test_args, repro_dir)
-
-    tty.debug(f"spack test exited {exit_code}")
+    test_cmd(*test_args, capture=False)

--- a/lib/spack/spack/cmd/ci.py
+++ b/lib/spack/spack/cmd/ci.py
@@ -487,7 +487,6 @@ def ci_rebuild(args):
     with spack.bootstrap.ensure_bootstrap_configuration():
         spack.bootstrap.ensure_core_dependencies()
 
-
     # TODO: (kwryankrattiger) Reproduce build is currently broken. Suppress the output of these
     # instructions for now. When the feature is working again move the print to before the
     # installation is printed to avoid the details be lost to install log truncation.
@@ -529,8 +528,6 @@ If this project does not have public pipelines, you will need to first:
         install_cmd(install_args + ["--only=dependencies", spec_hash])
     except spack.error.SpackError as e:
         # If the deps fail to install early exit
-        # Don't try to run tests or push to the cache
-        # Don't add this package to broken-specs list, dependecy install error is not a package error
         tty.error(f"Failed to install dependencies: {e}")
         raise
     finally:
@@ -545,11 +542,10 @@ If this project does not have public pipelines, you will need to first:
 
     tty.debug("Installing {0} from source".format(job_spec.name))
     try:
-
         # Install package
         install_cmd(install_args + ["--verbose", "--keep-stage", "--only=package", spec_hash])
         tty.debug("spack install succeeded")
-    except spack.error.SpackError as e:
+    except spack.error.SpackError:
         # If a spec fails to build in a spack develop pipeline, we add it to a
         # list of known broken hashes.  This allows spack PR pipelines to
         # avoid wasting compute cycles attempting to build those hashes.
@@ -583,11 +579,10 @@ If this project does not have public pipelines, you will need to first:
     finally:
         # Reset the color mode
         clr.set_color_when(reset_color)
-        # Copy logs and archived files from the install metadata (.spack) directory to artifacts now
+        # Copy logs and archived files from the install metadata (.spack) directory to artifacts
         spack_ci.copy_stage_logs_to_artifacts(job_spec, job_log_dir)
         # Clear the stage directory
         spack.stage.purge()
-
 
     # If the installation succeeded and we're running stand-alone tests for
     # the package, run them and copy the output. Failures of any kind should
@@ -598,7 +593,9 @@ If this project does not have public pipelines, you will need to first:
             and job_spec.name in ci_config["broken-tests-packages"]
         )
         if broken_tests:
-            tty.warn("Unable to run stand-alone tests since listed in ci's 'broken-tests-packages'")
+            tty.warn(
+                "Unable to run stand-alone tests since listed in ci's 'broken-tests-packages'"
+            )
             if cdash_handler:
                 msg = "Package is listed in ci's broken-tests-packages"
                 cdash_handler.report_skipped(job_spec, reports_dir, reason=msg)

--- a/lib/spack/spack/cmd/ci.py
+++ b/lib/spack/spack/cmd/ci.py
@@ -11,14 +11,17 @@ from typing import Dict, List
 from urllib.parse import urlparse, urlunparse
 
 import spack.binary_distribution
+import spack.bootstrap
 import spack.ci as spack_ci
 import spack.cmd
 import spack.cmd.common.arguments
+import spack.cmd.install
 import spack.config as cfg
 import spack.environment as ev
 import spack.error
 import spack.fetch_strategy
 import spack.hash_types as ht
+import spack.main
 import spack.mirrors.mirror
 import spack.package_base
 import spack.repo
@@ -41,8 +44,10 @@ section = "build"
 level = "long"
 
 SPACK_COMMAND = "spack"
-INSTALL_FAIL_CODE = 1
+INSTALL_SUCCESS_CODE = 0
 FAILED_CREATE_BUILDCACHE_CODE = 100
+
+install_cmd = spack.main.SpackCommand("install")
 
 
 def deindent(desc):
@@ -462,16 +467,7 @@ def ci_rebuild(args):
 
     # No hash match anywhere means we need to rebuild spec
 
-    # Start with spack arguments
-    spack_cmd = [SPACK_COMMAND, "--color=always", "install"]
-
-    config = cfg.CONFIG.get("config")
-    if not config["verify_ssl"]:
-        spack_cmd.append("-k")
-
-    install_args = [
-        f"--use-buildcache={spack_ci.common.win_quote('package:never,dependencies:only')}"
-    ]
+    install_args = ['--use-buildcache="package:never,dependencies:only"']
 
     can_verify = spack_ci.can_verify_binaries()
     verify_binaries = can_verify and spack_is_pr_pipeline is False
@@ -483,71 +479,131 @@ def ci_rebuild(args):
 
     fail_fast = bool(os.environ.get("SPACK_CI_FAIL_FAST", str(args.fail_fast)))
     if fail_fast:
-        install_args.append("--fail-fast")
+        install_args.append("--fail_fast")
 
-    slash_hash = spack_ci.common.win_quote("/" + job_spec.dag_hash())
+    spec_hash = "/" + job_spec.dag_hash()
 
-    # Arguments when installing the root from sources
-    deps_install_args = install_args + ["--only=dependencies"]
-    root_install_args = install_args + ["--verbose", "--keep-stage", "--only=package"]
+    # Run Bootstrap
+    with spack.bootstrap.ensure_bootstrap_configuration():
+        spack.bootstrap.ensure_core_dependencies()
 
+
+    # TODO: (kwryankrattiger) Reproduce build is currently broken. Suppress the output of these
+    # instructions for now. When the feature is working again move the print to before the
+    # installation is printed to avoid the details be lost to install log truncation.
+    if False:
+        # If the install did not succeed, print out some instructions on how to reproduce this
+        # build failure outside of the pipeline environment.
+        tty.debug("spack install exited non-zero, will not create buildcache")
+
+        api_root_url = os.environ.get("CI_API_V4_URL")
+        ci_project_id = os.environ.get("CI_PROJECT_ID")
+        ci_job_id = os.environ.get("CI_JOB_ID")
+
+        repro_job_url = f"{api_root_url}/projects/{ci_project_id}/jobs/{ci_job_id}/artifacts"
+        # Control characters cause this to be printed in blue so it stands out
+        print(
+            f"""
+
+\033[34mTo reproduce this build locally, run:
+
+    spack ci reproduce-build {repro_job_url} [--working-dir <dir>] [--autostart]
+
+If this project does not have public pipelines, you will need to first:
+
+    export GITLAB_PRIVATE_TOKEN=<generated_token>
+
+... then follow the printed instructions.\033[0;0m
+
+"""
+        )
+
+    # Turn color output on
+    reset_color = clr.get_color_when()
+    clr.set_color_when(True)
+
+    install_exit_code = INSTALL_SUCCESS_CODE
+    tty.debug("Installing dependencies for {0} from cache ".format(job_spec.name))
+    try:
+        # Install deps
+        install_cmd(install_args + ["--only=dependencies", spec_hash])
+    except spack.error.SpackError as e:
+        # If the deps fail to install early exit
+        # Don't try to run tests or push to the cache
+        # Don't add this package to broken-specs list, dependecy install error is not a package error
+        tty.error(f"Failed to install dependencies: {e}")
+        raise
+    finally:
+        # Reset the color mode
+        clr.set_color_when(reset_color)
+
+    # CDash reporting for the current spec
     if cdash_handler:
         # Add additional arguments to `spack install` for CDash reporting.
-        root_install_args.extend(cdash_handler.args())
+        install_args.extend(cdash_handler.args())
+        reports_dir = fs.join_path(os.getcwd(), "cdash_report")
 
-    commands = [
-        # apparently there's a race when spack bootstraps? do it up front once
-        [SPACK_COMMAND, "-e", unicode_escape(env.path), "bootstrap", "now"],
-        spack_cmd + deps_install_args + [slash_hash],
-        spack_cmd + root_install_args + [slash_hash],
-    ]
     tty.debug("Installing {0} from source".format(job_spec.name))
-    install_exit_code = spack_ci.process_command("install", commands, repro_dir)
+    try:
 
-    # Now do the post-install tasks
-    tty.debug("spack install exited {0}".format(install_exit_code))
+        # Install package
+        install_cmd(install_args + ["--verbose", "--keep-stage", "--only=package", spec_hash])
+        tty.debug("spack install succeeded")
+    except spack.error.SpackError as e:
+        # If a spec fails to build in a spack develop pipeline, we add it to a
+        # list of known broken hashes.  This allows spack PR pipelines to
+        # avoid wasting compute cycles attempting to build those hashes.
+        tty.debug("spack install failed")
+        if spack_is_develop_pipeline:
+            tty.debug("Install failed on develop")
+            if "broken-specs-url" in ci_config:
+                broken_specs_url = ci_config["broken-specs-url"]
+                dev_fail_hash = job_spec.dag_hash()
+                broken_spec_path = url_util.join(broken_specs_url, dev_fail_hash)
+                tty.msg("Reporting broken develop build as: {0}".format(broken_spec_path))
+                spack_ci.write_broken_spec(
+                    broken_spec_path,
+                    job_spec_pkg_name,
+                    spack_ci_stack_name,
+                    os.environ.get("CI_JOB_URL"),
+                    os.environ.get("CI_PIPELINE_URL"),
+                    job_spec.to_dict(hash=ht.dag_hash),
+                )
 
-    # If a spec fails to build in a spack develop pipeline, we add it to a
-    # list of known broken hashes.  This allows spack PR pipelines to
-    # avoid wasting compute cycles attempting to build those hashes.
-    if install_exit_code == INSTALL_FAIL_CODE and spack_is_develop_pipeline:
-        tty.debug("Install failed on develop")
-        if "broken-specs-url" in ci_config:
-            broken_specs_url = ci_config["broken-specs-url"]
-            dev_fail_hash = job_spec.dag_hash()
-            broken_spec_path = url_util.join(broken_specs_url, dev_fail_hash)
-            tty.msg("Reporting broken develop build as: {0}".format(broken_spec_path))
-            spack_ci.write_broken_spec(
-                broken_spec_path,
-                job_spec_pkg_name,
-                spack_ci_stack_name,
-                os.environ.get("CI_JOB_URL"),
-                os.environ.get("CI_PIPELINE_URL"),
-                job_spec.to_dict(hash=ht.dag_hash),
-            )
+        # Skip tests
+        tty.warn("Unable to run stand-alone tests due to unsuccessful installation")
+        if cdash_handler:
+            msg = "Failed to install the package"
+            cdash_handler.report_skipped(job_spec, reports_dir, reason=msg)
+            cdash_handler.copy_test_results(reports_dir, job_test_dir)
 
-    # Copy logs and archived files from the install metadata (.spack) directory to artifacts now
-    spack_ci.copy_stage_logs_to_artifacts(job_spec, job_log_dir)
+        # Forward install error
+        raise
 
-    # Clear the stage directory
-    spack.stage.purge()
+    finally:
+        # Reset the color mode
+        clr.set_color_when(reset_color)
+        # Copy logs and archived files from the install metadata (.spack) directory to artifacts now
+        spack_ci.copy_stage_logs_to_artifacts(job_spec, job_log_dir)
+        # Clear the stage directory
+        spack.stage.purge()
+
 
     # If the installation succeeded and we're running stand-alone tests for
     # the package, run them and copy the output. Failures of any kind should
     # *not* terminate the build process or preclude creating the build cache.
-    broken_tests = (
-        "broken-tests-packages" in ci_config
-        and job_spec.name in ci_config["broken-tests-packages"]
-    )
-    reports_dir = fs.join_path(os.getcwd(), "cdash_report")
-    if args.tests and broken_tests:
-        tty.warn("Unable to run stand-alone tests since listed in ci's 'broken-tests-packages'")
-        if cdash_handler:
-            msg = "Package is listed in ci's broken-tests-packages"
-            cdash_handler.report_skipped(job_spec, reports_dir, reason=msg)
-            cdash_handler.copy_test_results(reports_dir, job_test_dir)
-    elif args.tests:
-        if install_exit_code == 0:
+    if args.tests:
+        broken_tests = (
+            "broken-tests-packages" in ci_config
+            and job_spec.name in ci_config["broken-tests-packages"]
+        )
+        if broken_tests:
+            tty.warn("Unable to run stand-alone tests since listed in ci's 'broken-tests-packages'")
+            if cdash_handler:
+                msg = "Package is listed in ci's broken-tests-packages"
+                cdash_handler.report_skipped(job_spec, reports_dir, reason=msg)
+                cdash_handler.copy_test_results(reports_dir, job_test_dir)
+        else:
             try:
                 # First ensure we will use a reasonable test stage directory
                 stage_root = os.path.dirname(str(job_spec.package.stage.path))
@@ -584,72 +640,37 @@ def ci_rebuild(args):
                 else:
                     tty.warn("No recognized test results reporting option")
 
-        else:
-            tty.warn("Unable to run stand-alone tests due to unsuccessful installation")
-            if cdash_handler:
-                msg = "Failed to install the package"
-                cdash_handler.report_skipped(job_spec, reports_dir, reason=msg)
-                cdash_handler.copy_test_results(reports_dir, job_test_dir)
-
-    if install_exit_code == 0:
-        # If the install succeeded, push it to the buildcache destination. Failure to push
-        # will result in a non-zero exit code. Pushing is best-effort.
-        for result in spack_ci.create_buildcache(
-            input_spec=job_spec,
-            destination_mirror_urls=[buildcache_destination.push_url],
-            sign_binaries=spack_ci.can_sign_binaries(),
-        ):
-            if not result.success:
-                install_exit_code = FAILED_CREATE_BUILDCACHE_CODE
-            (tty.msg if result.success else tty.error)(
-                f"{'Pushed' if result.success else 'Failed to push'} "
-                f"{job_spec.format('{name}{@version}{/hash:7}', color=clr.get_color_when())} "
-                f"to {result.url}"
-            )
-
-        # If this is a develop pipeline, check if the spec that we just built is
-        # on the broken-specs list. If so, remove it.
-        if spack_is_develop_pipeline and "broken-specs-url" in ci_config:
-            broken_specs_url = ci_config["broken-specs-url"]
-            just_built_hash = job_spec.dag_hash()
-            broken_spec_path = url_util.join(broken_specs_url, just_built_hash)
-            if web_util.url_exists(broken_spec_path):
-                tty.msg("Removing {0} from the list of broken specs".format(broken_spec_path))
-                try:
-                    web_util.remove_url(broken_spec_path)
-                except Exception as err:
-                    # If there is an S3 error (e.g., access denied or connection
-                    # error), the first non boto-specific class in the exception
-                    # hierarchy is Exception.  Just print a warning and return.
-                    msg = "Error removing {0} from broken specs list: {1}"
-                    tty.warn(msg.format(broken_spec_path, err))
-
-    else:
-        # If the install did not succeed, print out some instructions on how to reproduce this
-        # build failure outside of the pipeline environment.
-        tty.debug("spack install exited non-zero, will not create buildcache")
-
-        api_root_url = os.environ.get("CI_API_V4_URL")
-        ci_project_id = os.environ.get("CI_PROJECT_ID")
-        ci_job_id = os.environ.get("CI_JOB_ID")
-
-        repro_job_url = f"{api_root_url}/projects/{ci_project_id}/jobs/{ci_job_id}/artifacts"
-        # Control characters cause this to be printed in blue so it stands out
-        print(
-            f"""
-
-\033[34mTo reproduce this build locally, run:
-
-    spack ci reproduce-build {repro_job_url} [--working-dir <dir>] [--autostart]
-
-If this project does not have public pipelines, you will need to first:
-
-    export GITLAB_PRIVATE_TOKEN=<generated_token>
-
-... then follow the printed instructions.\033[0;0m
-
-"""
+    # If the install succeeded, push it to the buildcache destination. Failure to push
+    # will result in a non-zero exit code. Pushing is best-effort.
+    for result in spack_ci.create_buildcache(
+        input_spec=job_spec,
+        destination_mirror_urls=[buildcache_destination.push_url],
+        sign_binaries=spack_ci.can_sign_binaries(),
+    ):
+        if not result.success:
+            install_exit_code = FAILED_CREATE_BUILDCACHE_CODE
+        (tty.msg if result.success else tty.error)(
+            f"{'Pushed' if result.success else 'Failed to push'} "
+            f"{job_spec.format('{name}{@version}{/hash:7}', color=clr.get_color_when())} "
+            f"to {result.url}"
         )
+
+    # If this is a develop pipeline, check if the spec that we just built is
+    # on the broken-specs list. If so, remove it.
+    if spack_is_develop_pipeline and "broken-specs-url" in ci_config:
+        broken_specs_url = ci_config["broken-specs-url"]
+        just_built_hash = job_spec.dag_hash()
+        broken_spec_path = url_util.join(broken_specs_url, just_built_hash)
+        if web_util.url_exists(broken_spec_path):
+            tty.msg("Removing {0} from the list of broken specs".format(broken_spec_path))
+            try:
+                web_util.remove_url(broken_spec_path)
+            except Exception as err:
+                # If there is an S3 error (e.g., access denied or connection
+                # error), the first non boto-specific class in the exception
+                # hierarchy is Exception.  Just print a warning and return.
+                msg = "Error removing {0} from broken specs list: {1}"
+                tty.warn(msg.format(broken_spec_path, err))
 
     rebuild_timer.stop()
     try:

--- a/lib/spack/spack/cmd/ci.py
+++ b/lib/spack/spack/cmd/ci.py
@@ -15,7 +15,6 @@ import spack.bootstrap
 import spack.ci as spack_ci
 import spack.cmd
 import spack.cmd.common.arguments
-import spack.cmd.install
 import spack.config as cfg
 import spack.environment as ev
 import spack.error

--- a/lib/spack/spack/cmd/ci.py
+++ b/lib/spack/spack/cmd/ci.py
@@ -525,7 +525,7 @@ If this project does not have public pipelines, you will need to first:
     tty.debug("Installing dependencies for {0} from cache ".format(job_spec.name))
     try:
         # Install deps
-        install_cmd(install_args + ["--only=dependencies", spec_hash])
+        install_cmd(*install_args, "--only=dependencies", spec_hash)
     except spack.error.SpackError as e:
         # If the deps fail to install early exit
         tty.error(f"Failed to install dependencies: {e}")
@@ -543,7 +543,7 @@ If this project does not have public pipelines, you will need to first:
     tty.debug("Installing {0} from source".format(job_spec.name))
     try:
         # Install package
-        install_cmd(install_args + ["--verbose", "--keep-stage", "--only=package", spec_hash])
+        install_cmd(*install_args, "--verbose", "--keep-stage", "--only=package", spec_hash)
         tty.debug("spack install succeeded")
     except spack.error.SpackError:
         # If a spec fails to build in a spack develop pipeline, we add it to a

--- a/lib/spack/spack/cmd/ci.py
+++ b/lib/spack/spack/cmd/ci.py
@@ -466,7 +466,7 @@ def ci_rebuild(args):
 
     # No hash match anywhere means we need to rebuild spec
 
-    install_args = ['--use-buildcache="package:never,dependencies:only"']
+    install_args = ["--use-buildcache", "package:never,dependencies:only"]
 
     can_verify = spack_ci.can_verify_binaries()
     verify_binaries = can_verify and spack_is_pr_pipeline is False
@@ -478,7 +478,7 @@ def ci_rebuild(args):
 
     fail_fast = bool(os.environ.get("SPACK_CI_FAIL_FAST", str(args.fail_fast)))
     if fail_fast:
-        install_args.append("--fail_fast")
+        install_args.append("--fail-fast")
 
     spec_hash = "/" + job_spec.dag_hash()
 
@@ -524,14 +524,11 @@ If this project does not have public pipelines, you will need to first:
     tty.debug("Installing dependencies for {0} from cache ".format(job_spec.name))
     try:
         # Install deps
-        install_cmd(*install_args, "--only=dependencies", spec_hash)
+        install_cmd(*install_args, "--only=dependencies", spec_hash, capture=False)
     except spack.error.SpackError as e:
         # If the deps fail to install early exit
         tty.error(f"Failed to install dependencies: {e}")
         raise
-    finally:
-        # Reset the color mode
-        clr.set_color_when(reset_color)
 
     # CDash reporting for the current spec
     if cdash_handler:
@@ -542,7 +539,9 @@ If this project does not have public pipelines, you will need to first:
     tty.debug("Installing {0} from source".format(job_spec.name))
     try:
         # Install package
-        install_cmd(*install_args, "--verbose", "--keep-stage", "--only=package", spec_hash)
+        install_cmd(
+            *install_args, "--verbose", "--keep-stage", "--only=package", spec_hash, capture=False
+        )
         tty.debug("spack install succeeded")
     except spack.error.SpackError:
         # If a spec fails to build in a spack develop pipeline, we add it to a
@@ -603,7 +602,7 @@ If this project does not have public pipelines, you will need to first:
             try:
                 # First ensure we will use a reasonable test stage directory
                 stage_root = os.path.dirname(str(job_spec.package.stage.path))
-                test_stage = fs.join_path(stage_root, "spack-standalone-tests")
+                test_stage = fs.join_path(stage_root, "spack-stage-standalone-tests")
                 tty.debug("Configuring test_stage to {0}".format(test_stage))
                 config_test_path = "config:test_stage:{0}".format(test_stage)
                 cfg.CONFIG.add(config_test_path, scope=cfg.CONFIG.default_modify_scope())
@@ -617,7 +616,6 @@ If this project does not have public pipelines, you will need to first:
                     job_spec=job_spec,
                     fail_fast=fail_fast,
                     log_file=log_file,
-                    repro_dir=repro_dir,
                     timeout=args.timeout,
                 )
 
@@ -635,6 +633,8 @@ If this project does not have public pipelines, you will need to first:
                     spack_ci.copy_files_to_artifacts(log_file, job_test_dir)
                 else:
                     tty.warn("No recognized test results reporting option")
+
+                spack.stage.purge()
 
     # If the install succeeded, push it to the buildcache destination. Failure to push
     # will result in a non-zero exit code. Pushing is best-effort.

--- a/lib/spack/spack/test/ci.py
+++ b/lib/spack/spack/test/ci.py
@@ -12,6 +12,7 @@ import pytest
 import spack.concretize
 import spack.environment as ev
 import spack.error
+import spack.main
 import spack.paths
 import spack.reporters.cdash
 import spack.util.filesystem as fs
@@ -471,24 +472,16 @@ def test_ci_run_standalone_tests_missing_requirements(working_env, config, capfd
     err = capfd.readouterr()[1]
     assert "Job spec is required" in err
 
-    args = {"job_spec": spack.concretize.concretize_one("printing-package")}
-    ci.run_standalone_tests(**args)
-    err = capfd.readouterr()[1]
-    assert "Reproduction directory is required" in err
-
 
 @pytest.mark.not_on_windows("Reliance on bash script not supported on Windows")
 def test_ci_run_standalone_tests_not_installed_junit(
-    tmp_path: pathlib.Path, repro_dir, working_env, mock_test_stage, capfd, monkeypatch
+    tmp_path: pathlib.Path, working_env, mock_test_stage, capfd, monkeypatch
 ):
-    # the generated test script runs `spack` from PATH
-    monkeypatch.setenv("PATH", f"{spack.paths.bin_path}{os.pathsep}{os.environ['PATH']}")
     log_file = tmp_path / "junit.xml"
 
     ci.run_standalone_tests(
         log_file=str(log_file),
         job_spec=spack.concretize.concretize_one("printing-package"),
-        repro_dir=str(repro_dir),
         fail_fast=True,
     )
     err = capfd.readouterr()[1]
@@ -501,8 +494,6 @@ def test_ci_run_standalone_tests_not_installed_cdash(
     tmp_path: pathlib.Path, repro_dir, working_env, mock_test_stage, capfd, monkeypatch
 ):
     """Test run_standalone_tests with cdash and related options."""
-    # the generated test script runs `spack` from PATH
-    monkeypatch.setenv("PATH", f"{spack.paths.bin_path}{os.pathsep}{os.environ['PATH']}")
     log_file = tmp_path / "junit.xml"
 
     # Cover when CDash handler provided (with the log file as well)
@@ -519,7 +510,6 @@ def test_ci_run_standalone_tests_not_installed_cdash(
     ci.run_standalone_tests(
         log_file=str(log_file),
         job_spec=spack.concretize.concretize_one("printing-package"),
-        repro_dir=str(repro_dir),
         cdash=handler,
     )
     out = capfd.readouterr()[0]

--- a/lib/spack/spack/test/ci.py
+++ b/lib/spack/spack/test/ci.py
@@ -12,7 +12,6 @@ import pytest
 import spack.concretize
 import spack.environment as ev
 import spack.error
-import spack.main
 import spack.paths
 import spack.reporters.cdash
 import spack.util.filesystem as fs

--- a/lib/spack/spack/test/cmd/ci.py
+++ b/lib/spack/spack/test/cmd/ci.py
@@ -637,14 +637,9 @@ def test_ci_rebuild_mock_success(
     monkeypatch,
     broken_tests,
 ):
-    pkg_name = "archive-files"
+    pkg_name = "simple-standalone-test"
     rebuild_env = create_rebuild_env(tmp_path, pkg_name, broken_tests)
 
-    def _install_echo_cmd(cmd, *args, **kwargs):
-        print("spack install " + " ".join(cmd))
-        return 0
-
-    monkeypatch.setattr(spack.cmd.ci, "install_cmd", _install_echo_cmd)
     # the cdash url in the environment is fake; never upload reports to it
     monkeypatch.setattr(spack.reporters.cdash.CDash, "upload", lambda self, filename: None)
 
@@ -662,7 +657,7 @@ def test_ci_rebuild_mock_success(
             assert "Unable to run stand-alone tests" in out
         else:
             # No installation means no package to test and no test log to copy
-            assert "Cannot copy test logs" in out
+            assert "Testing package " in out
 
 
 def test_ci_rebuild_mock_failure_to_push(
@@ -2275,7 +2270,6 @@ def test_ci_verify_versions_standard_duplicates(
         monkeypatch.setattr(spack.repo, "builtin_repo", lambda: repo)
 
         out = ci_cmd("verify-versions", commits[-3], commits[-4], fail_on_error=False)
-        print(f"'{out}'")
         assert "Validated diff-test@2.1.7" in out
         assert "Invalid checksum found diff-test@2.1.8" in out
 

--- a/lib/spack/spack/test/cmd/ci.py
+++ b/lib/spack/spack/test/cmd/ci.py
@@ -639,6 +639,9 @@ def test_ci_rebuild_mock_success(
 ):
     pkg_name = "simple-standalone-test"
     rebuild_env = create_rebuild_env(tmp_path, pkg_name, broken_tests)
+    broken_spec_path = tmp_path / "working_dir" / "naughty-list" / rebuild_env.root_spec_dag_hash
+    broken_spec_path.parent.mkdir(exist_ok=True)
+    broken_spec_path.write_text("")
 
     # the cdash url in the environment is fake; never upload reports to it
     monkeypatch.setattr(spack.reporters.cdash.CDash, "upload", lambda self, filename: None)
@@ -658,6 +661,42 @@ def test_ci_rebuild_mock_success(
         else:
             # No installation means no package to test and no test log to copy
             assert "Testing package " in out
+
+        assert not broken_spec_path.exists()
+
+
+def test_ci_rebuild_mock_failure(
+    tmp_path: pathlib.Path,
+    working_env,
+    mutable_mock_env_path,
+    install_mockery,
+    mock_fetch,
+    mock_binary_index,
+    monkeypatch,
+):
+    pkg_name = "failing-build"
+    rebuild_env = create_rebuild_env(tmp_path, pkg_name, False)
+
+    # the cdash url in the environment is fake; never upload reports to it
+    monkeypatch.setattr(spack.reporters.cdash.CDash, "upload", lambda self, filename: None)
+
+    with working_dir(rebuild_env.env_dir):
+        activate_rebuild_env(tmp_path, pkg_name, rebuild_env)
+
+        out = ci_cmd("rebuild", "--tests", fail_on_error=False)
+        print(out)
+
+        # We didn"t really run the build so build output file(s) are missing
+        assert "Reporting broken develop build" in out
+        assert "Unable to run stand-alone tests due to unsuccessful installation" in out
+        assert "Unable to copy files" in out
+        assert "No such file or directory" in out
+
+        # Make sure the broken spec is reported
+        # rebuild env is mocked as spack_protected_branch
+        assert (
+            tmp_path / "working_dir" / "naughty-list" / rebuild_env.root_spec_dag_hash
+        ).exists()
 
 
 def test_ci_rebuild_mock_failure_to_push(

--- a/lib/spack/spack/test/cmd/ci.py
+++ b/lib/spack/spack/test/cmd/ci.py
@@ -640,7 +640,11 @@ def test_ci_rebuild_mock_success(
     pkg_name = "archive-files"
     rebuild_env = create_rebuild_env(tmp_path, pkg_name, broken_tests)
 
-    monkeypatch.setattr(spack.cmd.ci, "SPACK_COMMAND", "echo")
+    def _install_echo_cmd(cmd, *args, **kwargs):
+        print("spack install " + " ".join(cmd))
+        return 0
+
+    monkeypatch.setattr(spack.cmd.ci, "install_cmd", _install_echo_cmd)
     # the cdash url in the environment is fake; never upload reports to it
     monkeypatch.setattr(spack.reporters.cdash.CDash, "upload", lambda self, filename: None)
 
@@ -679,7 +683,7 @@ def test_ci_rebuild_mock_failure_to_push(
     def mock_success(*args, **kwargs):
         return 0
 
-    monkeypatch.setattr(ci, "process_command", mock_success)
+    monkeypatch.setattr(spack.cmd.ci, "install_cmd", mock_success)
 
     # Mock failure to push to the build cache
     def mock_push_or_raise(*args, **kwargs):


### PR DESCRIPTION
Convert from writing and calling a script to using internal commands directly.

- Avoids some of the errors around argument quoting/escaping that arise on windows
- Improve error handling around when the install command fails (bootstrap vs dependency install vs source build)
- Testing and execution when running install from the `spack ci rebuild` command is now more straight forward as the indirection is not gone.
- Fixes a bug when running unit tests tests with `pytest` and `spack` is not in the `PATH`. (reported by @haampie)


**Note**: The only reason CI was writing and `install.sh|ps1` file for the install commands was to facilitate `spack ci reproduce-build`. The reproduce build functionality is current broken and is going to require a re-write. The re-write for that command will come later and will not rely on the install.* script as a build artifact.