### PR TITLE
pyproject.toml: do not format *.md with ruff

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,10 +60,12 @@ fix = true
 target-version = "py37"
 line-length = 99
 extend-include = ["bin/spack"]
+force-exclude = true
 exclude = [
   "var/spack/environments",
   "lib/spack/spack/vendor",
   "opt/spack",
+  "*.md",
 ]
 src = ["lib"]
 


### PR DESCRIPTION
Ruff 0.16 starts modifying historical CHANGELOG.md code snippets.
Disable all *.md formatting.

Also use `force-exclude` which is useful when using ruff automatically.
