### PR TITLE
[codex] Document macOS DYLD module behavior

### DIFF
--- a/lib/spack/docs/module_file_support.rst
+++ b/lib/spack/docs/module_file_support.rst
@@ -396,6 +396,9 @@ The table below lists the default inspections:
 +--------------------------------+--------------------------------+
 
 On Linux, ``LD_LIBRARY_PATH`` is omitted: Spack packages embed RPATHs, making it unnecessary, and setting it globally affects system executables.
+On macOS Big Sur and newer, System Integrity Protection may remove ``DYLD_FALLBACK_LIBRARY_PATH`` from the environment of protected system executables.
+After loading a module, the variable can appear in the current shell but be absent from subprocesses launched through protected executables such as ``/usr/bin/env``.
+Run the target program directly, or through a non-system interpreter or launcher, when a package depends on ``DYLD_FALLBACK_LIBRARY_PATH``.
 
 To suppress a variable from all module files, use ``exclude_env_vars``:
 


### PR DESCRIPTION
## Summary

- document macOS Big Sur and newer behavior where System Integrity Protection can strip `DYLD_FALLBACK_LIBRARY_PATH` from protected subprocess environments
- place the note near the default module `prefix_inspections` table

Fixes spack/spack#24306.

## Testing

- Documentation-only change; not run locally.
