### PR TITLE
log-parse: fix reading a log from stdin

### DIFF
--- a/lib/spack/spack/cmd/log_parse.py
+++ b/lib/spack/spack/cmd/log_parse.py
@@ -59,9 +59,7 @@ def setup_parser(subparser: argparse.ArgumentParser) -> None:
 def log_parse(parser, args):
     input = args.file
     if args.file == "-":
-        input = io.TextIOWrapper(
-            sys.stdin.buffer, encoding="utf-8", errors="replace", closefd=False
-        )
+        input = io.TextIOWrapper(sys.stdin.buffer, encoding="utf-8", errors="replace")
 
     if args.width is not None:
         warnings.warn("The --width option is deprecated and will be removed in Spack v1.3")
@@ -82,12 +80,15 @@ def log_parse(parser, args):
     events = []
     if "errors" in types:
         events.extend(log_errors)
-        print("%d errors" % len(log_errors))
     if "warnings" in types:
         events.extend(log_warnings)
-        print("%d warnings" % len(log_warnings))
 
     if tail:
         events.append(tail)
 
     print(make_log_context(events), end="")
+
+    if "errors" in types:
+        print("%d errors" % len(log_errors))
+    if "warnings" in types:
+        print("%d warnings" % len(log_warnings))

--- a/lib/spack/spack/test/cmd/log_parse.py
+++ b/lib/spack/spack/test/cmd/log_parse.py
@@ -1,0 +1,61 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+import io
+import pathlib
+import sys
+
+from spack.main import SpackCommand
+
+log_parse = SpackCommand("log-parse")
+
+LOG = b"""line 1
+line 2
+/path/to/file.c:10: error: use of undeclared identifier 'x'
+line 4
+line 5
+/tmp/foo.c:1: warning: unused variable 'z'
+line 7
+"""
+
+
+class FakeStdin:
+    """Just enough of sys.stdin for the command to read bytes from it."""
+
+    def __init__(self, data: bytes) -> None:
+        self.buffer = io.BytesIO(data)
+
+
+def test_log_parse_file(tmp_path: pathlib.Path):
+    log_file = tmp_path / "build.log"
+    log_file.write_bytes(LOG)
+
+    out = log_parse("--show", "errors,warnings", "-c", "1", str(log_file))
+
+    assert "> /path/to/file.c:10: error: use of undeclared identifier 'x'" in out
+    assert "> /tmp/foo.c:1: warning: unused variable 'z'" in out
+    # Counts are reported after the log, since it is written as it is scanned.
+    assert out.rstrip().endswith("1 errors\n1 warnings")
+
+
+def test_log_parse_stdin(monkeypatch):
+    """The log can be read from stdin with -."""
+    monkeypatch.setattr(sys, "stdin", FakeStdin(LOG))
+
+    out = log_parse("--show", "warnings", "-c", "1", "-")
+
+    assert "> /tmp/foo.c:1: warning: unused variable 'z'" in out
+    assert "1 warnings" in out
+    # Only warnings were asked for, so the error is context at most, never highlighted.
+    assert "> /path/to/file.c:10:" not in out
+
+
+def test_log_parse_stdin_non_utf8(monkeypatch):
+    """Undecodable bytes on stdin are replaced rather than raising."""
+    monkeypatch.setattr(sys, "stdin", FakeStdin(b"ok\nerror: \x80\xff broke\ndone\n"))
+
+    out = log_parse("-c", "1", "-")
+
+    assert "> error:" in out
+    assert "1 errors" in out


### PR DESCRIPTION
Reading from stdin passed closefd to TextIOWrapper, which is not
supported, so drop that. Also add missing tests.

While at it, move summary to the bottom, so the implementation can later
be done in a streaming fashion.

