### PR TITLE
Deprecate `spack solve` in favor of `spack spec`

### DIFF
--- a/.github/workflows/bootstrap.yml
+++ b/.github/workflows/bootstrap.yml
@@ -47,7 +47,7 @@ jobs:
           spack config add config:installer:new
           spack bootstrap disable github-actions-v2
           spack bootstrap disable github-actions-v0.6
-          spack solve zlib
+          spack spec --show opt,solutions zlib
           tree ~/.spack/bootstrap/store/
 
   clingo-sources:
@@ -74,7 +74,7 @@ jobs:
           spack bootstrap disable github-actions-v2
           spack bootstrap disable github-actions-v0.6
           export PATH="$(brew --prefix bison)/bin:$(brew --prefix cmake)/bin:$PATH"
-          spack solve zlib
+          spack spec --show opt,solutions zlib
           tree ~/.spack/bootstrap/store/
 
   gnupg-sources:
@@ -100,7 +100,7 @@ jobs:
         run: |
           . share/spack/setup-env.sh
           spack config add config:installer:new
-          spack solve zlib
+          spack spec --show opt,solutions zlib
           spack bootstrap disable github-actions-v2
           spack bootstrap disable github-actions-v0.6
           spack gpg list
@@ -150,7 +150,7 @@ jobs:
               echo "Python $ver not found"
               exit 1
             fi
-            spack solve zlib
+            spack spec --show opt,solutions zlib
           done
           tree ~/.spack/bootstrap/store
       - name: Bootstrap GnuPG
@@ -180,7 +180,7 @@ jobs:
           ./share/spack/setup-env.ps1
           spack bootstrap disable github-actions-v2
           spack bootstrap disable github-actions-v0.6
-          spack -d solve zlib
+          spack -d spec --show "opt,solutions" zlib
           ./share/spack/qa/validate_last_exit.ps1
           tree $env:userprofile/.spack/bootstrap/store/
       - name: Bootstrap GnuPG

--- a/lib/spack/docs/bootstrapping.rst
+++ b/lib/spack/docs/bootstrapping.rst
@@ -50,7 +50,7 @@ Running a command that concretizes a spec, like:
 
 .. code-block:: console
 
-   % spack solve zlib
+   % spack spec zlib
    ==> Installing "clingo-bootstrap@spack%apple-clang@12.0.0~docs~ipo+python build_type=Release arch=darwin-catalina-x86_64" from a buildcache
    [ ... ]
 

--- a/lib/spack/docs/conf.py
+++ b/lib/spack/docs/conf.py
@@ -369,6 +369,7 @@ nitpick_ignore = [
     ("py:class", "spack.vendor.archspec.cpu.microarchitecture.Microarchitecture"),
     ("py:class", "spack.vendor.jinja2.Environment"),
     ("py:class", "SpecFiltersFactory"),
+    ("py:class", "OutputConfiguration"),  # because it's imported only when TYPE_CHECKING
     ("py:exc", "CoreCompilersNotFoundError"),
     # TypeVar that is not handled correctly
     ("py:class", "spack.util.lang.ClassPropertyType"),

--- a/lib/spack/docs/config_yaml.rst
+++ b/lib/spack/docs/config_yaml.rst
@@ -295,7 +295,7 @@ When set to ``true``, Spack will utilize a cache of solver outputs from successf
 When enabled, Spack will check the concretization cache prior to running the solver.
 If a previous request to solve a given problem is present in the cache, Spack will load the concrete specs and other solver data from the cache rather than running the solver.
 Specs not previously concretized will be added to the cache on a successful solve.
-The cache additionally holds solver statistics, so commands like ``spack solve`` will still return information about the run that produced a given solver result.
+The cache additionally holds solver statistics, so commands like ``spack spec --show opt <spec>`` will still return information about the run that produced a given solver result.
 
 This cache is a subcache of the :ref:`Misc Cache` and as such will be cleaned when the Misc Cache is cleaned.
 

--- a/lib/spack/docs/developer_guide.rst
+++ b/lib/spack/docs/developer_guide.rst
@@ -771,11 +771,11 @@ When working on the ASP-based solver in ``lib/spack/spack/solver/``, it is often
 Generating ASP facts
 ^^^^^^^^^^^^^^^^^^^^
 
-The ``spack solve --show=asp`` flag dumps all ASP facts generated for a given spec to stdout:
+The ``spack spec --show=asp`` flag dumps all ASP facts generated for a given spec to stdout:
 
 .. code-block:: console
 
-   $ spack solve --show=asp zlib-ng > zlib.lp
+   $ spack spec --show=asp zlib-ng > zlib.lp
 
 The resulting file contains both the package facts (versions, variants, dependencies) and the problem-specific facts derived from the user's configuration.
 It can be fed directly to clingo alongside the solver rules.

--- a/lib/spack/docs/frequently_asked_questions.rst
+++ b/lib/spack/docs/frequently_asked_questions.rst
@@ -166,7 +166,7 @@ If it is not obvious *why* the solver made a particular decision -- for example,
 
 .. code-block:: console
 
-   $ spack solve <spec>
+   $ spack spec --show opt,solutions <spec>
 
 The output shows the optimization criteria and the weights assigned to each choice.
 This makes it possible to trace which preference or requirement is driving an unexpected result.

--- a/lib/spack/docs/packages_yaml.rst
+++ b/lib/spack/docs/packages_yaml.rst
@@ -516,7 +516,7 @@ In the example above, that means you could build ``mpich+cuda`` or ``mpich+rocm`
 .. note::
 
    When using a conditional requirement, Spack is allowed to actively avoid the triggering condition (the ``when=...`` spec) if that leads to a concrete spec with better scores in the optimization criteria.
-   To check the current optimization criteria and their priorities you can run ``spack solve zlib``.
+   To check the current optimization criteria and their priorities you can run ``spack spec --show opt,solutions zlib``.
 
 Setting default requirements
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/lib/spack/spack/cmd/__init__.py
+++ b/lib/spack/spack/cmd/__init__.py
@@ -10,7 +10,6 @@ import re
 import subprocess
 import sys
 import textwrap
-from collections import Counter
 from typing import Callable, Container, Generator, List, Optional, Sequence, Union
 
 import spack.concretize
@@ -208,37 +207,9 @@ def _concretize_spec_pairs(
         abstract, concrete = to_concretize[0]
         return [concrete or spack.concretize.concretize_one(abstract, tests=tests)]
 
-    # Special case if every spec is either concrete or has an abstract hash
-    if all(
-        concrete or abstract.concrete or abstract.abstract_hash
-        for abstract, concrete in to_concretize
-    ):
-        # Get all the concrete specs
-        ret = [
-            concrete
-            or (abstract if abstract.concrete else spack.hash_lookup.lookup_hash(abstract))
-            for abstract, concrete in to_concretize
-        ]
-
-        # If unify: true, check that specs don't conflict
-        # Since all concrete, "when_possible" is not relevant
-        if unify is True:  # True, "when_possible", False are possible values
-            runtimes = spack.repo.PATH.packages_with_tags("runtime")
-            specs_per_name = Counter(
-                spec.name
-                for spec in traverse.traverse_nodes(
-                    ret, deptype=("link", "run"), key=traverse.by_dag_hash
-                )
-                if spec.name not in runtimes  # runtimes are allowed multiple times
-            )
-
-            conflicts = sorted(name for name, count in specs_per_name.items() if count > 1)
-            if conflicts:
-                raise spack.error.SpecError(
-                    "Specs conflict and `concretizer:unify` is configured true.",
-                    f"    specs depend on multiple versions of {', '.join(conflicts)}",
-                )
-        return ret
+    all_concrete = spack.concretize.short_circuit_all_concrete()
+    if all_concrete:
+        return all_concrete
 
     # Standard case
     concretize_method = spack.concretize.concretize_separately  # unify: false

--- a/lib/spack/spack/cmd/__init__.py
+++ b/lib/spack/spack/cmd/__init__.py
@@ -207,7 +207,7 @@ def _concretize_spec_pairs(
         abstract, concrete = to_concretize[0]
         return [concrete or spack.concretize.concretize_one(abstract, tests=tests)]
 
-    all_concrete = spack.concretize.short_circuit_all_concrete()
+    all_concrete = spack.concretize.short_circuit_all_concrete(to_concretize)
     if all_concrete:
         return all_concrete
 

--- a/lib/spack/spack/cmd/__init__.py
+++ b/lib/spack/spack/cmd/__init__.py
@@ -17,9 +17,7 @@ import spack.config
 import spack.environment as ev
 import spack.error
 import spack.extensions
-import spack.hash_lookup
 import spack.paths
-import spack.repo
 import spack.spec
 import spack.spec_parser
 import spack.store

--- a/lib/spack/spack/cmd/solve.py
+++ b/lib/spack/spack/cmd/solve.py
@@ -1,225 +1,25 @@
 # Copyright Spack Project Developers. See COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
-
 import argparse
-import re
-import sys
+import warnings
 
-import spack
-import spack.binary_distribution
-import spack.cmd
 import spack.cmd.spec
-import spack.config
-import spack.hash_types as ht
-import spack.package_base
-import spack.spec
-from spack.active_environment import active_environment
-from spack.solver import asp
-from spack.util import tty
-from spack.util.tty import color
 
 description = "concretize a specs using an ASP solver"
 section = "developer"
 level = "long"
 
 
-#: output options
-show_options = ("asp", "opt", "output", "solutions")
-
-
 def setup_parser(subparser: argparse.ArgumentParser) -> None:
-    # Solver arguments
-    subparser.add_argument(
-        "--show",
-        action="store",
-        default="opt,solutions",
-        help="select outputs\n\ncomma-separated list of:\n"
-        "  asp          asp program text\n"
-        "  opt          optimization criteria for best model\n"
-        "  output       raw clingo output\n"
-        "  solutions    models found by asp program\n"
-        "  all          all of the above",
-    )
-    subparser.add_argument(
-        "--timers",
-        action="store_true",
-        default=False,
-        help="print out timers for different solve phases",
-    )
-    subparser.add_argument(
-        "--stats", action="store_true", default=False, help="print out statistics from clingo"
-    )
-
     spack.cmd.spec.setup_parser(subparser)
 
 
-def _process_result(result, show, required_format, kwargs):
-    opt, _, _ = min(result.answers)
-    if ("opt" in show) and (not required_format):
-        tty.msg("Best of %d considered solutions." % result.nmodels)
-
-        print()
-        maxlen = max(len(s.name) for s in result.criteria)
-        color.cprint("@*{  Priority  Value  Criterion}")
-
-        # Width of a data row past its 2-space indent, matching the row format below:
-        # 8-wide priority + 2 gap + 5-wide value + 2 gap + maxlen-wide criterion name.
-        divider_width = 8 + 2 + 5 + 2 + maxlen
-        prev_band = None
-
-        for i, criterion in enumerate(result.criteria, 1):
-            # Criteria are grouped into priority bands; print a header when the band changes.
-            band = criterion.band
-            if band != prev_band:
-                label = f"-- {band}"
-                dashes = "-" * max(0, divider_width - len(label) - 1)
-                color.cprint(f"  @*{{{label}}} @K{{{dashes}}}")
-                prev_band = band
-
-            value = f"@K{{{criterion.value:>5}}}"
-            grey_out = True
-            if criterion.value > 0:
-                value = f"@*{{{criterion.value:>5}}}"
-                grey_out = False
-
-            if grey_out:
-                lc = "@K"
-            elif criterion.kind == asp.OptimizationKind.CONCRETE:
-                lc = "@b"
-            elif criterion.kind == asp.OptimizationKind.BUILD:
-                lc = "@g"
-            else:
-                lc = "@y"
-
-            color.cprint(f"  @K{{{i:8}}}  {value}  {lc}{{{criterion.name:<{maxlen}}}}")
-        print()
-        print()
-        color.cprint("  @*{Legend:}")
-        color.cprint("    @g{Specs to be built}")
-        color.cprint("    @b{Reused specs}")
-        color.cprint("    @y{Other criteria}")
-        print()
-
-    # dump the solutions as concretized specs
-    if "solutions" in show:
-        if required_format:
-            for spec in result.specs:
-                # With -y, just print YAML to output.
-                if required_format == "yaml":
-                    # use write because to_yaml already has a newline.
-                    sys.stdout.write(spec.to_yaml(hash=ht.dag_hash))
-                elif required_format == "json":
-                    sys.stdout.write(spec.to_json(hash=ht.dag_hash))
-                else:
-                    print(spec.format(required_format))
-        else:
-            tree_str = spack.spec.tree(
-                result.specs, color=color.get_color_when(sys.stdout), **kwargs
-            )
-            sys.stdout.write(tree_str)
-        print()
-
-    if result.unsolved_specs and "solutions" in show:
-        tty.msg(asp.Result.format_unsolved(result.unsolved_specs))
-
-
 def solve(parser, args):
-    # these are the same options as `spack spec`
-    fmt = spack.spec.DISPLAY_FORMAT
-    if args.namespaces:
-        fmt = "{namespace}." + fmt
+    msg = (
+        "The `spack solve` command is deprecated in favor of options added to the "
+        "`spack spec` command and will be removed in Spack v1.4"
+    )
+    warnings.warn(msg)
 
-    show_status = args.install_status
-    if show_status:
-        spack.binary_distribution.load_buildcache_index()
-        status_fn = spack.cmd.buildcache_status_fn(spack.binary_distribution.BINARY_INDEX)
-    else:
-        status_fn = None
-
-    kwargs = {
-        "cover": args.cover,
-        "format": fmt,
-        "hashlen": None if args.very_long else 7,
-        "show_types": args.types,
-        "status_fn": status_fn,
-        "hashes": args.long or args.very_long,
-        "version_style_fn": (
-            spack.package_base.non_preferred_version if args.non_defaults else None
-        ),
-        "variant_style_fn": (
-            spack.package_base.non_default_variant if args.non_defaults else None
-        ),
-    }
-
-    # process output options
-    show = re.split(r"\s*,\s*", args.show)
-    if "all" in show:
-        show = show_options
-    for d in show:
-        if d not in show_options:
-            raise ValueError(
-                "Invalid option for '--show': '%s'\nchoose from: (%s)"
-                % (d, ", ".join(show_options + ("all",)))
-            )
-
-    # Format required for the output (JSON, YAML or None)
-    required_format = args.format
-
-    # If we have an active environment, pick the specs from there
-    env = active_environment()
-    if args.specs:
-        specs = spack.cmd.parse_specs(args.specs)
-    elif env:
-        specs = list(env.user_specs)
-    else:
-        args.subparser.error("requires at least one spec or an active environment")
-
-    solver = asp.Solver()
-    output = sys.stdout if "asp" in show else None
-    setup_only = set(show) == {"asp"}
-    unify = spack.config.CONFIG.get("concretizer:unify")
-    allow_deprecated = spack.config.CONFIG.get("config:deprecated", False)
-    if unify == "when_possible":
-        for idx, result in enumerate(
-            solver.solve_in_rounds(
-                specs,
-                out=output,
-                timers=args.timers,
-                stats=args.stats,
-                allow_deprecated=allow_deprecated,
-            )
-        ):
-            if "solutions" in show:
-                tty.msg("ROUND {0}".format(idx))
-                tty.msg("")
-            else:
-                print("% END ROUND {0}\n".format(idx))
-            if not setup_only:
-                _process_result(result, show, required_format, kwargs)
-    elif unify:
-        # set up solver parameters
-        # Note: reuse and other concretizer prefs are passed as configuration
-        result = solver.solve(
-            specs,
-            out=output,
-            timers=args.timers,
-            stats=args.stats,
-            setup_only=setup_only,
-            allow_deprecated=allow_deprecated,
-        )
-        if not setup_only:
-            _process_result(result, show, required_format, kwargs)
-    else:
-        for spec in specs:
-            tty.msg("SOLVING SPEC:", spec)
-            result = solver.solve(
-                [spec],
-                out=output,
-                timers=args.timers,
-                stats=args.stats,
-                setup_only=setup_only,
-                allow_deprecated=allow_deprecated,
-            )
-            if not setup_only:
-                _process_result(result, show, required_format, kwargs)
+    spack.cmd.spec.spec(parser, args)

--- a/lib/spack/spack/cmd/spec.py
+++ b/lib/spack/spack/cmd/spec.py
@@ -10,6 +10,7 @@ from typing import List, Optional
 import spack
 import spack.binary_distribution
 import spack.cmd
+import spack.concretize
 import spack.config
 import spack.environment as ev
 import spack.hash_types as ht

--- a/lib/spack/spack/cmd/spec.py
+++ b/lib/spack/spack/cmd/spec.py
@@ -5,11 +5,13 @@
 import argparse
 import re
 import sys
+from typing import List, Optional
 
 import spack
 import spack.binary_distribution
 import spack.cmd
 import spack.config
+import spack.environment as ev
 import spack.hash_types as ht
 import spack.package_base
 import spack.spec
@@ -17,7 +19,6 @@ from spack.active_environment import active_environment
 from spack.cmd.common import arguments
 from spack.solver import asp
 from spack.util import tty
-from spack.util.tty import color
 
 description = "show what would be installed, given a spec"
 section = "build"
@@ -103,74 +104,70 @@ for further documentation regarding the spec syntax, see:
     )
 
 
-def _process_result(result, show, required_format, kwargs):
-    opt, _, _ = min(result.answers)
-    if ("opt" in show) and (not required_format):
-        tty.msg("Best of %d considered solutions." % result.nmodels)
-
-        print()
-        maxlen = max(len(s.name) for s in result.criteria)
-        color.cprint("@*{  Priority  Value  Criterion}")
-
-        # Width of a data row past its 2-space indent, matching the row format below:
-        # 8-wide priority + 2 gap + 5-wide value + 2 gap + maxlen-wide criterion name.
-        divider_width = 8 + 2 + 5 + 2 + maxlen
-        prev_band = None
-
-        for i, criterion in enumerate(result.criteria, 1):
-            # Criteria are grouped into priority bands; print a header when the band changes.
-            band = criterion.band
-            if band != prev_band:
-                label = f"-- {band}"
-                dashes = "-" * max(0, divider_width - len(label) - 1)
-                color.cprint(f"  @*{{{label}}} @K{{{dashes}}}")
-                prev_band = band
-
-            value = f"@K{{{criterion.value:>5}}}"
-            grey_out = True
-            if criterion.value > 0:
-                value = f"@*{{{criterion.value:>5}}}"
-                grey_out = False
-
-            if grey_out:
-                lc = "@K"
-            elif criterion.kind == asp.OptimizationKind.CONCRETE:
-                lc = "@b"
-            elif criterion.kind == asp.OptimizationKind.BUILD:
-                lc = "@g"
+def _display_specs(specs: List[spack.spec.Spec], required_format: Optional[str], kwargs) -> None:
+    """Print concrete specs in the requested format (tree by default)."""
+    if required_format:
+        for spec in specs:
+            # With -y, just print YAML to output.
+            if required_format == "yaml":
+                # use write because to_yaml already has a newline.
+                sys.stdout.write(spec.to_yaml(hash=ht.dag_hash))
+            elif required_format == "json":
+                sys.stdout.write(spec.to_json(hash=ht.dag_hash))
             else:
-                lc = "@y"
+                print(spec.format(required_format))
+    else:
+        tree_str = spack.spec.tree(specs, color=sys.stdout.isatty(), **kwargs)
+        sys.stdout.write(tree_str)
+    print()
 
-            color.cprint(f"  @K{{{i:8}}}  {value}  {lc}{{{criterion.name:<{maxlen}}}}")
-        print()
-        print()
-        color.cprint("  @*{Legend:}")
-        color.cprint("    @g{Specs to be built}")
-        color.cprint("    @b{Reused specs}")
-        color.cprint("    @y{Other criteria}")
-        print()
+
+def _process_result(result, show, required_format, kwargs):
+    if ("opt" in show) and (not required_format):
+        result.show_criteria()
 
     # dump the solutions as concretized specs
     if "solutions" in show:
-        if required_format:
-            for spec in result.specs:
-                # With -y, just print YAML to output.
-                if required_format == "yaml":
-                    # use write because to_yaml already has a newline.
-                    sys.stdout.write(spec.to_yaml(hash=ht.dag_hash))
-                elif required_format == "json":
-                    sys.stdout.write(spec.to_json(hash=ht.dag_hash))
-                else:
-                    print(spec.format(required_format))
-        else:
-            tree_str = spack.spec.tree(
-                result.specs, color=color.get_color_when(sys.stdout), **kwargs
-            )
-            sys.stdout.write(tree_str)
-        print()
+        _display_specs(result.specs, required_format, kwargs)
 
     if result.unsolved_specs and "solutions" in show:
         tty.msg(asp.Result.format_unsolved(result.unsolved_specs))
+
+
+def _env_spec(env: ev.Environment, args, show, required_format, kwargs) -> None:
+    """Show the environment roots, concretizing only the ones that aren't yet concrete.
+
+    The environment is not modified, in memory or on disk. Solver diagnostics (asp
+    program, optimization criteria, timers, statistics) cover only the new solves.
+    """
+    diagnostics = asp.OutputConfiguration(
+        timers=args.timers,
+        stats=args.stats,
+        out=sys.stdout if "asp" in show else None,
+        setup_only=set(show) == {"asp"},
+        criteria="opt" in show and not required_format,
+    )
+    wants_diagnostics = any(diagnostics)
+
+    # With setup_only nothing concretizes, so we can't use the result to detect a
+    # fully concrete environment; check the roots upfront instead.
+    force = spack.config.CONFIG.get("concretizer:force")
+    already_concrete = {x.root for x in env.concretized_roots}
+    fully_concrete = not force and all(s in already_concrete for s in env.user_specs)
+
+    if wants_diagnostics and fully_concrete:
+        tty.msg(
+            "The environment is already concrete, so there is nothing to solve and no"
+            " solver diagnostics to show. Re-run with --force to see diagnostics for a"
+            " full re-concretization."
+        )
+
+    with env.transient_concretization():
+        env.concretize(output=diagnostics if wants_diagnostics else None)
+        concrete_specs = [concrete for _, concrete in env.concretized_specs()]
+
+    if "solutions" in show and not diagnostics.setup_only:
+        _display_specs(concrete_specs, required_format, kwargs)
 
 
 def spec(parser, args):
@@ -220,7 +217,10 @@ def spec(parser, args):
     if args.specs:
         specs = spack.cmd.parse_specs(args.specs)
     elif env:
-        specs = list(env.user_specs)
+        # Concretize through the environment, so specs that are already concrete
+        # are kept as-is and only new user specs are solved for.
+        _env_spec(env, args, show, required_format, kwargs)
+        return
     else:
         args.subparser.error("requires at least one spec or an active environment")
 

--- a/lib/spack/spack/cmd/spec.py
+++ b/lib/spack/spack/cmd/spec.py
@@ -224,6 +224,16 @@ def spec(parser, args):
     else:
         args.subparser.error("requires at least one spec or an active environment")
 
+    # If we only need the solutions, don't go through the solver if everything is from hashes
+    solutions_only = set(show) == {"solutions"}
+    if solutions_only:
+        all_concrete = spack.concretize.short_circuit_all_concrete(
+            [(s, None) for s in specs]
+        )
+        if all_concrete:
+            _display_specs(all_concrete, required_format, kwargs)
+            return
+
     solver = asp.Solver()
     output = sys.stdout if "asp" in show else None
     setup_only = set(show) == {"asp"}

--- a/lib/spack/spack/cmd/spec.py
+++ b/lib/spack/spack/cmd/spec.py
@@ -130,8 +130,8 @@ def _process_result(result, show, required_format, kwargs):
     if "solutions" in show:
         _display_specs(result.specs, required_format, kwargs)
 
-    if result.unsolved_specs and "solutions" in show:
-        tty.msg(asp.Result.format_unsolved(result.unsolved_specs))
+        if result.unsolved_specs:
+            tty.msg(asp.Result.format_unsolved(result.unsolved_specs))
 
 
 def _env_spec(env: ev.Environment, args, show, required_format, kwargs) -> None:

--- a/lib/spack/spack/cmd/spec.py
+++ b/lib/spack/spack/cmd/spec.py
@@ -3,23 +3,28 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 import argparse
+import re
 import sys
 
 import spack
 import spack.binary_distribution
 import spack.cmd
+import spack.config
 import spack.hash_types as ht
 import spack.package_base
 import spack.spec
-import spack.store
-import spack.traverse
 from spack.active_environment import active_environment
 from spack.cmd.common import arguments
-from spack.util.lang import nullcontext
+from spack.solver import asp
+from spack.util import tty
+from spack.util.tty import color
 
 description = "show what would be installed, given a spec"
 section = "build"
 level = "short"
+
+#: output options
+show_options = ("asp", "opt", "solutions")
 
 
 def setup_parser(subparser: argparse.ArgumentParser) -> None:
@@ -75,21 +80,104 @@ for further documentation regarding the spec syntax, see:
     arguments.add_common_arguments(subparser, ["specs"])
     arguments.add_concretizer_args(subparser)
 
+    # debugging arguments
+    subparser.add_argument(
+        "--show",
+        action="store",
+        default="solutions",
+        help="select outputs\n\ncomma-separated list of:\n"
+        "  asp          asp program text\n"
+        "  opt          optimization criteria for best model\n"
+        "  output       raw clingo output\n"
+        "  solutions    models found by asp program\n"
+        "  all          all of the above",
+    )
+    subparser.add_argument(
+        "--timers",
+        action="store_true",
+        default=False,
+        help="print out timers for different solve phases",
+    )
+    subparser.add_argument(
+        "--stats", action="store_true", default=False, help="print out statistics from clingo"
+    )
+
+
+def _process_result(result, show, required_format, kwargs):
+    opt, _, _ = min(result.answers)
+    if ("opt" in show) and (not required_format):
+        tty.msg("Best of %d considered solutions." % result.nmodels)
+
+        print()
+        maxlen = max(len(s.name) for s in result.criteria)
+        color.cprint("@*{  Priority  Value  Criterion}")
+
+        # Width of a data row past its 2-space indent, matching the row format below:
+        # 8-wide priority + 2 gap + 5-wide value + 2 gap + maxlen-wide criterion name.
+        divider_width = 8 + 2 + 5 + 2 + maxlen
+        prev_band = None
+
+        for i, criterion in enumerate(result.criteria, 1):
+            # Criteria are grouped into priority bands; print a header when the band changes.
+            band = criterion.band
+            if band != prev_band:
+                label = f"-- {band}"
+                dashes = "-" * max(0, divider_width - len(label) - 1)
+                color.cprint(f"  @*{{{label}}} @K{{{dashes}}}")
+                prev_band = band
+
+            value = f"@K{{{criterion.value:>5}}}"
+            grey_out = True
+            if criterion.value > 0:
+                value = f"@*{{{criterion.value:>5}}}"
+                grey_out = False
+
+            if grey_out:
+                lc = "@K"
+            elif criterion.kind == asp.OptimizationKind.CONCRETE:
+                lc = "@b"
+            elif criterion.kind == asp.OptimizationKind.BUILD:
+                lc = "@g"
+            else:
+                lc = "@y"
+
+            color.cprint(f"  @K{{{i:8}}}  {value}  {lc}{{{criterion.name:<{maxlen}}}}")
+        print()
+        print()
+        color.cprint("  @*{Legend:}")
+        color.cprint("    @g{Specs to be built}")
+        color.cprint("    @b{Reused specs}")
+        color.cprint("    @y{Other criteria}")
+        print()
+
+    # dump the solutions as concretized specs
+    if "solutions" in show:
+        if required_format:
+            for spec in result.specs:
+                # With -y, just print YAML to output.
+                if required_format == "yaml":
+                    # use write because to_yaml already has a newline.
+                    sys.stdout.write(spec.to_yaml(hash=ht.dag_hash))
+                elif required_format == "json":
+                    sys.stdout.write(spec.to_json(hash=ht.dag_hash))
+                else:
+                    print(spec.format(required_format))
+        else:
+            tree_str = spack.spec.tree(
+                result.specs, color=color.get_color_when(sys.stdout), **kwargs
+            )
+            sys.stdout.write(tree_str)
+        print()
+
+    if result.unsolved_specs and "solutions" in show:
+        tty.msg(asp.Result.format_unsolved(result.unsolved_specs))
+
 
 def spec(parser, args):
+    # these are the same options as `spack spec`
     fmt = spack.spec.DISPLAY_FORMAT
     if args.namespaces:
         fmt = "{namespace}." + fmt
-
-    env = active_environment()
-
-    if args.specs:
-        concrete_specs = spack.cmd.parse_specs(args.specs, concretize=True)
-    elif env:
-        env.concretize()
-        concrete_specs = env.concrete_roots()
-    else:
-        args.subparser.error("requires at least one spec or an active environment")
 
     show_status = args.install_status
     if show_status:
@@ -98,38 +186,88 @@ def spec(parser, args):
     else:
         status_fn = None
 
-    # use a read transaction if we are getting install status for every
-    # spec in the DAG.  This avoids repeatedly querying the DB.
-    tree_context = spack.store.STORE.db.read_transaction if show_status else nullcontext
+    kwargs = {
+        "cover": args.cover,
+        "format": fmt,
+        "hashlen": None if args.very_long else 7,
+        "show_types": args.types,
+        "status_fn": status_fn,
+        "hashes": args.long or args.very_long,
+        "version_style_fn": (
+            spack.package_base.non_preferred_version if args.non_defaults else None
+        ),
+        "variant_style_fn": (
+            spack.package_base.non_default_variant if args.non_defaults else None
+        ),
+    }
 
-    # With --yaml, --json, or --format, just print the raw specs to output
-    if args.format:
-        for spec in concrete_specs:
-            if args.format == "yaml":
-                # use write because to_yaml already has a newline.
-                sys.stdout.write(spec.to_yaml(hash=ht.dag_hash))
-            elif args.format == "json":
-                print(spec.to_json(hash=ht.dag_hash))
-            else:
-                print(spec.format(args.format))
-        return
-
-    with tree_context():
-        print(
-            spack.spec.tree(
-                concrete_specs,
-                cover=args.cover,
-                format=fmt,
-                hashlen=None if args.very_long else 7,
-                show_types=args.types,
-                status_fn=status_fn,
-                hashes=args.long or args.very_long,
-                key=spack.traverse.by_dag_hash,
-                version_style_fn=(
-                    spack.package_base.non_preferred_version if args.non_defaults else None
-                ),
-                variant_style_fn=(
-                    spack.package_base.non_default_variant if args.non_defaults else None
-                ),
+    # process output options
+    show = re.split(r"\s*,\s*", args.show)
+    if "all" in show:
+        show = show_options
+    for d in show:
+        if d not in show_options:
+            raise ValueError(
+                "Invalid option for '--show': '%s'\nchoose from: (%s)"
+                % (d, ", ".join(show_options + ("all",)))
             )
+
+    # Format required for the output (JSON, YAML or None)
+    required_format = args.format
+
+    # If we have an active environment, pick the specs from there
+    env = active_environment()
+    if args.specs:
+        specs = spack.cmd.parse_specs(args.specs)
+    elif env:
+        specs = list(env.user_specs)
+    else:
+        args.subparser.error("requires at least one spec or an active environment")
+
+    solver = asp.Solver()
+    output = sys.stdout if "asp" in show else None
+    setup_only = set(show) == {"asp"}
+    unify = spack.config.CONFIG.get("concretizer:unify")
+    allow_deprecated = spack.config.CONFIG.get("config:deprecated", False)
+    if unify == "when_possible":
+        for idx, result in enumerate(
+            solver.solve_in_rounds(
+                specs,
+                out=output,
+                timers=args.timers,
+                stats=args.stats,
+                allow_deprecated=allow_deprecated,
+            )
+        ):
+            if "solutions" in show:
+                tty.msg("ROUND {0}".format(idx))
+                tty.msg("")
+            else:
+                print("% END ROUND {0}\n".format(idx))
+            if not setup_only:
+                _process_result(result, show, required_format, kwargs)
+    elif unify:
+        # set up solver parameters
+        # Note: reuse and other concretizer prefs are passed as configuration
+        result = solver.solve(
+            specs,
+            out=output,
+            timers=args.timers,
+            stats=args.stats,
+            setup_only=setup_only,
+            allow_deprecated=allow_deprecated,
         )
+        if not setup_only:
+            _process_result(result, show, required_format, kwargs)
+    else:
+        for spec in specs:
+            result = solver.solve(
+                [spec],
+                out=output,
+                timers=args.timers,
+                stats=args.stats,
+                setup_only=setup_only,
+                allow_deprecated=allow_deprecated,
+            )
+            if not setup_only:
+                _process_result(result, show, required_format, kwargs)

--- a/lib/spack/spack/cmd/spec.py
+++ b/lib/spack/spack/cmd/spec.py
@@ -227,9 +227,7 @@ def spec(parser, args):
     # If we only need the solutions, don't go through the solver if everything is from hashes
     solutions_only = set(show) == {"solutions"}
     if solutions_only:
-        all_concrete = spack.concretize.short_circuit_all_concrete(
-            [(s, None) for s in specs]
-        )
+        all_concrete = spack.concretize.short_circuit_all_concrete([(s, None) for s in specs])
         if all_concrete:
             _display_specs(all_concrete, required_format, kwargs)
             return

--- a/lib/spack/spack/concretize.py
+++ b/lib/spack/spack/concretize.py
@@ -388,7 +388,7 @@ def concretize_one(
     return concretized
 
 
-def short_circuit_all_concrete(to_concretize: List[SpecPairInput]) -> Optional[List[SpecPair]]:
+def short_circuit_all_concrete(to_concretize: List[SpecPairInput]) -> Optional[List[Spec]]:
     unify = spack.config.CONFIG.get("concretizer:unify", False)
 
     if all(
@@ -420,3 +420,4 @@ def short_circuit_all_concrete(to_concretize: List[SpecPairInput]) -> Optional[L
                     f"    specs depend on multiple versions of {comma_and(conflicts)}",
                 )
         return ret
+    return None

--- a/lib/spack/spack/concretize.py
+++ b/lib/spack/spack/concretize.py
@@ -4,9 +4,20 @@
 """High-level functions to concretize list of specs"""
 
 import importlib
+import io
 import sys
 import time
-from typing import TYPE_CHECKING, Dict, Iterable, List, Optional, Sequence, Tuple, Union
+from typing import (
+    TYPE_CHECKING,
+    Dict,
+    Iterable,
+    List,
+    NamedTuple,
+    Optional,
+    Sequence,
+    Tuple,
+    Union,
+)
 
 import spack.compilers
 import spack.compilers.config
@@ -23,7 +34,49 @@ SpecPair = Tuple[Spec, Spec]
 TestsType = Union[bool, Iterable[str]]
 
 if TYPE_CHECKING:
+    from spack.solver.asp import OutputConfiguration
     from spack.solver.reuse import SpecFiltersFactory
+
+
+class _DiagnosticFlags(NamedTuple):
+    """Picklable subset of ``OutputConfiguration`` for solves in worker processes.
+
+    Workers can't share the parent's output streams, so they get these flags, capture
+    diagnostics in a local buffer, and return the captured text with the result.
+    """
+
+    timers: bool = False
+    stats: bool = False
+    criteria: bool = False
+    asp: bool = False
+    setup_only: bool = False
+
+    @staticmethod
+    def from_output(output: Optional["OutputConfiguration"]) -> Optional["_DiagnosticFlags"]:
+        if output is None:
+            return None
+        flags = _DiagnosticFlags(
+            timers=output.timers,
+            stats=output.stats,
+            criteria=output.criteria,
+            asp=output.out is not None,
+            setup_only=output.setup_only,
+        )
+        # all-default flags mean there is nothing to capture
+        return flags if any(flags) else None
+
+    def to_output(self, buffer: io.StringIO) -> "OutputConfiguration":
+        """Build an ``OutputConfiguration`` that captures all diagnostics in ``buffer``."""
+        from spack.solver.asp import OutputConfiguration
+
+        return OutputConfiguration(
+            timers=self.timers,
+            stats=self.stats,
+            criteria=self.criteria,
+            out=buffer if self.asp else None,
+            setup_only=self.setup_only,
+            stream=buffer,
+        )
 
 
 def _concretize_specs_together(
@@ -31,6 +84,7 @@ def _concretize_specs_together(
     *,
     tests: TestsType = False,
     factory: Optional["SpecFiltersFactory"] = None,
+    output: Optional["OutputConfiguration"] = None,
 ) -> List[Spec]:
     """Given a number of specs as input, tries to concretize them together.
 
@@ -39,13 +93,16 @@ def _concretize_specs_together(
         tests: list of package names for which to consider tests dependencies. If True, all nodes
             will have test dependencies. If False, test dependencies will be disregarded.
         factory: optional factory to produce a list of specs to be reused
+        output: optional configuration for solver diagnostics
     """
     from spack.solver.asp import Solver
 
     allow_deprecated = spack.config.CONFIG.get("config:deprecated", False)
     result = Solver(specs_factory=factory).solve(
-        abstract_specs, tests=tests, allow_deprecated=allow_deprecated
+        abstract_specs, tests=tests, allow_deprecated=allow_deprecated, output=output
     )
+    if output is not None and output.setup_only:
+        return []
     return [s.copy() for s in result.specs]
 
 
@@ -54,6 +111,7 @@ def concretize_together(
     *,
     tests: TestsType = False,
     factory: Optional["SpecFiltersFactory"] = None,
+    output: Optional["OutputConfiguration"] = None,
 ) -> List[SpecPair]:
     """Given a number of specs as input, tries to concretize them together.
 
@@ -63,10 +121,14 @@ def concretize_together(
         tests: list of package names for which to consider tests dependencies. If True, all nodes
             will have test dependencies. If False, test dependencies will be disregarded.
         factory: optional factory to produce a list of specs to be reused
+        output: optional configuration for solver diagnostics. With ``setup_only`` no
+            concretization is performed and the result is empty.
     """
     to_concretize = [concrete if concrete else abstract for abstract, concrete in spec_list]
     abstract_specs = [abstract for abstract, _ in spec_list]
-    concrete_specs = _concretize_specs_together(to_concretize, tests=tests, factory=factory)
+    concrete_specs = _concretize_specs_together(
+        to_concretize, tests=tests, factory=factory, output=output
+    )
     return list(zip(abstract_specs, concrete_specs))
 
 
@@ -75,6 +137,7 @@ def concretize_together_when_possible(
     *,
     tests: TestsType = False,
     factory: Optional["SpecFiltersFactory"] = None,
+    output: Optional["OutputConfiguration"] = None,
 ) -> List[SpecPair]:
     """Given a number of specs as input, tries to concretize them together to the extent possible.
 
@@ -87,6 +150,8 @@ def concretize_together_when_possible(
         tests: list of package names for which to consider tests dependencies. If True, all nodes
             will have test dependencies. If False, test dependencies will be disregarded.
         factory: optional factory to produce a list of specs to be reused
+        output: optional configuration for solver diagnostics, applied to every round. With
+            ``setup_only`` only the first round is set up and the result is empty.
     """
     from spack.solver.asp import Solver
 
@@ -100,8 +165,10 @@ def concretize_together_when_possible(
     j = 0
     start = time.monotonic()
     for result in Solver(specs_factory=factory).solve_in_rounds(
-        to_concretize, tests=tests, allow_deprecated=allow_deprecated
+        to_concretize, tests=tests, allow_deprecated=allow_deprecated, output=output
     ):
+        if output is not None and output.setup_only:
+            return []
         now = time.monotonic()
         duration = now - start
         percentage = int((j + 1) / len(to_concretize) * 100)
@@ -128,6 +195,7 @@ def concretize_separately(
     *,
     tests: TestsType = False,
     factory: Optional["SpecFiltersFactory"] = None,
+    output: Optional["OutputConfiguration"] = None,
 ) -> List[SpecPair]:
     """Concretizes the input specs separately from each other.
 
@@ -137,6 +205,10 @@ def concretize_separately(
         tests: list of package names for which to consider tests dependencies. If True, all nodes
             will have test dependencies. If False, test dependencies will be disregarded.
         factory: optional factory to produce a list of specs to be reused
+        output: optional configuration for solver diagnostics. Each solve captures its
+            diagnostics in the worker process; they are printed to ``output.stream`` as
+            results arrive, labeled with the input spec. With ``setup_only`` no
+            concretization is performed and the result is empty.
     """
     from spack.bootstrap import (
         ensure_bootstrap_configuration,
@@ -144,9 +216,10 @@ def concretize_separately(
         ensure_winsdk_external_or_raise,
     )
 
+    diag_flags = _DiagnosticFlags.from_output(output)
     to_concretize = [abstract for abstract, concrete in spec_list if not concrete]
     args = [
-        (i, str(abstract), tests, factory)
+        (i, str(abstract), tests, factory, diag_flags)
         for i, abstract in enumerate(to_concretize)
         if not abstract.concrete
     ]
@@ -190,7 +263,8 @@ def concretize_separately(
         msg += f" pool with {num_procs} processes"
     tty.msg(msg)
 
-    for j, (i, concrete, duration) in enumerate(
+    diag_stream = (output.stream or sys.stdout) if output is not None else sys.stdout
+    for j, (i, concrete, duration, diagnostics) in enumerate(
         spack.util.parallel.imap_unordered(
             _concretize_task,
             args,
@@ -200,6 +274,14 @@ def concretize_separately(
             serialize_env=True,
         )
     ):
+        if diagnostics:
+            # Blocks are captured atomically per solve, so parallel completion can't
+            # interleave lines; they arrive in completion order, hence the spec label.
+            print(f"==> Solve diagnostics for {to_concretize[i].colored_str}", file=diag_stream)
+            diag_stream.write(diagnostics)
+            diag_stream.flush()
+        if concrete is None:  # setup only, no answer to record
+            continue
         ret.append((i, concrete))
         percentage = int((j + 1) / len(args) * 100)
         tty.verbose(
@@ -207,6 +289,9 @@ def concretize_separately(
             f"{to_concretize[i].colored_str}"
         )
         sys.stdout.flush()
+
+    if diag_flags is not None and diag_flags.setup_only:
+        return []
 
     # Add specs in original order
     ret.sort(key=lambda x: x[0])
@@ -217,13 +302,31 @@ def concretize_separately(
 
 
 def _concretize_task(
-    packed_arguments: Tuple[int, str, TestsType, Optional["SpecFiltersFactory"]],
-) -> Tuple[int, Spec, float]:
-    index, spec_str, tests, factory = packed_arguments
+    packed_arguments: Tuple[
+        int, str, TestsType, Optional["SpecFiltersFactory"], Optional[_DiagnosticFlags]
+    ],
+) -> Tuple[int, Optional[Spec], float, str]:
+    index, spec_str, tests, factory, diag_flags = packed_arguments
+    output = None
+    buffer = None
+    if diag_flags is not None:
+        buffer = io.StringIO()
+        output = diag_flags.to_output(buffer)
     with tty.SuppressOutput(msg_enabled=False):
         start = time.time()
-        spec = concretize_one(Spec(spec_str), tests=tests, factory=factory)
-        return index, spec, time.time() - start
+        spec: Optional[Spec] = None
+        if diag_flags is not None and diag_flags.setup_only:
+            # There is no answer to extract, so don't go through concretize_one
+            from spack.solver.asp import Solver
+
+            allow_deprecated = spack.config.CONFIG.get("config:deprecated", False)
+            Solver(specs_factory=factory).solve(
+                [Spec(spec_str)], tests=tests, allow_deprecated=allow_deprecated, output=output
+            )
+        else:
+            spec = concretize_one(Spec(spec_str), tests=tests, factory=factory, output=output)
+        diagnostics = buffer.getvalue() if buffer is not None else ""
+        return index, spec, time.time() - start, diagnostics
 
 
 def concretize_one(
@@ -231,14 +334,21 @@ def concretize_one(
     *,
     tests: TestsType = False,
     factory: Optional["SpecFiltersFactory"] = None,
+    output: Optional["OutputConfiguration"] = None,
 ) -> Spec:
     """Return a concretized copy of the given spec.
 
     Args:
         tests: if False disregard test dependencies, if a list of names activate them for
             the packages in the list, if True activate test dependencies for all packages.
+        factory: optional factory to produce a list of specs to be reused
+        output: optional configuration for solver diagnostics. ``setup_only`` is not
+            supported here since there would be no concrete spec to return.
     """
     from spack.solver.asp import Solver, SpecBuilder
+
+    if output is not None and output.setup_only:
+        raise ValueError("concretize_one does not support setup-only solves")
 
     if isinstance(spec, str):
         spec = Spec(spec)
@@ -255,7 +365,7 @@ def concretize_one(
 
     allow_deprecated = spack.config.CONFIG.get("config:deprecated", False)
     result = Solver(specs_factory=factory).solve(
-        [spec], tests=tests, allow_deprecated=allow_deprecated
+        [spec], tests=tests, allow_deprecated=allow_deprecated, output=output
     )
 
     # take the best answer

--- a/lib/spack/spack/concretize.py
+++ b/lib/spack/spack/concretize.py
@@ -7,6 +7,7 @@ import importlib
 import io
 import sys
 import time
+from collections import Counter
 from typing import (
     TYPE_CHECKING,
     Dict,
@@ -25,9 +26,11 @@ import spack.config
 import spack.error
 import spack.hash_lookup
 import spack.repo
+import spack.traverse as traverse
 import spack.util.parallel
 from spack.spec import Spec
 from spack.util import tty
+from spack.util.string import comma_and
 
 SpecPairInput = Tuple[Spec, Optional[Spec]]
 SpecPair = Tuple[Spec, Spec]
@@ -383,3 +386,37 @@ def concretize_one(
 
     concretized = answer[node]
     return concretized
+
+
+def short_circuit_all_concrete(to_concretize: List[SpecPairInput]) -> Optional[List[SpecPair]]:
+    unify = spack.config.CONFIG.get("concretizer:unify", False)
+
+    if all(
+        concrete or abstract.concrete or abstract.abstract_hash
+        for abstract, concrete in to_concretize
+    ):
+        ret = [
+            concrete
+            or (abstract if abstract.concrete else spack.hash_lookup.lookup_hash(abstract))
+            for abstract, concrete in to_concretize
+        ]
+
+        # If unify: true, check that specs don't conflict
+        # Since all concrete, "when_possible" is not relevant
+        if unify is True:  # True, "when_possible", False are possible values
+            runtimes = spack.repo.PATH.packages_with_tags("runtime")
+            specs_per_name = Counter(
+                spec.name
+                for spec in traverse.traverse_nodes(
+                    ret, deptype=("link", "run"), key=traverse.by_dag_hash
+                )
+                if spec.name not in runtimes  # runtimes are allowed multiple times
+            )
+
+            conflicts = sorted(name for name, count in specs_per_name.items() if count > 1)
+            if conflicts:
+                raise spack.error.SpecError(
+                    "Specs conflict and `concretizer:unify` is configured true.",
+                    f"    specs depend on multiple versions of {comma_and(conflicts)}",
+                )
+        return ret

--- a/lib/spack/spack/environment/environment.py
+++ b/lib/spack/spack/environment/environment.py
@@ -16,10 +16,12 @@ import warnings
 from collections.abc import KeysView
 from itertools import zip_longest
 from typing import (
+    TYPE_CHECKING,
     Any,
     Callable,
     Dict,
     Iterable,
+    Iterator,
     List,
     Mapping,
     Optional,
@@ -66,6 +68,9 @@ from spack.util.lang import ensure_unwrapped, stable_partition
 from spack.util.link_tree import ConflictingSpecsError
 
 from .list import SpecList, SpecListError, SpecListParser
+
+if TYPE_CHECKING:
+    from spack.solver.asp import OutputConfiguration
 
 SpecPair = Tuple[Spec, Spec]
 
@@ -1100,6 +1105,9 @@ class Environment:
         self._previous_active = None
         self._dev_specs = None
 
+        #: When True (set by ``transient_concretization()``), ``write()`` is a no-op
+        self._transient = False
+
         # Load the manifest file contents into memory
         self._load_manifest_file()
 
@@ -1711,8 +1719,60 @@ class Environment:
         if modified_roots:
             self.write()
 
+    def _concrete_state_snapshot(self) -> Dict[str, Any]:
+        """Return a snapshot of the in-memory concrete state of this environment.
+
+        The snapshot contains everything that concretization may modify, copied by value
+        the correct portion of the way down the stack.
+        """
+        return {
+            "concretized_roots": self.concretized_roots[:],
+            "specs_by_hash": self.specs_by_hash.copy(),
+            "included_concrete_spec_data": {
+                env_name: env_data.copy()
+                for env_name, env_data in self.included_concrete_spec_data.items()
+            },
+            "included_specs_by_hash": {
+                env_name: env_by_hash.copy()
+                for env_name, env_by_hash in self.included_specs_by_hash.items()
+            },
+            "included_concretized_roots": {
+                env_name: roots[:] for env_name, roots in self.included_concretized_roots.items()
+            },
+        }
+
+    def _restore_concrete_state(self, snapshot: Dict[str, Any]) -> None:
+        """Restore the in-memory concrete state taken with ``_concrete_state_snapshot``."""
+        self.concretized_roots = snapshot["concretized_roots"]
+        self.specs_by_hash = snapshot["specs_by_hash"]
+        self.included_concrete_spec_data = snapshot["included_concrete_spec_data"]
+        self.included_specs_by_hash = snapshot["included_specs_by_hash"]
+        self.included_concretized_roots = snapshot["included_concretized_roots"]
+
+    @contextlib.contextmanager
+    def transient_concretization(self) -> Iterator["Environment"]:
+        """Context manager within which concretization does not modify this environment.
+
+        Any changes to the in-memory concrete state (e.g. from ``concretize()``) are
+        visible inside the context, and rolled back on exit. ``write()`` is a no-op
+        within the context, so nothing reaches disk either.
+        """
+        snapshot = self._concrete_state_snapshot()
+        # write() also flips ConcretizedRootInfo.new in place on objects shared with the
+        # snapshot; the transient flag makes it a no-op so the snapshot stays intact.
+        self._transient = True
+        try:
+            yield self
+        finally:
+            self._transient = False
+            self._restore_concrete_state(snapshot)
+
     def concretize(
-        self, *, force: Optional[bool] = None, tests: Union[bool, Sequence[str]] = False
+        self,
+        *,
+        force: Optional[bool] = None,
+        tests: Union[bool, Sequence[str]] = False,
+        output: Optional["OutputConfiguration"] = None,
     ) -> Sequence[SpecPair]:
         """Concretize user_specs in this environment.
 
@@ -1726,32 +1786,19 @@ class Environment:
                 defaults to ``spack.config.CONFIG.get("concretizer:force")``
             tests: False to run no tests, True to test all packages, or a list of
                 package names to run tests for some
+            output: optional configuration for solver diagnostics (ASP program, timers,
+                statistics, optimization criteria). Diagnostics cover only the solves
+                performed for specs that were not already concrete.
 
         Returns:
             List of specs that have been concretized. Each entry is a tuple of
             the user spec and the corresponding concretized spec.
         """
-        old_concretized_roots = self.concretized_roots[:]
-        old_specs_by_hash = self.specs_by_hash.copy()
-
-        # This is slightly complicated to pass by value the correct portion of the way
-        # down the stack
-        old_concrete_data = {
-            env_name: env_data.copy()
-            for env_name, env_data in self.included_concrete_spec_data.items()
-        }
-        old_included_by_hash = {
-            env_name: env_by_hash.copy()
-            for env_name, env_by_hash in self.included_specs_by_hash.items()
-        }
-
+        snapshot = self._concrete_state_snapshot()
         try:
-            return EnvironmentConcretizer(self).concretize(force=force, tests=tests)
+            return EnvironmentConcretizer(self).concretize(force=force, tests=tests, output=output)
         except BaseException:
-            self.concretized_roots = old_concretized_roots
-            self.specs_by_hash = old_specs_by_hash
-            self.included_specs_by_hash = old_included_by_hash
-            self.included_concrete_spec_data = old_concrete_data
+            self._restore_concrete_state(snapshot)
             raise
 
     def sync_concretized_specs(self) -> None:
@@ -2503,6 +2550,9 @@ class Environment:
         Args:
             regenerate: regenerate views and run post-write hooks as well as writing if True.
         """
+        if self._transient:
+            tty.debug(f"Skipping write of transient environment {self.name}")
+            return
         self.manifest_uptodate_or_warn()
         if self.specs_by_hash or self.included_concrete_env_root_dirs:
             self.ensure_env_directory_exists(dot_env=True)
@@ -2702,12 +2752,20 @@ class ReusableSpecsFactory:
 
 
 class EnvironmentConcretizer:
-    def __init__(self, env: Environment):
+    def __init__(self, env: Environment, *, output: Optional["OutputConfiguration"] = None):
         self.env = env
+        #: Optional configuration for solver diagnostics
+        self.output = output
 
     def concretize(
-        self, *, force: Optional[bool] = None, tests: Union[bool, Sequence[str]] = False
+        self,
+        *,
+        force: Optional[bool] = None,
+        tests: Union[bool, Sequence[str]] = False,
+        output: Optional["OutputConfiguration"] = None,
     ) -> List[SpecPair]:
+        if output is not None:
+            self.output = output
         if force is None:
             force = spack.config.CONFIG.get("concretizer:force")
         self._prepare_environment_for_concretization(force=force)
@@ -2837,7 +2895,7 @@ class EnvironmentConcretizer:
 
         specs_to_concretize = self._user_spec_pairs(to_compute, to_keep)
         result = spack.concretize.concretize_together_when_possible(
-            specs_to_concretize, tests=tests, factory=factory
+            specs_to_concretize, tests=tests, factory=factory, output=self.output
         )
         result = [x for x in result if x[0] in to_compute]
         for abstract, concrete in result:
@@ -2859,7 +2917,7 @@ class EnvironmentConcretizer:
         to_concretize = self._user_spec_pairs(to_compute, to_keep)
         try:
             concrete_pairs = spack.concretize.concretize_together(
-                to_concretize, tests=tests, factory=factory
+                to_concretize, tests=tests, factory=factory, output=self.output
             )
         except spack.error.UnsatisfiableSpecError as e:
             # "Enhance" the error message for multiple root specs, suggest a less strict
@@ -2897,7 +2955,7 @@ class EnvironmentConcretizer:
 
         to_concretize = [(x, None) for x in to_compute]
         concrete_pairs = spack.concretize.concretize_separately(
-            to_concretize, tests=tests, factory=factory
+            to_concretize, tests=tests, factory=factory, output=self.output
         )
 
         for abstract, concrete in concrete_pairs:

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -71,6 +71,7 @@ from spack.compilers.libraries import CompilerPropertyDetector
 from spack.spec import EMPTY_SPEC
 from spack.util import tty
 from spack.util.lang import elide_list
+from spack.util.tty import color
 
 from .compat import default_clingo_control, make_error_control
 from .core import AspFunction, AspVar, NodeId, SourceContext, extract_args, fn
@@ -89,19 +90,21 @@ class OutputConfiguration(NamedTuple):
     """Data class that contains configuration on what a clingo solve should output."""
 
     #: Print out coarse timers for different solve phases
-    timers: bool
+    timers: bool = False
     #: Whether to output Clingo's internal solver statistics
-    stats: bool
+    stats: bool = False
     #: Optional output stream for the generated ASP program
-    out: Optional[IO[str]]
+    out: Optional[IO[str]] = None
     #: If True, stop after setup and don't solve
-    setup_only: bool
+    setup_only: bool = False
+    #: Whether to print the optimization criteria of the best model
+    criteria: bool = False
+    #: Destination stream for timers, statistics and criteria (defaults to stdout)
+    stream: Optional[IO[str]] = None
 
 
 #: Default output configuration for a solve
-DEFAULT_OUTPUT_CONFIGURATION = OutputConfiguration(
-    timers=False, stats=False, out=None, setup_only=False
-)
+DEFAULT_OUTPUT_CONFIGURATION = OutputConfiguration()
 
 
 # type aliases for the data structures we get back from the solver
@@ -479,6 +482,60 @@ class Result:
             else:
                 msg += "\n\t(No candidate specs from solver)"
         return msg
+
+    def show_criteria(self, stream: Optional[IO[str]] = None) -> None:
+        """Print a table of the optimization criteria for the best model.
+
+        Args:
+            stream: destination stream (defaults to stdout)
+        """
+        stream = stream or sys.stdout
+
+        def cprint(string: str) -> None:
+            color.cprint(string, stream=stream)
+
+        cprint(f"@*b{{==>}} Best of {self.nmodels} considered solutions.")
+        cprint("")
+        maxlen = max(len(s.name) for s in self.criteria)
+        cprint("@*{  Priority  Value  Criterion}")
+
+        # Width of a data row past its 2-space indent, matching the row format below:
+        # 8-wide priority + 2 gap + 5-wide value + 2 gap + maxlen-wide criterion name.
+        divider_width = 8 + 2 + 5 + 2 + maxlen
+        prev_band = None
+
+        for i, criterion in enumerate(self.criteria, 1):
+            # Criteria are grouped into priority bands; print a header when the band changes.
+            band = optimization_band(criterion.priority)
+            if band != prev_band:
+                label = f"-- {band.value}"
+                dashes = "-" * max(0, divider_width - len(label) - 1)
+                cprint(f"  @*{{{label}}} @K{{{dashes}}}")
+                prev_band = band
+
+            value = f"@K{{{criterion.value:>5}}}"
+            grey_out = True
+            if criterion.value > 0:
+                value = f"@*{{{criterion.value:>5}}}"
+                grey_out = False
+
+            if grey_out:
+                lc = "@K"
+            elif criterion.kind == OptimizationKind.CONCRETE:
+                lc = "@b"
+            elif criterion.kind == OptimizationKind.BUILD:
+                lc = "@g"
+            else:
+                lc = "@y"
+
+            cprint(f"  @K{{{i:8}}}  {value}  {lc}{{{criterion.name:<{maxlen}}}}")
+        cprint("")
+        cprint("")
+        cprint("  @*{Legend:}")
+        cprint("    @g{Specs to be built}")
+        cprint("    @b{Reused specs}")
+        cprint("    @y{Other criteria}")
+        cprint("")
 
     def to_dict(self) -> dict:
         """Produces dict representation of Result object
@@ -1146,13 +1203,18 @@ class PyclingoDriver:
         if result.satisfiable and result.unsolved_specs and setup.concretize_everything:
             raise OutputDoesNotSatisfyInputError(result.unsolved_specs)
 
+        stream = output.stream or sys.stdout
+
         if output.timers:
-            timer.write_tty()
-            print()
+            timer.write_tty(out=stream)
+            print(file=stream)
 
         if output.stats:
-            print("Statistics:")
-            pprint.pprint(concretization_stats)
+            print("Statistics:", file=stream)
+            pprint.pprint(concretization_stats, stream=stream)
+
+        if output.criteria:
+            result.show_criteria(stream=stream)
 
         return result, timer, concretization_stats
 
@@ -4006,6 +4068,7 @@ class Solver:
         tests: spack.concretize.TestsType = False,
         setup_only: bool = False,
         allow_deprecated: bool = False,
+        output: Optional[OutputConfiguration] = None,
     ) -> Tuple[Result, Optional[spack.util.timer.Timer], Optional[Dict]]:
         """
         Concretize a set of specs and track the timing and statistics for the solve
@@ -4020,12 +4083,17 @@ class Solver:
             packages (defaults to False: do not concretize test dependencies).
           setup_only: if True, stop after setup and don't solve (default False).
           allow_deprecated: allow deprecated version in the solve
+          output: full output configuration for the solve; takes precedence over
+            the individual ``out``, ``timers``, ``stats`` and ``setup_only`` arguments
         """
         specs = [spack.hash_lookup.lookup_hash(s) for s in specs]
         reusable_specs = self._extract_concrete_specs(specs)
         reusable_specs.extend(self.selector.reusable_specs(specs))
         setup = SpackSolverSetup(tests=tests)
-        output = OutputConfiguration(timers=timers, stats=stats, out=out, setup_only=setup_only)
+        if output is None:
+            output = OutputConfiguration(
+                timers=timers, stats=stats, out=out, setup_only=setup_only
+            )
 
         result = self.driver.solve(
             setup,
@@ -4054,6 +4122,7 @@ class Solver:
         stats: bool = False,
         tests: spack.concretize.TestsType = False,
         allow_deprecated: bool = False,
+        output: Optional[OutputConfiguration] = None,
     ) -> Generator[Result, None, None]:
         """Solve for a stable model of specs in multiple rounds.
 
@@ -4070,6 +4139,9 @@ class Solver:
             stats (bool): print internal statistics if set to True
             tests (bool): add test dependencies to the solve
             allow_deprecated (bool): allow deprecated version in the solve
+            output: full output configuration for the solve; takes precedence over
+                the individual ``out``, ``timers`` and ``stats`` arguments. Note that
+                ``setup_only`` stops after the setup of the first round.
         """
         # "when_possible" requires at least one literal to be solved, so an empty input is unsat
         if not specs:
@@ -4084,7 +4156,8 @@ class Solver:
         setup.concretize_everything = False
 
         input_specs = specs
-        output = OutputConfiguration(timers=timers, stats=stats, out=out, setup_only=False)
+        if output is None:
+            output = OutputConfiguration(timers=timers, stats=stats, out=out)
         while True:
             result, _, _ = self.driver.solve(
                 setup,
@@ -4095,6 +4168,10 @@ class Solver:
                 allow_deprecated=allow_deprecated,
             )
             yield result
+
+            # With setup_only there is no answer to base further rounds on
+            if output.setup_only:
+                break
 
             # If we don't have unsolved specs we are done
             if not result.unsolved_specs:

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -495,7 +495,7 @@ class Result:
             color.cprint(string, stream=stream)
 
         cprint(f"@*b{{==>}} Best of {self.nmodels} considered solutions.")
-        cprint("")
+        print()
         maxlen = max(len(s.name) for s in self.criteria)
         cprint("@*{  Priority  Value  Criterion}")
 
@@ -506,9 +506,9 @@ class Result:
 
         for i, criterion in enumerate(self.criteria, 1):
             # Criteria are grouped into priority bands; print a header when the band changes.
-            band = optimization_band(criterion.priority)
+            band = criterion.band
             if band != prev_band:
-                label = f"-- {band.value}"
+                label = f"-- {band}"
                 dashes = "-" * max(0, divider_width - len(label) - 1)
                 cprint(f"  @*{{{label}}} @K{{{dashes}}}")
                 prev_band = band
@@ -529,13 +529,13 @@ class Result:
                 lc = "@y"
 
             cprint(f"  @K{{{i:8}}}  {value}  {lc}{{{criterion.name:<{maxlen}}}}")
-        cprint("")
-        cprint("")
+        print()
+        print()
         cprint("  @*{Legend:}")
         cprint("    @g{Specs to be built}")
         cprint("    @b{Reused specs}")
         cprint("    @y{Other criteria}")
-        cprint("")
+        print()
 
     def to_dict(self) -> dict:
         """Produces dict representation of Result object

--- a/lib/spack/spack/test/cmd/spec.py
+++ b/lib/spack/spack/test/cmd/spec.py
@@ -107,6 +107,7 @@ def test_spec_json():
 
 def test_spec_format(mutable_database):
     output = spec("--format", "{name}-{^mpi.name}", "mpileaks^mpich")
+    print(output)
     assert output.rstrip("\n") == "mpileaks-mpich"
 
 
@@ -206,7 +207,7 @@ def test_spec_version_assigned_git_ref_as_version(name, version, error):
         (False, ["mpileaks_mpich", "dyninst"], "mpich", None),
         (False, ["mpileaks_zmpi", "dyninst"], "zmpi", None),
         # cases with unfiy:false
-        (True, ["mpileaks_mpich", "mpileaks_zmpi"], "callpath, mpileaks", spack.error.SpecError),
+        (True, ["mpileaks_mpich", "mpileaks_zmpi"], "mpileaks.*, mpileaks", spack.error.SpecError),
         (False, ["mpileaks_mpich", "mpileaks_zmpi"], "zmpi", None),
     ],
 )

--- a/lib/spack/spack/test/cmd/spec.py
+++ b/lib/spack/spack/test/cmd/spec.py
@@ -10,6 +10,7 @@ import spack.cmd
 import spack.concretize
 import spack.environment as ev
 import spack.error
+import spack.solver.asp
 import spack.spec
 from spack.config import Configuration
 from spack.main import SpackCommand, SpackCommandError
@@ -172,6 +173,165 @@ def test_env_aware_spec(mutable_mock_env_path):
         assert "libdwarf@20130729" in output
         assert "libelf@0.8.1" in output
         assert "mpich@3.0.4" in output
+
+
+def _concretize_and_lock(env: ev.Environment) -> None:
+    with env:
+        env.concretize()
+        env.write()
+
+
+@pytest.mark.parametrize("unify", [True, False, "when_possible"])
+def test_spec_does_not_reconcretize_concrete_env(
+    unify, mutable_mock_env_path, mutable_config: Configuration
+):
+    """A concrete environment's roots must be shown as-is, even if a fresh solve
+    would pick something different (regression for spack/spack#...)."""
+    mutable_config.set("concretizer:unify", unify)
+    env = ev.create("test")
+    env.add("mpileaks")
+    _concretize_and_lock(env)
+    locked_hashes = {s.dag_hash() for s in env.concrete_roots()}
+
+    # A fresh solve would now pick a different mpileaks version
+    mutable_config.set("packages", {"mpileaks": {"require": ["@2.2"]}})
+
+    with env:
+        output = spec("-l")
+    assert "mpileaks@2.3" in output
+    assert any(h[:7] in output for h in locked_hashes)
+    assert "mpileaks@2.2" not in output
+
+
+def test_spec_env_force_reconcretizes_without_modifying(
+    mutable_mock_env_path, mutable_config: Configuration
+):
+    """--force shows a full re-solve, but the environment is not modified."""
+    env = ev.create("test")
+    env.add("mpileaks")
+    _concretize_and_lock(env)
+    lock_content = env.lock_path and open(env.lock_path).read()
+
+    mutable_config.set("packages", {"mpileaks": {"require": ["@2.2"]}})
+
+    with env:
+        output = spec("--force")
+    assert "mpileaks@2.2" in output
+
+    # neither the in-memory state nor the lockfile changed
+    reread = ev.Environment(env.path)
+    assert {s.dag_hash() for s in reread.concrete_roots()} == {
+        s.dag_hash() for s in env.concrete_roots()
+    }
+    assert open(env.lock_path).read() == lock_content
+    assert any(s.satisfies("mpileaks@2.3") for s in env.concrete_roots())
+
+
+@pytest.mark.parametrize("unify", [True, False, "when_possible"])
+def test_spec_env_concretizes_only_new_specs(
+    unify, mutable_mock_env_path, mutable_config: Configuration
+):
+    """Only not-yet-concrete user specs are solved; kept roots are not changed, and
+    the environment is not modified."""
+    mutable_config.set("concretizer:unify", unify)
+    env = ev.create("test")
+    env.add("mpileaks")
+    _concretize_and_lock(env)
+    mpileaks_hash = next(iter(s.dag_hash() for s in env.concrete_roots()))
+    lock_content = open(env.lock_path).read()
+
+    # A fresh solve of mpileaks would now pick 2.2: proof it isn't re-solved
+    mutable_config.set("packages", {"mpileaks": {"version": ["2.2"]}})
+
+    with env:
+        env.add("libelf")
+        output = spec("-l")
+
+    assert "libelf" in output
+    assert "mpileaks@2.3" in output
+    assert mpileaks_hash[:7] in output
+
+    # the new root was not committed to the environment
+    reread = ev.Environment(env.path)
+    assert {s.name for s in reread.concrete_roots()} == {"mpileaks"}
+    assert open(env.lock_path).read() == lock_content
+
+
+def test_spec_env_fully_concrete_skips_solver(mutable_mock_env_path, monkeypatch):
+    """Displaying a fully concrete environment must not invoke the solver."""
+    env = ev.create("test")
+    env.add("mpileaks")
+    _concretize_and_lock(env)
+
+    def no_solve(*args, **kwargs):
+        raise AssertionError("solver should not run for a fully concrete environment")
+
+    monkeypatch.setattr(spack.solver.asp.PyclingoDriver, "solve", no_solve)
+    with env:
+        output = spec()
+    assert "mpileaks@2.3" in output
+
+
+def test_spec_env_show_opt_reports_fully_concrete(mutable_mock_env_path):
+    """--show opt on a fully concrete environment explains there is nothing to solve."""
+    env = ev.create("test")
+    env.add("mpileaks")
+    _concretize_and_lock(env)
+
+    with env:
+        output = spec("--show", "opt")
+    assert "already concrete" in output
+    assert "Priority" not in output
+
+
+@pytest.mark.parametrize("unify", [True, False, "when_possible"])
+def test_spec_env_show_opt_for_new_specs(
+    unify, mutable_mock_env_path, mutable_config: Configuration
+):
+    """--show opt prints optimization criteria for the newly solved portion."""
+    mutable_config.set("concretizer:unify", unify)
+    env = ev.create("test")
+    env.add("mpileaks")
+    _concretize_and_lock(env)
+
+    with env:
+        env.add("libelf")
+        output = spec("--show", "opt")
+    assert "Priority" in output
+    assert "considered solutions" in output
+
+
+def test_spec_env_show_asp(mutable_mock_env_path):
+    """--show asp prints the ASP program for the new solve, without concretizing."""
+    env = ev.create("test")
+    env.add("mpileaks")
+    _concretize_and_lock(env)
+    lock_content = open(env.lock_path).read()
+
+    with env:
+        env.add("libelf")
+        output = spec("--show", "asp")
+    assert "Target Constraints" in output
+    assert open(env.lock_path).read() == lock_content
+
+
+def test_spec_env_diagnostics_per_spec_blocks(
+    mutable_mock_env_path, mutable_config: Configuration
+):
+    """With unify:false, each newly solved spec gets its own labeled diagnostics block."""
+    mutable_config.set("concretizer:unify", False)
+    env = ev.create("test")
+    env.add("mpileaks")
+    _concretize_and_lock(env)
+
+    with env:
+        env.add("libelf")
+        env.add("libdwarf")
+        output = spec("--show", "opt")
+
+    blocks = re.findall(r"Solve diagnostics for (\S+)", output)
+    assert sorted(blocks) == ["libdwarf", "libelf"]
+    assert output.count("considered solutions") == 2
 
 
 @pytest.mark.parametrize(

--- a/lib/spack/spack/test/cmd/spec.py
+++ b/lib/spack/spack/test/cmd/spec.py
@@ -371,7 +371,7 @@ def test_spec_version_assigned_git_ref_as_version(name, version, error):
             True,
             ["mpileaks_mpich", "mpileaks_zmpi"],
             "callpath and mpileaks",
-            spack.error.SpecError
+            spack.error.SpecError,
         ),
         (False, ["mpileaks_mpich", "mpileaks_zmpi"], "zmpi", None),
     ],

--- a/lib/spack/spack/test/cmd/spec.py
+++ b/lib/spack/spack/test/cmd/spec.py
@@ -210,7 +210,7 @@ def test_spec_env_force_reconcretizes_without_modifying(
     env = ev.create("test")
     env.add("mpileaks")
     _concretize_and_lock(env)
-    lock_content = env.lock_path and open(env.lock_path).read()
+    lock_content = env.lock_path and open(env.lock_path, encoding="utf-8").read()
 
     mutable_config.set("packages", {"mpileaks": {"require": ["@2.2"]}})
 
@@ -223,7 +223,7 @@ def test_spec_env_force_reconcretizes_without_modifying(
     assert {s.dag_hash() for s in reread.concrete_roots()} == {
         s.dag_hash() for s in env.concrete_roots()
     }
-    assert open(env.lock_path).read() == lock_content
+    assert open(env.lock_path, encoding="utf-8").read() == lock_content
     assert any(s.satisfies("mpileaks@2.3") for s in env.concrete_roots())
 
 
@@ -238,7 +238,7 @@ def test_spec_env_concretizes_only_new_specs(
     env.add("mpileaks")
     _concretize_and_lock(env)
     mpileaks_hash = next(iter(s.dag_hash() for s in env.concrete_roots()))
-    lock_content = open(env.lock_path).read()
+    lock_content = open(env.lock_path, encoding="utf-8").read()
 
     # A fresh solve of mpileaks would now pick 2.2: proof it isn't re-solved
     mutable_config.set("packages", {"mpileaks": {"version": ["2.2"]}})
@@ -254,7 +254,7 @@ def test_spec_env_concretizes_only_new_specs(
     # the new root was not committed to the environment
     reread = ev.Environment(env.path)
     assert {s.name for s in reread.concrete_roots()} == {"mpileaks"}
-    assert open(env.lock_path).read() == lock_content
+    assert open(env.lock_path, encoding="utf-8").read() == lock_content
 
 
 def test_spec_env_fully_concrete_skips_solver(mutable_mock_env_path, monkeypatch):
@@ -306,13 +306,13 @@ def test_spec_env_show_asp(mutable_mock_env_path):
     env = ev.create("test")
     env.add("mpileaks")
     _concretize_and_lock(env)
-    lock_content = open(env.lock_path).read()
+    lock_content = open(env.lock_path, encoding="utf-8").read()
 
     with env:
         env.add("libelf")
         output = spec("--show", "asp")
     assert "Target Constraints" in output
-    assert open(env.lock_path).read() == lock_content
+    assert open(env.lock_path, encoding="utf-8").read() == lock_content
 
 
 def test_spec_env_diagnostics_per_spec_blocks(

--- a/lib/spack/spack/test/cmd/spec.py
+++ b/lib/spack/spack/test/cmd/spec.py
@@ -367,7 +367,12 @@ def test_spec_version_assigned_git_ref_as_version(name, version, error):
         (False, ["mpileaks_mpich", "dyninst"], "mpich", None),
         (False, ["mpileaks_zmpi", "dyninst"], "zmpi", None),
         # cases with unfiy:false
-        (True, ["mpileaks_mpich", "mpileaks_zmpi"], "mpileaks.*, mpileaks", spack.error.SpecError),
+        (
+            True,
+            ["mpileaks_mpich", "mpileaks_zmpi"],
+            "callpath and mpileaks",
+            spack.error.SpecError
+        ),
         (False, ["mpileaks_mpich", "mpileaks_zmpi"], "zmpi", None),
     ],
 )

--- a/lib/spack/spack/test/env.py
+++ b/lib/spack/spack/test/env.py
@@ -783,7 +783,7 @@ def test_transient_concretization_restores_state(mutable_mock_env_path):
     with env:
         env.concretize()
         env.write()
-    lock_content = pathlib.Path(env.lock_path).read_text()
+    lock_content = pathlib.Path(env.lock_path).read_text(encoding="utf-8")
     old_roots = env.concretized_roots[:]
     old_hashes = set(env.specs_by_hash)
 
@@ -796,7 +796,7 @@ def test_transient_concretization_restores_state(mutable_mock_env_path):
 
     assert env.concretized_roots == old_roots
     assert set(env.specs_by_hash) == old_hashes
-    assert pathlib.Path(env.lock_path).read_text() == lock_content
+    assert pathlib.Path(env.lock_path).read_text(encoding="utf-8") == lock_content
 
 
 def test_transient_concretization_restores_state_on_error(mutable_mock_env_path):

--- a/lib/spack/spack/test/env.py
+++ b/lib/spack/spack/test/env.py
@@ -775,6 +775,46 @@ def test_env_with_include_def_missing(mutable_mock_env_path):
         _ = ev.Environment(env_path)
 
 
+def test_transient_concretization_restores_state(mutable_mock_env_path):
+    """Concrete state changes inside transient_concretization() are visible within the
+    context and rolled back on exit; write() is a no-op inside the context."""
+    env = ev.create("test")
+    env.add("mpileaks")
+    with env:
+        env.concretize()
+        env.write()
+    lock_content = pathlib.Path(env.lock_path).read_text()
+    old_roots = env.concretized_roots[:]
+    old_hashes = set(env.specs_by_hash)
+
+    with env:
+        env.add("libelf")
+        with env.transient_concretization():
+            env.concretize()
+            assert {s.name for s in env.concrete_roots()} == {"mpileaks", "libelf"}
+            env.write()  # no-op: nothing must reach disk
+
+    assert env.concretized_roots == old_roots
+    assert set(env.specs_by_hash) == old_hashes
+    assert pathlib.Path(env.lock_path).read_text() == lock_content
+
+
+def test_transient_concretization_restores_state_on_error(mutable_mock_env_path):
+    """The snapshot is restored even when the body raises."""
+    env = ev.create("test")
+    env.add("mpileaks")
+    with env:
+        env.concretize()
+    old_roots = env.concretized_roots[:]
+
+    with pytest.raises(RuntimeError, match="boom"):
+        with env.transient_concretization():
+            env.clear_concretized_specs()
+            raise RuntimeError("boom")
+
+    assert env.concretized_roots == old_roots
+
+
 @pytest.mark.regression("41292")
 @pytest.mark.parametrize("unify", ["true", "false", "when_possible"])
 def test_deconcretize_then_concretize_does_not_error(mutable_mock_env_path, unify):

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -1929,7 +1929,7 @@ _spack_restage() {
 _spack_solve() {
     if $list_options
     then
-        SPACK_COMPREPLY="-h --help --show --timers --stats -l --long -L --very-long -N --namespaces -I --install-status --no-install-status -y --yaml -j --json --format --non-defaults -c --cover -t --types -f --force -U --fresh --reuse --fresh-roots --reuse-deps --deprecated"
+        SPACK_COMPREPLY="-h --help -l --long -L --very-long -N --namespaces -I --install-status --no-install-status -y --yaml -j --json --format --non-defaults -c --cover -t --types -f --force -U --fresh --reuse --fresh-roots --reuse-deps --deprecated --show --timers --stats"
     else
         _all_packages
     fi
@@ -1938,7 +1938,7 @@ _spack_solve() {
 _spack_spec() {
     if $list_options
     then
-        SPACK_COMPREPLY="-h --help -l --long -L --very-long -N --namespaces -I --install-status --no-install-status -y --yaml -j --json --format --non-defaults -c --cover -t --types -f --force -U --fresh --reuse --fresh-roots --reuse-deps --deprecated"
+        SPACK_COMPREPLY="-h --help -l --long -L --very-long -N --namespaces -I --install-status --no-install-status -y --yaml -j --json --format --non-defaults -c --cover -t --types -f --force -U --fresh --reuse --fresh-roots --reuse-deps --deprecated --show --timers --stats"
     else
         _all_packages
     fi

--- a/share/spack/spack-completion.fish
+++ b/share/spack/spack-completion.fish
@@ -3013,16 +3013,10 @@ complete -c spack -n '__fish_spack_using_command restage' -s h -l help -f -a hel
 complete -c spack -n '__fish_spack_using_command restage' -s h -l help -d 'show this help message and exit'
 
 # spack solve
-set -g __fish_spack_optspecs_spack_solve h/help show= timers stats l/long L/very-long N/namespaces I/install-status no-install-status y/yaml j/json format= non-defaults c/cover= t/types f/force U/fresh reuse fresh-roots deprecated
+set -g __fish_spack_optspecs_spack_solve h/help l/long L/very-long N/namespaces I/install-status no-install-status y/yaml j/json format= non-defaults c/cover= t/types f/force U/fresh reuse fresh-roots deprecated show= timers stats
 complete -c spack -n '__fish_spack_using_command_pos_remainder 0 solve' -f -k -a '(__fish_spack_specs_or_id)'
 complete -c spack -n '__fish_spack_using_command solve' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command solve' -s h -l help -d 'show this help message and exit'
-complete -c spack -n '__fish_spack_using_command solve' -l show -r -f -a show
-complete -c spack -n '__fish_spack_using_command solve' -l show -r -d 'select outputs'
-complete -c spack -n '__fish_spack_using_command solve' -l timers -f -a timers
-complete -c spack -n '__fish_spack_using_command solve' -l timers -d 'print out timers for different solve phases'
-complete -c spack -n '__fish_spack_using_command solve' -l stats -f -a stats
-complete -c spack -n '__fish_spack_using_command solve' -l stats -d 'print out statistics from clingo'
 complete -c spack -n '__fish_spack_using_command solve' -s l -l long -f -a long
 complete -c spack -n '__fish_spack_using_command solve' -s l -l long -d 'show dependency hashes as well as versions'
 complete -c spack -n '__fish_spack_using_command solve' -s L -l very-long -f -a very_long
@@ -3055,9 +3049,15 @@ complete -c spack -n '__fish_spack_using_command solve' -l fresh-roots -l reuse-
 complete -c spack -n '__fish_spack_using_command solve' -l fresh-roots -l reuse-deps -d 'concretize with fresh roots and reused dependencies'
 complete -c spack -n '__fish_spack_using_command solve' -l deprecated -f -a config_deprecated
 complete -c spack -n '__fish_spack_using_command solve' -l deprecated -d 'allow concretizer to select deprecated versions'
+complete -c spack -n '__fish_spack_using_command solve' -l show -r -f -a show
+complete -c spack -n '__fish_spack_using_command solve' -l show -r -d 'select outputs'
+complete -c spack -n '__fish_spack_using_command solve' -l timers -f -a timers
+complete -c spack -n '__fish_spack_using_command solve' -l timers -d 'print out timers for different solve phases'
+complete -c spack -n '__fish_spack_using_command solve' -l stats -f -a stats
+complete -c spack -n '__fish_spack_using_command solve' -l stats -d 'print out statistics from clingo'
 
 # spack spec
-set -g __fish_spack_optspecs_spack_spec h/help l/long L/very-long N/namespaces I/install-status no-install-status y/yaml j/json format= non-defaults c/cover= t/types f/force U/fresh reuse fresh-roots deprecated
+set -g __fish_spack_optspecs_spack_spec h/help l/long L/very-long N/namespaces I/install-status no-install-status y/yaml j/json format= non-defaults c/cover= t/types f/force U/fresh reuse fresh-roots deprecated show= timers stats
 complete -c spack -n '__fish_spack_using_command_pos_remainder 0 spec' -f -k -a '(__fish_spack_specs_or_id)'
 complete -c spack -n '__fish_spack_using_command spec' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command spec' -s h -l help -d 'show this help message and exit'
@@ -3093,6 +3093,12 @@ complete -c spack -n '__fish_spack_using_command spec' -l fresh-roots -l reuse-d
 complete -c spack -n '__fish_spack_using_command spec' -l fresh-roots -l reuse-deps -d 'concretize with fresh roots and reused dependencies'
 complete -c spack -n '__fish_spack_using_command spec' -l deprecated -f -a config_deprecated
 complete -c spack -n '__fish_spack_using_command spec' -l deprecated -d 'allow concretizer to select deprecated versions'
+complete -c spack -n '__fish_spack_using_command spec' -l show -r -f -a show
+complete -c spack -n '__fish_spack_using_command spec' -l show -r -d 'select outputs'
+complete -c spack -n '__fish_spack_using_command spec' -l timers -f -a timers
+complete -c spack -n '__fish_spack_using_command spec' -l timers -d 'print out timers for different solve phases'
+complete -c spack -n '__fish_spack_using_command spec' -l stats -f -a stats
+complete -c spack -n '__fish_spack_using_command spec' -l stats -d 'print out statistics from clingo'
 
 # spack stage
 set -g __fish_spack_optspecs_spack_stage h/help n/no-checksum p/path= e/exclude= s/skip-installed f/force U/fresh reuse fresh-roots deprecated


### PR DESCRIPTION
Reimplements #52596 , #52597 , #52655 

In addition:
- Fixes a regression caused by #52596 that caused `spack spec` to reconcretize even in a concrete environment.
  - Add diagnostic printing capabilities to the solver itself
  - Thread solver diagnostics through concretization functions
  - Add a `transient_concretization` context manager to `Environment`
  - Update the `spack spec` command to make use of all of the above.
- Fixes a regression caused by #52596 that cause `spack spec` not to bypass the solver for concrete specs from hashes.


Includes regression tests.