### PR TITLE
argparsewriter.py: hide argparse.SUPPRESS args

### DIFF
--- a/lib/spack/spack/cmd/commands.py
+++ b/lib/spack/spack/cmd/commands.py
@@ -9,7 +9,7 @@ import re
 import shlex
 import sys
 from argparse import ArgumentParser, Namespace
-from typing import IO, Any, Callable, Dict, Iterable, List, Optional, Sequence, Set, Tuple, Union
+from typing import IO, Any, Callable, Dict, List, Optional, Sequence, Set, Union
 
 import spack.cmd
 import spack.config
@@ -18,7 +18,14 @@ import spack.paths
 import spack.platforms
 from spack.main import SpackArgumentParser, section_descriptions
 from spack.util import tty
-from spack.util.argparsewriter import ArgparseRstWriter, ArgparseWriter, Command
+from spack.util.argparsewriter import (
+    ArgparseRstWriter,
+    ArgparseWriter,
+    Command,
+    Option,
+    Positional,
+    Subcommand,
+)
 from spack.util.tty.colify import colify
 
 description = "list available spack commands"
@@ -196,18 +203,12 @@ class BashCompletionWriter(ArgparseWriter):
         assert not (cmd.positionals and cmd.subcommands)  # one or the other
 
         # We only care about the arguments/flags, not the help messages
-        positionals = cmd.positionals or ()
-        optionals, _, _, _, _ = zip(*cmd.optionals)
-        subcommands: Tuple[str, ...] = ()
-        if cmd.subcommands:
-            _, subcommands, _ = zip(*cmd.subcommands)
-
-        # Flatten lists of lists
-        optionals = [x for xx in optionals for x in xx]
+        flags = [flag for option in cmd.optionals for flag in option.flags]
+        subcommands = [subcommand.name for subcommand in cmd.subcommands]
 
         return (
             self.start_function(cmd.prog)
-            + self.body(positionals, optionals, subcommands)
+            + self.body(cmd.positionals, flags, subcommands)
             + self.end_function(cmd.prog)
         )
 
@@ -235,14 +236,17 @@ class BashCompletionWriter(ArgparseWriter):
         return "}\n"
 
     def body(
-        self, positionals: Sequence, optionals: Sequence[str], subcommands: Sequence[str]
+        self,
+        positionals: Sequence[Positional],
+        optionals: Sequence[str],
+        subcommands: Sequence[str],
     ) -> str:
         """Return the body of the function.
 
         Args:
-            positionals: List of positional argument tuples (name, choices, nargs, help).
-            optionals: List of optional arguments.
-            subcommands: List of subcommand parsers.
+            positionals: List of positional arguments.
+            optionals: List of option flags.
+            subcommands: List of subcommand names.
 
         Returns:
             Function body.
@@ -270,22 +274,23 @@ class BashCompletionWriter(ArgparseWriter):
     {self.optionals(optionals)}
 """
 
-    def positionals(self, positionals: Sequence) -> str:
+    def positionals(self, positionals: Sequence[Positional]) -> str:
         """Return the syntax for reporting positional arguments.
 
         Args:
-            positionals: List of positional argument tuples (name, choices, nargs, help).
+            positionals: List of positional arguments.
 
         Returns:
             Syntax for positional arguments.
         """
-        for name, choices, nargs, help in positionals:
+        for positional in positionals:
             # Check for a predefined subroutine mapping
             for key, value in _positional_to_subroutine.items():
-                if name.startswith(key):
+                if positional.name.startswith(key):
                     return value
 
             # Use choices if available
+            choices = positional.choices
             if choices is not None:
                 if isinstance(choices, dict):
                     choices = sorted(choices.keys())
@@ -420,21 +425,13 @@ class FishCompletionWriter(ArgparseWriter):
 
         # We also need help messages and how arguments are used
         # So we pass everything to completion writer
-        positionals = cmd.positionals
-        optionals = cmd.optionals
-        subcommands = cmd.subcommands
-
         return (
             self.prog_comment(cmd.prog)
-            + self.optspecs(cmd.prog, optionals)
-            + self.complete(cmd.prog, positionals, optionals, subcommands)
+            + self.optspecs(cmd.prog, cmd.optionals)
+            + self.complete(cmd.prog, cmd.positionals, cmd.optionals, cmd.subcommands)
         )
 
-    def optspecs(
-        self,
-        prog: str,
-        optionals: List[Tuple[Sequence[str], List[str], str, Union[int, str, None], str]],
-    ) -> str:
+    def optspecs(self, prog: str, optionals: List[Option]) -> str:
         """Read the optionals and return the command to set optspec.
 
         Args:
@@ -453,7 +450,8 @@ class FishCompletionWriter(ArgparseWriter):
         # Build optspec by iterating over options
         args = []
 
-        for flags, dest, _, nargs, _ in optionals:
+        for option in optionals:
+            flags = option.flags
             if len(flags) == 0:
                 continue
 
@@ -462,7 +460,7 @@ class FishCompletionWriter(ArgparseWriter):
             # Because nargs '?' is treated differently in fish, we treat it as required.
             # Because multi-argument options are not supported, we treat it like one argument.
             required = "="
-            if nargs == 0:
+            if option.nargs == 0:
                 required = ""
 
             # Pair short options with long options
@@ -521,9 +519,9 @@ class FishCompletionWriter(ArgparseWriter):
     def complete(
         self,
         prog: str,
-        positionals: List[Tuple[str, Optional[Iterable[Any]], Union[int, str, None], str]],
-        optionals: List[Tuple[Sequence[str], List[str], str, Union[int, str, None], str]],
-        subcommands: List[Tuple[ArgumentParser, str, str]],
+        positionals: List[Positional],
+        optionals: List[Option],
+        subcommands: List[Subcommand],
     ) -> str:
         """Return all the completion commands.
 
@@ -549,11 +547,7 @@ class FishCompletionWriter(ArgparseWriter):
 
         return "".join(commands)
 
-    def positionals(
-        self,
-        prog: str,
-        positionals: List[Tuple[str, Optional[Iterable[Any]], Union[int, str, None], str]],
-    ) -> str:
+    def positionals(self, prog: str, positionals: List[Positional]) -> str:
         """Return the completion for positional arguments.
 
         Args:
@@ -565,7 +559,9 @@ class FishCompletionWriter(ArgparseWriter):
         """
         commands = []
 
-        for idx, (args, choices, nargs, help) in enumerate(positionals):
+        for idx, positional in enumerate(positionals):
+            choices = positional.choices
+
             # Make sure we always get same order of output
             if isinstance(choices, dict):
                 choices = sorted(choices.keys())
@@ -580,14 +576,14 @@ class FishCompletionWriter(ArgparseWriter):
                         valid_choices.append(choice)
                 choices = valid_choices
 
-            head = self.complete_head(prog, idx, nargs)
+            head = self.complete_head(prog, idx, positional.nargs)
 
             if choices is not None:
                 # If there are choices, we provide a completion for all possible values.
                 commands.append(f"{head} -f -a {shlex.quote(' '.join(choices))}")
             else:
                 # Otherwise, we try to find a predefined completion for it
-                value = _fish_dest_get_complete(prog, args)
+                value = _fish_dest_get_complete(prog, positional.name)
                 if value is not None:
                     commands.append(f"{head} {value}")
 
@@ -597,11 +593,7 @@ class FishCompletionWriter(ArgparseWriter):
         """Return a comment line for the command."""
         return f"\n# {prog}\n"
 
-    def optionals(
-        self,
-        prog: str,
-        optionals: List[Tuple[Sequence[str], List[str], str, Union[int, str, None], str]],
-    ) -> str:
+    def optionals(self, prog: str, optionals: List[Option]) -> str:
         """Return the completion for optional arguments.
 
         Args:
@@ -614,7 +606,9 @@ class FishCompletionWriter(ArgparseWriter):
         commands = []
         head = self.complete_head(prog)
 
-        for flags, dest, _, nargs, help in optionals:
+        for option in optionals:
+            dest = option.dest
+
             # Make sure we always get same order of output
             if isinstance(dest, dict):
                 dest = sorted(dest.keys())
@@ -635,7 +629,7 @@ class FishCompletionWriter(ArgparseWriter):
             prefix = head
 
             # Add all flags to the completion
-            for f in flags:
+            for f in option.flags:
                 if f.startswith("--"):
                     long = f[2:]
                     prefix = f"{prefix} -l {long}"
@@ -646,7 +640,7 @@ class FishCompletionWriter(ArgparseWriter):
 
             # Check if option require argument.
             # Currently multi-argument options are not supported, so we treat it like one argument.
-            if nargs != 0:
+            if option.nargs != 0:
                 prefix = f"{prefix} -r"
 
             if dest is not None:
@@ -658,12 +652,12 @@ class FishCompletionWriter(ArgparseWriter):
                 if value is not None:
                     commands.append(f"{prefix} {value}")
 
-            if help:
-                commands.append(f"{prefix} -d {shlex.quote(help)}")
+            if option.help:
+                commands.append(f"{prefix} -d {shlex.quote(option.help)}")
 
         return "\n".join(commands) + "\n"
 
-    def subcommands(self, prog: str, subcommands: List[Tuple[ArgumentParser, str, str]]) -> str:
+    def subcommands(self, prog: str, subcommands: List[Subcommand]) -> str:
         """Return the completion for subcommands.
 
         Args:
@@ -676,11 +670,11 @@ class FishCompletionWriter(ArgparseWriter):
         commands = []
         head = self.complete_head(prog, 0)
 
-        for _, subcommand, help in subcommands:
-            command = f"{head} -f -a {shlex.quote(subcommand)}"
+        for subcommand in subcommands:
+            command = f"{head} -f -a {shlex.quote(subcommand.name)}"
 
-            if help is not None and len(help) > 0:
-                help = help.split("\n")[0]
+            if subcommand.help:
+                help = subcommand.help.split("\n")[0]
                 command = f"{command} -d {shlex.quote(help)}"
 
             commands.append(command)

--- a/lib/spack/spack/test/util/argparsewriter.py
+++ b/lib/spack/spack/test/util/argparsewriter.py
@@ -8,6 +8,9 @@ These tests are fairly minimal, and ArgparseWriter is more extensively
 tested in ``cmd/commands.py``.
 """
 
+import argparse
+import io
+
 import pytest
 
 import spack.main
@@ -17,6 +20,51 @@ parser = spack.main.make_argument_parser()
 spack.main.add_all_commands(parser)
 
 
+class ProgWriter(aw.ArgparseWriter):
+    """Writer that prints the program name of every parser it visits."""
+
+    def format(self, cmd: aw.Command) -> str:
+        return cmd.prog + "\n"
+
+
 def test_format_not_overridden():
     with pytest.raises(TypeError):
         aw.ArgparseWriter("spack")
+
+
+def suppress_parser() -> argparse.ArgumentParser:
+    """Parser with a shown and a hidden argument of every kind."""
+    root = argparse.ArgumentParser(prog="root")
+    root.add_argument("--shown-flag", help="shown")
+    root.add_argument("--hidden-flag", help=argparse.SUPPRESS)
+
+    subparsers = root.add_subparsers()
+    shown = subparsers.add_parser("shown-command", help="shown")
+    subparsers.add_parser("hidden-command", help=argparse.SUPPRESS)
+
+    shown.add_argument("shown_positional", help="shown")
+    shown.add_argument("hidden_positional", help=argparse.SUPPRESS)
+
+    return root
+
+
+def test_suppressed_arguments_not_parsed():
+    """Arguments with suppressed help are left out entirely."""
+    writer = ProgWriter("root")
+    cmd = writer.parse(suppress_parser(), "root")
+
+    flags = [flag for option in cmd.optionals for flag in option.flags]
+    assert "--shown-flag" in flags
+    assert "--hidden-flag" not in flags
+
+    assert [subcommand.name for subcommand in cmd.subcommands] == ["shown-command"]
+
+    sub = writer.parse(cmd.subcommands[0].parser, "shown-command")
+    assert [positional.name for positional in sub.positionals] == ["shown_positional"]
+
+
+def test_suppressed_subcommand_not_written():
+    """Suppressed subcommands are not recursed into."""
+    out = io.StringIO()
+    ProgWriter("root", out=out).write(suppress_parser())
+    assert out.getvalue().splitlines() == ["root", "root shown-command"]

--- a/lib/spack/spack/util/argparsewriter.py
+++ b/lib/spack/spack/util/argparsewriter.py
@@ -118,13 +118,13 @@ class ArgparseWriter(argparse.HelpFormatter, abc.ABC):
         positionals: List[Positional] = []
         subcommands: List[Subcommand] = []
         for action in actions:
+            # arguments hidden from --help are not documented or completed either
+            if action.help == argparse.SUPPRESS:
+                continue
+
             if action.option_strings:
                 dest_flags = fmt._format_action_invocation(action)
-                help = (
-                    self._expand_help(action)
-                    if action.help and action.help != argparse.SUPPRESS
-                    else ""
-                )
+                help = self._expand_help(action) if action.help else ""
                 help = help.split("\n")[0]
 
                 if action.choices is not None:
@@ -137,12 +137,11 @@ class ArgparseWriter(argparse.HelpFormatter, abc.ABC):
                 )
             elif isinstance(action, argparse._SubParsersAction):
                 for subaction in action._choices_actions:
+                    if subaction.help == argparse.SUPPRESS:
+                        continue
+
                     subparser = action._name_parser_map[subaction.dest]
-                    help = (
-                        self._expand_help(subaction)
-                        if subaction.help and action.help != argparse.SUPPRESS
-                        else ""
-                    )
+                    help = self._expand_help(subaction) if subaction.help else ""
                     help = help.split("\n")[0]
                     subcommands.append(Subcommand(subparser, subaction.dest, help))
 
@@ -153,20 +152,10 @@ class ArgparseWriter(argparse.HelpFormatter, abc.ABC):
                             aliases = match.group(2).split(", ")
                             for alias in aliases:
                                 subparser = action._name_parser_map[alias]
-                                help = (
-                                    self._expand_help(subaction)
-                                    if subaction.help and action.help != argparse.SUPPRESS
-                                    else ""
-                                )
-                                help = help.split("\n")[0]
                                 subcommands.append(Subcommand(subparser, alias, help))
             else:
                 name = fmt._format_action_invocation(action)
-                help = (
-                    self._expand_help(action)
-                    if action.help and action.help != argparse.SUPPRESS
-                    else ""
-                )
+                help = self._expand_help(action) if action.help else ""
                 help = help.split("\n")[0]
                 positionals.append(Positional(name, action.choices, action.nargs, help))
 

--- a/lib/spack/spack/util/argparsewriter.py
+++ b/lib/spack/spack/util/argparsewriter.py
@@ -8,10 +8,49 @@ import io
 import re
 import sys
 from argparse import ArgumentParser
-from typing import IO, Any, Iterable, List, Optional, Sequence, Tuple, Union
+from typing import IO, Any, Iterable, List, NamedTuple, Optional, Sequence, Union
 
 
-class Command:
+class Positional(NamedTuple):
+    """A positional argument of a command."""
+
+    #: Name of the argument as it appears in the usage string
+    name: str
+    #: Allowed values, if the argument is restricted to a set of choices
+    choices: Optional[Iterable[Any]]
+    #: Number of values the argument takes
+    nargs: Union[int, str, None]
+    #: First line of the help message
+    help: str
+
+
+class Option(NamedTuple):
+    """An optional argument of a command."""
+
+    #: Flags that select this option, such as ``-h`` and ``--help``
+    flags: Sequence[str]
+    #: Allowed values if the option is restricted to a set of choices, otherwise the destination
+    dest: List[str]
+    #: Flags with their arguments, as they appear in the usage string
+    dest_flags: str
+    #: Number of values the option takes
+    nargs: Union[int, str, None]
+    #: First line of the help message
+    help: str
+
+
+class Subcommand(NamedTuple):
+    """A subcommand of a command."""
+
+    #: Parser of the subcommand
+    parser: ArgumentParser
+    #: Name of the subcommand, which is an alias if the command was reached through one
+    name: str
+    #: First line of the help message
+    help: str
+
+
+class Command(NamedTuple):
     """Parsed representation of a command from argparse.
 
     This is a single command from an argparse parser. ``ArgparseWriter`` creates these and returns
@@ -19,31 +58,18 @@ class Command:
     take an action for a single command.
     """
 
-    def __init__(
-        self,
-        prog: str,
-        description: Optional[str],
-        usage: str,
-        positionals: List[Tuple[str, Optional[Iterable[Any]], Union[int, str, None], str]],
-        optionals: List[Tuple[Sequence[str], List[str], str, Union[int, str, None], str]],
-        subcommands: List[Tuple[ArgumentParser, str, str]],
-    ) -> None:
-        """Initialize a new Command instance.
-
-        Args:
-            prog: Program name.
-            description: Command description.
-            usage: Command usage.
-            positionals: List of positional arguments.
-            optionals: List of optional arguments.
-            subcommands: List of subcommand parsers.
-        """
-        self.prog = prog
-        self.description = description
-        self.usage = usage
-        self.positionals = positionals
-        self.optionals = optionals
-        self.subcommands = subcommands
+    #: Program name.
+    prog: str
+    #: Command description.
+    description: Optional[str]
+    #: Command usage.
+    usage: str
+    #: List of positional arguments.
+    positionals: List[Positional]
+    #: List of optional arguments.
+    optionals: List[Option]
+    #: List of subcommands.
+    subcommands: List[Subcommand]
 
 
 # NOTE: The only reason we subclass argparse.HelpFormatter is to get access to self._expand_help(),
@@ -88,14 +114,12 @@ class ArgparseWriter(argparse.HelpFormatter, abc.ABC):
         usage = fmt._format_usage(None, actions, groups, "").strip()
 
         # Go through actions and split them into optionals, positionals, and subcommands
-        optionals = []
-        positionals = []
-        subcommands = []
+        optionals: List[Option] = []
+        positionals: List[Positional] = []
+        subcommands: List[Subcommand] = []
         for action in actions:
             if action.option_strings:
-                flags = action.option_strings
                 dest_flags = fmt._format_action_invocation(action)
-                nargs = action.nargs
                 help = (
                     self._expand_help(action)
                     if action.help and action.help != argparse.SUPPRESS
@@ -108,7 +132,9 @@ class ArgparseWriter(argparse.HelpFormatter, abc.ABC):
                 else:
                     dest = [action.dest]
 
-                optionals.append((flags, dest, dest_flags, nargs, help))
+                optionals.append(
+                    Option(action.option_strings, dest, dest_flags, action.nargs, help)
+                )
             elif isinstance(action, argparse._SubParsersAction):
                 for subaction in action._choices_actions:
                     subparser = action._name_parser_map[subaction.dest]
@@ -118,7 +144,7 @@ class ArgparseWriter(argparse.HelpFormatter, abc.ABC):
                         else ""
                     )
                     help = help.split("\n")[0]
-                    subcommands.append((subparser, subaction.dest, help))
+                    subcommands.append(Subcommand(subparser, subaction.dest, help))
 
                     # Look for aliases of the form 'name (alias, ...)'
                     if self.aliases and isinstance(subaction.metavar, str):
@@ -133,16 +159,16 @@ class ArgparseWriter(argparse.HelpFormatter, abc.ABC):
                                     else ""
                                 )
                                 help = help.split("\n")[0]
-                                subcommands.append((subparser, alias, help))
+                                subcommands.append(Subcommand(subparser, alias, help))
             else:
-                args = fmt._format_action_invocation(action)
+                name = fmt._format_action_invocation(action)
                 help = (
                     self._expand_help(action)
                     if action.help and action.help != argparse.SUPPRESS
                     else ""
                 )
                 help = help.split("\n")[0]
-                positionals.append((args, action.choices, action.nargs, help))
+                positionals.append(Positional(name, action.choices, action.nargs, help))
 
         return Command(prog, description, usage, positionals, optionals, subcommands)
 
@@ -172,8 +198,8 @@ class ArgparseWriter(argparse.HelpFormatter, abc.ABC):
         cmd = self.parse(parser, prog)
         self.out.write(self.format(cmd))
 
-        for subparser, prog, help in cmd.subcommands:
-            self._write(subparser, prog, level=level + 1)
+        for subcommand in cmd.subcommands:
+            self._write(subcommand.parser, subcommand.name, level=level + 1)
 
     def write(self, parser: ArgumentParser) -> None:
         """Write out details about an ArgumentParser.
@@ -231,14 +257,14 @@ class ArgparseRstWriter(ArgparseWriter):
 
         if cmd.positionals:
             string.write(self.begin_positionals())
-            for args, choices, nargs, help in cmd.positionals:
-                string.write(self.positional(args, help))
+            for positional in cmd.positionals:
+                string.write(self.positional(positional.name, positional.help))
             string.write(self.end_positionals())
 
         if cmd.optionals:
             string.write(self.begin_optionals())
-            for flags, dest, dest_flags, nargs, help in cmd.optionals:
-                string.write(self.optional(dest_flags, help))
+            for option in cmd.optionals:
+                string.write(self.optional(option.dest_flags, option.help))
             string.write(self.end_optionals())
 
         if cmd.subcommands:
@@ -356,7 +382,7 @@ class ArgparseRstWriter(ArgparseWriter):
         """
         return ""
 
-    def begin_subcommands(self, subcommands: List[Tuple[ArgumentParser, str, str]]) -> str:
+    def begin_subcommands(self, subcommands: List[Subcommand]) -> str:
         """Table with links to other subcommands.
 
         Arguments:
@@ -373,8 +399,9 @@ class ArgparseRstWriter(ArgparseWriter):
 
 """
 
-        for cmd, _, _ in subcommands:
-            prog = re.sub(r"^[^ ]* ", "", cmd.prog)
-            string += "   * :ref:`{0} <{1}>`\n".format(prog, cmd.prog.replace(" ", "-"))
+        for subcommand in subcommands:
+            full_prog = subcommand.parser.prog
+            prog = re.sub(r"^[^ ]* ", "", full_prog)
+            string += "   * :ref:`{0} <{1}>`\n".format(prog, full_prog.replace(" ", "-"))
 
         return string + "\n"

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -394,7 +394,7 @@ SPACK_ALIASES="concretise:concretize;containerise:containerize;rm:remove"
 _spack() {
     if $list_options
     then
-        SPACK_COMPREPLY="--color -v --verbose -k --insecure -b --bootstrap -V --version -h --help -H --all-help -c --config -C --config-scope -e --env -D --env-dir -E --no-env --use-env-repo -d --debug -t --backtrace --pdb --timestamp -m --mock --print-shell-vars --stacktrace -l --enable-locks -L --disable-locks -p --profile --profile-file --sorted-profile --lines"
+        SPACK_COMPREPLY="--color -v --verbose -k --insecure -b --bootstrap -V --version -h --help -H --all-help -c --config -C --config-scope -e --env -D --env-dir -E --no-env --use-env-repo -d --debug -t --backtrace --timestamp -m --mock --print-shell-vars --stacktrace -l --enable-locks -L --disable-locks"
     else
         SPACK_COMPREPLY="add arch audit blame bootstrap build-env buildcache cd change checksum ci clean commands compiler compilers concretize concretise config containerize containerise create debug deconcretize dependencies dependents deprecate dev-build develop diff docs edit env extensions external fetch find gc gpg graph help info install isolate license list load location log-parse logs maintainers make-installer mark mirror module patch pkg providers pydoc python reindex remove rm repo resource restage solve spec stage style tags test test-env tutorial undevelop uninstall unit-test unload url verify versions view"
     fi
@@ -1298,7 +1298,7 @@ _spack_gpg_list() {
 }
 
 _spack_gpg_init() {
-    SPACK_COMPREPLY="-h --help --from -y --yes-to-all"
+    SPACK_COMPREPLY="-h --help -y --yes-to-all"
 }
 
 _spack_gpg_export() {
@@ -1358,7 +1358,7 @@ _spack_help() {
 _spack_info() {
     if $list_options
     then
-        SPACK_COMPREPLY="-h --help -a --all --by-name --by-when --detectable --maintainers --namespace --no-dependencies --no-variants --no-versions --phases --tags --tests --virtuals --variants-by-name"
+        SPACK_COMPREPLY="-h --help -a --all --by-name --by-when --detectable --maintainers --namespace --no-dependencies --no-variants --no-versions --phases --tags --tests --virtuals"
     else
         _all_packages
     fi
@@ -1367,7 +1367,7 @@ _spack_info() {
 _spack_install() {
     if $list_options
     then
-        SPACK_COMPREPLY="-h --help --only -u --until -p --concurrent-packages -j --jobs --overwrite --fail-fast --keep-prefix --keep-stage --dont-restage --use-cache --no-cache --cache-only --use-buildcache --include-build-deps --no-check-signature --show-log-on-error --source -n --no-checksum -v --verbose --fake --only-concrete --add --no-add --clean --dirty --test --log-format --log-file --help-cdash --cdash-upload-url --cdash-build --cdash-site --cdash-track --cdash-buildstamp -y --yes-to-all -f --force -U --fresh --reuse --fresh-roots --reuse-deps --deprecated"
+        SPACK_COMPREPLY="-h --help --only -u --until -p --concurrent-packages -j --jobs --overwrite --fail-fast --keep-prefix --keep-stage --dont-restage --use-cache --no-cache --cache-only --use-buildcache --include-build-deps --no-check-signature --show-log-on-error --source -n --no-checksum -v --verbose --fake --only-concrete --add --no-add --clean --dirty --test --log-format --log-file --help-cdash -y --yes-to-all -f --force -U --fresh --reuse --fresh-roots --reuse-deps --deprecated"
     else
         _all_packages
     fi
@@ -1424,7 +1424,7 @@ _spack_location() {
 _spack_log_parse() {
     if $list_options
     then
-        SPACK_COMPREPLY="-h --help --show -c --context -p --profile -w --width -j --jobs -t --tail"
+        SPACK_COMPREPLY="-h --help --show -c --context -p --profile -t --tail"
     else
         SPACK_COMPREPLY=""
     fi
@@ -1983,7 +1983,7 @@ _spack_test() {
 _spack_test_run() {
     if $list_options
     then
-        SPACK_COMPREPLY="-h --help --alias --fail-fast --fail-first --externals -x --explicit --keep-stage --log-format --log-file --cdash-upload-url --cdash-build --cdash-site --cdash-track --cdash-buildstamp --help-cdash --timeout --clean --dirty"
+        SPACK_COMPREPLY="-h --help --alias --fail-fast --fail-first --externals -x --explicit --keep-stage --log-format --log-file --help-cdash --timeout --clean --dirty"
     else
         _installed_packages
     fi

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -1491,7 +1491,7 @@ _spack_mirror_destroy() {
 _spack_mirror_add() {
     if $list_options
     then
-        SPACK_COMPREPLY="-h --help --scope --type --autopush --unsigned --signed --view --name -n --s3-access-key-id --s3-access-key-id-variable --s3-access-key-secret-variable --s3-access-token-variable --s3-profile --s3-endpoint-url --oci-username --oci-username-variable --oci-password-variable"
+        SPACK_COMPREPLY="-h --help --scope --type --autopush --unsigned --signed --view --s3-access-key-id --s3-access-key-id-variable --s3-access-key-secret-variable --s3-access-token-variable --s3-profile --s3-endpoint-url --oci-username --oci-username-variable --oci-password-variable"
     else
         _mirrors
     fi

--- a/share/spack/spack-completion.fish
+++ b/share/spack/spack-completion.fish
@@ -346,7 +346,7 @@ complete -c spack --erase
 # Everything below here is auto-generated.
 
 # spack
-set -g __fish_spack_optspecs_spack color= v/verbose k/insecure b/bootstrap V/version h/help H/all-help c/config= C/config-scope= e/env= D/env-dir= E/no-env use-env-repo d/debug t/backtrace pdb timestamp m/mock print-shell-vars= stacktrace l/enable-locks L/disable-locks p/profile profile-file= sorted-profile= lines=
+set -g __fish_spack_optspecs_spack color= v/verbose k/insecure b/bootstrap V/version h/help H/all-help c/config= C/config-scope= e/env= D/env-dir= E/no-env use-env-repo d/debug t/backtrace timestamp m/mock print-shell-vars= stacktrace l/enable-locks L/disable-locks
 complete -c spack -n '__fish_spack_using_command_pos 0 ' -f -a add -d 'add a spec to an environment'
 complete -c spack -n '__fish_spack_using_command_pos 0 ' -f -a arch -d 'print architecture information about this machine'
 complete -c spack -n '__fish_spack_using_command_pos 0 ' -f -a audit -d 'audit configuration files, packages, etc.'
@@ -458,7 +458,6 @@ complete -c spack -n '__fish_spack_using_command ' -s d -l debug -f -a debug
 complete -c spack -n '__fish_spack_using_command ' -s d -l debug -d 'write out debug messages'
 complete -c spack -n '__fish_spack_using_command ' -s t -l backtrace -f -a backtrace
 complete -c spack -n '__fish_spack_using_command ' -s t -l backtrace -d 'always show backtraces for exceptions'
-complete -c spack -n '__fish_spack_using_command ' -l pdb -f -a pdb
 complete -c spack -n '__fish_spack_using_command ' -l timestamp -f -a timestamp
 complete -c spack -n '__fish_spack_using_command ' -l timestamp -d 'add a timestamp to tty output'
 complete -c spack -n '__fish_spack_using_command ' -s m -l mock -f -a mock
@@ -471,10 +470,6 @@ complete -c spack -n '__fish_spack_using_command ' -s l -l enable-locks -f -a lo
 complete -c spack -n '__fish_spack_using_command ' -s l -l enable-locks -d 'use filesystem locking (default)'
 complete -c spack -n '__fish_spack_using_command ' -s L -l disable-locks -f -a locks
 complete -c spack -n '__fish_spack_using_command ' -s L -l disable-locks -d 'do not use filesystem locking (unsafe)'
-complete -c spack -n '__fish_spack_using_command ' -s p -l profile -f -a spack_profile
-complete -c spack -n '__fish_spack_using_command ' -l profile-file -r -f -a profile_file
-complete -c spack -n '__fish_spack_using_command ' -l sorted-profile -r -f -a sorted_profile
-complete -c spack -n '__fish_spack_using_command ' -l lines -r -f -a lines
 
 # spack add
 set -g __fish_spack_optspecs_spack_add h/help l/list-name=
@@ -2023,10 +2018,9 @@ complete -c spack -n '__fish_spack_using_command gpg list' -l signing -f -a sign
 complete -c spack -n '__fish_spack_using_command gpg list' -l signing -d 'list keys which may be used for signing'
 
 # spack gpg init
-set -g __fish_spack_optspecs_spack_gpg_init h/help from= y/yes-to-all
+set -g __fish_spack_optspecs_spack_gpg_init h/help y/yes-to-all
 complete -c spack -n '__fish_spack_using_command gpg init' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command gpg init' -s h -l help -d 'show this help message and exit'
-complete -c spack -n '__fish_spack_using_command gpg init' -l from -r -f -a import_dir
 complete -c spack -n '__fish_spack_using_command gpg init' -s y -l yes-to-all -f -a yes_to_all
 complete -c spack -n '__fish_spack_using_command gpg init' -s y -l yes-to-all -d 'assume "yes" is the answer to every confirmation request'
 
@@ -2103,7 +2097,7 @@ complete -c spack -n '__fish_spack_using_command help' -l spec -f -a guide
 complete -c spack -n '__fish_spack_using_command help' -l spec -d 'help on the package specification syntax'
 
 # spack info
-set -g __fish_spack_optspecs_spack_info h/help a/all by-name by-when detectable maintainers namespace no-dependencies no-variants no-versions phases tags tests virtuals variants-by-name
+set -g __fish_spack_optspecs_spack_info h/help a/all by-name by-when detectable maintainers namespace no-dependencies no-variants no-versions phases tags tests virtuals
 complete -c spack -n '__fish_spack_using_command_pos_remainder 0 info' -f -k -a '(__fish_spack_specs)'
 complete -c spack -n '__fish_spack_using_command info' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command info' -s h -l help -d 'show this help message and exit'
@@ -2133,10 +2127,9 @@ complete -c spack -n '__fish_spack_using_command info' -l tests -f -a tests
 complete -c spack -n '__fish_spack_using_command info' -l tests -d 'output relevant build-time and stand-alone tests'
 complete -c spack -n '__fish_spack_using_command info' -l virtuals -f -a virtuals
 complete -c spack -n '__fish_spack_using_command info' -l virtuals -d 'output virtual packages'
-complete -c spack -n '__fish_spack_using_command info' -l variants-by-name -f -a by_name
 
 # spack install
-set -g __fish_spack_optspecs_spack_install h/help only= u/until= p/concurrent-packages= j/jobs= overwrite fail-fast keep-prefix keep-stage dont-restage use-cache no-cache cache-only use-buildcache= include-build-deps no-check-signature show-log-on-error source n/no-checksum v/verbose fake only-concrete add no-add clean dirty test= log-format= log-file= help-cdash cdash-upload-url= cdash-build= cdash-site= cdash-track= cdash-buildstamp= y/yes-to-all f/force U/fresh reuse fresh-roots deprecated
+set -g __fish_spack_optspecs_spack_install h/help only= u/until= p/concurrent-packages= j/jobs= overwrite fail-fast keep-prefix keep-stage dont-restage use-cache no-cache cache-only use-buildcache= include-build-deps no-check-signature show-log-on-error source n/no-checksum v/verbose fake only-concrete add no-add clean dirty test= log-format= log-file= help-cdash y/yes-to-all f/force U/fresh reuse fresh-roots deprecated
 complete -c spack -n '__fish_spack_using_command_pos_remainder 0 install' -f -k -a '(__fish_spack_specs)'
 complete -c spack -n '__fish_spack_using_command install' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command install' -s h -l help -d 'show this help message and exit'
@@ -2198,11 +2191,6 @@ complete -c spack -n '__fish_spack_using_command install' -l log-file -r -f -a l
 complete -c spack -n '__fish_spack_using_command install' -l log-file -r -d 'filename for the log file'
 complete -c spack -n '__fish_spack_using_command install' -l help-cdash -f -a help_cdash
 complete -c spack -n '__fish_spack_using_command install' -l help-cdash -d 'show usage instructions for CDash reporting'
-complete -c spack -n '__fish_spack_using_command install' -l cdash-upload-url -r -f -a cdash_upload_url
-complete -c spack -n '__fish_spack_using_command install' -l cdash-build -r -f -a cdash_build
-complete -c spack -n '__fish_spack_using_command install' -l cdash-site -r -f -a cdash_site
-complete -c spack -n '__fish_spack_using_command install' -l cdash-track -r -f -a cdash_track
-complete -c spack -n '__fish_spack_using_command install' -l cdash-buildstamp -r -f -a cdash_buildstamp
 complete -c spack -n '__fish_spack_using_command install' -s y -l yes-to-all -f -a yes_to_all
 complete -c spack -n '__fish_spack_using_command install' -s y -l yes-to-all -d 'assume "yes" is the answer to every confirmation request'
 complete -c spack -n '__fish_spack_using_command install' -s f -l force -f -a concretizer_force
@@ -2319,7 +2307,7 @@ complete -c spack -n '__fish_spack_using_command location' -l first -f -a find_f
 complete -c spack -n '__fish_spack_using_command location' -l first -d 'use the first match if multiple packages match the spec'
 
 # spack log-parse
-set -g __fish_spack_optspecs_spack_log_parse h/help show= c/context= p/profile w/width= j/jobs= t/tail=
+set -g __fish_spack_optspecs_spack_log_parse h/help show= c/context= p/profile t/tail=
 
 complete -c spack -n '__fish_spack_using_command log-parse' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command log-parse' -s h -l help -d 'show this help message and exit'
@@ -2329,8 +2317,6 @@ complete -c spack -n '__fish_spack_using_command log-parse' -s c -l context -r -
 complete -c spack -n '__fish_spack_using_command log-parse' -s c -l context -r -d 'lines of context to show around lines of interest'
 complete -c spack -n '__fish_spack_using_command log-parse' -s p -l profile -f -a profile
 complete -c spack -n '__fish_spack_using_command log-parse' -s p -l profile -d 'print out a profile of time spent in regexes during parse'
-complete -c spack -n '__fish_spack_using_command log-parse' -s w -l width -r -f -a width
-complete -c spack -n '__fish_spack_using_command log-parse' -s j -l jobs -r -f -a jobs
 complete -c spack -n '__fish_spack_using_command log-parse' -s t -l tail -r -f -a tail
 complete -c spack -n '__fish_spack_using_command log-parse' -s t -l tail -r -d 'number of trailing log lines to show (0 to disable)'
 
@@ -3185,7 +3171,7 @@ complete -c spack -n '__fish_spack_using_command test' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command test' -s h -l help -d 'show this help message and exit'
 
 # spack test run
-set -g __fish_spack_optspecs_spack_test_run h/help alias= fail-fast fail-first externals x/explicit keep-stage log-format= log-file= cdash-upload-url= cdash-build= cdash-site= cdash-track= cdash-buildstamp= help-cdash timeout= clean dirty
+set -g __fish_spack_optspecs_spack_test_run h/help alias= fail-fast fail-first externals x/explicit keep-stage log-format= log-file= help-cdash timeout= clean dirty
 complete -c spack -n '__fish_spack_using_command_pos_remainder 0 test run' -f -a '(__fish_spack_installed_specs)'
 complete -c spack -n '__fish_spack_using_command test run' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command test run' -s h -l help -d 'show this help message and exit'
@@ -3205,11 +3191,6 @@ complete -c spack -n '__fish_spack_using_command test run' -l log-format -r -f -
 complete -c spack -n '__fish_spack_using_command test run' -l log-format -r -d 'format to be used for log files'
 complete -c spack -n '__fish_spack_using_command test run' -l log-file -r -f -a log_file
 complete -c spack -n '__fish_spack_using_command test run' -l log-file -r -d 'filename for the log file'
-complete -c spack -n '__fish_spack_using_command test run' -l cdash-upload-url -r -f -a cdash_upload_url
-complete -c spack -n '__fish_spack_using_command test run' -l cdash-build -r -f -a cdash_build
-complete -c spack -n '__fish_spack_using_command test run' -l cdash-site -r -f -a cdash_site
-complete -c spack -n '__fish_spack_using_command test run' -l cdash-track -r -f -a cdash_track
-complete -c spack -n '__fish_spack_using_command test run' -l cdash-buildstamp -r -f -a cdash_buildstamp
 complete -c spack -n '__fish_spack_using_command test run' -l help-cdash -f -a help_cdash
 complete -c spack -n '__fish_spack_using_command test run' -l help-cdash -d 'show usage instructions for CDash reporting'
 complete -c spack -n '__fish_spack_using_command test run' -l timeout -r -f -a timeout

--- a/share/spack/spack-completion.fish
+++ b/share/spack/spack-completion.fish
@@ -2426,7 +2426,7 @@ complete -c spack -n '__fish_spack_using_command mirror destroy' -l mirror-url -
 complete -c spack -n '__fish_spack_using_command mirror destroy' -l mirror-url -r -d 'find mirror to destroy by url'
 
 # spack mirror add
-set -g __fish_spack_optspecs_spack_mirror_add h/help scope= type= autopush unsigned signed view= n/name= s3-access-key-id= s3-access-key-id-variable= s3-access-key-secret-variable= s3-access-token-variable= s3-profile= s3-endpoint-url= oci-username= oci-username-variable= oci-password-variable=
+set -g __fish_spack_optspecs_spack_mirror_add h/help scope= type= autopush unsigned signed view= s3-access-key-id= s3-access-key-id-variable= s3-access-key-secret-variable= s3-access-token-variable= s3-profile= s3-endpoint-url= oci-username= oci-username-variable= oci-password-variable=
 complete -c spack -n '__fish_spack_using_command_pos 0 mirror add' -f
 complete -c spack -n '__fish_spack_using_command mirror add' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command mirror add' -s h -l help -d 'show this help message and exit'
@@ -2442,7 +2442,6 @@ complete -c spack -n '__fish_spack_using_command mirror add' -l signed -f -a sig
 complete -c spack -n '__fish_spack_using_command mirror add' -l signed -d 'require signing and signature verification when pushing and installing from this build cache'
 complete -c spack -n '__fish_spack_using_command mirror add' -l view -r -f -a view_name
 complete -c spack -n '__fish_spack_using_command mirror add' -l view -r -d 'Name of the index view for a binary mirror'
-complete -c spack -n '__fish_spack_using_command mirror add' -l name -s n -r -f -a view_name
 complete -c spack -n '__fish_spack_using_command mirror add' -l s3-access-key-id -r -f -a s3_access_key_id
 complete -c spack -n '__fish_spack_using_command mirror add' -l s3-access-key-id -r -d 'ID string to use to connect to this S3 mirror'
 complete -c spack -n '__fish_spack_using_command mirror add' -l s3-access-key-id-variable -r -f -a s3_access_key_id_variable


### PR DESCRIPTION
Arguments with suppressed help were left out of help messages, but still
showed up in the generated shell completions and in the command docs.
Skip them entirely and regenerate the completion scripts.

Note: the first commit switches from long tuples to named tuples so the
second commit's tests are readable.