### PR TITLE
spec: make satisfies, intersects and constrain stateless

### DIFF
--- a/lib/spack/spack/cray_manifest.py
+++ b/lib/spack/spack/cray_manifest.py
@@ -214,8 +214,8 @@ def entries_to_specs(entries):
                 dep_spec = spec_dict[dep_hash]
                 parent_spec._add_dependency(dep_spec, depflag=depflag, virtuals=())
 
-    for spec in spec_dict.values():
-        spack.spec.reconstruct_virtuals_on_edges(spec)
+    # Edges above are added with virtuals=(), and the specs report the current format.
+    spack.repo.reconstruct_virtuals(spec_dict.values(), edges_lack_virtuals=True)
 
     return spec_dict
 

--- a/lib/spack/spack/database.py
+++ b/lib/spack/spack/database.py
@@ -926,6 +926,11 @@ class Database:
         for hash_key, rec in data.items():
             rec.spec._mark_root_concrete()
 
+        # Pass 4: fill in the virtual data that databases written by older Spack versions
+        # omit. Like pass 3, this runs once the DAG is connected, and before anything hashes
+        # a node.
+        spack.repo.reconstruct_virtuals([rec.spec for rec in data.values()])
+
         self._data = data
         self._installed_prefixes = installed_prefixes
 

--- a/lib/spack/spack/database.py
+++ b/lib/spack/spack/database.py
@@ -805,27 +805,28 @@ class Database:
             spec_node_dict = spec_node_dict[spec.name]
         if "dependencies" in spec_node_dict:
             yaml_deps = spec_node_dict["dependencies"]
-            for dname, dhash, dtypes, _, virtuals, direct in spec_reader.read_specfile_dep_specs(
-                yaml_deps
-            ):
+            for dep in spec_reader.read_specfile_dep_specs(yaml_deps):
                 # It is important that we always check upstream installations in the same order,
                 # and that we always check the local installation first: if a downstream Spack
                 # installs a package then dependents in that installation could be using it. If a
                 # hash is installed locally and upstream, there isn't enough information to
                 # determine which one a local package depends on, so the convention ensures that
                 # this isn't an issue.
-                _, record = self.query_by_spec_hash(dhash, data=data)
+                _, record = self.query_by_spec_hash(dep.hash, data=data)
                 child = record.spec if record else None
 
                 if not child:
                     tty.warn(
                         f"Missing dependency not in database: "
-                        f"{spec.cformat('{name}{/hash:7}')} needs {dname}-{dhash[:7]}"
+                        f"{spec.cformat('{name}{/hash:7}')} needs {dep.name}-{dep.hash[:7]}"
                     )
                     continue
 
                 spec._add_dependency(
-                    child, depflag=dt.canonicalize(dtypes), virtuals=virtuals, direct=direct
+                    child,
+                    depflag=dt.canonicalize(dep.deptypes),
+                    virtuals=dep.virtuals,
+                    direct=dep.direct,
                 )
 
     def _read_from_file(self, filename: pathlib.Path, *, reindex: bool = False) -> None:

--- a/lib/spack/spack/directives.py
+++ b/lib/spack/spack/directives.py
@@ -133,7 +133,7 @@ def _make_when_spec(value: Union[WhenType, Tuple[str, ...]]) -> Optional[spack.s
         # reduce the when-stack to a single spec by combining all constraints.
         combined_spec = spack.spec.Spec(value[0])
         for cond in value[1:]:
-            combined_spec._constrain_symbolically(get_spec(cond))
+            combined_spec.constrain(get_spec(cond))
         return combined_spec
 
     # Unsatisfiable conditions are discarded by the caller, and never

--- a/lib/spack/spack/enums.py
+++ b/lib/spack/spack/enums.py
@@ -27,7 +27,7 @@ class ConfigScopePriority(enum.IntEnum):
     ENVIRONMENT_SPEC_GROUPS = 5
 
 
-class PropagationPolicy(enum.Enum):
+class PropagationPolicy(enum.IntEnum):
     """Enum to specify the behavior of a propagated dependency"""
 
     NONE = enum.auto()

--- a/lib/spack/spack/environment/environment.py
+++ b/lib/spack/spack/environment/environment.py
@@ -2462,14 +2462,12 @@ class Environment:
         # and add them to the spec, including build specs
         for lockfile_key, node_dict in json_specs_by_hash.items():
             name, data = reader.name_and_data(node_dict)
-            for _, dep_hash, deptypes, _, virtuals, direct in reader.dependencies_from_node_dict(
-                data
-            ):
+            for dep in reader.dependencies_from_node_dict(data):
                 specs_by_hash[lockfile_key]._add_dependency(
-                    specs_by_hash[dep_hash],
-                    depflag=dt.canonicalize(deptypes),
-                    virtuals=virtuals,
-                    direct=direct,
+                    specs_by_hash[dep.hash],
+                    depflag=dt.canonicalize(dep.deptypes),
+                    virtuals=dep.virtuals,
+                    direct=dep.direct,
                 )
 
             if "build_spec" in node_dict:

--- a/lib/spack/spack/environment/environment.py
+++ b/lib/spack/spack/environment/environment.py
@@ -2474,6 +2474,10 @@ class Environment:
                 _, bhash, _ = reader.extract_build_spec_info_from_node_dict(node_dict)
                 specs_by_hash[lockfile_key]._build_spec = specs_by_hash[bhash]
 
+        # This wires up the DAG by hand rather than going through the spec file readers, so
+        # fill in the virtual data that lockfiles written by older Spack versions omit.
+        spack.repo.reconstruct_virtuals(specs_by_hash.values())
+
         # Traverse the root specs one at a time in the order they appear.
         # The first time we see each DAG hash, that's the one we want to
         # keep.  This is only required as long as we support older lockfile

--- a/lib/spack/spack/externals.py
+++ b/lib/spack/spack/externals.py
@@ -274,11 +274,17 @@ class ExternalSpecsParser:
                     # Infer the deptype if only '%' was used in the spec
                     inferred_virtuals = []
                     for name, current_flag in deptypes_by_package.items():
-                        if not dependency_node.intersects(name):
-                            continue
-                        depflag |= current_flag
                         if spack.repo.PATH.is_virtual(name):
-                            inferred_virtuals.append(name)
+                            # dependency_node is abstract, so ask the repository which providers
+                            # exist for this virtual; the node provides it if it matches one.
+                            if any(
+                                dependency_node.intersects(p)
+                                for p in spack.repo.PATH.providers_for(name)
+                            ):
+                                depflag |= current_flag
+                                inferred_virtuals.append(name)
+                        elif dependency_node.intersects(name):
+                            depflag |= current_flag
                     virtuals = tuple(inferred_virtuals)
                 elif depflag == spack.deptypes.NONE:
                     depflag = spack.deptypes.DEFAULT

--- a/lib/spack/spack/repo.py
+++ b/lib/spack/spack/repo.py
@@ -27,6 +27,7 @@ from typing import (
     Callable,
     Dict,
     Generator,
+    Iterable,
     Iterator,
     List,
     Mapping,
@@ -47,6 +48,7 @@ import spack.patch
 import spack.paths
 import spack.provider_index
 import spack.tag
+import spack.traverse
 import spack.util.executable
 import spack.util.file_cache
 import spack.util.filesystem as fs
@@ -56,6 +58,7 @@ import spack.util.lock
 import spack.util.naming as nm
 import spack.util.path
 import spack.util.spack_yaml as syaml
+import spack.version
 from spack.util import tty
 from spack.util.filesystem import working_dir
 from spack.util.lang import Singleton, ensure_unwrapped, memoized
@@ -2127,6 +2130,91 @@ PATH = cast(RepoPath, Singleton(lambda: create_and_enable(spack.config.CONFIG)))
 # Add the finder to sys.meta_path
 REPOS_FINDER = ReposFinder()
 sys.meta_path.append(REPOS_FINDER)
+
+
+def reconstruct_virtuals(
+    specs: Iterable["spack.spec.Spec"], *, edges_lack_virtuals: bool = False
+) -> None:
+    """Fill in, from ``package.py``, the virtual data that belongs on a concrete spec but that
+    older spec documents did not record:
+
+    - on each node, the versions of the virtuals it provides, absent before the
+      ``provided_virtuals`` key existed
+    - on each edge, the virtuals it resolves, absent before specfile format 3
+
+    The two are guarded independently, since the node data was added without a specfile format
+    bump: a format 5 document written by an older Spack has edge virtuals but no node ones.
+
+    Edges are only revisited for documents that predate format 3, since doing so costs a
+    package class lookup per node. Pass ``edges_lack_virtuals`` for specs assembled outside the
+    spec file readers, whose edges have no virtuals set regardless of the format they report.
+
+    Nodes and edges that already have the data keep it, so this is idempotent and cheap to
+    call defensively. It runs on a wired DAG, since ``provides`` and ``depends_on`` when
+    clauses may constrain dependencies.
+
+    Everything is read off the package class, never an instance: constructing a package can
+    format a spec, which hashes it, and the provided virtuals have to be in place before any
+    node is hashed."""
+    # Post order, so a `provides` when clause constraining a dependency sees frozen children.
+    nodes = list(spack.traverse.traverse_nodes(list(specs), order="post", key=id))
+
+    for spec in nodes:
+        if spec._provided_virtuals is not None:
+            continue
+
+        # When several `provides` clauses match, the provided version is their intersection,
+        # which is what the solver enforces by imposing each clause as a node_version_satisfies
+        # constraint on the virtual node.
+        provided: Dict[str, spack.version.VersionList] = {}
+        try:
+            declared = PATH.get_pkg_class(spec.fullname).provided
+        except Exception as e:
+            warnings.warn(f"cannot reconstruct provided virtuals on {spec.name}: {e}")
+        else:
+            for when_spec, vspecs in declared.items():
+                if not spec.satisfies(when_spec):
+                    continue
+                for vspec in vspecs:
+                    if vspec.name in provided:
+                        provided[vspec.name] = provided[vspec.name].intersection(vspec.versions)
+                    else:
+                        provided[vspec.name] = vspec.versions.copy()
+
+        spec._provided_virtuals = provided
+
+    for spec in nodes:
+        if not spec.concrete:
+            continue
+
+        if not edges_lack_virtuals and spec.original_spec_format() >= 3:
+            continue
+
+        try:
+            pkg_cls = PATH.get_pkg_class(spec.fullname)
+        except Exception as e:
+            warnings.warn(f"cannot reconstruct virtual dependencies on {spec.name}: {e}")
+            continue
+
+        needed: Set[str] = set()
+        for name, when_deps in pkg_cls.dependencies_by_name(when=True).items():
+            if not PATH.is_virtual(name):
+                continue
+            for when_dep in when_deps:
+                if spec.satisfies(when_dep):
+                    needed.add(name)
+                    break
+
+        if not needed:
+            continue
+
+        # The provided virtuals were frozen above, so the child side needs no package instance.
+        for edge in spec.edges_to_dependencies():
+            if not edge.spec.concrete:
+                continue
+            virtuals_to_add = needed & set(edge.spec.provided_virtuals)
+            if virtuals_to_add:
+                edge.update_virtuals(virtuals_to_add)
 
 
 @contextlib.contextmanager

--- a/lib/spack/spack/schema/spec.py
+++ b/lib/spack/spack/schema/spec.py
@@ -121,6 +121,16 @@ dependencies_v4_plus = {
                         "type": "boolean",
                         "description": "Whether the dependency is direct (only on abstract specs)",
                     },
+                    "when": {
+                        "type": "string",
+                        "description": "Condition under which the dependency holds, as a spec "
+                        "string (only on abstract specs)",
+                    },
+                    "propagation": {
+                        "type": "string",
+                        "description": "Propagation policy of a direct dependency (only on "
+                        "abstract specs)",
+                    },
                 },
             },
         },
@@ -188,6 +198,24 @@ spec_node = {
             "dependencies)",
         },
         "namespace": {"type": "string", "description": "Package repository namespace"},
+        "abstract_hash": {
+            "type": "string",
+            "description": "Hash prefix of the concrete spec this refers to (for abstract specs)",
+        },
+        "compiler_flags": {
+            "type": "object",
+            "description": "Compiler flags with their propagation (for abstract specs). "
+            "Supersedes the flags under parameters",
+            "additionalProperties": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "additionalProperties": False,
+                    "required": ["value"],
+                    "properties": {"value": {"type": "string"}, "propagate": {"type": "boolean"}},
+                },
+            },
+        },
         "parameters": {
             "type": "object",
             "additionalProperties": True,

--- a/lib/spack/spack/schema/spec.py
+++ b/lib/spack/spack/schema/spec.py
@@ -235,6 +235,12 @@ spec_node = {
             "items": {"type": "string"},
             "description": "List of patches, similar to the patches variant under parameters",
         },
+        "provided_virtuals": {
+            "type": "object",
+            "additionalProperties": {"type": "string"},
+            "description": "Virtual name -> provided version(s), frozen at concretization time. "
+            "Part of the DAG hash, since `provides` is stripped from the package hash.",
+        },
         "dependencies": dependencies,
         "build_spec": build_spec,
         "external": {

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -543,6 +543,12 @@ class ArchSpec:
             self.target = other.target
             return True
 
+        # self already inside other: the intersection is self, textually different or not (an
+        # unbounded ":icelake" and its resolved "x86_64:icelake" denote the same range, but are
+        # not the same string, which the equality check below would otherwise miss).
+        if self._target_satisfies(other, strict=True):
+            return False
+
         # Compute the intersection of every combination of ranges in the lists
         results = self._target_intersection(other)
         attribute_str = ",".join(results)

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -851,6 +851,11 @@ class DependencySpec:
         if not self.direct and other.direct:
             changed = True
             self.direct = True
+        # A propagated edge constrains the whole DAG, so it is the narrower of the two policies.
+        # It is also always direct, which the assignment above has already taken care of.
+        if self.propagation == PropagationPolicy.NONE and other.propagation != self.propagation:
+            changed = True
+            self.propagation = other.propagation
         return changed
 
     def _cmp_iter(self):

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -68,6 +68,7 @@ from typing import (
     Iterable,
     List,
     Match,
+    NamedTuple,
     Optional,
     Sequence,
     Set,
@@ -907,6 +908,20 @@ class CompilerFlag(str):
         obj.source = kwargs.pop("source", None)
         return obj
 
+    def to_dict(self) -> Dict[str, Any]:
+        """Value and propagation of this flag, unlike ``FlagMap.yaml_entry``, which is its value
+        only. ``flag_group`` and ``source`` are not included: they are bookkeeping for a single
+        solve, and nothing reads them back. Attributes that have their default value are
+        omitted."""
+        d: Dict[str, Any] = {"value": str(self)}
+        if self.propagate:
+            d["propagate"] = True
+        return d
+
+    @staticmethod
+    def from_dict(d: Dict[str, Any]) -> "CompilerFlag":
+        return CompilerFlag(d["value"], propagate=d.get("propagate", False))
+
 
 _valid_compiler_flags = ["cflags", "cxxflags", "fflags", "ldflags", "ldlibs", "cppflags"]
 
@@ -972,6 +987,21 @@ class FlagMap(lang.HashableMap[str, List[CompilerFlag]]):
         # intersection specify different behaviors for flag propagation?
 
         return changed
+
+    def to_dict(self) -> Dict[str, List[Dict[str, Any]]]:
+        """Values and propagation of the flags, unlike ``yaml_entry``, which drops everything but
+        their values."""
+        return {
+            flag_type: [flag.to_dict() for flag in flags]
+            for flag_type, flags in sorted(self.items())
+        }
+
+    @staticmethod
+    def from_dict(d: Dict[str, List[Dict[str, Any]]]) -> "FlagMap":
+        result = FlagMap()
+        for flag_type, flags in d.items():
+            result[flag_type] = [CompilerFlag.from_dict(flag) for flag in flags]
+        return result
 
     @staticmethod
     def valid_compiler_flags():
@@ -2399,6 +2429,15 @@ class Spec:
             )
             d["abstract"] = sorted(v.name for v in self.variants.values() if not v.concrete)
 
+        if not self._concrete:
+            # State that only abstract specs have, or that "parameters" and "propagate" above are
+            # too coarse to express. Concrete node dicts are left alone: they feed the DAG hash.
+            if self.abstract_hash:
+                d["abstract_hash"] = self.abstract_hash
+
+            if self.compiler_flags:
+                d["compiler_flags"] = self.compiler_flags.to_dict()
+
         if self.external:
             d["external"] = {
                 "path": self.external_path,
@@ -2448,6 +2487,11 @@ class Spec:
                     }
                     if dspec.direct:
                         dep_attrs["parameters"]["direct"] = True
+                    if not self._concrete:
+                        if dspec.when != EMPTY_SPEC:
+                            dep_attrs["parameters"]["when"] = str(dspec.when)
+                        if dspec.propagation != PropagationPolicy.NONE:
+                            dep_attrs["parameters"]["propagation"] = dspec.propagation.name
                     dependencies.append(dep_attrs)
 
             d["dependencies"] = dependencies
@@ -5268,7 +5312,18 @@ def reconstruct_virtuals_on_edges(spec: Spec) -> None:
             edge.update_virtuals(virtuals_to_add)
 
 
-DepSpecComponents = Tuple[str, str, List[str], str, Tuple[str, ...], bool]
+class DepSpecComponents(NamedTuple):
+    """A dependency edge as it is stored in a spec file. The fields ``direct``, ``when``, and
+    ``propagation`` only occur on edges of abstract specs, and only from specfile v5 on."""
+
+    name: str
+    hash: str
+    deptypes: List[str]
+    hash_type: str
+    virtuals: Tuple[str, ...]
+    direct: bool
+    when: str = ""
+    propagation: str = PropagationPolicy.NONE.name
 
 
 _SPECFILE_READERS: Dict[int, Type["SpecfileReaderBase"]] = {}
@@ -5316,6 +5371,7 @@ class SpecfileReaderBase(abc.ABC):
         # old anonymous spec files had name=None, we use name="" now
         spec.name = name if isinstance(name, str) else ""
         spec.namespace = node.get("namespace", None)
+        spec.abstract_hash = node.get("abstract_hash", None)
 
         if "version" in node or "versions" in node:
             spec.versions = vn.VersionList.from_dict(node)
@@ -5324,11 +5380,17 @@ class SpecfileReaderBase(abc.ABC):
         if "arch" in node:
             spec.architecture = ArchSpec.from_dict(node)
 
+        # "compiler_flags" supersedes the flags under "parameters": it records propagation per
+        # flag, where "propagate" only records propagation per flag type.
+        spec.compiler_flags = FlagMap.from_dict(node.get("compiler_flags", {}))
+
         propagated_names = node.get("propagate", [])
         abstract_variants = set(node.get("abstract", ()))
         for name, values in node.get("parameters", {}).items():
             propagate = name in propagated_names
             if name in _valid_compiler_flags:
+                if name in spec.compiler_flags:
+                    continue
                 spec.compiler_flags[name] = []
                 for val in values:
                     spec.compiler_flags.add_flag(name, val, propagate)
@@ -5404,10 +5466,10 @@ class SpecfileReaderBase(abc.ABC):
         hash_type = None
         any_deps = False
         for node in nodes:
-            for _, _, _, dhash_type, _, _ in cls.dependencies_from_node_dict(node):
+            for dep in cls.dependencies_from_node_dict(node):
                 any_deps = True
-                if dhash_type:
-                    hash_type = dhash_type
+                if dep.hash_type:
+                    hash_type = dep.hash_type
                     break
 
         if not any_deps:  # If we never see a dependency...
@@ -5440,14 +5502,19 @@ def wire_spec_nodes(
     for node in nodes:
         node_spec = specs_by_hash[node[hash_type]]
 
-        for dname, dhash, dtype, _, virtuals, direct in reader.dependencies_from_node_dict(node):
-            dep_spec = specs_by_hash.get(dhash)
+        for dep in reader.dependencies_from_node_dict(node):
+            dep_spec = specs_by_hash.get(dep.hash)
             if dep_spec is None:
                 raise MissingSpecHashError(
-                    f"node '{node['name']}' references missing dep hash {dname}/{dhash}"
+                    f"node '{node['name']}' references missing dep hash {dep.name}/{dep.hash}"
                 )
             node_spec._add_dependency(
-                dep_spec, depflag=dt.canonicalize(dtype), virtuals=virtuals, direct=direct
+                dep_spec,
+                depflag=dt.canonicalize(dep.deptypes),
+                virtuals=dep.virtuals,
+                direct=dep.direct,
+                when=Spec(dep.when) if dep.when else None,
+                propagation=PropagationPolicy[dep.propagation],
             )
 
         if "build_spec" in node.keys():
@@ -5493,9 +5560,12 @@ class SpecfileV1(SpecfileReaderBase):
         for node in nodes:
             # get dependency dict from the node.
             name, data = cls.name_and_data(node)
-            for dname, _, dtypes, _, virtuals, direct in cls.dependencies_from_node_dict(data):
+            for dep in cls.dependencies_from_node_dict(data):
                 deps[name]._add_dependency(
-                    deps[dname], depflag=dt.canonicalize(dtypes), virtuals=virtuals, direct=direct
+                    deps[dep.name],
+                    depflag=dt.canonicalize(dep.deptypes),
+                    virtuals=dep.virtuals,
+                    direct=dep.direct,
                 )
 
         reconstruct_virtuals_on_edges(result)
@@ -5527,7 +5597,6 @@ class SpecfileV1(SpecfileReaderBase):
                     if h.name in elt:
                         dep_hash, deptypes = elt[h.name], elt["type"]
                         hash_type = h.name
-                        virtuals: Tuple[str, ...] = ()
                         break
                 else:  # We never determined a hash type...
                     raise spack.error.SpecError("Couldn't parse dependency spec.")
@@ -5535,7 +5604,14 @@ class SpecfileV1(SpecfileReaderBase):
                 raise spack.error.SpecError("Couldn't parse dependency types in spec.")
 
             dspec_list.append(
-                (dep_name, dep_hash, list(deptypes), hash_type, tuple(virtuals), True)
+                DepSpecComponents(
+                    name=dep_name,
+                    hash=dep_hash,
+                    deptypes=list(deptypes),
+                    hash_type=hash_type,
+                    virtuals=(),
+                    direct=True,
+                )
             )
 
         return dspec_list
@@ -5576,31 +5652,29 @@ class SpecfileV2(SpecfileReaderBase):
             raise spack.error.SpecError("Spec dictionary contains malformed dependencies")
 
         result = []
-        for dep in deps:
-            elt = dep
-            dep_name = dep["name"]
+        for elt in deps:
             if isinstance(elt, dict):
                 # new format: elements of dependency spec are keyed.
                 for h in ht.HASHES:
                     if h.name in elt:
-                        dep_hash, deptypes, hash_type, virtuals, direct = (
-                            cls.extract_info_from_dep(elt, h)
-                        )
+                        result.append(cls.extract_info_from_dep(elt, h))
                         break
                 else:  # We never determined a hash type...
                     raise spack.error.SpecError("Couldn't parse dependency spec.")
             else:
                 raise spack.error.SpecError("Couldn't parse dependency types in spec.")
-            result.append((dep_name, dep_hash, list(deptypes), hash_type, tuple(virtuals), direct))
         return result
 
     @classmethod
-    def extract_info_from_dep(cls, elt, hash):
-        dep_hash, deptypes = elt[hash.name], elt["type"]
-        hash_type = hash.name
-        virtuals = []
-        direct = True
-        return dep_hash, deptypes, hash_type, virtuals, direct
+    def extract_info_from_dep(cls, elt, hash) -> DepSpecComponents:
+        return DepSpecComponents(
+            name=elt["name"],
+            hash=elt[hash.name],
+            deptypes=list(elt["type"]),
+            hash_type=hash.name,
+            virtuals=(),
+            direct=True,
+        )
 
     @classmethod
     def extract_build_spec_info_from_node_dict(cls, node, hash_type=ht.dag_hash.name):
@@ -5618,13 +5692,15 @@ class SpecfileV4(SpecfileV2):
     SPEC_VERSION = 4
 
     @classmethod
-    def extract_info_from_dep(cls, elt, hash):
-        dep_hash = elt[hash.name]
-        deptypes = elt["parameters"]["deptypes"]
-        hash_type = hash.name
-        virtuals = elt["parameters"]["virtuals"]
-        direct = True
-        return dep_hash, deptypes, hash_type, virtuals, direct
+    def extract_info_from_dep(cls, elt, hash) -> DepSpecComponents:
+        return DepSpecComponents(
+            name=elt["name"],
+            hash=elt[hash.name],
+            deptypes=list(elt["parameters"]["deptypes"]),
+            hash_type=hash.name,
+            virtuals=tuple(elt["parameters"]["virtuals"]),
+            direct=True,
+        )
 
     @classmethod
     def load(cls, data) -> Spec:
@@ -5633,6 +5709,10 @@ class SpecfileV4(SpecfileV2):
 
 @register_reader
 class SpecfileV5(SpecfileV4):
+    """abstract_hash, compiler_flags, when and propagation are optional node/dependency keys,
+    used only for abstract specs. Not enforcing them is what avoids a version bump: an older
+    reader ignores an unknown key, and a spec file without one stays valid."""
+
     SPEC_VERSION = 5
 
     @classmethod
@@ -5640,13 +5720,18 @@ class SpecfileV5(SpecfileV4):
         raise RuntimeError("The 'compiler' option is unexpected in specfiles at v5 or greater")
 
     @classmethod
-    def extract_info_from_dep(cls, elt, hash):
-        dep_hash = elt[hash.name]
-        deptypes = elt["parameters"]["deptypes"]
-        hash_type = hash.name
-        virtuals = elt["parameters"]["virtuals"]
-        direct = elt["parameters"].get("direct", False)
-        return dep_hash, deptypes, hash_type, virtuals, direct
+    def extract_info_from_dep(cls, elt, hash) -> DepSpecComponents:
+        parameters = elt["parameters"]
+        return DepSpecComponents(
+            name=elt["name"],
+            hash=elt[hash.name],
+            deptypes=list(parameters["deptypes"]),
+            hash_type=hash.name,
+            virtuals=tuple(parameters["virtuals"]),
+            direct=parameters.get("direct", False),
+            when=parameters.get("when", ""),
+            propagation=parameters.get("propagation", PropagationPolicy.NONE.name),
+        )
 
 
 #: Alias to the latest version of specfiles

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -90,7 +90,6 @@ import spack.hash_types as ht
 import spack.patch
 import spack.paths
 import spack.platforms
-import spack.provider_index
 import spack.repo
 import spack.spec_parser
 import spack.traverse
@@ -1585,9 +1584,7 @@ def _anonymous_star(dep: DependencySpec, dep_format: str) -> str:
     return "*" if dep.spec.architecture else ""
 
 
-def _get_satisfying_edge(
-    lhs_node: "Spec", rhs_edge: DependencySpec, *, resolve_virtuals: bool
-) -> Optional[DependencySpec]:
+def _get_satisfying_edge(lhs_node: "Spec", rhs_edge: DependencySpec) -> Optional[DependencySpec]:
     """Search for an edge in ``lhs_node`` that satisfies ``rhs_edge``."""
     # First check direct deps of all types. An abstract edge that is not direct says its target
     # is somewhere in the DAG, which does not answer a question about a direct dependency. On a
@@ -1596,7 +1593,7 @@ def _get_satisfying_edge(
     for lhs_edge in lhs_node.edges_to_dependencies():
         if require_direct and not lhs_edge.direct:
             continue
-        if _satisfies_edge(lhs_edge, rhs_edge, resolve_virtuals):
+        if _satisfies_edge(lhs_edge, rhs_edge):
             return lhs_edge
 
     # Include the historical compiler node if available as an ad-hoc edge.
@@ -1609,7 +1606,7 @@ def _get_satisfying_edge(
             virtuals=("c", "cxx", "fortran"),
             direct=True,
         )
-        if _satisfies_edge(compiler_edge, rhs_edge, resolve_virtuals):
+        if _satisfies_edge(compiler_edge, rhs_edge):
             return compiler_edge
 
     if rhs_edge.direct:
@@ -1622,7 +1619,7 @@ def _get_satisfying_edge(
     while queue:
         lhs_edge = queue.popleft()
 
-        if _satisfies_edge(lhs_edge, rhs_edge, resolve_virtuals):
+        if _satisfies_edge(lhs_edge, rhs_edge):
             return lhs_edge
 
         for lhs_edge in lhs_edge.spec.edges_to_dependencies(depflag=depflag):
@@ -1633,14 +1630,14 @@ def _get_satisfying_edge(
     return None
 
 
-def _satisfies_edge(lhs: "DependencySpec", rhs: "DependencySpec", resolve_virtuals: bool) -> bool:
+def _satisfies_edge(lhs: "DependencySpec", rhs: "DependencySpec") -> bool:
     """Helper function for satisfaction tests, which checks edge attributes and the target node.
     It skips verification of the parent node."""
     name_mismatch = rhs.spec.name and lhs.spec.name != rhs.spec.name
     if name_mismatch and rhs.spec.name not in lhs.virtuals:
         return False
 
-    if not rhs.when._satisfies(lhs.when, resolve_virtuals=resolve_virtuals):
+    if not rhs.when.satisfies(lhs.when):
         return False
 
     # Subset semantics for virtuals
@@ -1653,17 +1650,14 @@ def _satisfies_edge(lhs: "DependencySpec", rhs: "DependencySpec", resolve_virtua
         return False
 
     if not name_mismatch:
-        return lhs.spec._satisfies_node(rhs.spec, resolve_virtuals=resolve_virtuals)
+        return lhs.spec._satisfies_node(rhs.spec)
 
     # rhs.spec.name being in lhs.virtuals above already established that lhs provides this
     # virtual: an abstract lhs has no _provided_virtuals to check that against, only the
     # edge's own declared virtuals. Only fall back to the node's frozen versions when rhs
     # narrows them; skip it in the common case where rhs is unconstrained, e.g. %cxx.
-    if rhs.spec.versions != spack.version.any_version:
-        if not resolve_virtuals:
-            return False
-        if not lhs.spec._provides_virtual(rhs.spec):
-            return False
+    if rhs.spec.versions != spack.version.any_version and not lhs.spec._provides_virtual(rhs.spec):
+        return False
 
     return lhs.spec._satisfies_node_attributes(rhs.spec)
 
@@ -1719,8 +1713,8 @@ class Spec:
         # cache of package for this spec
         self._package = None
 
-        # Virtual name -> version(s) this spec provides, frozen at concretization time from the
-        # package's `provides`. None means "not populated"; callers fall back to a package lookup.
+        # Virtual name -> version(s) this spec provides, frozen at concretization from the
+        # package's `provides`. None on abstract specs.
         self._provided_virtuals: Optional[Dict[str, vn.VersionList]] = None
 
         # whether the spec is concrete or not; set at the end of concretization
@@ -3165,49 +3159,20 @@ class Spec:
         Raises:
              spack.error.UnsatisfiableSpecError: when self cannot be constrained
         """
-        return self._constrain(other, deps=deps, resolve_virtuals=True)
+        return self._constrain(other, deps=deps)
 
-    def _constrain_symbolically(self, other, deps=True) -> bool:
-        """Constrains self with other, and returns True if self changed, False otherwise.
-
-        This function has no notion of virtuals, so it does not need a repository.
-
-        Args:
-            other: constraint to be added to self
-            deps: if False, constrain only the root node, otherwise constrain dependencies as well
-
-        Raises:
-            spack.error.UnsatisfiableSpecError: when self cannot be constrained
-
-        Examples:
-            >>> from spack.spec import Spec, UnsatisfiableDependencySpecError
-            >>> s = Spec("hdf5 ^mpi@4")
-            >>> t = Spec("hdf5 ^mpi=openmpi")
-            >>> try:
-            ...     s.constrain(t)
-            ... except UnsatisfiableDependencySpecError as e:
-            ...     print(e)
-            ...
-            hdf5 ^mpi=openmpi does not satisfy hdf5 ^mpi@4
-            >>> s._constrain_symbolically(t)
-            True
-            >>> s
-            hdf5 ^mpi@4 ^mpi=openmpi
-        """
-        return self._constrain(other, deps=deps, resolve_virtuals=False)
-
-    def _constrain(self, other, deps=True, *, resolve_virtuals: bool):
+    def _constrain(self, other, deps=True):
         # If we are trying to constrain a concrete spec, either the spec
         # already satisfies the constraint (and the method returns False)
         # or it raises an exception
         if self.concrete:
-            if self._satisfies(other, resolve_virtuals=resolve_virtuals):
+            if self.satisfies(other):
                 return False
             else:
                 raise spack.error.UnsatisfiableSpecError(self, other, "constrain a concrete spec")
 
         other = self._autospec(other)
-        if other.concrete and other._satisfies(self, resolve_virtuals=resolve_virtuals):
+        if other.concrete and other.satisfies(self):
             self._dup(other)
             return True
 
@@ -3255,7 +3220,7 @@ class Spec:
             # TODO: might want more detail than this, e.g. specific deps
             # in violation. if this becomes a priority get rid of this
             # check and be more specific about what's wrong.
-            if not other._intersects_dependencies(self, resolve_virtuals=resolve_virtuals):
+            if not other._intersects_dependencies(self):
                 raise UnsatisfiableDependencySpecError(other, self)
 
             for d in other.traverse(root=False):
@@ -3351,11 +3316,6 @@ class Spec:
             other: spec to be checked for compatibility
             deps: if True check compatibility of dependency nodes too, if False only check root
         """
-        return self._intersects(other=other, deps=deps, resolve_virtuals=True)
-
-    def _intersects(
-        self, other: Union[str, "Spec"], deps: bool = True, resolve_virtuals: bool = True
-    ) -> bool:
         if other is EMPTY_SPEC:
             return True
         other = self._autospec(other)
@@ -3364,10 +3324,10 @@ class Spec:
             return self.dag_hash() == other.dag_hash()
 
         elif self.concrete:
-            return self._satisfies(other, resolve_virtuals=resolve_virtuals)
+            return self.satisfies(other)
 
         elif other.concrete:
-            return other._satisfies(self, resolve_virtuals=resolve_virtuals)
+            return other.satisfies(self)
 
         # From here we know both self and other are not concrete
         self_hash = self.abstract_hash
@@ -3380,37 +3340,9 @@ class Spec:
         ):
             return False
 
-        # If the names are different, we need to consider virtuals
+        # Two abstract roots with different names do not intersect. We cannot lookup whether the
+        # one spec provides the other, because that would make intersection stateful.
         if self.name != other.name and self.name and other.name:
-            if not resolve_virtuals:
-                return False
-
-            self_virtual = spack.repo.PATH.is_virtual(self.name)
-            other_virtual = spack.repo.PATH.is_virtual(other.name)
-            if self_virtual and other_virtual:
-                # Two virtual specs intersect only if there are providers for both
-                lhs = spack.repo.PATH.providers_for(str(self))
-                rhs = spack.repo.PATH.providers_for(str(other))
-                intersection = [s for s in lhs if any(s.intersects(z) for z in rhs)]
-                return bool(intersection)
-
-            # A provider can satisfy a virtual dependency.
-            elif self_virtual or other_virtual:
-                virtual_spec, non_virtual_spec = (self, other) if self_virtual else (other, self)
-                try:
-                    # Here we might get an abstract spec
-                    pkg_cls = spack.repo.PATH.get_pkg_class(non_virtual_spec.fullname)
-                    pkg = pkg_cls(non_virtual_spec)
-                except spack.repo.UnknownEntityError:
-                    # If we can't get package info on this spec, don't treat
-                    # it as a provider of this vdep.
-                    return False
-
-                if pkg.provides(virtual_spec.name):
-                    for when_spec, provided in pkg.provided.items():
-                        if non_virtual_spec.intersects(when_spec, deps=False):
-                            if any(vpkg.intersects(virtual_spec) for vpkg in provided):
-                                return True
             return False
 
         # namespaces either match, or other doesn't require one.
@@ -3437,11 +3369,11 @@ class Spec:
 
         # If we need to descend into dependencies, do it, otherwise we're done.
         if deps:
-            return self._intersects_dependencies(other, resolve_virtuals=resolve_virtuals)
+            return self._intersects_dependencies(other)
 
         return True
 
-    def _intersects_dependencies(self, other, resolve_virtuals: bool = True):
+    def _intersects_dependencies(self, other):
         if not other._dependencies or not self._dependencies:
             # one spec *could* eventually satisfy the other
             return True
@@ -3450,39 +3382,7 @@ class Spec:
         common_dependencies = {x.name for x in self.dependencies()}
         common_dependencies &= {x.name for x in other.dependencies()}
         for name in common_dependencies:
-            if not self[name]._intersects(
-                other[name], deps=True, resolve_virtuals=resolve_virtuals
-            ):
-                return False
-
-        if not resolve_virtuals:
-            return True
-
-        # For virtual dependencies, we need to dig a little deeper.
-        self_index = spack.provider_index.ProviderIndex(
-            repository=spack.repo.PATH, specs=self.traverse(), restrict=True
-        )
-        other_index = spack.provider_index.ProviderIndex(
-            repository=spack.repo.PATH, specs=other.traverse(), restrict=True
-        )
-
-        # These two loops handle cases where there is an overly restrictive
-        # vpkg in one spec for a provider in the other (e.g., mpi@3: is not
-        # compatible with mpich2)
-        for spec in self.traverse():
-            if (
-                spack.repo.PATH.is_virtual(spec.name)
-                and spec.name in other_index
-                and not other_index.providers_for(spec)
-            ):
-                return False
-
-        for spec in other.traverse():
-            if (
-                spack.repo.PATH.is_virtual(spec.name)
-                and spec.name in self_index
-                and not self_index.providers_for(spec)
-            ):
+            if not self[name].intersects(other[name], deps=True):
                 return False
 
         return True
@@ -3494,61 +3394,12 @@ class Spec:
             other: spec to be satisfied
             deps: if True, descend to dependencies, otherwise only check root node
         """
-        return self._satisfies(other=other, deps=deps, resolve_virtuals=True)
-
-    def _provides_virtual(self, virtual_spec: "Spec") -> bool:
-        """Return True if this spec provides the given virtual spec.
-
-        Args:
-            virtual_spec: abstract virtual spec (e.g. ``"mpi"`` or ``"mpi@3:"``)
-        """
-        if not virtual_spec.name:
-            return False
-
-        # Get the package instance
-        if self.concrete:
-            try:
-                pkg = self.package
-            except spack.repo.UnknownPackageError:
-                return False
-        else:
-            try:
-                pkg_cls = spack.repo.PATH.get_pkg_class(self.fullname)
-                pkg = pkg_cls(self)
-            except spack.repo.UnknownEntityError:
-                # If we can't get package info on this spec, don't treat
-                # it as a provider of this vdep.
-                return False
-
-        for when_spec, provided in pkg.provided.items():
-            # Don't use satisfies for virtuals, because an abstract vs. abstract spec may use the
-            # repo index
-            if self.satisfies(when_spec, deps=False) and any(
-                provided_virtual.name == virtual_spec.name
-                and provided_virtual.versions.intersects(virtual_spec.versions)
-                for provided_virtual in provided
-            ):
-                return True
-
-        return False
-
-    def _satisfies(
-        self, other: Union[str, "Spec"], deps: bool = True, resolve_virtuals: bool = True
-    ) -> bool:
-        """Return True if all concrete specs matching self also match other, otherwise False.
-
-        Args:
-            other: spec to be satisfied
-            deps: if True, descend to dependencies, otherwise only check root node
-            resolve_virtuals: if True, resolve virtuals in self and other. This requires a
-                repository to be available.
-        """
         if other is EMPTY_SPEC:
             return True
 
         other = self._autospec(other)
 
-        if not self._satisfies_node(other, resolve_virtuals=resolve_virtuals):
+        if not self._satisfies_node(other):
             return False
 
         # If there are no dependencies on the rhs, or we don't recurse, they are satisfied.
@@ -3562,12 +3413,10 @@ class Spec:
 
             for rhs_edge in rhs.edges_to_dependencies():
                 # Skip rhs edges whose when condition doesn't apply to the lhs node.
-                if rhs_edge.when is not EMPTY_SPEC and not lhs._intersects(
-                    rhs_edge.when, resolve_virtuals=resolve_virtuals
-                ):
+                if rhs_edge.when is not EMPTY_SPEC and not lhs.intersects(rhs_edge.when):
                     continue
 
-                lhs_edge = _get_satisfying_edge(lhs, rhs_edge, resolve_virtuals=resolve_virtuals)
+                lhs_edge = _get_satisfying_edge(lhs, rhs_edge)
 
                 if not lhs_edge:
                     return False
@@ -3578,7 +3427,16 @@ class Spec:
 
         return True
 
-    def _satisfies_node(self, other: "Spec", resolve_virtuals: bool) -> bool:
+    def _provides_virtual(self, virtual_spec: "Spec") -> bool:
+        """Return True if this spec provides the given virtual spec, using the provided virtual
+        versions frozen on the node, without consulting a package class/repository."""
+        provided = self._provided_virtuals
+        if provided is None or not virtual_spec.name:
+            return False
+        versions = provided.get(virtual_spec.name)
+        return versions is not None and versions.intersects(virtual_spec.versions)
+
+    def _satisfies_node(self, other: "Spec") -> bool:
         """Compares self and other without looking at dependencies"""
         if other.concrete:
             # The left-hand side must be the same singleton with identical hash. Notice that
@@ -3596,8 +3454,6 @@ class Spec:
             # rhs. other.versions constrains the virtual's provided-version range there, which
             # _provides_virtual already checks, not self's own version, so self.versions is not
             # compared in this branch. Every other dimension still has to hold of the provider.
-            if not resolve_virtuals:
-                return False
             return self._provides_virtual(other) and self._satisfies_node_attributes(other)
 
         if not self.versions.satisfies(other.versions):
@@ -4802,11 +4658,13 @@ class Spec:
                         _add_edge_to_map(new_dependencies, edge.spec.name, edge)
             spec._dependencies = new_dependencies
 
-    def _virtuals_provided(self, root):
-        """Return set of virtuals provided by self in the context of root"""
+    def _virtuals_provided(self, root) -> Set[str]:
+        """Return set of virtuals provided by self in the context of root.
+
+        A non-root node provides the virtuals annotated on its incoming edges, while the root
+        could be using any virtual it provides."""
         if root is self:
-            # Could be using any virtual the package can provide
-            return {v.name for v in self.package.virtuals_provided}
+            return set(self.provided_virtuals)
 
         hashes = [s.dag_hash() for s in root.traverse()]
         in_edges = set(

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -1605,16 +1605,17 @@ def _satisfies_edge(lhs: "DependencySpec", rhs: "DependencySpec", resolve_virtua
     if not name_mismatch:
         return lhs.spec._satisfies_node(rhs.spec, resolve_virtuals=resolve_virtuals)
 
-    # Right-hand side is virtual provided by left-hand side. The only node attribute supported is
-    # the version of the virtual. Avoid expensive lookups for provider metadata if there's no
-    # version constraint to check.
-    if rhs.spec.versions == spack.version.any_version:
-        return True
+    # rhs.spec.name being in lhs.virtuals above already established that lhs provides this
+    # virtual: an abstract lhs has no _provided_virtuals to check that against, only the
+    # edge's own declared virtuals. Only fall back to the node's frozen versions when rhs
+    # narrows them; skip it in the common case where rhs is unconstrained, e.g. %cxx.
+    if rhs.spec.versions != spack.version.any_version:
+        if not resolve_virtuals:
+            return False
+        if not lhs.spec._provides_virtual(rhs.spec):
+            return False
 
-    if not resolve_virtuals:
-        return False
-
-    return lhs.spec._provides_virtual(rhs.spec)
+    return lhs.spec._satisfies_node_attributes(rhs.spec)
 
 
 @lang.lazy_lexicographic_ordering(set_hash=False)
@@ -3492,11 +3493,22 @@ class Spec:
             return self.concrete and self.dag_hash() == other.dag_hash()
 
         if self.name != other.name and self.name and other.name:
-            # Name mismatch can still be satisfiable if lhs provides the virtual mentioned by rhs.
+            # Name mismatch can still be satisfiable if lhs provides the virtual mentioned by
+            # rhs. other.versions constrains the virtual's provided-version range there, which
+            # _provides_virtual already checks, not self's own version, so self.versions is not
+            # compared in this branch. Every other dimension still has to hold of the provider.
             if not resolve_virtuals:
                 return False
-            return self._provides_virtual(other)
+            return self._provides_virtual(other) and self._satisfies_node_attributes(other)
 
+        if not self.versions.satisfies(other.versions):
+            return False
+
+        return self._satisfies_node_attributes(other)
+
+    def _satisfies_node_attributes(self, other: "Spec") -> bool:
+        """The dimensions of _satisfies_node that do not depend on how the name and version were
+        matched: abstract hash, namespace, variants, architecture and compiler flags."""
         # If the right-hand side has an abstract hash, make sure it's a prefix of the
         # left-hand side's (abstract) hash.
         if other.abstract_hash:
@@ -3510,9 +3522,6 @@ class Spec:
             and self.namespace is not None
             and self.namespace != other.namespace
         ):
-            return False
-
-        if not self.versions.satisfies(other.versions):
             return False
 
         if not self._satisfies_variants(other):

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -933,29 +933,6 @@ class CompilerFlag(str):
 _valid_compiler_flags = ["cflags", "cxxflags", "fflags", "ldflags", "ldlibs", "cppflags"]
 
 
-def _shared_subset_pair_iterate(container1, container2):
-    """
-    [0, a, c, d, f]
-    [a, d, e, f]
-
-    yields [(a, a), (d, d), (f, f)]
-
-    no repeated elements
-    """
-    a_idx, b_idx = 0, 0
-    max_a, max_b = len(container1), len(container2)
-    while a_idx < max_a and b_idx < max_b:
-        if container1[a_idx] == container2[b_idx]:
-            yield (container1[a_idx], container2[b_idx])
-            a_idx += 1
-            b_idx += 1
-        else:
-            while container1[a_idx] < container2[b_idx]:
-                a_idx += 1
-            while container1[a_idx] > container2[b_idx]:
-                b_idx += 1
-
-
 class FlagMap(lang.HashableMap[str, List[CompilerFlag]]):
     __slots__ = ()
 
@@ -985,22 +962,18 @@ class FlagMap(lang.HashableMap[str, List[CompilerFlag]]):
                 ]
                 changed = True
 
-            # Next, if any flags in other propagate, we force them to propagate in our case.
-            # CompilerFlag objects can be shared with other specs, so they are replaced rather
-            # than modified in place.
-            shared = sorted(set(other[flag_type]) - extra_other)
-            demoted = {
-                id(y)
-                for x, y in _shared_subset_pair_iterate(shared, sorted(self[flag_type]))
-                if y.propagate is True and x.propagate is False
-            }
-            if demoted:
+            # A flag that propagates is the narrower of the two, so a value that propagates on
+            # either side propagates in the result. CompilerFlag objects can be shared with other
+            # specs, so they are replaced rather than modified in place.
+            propagating = {str(f) for f in other[flag_type] if f.propagate}
+            promoted = [not f.propagate and str(f) in propagating for f in self[flag_type]]
+            if any(promoted):
                 changed = True
                 self[flag_type] = [
-                    CompilerFlag(f, propagate=False, flag_group=f.flag_group, source=f.source)
-                    if id(f) in demoted
+                    CompilerFlag(f, propagate=True, flag_group=f.flag_group, source=f.source)
+                    if promote
                     else f
-                    for f in self[flag_type]
+                    for f, promote in zip(self[flag_type], promoted)
                 ]
 
         # TODO: what happens if flag groups with a partial (but not complete)

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -59,7 +59,6 @@ import pathlib
 import platform
 import re
 import socket
-import warnings
 from typing import (
     Any,
     Callable,
@@ -1720,6 +1719,10 @@ class Spec:
         # cache of package for this spec
         self._package = None
 
+        # Virtual name -> version(s) this spec provides, frozen at concretization time from the
+        # package's `provides`. None means "not populated"; callers fall back to a package lookup.
+        self._provided_virtuals: Optional[Dict[str, vn.VersionList]] = None
+
         # whether the spec is concrete or not; set at the end of concretization
         self._concrete = False
 
@@ -2546,6 +2549,13 @@ class Spec:
                 package_hash = package_hash.decode("utf-8")
             d["package_hash"] = package_hash
 
+        # Always written for concrete nodes, even when empty, so that an absent key means the
+        # document was written by a Spack that predates this field.
+        if self._concrete:
+            d["provided_virtuals"] = {
+                name: str(versions) for name, versions in sorted(self.provided_virtuals.items())
+            }
+
         # Note: Relies on sorting dict by keys later in algorithm.
         deps = self._dependencies_dict(depflag=hash.depflag)
         if deps:
@@ -2973,6 +2983,9 @@ class Spec:
     def _mark_root_concrete(self, value=True):
         """Mark just this spec (not dependencies) concrete."""
         self._concrete = value
+        if not value:
+            # Frozen provided virtuals are no longer valid; repopulated on re-concretization.
+            self._provided_virtuals = None
         # A direct dependency is a constraint written with %, so the flag belongs on abstract
         # specs only. Every edge of a materialized DAG is a direct dependency in fact.
         for edge in self.edges_to_dependencies():
@@ -3009,6 +3022,11 @@ class Spec:
         # if set to false, clear out all hashes (set to None or remove attr)
         # may need to change references to respect None
         for s in self.traverse():
+            # A node that is turned concrete here provides no virtuals unless something says
+            # otherwise. Nodes that are concrete already are left alone: they may come from a
+            # document that predates `provided_virtuals`, and still need reconstruction.
+            if value and not s._concrete and s._provided_virtuals is None:
+                s._provided_virtuals = {}
             if not value:
                 s.clear_caches()
             s._mark_root_concrete(value)
@@ -3049,6 +3067,11 @@ class Spec:
                 # keep this check here to ensure package hash is saved
                 assert getattr(spec, ht.package_hash.attr)
 
+        # Freeze the virtual versions each node provides. Before marking concrete, which
+        # defaults the freshly concrete nodes to providing nothing, and before any hash is
+        # computed, since the frozen versions are part of it.
+        spack.repo.reconstruct_virtuals([self])
+
         # Mark everything in the spec as concrete
         self._mark_concrete()
 
@@ -3058,6 +3081,19 @@ class Spec:
         # DAG hash.
         for spec in self.traverse():
             spec._cached_hash(ht.dag_hash)
+
+    @property
+    def provided_virtuals(self) -> Dict[str, vn.VersionList]:
+        """Virtual name -> version(s) this concrete node provides, frozen at concretization.
+
+        The values are assigned by ``spack.repo.reconstruct_virtuals``; this property only
+        returns the cached result."""
+        if self._provided_virtuals is None:
+            raise spack.error.SpecError(
+                f"the provided virtuals of {self.name} were never frozen; "
+                f"call spack.repo.reconstruct_virtuals(specs) first"
+            )
+        return self._provided_virtuals
 
     def index(self, deptype="all"):
         """Return a dictionary that points to all the dependencies in this
@@ -3750,6 +3786,9 @@ class Spec:
             )
 
         self._package = None
+        self._provided_virtuals = (
+            None if other._provided_virtuals is None else dict(other._provided_virtuals)
+        )
 
         # Local node attributes get copied first.
         self.name = other.name
@@ -5378,53 +5417,6 @@ def parse_with_version_concrete(spec_like: Union[str, Spec]):
     return s
 
 
-def reconstruct_virtuals_on_edges(spec: Spec) -> None:
-    """Reconstruct virtuals on edges. Used to read from old DB and reindex."""
-    virtuals_needed: Dict[str, Set[str]] = {}
-    virtuals_provided: Dict[str, Set[str]] = {}
-    for edge in spec.traverse_edges(cover="edges", root=False):
-        parent_key = edge.parent.dag_hash()
-        if parent_key not in virtuals_needed:
-            # Construct which virtuals are needed by parent
-            virtuals_needed[parent_key] = set()
-            try:
-                parent_pkg = edge.parent.package
-            except Exception as e:
-                warnings.warn(
-                    f"cannot reconstruct virtual dependencies on {edge.parent.name}: {e}"
-                )
-                continue
-
-            virtuals_needed[parent_key].update(
-                name
-                for name, when_deps in parent_pkg.dependencies_by_name(when=True).items()
-                if spack.repo.PATH.is_virtual(name)
-                and any(edge.parent.satisfies(x) for x in when_deps)
-            )
-
-        if not virtuals_needed[parent_key]:
-            continue
-
-        child_key = edge.spec.dag_hash()
-        if child_key not in virtuals_provided:
-            virtuals_provided[child_key] = set()
-            try:
-                child_pkg = edge.spec.package
-            except Exception as e:
-                warnings.warn(
-                    f"cannot reconstruct virtual dependencies on {edge.parent.name}: {e}"
-                )
-                continue
-            virtuals_provided[child_key].update(x.name for x in child_pkg.virtuals_provided)
-
-        if not virtuals_provided[child_key]:
-            continue
-
-        virtuals_to_add = virtuals_needed[parent_key] & virtuals_provided[child_key]
-        if virtuals_to_add:
-            edge.update_virtuals(virtuals_to_add)
-
-
 class DepSpecComponents(NamedTuple):
     """A dependency edge as it is stored in a spec file. The fields ``direct``, ``when``, and
     ``propagation`` only occur on edges of abstract specs, and only from specfile v5 on."""
@@ -5529,6 +5521,14 @@ class SpecfileReaderBase(abc.ABC):
         # specs read in are concrete unless marked abstract
         if node.get("concrete", True):
             spec._mark_root_concrete()
+            # An absent key means the document predates this field; it is left as None here and
+            # reconstructed from package.py once the DAG is wired up, since `provides` when
+            # clauses may constrain dependencies.
+            if "provided_virtuals" in node:
+                spec._provided_virtuals = {
+                    name: vn.VersionList(versions)
+                    for name, versions in node["provided_virtuals"].items()
+                }
 
         if "patches" in node:
             patches = node["patches"]
@@ -5651,6 +5651,9 @@ def wire_spec_nodes(
                 )
             node_spec._build_spec = build_spec
 
+    # Fill virtual/provider data for files that predate the `provided_virtuals` key
+    spack.repo.reconstruct_virtuals([s for s in specs_by_hash.values() if s.concrete])
+
     return specs_by_hash
 
 
@@ -5691,7 +5694,7 @@ class SpecfileV1(SpecfileReaderBase):
                     direct=dep.direct,
                 )
 
-        reconstruct_virtuals_on_edges(result)
+        spack.repo.reconstruct_virtuals(dep_list)
         return result
 
     @classmethod
@@ -5753,9 +5756,7 @@ class SpecfileV2(SpecfileReaderBase):
 
     @classmethod
     def load(cls, data) -> Spec:
-        result = cls._load(data)
-        reconstruct_virtuals_on_edges(result)
-        return result
+        return cls._load(data)
 
     @classmethod
     def name_and_data(cls, node):

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -5508,14 +5508,24 @@ def wire_spec_nodes(
                 raise MissingSpecHashError(
                     f"node '{node['name']}' references missing dep hash {dep.name}/{dep.hash}"
                 )
-            node_spec._add_dependency(
+            # Register the edge directly instead of going through _add_dependency: each entry
+            # here is already a fully resolved, distinct edge from a concrete DAG, so there is
+            # nothing to merge. Two entries can reference the same dep hash (a build-only edge
+            # and a link-only edge to the same node, say), which would make dep_spec the same
+            # object both times - _add_dependency's identity-based merge detection exists for
+            # incrementally building up one edge's deptypes call by call, and would wrongly fold
+            # this into one edge instead of registering a second, parallel one.
+            edge = DependencySpec(
+                node_spec,
                 dep_spec,
                 depflag=dt.canonicalize(dep.deptypes),
                 virtuals=dep.virtuals,
                 direct=dep.direct,
-                when=Spec(dep.when) if dep.when else None,
+                when=Spec(dep.when) if dep.when else EMPTY_SPEC,
                 propagation=PropagationPolicy[dep.propagation],
             )
+            _add_edge_to_map(node_spec._dependencies, edge.spec.name, edge)
+            _add_edge_to_map(edge.spec._dependents, edge.parent.name, edge)
 
         if "build_spec" in node.keys():
             bname, bhash, _ = reader.extract_build_spec_info_from_node_dict(

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -231,6 +231,22 @@ def _make_microarchitecture(name: str) -> spack.vendor.archspec.cpu.Microarchite
     )
 
 
+def _attr_satisfies(lhs: Optional[str], rhs: Optional[str]) -> bool:
+    """Whether a platform or operating system on the lhs satisfies the one on the rhs. A star
+    requires a value without naming one, so any value on the lhs satisfies it."""
+    if not rhs:
+        return True
+    return bool(lhs) if rhs == "*" else lhs == rhs
+
+
+def _attr_intersects(lhs: Optional[str], rhs: Optional[str]) -> bool:
+    """Whether a platform or operating system on either side can be made equal to the other. An
+    unset value is still open to any value, and a star is satisfied by any of them."""
+    if not lhs or not rhs:
+        return True
+    return lhs == "*" or rhs == "*" or lhs == rhs
+
+
 @lang.lazy_lexicographic_ordering
 class ArchSpec:
     """Aggregate the target platform, the operating system and the target microarchitecture."""
@@ -406,16 +422,8 @@ class ArchSpec:
         """
         other = self._autospec(other)
 
-        # Check platform and os
         for attribute in ("platform", "os"):
-            other_attribute = getattr(other, attribute)
-            self_attribute = getattr(self, attribute)
-
-            # platform=* or os=*
-            if self_attribute and other_attribute == "*":
-                return True
-
-            if other_attribute and self_attribute != other_attribute:
+            if not _attr_satisfies(getattr(self, attribute), getattr(other, attribute)):
                 return False
 
         return self._target_satisfies(other, strict=True)
@@ -432,11 +440,8 @@ class ArchSpec:
         """
         other = self._autospec(other)
 
-        # Check platform and os
         for attribute in ("platform", "os"):
-            other_attribute = getattr(other, attribute)
-            self_attribute = getattr(self, attribute)
-            if other_attribute and self_attribute and self_attribute != other_attribute:
+            if not _attr_intersects(getattr(self, attribute), getattr(other, attribute)):
                 return False
 
         return self._target_satisfies(other, strict=False)
@@ -458,6 +463,10 @@ class ArchSpec:
         if other.target == ArchSpec.ANY_TARGET:
             return True
 
+        # target=* on the lhs overlaps any target, but is too broad to satisfy a specific one
+        if not strict and self.target == ArchSpec.ANY_TARGET:
+            return True
+
         return bool(self._target_intersection(other))
 
     def _target_constrain(self, other: "ArchSpec") -> bool:
@@ -466,6 +475,18 @@ class ArchSpec:
         # the two has no target, which would turn into an empty target below.
         if other.target is None:
             return False
+
+        # target=* constrains a target to be set without naming one, so any target already
+        # satisfies it and a side without one becomes the star. It is also concrete by the
+        # definition below, which would otherwise make it override a real target.
+        if other.target == ArchSpec.ANY_TARGET:
+            if self.target is not None:
+                return False
+            self.target = other.target
+            return True
+        if self.target == ArchSpec.ANY_TARGET:
+            self.target = other.target
+            return True
 
         if not other._target_satisfies(self, strict=False):
             raise UnsatisfiableArchitectureSpecError(self, other)
@@ -592,7 +613,9 @@ class ArchSpec:
         constrained = False
         for attr in ("platform", "os"):
             svalue, ovalue = getattr(self, attr), getattr(other, attr)
-            if svalue is None and ovalue is not None:
+            # a star constrains the value to be set, so it is kept when there is none yet and
+            # is replaced by a real value from the other side
+            if ovalue is not None and (svalue is None or (svalue == "*" and ovalue != "*")):
                 setattr(self, attr, ovalue)
                 constrained = True
 

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -247,6 +247,37 @@ def _attr_intersects(lhs: Optional[str], rhs: Optional[str]) -> bool:
     return lhs == "*" or rhs == "*" or lhs == rhs
 
 
+def _target_range_contains(container: str, target: str) -> bool:
+    """Whether every microarchitecture ``target`` (a single ``min:max`` range, or the name of a
+    concrete one) denotes is also denoted by ``container``, in the same sense."""
+    t_min, t_sep, t_max = target.partition(":")
+    c_min, c_sep, c_max = container.partition(":")
+
+    if not t_sep:
+        # target is concrete: contained iff it falls within container's bounds.
+        t = _make_microarchitecture(t_min)
+        if not c_sep:
+            return t_min == c_min
+        return (not c_min or t >= c_min) and (not c_max or t <= c_max)
+
+    if not c_sep:
+        # container is a single point: a range is inside it only by denoting that point too.
+        return t_min == t_max == c_min
+
+    # Both are ranges. An empty target bound resolves to the family root (floor) or stays
+    # unbounded (ceiling): nothing but an unbounded container range covers an unbounded one.
+    if c_min:
+        if not t_min and not t_max:
+            return False
+        floor = _make_microarchitecture(t_min) if t_min else _make_microarchitecture(t_max).family
+        if not floor >= c_min:
+            return False
+    if c_max:
+        if not t_max or not _make_microarchitecture(t_max) <= c_max:
+            return False
+    return True
+
+
 @lang.lazy_lexicographic_ordering
 class ArchSpec:
     """Aggregate the target platform, the operating system and the target microarchitecture."""
@@ -467,7 +498,17 @@ class ArchSpec:
         if not strict and self.target == ArchSpec.ANY_TARGET:
             return True
 
-        return bool(self._target_intersection(other))
+        if not strict:
+            return bool(self._target_intersection(other))
+
+        # Subset test: every target self's ranges denote must be covered by one of other's.
+        return all(
+            any(
+                _target_range_contains(o_range, s_range)
+                for o_range in str(other.target).split(",")
+            )
+            for s_range in str(self.target).split(",")
+        )
 
     def _target_constrain(self, other: "ArchSpec") -> bool:
         # An unconstrained target on either side means the other side is the intersection.

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -1147,10 +1147,6 @@ class FlagMap(lang.HashableMap[str, List[CompilerFlag]]):
         return result
 
 
-def _sort_by_dep_types(dspec: DependencySpec):
-    return dspec.depflag
-
-
 EdgeMap = Dict[str, List[DependencySpec]]
 
 
@@ -1158,7 +1154,10 @@ def _add_edge_to_map(edge_map: EdgeMap, key: str, edge: DependencySpec) -> None:
     if key in edge_map:
         lst = edge_map[key]
         lst.append(edge)
-        lst.sort(key=_sort_by_dep_types)
+        # Edges compare by dependency types first and then by every other attribute that tells
+        # two of them apart, so parallel edges are ordered by what they are rather than by the
+        # order in which they happened to be added.
+        lst.sort()  # type: ignore[call-arg,call-overload]
     else:
         edge_map[key] = [edge]
 
@@ -1928,11 +1927,14 @@ class Spec:
         Args:
             deptype: allowed dependency types
         """
-        _sort_fn = lambda x: (x.spec.name, _sort_by_dep_types(x))
+        # Edges compare by name, dependency types and then every other attribute that tells two
+        # of them apart, so parallel edges are ordered by what they are instead of by the order
+        # they happened to be added in.
         _group_fn = lambda x: x.spec.name
         selected_edges = _select_edges(self._dependencies, depflag=depflag)
+        edges = sorted(selected_edges)  # type: ignore[type-var]
         result = {}
-        for key, group in itertools.groupby(sorted(selected_edges, key=_sort_fn), key=_group_fn):
+        for key, group in itertools.groupby(edges, key=_group_fn):
             result[key] = list(group)
         return result
 

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -2919,6 +2919,10 @@ class Spec:
     def _mark_root_concrete(self, value=True):
         """Mark just this spec (not dependencies) concrete."""
         self._concrete = value
+        # A direct dependency is a constraint written with %, so the flag belongs on abstract
+        # specs only. Every edge of a materialized DAG is a direct dependency in fact.
+        for edge in self.edges_to_dependencies():
+            edge.direct = not value
         self._validate_version()
         for variant in self.variants.values():
             variant.concrete = True

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -655,6 +655,13 @@ class ArchSpec:
         if not other.intersects(self):
             raise UnsatisfiableArchitectureSpecError(other, self)
 
+        return self._merge(other)
+
+    def _merge(self, other: "ArchSpec") -> bool:
+        """Intersect self with other in place, and return True iff self changed.
+
+        Precondition: the two intersect. Total, so that a caller which has already checked
+        cannot end up with platform and os applied but not the target."""
         constrained = False
         for attr in ("platform", "os"):
             svalue, ovalue = getattr(self, attr), getattr(other, attr)
@@ -878,10 +885,10 @@ class DependencySpec:
             when=self.when,
         )
 
-    def _constrain(self, other: "DependencySpec") -> bool:
-        """Constrain this edge with another edge. Precondition: parent and child of self and other
-        are compatible, and both edges have the same when condition. Used as an internal helper
-        function in Spec.constrain.
+    def _merge(self, other: "DependencySpec") -> bool:
+        """Merge another edge into this one. Precondition: the two were paired by
+        ``_paired_edges``, so they point at the same package under the same when condition, and
+        their target specs have been checked to intersect. Total, see ``Spec._merge``.
 
         Args:
             other: edge to use as constraint
@@ -890,7 +897,7 @@ class DependencySpec:
             True if the current edge was changed, False otherwise.
         """
         changed = False
-        changed |= self.spec.constrain(other.spec)
+        changed |= self.spec._merge(other.spec, deps=True)
         changed |= self.update_deptypes(other.depflag)
         changed |= self.update_virtuals(other.virtuals)
         if not self.direct and other.direct:
@@ -1013,9 +1020,6 @@ class FlagMap(lang.HashableMap[str, List[CompilerFlag]]):
 
     def satisfies(self, other):
         return all(f in self and set(self[f]) >= set(other[f]) for f in other)
-
-    def intersects(self, other):
-        return True
 
     def constrain(self, other):
         """Add all flags in other that aren't in self to self.
@@ -1582,6 +1586,32 @@ def _anonymous_star(dep: DependencySpec, dep_format: str) -> str:
         return "*"
 
     return "*" if dep.spec.architecture else ""
+
+
+def _paired_edges(
+    node: "Spec", other: "Spec"
+) -> List[Tuple[Optional[DependencySpec], DependencySpec]]:
+    """Pair every edge of ``other`` with the edge of ``node`` it is merged into.
+
+    Two edges match when they point at the same package name under the same ``when`` condition.
+    The matching is a greedy injection over the edges ``node`` has right now, so each of them is
+    claimed by at most one edge of ``other``, and an edge added during a merge cannot be claimed
+    by a later one. Edges without a match are paired with None and get copied in.
+
+    Both the intersection test and the merge pair edges here, so the test cannot accept a pairing
+    that the merge would not perform, and the merge never has to re-check one.
+    """
+    result: List[Tuple[Optional[DependencySpec], DependencySpec]] = []
+    claimed: Set[int] = set()
+    for other_edge in other.edges_to_dependencies():
+        match = None
+        for candidate in node.edges_to_dependencies(other_edge.spec.name):
+            if candidate.when == other_edge.when and id(candidate) not in claimed:
+                match = candidate
+                claimed.add(id(candidate))
+                break
+        result.append((match, other_edge))
+    return result
 
 
 def _get_satisfying_edge(lhs_node: "Spec", rhs_edge: DependencySpec) -> Optional[DependencySpec]:
@@ -3162,71 +3192,125 @@ class Spec:
         return self._constrain(other, deps=deps)
 
     def _constrain(self, other, deps=True):
-        # If we are trying to constrain a concrete spec, either the spec
-        # already satisfies the constraint (and the method returns False)
-        # or it raises an exception
-        if self.concrete:
-            if self.satisfies(other):
-                return False
-            else:
-                raise spack.error.UnsatisfiableSpecError(self, other, "constrain a concrete spec")
-
         other = self._autospec(other)
-        if other.concrete and other.satisfies(self):
+
+        # A concrete other that already implies self is copied wholesale.
+        if other.concrete and not self.concrete and other.satisfies(self):
             self._dup(other)
             return True
 
-        # Every dimension is validated before any of them is merged, so that a conflict in one
-        # dimension does not leave the others already applied to self.
+        error = self._disjoint_reason(other, deps=deps)
+        if error is not None:
+            raise error
+
+        # A concrete self that intersects the constraint already satisfies it.
+        if self.concrete:
+            return False
+
+        return self._merge(other, deps=deps)
+
+    def _disjoint_reason(self, other: "Spec", deps: bool) -> Optional[spack.error.SpecError]:
+        """Return None when at least one concrete spec matches both self and other, otherwise
+        the reason the two are disjoint.
+
+        A spec is a set of points in a product space of names, versions, variants, flags,
+        architectures and dependency edges. This decides whether two such sets overlap, and it
+        is the only place that decision is made: ``intersects`` tests the result against None
+        and ``constrain`` raises it. Returning the error rather than raising keeps the
+        overlapping path, which is the hot one, free of exception construction.
+
+        Args:
+            other: spec to intersect with
+            deps: if True compare dependency edges too, if False only the node
+        """
+        if other is EMPTY_SPEC:
+            return None
+
+        # A concrete spec is a singleton, so intersection reduces to satisfaction. Note that
+        # deps is deliberately not forwarded, matching the historical behavior.
+        if self.concrete or other.concrete:
+            lhs, rhs = (self, other) if self.concrete else (other, self)
+            if lhs.satisfies(rhs):
+                return None
+            return spack.error.UnsatisfiableSpecError(self, other, "constrain a concrete spec")
+
+        error = self._disjoint_node_reason(other)
+        if error is not None or not deps:
+            return error
+
+        return self._disjoint_dependencies_reason(other)
+
+    def _disjoint_node_reason(self, other: "Spec") -> Optional[spack.error.SpecError]:
+        """Node half of :meth:`_disjoint_reason`, which never looks at edges.
+
+        Precondition: neither side is concrete."""
         if (
             self.abstract_hash
             and other.abstract_hash
-            and not other.abstract_hash.startswith(self.abstract_hash)
             and not self.abstract_hash.startswith(other.abstract_hash)
+            and not other.abstract_hash.startswith(self.abstract_hash)
         ):
-            raise InvalidHashError(self, other.abstract_hash)
+            return InvalidHashError(self, other.abstract_hash)
 
-        if not (self.name == other.name or (not self.name) or (not other.name)):
-            raise UnsatisfiableSpecNameError(self.name, other.name)
+        # Two abstract nodes with different names do not intersect. We cannot look up whether
+        # one provides the other, because that would make intersection stateful.
+        if self.name != other.name and self.name and other.name:
+            return UnsatisfiableSpecNameError(self.name, other.name)
 
         if (
-            other.namespace is not None
-            and self.namespace is not None
-            and other.namespace != self.namespace
+            self.namespace is not None
+            and other.namespace is not None
+            and self.namespace != other.namespace
         ):
-            raise UnsatisfiableSpecNameError(self.fullname, other.fullname)
+            return UnsatisfiableSpecNameError(self.fullname, other.fullname)
 
-        if not self.versions.overlaps(other.versions):
-            raise UnsatisfiableVersionSpecError(self.versions, other.versions)
+        if not self.versions.intersects(other.versions):
+            return UnsatisfiableVersionSpecError(self.versions, other.versions)
 
-        for v in [x for x in other.variants if x in self.variants]:
-            if not self.variants[v].intersects(other.variants[v]):
-                raise vt.UnsatisfiableVariantSpecError(self.variants[v], other.variants[v])
+        self_variants = self.variants.dict
+        for name, other_variant in other.variants.dict.items():
+            self_variant = self_variants.get(name)
+            if self_variant is not None and not self_variant.intersects(other_variant):
+                return vt.UnsatisfiableVariantSpecError(self_variant, other_variant)
 
-        if other._concrete:
-            for v in self.variants:
-                if v not in other.variants:
-                    raise vt.UnsatisfiableVariantSpecError(self.variants[v], "<absent>")
-
-        sarch, oarch = self.architecture, other.architecture
         if (
-            sarch is not None
-            and oarch is not None
+            self.architecture is not None
+            and other.architecture is not None
             and not self.architecture.intersects(other.architecture)
         ):
-            raise UnsatisfiableArchitectureSpecError(sarch, oarch)
+            return UnsatisfiableArchitectureSpecError(self.architecture, other.architecture)
 
-        if deps and other._dependencies:
-            # TODO: might want more detail than this, e.g. specific deps
-            # in violation. if this becomes a priority get rid of this
-            # check and be more specific about what's wrong.
-            if not other._intersects_dependencies(self):
-                raise UnsatisfiableDependencySpecError(other, self)
+        # Compiler flags always intersect, since merging them is a union.
+        return None
 
-            for d in other.traverse(root=False):
-                if not d.name:
-                    raise UnconstrainableDependencySpecError(other)
+    def _disjoint_dependencies_reason(self, other: "Spec") -> Optional[spack.error.SpecError]:
+        """Dependency half of :meth:`_disjoint_reason`.
 
+        Edges are paired exactly the way the merge pairs them, so a pairing accepted here is
+        the one that gets applied. Edges of other that no edge of self matches intersect
+        trivially: merging simply adds them, the same way ``^foo`` and ``^bar`` intersect and
+        merge into ``^foo ^bar``."""
+        if not other._dependencies:
+            return None
+
+        for dependency in other.traverse(root=False):
+            if not dependency.name:
+                return UnconstrainableDependencySpecError(other)
+
+        for self_edge, other_edge in _paired_edges(self, other):
+            if self_edge is None:
+                continue
+            # TODO: might want more detail than this, e.g. specific deps in violation.
+            if self_edge.spec._disjoint_reason(other_edge.spec, deps=True) is not None:
+                return UnsatisfiableDependencySpecError(other, self)
+
+        return None
+
+    def _merge(self, other: "Spec", deps: bool) -> bool:
+        """Intersect self with other in place, and return True iff self changed.
+
+        Precondition: :meth:`_disjoint_reason` returned None. Every step below is check-free,
+        so there is no path that applies part of the intersection and then raises."""
         changed = False
 
         if other.abstract_hash and (
@@ -3244,49 +3328,56 @@ class Spec:
             changed = True
 
         changed |= self.versions.intersect(other.versions)
-        changed |= self._constrain_variants(other)
-
+        changed |= self._merge_variants(other)
         changed |= self.compiler_flags.constrain(other.compiler_flags)
 
-        sarch, oarch = self.architecture, other.architecture
-        if sarch is not None and oarch is not None:
-            changed |= self.architecture.constrain(other.architecture)
-        elif oarch is not None:
-            # copy, so that a later constrain on self does not write through into other
-            self.architecture = oarch.copy()
+        if self.architecture is not None and other.architecture is not None:
+            changed |= self.architecture._merge(other.architecture)
+        elif other.architecture is not None:
+            # copy, so that a later merge on self does not write through into other
+            self.architecture = other.architecture.copy()
             changed = True
 
         if deps:
-            changed |= self._constrain_dependencies(other)
+            changed |= self._merge_dependencies(other)
 
         return changed
 
-    def _constrain_dependencies(self, other: "Spec") -> bool:
-        """Apply constraints of other spec's dependencies to this spec.
-
-        Precondition: ``_constrain`` has checked that the two intersect and that every
-        dependency of other is named."""
-        if not other._dependencies:
-            return False
-
+    def _merge_variants(self, other: "Spec") -> bool:
+        """Add the variants of other, merging the ones already present. Total, see _merge."""
         changed = False
-        for other_edge in other.edges_to_dependencies():
-            # Find the first edge in self that matches other_edge by name and when clause.
-            for self_edge in self.edges_to_dependencies(other_edge.spec.name):
-                if self_edge.when == other_edge.when:
-                    changed |= self_edge._constrain(other_edge)
-                    break
-            else:
-                # Otherwise, a copy of the edge is added as a constraint to self.
+        for name, other_variant in other.variants.items():
+            self_variant = self.variants.get(name)
+            if self_variant is None:
+                self.variants[name] = other_variant.copy()
                 changed = True
-                self.add_dependency_edge(
-                    other_edge.spec.copy(deps=True),
-                    depflag=other_edge.depflag,
-                    virtuals=other_edge.virtuals,
-                    direct=other_edge.direct,
-                    propagation=other_edge.propagation,
-                    when=other_edge.when,  # no need to copy; when conditions are immutable
-                )
+            else:
+                changed |= self_variant._merge(other_variant)
+        return changed
+
+    def _merge_dependencies(self, other: "Spec") -> bool:
+        """Add the edges of other, merging the ones it shares with self. Total, see _merge."""
+        changed = False
+        for self_edge, other_edge in _paired_edges(self, other):
+            if self_edge is not None:
+                changed |= self_edge._merge(other_edge)
+                continue
+
+            # _paired_edges established that this edge is new to self, so it is registered
+            # directly: add_dependency_edge would look for an edge to merge with and can
+            # raise, which would leave self half-way through the intersection.
+            changed = True
+            edge = DependencySpec(
+                self,
+                other_edge.spec.copy(deps=True),
+                depflag=other_edge.depflag,
+                virtuals=other_edge.virtuals,
+                direct=other_edge.direct,
+                propagation=other_edge.propagation,
+                when=other_edge.when,  # no need to copy; when conditions are immutable
+            )
+            _add_edge_to_map(self._dependencies, edge.spec.name, edge)
+            _add_edge_to_map(edge.spec._dependents, self.name, edge)
         return changed
 
     def constrained(self, other, deps=True):
@@ -3316,76 +3407,7 @@ class Spec:
             other: spec to be checked for compatibility
             deps: if True check compatibility of dependency nodes too, if False only check root
         """
-        if other is EMPTY_SPEC:
-            return True
-        other = self._autospec(other)
-
-        if other.concrete and self.concrete:
-            return self.dag_hash() == other.dag_hash()
-
-        elif self.concrete:
-            return self.satisfies(other)
-
-        elif other.concrete:
-            return other.satisfies(self)
-
-        # From here we know both self and other are not concrete
-        self_hash = self.abstract_hash
-        other_hash = other.abstract_hash
-
-        if (
-            self_hash
-            and other_hash
-            and not (self_hash.startswith(other_hash) or other_hash.startswith(self_hash))
-        ):
-            return False
-
-        # Two abstract roots with different names do not intersect. We cannot lookup whether the
-        # one spec provides the other, because that would make intersection stateful.
-        if self.name != other.name and self.name and other.name:
-            return False
-
-        # namespaces either match, or other doesn't require one.
-        if (
-            other.namespace is not None
-            and self.namespace is not None
-            and self.namespace != other.namespace
-        ):
-            return False
-
-        if self.versions and other.versions:
-            if not self.versions.intersects(other.versions):
-                return False
-
-        if not self._intersects_variants(other):
-            return False
-
-        if self.architecture and other.architecture:
-            if not self.architecture.intersects(other.architecture):
-                return False
-
-        if not self.compiler_flags.intersects(other.compiler_flags):
-            return False
-
-        # If we need to descend into dependencies, do it, otherwise we're done.
-        if deps:
-            return self._intersects_dependencies(other)
-
-        return True
-
-    def _intersects_dependencies(self, other):
-        if not other._dependencies or not self._dependencies:
-            # one spec *could* eventually satisfy the other
-            return True
-
-        # Handle first-order constraints directly
-        common_dependencies = {x.name for x in self.dependencies()}
-        common_dependencies &= {x.name for x in other.dependencies()}
-        for name in common_dependencies:
-            if not self[name].intersects(other[name], deps=True):
-                return False
-
-        return True
+        return self._disjoint_reason(self._autospec(other), deps=deps) is None
 
     def satisfies(self, other: Union[str, "Spec"], deps: bool = True) -> bool:
         """Return True if all concrete specs matching self also match other, otherwise False.
@@ -3553,33 +3575,6 @@ class Spec:
                     return False
 
         return result
-
-    def _intersects_variants(self, other: "Spec") -> bool:
-        self_dict = self.variants.dict
-        other_dict = other.variants.dict
-        return all(self_dict[k].intersects(other_dict[k]) for k in other_dict if k in self_dict)
-
-    def _constrain_variants(self, other: "Spec") -> bool:
-        """Add all variants in other that aren't in self to self. Also constrain all multi-valued
-        variants that are already present. Return True iff self changed"""
-        if other is not None and other._concrete:
-            for k in self.variants:
-                if k not in other.variants:
-                    raise vt.UnsatisfiableVariantSpecError(self.variants[k], "<absent>")
-
-        changed = False
-        for k in other.variants:
-            if k in self.variants:
-                if not self.variants[k].intersects(other.variants[k]):
-                    raise vt.UnsatisfiableVariantSpecError(self.variants[k], other.variants[k])
-                # If they are compatible merge them
-                changed |= self.variants[k].constrain(other.variants[k])
-            else:
-                # If it is not present copy it straight away
-                self.variants[k] = other.variants[k].copy()
-                changed = True
-
-        return changed
 
     @property  # type: ignore[misc] # decorated prop not supported in mypy
     def patches(self):
@@ -6051,6 +6046,12 @@ class _ImmutableSpec(Spec):
     def constrain(self, *args, **kwargs) -> bool:
         assert self._mutable
         return super().constrain(*args, **kwargs)
+
+    def _merge(self, *args, **kwargs) -> bool:
+        # constrain applies the intersection through _merge, which also registers new edges
+        # without going through add_dependency_edge
+        assert self._mutable
+        return super()._merge(*args, **kwargs)
 
     def add_dependency_edge(self, *args, **kwargs):
         assert self._mutable

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -3170,9 +3170,10 @@ class Spec:
         changed = False
 
         if other.abstract_hash and (
-            not self.abstract_hash or other.abstract_hash.startswith(self.abstract_hash)
+            not self.abstract_hash or len(other.abstract_hash) > len(self.abstract_hash)
         ):
             self.abstract_hash = other.abstract_hash
+            changed = True
 
         if not self.name and other.name:
             self.name = other.name

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -1544,8 +1544,13 @@ def _get_satisfying_edge(
     lhs_node: "Spec", rhs_edge: DependencySpec, *, resolve_virtuals: bool
 ) -> Optional[DependencySpec]:
     """Search for an edge in ``lhs_node`` that satisfies ``rhs_edge``."""
-    # First check direct deps of all types.
+    # First check direct deps of all types. An abstract edge that is not direct says its target
+    # is somewhere in the DAG, which does not answer a question about a direct dependency. On a
+    # concrete node the flag is not set at all and every edge is a direct dependency in fact.
+    require_direct = rhs_edge.direct and not lhs_node.concrete
     for lhs_edge in lhs_node.edges_to_dependencies():
+        if require_direct and not lhs_edge.direct:
+            continue
         if _satisfies_edge(lhs_edge, rhs_edge, resolve_virtuals):
             return lhs_edge
 

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -1083,15 +1083,12 @@ class FlagMap(lang.HashableMap[str, List[CompilerFlag]]):
 
         result = ""
         for flag_type, flags in sorted_items:
-            normal = [f for f in flags if not f.propagate]
-            if normal:
-                value = spack.spec_parser.quote_if_needed(" ".join(normal))
-                result += f" {flag_type}={value}"
-
-            propagated = [f for f in flags if f.propagate]
-            if propagated:
-                value = spack.spec_parser.quote_if_needed(" ".join(propagated))
-                result += f" {flag_type}=={value}"
+            # The order of the flags of one type is significant, so they are printed in the order
+            # they are stored, in runs of flags that agree on whether they propagate.
+            for propagate, group in itertools.groupby(flags, key=lambda flag: flag.propagate):
+                sigil = "==" if propagate else "="
+                value = spack.spec_parser.quote_if_needed(" ".join(group))
+                result += f" {flag_type}{sigil}{value}"
 
         # TODO: somehow add this space only if something follows in Spec.format()
         if sorted_items:

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -3501,6 +3501,11 @@ class Spec:
             # objects.
             return self.concrete and self.dag_hash() == other.dag_hash()
 
+        if other.name and not self.name:
+            # A spec that leaves the name unset denotes every package, so it is not inside one
+            # that names a package, however little else it constrains.
+            return False
+
         if self.name != other.name and self.name and other.name:
             # Name mismatch can still be satisfiable if lhs provides the virtual mentioned by
             # rhs. other.versions constrains the virtual's provided-version range there, which

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -879,7 +879,9 @@ class DependencySpec:
             keywords.append(f"when={self.when}")
 
         if self.propagation != PropagationPolicy.NONE:
-            keywords.append(f"propagation={self.propagation}")
+            # IntEnum's default formatting renders as its int value, not its name, so the name
+            # is spelled out explicitly here.
+            keywords.append(f"propagation=PropagationPolicy.{self.propagation.name}")
 
         keywords_str = ", ".join(keywords)
         return f"DependencySpec({self.parent.format()!r}, {self.spec.format()!r}, {keywords_str})"

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -3116,11 +3116,15 @@ class Spec:
             self._dup(other)
             return True
 
-        if other.abstract_hash:
-            if not self.abstract_hash or other.abstract_hash.startswith(self.abstract_hash):
-                self.abstract_hash = other.abstract_hash
-            elif not self.abstract_hash.startswith(other.abstract_hash):
-                raise InvalidHashError(self, other.abstract_hash)
+        # Every dimension is validated before any of them is merged, so that a conflict in one
+        # dimension does not leave the others already applied to self.
+        if (
+            self.abstract_hash
+            and other.abstract_hash
+            and not other.abstract_hash.startswith(self.abstract_hash)
+            and not self.abstract_hash.startswith(other.abstract_hash)
+        ):
+            raise InvalidHashError(self, other.abstract_hash)
 
         if not (self.name == other.name or (not self.name) or (not other.name)):
             raise UnsatisfiableSpecNameError(self.name, other.name)
@@ -3139,6 +3143,11 @@ class Spec:
             if not self.variants[v].intersects(other.variants[v]):
                 raise vt.UnsatisfiableVariantSpecError(self.variants[v], other.variants[v])
 
+        if other._concrete:
+            for v in self.variants:
+                if v not in other.variants:
+                    raise vt.UnsatisfiableVariantSpecError(self.variants[v], "<absent>")
+
         sarch, oarch = self.architecture, other.architecture
         if (
             sarch is not None
@@ -3147,7 +3156,23 @@ class Spec:
         ):
             raise UnsatisfiableArchitectureSpecError(sarch, oarch)
 
+        if deps and other._dependencies:
+            # TODO: might want more detail than this, e.g. specific deps
+            # in violation. if this becomes a priority get rid of this
+            # check and be more specific about what's wrong.
+            if not other._intersects_dependencies(self, resolve_virtuals=resolve_virtuals):
+                raise UnsatisfiableDependencySpecError(other, self)
+
+            for d in other.traverse(root=False):
+                if not d.name:
+                    raise UnconstrainableDependencySpecError(other)
+
         changed = False
+
+        if other.abstract_hash and (
+            not self.abstract_hash or other.abstract_hash.startswith(self.abstract_hash)
+        ):
+            self.abstract_hash = other.abstract_hash
 
         if not self.name and other.name:
             self.name = other.name
@@ -3171,24 +3196,18 @@ class Spec:
             changed = True
 
         if deps:
-            changed |= self._constrain_dependencies(other, resolve_virtuals=resolve_virtuals)
+            changed |= self._constrain_dependencies(other)
 
         return changed
 
-    def _constrain_dependencies(self, other: "Spec", resolve_virtuals: bool = True) -> bool:
-        """Apply constraints of other spec's dependencies to this spec."""
+    def _constrain_dependencies(self, other: "Spec") -> bool:
+        """Apply constraints of other spec's dependencies to this spec.
+
+        Precondition: ``_constrain`` has checked that the two intersect and that every
+        dependency of other is named."""
         if not other._dependencies:
             return False
 
-        # TODO: might want more detail than this, e.g. specific deps
-        # in violation. if this becomes a priority get rid of this
-        # check and be more specific about what's wrong.
-        if not other._intersects_dependencies(self, resolve_virtuals=resolve_virtuals):
-            raise UnsatisfiableDependencySpecError(other, self)
-
-        for d in other.traverse(root=False):
-            if not d.name:
-                raise UnconstrainableDependencySpecError(other)
         changed = False
         for other_edge in other.edges_to_dependencies():
             # Find the first edge in self that matches other_edge by name and when clause.

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -973,22 +973,35 @@ class FlagMap(lang.HashableMap[str, List[CompilerFlag]]):
         changed = False
         for flag_type in other:
             if flag_type not in self:
-                self[flag_type] = other[flag_type]
+                # copy the list, so that self and other do not share it
+                self[flag_type] = list(other[flag_type])
                 changed = True
-            else:
-                extra_other = set(other[flag_type]) - set(self[flag_type])
-                if extra_other:
-                    self[flag_type] = list(self[flag_type]) + [
-                        x for x in other[flag_type] if x in extra_other
-                    ]
-                    changed = True
+                continue
 
-                # Next, if any flags in other propagate, we force them to propagate in our case
-                shared = list(sorted(set(other[flag_type]) - extra_other))
-                for x, y in _shared_subset_pair_iterate(shared, sorted(self[flag_type])):
-                    if y.propagate is True and x.propagate is False:
-                        changed = True
-                        y.propagate = False
+            extra_other = set(other[flag_type]) - set(self[flag_type])
+            if extra_other:
+                self[flag_type] = list(self[flag_type]) + [
+                    x for x in other[flag_type] if x in extra_other
+                ]
+                changed = True
+
+            # Next, if any flags in other propagate, we force them to propagate in our case.
+            # CompilerFlag objects can be shared with other specs, so they are replaced rather
+            # than modified in place.
+            shared = sorted(set(other[flag_type]) - extra_other)
+            demoted = {
+                id(y)
+                for x, y in _shared_subset_pair_iterate(shared, sorted(self[flag_type]))
+                if y.propagate is True and x.propagate is False
+            }
+            if demoted:
+                changed = True
+                self[flag_type] = [
+                    CompilerFlag(f, propagate=False, flag_group=f.flag_group, source=f.source)
+                    if id(f) in demoted
+                    else f
+                    for f in self[flag_type]
+                ]
 
         # TODO: what happens if flag groups with a partial (but not complete)
         # intersection specify different behaviors for flag propagation?
@@ -3153,7 +3166,8 @@ class Spec:
         if sarch is not None and oarch is not None:
             changed |= self.architecture.constrain(other.architecture)
         elif oarch is not None:
-            self.architecture = oarch
+            # copy, so that a later constrain on self does not write through into other
+            self.architecture = oarch.copy()
             changed = True
 
         if deps:

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -461,11 +461,18 @@ class ArchSpec:
         return bool(self._target_intersection(other))
 
     def _target_constrain(self, other: "ArchSpec") -> bool:
-        if self.target is None and other.target is None:
+        # An unconstrained target on either side means the other side is the intersection.
+        # _target_intersection cannot express that: it returns an empty list whenever one of
+        # the two has no target, which would turn into an empty target below.
+        if other.target is None:
             return False
 
         if not other._target_satisfies(self, strict=False):
             raise UnsatisfiableArchitectureSpecError(self, other)
+
+        if self.target is None:
+            self.target = other.target
+            return True
 
         if self.target_concrete:
             return False

--- a/lib/spack/spack/test/architecture.py
+++ b/lib/spack/spack/test/architecture.py
@@ -8,6 +8,7 @@ import pytest
 import spack.vendor.archspec.cpu
 
 import spack.concretize
+import spack.error
 import spack.operating_systems
 import spack.platforms
 from spack.spec import ArchSpec, Spec
@@ -107,6 +108,27 @@ def test_satisfy_strict_constraint_when_not_concrete(architecture_tuple, constra
     architecture = ArchSpec(architecture_tuple)
     constraint = ArchSpec(constraint_tuple)
     assert not architecture.satisfies(constraint)
+
+
+@pytest.mark.xfail(
+    reason="_target_intersection returns an empty list when the lhs has no target, and "
+    "_target_constrain turns that into an empty target",
+    strict=True,
+)
+def test_constrain_range_target_onto_missing_target():
+    """A target range from the rhs is adopted as is when the lhs has no target."""
+    architecture = ArchSpec((None, "debian6", None))
+    assert architecture.constrain(ArchSpec((None, None, "x86_64:"))) is True
+    assert architecture.target == ArchSpec((None, None, "x86_64:")).target
+
+
+def test_constrain_is_atomic_when_targets_are_disjoint():
+    """platform and os are applied before the target, so the up-front intersection check is what
+    keeps a failed constrain from leaving them behind."""
+    architecture = ArchSpec(("linux", None, "haswell"))
+    with pytest.raises(spack.error.UnsatisfiableSpecError):
+        architecture.constrain(ArchSpec((None, "ubuntu18.04", "ppc64le")))
+    assert architecture == ArchSpec(("linux", None, "haswell"))
 
 
 @pytest.mark.parametrize(

--- a/lib/spack/spack/test/architecture.py
+++ b/lib/spack/spack/test/architecture.py
@@ -110,16 +110,19 @@ def test_satisfy_strict_constraint_when_not_concrete(architecture_tuple, constra
     assert not architecture.satisfies(constraint)
 
 
-@pytest.mark.xfail(
-    reason="_target_intersection returns an empty list when the lhs has no target, and "
-    "_target_constrain turns that into an empty target",
-    strict=True,
+@pytest.mark.parametrize(
+    "lhs_tuple,rhs_tuple,expected_target",
+    [
+        ((None, "debian6", None), (None, None, "x86_64:"), "x86_64:"),
+        ((None, None, "x86_64:"), (None, "debian6", None), "x86_64:"),
+        ((None, "debian6", None), (None, None, "haswell"), "haswell"),
+    ],
 )
-def test_constrain_range_target_onto_missing_target():
-    """A target range from the rhs is adopted as is when the lhs has no target."""
-    architecture = ArchSpec((None, "debian6", None))
-    assert architecture.constrain(ArchSpec((None, None, "x86_64:"))) is True
-    assert architecture.target == ArchSpec((None, None, "x86_64:")).target
+def test_constrain_target_when_only_one_side_has_one(lhs_tuple, rhs_tuple, expected_target):
+    """The side that has a target wins, ranges included."""
+    architecture = ArchSpec(lhs_tuple)
+    architecture.constrain(ArchSpec(rhs_tuple))
+    assert architecture.target == ArchSpec((None, None, expected_target)).target
 
 
 def test_constrain_is_atomic_when_targets_are_disjoint():

--- a/lib/spack/spack/test/architecture.py
+++ b/lib/spack/spack/test/architecture.py
@@ -135,6 +135,50 @@ def test_constrain_is_atomic_when_targets_are_disjoint():
 
 
 @pytest.mark.parametrize(
+    "architecture_tuple,constraint_tuple",
+    [
+        (("linux", "ubuntu18.04", "x86_64"), ("*", None, None)),
+        (("linux", "ubuntu18.04", "x86_64"), (None, "*", None)),
+        (("linux", "ubuntu18.04", "x86_64"), (None, None, "*")),
+        (("linux", "ubuntu18.04", "x86_64"), ("*", "*", "*")),
+        (("linux", None, None), ("*", None, None)),
+    ],
+)
+def test_star_is_satisfied_and_intersected_and_does_not_constrain(
+    architecture_tuple, constraint_tuple
+):
+    """A star requires the attribute to be set, so a spec that sets it satisfies the star, the
+    two overlap in both directions, and merging changes nothing."""
+    architecture = ArchSpec(architecture_tuple)
+    constraint = ArchSpec(constraint_tuple)
+
+    assert architecture.satisfies(constraint)
+    assert architecture.intersects(constraint)
+    assert constraint.intersects(architecture)
+
+    merged = architecture.copy()
+    assert merged.constrain(constraint) is False
+    assert merged == architecture
+
+
+def test_star_does_not_short_circuit_the_other_attributes():
+    """A star on one attribute used to return from satisfies straight away, leaving the
+    remaining attributes unchecked."""
+    architecture = ArchSpec(("linux", "ubuntu18.04", "x86_64"))
+    assert not architecture.satisfies(ArchSpec(("*", "rhel6", None)))
+    assert not architecture.satisfies(ArchSpec(("*", None, "aarch64")))
+    assert not architecture.intersects(ArchSpec(("*", "rhel6", None)))
+
+
+def test_star_target_is_replaced_by_a_real_target_when_constrained():
+    """target=* names no target, so the other side is the intersection. It is concrete by the
+    definition in ArchSpec, which would otherwise make it override a real target."""
+    architecture = ArchSpec((None, None, "*"))
+    assert architecture.constrain(ArchSpec((None, None, "x86_64"))) is True
+    assert str(architecture.target) == "x86_64"
+
+
+@pytest.mark.parametrize(
     "root_target_range,dep_target_range,result",
     [
         ("x86_64:nocona", "x86_64:core2", "nocona"),  # pref not in intersection

--- a/lib/spack/spack/test/bootstrap.py
+++ b/lib/spack/spack/test/bootstrap.py
@@ -14,11 +14,14 @@ import spack.bootstrap.status
 import spack.compilers.config
 import spack.config
 import spack.environment
+import spack.spec
 import spack.store
 import spack.util.executable
 from spack.active_environment import active_environment
 
 from .conftest import _true
+
+PROTOTYPE_DIR = pathlib.Path(spack.bootstrap.clingo.__file__).parent / "prototypes"
 
 
 @pytest.fixture
@@ -308,3 +311,17 @@ def test_use_store_does_not_try_writing_outside_root(
     with spack.store.use_store(user_store):
         assert spack.config.CONFIG.get("config:install_tree:root") == str(user_store)
     assert spack.config.CONFIG.get("config:install_tree:root") == initial_store
+
+
+@pytest.mark.parametrize("prototype", sorted(x.name for x in PROTOTYPE_DIR.glob("*.json")))
+def test_prototype_answers_a_constraint_on_its_compiler(prototype):
+    """The bootstrap concretizer edits a prototype with the concreteness flag cleared, and then
+    picks the patches to apply from conditions such as '%msvc@19.38:'. Its edges are still the
+    edges of a concrete DAG there, so the compiler it records answers such a condition."""
+    s = spack.spec.Spec.from_specfile(str(PROTOTYPE_DIR / prototype))
+    compiler = next(x.spec for x in s.edges_to_dependencies() if "cxx" in x.virtuals)
+
+    s._mark_concrete(False)
+
+    assert s.satisfies(f"%{compiler.name}")
+    assert s.satisfies(f"%{compiler.name}@{compiler.version}")

--- a/lib/spack/spack/test/spec_semantics.py
+++ b/lib/spack/spack/test/spec_semantics.py
@@ -2037,7 +2037,6 @@ def test_intersects_and_satisfies(mock_packages, factory, lhs_str, rhs_str, resu
         (Spec, "cppflags=-foo", "cflags=-foo", True, "cppflags=-foo cflags=-foo"),
         # Target ranges
         (Spec, "target=x86_64:", "target=x86_64:", False, "target=x86_64:"),
-        (Spec, "target=x86_64:", "target=:haswell", True, "target=x86_64:haswell"),
         (
             Spec,
             "target=x86_64:haswell",
@@ -2059,6 +2058,27 @@ def test_constrain(factory, lhs_str, rhs_str, result, constrained_str, mock_pack
     rhs = factory(rhs_str)
     rhs.constrain(lhs)
     assert rhs == factory(constrained_str)
+
+
+def test_constrain_target_range_representation_depends_on_operand_order():
+    """':haswell' is a strict subset of 'x86_64:' (x86_64 is the family root, and broadwell and
+    later are in 'x86_64:' but not '<=haswell'), so constraining it narrows nothing and it stays
+    ':haswell'. Constraining the other way narrows 'x86_64:' down to the same set, but through
+    'x86_64:haswell': _target_intersection resolves an unbounded end to the other operand's bound
+    when there is one, rather than reconstructing the tighter side's own spelling. The two results
+    denote the same set of targets, unlike test_constrain's invariant assumes."""
+    narrower = Spec("target=:haswell")
+    wider = Spec("target=x86_64:")
+
+    assert narrower.intersects(wider)
+    assert narrower.satisfies(wider)
+    assert not wider.satisfies(narrower)
+
+    assert narrower.copy().constrain(wider) is False
+    assert narrower == Spec("target=:haswell")
+
+    assert wider.copy().constrain(narrower) is True
+    assert wider.constrained(narrower) == Spec("target=x86_64:haswell")
 
 
 def test_constrain_dependencies_copies(mock_packages):

--- a/lib/spack/spack/test/spec_semantics.py
+++ b/lib/spack/spack/test/spec_semantics.py
@@ -2395,6 +2395,18 @@ def test_flag_propagation_is_invisible_to_satisfies(mock_packages):
     assert merged.compiler_flags["cflags"][0].propagate
 
 
+def test_edge_propagation_is_merged(mock_packages):
+    """A propagated edge constrains the whole DAG, so it is the narrower of the two policies and
+    the meet takes it from whichever operand has it."""
+    lhs, rhs = Spec("pkg-a ^pkg-b"), Spec("pkg-a %%pkg-b")
+    forward = lhs.copy()
+    forward.constrain(rhs)
+    backward = rhs.copy()
+    backward.constrain(lhs)
+    assert forward.to_dict() == backward.to_dict()
+    assert forward.edges_to_dependencies()[0].propagation == PropagationPolicy.PREFERENCE
+
+
 def test_flag_order_survives_formatting(mock_packages):
     """Compiler flags are printed in the order they are stored, in runs of flags that agree on
     whether they propagate, so a propagating flag followed by a plain one comes back in that

--- a/lib/spack/spack/test/spec_semantics.py
+++ b/lib/spack/spack/test/spec_semantics.py
@@ -359,6 +359,13 @@ class TestSpecSemantics:
                 "%[when='%c' virtuals=c]gcc@10.3.1",
                 "libelf %[when='+c' virtuals=c]gcc %[when='%c' virtuals=c]gcc@10.3.1",
             ),
+            # Edges under different when conditions are never in effect at the same time, so
+            # they are two separate constraints even when they cannot both be met at once.
+            (
+                "libelf ^[when='+foo'] mpich@3.0",
+                "^[when='+bar'] mpich@4.0",
+                "libelf ^[when='+foo'] mpich@3.0 ^[when='+bar'] mpich@4.0",
+            ),
         ],
     )
     def test_abstract_specs_can_constrain_each_other(self, lhs, rhs, expected):

--- a/lib/spack/spack/test/spec_semantics.py
+++ b/lib/spack/spack/test/spec_semantics.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+import itertools
 import pathlib
 
 import pytest
@@ -2439,6 +2440,188 @@ def test_constrain_symbolically(constraints, expected):
     for c in reversed(constraints):
         reverse_order._constrain_symbolically(c)
     assert reverse_order == Spec(expected)
+
+
+#: Abstract specs covering every dimension ``constrain`` merges, and pairs that conflict within
+#: each dimension. The properties below are checked over the product of this list with itself.
+CONSTRAIN_CORPUS = [
+    # names and namespaces
+    "",
+    "pkg-a",
+    "pkg-b",
+    "builtin_mock.pkg-a",
+    # versions
+    "pkg-a@1:3",
+    "pkg-a@2",
+    "@:1",
+    # variants, including propagation and concrete multi-valued
+    "pkg-a+foo",
+    "pkg-a~foo",
+    "pkg-a++foo",
+    "pkg-a foo=bar",
+    "pkg-a foo=baz",
+    "pkg-a foo=bar,baz",
+    "pkg-a foo:=bar",
+    # compiler flags. The propagating entries are what reaches the propagate reset in
+    # FlagMap.constrain.
+    "pkg-a cflags=-O2",
+    "pkg-a cflags=-g",
+    "pkg-a cflags==-O2",
+    "pkg-a cflags=-g cflags==-O2",
+    # architecture
+    "pkg-a target=haswell",
+    "pkg-a target=x86_64:",
+    "pkg-a target=:icelake",
+    "pkg-a os=debian6",
+    # abstract hashes
+    "pkg-a/abcdef",
+    "pkg-a/abc",
+    # dependency edges
+    "^pkg-b",
+    "^pkg-b@1",
+    "^pkg-b@2",
+    "pkg-a ^pkg-b@1 ^pkg-c",
+    "%pkg-b",
+    "%%pkg-b",
+    "%[deptypes=build] pkg-b",
+    "%[deptypes=link] pkg-b",
+    "pkg-a ^[when='+foo'] pkg-b@1",
+    "pkg-a ^[when='+bar'] pkg-b@2",
+    # virtuals
+    "pkg-a ^[virtuals=mpi] mpich",
+    "mpi",
+]
+
+
+def _constrain_corpus_pairs():
+    for lhs_str, rhs_str in itertools.product(CONSTRAIN_CORPUS, repeat=2):
+        yield lhs_str, rhs_str, Spec(lhs_str), Spec(rhs_str)
+
+
+def _try_constrain(lhs, rhs):
+    """Return ``(changed, error)``, exactly one of which is None."""
+    try:
+        return lhs.constrain(rhs), None
+    except SpecError as e:
+        return None, e
+
+
+class TestConstrainMutationSafety:
+    """``Spec.constrain`` intersects the left-hand side with the right-hand side in place. It
+    must apply the whole intersection or nothing at all, and it must never write to the
+    right-hand side, now or through an object the two ends up sharing.
+
+    These properties are checked over the product of ``CONSTRAIN_CORPUS`` rather than over
+    hand-written cases, so a dimension added later is covered as soon as it appears in the
+    corpus, and a refactor that reintroduces partial mutation in any dimension is caught.
+
+    Specs are snapshotted with ``to_dict()``, which round-trips abstract specs and so compares
+    their state directly. ``Spec.__eq__`` is semantic equality instead: it leaves the propagation
+    policy of an edge out of the comparison, so ``pkg-a %pkg-b`` and ``pkg-a %%pkg-b`` are equal,
+    as they are also mutually satisfying.
+    """
+
+    @pytest.mark.xfail(
+        reason="_constrain assigns abstract_hash and merges node attributes before validating "
+        "the remaining dimensions",
+        strict=True,
+    )
+    def test_lhs_is_unchanged_when_constrain_raises(self, mock_packages):
+        for lhs_str, rhs_str, lhs, rhs in _constrain_corpus_pairs():
+            before = lhs.to_dict()
+            _, error = _try_constrain(lhs, rhs)
+            if error is None:
+                continue
+            assert lhs.to_dict() == before, f"'{lhs_str}' mutated by failed constrain '{rhs_str}'"
+
+    def test_rhs_is_never_mutated(self, mock_packages):
+        for lhs_str, rhs_str, lhs, rhs in _constrain_corpus_pairs():
+            before = rhs.to_dict()
+            _try_constrain(lhs, rhs)
+            assert rhs.to_dict() == before, f"'{lhs_str}'.constrain('{rhs_str}') mutated the rhs"
+
+    @pytest.mark.xfail(
+        reason="FlagMap.constrain shares the flag list, and _constrain shares the ArchSpec, "
+        "so a later constrain on the lhs writes through into the rhs",
+        strict=True,
+    )
+    def test_rhs_is_not_corrupted_by_later_constraints(self, mock_packages):
+        """A successful constrain must not leave the two specs sharing a mutable object, which
+        a later constrain on the lhs would then write through into the rhs."""
+        for lhs_str, rhs_str, lhs, rhs in _constrain_corpus_pairs():
+            if _try_constrain(lhs, rhs)[1] is not None:
+                continue
+            before = rhs.to_dict()
+            for extra_str in CONSTRAIN_CORPUS:
+                _try_constrain(lhs, Spec(extra_str))
+                assert rhs.to_dict() == before, (
+                    f"'{lhs_str}'.constrain('{rhs_str}') shares state with the rhs: "
+                    f"constraining with '{extra_str}' afterwards changed it"
+                )
+
+    @pytest.mark.xfail(
+        reason="extending abstract_hash mutates the lhs without feeding the changed flag",
+        strict=True,
+    )
+    def test_returned_changed_flag_is_honest(self, mock_packages):
+        """Callers use the return value to decide whether to redo work, so it has to report
+        exactly whether the lhs changed."""
+        for lhs_str, rhs_str, lhs, rhs in _constrain_corpus_pairs():
+            before = lhs.to_dict()
+            changed, error = _try_constrain(lhs, rhs)
+            if error is not None:
+                continue
+            assert changed is (lhs.to_dict() != before), (
+                f"'{lhs_str}'.constrain('{rhs_str}') returned {changed}"
+            )
+
+    def test_intersects_agrees_with_constrain(self, mock_packages):
+        """``intersects`` is the question ``constrain`` answers by raising or not. The product
+        covers both orders, so this also pins the commutativity of ``intersects``."""
+        for lhs_str, rhs_str, lhs, rhs in _constrain_corpus_pairs():
+            intersects = lhs.intersects(rhs)
+            _, error = _try_constrain(lhs, rhs)
+            assert intersects is (error is None), (
+                f"'{lhs_str}'.intersects('{rhs_str}') is {intersects}, but constrain "
+                f"{'raised ' + type(error).__name__ if error else 'succeeded'}"
+            )
+
+    @pytest.mark.xfail(
+        reason="ArchSpec._target_constrain empties the target when the lhs has none and the "
+        "rhs has a range, so constraining again raises",
+        strict=True,
+    )
+    def test_constrain_is_idempotent(self, mock_packages):
+        for lhs_str, rhs_str, lhs, rhs in _constrain_corpus_pairs():
+            if _try_constrain(lhs, rhs)[1] is not None:
+                continue
+            before = lhs.to_dict()
+            assert lhs.constrain(rhs) is False, f"'{lhs_str}'.constrain('{rhs_str}') twice"
+            assert lhs.to_dict() == before
+
+    @pytest.mark.xfail(
+        reason="ArchSpec._target_constrain empties the target when the lhs has none and the "
+        "rhs has a range, dropping the constraint instead of applying it",
+        strict=True,
+    )
+    def test_constrained_lhs_satisfies_rhs(self, mock_packages):
+        """Guards against making constrain atomic by making it do nothing."""
+        for lhs_str, rhs_str, lhs, rhs in _constrain_corpus_pairs():
+            if _try_constrain(lhs, rhs)[1] is not None:
+                continue
+            assert lhs.satisfies(rhs), f"'{lhs_str}'.constrain('{rhs_str}') gave '{lhs}'"
+
+    @pytest.mark.xfail(
+        reason="ArchSpec._target_constrain empties the target when only one side has one",
+        strict=True,
+    )
+    def test_constrain_never_weakens_the_lhs(self, mock_packages):
+        """The result is the intersection of both operands, so together with the property above
+        this pins that constrain narrows and never drops a constraint."""
+        for lhs_str, rhs_str, lhs, rhs in _constrain_corpus_pairs():
+            if _try_constrain(lhs, rhs)[1] is not None:
+                continue
+            assert lhs.satisfies(Spec(lhs_str)), f"'{lhs_str}'.constrain('{rhs_str}') gave '{lhs}'"
 
 
 @pytest.mark.parametrize(

--- a/lib/spack/spack/test/spec_semantics.py
+++ b/lib/spack/spack/test/spec_semantics.py
@@ -495,9 +495,6 @@ class TestSpecSemantics:
             ("mpileaks^mpich@2.0^callpath@1.7", "^mpich@1:3^callpath@1.4:1.6"),
             ("mpileaks^mpich@4.0^callpath@1.7", "^mpich@1:3^callpath@1.4:1.6"),
             ("mpileaks^mpi@3", "^mpi@1.2:1.6"),
-            ("mpileaks^mpi@3:", "^mpich2@1.4"),
-            ("mpileaks^mpi@3:", "^mpich2"),
-            ("mpileaks^mpi@3:", "^mpich@1.0"),
             ("mpich~foo", "mpich+foo"),
             ("mpich+foo", "mpich~foo"),
             ("mpich foo=True", "mpich foo=False"),
@@ -710,10 +707,15 @@ class TestSpecSemantics:
     def test_provided_virtuals_frozen_at_concretization(self):
         """Each concrete node freezes the versions of the virtuals it provides. When several
         ``provides`` clauses match, the frozen version is their intersection (the tightest range),
-        matching the solver: mpich2 provides mpi@:2.0 (bare), mpi@:2.1 (@1.1:) and mpi@:2.2 (@1.2:);
-        a recent version matches all three -> intersection mpi@:2.0 (not the union :2.2)."""
+        matching the solver: mpich2 provides mpi@:2.0 (bare), mpi@:2.1 (@1.1:) and mpi@:2.2
+        (@1.2:); a recent version matches all three -> intersection mpi@:2.0 (not union :2.2)."""
         provider = spack.concretize.concretize_one("mpich2@1.5")
         assert provider._provided_virtuals["mpi"] == vn.VersionList(":2.0")
+
+        # The frozen intersection is what satisfies queries; a naive union (mpi@:2.2) would
+        # wrongly answer True to mpi@2.1:.
+        assert provider.satisfies("mpi@:2.0")
+        assert not provider.satisfies("mpi@2.1:")
 
     def test_provided_virtuals_serialization_roundtrip(self):
         """Frozen provided virtuals survive a JSON round-trip and are part of the dag hash."""
@@ -747,6 +749,24 @@ class TestSpecSemantics:
         assert provider._provided_virtuals["mpi"] == vn.VersionList(":3")
         # The stored dag hash is trusted on read, so dropping the field does not change it.
         assert old.dag_hash() == concrete.dag_hash()
+
+    def test_versioned_virtual_queries_on_concrete_specs_are_stateless(self, monkeypatch):
+        """Versioned virtual queries on concrete specs are answered from the frozen provided
+        versions, with no repository access."""
+        concrete = spack.concretize.concretize_one("mpileaks ^mpich")
+        provider = concrete["mpich"]  # provides mpi@:3
+
+        monkeypatch.setattr(spack.repo, "PATH", None)
+
+        # On the provider node directly.
+        assert provider.satisfies("mpi")
+        assert provider.satisfies("mpi@:3")
+        assert not provider.satisfies("mpi@4:")
+        assert not provider.satisfies("lapack")
+
+        # Through the edge, from the root.
+        assert concrete.satisfies("^mpi@:3")
+        assert not concrete.satisfies("^mpi@4:")
 
     def test_satisfies_single_valued_variant(self):
         """Tests that the case reported in
@@ -858,9 +878,18 @@ class TestSpecSemantics:
             assert t.satisfies(s)
 
     def test_intersects_virtual(self):
-        assert Spec("mpich").intersects(Spec("mpi"))
-        assert Spec("mpich2").intersects(Spec("mpi"))
-        assert Spec("zmpi").intersects(Spec("mpi"))
+        """Abstract specs with different names do not intersect, even if one could provide the
+        other: comparison no longer resolves virtuals against the repository. Virtual queries are
+        expanded into providers at the call site instead."""
+        assert not Spec("mpich").intersects(Spec("mpi"))
+        assert not Spec("mpich2").intersects(Spec("mpi"))
+        assert not Spec("zmpi").intersects(Spec("mpi"))
+
+        # if intersects is False, constrain raises
+        with pytest.raises(UnsatisfiableSpecError):
+            Spec("mpich").constrain(Spec("mpi"))
+        with pytest.raises(UnsatisfiableSpecError):
+            Spec("mpi").constrain(Spec("lapack"))
 
     def test_intersects_virtual_providers(self):
         """Tests that we can always intersect virtual providers from abstract specs.
@@ -2008,8 +2037,9 @@ def test_abstract_contains_semantic(lhs, rhs, expected, mock_packages):
         (Spec, "cppflags=-foo", "cflags=-foo", (True, False, False)),
         # Versions
         (Spec, "@0.94h", "@:0.94i", (True, True, False)),
-        # Different virtuals intersect if there is at least package providing both
-        (Spec, "mpi", "lapack", (True, False, False)),
+        # Abstract specs with different names (incl. virtuals) do not intersect: comparison does
+        # not resolve virtuals against the repository.
+        (Spec, "mpi", "lapack", (False, False, False)),
         (Spec, "mpi", "pkgconfig", (False, False, False)),
         # Intersection among target ranges for different architectures
         (Spec, "target=x86_64:", "target=ppc64le:", (False, False, False)),
@@ -2628,8 +2658,7 @@ def test_long_spec():
         (["@2.0:", "@:5.1", "+bar"], "@2.0:5.1 +bar"),
         # Anonymous specs with dependencies
         (["^mpich@3.2", "^mpich@:4.0+foo"], "^mpich@3.2 +foo"),
-        # Mix a real package with a virtual one. This test
-        # should fail if we start using the repository
+        # Mix a real package with a virtual one; virtuals are not resolved.
         (["^mpich@3.2", "^mpi+foo"], "^mpich@3.2 ^mpi+foo"),
         # Non direct dependencies + direct dependencies
         (["^mpich", "%mpich"], "%mpich"),
@@ -2638,15 +2667,15 @@ def test_long_spec():
     ],
 )
 def test_constrain_symbolically(constraints, expected):
-    """Tests the semantics of constraining a spec when we don't resolve virtuals."""
+    """Tests the semantics of constraining a spec: virtuals are never resolved."""
     merged = Spec()
     for c in constraints:
-        merged._constrain_symbolically(c)
+        merged.constrain(c)
     assert merged == Spec(expected)
 
     reverse_order = Spec()
     for c in reversed(constraints):
-        reverse_order._constrain_symbolically(c)
+        reverse_order.constrain(c)
     assert reverse_order == Spec(expected)
 
 
@@ -2706,6 +2735,7 @@ CONSTRAIN_CORPUS = [
     # virtuals
     "pkg-a ^[virtuals=mpi] mpich",
     "mpi",
+    "mpich",
 ]
 
 

--- a/lib/spack/spack/test/spec_semantics.py
+++ b/lib/spack/spack/test/spec_semantics.py
@@ -449,8 +449,9 @@ class TestSpecSemantics:
         """Test that Specs specified only by their hashes can constrain each other."""
         mpich_dag_hash = "/" + database.query_one("mpich").dag_hash()
         spec = Spec(mpich_dag_hash[:7])
-        assert spec.constrain(Spec(mpich_dag_hash)) is False
+        assert spec.constrain(Spec(mpich_dag_hash)) is True
         assert spec.abstract_hash == mpich_dag_hash[1:]
+        assert spec.constrain(Spec(mpich_dag_hash[:7])) is False
 
     def test_mismatched_constrain_spec_by_hash(self, database):
         """Test that Specs specified only by their incompatible hashes fail appropriately."""
@@ -2549,10 +2550,6 @@ class TestConstrainMutationSafety:
                     f"constraining with '{extra_str}' afterwards changed it"
                 )
 
-    @pytest.mark.xfail(
-        reason="extending abstract_hash mutates the lhs without feeding the changed flag",
-        strict=True,
-    )
     def test_returned_changed_flag_is_honest(self, mock_packages):
         """Callers use the return value to decide whether to redo work, so it has to report
         exactly whether the lhs changed."""

--- a/lib/spack/spack/test/spec_semantics.py
+++ b/lib/spack/spack/test/spec_semantics.py
@@ -1975,8 +1975,10 @@ def test_abstract_contains_semantic(lhs, rhs, expected, mock_packages):
         (Spec, "target=x86_64:", "target=:power9", (False, False, False)),
         (Spec, "target=:haswell", "target=:power9", (False, False, False)),
         (Spec, "target=:haswell", "target=ppc64le:", (False, False, False)),
-        # Intersection among target ranges for the same architecture
-        (Spec, "target=:haswell", "target=x86_64:", (True, True, True)),
+        # Intersection among target ranges for the same architecture. ":haswell" is a strict
+        # subset of "x86_64:" (x86_64 is the family root, and broadwell and later are in
+        # "x86_64:" but not "<=haswell"), so only the narrower range satisfies the wider one.
+        (Spec, "target=:haswell", "target=x86_64:", (True, True, False)),
         (Spec, "target=:haswell", "target=x86_64_v4:", (False, False, False)),
         # Edge case of uarch that split in a diamond structure, from a common ancestor
         (Spec, "target=:cascadelake", "target=:cannonlake", (False, False, False)),

--- a/lib/spack/spack/test/spec_semantics.py
+++ b/lib/spack/spack/test/spec_semantics.py
@@ -390,10 +390,10 @@ class TestSpecSemantics:
             (
                 'mpich cflags="-O3 -g"',
                 'mpich cflags=="-O3"',
-                'mpich cflags="-O3 -g"',
-                'mpich cflags="-O3 -g"',
-                [],
-                [],
+                'mpich cflags=="-O3" cflags="-g"',
+                'mpich cflags=="-O3" cflags="-g"',
+                [("cflags", "-O3")],
+                [("cflags", "-O3")],
             ),
             (
                 'mpich cflags=="-O3 -g"',
@@ -2375,6 +2375,24 @@ def test_the_default_format_leaves_out_the_namespace(mock_packages):
     assert spec.namespace == "builtin_mock"
     assert round_tripped.namespace is None
     assert round_tripped.satisfies(spec) and spec.satisfies(round_tripped)
+
+
+def test_flag_propagation_is_invisible_to_satisfies(mock_packages):
+    """A propagating flag applies to a package and to the packages it is built against, which is
+    a condition on the whole DAG that concretization discharges into plain flags on every node it
+    reaches, so satisfies follows non-contradiction here the same way it does for a propagating
+    variant. CompilerFlag subclasses str, so == and hash ignore the propagation and that falls
+    out by itself.
+
+    The merge does keep the propagation of either side, though, which is what makes the meet the
+    narrower of the two constraints rather than the plain flag."""
+    propagating, plain = Spec("pkg-a cflags==-O2"), Spec("pkg-a cflags=-O2")
+    assert propagating.satisfies(plain)
+    assert plain.satisfies(propagating)
+
+    merged = plain.copy()
+    merged.constrain(propagating)
+    assert merged.compiler_flags["cflags"][0].propagate
 
 
 def test_flag_order_survives_formatting(mock_packages):

--- a/lib/spack/spack/test/spec_semantics.py
+++ b/lib/spack/spack/test/spec_semantics.py
@@ -325,12 +325,7 @@ class TestSpecSemantics:
             (
                 "libelf patches=ba5e334fe247335f3a116decfb5284100791dc302b5571ff5e664d8f9a6806c2",
                 "libelf patches=ba5e3",  # constrain by a patch sha256 prefix
-                # TODO: the result below is not ideal. Prefix satisfies() works for patches, but
-                # constrain() isn't similarly special-cased to do the same thing
-                (
-                    "libelf patches=ba5e3,"
-                    "ba5e334fe247335f3a116decfb5284100791dc302b5571ff5e664d8f9a6806c2"
-                ),
+                "libelf patches=ba5e334fe247335f3a116decfb5284100791dc302b5571ff5e664d8f9a6806c2",
             ),
             # deptypes on direct deps
             (

--- a/lib/spack/spack/test/spec_semantics.py
+++ b/lib/spack/spack/test/spec_semantics.py
@@ -2395,6 +2395,15 @@ def test_flag_propagation_is_invisible_to_satisfies(mock_packages):
     assert merged.compiler_flags["cflags"][0].propagate
 
 
+def test_parallel_edges_sort_with_differing_propagation(mock_packages):
+    """Parallel edges to one package are sorted to give ``_add_edge_to_map`` a canonical order.
+    ``DependencySpec._cmp_iter`` yields ``propagation``, so two edges that differ only in it must
+    be orderable, which requires ``PropagationPolicy`` to support ``<`` and not just ``==``."""
+    spec = Spec("pkg-a %%pkg-e %[when='+bvv'] pkg-e")
+    spec.to_dict()
+    assert spec.copy() == spec
+
+
 def test_edge_propagation_is_merged(mock_packages):
     """A propagated edge constrains the whole DAG, so it is the narrower of the two policies and
     the meet takes it from whichever operand has it."""

--- a/lib/spack/spack/test/spec_semantics.py
+++ b/lib/spack/spack/test/spec_semantics.py
@@ -2586,11 +2586,6 @@ class TestConstrainMutationSafety:
                 f"{'raised ' + type(error).__name__ if error else 'succeeded'}"
             )
 
-    @pytest.mark.xfail(
-        reason="ArchSpec._target_constrain empties the target when the lhs has none and the "
-        "rhs has a range, so constraining again raises",
-        strict=True,
-    )
     def test_constrain_is_idempotent(self, mock_packages):
         for lhs_str, rhs_str, lhs, rhs in _constrain_corpus_pairs():
             if _try_constrain(lhs, rhs)[1] is not None:
@@ -2599,11 +2594,6 @@ class TestConstrainMutationSafety:
             assert lhs.constrain(rhs) is False, f"'{lhs_str}'.constrain('{rhs_str}') twice"
             assert lhs.to_dict() == before
 
-    @pytest.mark.xfail(
-        reason="ArchSpec._target_constrain empties the target when the lhs has none and the "
-        "rhs has a range, dropping the constraint instead of applying it",
-        strict=True,
-    )
     def test_constrained_lhs_satisfies_rhs(self, mock_packages):
         """Guards against making constrain atomic by making it do nothing."""
         for lhs_str, rhs_str, lhs, rhs in _constrain_corpus_pairs():
@@ -2611,10 +2601,6 @@ class TestConstrainMutationSafety:
                 continue
             assert lhs.satisfies(rhs), f"'{lhs_str}'.constrain('{rhs_str}') gave '{lhs}'"
 
-    @pytest.mark.xfail(
-        reason="ArchSpec._target_constrain empties the target when only one side has one",
-        strict=True,
-    )
     def test_constrain_never_weakens_the_lhs(self, mock_packages):
         """The result is the intersection of both operands, so together with the property above
         this pins that constrain narrows and never drops a constraint."""

--- a/lib/spack/spack/test/spec_semantics.py
+++ b/lib/spack/spack/test/spec_semantics.py
@@ -2459,6 +2459,31 @@ def test_concrete_patches_are_truncated_by_formatting(mock_packages):
     assert not spec.intersects(round_tripped)
 
 
+def test_the_direct_flag_follows_concreteness(config, mock_packages):
+    """A direct dependency is a constraint written with %, so the flag is set when a spec stops
+    being concrete and cleared when it becomes concrete again. The DAG is materialized either
+    way, which is why its edges are direct dependencies."""
+    mpileaks = spack.concretize.concretize_one("mpileaks")
+    assert not any(edge.direct for edge in mpileaks.traverse_edges(root=False))
+
+    mpileaks._mark_concrete(False)
+    assert all(edge.direct for edge in mpileaks.traverse_edges(root=False))
+
+    mpileaks._mark_concrete(True)
+    assert not any(edge.direct for edge in mpileaks.traverse_edges(root=False))
+
+
+def test_a_spec_that_stopped_being_concrete_answers_a_direct_constraint(config, mock_packages):
+    """A spec that stops being concrete keeps every edge it had, so a question about a direct
+    dependency is answered by the package it depends on and not by one further down."""
+    mpileaks = spack.concretize.concretize_one("mpileaks")
+    mpileaks._mark_concrete(False)
+
+    assert mpileaks.satisfies("mpileaks %callpath")
+    assert mpileaks.satisfies("mpileaks ^libelf")
+    assert not mpileaks.satisfies("mpileaks %libelf")
+
+
 @pytest.mark.parametrize(
     "spec_str,spec_fmt,expected",
     [

--- a/lib/spack/spack/test/spec_semantics.py
+++ b/lib/spack/spack/test/spec_semantics.py
@@ -2540,11 +2540,6 @@ class TestConstrainMutationSafety:
             _try_constrain(lhs, rhs)
             assert rhs.to_dict() == before, f"'{lhs_str}'.constrain('{rhs_str}') mutated the rhs"
 
-    @pytest.mark.xfail(
-        reason="FlagMap.constrain shares the flag list, and _constrain shares the ArchSpec, "
-        "so a later constrain on the lhs writes through into the rhs",
-        strict=True,
-    )
     def test_rhs_is_not_corrupted_by_later_constraints(self, mock_packages):
         """A successful constrain must not leave the two specs sharing a mutable object, which
         a later constrain on the lhs would then write through into the rhs."""

--- a/lib/spack/spack/test/spec_semantics.py
+++ b/lib/spack/spack/test/spec_semantics.py
@@ -2540,6 +2540,14 @@ CONSTRAIN_CORPUS = [
     "%[deptypes=link] pkg-b",
     "pkg-a ^[when='+foo'] pkg-b@1",
     "pkg-a ^[when='+bar'] pkg-b@2",
+    # architecture wildcards, which stand for "this attribute is set"
+    "pkg-a platform=test",
+    "pkg-a platform=*",
+    "pkg-a os=*",
+    "pkg-a target=*",
+    # patches, where an abstract value may be a prefix of a concrete one
+    "pkg-a patches=abcdef",
+    "pkg-a patches:=abcdef1234567890",
     # virtuals
     "pkg-a ^[virtuals=mpi] mpich",
     "mpi",
@@ -2647,6 +2655,51 @@ class TestConstrainMutationSafety:
             if _try_constrain(lhs, rhs)[1] is not None:
                 continue
             assert lhs.satisfies(Spec(lhs_str)), f"'{lhs_str}'.constrain('{rhs_str}') gave '{lhs}'"
+
+    def test_satisfies_implies_intersects(self, mock_packages):
+        """Satisfaction is subset and intersection is non-empty overlap, so a spec that is inside
+        another one also overlaps it. Each dimension implements the two separately, which is why
+        they can diverge, as they did for patch prefixes and architecture wildcards."""
+        for lhs_str, rhs_str, lhs, rhs in _constrain_corpus_pairs():
+            if not lhs.satisfies(rhs):
+                continue
+            assert lhs.intersects(rhs), (
+                f"'{lhs_str}' satisfies '{rhs_str}' but does not intersect it"
+            )
+
+    def test_satisfies_implies_constrain_succeeds(self, mock_packages):
+        """Constrain is only undefined where the two are disjoint, so it cannot reject a
+        constraint the lhs already satisfies."""
+        for lhs_str, rhs_str, lhs, rhs in _constrain_corpus_pairs():
+            if not lhs.satisfies(rhs):
+                continue
+            _, error = _try_constrain(lhs, rhs)
+            assert error is None, (
+                f"'{lhs_str}' satisfies '{rhs_str}' but constrain raised {type(error).__name__}"
+            )
+
+    def test_satisfies_implies_variants_are_unchanged(self, mock_packages):
+        """An lhs that is already inside the rhs has nothing left to intersect in the variant
+        dimension.
+
+        Only variants are asserted. Names, namespaces and edges whose when condition does not
+        apply are read as satisfied when the lhs leaves them unset, so constrain legitimately
+        fills those in without narrowing the set the lhs denotes. Propagated variants follow a
+        non-contradiction rule rather than subset semantics: a spec without such a variant
+        satisfies one that propagates it, and still acquires it when constrained; see
+        test_abstract_specs_with_propagation.
+        """
+        for lhs_str, rhs_str, lhs, rhs in _constrain_corpus_pairs():
+            if not lhs.satisfies(rhs):
+                continue
+            if any(value.propagate for value in rhs.variants.values()):
+                continue
+            before = {name: str(value) for name, value in lhs.variants.items()}
+            _try_constrain(lhs, rhs)
+            after = {name: str(value) for name, value in lhs.variants.items()}
+            assert after == before, (
+                f"'{lhs_str}' satisfies '{rhs_str}' but constrain changed its variants to '{lhs}'"
+            )
 
 
 @pytest.mark.parametrize(

--- a/lib/spack/spack/test/spec_semantics.py
+++ b/lib/spack/spack/test/spec_semantics.py
@@ -707,6 +707,47 @@ class TestSpecSemantics:
 
         assert not concrete.satisfies("%c,mpi=mpich")
 
+    def test_provided_virtuals_frozen_at_concretization(self):
+        """Each concrete node freezes the versions of the virtuals it provides. When several
+        ``provides`` clauses match, the frozen version is their intersection (the tightest range),
+        matching the solver: mpich2 provides mpi@:2.0 (bare), mpi@:2.1 (@1.1:) and mpi@:2.2 (@1.2:);
+        a recent version matches all three -> intersection mpi@:2.0 (not the union :2.2)."""
+        provider = spack.concretize.concretize_one("mpich2@1.5")
+        assert provider._provided_virtuals["mpi"] == vn.VersionList(":2.0")
+
+    def test_provided_virtuals_serialization_roundtrip(self):
+        """Frozen provided virtuals survive a JSON round-trip and are part of the dag hash."""
+        provider = spack.concretize.concretize_one("mpileaks ^mpich")["mpich"]
+
+        roundtrip = Spec.from_json(provider.to_json())
+        assert {k: str(v) for k, v in roundtrip._provided_virtuals.items()} == {
+            k: str(v) for k, v in provider._provided_virtuals.items()
+        }
+        assert "mpi" in provider._provided_virtuals
+
+        # to_node_dict() is exactly the dag-hash preimage, so appearing there means the field
+        # contributes to the dag hash (`provides` is stripped from the package hash).
+        assert roundtrip.dag_hash() == provider.dag_hash()
+        assert "provided_virtuals" in provider.to_node_dict()
+
+    def test_provided_virtuals_reconstructed_from_legacy_specfile(self):
+        """A specfile written before this field existed has no ``provided_virtuals`` key. Reading
+        it reconstructs the data from package.py, and the stored dag hash is used verbatim, so
+        hashes are unchanged across Spack versions."""
+        concrete = spack.concretize.concretize_one("mpileaks ^mpich")
+
+        as_dict = concrete.to_dict()
+        for node in as_dict["spec"]["nodes"]:
+            node.pop("provided_virtuals", None)
+
+        old = Spec.from_dict(as_dict)
+        provider = old["mpich"]
+
+        # Reconstructed from package.py rather than left empty / None.
+        assert provider._provided_virtuals["mpi"] == vn.VersionList(":3")
+        # The stored dag hash is trusted on read, so dropping the field does not change it.
+        assert old.dag_hash() == concrete.dag_hash()
+
     def test_satisfies_single_valued_variant(self):
         """Tests that the case reported in
         https://github.com/spack/spack/pull/2386#issuecomment-282147639

--- a/lib/spack/spack/test/spec_semantics.py
+++ b/lib/spack/spack/test/spec_semantics.py
@@ -2364,6 +2364,45 @@ def test_satisfies_and_subscript_with_compilers(config, mock_packages):
     assert s["pkg-a"].dependencies(name="gmake")[0] == s["pkg-a"]["gmake"]
 
 
+def test_the_default_format_leaves_out_the_namespace(mock_packages):
+    """The default format prints the namespace only for an anonymous spec, since every concrete
+    spec has one and printing it everywhere would be noise, so a named spec that has one loses it
+    when it goes through a string. The two still denote the same set, since an unset namespace on
+    the left is read as no constraint."""
+    spec = Spec("builtin_mock.pkg-a")
+    round_tripped = Spec(str(spec))
+
+    assert spec.namespace == "builtin_mock"
+    assert round_tripped.namespace is None
+    assert round_tripped.satisfies(spec) and spec.satisfies(round_tripped)
+
+
+def test_flag_order_survives_formatting(mock_packages):
+    """Compiler flags are printed in the order they are stored, in runs of flags that agree on
+    whether they propagate, so a propagating flag followed by a plain one comes back in that
+    order. Flag order is significant to the build, so losing it would change the hash."""
+    spec = Spec("pkg-a cflags==-O2").copy()
+    spec.constrain(Spec("pkg-a cflags=-g"))
+    assert [str(flag) for flag in spec.compiler_flags["cflags"]] == ["-O2", "-g"]
+    assert str(spec) == "pkg-a cflags==-O2 cflags=-g"
+
+    round_tripped = Spec(str(spec))
+    assert [str(flag) for flag in round_tripped.compiler_flags["cflags"]] == ["-O2", "-g"]
+    assert round_tripped.dag_hash() == spec.dag_hash()
+
+
+def test_concrete_patches_are_truncated_by_formatting(mock_packages):
+    """Patch checksums are abbreviated to seven characters when printed. A concrete patches value
+    takes exactly the values it lists, so the abbreviation is not a prefix constraint that the
+    full checksum satisfies: the spec that comes back out of a string is disjoint from the one
+    that went in."""
+    spec = Spec("pkg-a patches:=abcdef1234567890")
+    round_tripped = Spec(str(spec))
+
+    assert round_tripped.variants["patches"].value == ("abcdef1",)
+    assert not spec.intersects(round_tripped)
+
+
 @pytest.mark.parametrize(
     "spec_str,spec_fmt,expected",
     [

--- a/lib/spack/spack/test/spec_semantics.py
+++ b/lib/spack/spack/test/spec_semantics.py
@@ -2484,6 +2484,26 @@ def test_a_spec_that_stopped_being_concrete_answers_a_direct_constraint(config, 
     assert not mpileaks.satisfies("mpileaks %libelf")
 
 
+def test_a_direct_dependency_is_inside_a_transitive_one(mock_packages):
+    """'pkg-a ^pkg-b' means pkg-b is somewhere in the DAG and 'pkg-a %pkg-b' means it is a direct
+    dependency, so the second is inside the first and not the other way around."""
+    anywhere_in_dag = Spec("pkg-a ^pkg-b")
+    direct_dependency = Spec("pkg-a %pkg-b")
+    assert direct_dependency.satisfies(anywhere_in_dag)
+    assert not anywhere_in_dag.satisfies(direct_dependency)
+
+
+def test_every_edge_of_a_concrete_node_is_a_direct_dependency(mock_packages, config):
+    """A concrete spec records its edges without the direct flag, but each of them is a direct
+    dependency in fact, so it answers a direct constraint. A package further down does not."""
+    mpileaks = spack.concretize.concretize_one("mpileaks")
+    assert not mpileaks.edges_to_dependencies(name="callpath")[0].direct
+
+    assert mpileaks.satisfies("mpileaks %callpath")
+    assert mpileaks.satisfies("mpileaks ^libelf")
+    assert not mpileaks.satisfies("mpileaks %libelf")
+
+
 @pytest.mark.parametrize(
     "spec_str,spec_fmt,expected",
     [

--- a/lib/spack/spack/test/spec_semantics.py
+++ b/lib/spack/spack/test/spec_semantics.py
@@ -2521,11 +2521,6 @@ class TestConstrainMutationSafety:
     as they are also mutually satisfying.
     """
 
-    @pytest.mark.xfail(
-        reason="_constrain assigns abstract_hash and merges node attributes before validating "
-        "the remaining dimensions",
-        strict=True,
-    )
     def test_lhs_is_unchanged_when_constrain_raises(self, mock_packages):
         for lhs_str, rhs_str, lhs, rhs in _constrain_corpus_pairs():
             before = lhs.to_dict()

--- a/lib/spack/spack/test/spec_semantics.py
+++ b/lib/spack/spack/test/spec_semantics.py
@@ -618,6 +618,23 @@ class TestSpecSemantics:
         assert concrete.satisfies("^[when='^notapackage'] zmpi")
         assert not concrete.satisfies("^[when='^mpi'] zmpi")
 
+    def test_virtual_name_on_the_rhs_decides_only_the_name(self):
+        """A virtual the lhs provides settles the name dimension. Every other dimension the rhs
+        constrains still has to hold of the provider."""
+        mpich = spack.concretize.concretize_one("mpileaks ^mpich")["mpich"]
+
+        assert mpich.satisfies("mpi")
+
+        # A variant the provider does not have, an architecture it does not have, and a hash it
+        # does not have, all asked for through the virtual name.
+        assert not mpich.satisfies("mpi+no-such-variant")
+        assert not mpich.satisfies("mpi platform=no-such-platform")
+        assert not mpich.satisfies("mpi/abcdef")
+
+        # Its own hash still matches, through the virtual name as well as the package name.
+        assert mpich.satisfies(f"mpi/{mpich.dag_hash()}")
+        assert mpich.satisfies(f"mpich/{mpich.dag_hash()}")
+
     def test_concrete_satisfies_does_not_consult_repo(self, monkeypatch):
         """Tests that `satisfies()` on a concrete lhs doesn't need the provider index, when the rhs
         contains a virtual name.

--- a/lib/spack/spack/test/spec_semantics.py
+++ b/lib/spack/spack/test/spec_semantics.py
@@ -2484,6 +2484,15 @@ def test_a_spec_that_stopped_being_concrete_answers_a_direct_constraint(config, 
     assert not mpileaks.satisfies("mpileaks %libelf")
 
 
+def test_an_anonymous_spec_is_the_top_of_the_order_only(mock_packages):
+    """A spec that leaves the name unset denotes every package, so everything is inside it and it
+    is inside nothing that names one. Being the bottom of the order as well would break
+    transitivity, since 'pkg-a' would be inside '' inside 'pkg-b'."""
+    assert Spec("pkg-a").satisfies("")
+    assert Spec("").satisfies("")
+    assert not Spec("").satisfies("pkg-b")
+
+
 def test_a_direct_dependency_is_inside_a_transitive_one(mock_packages):
     """'pkg-a ^pkg-b' means pkg-b is somewhere in the DAG and 'pkg-a %pkg-b' means it is a direct
     dependency, so the second is inside the first and not the other way around."""

--- a/lib/spack/spack/test/spec_yaml.py
+++ b/lib/spack/spack/test/spec_yaml.py
@@ -23,6 +23,7 @@ import spack.vendor.ruamel.yaml
 
 import spack.concretize
 import spack.config
+import spack.deptypes as dt
 import spack.error
 import spack.hash_types as ht
 import spack.paths
@@ -584,6 +585,18 @@ def test_direct_edges_and_round_tripping_to_dict(spec_str, config, mock_packages
             continue
         for dependency_data in node["dependencies"]:
             assert "direct" not in dependency_data["parameters"]
+
+
+def test_parallel_deptype_edges_survive_round_trip(mock_packages):
+    """Two parallel edges to one package, differing only in deptype, hash the same on the child
+    side and so share one object once read back from JSON. That must not fold them into a single
+    edge: to_node_dict already emits one entry per edge, with no uniqueness constraint on
+    dependencies, so a round trip needs to keep both."""
+    original = Spec("pkg-a ^[deptypes=build] pkg-b ^[deptypes=link] pkg-b")
+    reconstructed = Spec.from_dict(original.to_dict())
+    edges = reconstructed.edges_to_dependencies("pkg-b")
+    assert len(edges) == 2
+    assert {e.depflag for e in edges} == {dt.BUILD, dt.LINK}
 
 
 def test_pickle_preserves_identity_and_prefix(config, mock_packages):

--- a/lib/spack/spack/test/spec_yaml.py
+++ b/lib/spack/spack/test/spec_yaml.py
@@ -523,15 +523,38 @@ def test_pickle_roundtrip_for_abstract_specs(spec_str):
 
 
 @pytest.mark.parametrize(
-    "spec_str", ["zlib os=redhat6", "zlib platform=test", "zlib os=debian6 target=x86_64"]
+    "spec_str",
+    [
+        # partial architectures. Regression test: ArchSpec.to_dict crashed with AttributeError
+        # when target was None.
+        "zlib os=redhat6",
+        "zlib platform=test",
+        "zlib os=debian6 target=x86_64",
+        # abstract hash
+        "zlib/abcdef",
+        # conditional edges
+        "zlib ^[when='+mpi'] mpich@1",
+        "zlib ^[when='+mpi'] mpich@1 ^[when='~mpi'] mpich@2",
+        # propagated direct dependencies
+        "zlib %%gcc",
+        # flags that propagate and flags that don't, on the same flag type
+        "zlib cflags=-g cflags==-O2",
+        # several flags given as a single group
+        'zlib cflags="-O2 -g"',
+        # several dimensions at once
+        "zlib ++mpi cflags==-g foo=bar,baz target=x86_64:",
+    ],
 )
-def test_dict_roundtrip_for_abstract_specs_with_partial_arch(spec_str):
-    """Abstract specs with a partial architecture survive to_dict/from_dict.
-    Regression test: ArchSpec.to_dict crashed with AttributeError when target was None."""
+def test_dict_roundtrip_for_abstract_specs(spec_str):
+    """Abstract specs survive to_dict/from_dict.
+
+    This compares the spec objects, their string representation and the dicts themselves, since
+    `Spec.__eq__` is blind to some of what is serialized, and vice versa."""
     s = spack.spec.Spec(spec_str)
     t = spack.spec.Spec.from_dict(s.to_dict())
     assert s == t
     assert str(s) == str(t)
+    assert s.to_dict() == t.to_dict()
 
 
 def test_specfile_alias_is_updated():

--- a/lib/spack/spack/test/spec_yaml.py
+++ b/lib/spack/spack/test/spec_yaml.py
@@ -48,7 +48,7 @@ def check_json_round_trip(spec):
     assert spec.eq_dag(spec_from_json)
 
 
-def test_read_spec_from_signed_json():
+def test_read_spec_from_signed_json(mock_packages):
     spec_dir = os.path.join(spack.paths.test_path, "data", "mirrors", "signed_json")
     file_name = (
         "linux-ubuntu18.04-haswell-gcc-8.4.0-"

--- a/lib/spack/spack/test/spec_yaml.py
+++ b/lib/spack/spack/test/spec_yaml.py
@@ -599,6 +599,20 @@ def test_parallel_deptype_edges_survive_round_trip(mock_packages):
     assert {e.depflag for e in edges} == {dt.BUILD, dt.LINK}
 
 
+def test_parallel_edges_are_serialized_in_a_canonical_order(mock_packages):
+    """Two edges to the same package with the same dependency types are told apart by their when
+    condition, their virtuals and the rest of their attributes, so a meet that produces both is
+    one state with one hash however the operands were ordered."""
+    forward = Spec("%pkg-b").copy()
+    forward.constrain(Spec("pkg-a ^[when='+foo'] pkg-b@1"))
+    backward = Spec("pkg-a ^[when='+foo'] pkg-b@1").copy()
+    backward.constrain(Spec("%pkg-b"))
+
+    assert len(forward.edges_to_dependencies()) == 2
+    assert forward.to_dict() == backward.to_dict()
+    assert forward.dag_hash() == backward.dag_hash()
+
+
 def test_pickle_preserves_identity_and_prefix(config, mock_packages):
     """When pickling multiple specs that share dependencies, the identity of those dependencies
     should be preserved when unpickling."""

--- a/lib/spack/spack/test/variant.py
+++ b/lib/spack/spack/test/variant.py
@@ -879,6 +879,23 @@ def test_patches_variant():
     assert not Spec("patches:=abcdef").satisfies("patches:=abcdefghi")
 
 
+def test_patches_variant_prefix_intersects_and_constrains():
+    """Prefix matching applies to intersection too, so a spec that satisfies a prefix also
+    overlaps it and can be constrained by it."""
+    assert Spec("patches:=abcdef").intersects("patches=ab")
+    assert Spec("patches=ab").intersects("patches:=abcdef")
+    assert not Spec("patches:=abcdef").intersects("patches=xyz")
+    assert not Spec("patches:=abcdef").intersects("patches=abcdefghi")
+
+    s = Spec("patches:=abcdef")
+    assert s.constrain("patches=ab") is False
+    assert s.variants["patches"].values == ("abcdef",)
+
+    s = Spec("patches=ab")
+    assert s.constrain("patches:=abcdef") is True
+    assert s.variants["patches"].values == ("abcdef",)
+
+
 def test_constrain_narrowing():
     s = Spec("foo=*")
     assert s.variants["foo"].type == spack.variant.VariantType.MULTI

--- a/lib/spack/spack/test/variant.py
+++ b/lib/spack/spack/test/variant.py
@@ -480,7 +480,7 @@ class TestVariantMapTest:
 
         # concrete values cannot be constrained
         with pytest.raises(spack.variant.UnsatisfiableVariantSpecError):
-            a._constrain_variants(b)
+            a.constrain(b)
 
     def test_copy(self) -> None:
         a = VariantMap()

--- a/lib/spack/spack/variant.py
+++ b/lib/spack/spack/variant.py
@@ -467,6 +467,11 @@ class VariantValue:
         """Constrain self with other if they intersect. Returns true iff self was changed."""
         if not self.intersects(other):
             raise UnsatisfiableVariantSpecError(self, other)
+        return self._merge(other)
+
+    def _merge(self, other: "VariantValue") -> bool:
+        """Constrain self with other, which is known to intersect. Never raises, so that a
+        caller merging several variants cannot apply some of them and then fail."""
         old_values = self.values
         self.set(*self._merged_values(other))
         changed = old_values != self.values

--- a/lib/spack/spack/variant.py
+++ b/lib/spack/spack/variant.py
@@ -414,6 +414,29 @@ class VariantValue:
             self.type, self.name, self.values, propagate=self.propagate, concrete=self.concrete
         )
 
+    def _merged_values(self, other: "VariantValue") -> Tuple[Union[str, bool], ...]:
+        """The values of both sides. For patches a value identified by a checksum prefix and the
+        full checksum name the same patch, so only the longer one is kept."""
+        values = (*self.values, *other.values)
+        if self.name != "patches":
+            return values
+        return tuple(
+            v
+            for v in values
+            if not any(
+                w != v and isinstance(w, str) and isinstance(v, str) and w.startswith(v)
+                for w in values
+            )
+        )
+
+    def _contains(self, value: Union[str, bool]) -> bool:
+        """Whether this variant covers a single value of another one. A patch is identified by a
+        prefix of its checksum, so a shorter value is covered by any value starting with it.
+        """
+        if self.name == "patches" and isinstance(value, str):
+            return any(isinstance(w, str) and w.startswith(value) for w in self.values)
+        return value in self.values
+
     def satisfies(self, other: "VariantValue") -> bool:
         """The lhs satisfies the rhs if all possible concretizations of lhs are also
         possible concretizations of rhs."""
@@ -421,16 +444,7 @@ class VariantValue:
             return False
 
         if not other.concrete:
-            # rhs abstract means the lhs must at least contain its values.
-            # special-case patches with rhs abstract: their values may be prefixes of the lhs
-            # values.
-            if self.name == "patches":
-                return all(
-                    isinstance(v, str)
-                    and any(isinstance(w, str) and w.startswith(v) for w in self.values)
-                    for v in other.values
-                )
-            return all(v in self for v in other.values)
+            return all(self._contains(v) for v in other.values)
         if self.concrete:
             # both concrete: they must be equal
             return self.values == other.values
@@ -443,9 +457,9 @@ class VariantValue:
         if self.concrete:
             if other.concrete:
                 return self.values == other.values
-            return all(v in self for v in other.values)
+            return all(self._contains(v) for v in other.values)
         if other.concrete:
-            return all(v in other for v in self.values)
+            return all(other._contains(v) for v in self.values)
         # both abstract: the union is a valid concretization of both
         return True
 
@@ -454,7 +468,7 @@ class VariantValue:
         if not self.intersects(other):
             raise UnsatisfiableVariantSpecError(self, other)
         old_values = self.values
-        self.set(*self.values, *other.values)
+        self.set(*self._merged_values(other))
         changed = old_values != self.values
         if self.propagate and not other.propagate:
             self.propagate = False


### PR DESCRIPTION
Depends on #52798.

The base is `develop`, so the diff shows the PRs it depends on too. This one is about the last
three commits, `b1d277f1f9..7714b92a75`:

- `98f10c720f` spec.py: record provided virtual versions on concrete specs
- `f1b2061fab` spec: make satisfies, intersects and constrain stateless
- `7714b92a75` spec: make intersects the single source of truth for constrain

Makes `Spec.satisfies`, `Spec.intersects` and `Spec.constrain` stateless with respect to
`spack.repo`, and rebuilds `constrain` on top of `intersects`.

Concrete nodes now record the versions of the virtuals they provide: the intersection of the
matching `provides` clauses, which is what the solver enforces by imposing each clause as a
`node_version_satisfies` constraint on the virtual node. Populated from `package.py` at
concretization or read back from the spec file, that makes a versioned virtual query such as
`openmpi.satisfies("mpi@3:")` answerable without a `package.py` lookup.

With that in place, abstract-to-abstract virtual resolution is dropped from spec comparison:
different abstract names no longer intersect through the provider index, and the `resolve_virtuals`
flag threaded through `satisfies` / `intersects` / `constrain` goes away.

```python
Spec("mpich").intersects("mpi")   # True before, False now; satisfies was already False
```

`intersects` then becomes the single source of truth for `constrain`: the merge applies the same test the intersection does, so it can no longer accept a pairing the test would reject or
reject one it would accept.

One thing this PR deliberately does not do: pair edges by deptype. `_paired_edges` pairs two edges
to one package by name and `when` alone, ignoring deptype, so a build-only edge and a link-only
edge to the same package - which `spack.deptypes.compatible` allows to coexist, for splicing - are
paired together and reported as a version contradiction rather than the two separate edges they
are:

```python
Spec("^[deptypes=build] pkg-b@1").intersects("^[deptypes=link] pkg-b@2")   # False
```

An earlier revision of this PR fixed that, pairing edges only when their deptypes are equal or
cannot stand apart to begin with (`not dt.compatible`), plus a follow-up commit fusing a split pair
into a single edge combining both deptypes. Both are reverted: splitting the two edges apart while
a `%`-edge still fuses with any of them makes where a constraint lands depend on the order the
operands are met in, which breaks associativity of `constrain`:

```python
a, b, c = Spec("^pkg-b@1"), Spec("pkg-a ^[deptypes=build] pkg-b"), Spec("pkg-a %pkg-b@1 ^pkg-c")
(a ⊓ b) ⊓ c   # pkg-a %pkg-b@1 ^[deptypes=build] pkg-b ^pkg-c
a ⊓ (b ⊓ c)   # pkg-a %[deptypes=build] pkg-b@1 ^pkg-c
```

Settling it needs a normal form for parallel edges that the parser, `to_dict` and `constrain` agree
on, which is a separate problem. Left as is for now.

Not backported: `schema/spec.py` changes, and the semantics of comparing two abstract specs that
name different providers of a virtual change.

Supersedes #52786 and #52760, which were cut from an older base.


---

Part of a stack of fixes to `Spec.satisfies` / `intersects` / `constrain`, found by fuzzing their
algebraic identities. Each PR is based on the one above it and groups commits by how far they can
be backported, so a single label applies to the whole PR.

| PR | what | backport |
| --- | --- | --- |
| #52788 | round-trip abstract specs through `to_dict` | v1.0.5, v1.1.2, v1.2.3 |
| #52787 | `constrain` does not mutate on failure and reports what it changed | v1.0.5, v1.1.2, v1.2.3 |
| #52789 | the patch prefix rule applies to `intersects` and `constrain` too | v1.0.5, v1.1.2, v1.2.3 |
| #52796 | compiler flags keep their order and their propagation | v1.0.5, v1.1.2, v1.2.3 |
| #52790 | a star means any value; an edge merges its propagation policy | v1.1.2, v1.2.3 |
| #52797 | `satisfies` for virtual providers, direct edges and anonymous specs | v1.2.3 |
| #52798 | target satisfaction is containment; parallel edges have an order | none |
| #52800 | `satisfies`, `intersects` and `constrain` become stateless | none |
| #52799 | an edge naming a virtual is merged into the edge naming its provider | none |
| #52795 | the property tests | none |

The v1.0.5 and v1.1.2 backports need #51870 on `releases/v1.0` and `releases/v1.1` first: it
rewrote `_constrain_dependencies`, which these fixes build on. `releases/v1.2` already has it.


