### PR TITLE
refactor optimization criteria

### DIFF
--- a/lib/spack/spack/cmd/spec.py
+++ b/lib/spack/spack/cmd/spec.py
@@ -119,7 +119,7 @@ def _process_result(result, show, required_format, kwargs):
 
         for i, criterion in enumerate(result.criteria, 1):
             # Criteria are grouped into priority bands; print a header when the band changes.
-            band = asp.optimization_band(criterion.priority)
+            band = criterion.band
             if band != prev_band:
                 label = f"-- {band.value}"
                 dashes = "-" * max(0, divider_width - len(label) - 1)

--- a/lib/spack/spack/cmd/spec.py
+++ b/lib/spack/spack/cmd/spec.py
@@ -121,7 +121,7 @@ def _process_result(result, show, required_format, kwargs):
             # Criteria are grouped into priority bands; print a header when the band changes.
             band = criterion.band
             if band != prev_band:
-                label = f"-- {band.value}"
+                label = f"-- {band}"
                 dashes = "-" * max(0, divider_width - len(label) - 1)
                 color.cprint(f"  @*{{{label}}} @K{{{dashes}}}")
                 prev_band = band

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -136,7 +136,7 @@ class OptimizationCriteria(NamedTuple):
     priority: int
     value: int
     name: str
-    band: OptimizationBand
+    band: str
     kind: OptimizationKind
 
 
@@ -155,13 +155,13 @@ def build_criteria_names(costs, arg_tuples):
     }
 
     for args in arg_tuples:
-        priority, band, name = args[0], band_names[args[2]], args[4]
+        priority, band, name = args[0], band_names[args[2]].value, args[4]
         priority = int(priority)
 
-        if band == OptimizationBand.REUSED:
+        if band == OptimizationBand.REUSED.value:
             # Reused/concrete criterion
             priorities_names.append((priority, name, band, OptimizationKind.CONCRETE))
-        elif band == OptimizationBand.BUILD:
+        elif band == OptimizationBand.BUILD.value:
             # Build criterion
             priorities_names.append((priority, name, band, OptimizationKind.BUILD))
         else:

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -151,7 +151,7 @@ def build_criteria_names(costs, arg_tuples):
         "concr": OptimizationBand.REUSED,
         "hinge": OptimizationBand.FIXED,
         "built": OptimizationBand.BUILD,
-        "high": OptimizationBand.HIGHEST
+        "high": OptimizationBand.HIGHEST,
     }
 
     for args in arg_tuples:

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -104,62 +104,6 @@ DEFAULT_OUTPUT_CONFIGURATION = OutputConfiguration(
 )
 
 
-# Below numbers are used to map names of criteria to the order they appear in the solution
-#
-# The space of possible priorities for optimization targets is partitioned in the following ranges:
-#
-# [0-100)     Low-priority criteria (target-related criteria plus symmetry tie-breakers)
-# [100-200)   Optimization criteria for software being reused (concrete slot)
-# [200-300)   Fixed criteria higher priority than reuse, lower than build
-# [300-400)   Optimization criteria for software being built (build slot)
-# [400-1000)  High-priority fixed criteria
-# [1000-inf)  Error conditions
-#
-# The "low" band sits strictly below the reused/concrete band, so the solver decides compilers,
-# versions, etc. before targets and tie-breakers.
-#
-# The priority of an opt_criterion() fact is the level of its slot. Priorities in the "concrete"
-# band have an implicit "build" priority shifted by build_priority_offset.
-# Each optimization target is a minimization with optimal value 0.
-
-#: Exclusive upper bound of each priority band, in ascending order
-low_band_max = 100
-concrete_band_max = 200
-fixed_band_max = 300
-build_band_max = 400
-
-#: Displacement from a concrete-band criterion's level to its implicit build-band twin
-build_priority_offset = 200
-
-
-class OptimizationBand(enum.Enum):
-    """Grouping for optimization criteria by their priority range."""
-
-    LOW = "Lowest priority"
-    REUSED = "Reused nodes"
-    FIXED = "Fixed (reuse vs build)"
-    BUILD = "Built nodes"
-    HIGHEST = "Highest priority"
-
-
-#: Exclusive upper bound of each band's priority range, in ascending order.
-_BAND_UPPER_BOUNDS = (
-    (low_band_max, OptimizationBand.LOW),  # [0, 100)
-    (concrete_band_max, OptimizationBand.REUSED),  # [100, 200)
-    (fixed_band_max, OptimizationBand.FIXED),  # [200, 300)
-    (build_band_max, OptimizationBand.BUILD),  # [300, 400)
-    # [400, inf) -> OptimizationBand.HIGHEST (requirement weight, unsolved input specs)
-)
-
-
-def optimization_band(priority: int) -> OptimizationBand:
-    """Return the display band a criterion belongs to, given its clingo priority."""
-    for upper_bound, band in _BAND_UPPER_BOUNDS:
-        if priority < upper_bound:
-            return band
-    return OptimizationBand.HIGHEST
-
-
 # type aliases for the data structures we get back from the solver
 SpecDict = Dict[NodeId, spack.spec.Spec]
 SpliceDict = Dict[spack.spec.Spec, List[spack.solver.splicing.Splice]]
@@ -176,12 +120,23 @@ class OptimizationKind:
     OTHER = 2
 
 
+class OptimizationBand(enum.Enum):
+    """Grouping for optimization criteria by their priority range."""
+
+    LOW = "Lowest priority"
+    REUSED = "Reused nodes"
+    FIXED = "Fixed (reuse vs build)"
+    BUILD = "Built nodes"
+    HIGHEST = "Highest priority"
+
+
 class OptimizationCriteria(NamedTuple):
     """A named tuple describing an optimization criteria."""
 
     priority: int
     value: int
     name: str
+    band: OptimizationBand
     kind: OptimizationKind
 
 
@@ -190,20 +145,27 @@ def build_criteria_names(costs, arg_tuples):
     # pull optimization criteria names out of the solution
     priorities_names = []
 
+    # translate ASP band names into display names
+    band_names = {
+        "low": OptimizationBand.LOW,
+        "concr": OptimizationBand.REUSED,
+        "hinge": OptimizationBand.FIXED,
+        "built": OptimizationBand.BUILD,
+        "high": OptimizationBand.HIGHEST
+    }
+
     for args in arg_tuples:
-        priority, name = args[:2]
+        priority, band, name = args[0], band_names[args[2]], args[4]
         priority = int(priority)
 
-        if priority < low_band_max:
-            priorities_names.append((priority, name, OptimizationKind.OTHER))
-        elif priority < concrete_band_max:
-            # Reused/concrete criterion in the [100, 200) band.
-            priorities_names.append((priority, name, OptimizationKind.CONCRETE))
-            # Same build criterion in the [300, 400) band.
-            build_priority = priority + build_priority_offset
-            priorities_names.append((build_priority, name, OptimizationKind.BUILD))
+        if band == OptimizationBand.REUSED:
+            # Reused/concrete criterion
+            priorities_names.append((priority, name, band, OptimizationKind.CONCRETE))
+        elif band == OptimizationBand.BUILD:
+            # Build criterion
+            priorities_names.append((priority, name, band, OptimizationKind.BUILD))
         else:
-            priorities_names.append((priority, name, OptimizationKind.OTHER))
+            priorities_names.append((priority, name, band, OptimizationKind.OTHER))
 
     # sort the criteria by priority
     priorities_names = sorted(priorities_names, reverse=True)
@@ -214,8 +176,8 @@ def build_criteria_names(costs, arg_tuples):
     costs = costs[error_criteria:]
 
     return [
-        OptimizationCriteria(priority, value, name, status)
-        for (priority, name, status), value in zip(priorities_names, costs)
+        OptimizationCriteria(priority, value, name, band, status)
+        for (priority, name, band, status), value in zip(priorities_names, costs)
     ]
 
 
@@ -1060,7 +1022,7 @@ class PyclingoDriver:
         result.answers.append((list(min_cost), 0, spec_dict))
 
         # get optimization criteria
-        criteria_args = extract_args(best_model, "opt_criterion")
+        criteria_args = extract_args(best_model, "opt_priority")
         result.criteria = build_criteria_names(min_cost, criteria_args)
 
         # record the number of models the solver considered

--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -2319,23 +2319,7 @@ opt_priority(Priority, low_offset, "low", "", Description) :-
     Priority = N + low_offset.
 
 % show criteria
-#minimize {
-    % high
-    0@Priority:
-        opt_priority(Priority, high_offset, "high", _, _);
-    % built
-    0@Priority:
-        opt_priority(Priority, built_offset, "built", "fixed", _);
-    % hinge
-    0@Priority:
-        opt_priority(Priority, hinge_offset, "hinge", _, _);
-    % concrete
-    0@Priority:
-        opt_priority(Priority, concr_offset, "concr", "fixed", _);
-    % low
-    0@Priority:
-        opt_priority(Priority, low_offset, "low", _, _)
-}.
+#minimize { 0@Priority: opt_priority(Priority, _, _, _, _) }.
 
 %-----------------------------------------------------------------------------
 % Optimization minimize blocks

--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -2151,8 +2151,14 @@ impose(Hash, PackageNode) :- attr("hash", PackageNode, Hash), attr("node", Packa
 % If there is not a hash for a package, we build it.
 build(PackageNode) :- attr("node", PackageNode), not concrete(PackageNode).
 
-% Minimizing builds is tricky. We want a minimizing criterion
+% This statement, which is a hidden feature of clingo, let us avoid cycles in the DAG
+#edge (A, B) : depends_on(A, B).
 
+%-----------------------------------------------------------------------------------------
+% Optimization
+%-----------------------------------------------------------------------------------------
+%
+% Minimizing builds is tricky. We want a minimizing criterion
 % because we want to reuse what is available, but
 % we also want things that are built to stick to *default preferences* from
 % the package and from the user. We therefore treat built specs differently and apply
@@ -2162,163 +2168,296 @@ build(PackageNode) :- attr("node", PackageNode), not concrete(PackageNode).
 % criteria for built specs -- so that they take precedence over the otherwise
 % topmost-priority criterion to reuse what is installed.
 %
-
-% The priority ranges are:
-%   1000+       Optimizations for concretization errors
-%   300 - 1000  Highest priority optimizations for valid solutions
-%   200 - 299   Shifted priorities for build nodes; correspond to priorities 0 - 99.
-%   100 - 199   Unshifted priorities. Currently only includes minimizing #builds and minimizing dupes.
-%   0   -  99   Priorities for non-built nodes.
-
-treat_node_as_concrete(node(X, Package)) :- attr("node", node(X, Package)), runtime(Package).
-
-build_priority(PackageNode, 200) :- build(PackageNode), attr("node", PackageNode), not treat_node_as_concrete(PackageNode).
-build_priority(PackageNode, 0)   :- build(PackageNode), attr("node", PackageNode), treat_node_as_concrete(PackageNode).
-build_priority(PackageNode, 0)   :- concrete(PackageNode), attr("node", PackageNode).
-
-% This statement, which is a hidden feature of clingo, let us avoid cycles in the DAG
-#edge (A, B) : depends_on(A, B).
-
-%-----------------------------------------------------------------
-% Optimization to avoid errors
-%-----------------------------------------------------------------
-% Some errors are handled as rules instead of constraints because
-% it allows us to explain why something failed.
-#minimize{ 0@1000: #true}.
-
-#minimize{ Weight@1000,Msg: error(Weight, Msg) }.
-#minimize{ Weight@1000,Msg,Arg1: error(Weight, Msg, Arg1) }.
-#minimize{ Weight@1000,Msg,Arg1,Arg2: error(Weight, Msg, Arg1, Arg2) }.
-#minimize{ Weight@1000,Msg,Arg1,Arg2,Arg3: error(Weight, Msg, Arg1, Arg2, Arg3) }.
-#minimize{ Weight@1000,Msg,Arg1,Arg2,Arg3,Arg4: error(Weight, Msg, Arg1, Arg2, Arg3, Arg4) }.
-
 %-----------------------------------------------------------------------------
 % How to optimize the spec (high to low priority)
 %-----------------------------------------------------------------------------
-% Each criterion below has:
-%   1. an opt_criterion(ID, Name) fact that describes the criterion, and
-%   2. a `#minimize{ 0@2 : #true }.` statement that ensures the criterion
-%      is displayed (clingo doesn't display sums over empty sets by default)
+%
+% +-----+-----------------------------------------------------------------+
+% |prio |     high <---                                    ---> low       |
+% |-----|-------+------+-----------------+-------+-----------------+------|
+% |loc  | error | high |      built      | hinge |    concrete     | low  |
+% |-----|-------|------|-----------------|-------|-----------------|------|
+% |type | n/a   | n/a  |  fixed & level  | n/a   |  fixed & level  | n/a  |
+% |-----|-------|------|------+------+---|-------|------+------+---|------|
+% |level| n/a   | n/a  |  L0  |  L1  |...| n/a   |  L0  |  L1  |...| n/a  |
+% |-----|-------|------|------|------|---|-------|------|------|---|------|
+% |index| 1000  |0|1|..|0|1|..|0|1|..|...|0|1|...|0|1|..|0|1|..|...|0|1|..|
+% +-----+-------+------+------+------+---+-------+------+------+---+------+
+%
+% Locations:
+%   "error"     Highest priority (used for errors)
+%   "high"      Higher priority than built and concrete criteria
+%   "built"     Priority for built specs
+%   "hinge"     Priority between built and concrete specs
+%   "concrete"  Priority for concrete specs
+%   "low"       Priority below concrete specs
+%
+% Types:
+%   "fixed"     Criteria dependent on built/concrete. Independent of level
+%   "level"     Criteria dependent on built/concrete and level
+%
+%   Types are relevant only for built and concrete locations. "fixed" and
+%   "level" share the same index "namespace" per level. "fixed" criteria are
+%   only active level specified by `opt_criterion`.
+%
+% Note that level(PackageNode, Level)  is a computed value from the DAG and
+% is only used for "level" criteria.
+%
+% !! LEVEL IS NOT IMPLEMENTED AT THE MOMENT BUT KEPT HERE AS PLACEHOLDER !!
+
+% Constants for calculating optimization criterion priority
+%   level_opt is level & fixed per level
+%   indep_opt is per high/hinge/low
+#const max_depth = 1.
+#const level_opt = 32.
+#const indep_opt = 16.
+%   location
+#const low_offset   = 0.
+#const concr_offset = low_offset + indep_opt.
+#const hinge_offset = concr_offset + max_depth * level_opt.
+#const built_offset = hinge_offset + indep_opt.
+#const high_offset  = built_offset + max_depth * level_opt.
+#const error_offset = high_offset + indep_opt.
+%   type
+#const fixed_offset = (max_depth - 1) * level_opt.
+
+% Build priority
+
+treat_node_as_concrete(node(X, Package)) :- attr("node", node(X, Package)), runtime(Package).
+
+build_priority(PackageNode, built_offset) :- build(PackageNode), attr("node", PackageNode), not treat_node_as_concrete(PackageNode).
+build_priority(PackageNode, concr_offset) :- build(PackageNode), attr("node", PackageNode), treat_node_as_concrete(PackageNode).
+build_priority(PackageNode, concr_offset) :- concrete(PackageNode), attr("node", PackageNode).
+
+%----------------------------------------------------------------------
+% Errors
+%----------------------------------------------------------------------
+% Some errors are handled as rules instead of constraints because
+% it allows us to explain why something failed.
+#minimize{ 0@error_offset: #true}.
+
+#minimize{ Weight@error_offset,Msg: error(Weight, Msg) }.
+#minimize{ Weight@error_offset,Msg,Arg1: error(Weight, Msg, Arg1) }.
+#minimize{ Weight@error_offset,Msg,Arg1,Arg2: error(Weight, Msg, Arg1, Arg2) }.
+#minimize{ Weight@error_offset,Msg,Arg1,Arg2,Arg3: error(Weight, Msg, Arg1, Arg2, Arg3) }.
+#minimize{ Weight@error_offset,Msg,Arg1,Arg2,Arg3,Arg4: error(Weight, Msg, Arg1, Arg2, Arg3, Arg4) }.
+
+%-----------------------------------------------------------------------------
+% Optimization Criteria
+%-----------------------------------------------------------------------------
+% opt_criterion(Priority, Location, Type, Level (for fixed only), Description)
+
+opt_criterion(0, "high", "", 0, "requirement weight").
+
+opt_criterion(12, "built", "fixed", 0, "deprecated versions used").
+opt_criterion(11, "built", "fixed", 0, "version badness (roots)").
+opt_criterion(10, "built", "fixed", 0, "variant penalty (roots)").
+opt_criterion(9, "built", "fixed", 0, "default values of variants not being used (roots)").
+opt_criterion(8, "built", "fixed", 0, "preferred compilers").
+opt_criterion(7, "built", "fixed", 0, "compiler penalty from reuse").
+opt_criterion(6, "built", "fixed", 0, "variant penalty (non-roots)").
+opt_criterion(5, "built", "fixed", 0, "preferred providers (excluded compilers and language runtimes)").
+opt_criterion(4, "built", "fixed", 0, "number of compilers used on the same node").
+opt_criterion(3, "built", "fixed", 0, "non-preferred OS's").
+opt_criterion(2, "built", "fixed", 0, "version badness (non roots)").
+opt_criterion(1, "built", "fixed", 0, "default values of variants not being used (non-roots)").
+opt_criterion(0, "built", "fixed", 0, "preferred providers (language runtimes)").
+
+opt_criterion(2, "hinge", "", 0, "number of packages to build (vs. reuse)").
+opt_criterion(1, "hinge", "", 0, "number of nodes from the same package").
+opt_criterion(0, "hinge", "", 0, "build unification sets").
+
+opt_criterion(12, "concr", "fixed", 0, "deprecated versions used").
+opt_criterion(11, "concr", "fixed", 0, "version badness (roots)").
+opt_criterion(10, "concr", "fixed", 0, "variant penalty (roots)").
+opt_criterion(9, "concr", "fixed", 0, "default values of variants not being used (roots)").
+opt_criterion(8, "concr", "fixed", 0, "preferred compilers").
+opt_criterion(7, "concr", "fixed", 0, "compiler penalty from reuse").
+opt_criterion(6, "concr", "fixed", 0, "variant penalty (non-roots)").
+opt_criterion(5, "concr", "fixed", 0, "preferred providers (excluded compilers and language runtimes)").
+opt_criterion(4, "concr", "fixed", 0, "number of compilers used on the same node").
+opt_criterion(3, "concr", "fixed", 0, "non-preferred OS's").
+opt_criterion(2, "concr", "fixed", 0, "version badness (non roots)").
+opt_criterion(1, "concr", "fixed", 0, "default values of variants not being used (non-roots)").
+opt_criterion(0, "concr", "fixed", 0, "preferred providers (language runtimes)").
+
+opt_criterion(7, "low", "", 0, "target mismatches (built nodes)").
+opt_criterion(6, "low", "", 0, "non-preferred targets").
+opt_criterion(5, "low", "", 0, "target mismatches (reused nodes)").
+opt_criterion(4, "low", "", 0, "version badness (runtimes)").
+opt_criterion(3, "low", "", 0, "non-preferred targets (runtimes)").
+opt_criterion(2, "low", "", 0, "providers on edges").
+opt_criterion(1, "low", "", 0, "version badness on edges").
+opt_criterion(0, "low", "", 0, "penalty on symmetric duplicates").
+
+%----------------------------------------------------------------------------
+% Show optimization criteria
+%----------------------------------------------------------------------------
+% These statements ensure that the optimization criteria are displayed
+% they also serve as examples of correct priority calculation - this should
+% be used when writing the actual minimization criteria
+
+% compute criteria priority
+opt_priority(Priority, high_offset, "high", "", Description) :-
+    opt_criterion(N, "high", _, _, Description),
+    Priority = N + high_offset.
+
+opt_priority(Priority, built_offset, "built", "fixed", Description) :-
+    opt_criterion(N, "built", "fixed", Level, Description),
+    Priority = N + built_offset + fixed_offset - (Level*level_opt).
+
+opt_priority(Priority, hinge_offset, "hinge", "", Description) :-
+    opt_criterion(N, "hinge", _, _, Description),
+    Priority = N + hinge_offset.
+
+opt_priority(Priority, concr_offset, "concr", "fixed", Description) :-
+    opt_criterion(N, "concr", "fixed", Level, Description),
+    Priority = N + concr_offset + fixed_offset - (Level*level_opt).
+
+opt_priority(Priority, low_offset, "low", "", Description) :-
+    opt_criterion(N, "low", _, _, Description),
+    Priority = N + low_offset.
+
+% show criteria
+#minimize {
+    % high
+    0@Priority:
+        opt_priority(Priority, high_offset, "high", _, _);
+    % built
+    0@Priority:
+        opt_priority(Priority, built_offset, "built", "fixed", _);
+    % hinge
+    0@Priority:
+        opt_priority(Priority, hinge_offset, "hinge", _, _);
+    % concrete
+    0@Priority:
+        opt_priority(Priority, concr_offset, "concr", "fixed", _);
+    % low
+    0@Priority:
+        opt_priority(Priority, low_offset, "low", _, _)
+}.
+
+%-----------------------------------------------------------------------------
+% Optimization minimize blocks
+%-----------------------------------------------------------------------------
+% The actual minimize statements for the optimization criteria. Note that in
+% order to use `opt_priority` to bind Priority for the minimize statement, the
+% last field has to match `opt_criterion` exactly,
 
 % A condition group specifies one or more specs that must be satisfied.
 % Specs declared first are preferred, so we assign increasing weights and
 % minimize the weights.
-opt_criterion(410, "requirement weight").
-#minimize{ 0@410: #true }.
 #minimize {
-    Weight@410,PackageNode,Group
-    : requirement_penalty(PackageNode, Group, Weight)
-}.
-#minimize {
-    Weight@410,PackageNode,Language,Group
-    : requirement_penalty(PackageNode, Language, Group, Weight)
+    Weight@Priority, PackageNode,Group
+    : requirement_penalty(PackageNode, Group, Weight),
+      opt_priority(Priority, _, _, _, "requirement weight");
+
+    Weight@Priority, PackageNode,Language,Group
+    : requirement_penalty(PackageNode, Language, Group, Weight),
+      opt_priority(Priority, _, _, _, "requirement weight")
 }.
 
 % Try hard to reuse installed packages (i.e., minimize the number built)
-opt_criterion(220, "number of packages to build (vs. reuse)").
-#minimize { 0@220: #true }.
-#minimize { 1@220,PackageNode : build(PackageNode), not treat_node_as_concrete(PackageNode) }.
+#minimize {
+    1@Priority, PackageNode
+    : build(PackageNode), not treat_node_as_concrete(PackageNode),
+      opt_priority(Priority, _, _, _, "number of packages to build (vs. reuse)")
+}.
 
-opt_criterion(210, "number of nodes from the same package").
-#minimize { 0@210: #true }.
-#minimize { ID@210,Package : attr("node", node(ID, Package)), not is_self_build_req(node(ID, Package)) }.
-#minimize { ID@210,Package : attr("virtual_node", node(ID, Package)) }.
+% Minimize number of nodes from the same package
+#minimize {
+    ID@Priority, Package
+    : attr("node", node(ID, Package)), not is_self_build_req(node(ID, Package)),
+      opt_priority(Priority, _, _, _, "number of nodes from the same package");
+    ID@Priority, Package
+    : attr("virtual_node", node(ID, Package)),
+      opt_priority(Priority, _, _, _, "number of nodes from the same package")
+}.
 #defined optimize_for_reuse/0.
 
 % Minimize the unification set ID used for build dependencies. This reduces the number of optimal
 % solutions that differ only by which node belongs to which unification set.
-opt_criterion(200, "build unification sets").
-#minimize{ 0@200: #true }.
-#minimize{ ID@200,ParentNode : build_set_id(ParentNode, ID) }.
+#minimize{
+    ID@Priority, ParentNode
+    : build_set_id(ParentNode, ID),
+      opt_priority(Priority, _, _, _, "build unification sets")
+}.
 
 % Minimize the number of deprecated versions being used
-opt_criterion(173, "deprecated versions used").
-#minimize{ 0@373: #true }.
-#minimize{ 0@173: #true }.
-#minimize{
-    1@173+Priority,PackageNode
+#minimize {
+    1@Priority, PackageNode  
     : attr("deprecated", PackageNode, _),
       not external(PackageNode),
-      build_priority(PackageNode, Priority)
+      build_priority(PackageNode, BuildPriority),
+      opt_priority(Priority, BuildPriority, _, _, "deprecated versions used")
 }.
 
 % Minimize the:
 % 1. Version weight
 % 2. Number of variants with a non default value, if not set
 % for the root package.
-opt_criterion(170, "version badness (roots)").
-#minimize{ 0@370: #true }.
-#minimize{ 0@170: #true }.
 #minimize {
-    Weight@170+Priority,PackageNode
+    Weight@Priority, PackageNode
     : attr("root", PackageNode),
       version_weight(PackageNode, Weight),
-      build_priority(PackageNode, Priority)
-}.
-#minimize {
-    Penalty@170+Priority,PackageNode
+      build_priority(PackageNode, BuildPriority),
+      opt_priority(Priority, BuildPriority, _, _, "version badness (roots)");
+    
+    Penalty@Priority, PackageNode
     : attr("root", PackageNode),
       version_deprecation_penalty(PackageNode, Penalty),
-      build_priority(PackageNode, Priority)
+      build_priority(PackageNode, BuildPriority),
+      opt_priority(Priority, BuildPriority, _, _, "version badness (roots)")
 }.
 
-opt_criterion(165, "variant penalty (roots)").
-#minimize{ 0@365: #true }.
-#minimize{ 0@165: #true }.
 #minimize {
-    Penalty@165+Priority,PackageNode,Variant,Value
+    Penalty@Priority, PackageNode,Variant,Value
     : variant_penalty(PackageNode, Variant, Value, Penalty),
       attr("root", PackageNode),
-      build_priority(PackageNode, Priority)
+      build_priority(PackageNode, BuildPriority),
+      opt_priority(Priority, BuildPriority, _, _, "variant penalty (roots)")
 }.
 
-opt_criterion(155, "default values of variants not being used (roots)").
-#minimize{ 0@355: #true }.
-#minimize{ 0@155: #true }.
 #minimize{
-    1@155+Priority,PackageNode,Variant,Value
+    1@Priority, PackageNode,Variant,Value
     : variant_default_not_used(PackageNode, Variant, Value),
       attr("root", PackageNode),
-      build_priority(PackageNode, Priority)
+      build_priority(PackageNode, BuildPriority),
+      opt_priority(Priority, BuildPriority, _, _, "default values of variants not being used (roots)")
 }.
 
 % Choose the preferred compiler before penalizing variants, to avoid that a variant penalty
 % on e.g. gcc causes clingo to pick another compiler e.g. llvm
-opt_criterion(148, "preferred compilers").
-#minimize{ 0@348: #true }.
-#minimize{ 0@148: #true }.
-#minimize{
-    Weight@148+Priority,ProviderNode,X,Virtual
+#minimize{ 
+    Weight@Priority, ProviderNode,X,Virtual
     : provider_weight(ProviderNode, node(X, Virtual), Weight),
       language(Virtual),
-      build_priority(ProviderNode, Priority)
+      build_priority(ProviderNode, BuildPriority),
+      opt_priority(Priority, BuildPriority, _, _, "preferred compilers")
 }.
 
-opt_criterion(141, "compiler penalty from reuse").
-#minimize{ 0@341: #true }.
-#minimize{ 0@141: #true }.
-#minimize{1@141,Hash : compiler_penalty_from_reuse(Hash)}.
+#minimize{
+    1@Priority, Hash
+    : compiler_penalty_from_reuse(Hash),
+      opt_priority(Priority, concr_offset, _, _, "compiler penalty from reuse")
+}.
 
 % Try to use default variants or variants that have been set
-opt_criterion(140, "variant penalty (non-roots)").
-#minimize{ 0@340: #true }.
-#minimize{ 0@140: #true }.
-#minimize {
-    Penalty@140+Priority,PackageNode,Variant,Value
+#minimize { 
+    Penalty@Priority, PackageNode,Variant,Value
     : variant_penalty(PackageNode, Variant, Value, Penalty),
       not attr("root", PackageNode),
-      build_priority(PackageNode, Priority)
+      build_priority(PackageNode, BuildPriority),
+      opt_priority(Priority, BuildPriority, _, _, "variant penalty (non-roots)")
 }.
 
 % Minimize the weights of all the other providers (mpi, lapack, etc.)
-opt_criterion(138, "preferred providers (excluded compilers and language runtimes)").
-#minimize{ 0@338: #true }.
-#minimize{ 0@138: #true }.
 #minimize{
-    Weight@138+Priority,ProviderNode,X,Virtual
+    Weight@Priority, ProviderNode,X,Virtual
     : provider_weight(ProviderNode, node(X, Virtual), Weight),
       not language(Virtual), not language_runtime(Virtual),
-      build_priority(ProviderNode, Priority)
+      build_priority(ProviderNode, BuildPriority),
+      opt_priority(Priority, BuildPriority, _, _, "preferred providers (excluded compilers and language runtimes)")
 }.
 
 % Minimize the number of compilers used on nodes
@@ -2326,141 +2465,124 @@ compiler_penalty(PackageNode, C-1) :-
    C = #count { CompilerNode : node_compiler(PackageNode, CompilerNode) },
    node_compiler(PackageNode, _), C > 0.
 
-opt_criterion(136, "number of compilers used on the same node").
-#minimize{ 0@336: #true }.
-#minimize{ 0@136: #true }.
 #minimize{
-    Penalty@136+Priority,PackageNode
-    : compiler_penalty(PackageNode, Penalty), build_priority(PackageNode, Priority)
+    Penalty@Priority, PackageNode
+    : compiler_penalty(PackageNode, Penalty),
+      build_priority(PackageNode, BuildPriority),
+      opt_priority(Priority, BuildPriority, _, _, "number of compilers used on the same node")
 }.
 
-
-opt_criterion(130, "non-preferred OS's").
-#minimize{ 0@330: #true }.
-#minimize{ 0@130: #true }.
+% Minimize non-preferred OS's
 #minimize{
-    Weight@130+Priority,PackageNode
+    Weight@Priority, PackageNode
     : node_os_weight(PackageNode, Weight),
-      build_priority(PackageNode, Priority)
+      build_priority(PackageNode, BuildPriority),
+      opt_priority(Priority, BuildPriority, _, _, "non-preferred OS's")
 }.
 
 % Choose more recent versions for nodes
-opt_criterion(125, "version badness (non roots)").
-#minimize{ 0@325: #true }.
-#minimize{ 0@125: #true }.
 #minimize{
-    Weight@125+Priority,node(X, Package)
+    Weight@Priority, node(X, Package)
     : version_weight(node(X, Package), Weight),
-      build_priority(node(X, Package), Priority),
       not attr("root", node(X, Package)),
-      not runtime(Package)
-}.
-#minimize {
-    Penalty@125+Priority,node(X, Package)
-    : version_deprecation_penalty(node(X, Package), Penalty),
-      build_priority(node(X, Package), Priority),
-      not attr("root", node(X, Package)),
-      not runtime(Package)
-}.
+      not runtime(Package),
+      build_priority(node(X, Package), BuildPriority),
+      opt_priority(Priority, BuildPriority, _, _, "version badness (non roots)");
 
+    Penalty@Priority, node(X, Package)
+    : version_deprecation_penalty(node(X, Package), Penalty),
+      not attr("root", node(X, Package)),
+      not runtime(Package),
+      build_priority(node(X, Package), BuildPriority),
+      opt_priority(Priority, BuildPriority, _, _, "version badness (non roots)")
+}.
 
 % Try to use all the default values of variants
-opt_criterion(120, "default values of variants not being used (non-roots)").
-#minimize{ 0@320: #true }.
-#minimize{ 0@120: #true }.
 #minimize{
-    1@120+Priority,PackageNode,Variant,Value
+    1@Priority, PackageNode,Variant,Value
     : variant_default_not_used(PackageNode, Variant, Value),
       not attr("root", PackageNode),
-      build_priority(PackageNode, Priority)
+      build_priority(PackageNode, BuildPriority),
+      opt_priority(Priority, BuildPriority, _, _, "default values of variants not being used (non-roots)")
 }.
 
 % Prefer more optimal providers for language runtimes.
-opt_criterion(105, "preferred providers (language runtimes)").
-#minimize{ 0@305: #true }.
-#minimize{ 0@105: #true }.
 #minimize{
-    Weight@105+Priority,ProviderNode,X,Virtual
+    Weight@Priority, ProviderNode,X,Virtual
     : provider_weight(ProviderNode, node(X, Virtual), Weight),
       language_runtime(Virtual),
-      build_priority(ProviderNode, Priority)
+      build_priority(ProviderNode, BuildPriority),
+      opt_priority(Priority, BuildPriority, _, _, "preferred providers (language runtimes)")
 }.
 
 % Build and concrete mismatches are sandwiched between node target penalty so that
 % we can still reuse an old, available target and build a more specific software on
 % top of it by default
-opt_criterion(12, "target mismatches (built nodes)").
-#minimize{ 0@12: #true }.
 #minimize{
-    1@12,PackageNode,node(ID, Dependency)
+    1@Priority, PackageNode,node(ID, Dependency)
     : node_target_mismatch(PackageNode, node(ID, Dependency)),
-      build_priority(node(ID, Dependency), 200),
-      not runtime(Dependency)
+      not runtime(Dependency),
+      build_priority(node(ID, Dependency), built_offset),
+      opt_priority(Priority, _, _, _, "target mismatches (built nodes)")
 }.
 
-opt_criterion(10, "non-preferred targets").
-#minimize{ 0@10: #true }.
 #minimize{
-    Weight@10,node(X, Package)
+    Weight@Priority, node(X, Package)
     : node_target_weight(node(X, Package), Weight),
-      not runtime(Package)
+      not runtime(Package),
+      opt_priority(Priority, _, _, _, "non-preferred targets")
 }.
 
-opt_criterion(7, "target mismatches (reused nodes)").
-#minimize{ 0@7: #true }.
 #minimize{
-    1@7,PackageNode,node(ID, Dependency)
+    1@Priority, PackageNode,node(ID, Dependency)
     : node_target_mismatch(PackageNode, node(ID, Dependency)),
-      build_priority(node(ID, Dependency), 0),
-      not runtime(Dependency)
+      not runtime(Dependency),
+      build_priority(node(ID, Dependency), concr_offset),
+      opt_priority(Priority, _, _, _, "target mismatches (reused nodes)")
 }.
 
 % Choose more recent versions for runtimes
-opt_criterion(4, "version badness (runtimes)").
-#minimize{ 0@4: #true }.
 #minimize{
-    Weight@4,node(X, Package)
+    Weight@Priority, node(X, Package)
     : version_weight(node(X, Package), Weight),
-      runtime(Package)
+      runtime(Package),
+      opt_priority(Priority, _, _, _, "version badness (runtimes)")
 }.
 
 % Choose best target for runtimes
-opt_criterion(3, "non-preferred targets (runtimes)").
-#minimize{ 0@3: #true }.
 #minimize{
-    Weight@3,node(X, Package)
+    Weight@Priority, node(X, Package)
     : node_target_weight(node(X, Package), Weight),
-      runtime(Package)
+      runtime(Package),
+      opt_priority(Priority, _, _, _, "non-preferred targets (runtimes)")
 }.
 
 % Try to use the most optimal providers as much as possible
-opt_criterion(2, "providers on edges").
-#minimize{ 0@2: #true }.
 #minimize{
-    Weight@2,ParentNode,ProviderNode,node(X, Virtual)
+    Weight@Priority, ParentNode,ProviderNode,node(X, Virtual)
     : provider_weight(ProviderNode, node(X, Virtual), Weight),
       max_dupes(Virtual, MaxDupes), MaxDupes > 1,
       not attr("root", ProviderNode),
       language(Virtual),
-      depends_on(ParentNode, ProviderNode)
+      depends_on(ParentNode, ProviderNode),
+      opt_priority(Priority, _, _, _, "providers on edges")
 }.
 
 % Try to use latest versions of nodes as much as possible
-opt_criterion(1, "version badness on edges").
-#minimize{ 0@1: #true }.
 #minimize{
-    Weight@1,ParentNode,node(X, Package)
+    Weight@Priority, ParentNode,node(X, Package)
     : version_weight(node(X, Package), Weight),
       multiple_unification_sets(Package),
       not attr("root", node(X, Package)),
-      depends_on(ParentNode, node(X, Package))
+      depends_on(ParentNode, node(X, Package)),
+      opt_priority(Priority, _, _, _, "version badness on edges")
 }.
 
 % Reduce symmetry on duplicates
-opt_criterion(0, "penalty on symmetric duplicates").
-#minimize{ 0@0: #true }.
 #minimize{
-    Weight@1,PackageNode,Reason : duplicate_penalty(PackageNode, Weight, Reason)
+    Weight@Priority, PackageNode,Reason
+    : duplicate_penalty(PackageNode, Weight, Reason),
+      opt_priority(Priority, _, _, _, "penalty on symmetric duplicates")
 }.
 
 

--- a/lib/spack/spack/solver/display.lp
+++ b/lib/spack/spack/solver/display.lp
@@ -15,7 +15,7 @@
 #show attr/5.
 #show attr/6.
 % names of optimization criteria
-#show opt_criterion/2.
+#show opt_priority/5.
 
 % error types
 #show error/2.

--- a/lib/spack/spack/solver/when_possible.lp
+++ b/lib/spack/spack/solver/when_possible.lp
@@ -29,9 +29,12 @@ do_not_impose(EffectID, node(X, Package)) :-
   trigger_and_effect(_, TriggerID, EffectID),
   trigger_requestor_node(TriggerID, node(X, Package)).
 
-opt_criterion(420, "number of input specs not concretized").
-#minimize{ 0@420: #true }.
-#minimize { 1@420,ID : literal_not_solved(ID) }.
+opt_criterion(1, "high", "", 0, "number of input specs not concretized").
+#minimize {
+    1@Priority, ID
+    : literal_not_solved(ID),
+    opt_priority(Priority, _, _, _, "number of input specs not concretized")
+}.
 
 #heuristic solve_literal(ID) : literal(ID). [1, sign]
 #heuristic solve_literal(ID) : literal(ID). [1000, init]


### PR DESCRIPTION
Refactor optimization criteria to improve maintainability.

In this pull request, optimization criteria definitions are consolidated into a single list. Changing priority, band, type is as simple as modifying the `opt_criterion` atom and nothing else. This makes optimization criteria more readable, understandable, and maintainable, and reduces the risk of error (no duplicated information like the old encoding).

Performance is similar to `develop` (no significant changes with our standard benchmark).

Note that there is one functional change to the optimization criteria as a result of this PR. Previously, both "version badness on edges" and "penalty on symmetric duplicates" were optimized at priority 1 (I think erroneously). Now, duplicates is at 0, which is how it was declared in `opt_criterion()`. The actual `#minimize` statement used priority 1, which was likely an oversight. This may change some concretizations in small ways, but the fact that it was missed is an example of why the refactor here is an improvement.



