### PR TITLE
info: filter output by requested sections

### DIFF
--- a/lib/spack/spack/cmd/info.py
+++ b/lib/spack/spack/cmd/info.py
@@ -112,6 +112,14 @@ def setup_parser(subparser: argparse.ArgumentParser) -> None:
         help="group variants, dependencies, etc. first by when condition, then by name",
     )
 
+    subparser.add_argument(
+        "--show",
+        action="append",
+        default=[],
+        metavar="SECTIONS",
+        help="show only the specified comma-separated sections; may be repeated",
+    )
+
     options = [
         ("--detectable", print_detectable.__doc__),
         ("--maintainers", print_maintainers.__doc__),
@@ -643,43 +651,99 @@ def info(parser: argparse.ArgumentParser, args: Namespace) -> None:
     if len(specs) == 0:
         args.subparser.error("requires a spec")
 
+    requested_sections = set()
+
+    valid_sections = {
+        "package",
+        "description",
+        "homepage",
+        "maintainers",
+        "namespace",
+        "detectable",
+        "tags",
+        "versions",
+        "variants",
+        "phases",
+        "dependencies",
+        "virtuals",
+        "tests",
+        "licenses",
+    }
+
+    for arg in args.show:
+        for section in arg.split(","):
+            requested_sections.add(section.strip())
+
+    unknown_sections = requested_sections - valid_sections
+    if unknown_sections:
+        args.subparser.error(f"unknown section(s): {', '.join(sorted(unknown_sections))}")
+
+    other_section_option_requested = any(
+        (
+            args.all,
+            args.maintainers,
+            args.namespace,
+            args.detectable,
+            args.tags,
+            args.phases,
+            args.virtuals,
+            args.tests,
+            args.no_dependencies,
+            args.no_variants,
+            args.no_versions,
+        )
+    )
+
+    if args.show and other_section_option_requested:
+        args.subparser.error("--show cannot be combined with other section-selection options")
+
     spec = specs[0]
     pkg_cls = spack.repo.PATH.get_pkg_class(spec.fullname)
     pkg_cls.validate_variant_names(spec)
     pkg = pkg_cls(spec)
 
+    def should_show(section: str, default: bool) -> bool:
+        if args.show:
+            return section in requested_sections
+        return default
+
     # Output core package information
-    header = section_title("{0}:   ").format(pkg.build_system_class) + pkg.name
-    color.cprint(header)
+    if should_show("package", True):
+        header = section_title("{0}:   ").format(pkg.build_system_class) + pkg.name
+        color.cprint(header)
 
-    color.cprint("")
-    color.cprint(section_title("Description:"))
-    if pkg.__doc__:
-        color.cprint(color.cescape(pkg.format_doc(indent=4)))
-    else:
-        color.cprint("    None")
+    if should_show("description", True):
+        color.cprint("")
+        color.cprint(section_title("Description:"))
+        if pkg.__doc__:
+            color.cprint(color.cescape(pkg.format_doc(indent=4)))
+        else:
+            color.cprint("    None")
 
-    if getattr(pkg, "homepage"):
+    if should_show("homepage", True) and getattr(pkg, "homepage"):
         color.cprint(section_title("Homepage: ") + str(pkg.homepage))
 
-    # Now output optional information in expected order
+    show_dependencies = should_show("dependencies", args.all or not args.no_dependencies)
+
     sections = [
-        (args.all or args.maintainers, print_maintainers),
-        (args.all or args.namespace, print_namespace),
-        (args.all or args.detectable, print_detectable),
-        (args.all or args.tags, print_tags),
-        (args.all or not args.no_versions, print_versions),
-        (args.all or not args.no_variants, print_variants),
-        (args.all or args.phases, print_phases),
-        (args.all or not args.no_dependencies, print_dependencies),
-        (args.all or args.virtuals, print_virtuals),
-        (args.all or args.tests, print_tests),
-        (True, print_licenses),
+        (should_show("maintainers", args.all or args.maintainers), print_maintainers),
+        (should_show("namespace", args.all or args.namespace), print_namespace),
+        (should_show("detectable", args.all or args.detectable), print_detectable),
+        (should_show("tags", args.all or args.tags), print_tags),
+        (should_show("versions", args.all or not args.no_versions), print_versions),
+        (should_show("variants", args.all or not args.no_variants), print_variants),
+        (should_show("phases", args.all or args.phases), print_phases),
+        (show_dependencies, print_dependencies),
+        (should_show("virtuals", args.all or args.virtuals), print_virtuals),
+        (should_show("tests", args.all or args.tests), print_tests),
+        (should_show("licenses", True), print_licenses),
     ]
+
     for print_it, func in sections:
         if print_it:
             func(pkg, args)
 
-    print_dependency_suggestion(pkg)
+    if show_dependencies:
+        print_dependency_suggestion(pkg)
 
     color.cprint("")

--- a/lib/spack/spack/test/cmd/info.py
+++ b/lib/spack/spack/test/cmd/info.py
@@ -72,6 +72,36 @@ def test_info_fields(pkg_query, extra_args):
 
 
 @pytest.mark.parametrize(
+    "args",
+    [
+        ["--show", "unknown", "vtk-m"],
+        ["--show", "phases", "--all", "vtk-m"],
+        ["--show", "phases", "--maintainers", "vtk-m"],
+    ],
+)
+def test_info_show_failures(args):
+    with pytest.raises(SpackCommandError):
+        info(*args)
+
+
+@pytest.mark.parametrize(
+    "show_args", [["--show", "phases,homepage"], ["--show", "phases", "--show", "homepage"]]
+)
+def test_info_show_sections(show_args):
+    output = info(*show_args, "vtk-m")
+
+    assert "Homepage:" in output
+    assert "Installation Phases:" in output
+
+    assert "CMakePackage" not in output
+    assert "Description:" not in output
+    assert "Safe versions:" not in output
+    assert "Variants:" not in output
+    assert "Dependencies:" not in output
+    assert "Licenses:" not in output
+
+
+@pytest.mark.parametrize(
     "args,in_output,not_in_output",
     [
         # no variants

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -1358,7 +1358,7 @@ _spack_help() {
 _spack_info() {
     if $list_options
     then
-        SPACK_COMPREPLY="-h --help -a --all --by-name --by-when --detectable --maintainers --namespace --no-dependencies --no-variants --no-versions --phases --tags --tests --virtuals"
+        SPACK_COMPREPLY="-h --help -a --all --by-name --by-when --show --detectable --maintainers --namespace --no-dependencies --no-variants --no-versions --phases --tags --tests --virtuals"
     else
         _all_packages
     fi

--- a/share/spack/spack-completion.fish
+++ b/share/spack/spack-completion.fish
@@ -2097,7 +2097,7 @@ complete -c spack -n '__fish_spack_using_command help' -l spec -f -a guide
 complete -c spack -n '__fish_spack_using_command help' -l spec -d 'help on the package specification syntax'
 
 # spack info
-set -g __fish_spack_optspecs_spack_info h/help a/all by-name by-when detectable maintainers namespace no-dependencies no-variants no-versions phases tags tests virtuals
+set -g __fish_spack_optspecs_spack_info h/help a/all by-name by-when show= detectable maintainers namespace no-dependencies no-variants no-versions phases tags tests virtuals
 complete -c spack -n '__fish_spack_using_command_pos_remainder 0 info' -f -k -a '(__fish_spack_specs)'
 complete -c spack -n '__fish_spack_using_command info' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command info' -s h -l help -d 'show this help message and exit'
@@ -2107,6 +2107,8 @@ complete -c spack -n '__fish_spack_using_command info' -l by-name -f -a by_name
 complete -c spack -n '__fish_spack_using_command info' -l by-name -d 'list variants, dependency, etc. in name order, then by when condition'
 complete -c spack -n '__fish_spack_using_command info' -l by-when -f -a by_name
 complete -c spack -n '__fish_spack_using_command info' -l by-when -d 'group variants, dependencies, etc. first by when condition, then by name'
+complete -c spack -n '__fish_spack_using_command info' -l show -r -f -a show
+complete -c spack -n '__fish_spack_using_command info' -l show -r -d 'show only the specified comma-separated sections; may be repeated'
 complete -c spack -n '__fish_spack_using_command info' -l detectable -f -a detectable
 complete -c spack -n '__fish_spack_using_command info' -l detectable -d 'output information on external detection'
 complete -c spack -n '__fish_spack_using_command info' -l maintainers -f -a maintainers


### PR DESCRIPTION
## Summary

- Make explicit section options such as `--phases` and `--maintainers`
  suppress the default versions, variants, dependencies, and licenses sections.
- Preserve the existing default output when no explicit section option is used.
- Preserve `--all` behavior.
- Only print the dependency suggestion when dependencies are displayed.
- Add regression coverage for `--phases` and `--maintainers`.

Fixes #51222

## Design note

This implements existing positive section options as filters. I saw the
discussion in #51137 suggesting a more general `--show versions,phases`
interface, so I am opening this as a draft for confirmation of the direction.

## Testing

- `spack unit-test lib/spack/spack/test/cmd/info.py` — 47 passed
- `spack style --skip mypy lib/spack/spack/cmd/info.py lib/spack/spack/test/cmd/info.py` — clean
- Manually verified `spack info --phases kokkos`
- Manually verified `spack info --maintainers kokkos`

Full Mypy checking on native Windows reports existing POSIX-specific errors in
unrelated files; import and Ruff checks pass for the changed files.