### PR TITLE
log parsing: stream contiguous blocks

### DIFF
--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -55,6 +55,7 @@ from typing import (
     Optional,
     Sequence,
     Set,
+    TextIO,
     Tuple,
     Type,
     Union,
@@ -1660,7 +1661,12 @@ def _make_child_error(msg, module, name, traceback, log, log_type, context):
     return ChildError(msg, module, name, traceback, log, log_type, context)
 
 
-def write_log_summary(out, log_type, log, last=None):
+def write_log_summary(
+    out: TextIO, log_type: str, log: Union[str, TextIO, List[str]], last: Optional[int] = None
+) -> None:
+    """Print highlighted errors from a log file with surrounding context. If the log does not
+    contain errors, print warnings instead. If ``last`` is given, only show the last so many
+    excerpts from the log (which may contain more errors/warnings than ``last``)."""
     blocks = list(scan_log(log))
     if not blocks:
         return

--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -84,6 +84,7 @@ from spack.enums import Context
 from spack.error import InstallError, NoHeadersError, NoLibrariesError
 from spack.install_test import spack_install_test_log
 from spack.util import tty
+from spack.util.ctest_log_parser import Severity
 from spack.util.environment import (
     SYSTEM_DIR_CASE_ENTRY,
     EnvironmentModifications,
@@ -98,7 +99,7 @@ from spack.util.environment import (
 from spack.util.executable import Executable
 from spack.util.filesystem import join_path, symlink
 from spack.util.lang import dedupe, stable_partition
-from spack.util.log_parse import make_log_context, parse_log_events
+from spack.util.log_parse import scan_log, write_block
 from spack.util.string import plural
 from spack.util.tty.color import cescape, colorize
 
@@ -382,7 +383,7 @@ def clean_environment():
     build_lang = spack.config.CONFIG.get("config:build_language")
     if build_lang:
         # Override language-related variables. This can be used to force
-        # English compiler messages etc., which allows parse_log_events to
+        # English compiler messages etc., which allows the log parser to
         # show useful matches.
         env.set("LC_ALL", build_lang)
 
@@ -1660,26 +1661,22 @@ def _make_child_error(msg, module, name, traceback, log, log_type, context):
 
 
 def write_log_summary(out, log_type, log, last=None):
-    errors, warnings, _ = parse_log_events(log)
-    nerr = len(errors)
-    nwar = len(warnings)
-
-    if nerr > 0:
-        if last and nerr > last:
-            errors = errors[-last:]
-            nerr = last
-
-        # If errors are found, only display errors
-        out.write("\n%s found in %s log:\n" % (plural(nerr, "error"), log_type))
-        out.write(make_log_context(errors))
-    elif nwar > 0:
-        if last and nwar > last:
-            warnings = warnings[-last:]
-            nwar = last
-
-        # If no errors are found but warnings are, display warnings
-        out.write("\n%s found in %s log:\n" % (plural(nwar, "warning"), log_type))
-        out.write(make_log_context(warnings))
+    blocks = list(scan_log(log))
+    matches = [m for b in blocks for m in b.matches.values()]
+    # If errors are found, only display blocks containing errors.
+    has_errors = any(m.severity is Severity.ERROR for m in matches)
+    if has_errors:
+        matches = [m for m in matches if m.severity is Severity.ERROR]
+    if not matches:
+        return
+    if last:
+        matches = matches[-last:]
+    severity, min_line = matches[0].severity, matches[0].line_no
+    noun = "error" if has_errors else "warning"
+    out.write("\n%s found in %s log:\n" % (plural(len(matches), noun), log_type))
+    for block in blocks:
+        if any(m.severity is severity and m.line_no >= min_line for m in block.matches.values()):
+            write_block(out, block)
 
 
 class ModuleChangePropagator:

--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -1662,21 +1662,20 @@ def _make_child_error(msg, module, name, traceback, log, log_type, context):
 
 def write_log_summary(out, log_type, log, last=None):
     blocks = list(scan_log(log))
-    matches = [m for b in blocks for m in b.matches.values()]
-    # If errors are found, only display blocks containing errors.
-    has_errors = any(m.severity is Severity.ERROR for m in matches)
-    if has_errors:
-        matches = [m for m in matches if m.severity is Severity.ERROR]
-    if not matches:
+    if not blocks:
         return
+    # If errors are found, only display blocks containing errors.
+    error_blocks = [
+        b for b in blocks if any(m.severity is Severity.ERROR for m in b.matches.values())
+    ]
+    severity = Severity.ERROR if error_blocks else Severity.WARNING
+    blocks = error_blocks or blocks
     if last:
-        matches = matches[-last:]
-    severity, min_line = matches[0].severity, matches[0].line_no
-    noun = "error" if has_errors else "warning"
-    out.write("\n%s found in %s log:\n" % (plural(len(matches), noun), log_type))
+        blocks = blocks[-last:]
+    num = sum(m.severity is severity for b in blocks for m in b.matches.values())
+    out.write(f"\n{plural(num, severity.name.lower())} found in {log_type} log:\n")
     for block in blocks:
-        if any(m.severity is severity and m.line_no >= min_line for m in block.matches.values()):
-            write_block(out, block)
+        write_block(out, block)
 
 
 class ModuleChangePropagator:

--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -84,6 +84,7 @@ from spack.enums import Context
 from spack.error import InstallError, NoHeadersError, NoLibrariesError
 from spack.install_test import spack_install_test_log
 from spack.util import tty
+from spack.util.ctest_log_parser import Severity
 from spack.util.environment import (
     SYSTEM_DIR_CASE_ENTRY,
     EnvironmentModifications,
@@ -98,7 +99,7 @@ from spack.util.environment import (
 from spack.util.executable import Executable
 from spack.util.filesystem import join_path, symlink
 from spack.util.lang import dedupe, stable_partition
-from spack.util.log_parse import make_log_context, parse_log_events
+from spack.util.log_parse import scan_log, write_log_context
 from spack.util.string import plural
 from spack.util.tty.color import cescape, colorize
 
@@ -1660,26 +1661,24 @@ def _make_child_error(msg, module, name, traceback, log, log_type, context):
 
 
 def write_log_summary(out, log_type, log, last=None):
-    errors, warnings, _ = parse_log_events(log)
-    nerr = len(errors)
-    nwar = len(warnings)
+    # A first pass without context only collects the matched lines, so it stays cheap.
+    matches = [match for block in scan_log(log, context=0) for match in block.matches.values()]
+    errors = [m for m in matches if m.severity is Severity.ERROR]
+    warnings = [m for m in matches if m.severity is Severity.WARNING]
 
-    if nerr > 0:
-        if last and nerr > last:
-            errors = errors[-last:]
-            nerr = last
+    # If errors are found, only display errors, otherwise display warnings.
+    if errors:
+        severity, chosen, noun = Severity.ERROR, errors, "error"
+    elif warnings:
+        severity, chosen, noun = Severity.WARNING, warnings, "warning"
+    else:
+        return
 
-        # If errors are found, only display errors
-        out.write("\n%s found in %s log:\n" % (plural(nerr, "error"), log_type))
-        out.write(make_log_context(errors))
-    elif nwar > 0:
-        if last and nwar > last:
-            warnings = warnings[-last:]
-            nwar = last
+    if last and len(chosen) > last:
+        chosen = chosen[-last:]
 
-        # If no errors are found but warnings are, display warnings
-        out.write("\n%s found in %s log:\n" % (plural(nwar, "warning"), log_type))
-        out.write(make_log_context(warnings))
+    out.write("\n%s found in %s log:\n" % (plural(len(chosen), noun), log_type))
+    write_log_context(out, log, severities={severity}, min_line=chosen[0].line_no)
 
 
 class ModuleChangePropagator:

--- a/lib/spack/spack/cmd/log_parse.py
+++ b/lib/spack/spack/cmd/log_parse.py
@@ -3,11 +3,13 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 import argparse
+import collections
 import io
 import sys
 import warnings
 
-from spack.util.log_parse import make_log_context, parse_log_events
+from spack.util.ctest_log_parser import Severity
+from spack.util.log_parse import scan_log, write_block
 
 description = "filter errors and warnings from build logs"
 section = "developer"
@@ -66,29 +68,32 @@ def log_parse(parser, args):
     if args.jobs is not None:
         warnings.warn("The --jobs option is deprecated and will be removed in Spack v1.3")
 
-    log_errors, log_warnings, tail = parse_log_events(
-        input, args.context, args.profile, tail=args.tail
-    )
-    if args.profile:
-        return
-
     types = [s.strip() for s in args.show.split(",")]
     for e in types:
         if e not in event_types:
             args.subparser.error("invalid event type: %s" % e)
 
-    events = []
+    severities = set()
     if "errors" in types:
-        events.extend(log_errors)
+        severities.add(Severity.ERROR)
     if "warnings" in types:
-        events.extend(log_warnings)
+        severities.add(Severity.WARNING)
 
-    if tail:
-        events.append(tail)
+    blocks = scan_log(input, args.context, args.tail, severities, args.profile)
 
-    print(make_log_context(events), end="")
+    if args.profile:
+        # Consume the scan so the parser gets to print its timings, but show nothing else.
+        for _ in blocks:
+            pass
+        return
+
+    # Write the log as it is scanned, so the counts can only be reported afterwards.
+    counts = collections.Counter()
+    for block in blocks:
+        write_block(sys.stdout, block)
+        counts.update(match.severity for match in block.matches.values())
 
     if "errors" in types:
-        print("%d errors" % len(log_errors))
+        print("%d errors" % counts[Severity.ERROR])
     if "warnings" in types:
-        print("%d warnings" % len(log_warnings))
+        print("%d warnings" % counts[Severity.WARNING])

--- a/lib/spack/spack/cmd/log_parse.py
+++ b/lib/spack/spack/cmd/log_parse.py
@@ -3,11 +3,13 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 import argparse
+import collections
 import io
 import sys
 import warnings
 
-from spack.util.log_parse import make_log_context, parse_log_events
+from spack.util.ctest_log_parser import Severity
+from spack.util.log_parse import scan_log, write_block
 
 description = "filter errors and warnings from build logs"
 section = "developer"
@@ -68,26 +70,32 @@ def log_parse(parser, args):
     if args.jobs is not None:
         warnings.warn("The --jobs option is deprecated and will be removed in Spack v1.3")
 
-    log_errors, log_warnings, tail = parse_log_events(
-        input, args.context, args.profile, tail=args.tail
-    )
-    if args.profile:
-        return
-
     types = [s.strip() for s in args.show.split(",")]
     for e in types:
         if e not in event_types:
             args.subparser.error("invalid event type: %s" % e)
 
-    events = []
+    severities = set()
     if "errors" in types:
-        events.extend(log_errors)
-        print("%d errors" % len(log_errors))
+        severities.add(Severity.ERROR)
     if "warnings" in types:
-        events.extend(log_warnings)
-        print("%d warnings" % len(log_warnings))
+        severities.add(Severity.WARNING)
 
-    if tail:
-        events.append(tail)
+    blocks = scan_log(input, args.context, args.tail, severities, args.profile)
 
-    print(make_log_context(events), end="")
+    if args.profile:
+        # Consume the scan so the parser gets to print its timings, but show nothing else.
+        for _ in blocks:
+            pass
+        return
+
+    # Write the log as it is scanned, so the counts can only be reported afterwards.
+    counts = collections.Counter()
+    for block in blocks:
+        write_block(sys.stdout, block)
+        counts.update(match.severity for match in block.matches.values())
+
+    if "errors" in types:
+        print("%d errors" % counts[Severity.ERROR])
+    if "warnings" in types:
+        print("%d warnings" % counts[Severity.WARNING])

--- a/lib/spack/spack/installer/ui.py
+++ b/lib/spack/spack/installer/ui.py
@@ -12,12 +12,12 @@ import io
 import os
 import sys
 import time
-from typing import Callable, Dict, Generator, List, NamedTuple, Optional, Union, cast
+from typing import Callable, Dict, Generator, List, NamedTuple, Optional, TextIO, Union
 
 import spack.config
 import spack.util.tty.color
 from spack.util.lang import pretty_duration
-from spack.util.log_parse import make_log_context, parse_log_events
+from spack.util.log_parse import write_log_context
 from spack.util.path import padding_filter, padding_filter_bytes
 
 if sys.platform == "win32":
@@ -173,7 +173,8 @@ class TerminalUI(InstallerUI):
     def __init__(
         self,
         total: int,
-        stdout: Optional[io.TextIOWrapper] = None,
+        stdout: Optional[TextIO] = None,
+        stderr: Optional[TextIO] = None,
         get_terminal_size: Callable[[], os.terminal_size] = os.get_terminal_size,
         get_time: Callable[[], float] = time.monotonic,
         is_tty: Optional[bool] = None,
@@ -184,7 +185,7 @@ class TerminalUI(InstallerUI):
         super().__init__()
         self.reads_terminal_input = True
         if stdout is None:
-            stdout = cast(io.TextIOWrapper, sys.stdout)
+            stdout = sys.stdout
             if is_tty is None:
                 # For the real stdout, use GetConsoleMode-based detection on Windows, which is
                 # correct through ConPTY where isatty() is not.
@@ -210,6 +211,7 @@ class TerminalUI(InstallerUI):
         self.blocked: bool = False
 
         self.stdout = stdout
+        self.stderr = stderr if stderr is not None else sys.stderr
         self.get_terminal_size = get_terminal_size
         self.terminal_size = os.terminal_size((0, 0))
         self.terminal_size_changed: bool = True
@@ -449,22 +451,19 @@ class TerminalUI(InstallerUI):
             self.stdout.flush()
 
     def _parse_log_summary(self, build_info: BuildInfo) -> None:
-        """Parse the build log for errors/warnings and store the summary."""
+        """Store the interesting parts of a failed build's log."""
         if not build_info.log_path or not os.path.exists(build_info.log_path):
             return
-        errors, warnings, tail_event = parse_log_events(build_info.log_path, tail=20)
-        events = [*errors, *warnings]
-        if tail_event is not None:
-            events.append(tail_event)
-        if events:
-            build_info.log_summary = make_log_context(events)
+        out = io.StringIO()
+        write_log_context(out, build_info.log_path, tail=20)
+        build_info.log_summary = out.getvalue() or None
 
     def on_finished(self, failures: List[str]) -> None:
         """Write the stored log summaries of the failed builds to stderr."""
         for build_id in failures:
             build_info = self.builds.get(build_id)
             if build_info is not None and build_info.log_summary:
-                sys.stderr.write(build_info.log_summary)
+                self.stderr.write(build_info.log_summary)
 
     def on_total_increased(self, count: int) -> None:
         self.total += count

--- a/lib/spack/spack/installer/ui.py
+++ b/lib/spack/spack/installer/ui.py
@@ -12,12 +12,12 @@ import io
 import os
 import sys
 import time
-from typing import Callable, Dict, Generator, List, NamedTuple, Optional, Union, cast
+from typing import Callable, Dict, Generator, List, NamedTuple, Optional, TextIO, Union, cast
 
 import spack.config
 import spack.util.tty.color
 from spack.util.lang import pretty_duration
-from spack.util.log_parse import make_log_context, parse_log_events
+from spack.util.log_parse import write_log_context
 from spack.util.path import padding_filter, padding_filter_bytes
 
 if sys.platform == "win32":
@@ -174,6 +174,7 @@ class TerminalUI(InstallerUI):
         self,
         total: int,
         stdout: Optional[io.TextIOWrapper] = None,
+        stderr: Optional[TextIO] = None,
         get_terminal_size: Callable[[], os.terminal_size] = os.get_terminal_size,
         get_time: Callable[[], float] = time.monotonic,
         is_tty: Optional[bool] = None,
@@ -210,6 +211,7 @@ class TerminalUI(InstallerUI):
         self.blocked: bool = False
 
         self.stdout = stdout
+        self.stderr = stderr if stderr is not None else sys.stderr
         self.get_terminal_size = get_terminal_size
         self.terminal_size = os.terminal_size((0, 0))
         self.terminal_size_changed: bool = True
@@ -375,10 +377,10 @@ class TerminalUI(InstallerUI):
             if new_build.log_summary:
                 self.stdout.write(new_build.log_summary)
             if new_build.log_path:
-                if not new_build.log_summary:
-                    self.stdout.write("No errors parsed from log, see full log: ")
-                else:
+                if new_build.log_summary:
                     self.stdout.write("Full log: ")
+                else:
+                    self.stdout.write("No errors parsed from log, see full log: ")
                 self.stdout.write(f"{new_build.log_path}\n")
             self.stdout.flush()
         else:
@@ -449,22 +451,20 @@ class TerminalUI(InstallerUI):
             self.stdout.flush()
 
     def _parse_log_summary(self, build_info: BuildInfo) -> None:
-        """Parse the build log for errors/warnings and store the summary."""
+        """Store the interesting parts of a failed build's log."""
         if not build_info.log_path or not os.path.exists(build_info.log_path):
             return
-        errors, warnings, tail_event = parse_log_events(build_info.log_path, tail=20)
-        events = [*errors, *warnings]
-        if tail_event is not None:
-            events.append(tail_event)
-        if events:
-            build_info.log_summary = make_log_context(events)
+        out = io.StringIO()
+        with open(build_info.log_path, encoding="utf-8", errors="replace") as f:
+            write_log_context(out, f, tail=20)
+        build_info.log_summary = out.getvalue() or None
 
     def on_finished(self, failures: List[str]) -> None:
         """Write the stored log summaries of the failed builds to stderr."""
         for build_id in failures:
             build_info = self.builds.get(build_id)
             if build_info is not None and build_info.log_summary:
-                sys.stderr.write(build_info.log_summary)
+                self.stderr.write(build_info.log_summary)
 
     def on_total_increased(self, count: int) -> None:
         self.total += count

--- a/lib/spack/spack/reporters/cdash.py
+++ b/lib/spack/spack/reporters/cdash.py
@@ -12,7 +12,7 @@ import socket
 import time
 import warnings
 import xml.sax.saxutils
-from typing import Dict, Optional
+from typing import Any, Dict, List, Optional
 from urllib.parse import urlencode
 from urllib.request import Request
 
@@ -26,8 +26,9 @@ import spack.util.web as web_util
 from spack.error import SpackError
 from spack.util import tty
 from spack.util.crypto import checksum
+from spack.util.ctest_log_parser import Match, Severity
 from spack.util.filesystem import working_dir
-from spack.util.log_parse import parse_log_events
+from spack.util.log_parse import scan_log
 
 from .base import Reporter
 from .extract import extract_test_parts
@@ -58,6 +59,10 @@ MAP_PHASES_TO_CDASH = {
 # Initialize data structures common to each phase's report.
 CDASH_PHASES = set(MAP_PHASES_TO_CDASH.values())
 CDASH_PHASES.add("update")
+
+#: Lines of log context reported around each error and warning
+CDASH_CONTEXT = 6
+
 # CDash request timeout in seconds
 SPACK_CDASH_TIMEOUT = 45
 
@@ -133,6 +138,22 @@ class CDash(Reporter):
             buildname = buildname[:190]
         return buildname
 
+    @staticmethod
+    def clean_log_event(match: Match, loglines: List[str]) -> Dict[str, Any]:
+        """Render a matched log line and its context as the escaped fields the template wants."""
+        index = match.line_no - 1
+        pre_context = loglines[max(0, index - CDASH_CONTEXT) : index]
+        post_context = loglines[index + 1 : index + 1 + CDASH_CONTEXT]
+        escape = xml.sax.saxutils.escape
+        return {
+            "line_no": match.line_no,
+            "text": escape(loglines[index].rstrip()),
+            "pre_context": escape("\n".join(line.rstrip() for line in pre_context)),
+            "post_context": escape("\n".join(line.rstrip() for line in post_context)),
+            "source_file": escape(match.source_file) if match.source_file else "",
+            "source_line_no": match.source_line_no if match.source_file else "",
+        }
+
     def build_report_for_package(self, report_dir, package, duration):
         if "stdout" not in package:
             # Skip reporting on packages that do not generate output.
@@ -203,7 +224,11 @@ class CDash(Reporter):
         for phase in phases_encountered:
             report_data[phase]["endtime"] = self.endtime
             report_data[phase]["log"] = "\n".join(report_data[phase]["loglines"])
-            errors, warnings, _ = parse_log_events(report_data[phase]["loglines"])
+            loglines = report_data[phase]["loglines"]
+            blocks = scan_log(loglines, context=0)
+            matches = [match for block in blocks for match in block.matches.values()]
+            errors = [m for m in matches if m.severity is Severity.ERROR]
+            warnings = [m for m in matches if m.severity is Severity.WARNING]
 
             # Convert errors to warnings if the package reported success.
             if package["result"] == "success":
@@ -221,27 +246,12 @@ class CDash(Reporter):
                     report_data[phase]["status"] = 1
 
             if phase == "build":
-                # Convert log output from ASCII to Unicode and escape for XML.
-                def clean_log_event(event):
-                    event = vars(event)
-                    event["text"] = xml.sax.saxutils.escape(event["text"])
-                    event["pre_context"] = xml.sax.saxutils.escape("\n".join(event["pre_context"]))
-                    event["post_context"] = xml.sax.saxutils.escape(
-                        "\n".join(event["post_context"])
-                    )
-                    if event["source_file"] is None:
-                        event["source_file"] = ""
-                        event["source_line_no"] = ""
-                    else:
-                        event["source_file"] = xml.sax.saxutils.escape(event["source_file"])
-                    return event
-
-                report_data[phase]["errors"] = []
-                report_data[phase]["warnings"] = []
-                for error in errors:
-                    report_data[phase]["errors"].append(clean_log_event(error))
-                for warning in warnings:
-                    report_data[phase]["warnings"].append(clean_log_event(warning))
+                report_data[phase]["errors"] = [
+                    self.clean_log_event(match, loglines) for match in errors
+                ]
+                report_data[phase]["warnings"] = [
+                    self.clean_log_event(match, loglines) for match in warnings
+                ]
 
             if phase == "update":
                 report_data[phase]["revision"] = self.revision

--- a/lib/spack/spack/test/installer/ui.py
+++ b/lib/spack/spack/test/installer/ui.py
@@ -6,7 +6,7 @@
 import functools
 import io
 import os
-from typing import List, Optional, Tuple
+from typing import List, Optional, Tuple, cast
 
 import pytest
 
@@ -64,6 +64,7 @@ def create_tui(
     tui = TerminalUI(
         total=total,
         stdout=fake_stdout,
+        stderr=SimpleTextIOWrapper(tty=False),
         get_terminal_size=mock_get_terminal_size,
         get_time=mock_get_time,
         is_tty=is_tty,
@@ -73,6 +74,11 @@ def create_tui(
     )
 
     return tui, time_values, fake_stdout
+
+
+def get_stderr(tui: TerminalUI) -> SimpleTextIOWrapper:
+    """The fake stderr that create_tui installed on the UI."""
+    return cast(SimpleTextIOWrapper, tui.stderr)
 
 
 def on_build_added(
@@ -229,15 +235,19 @@ class TestBasicStateManagement:
         tui.on_state_changed(build_id, "failed")
         assert tui.builds[build_id].log_summary is None
 
-    def test_print_failure_summaries(self, capsys):
-        """print_failure_summaries writes stored summaries to stderr, skipping builds without a
-        summary and unknown build ids."""
+    def test_print_failure_summaries(self, tmp_path):
+        """on_finished writes the stored summaries to stderr, skipping builds without a summary
+        and unknown build ids."""
         tui, _, _ = create_tui()
         build_ids = add_mock_builds(tui, 2)
 
-        tui.builds[build_ids[0]].log_summary = "error: nope\n"
+        log_file = tmp_path / "build.log"
+        log_file.write_text("error: nope\n")
+        tui.builds[build_ids[0]].log_path = str(log_file)
+        tui.on_state_changed(build_ids[0], "failed")
+
         tui.on_finished([*build_ids, "unknown"])
-        assert capsys.readouterr().err == "error: nope\n"
+        assert get_stderr(tui).getvalue() == "-- lines 1 to 1 --\n> error: nope\n"
 
     def test_on_progress(self):
         """Test that on_progress updates percentages"""
@@ -811,16 +821,17 @@ class TestLogFollowing:
         # Nothing should be printed since we're tracking pkg0, not pkg1
         assert fake_stdout.getvalue() == ""
 
-    def test_can_navigate_to_failed_build(self):
+    def test_can_navigate_to_failed_build(self, tmp_path):
         """Test that navigating to a failed build shows log summary and path"""
         tui, _, fake_stdout = create_tui(total=3)
         build_ids = add_mock_builds(tui, 3)
 
-        # Mark the middle build as failed and set log info
+        log_file = tmp_path / "pkg1.log"
+        log_file.write_text("error: something went wrong\n")
+
+        # Set log info before marking the middle build as failed, since that parses the log
+        tui.builds[build_ids[1]].log_path = str(log_file)
         tui.on_state_changed(build_ids[1], "failed")
-        build_info = tui.builds[build_ids[1]]
-        build_info.log_summary = "Error: something went wrong\n"
-        build_info.log_path = "/tmp/spack/pkg1.log"
 
         # Navigate from pkg0 to next -- should land on failed pkg1
         tui.tracked_build_id = build_ids[0]
@@ -831,8 +842,8 @@ class TestLogFollowing:
         tui.next(1)
         output = fake_stdout.getvalue()
         assert "Log summary of pkg1" in output
-        assert "Error: something went wrong" in output
-        assert "/tmp/spack/pkg1.log" in output
+        assert "> error: something went wrong" in output
+        assert f"Full log: {log_file}" in output
 
     def test_navigate_to_failed_build_without_summary(self):
         """Navigating to a failed build with no parsed errors points at the full log."""

--- a/lib/spack/spack/test/util/log_parser.py
+++ b/lib/spack/spack/test/util/log_parser.py
@@ -5,10 +5,25 @@
 import io
 import pathlib
 import re
+from typing import List
 
-from spack.util.ctest_log_parser import CTestLogParser, LogEvent, _optimize_regexes
-from spack.util.log_parse import make_log_context
+import pytest
+
+from spack.util.ctest_log_parser import Block, CTestLogParser, Severity, _optimize_regexes
+from spack.util.log_parse import write_log_context
 from spack.util.tty.color import color_when
+
+
+def render(stream, **kwargs) -> str:
+    """Render a log the way the installer and spack log-parse do."""
+    out = io.StringIO()
+    write_log_context(out, stream, **kwargs)
+    return out.getvalue()
+
+
+def severities(blocks: List[Block]) -> List[Severity]:
+    """All matched severities of a list of blocks, in line order."""
+    return [match.severity for block in blocks for match in block.matches.values()]
 
 
 def test_log_parser(tmp_path: pathlib.Path):
@@ -32,29 +47,32 @@ configure: error: cannot run C compiled programs.                           E
         )
 
     parser = CTestLogParser()
-    errors, warnings, _ = parser.parse(str(log_file))
+    blocks = list(parser.scan(str(log_file)))
 
-    assert len(errors) == 4
-    assert all(e.text.endswith("E") for e in errors)
+    assert severities(blocks) == [
+        Severity.ERROR,
+        Severity.WARNING,
+        Severity.ERROR,
+        Severity.ERROR,
+        Severity.ERROR,
+    ]
 
-    assert len(warnings) == 1
-    assert all(w.text.endswith("W") for w in warnings)
+    # every matched line is the one the log marks with a trailing E or W
+    for block in blocks:
+        for line_no in block.matches:
+            assert block.lines[line_no - block.start].endswith(("E", "W"))
 
 
 def test_log_parser_stream():
-    """parse() accepts a file-like object."""
+    """scan() accepts a file-like object."""
     log = io.StringIO(
         "error: weird_error.c:145: something weird happened                 E\n"
         "checking for gcc... irrelevant line\n"
         "/var/tmp/build/foo.py:60: warning: some weird warning              W\n"
     )
-    parser = CTestLogParser()
-    errors, warnings, _ = parser.parse(log)
+    blocks = list(CTestLogParser().scan(log))
 
-    assert len(errors) == 1
-    assert errors[0].text.endswith("E")
-    assert len(warnings) == 1
-    assert warnings[0].text.endswith("W")
+    assert severities(blocks) == [Severity.ERROR, Severity.WARNING]
 
 
 def test_log_parser_preserves_leading_whitespace():
@@ -64,15 +82,25 @@ def test_log_parser_preserves_leading_whitespace():
         "    int y = x + 1;\n"
         "            ^\n"
     )
-    parser = CTestLogParser()
-    errors, _, _ = parser.parse(log, context=6)
+    (block,) = CTestLogParser().scan(log, context=6)
 
-    assert len(errors) == 1
-    assert errors[0].post_context[0] == "    int y = x + 1;"
-    assert errors[0].post_context[1] == "            ^"
+    assert block.lines == [
+        "/path/to/file.c:10: error: use of undeclared identifier 'x'",
+        "    int y = x + 1;",
+        "            ^",
+    ]
 
 
-def test_make_log_context_merges_overlapping_events(tmp_path: pathlib.Path):
+def test_source_file_of_match():
+    """A match records the file and line number the compiler pointed at."""
+    log = io.StringIO("/path/to/file.c:10: error: use of undeclared identifier 'x'\n")
+    (block,) = CTestLogParser().scan(log, context=0)
+
+    assert block.matches[1].source_file == "/path/to/file.c"
+    assert block.matches[1].source_line_no == "10"
+
+
+def test_merges_overlapping_events(tmp_path: pathlib.Path):
     """Overlapping or adjacent context windows should produce a single merged block."""
 
     # Two errors close together: lines 5 and 10 with context=3 means windows overlap.
@@ -83,20 +111,33 @@ def test_make_log_context_merges_overlapping_events(tmp_path: pathlib.Path):
     log_file = tmp_path / "log.txt"
     log_file.write_text("".join(lines))
 
-    parser = CTestLogParser()
-    errors, warnings, _ = parser.parse(str(log_file), context=3)
+    (block,) = CTestLogParser().scan(str(log_file), context=3)
 
-    log_events = sorted([*errors, *warnings], key=lambda e: e.line_no)
-    output = make_log_context(log_events)
+    assert (block.start, block.end) == (2, 13)
+    assert sorted(block.matches) == [5, 10]
 
     # Should be exactly one header for the merged block, not two.
+    output = render(str(log_file), context=3)
     assert output.count("-- lines") == 1
-
-    # The header should cover the full merged range.
     assert "-- lines 2 to 13 --" in output
 
 
-def test_make_log_context_warning_in_error_context_keeps_yellow(tmp_path: pathlib.Path):
+def test_separate_blocks_when_windows_do_not_touch(tmp_path: pathlib.Path):
+    """Errors far apart get one block each."""
+    lines = [f"line {i}\n" for i in range(1, 41)]
+    lines[4] = "error: first problem\n"  # line 5
+    lines[34] = "error: second problem\n"  # line 35
+
+    log_file = tmp_path / "log.txt"
+    log_file.write_text("".join(lines))
+
+    first, second = CTestLogParser().scan(str(log_file), context=3)
+
+    assert (first.start, first.end) == (2, 8)
+    assert (second.start, second.end) == (32, 38)
+
+
+def test_warning_in_error_context_keeps_yellow(tmp_path: pathlib.Path):
     """A warning line inside an error's context window must be highlighted yellow, not red."""
     # Line 5 = error, line 8 = warning, context=3 so error window covers lines 2-11
     # meaning the warning at line 8 falls inside the error's context.
@@ -107,39 +148,47 @@ def test_make_log_context_warning_in_error_context_keeps_yellow(tmp_path: pathli
     log_file = tmp_path / "log.txt"
     log_file.write_text("".join(lines))
 
-    parser = CTestLogParser()
-    errors, warnings, _ = parser.parse(str(log_file), context=3)
-
-    assert len(errors) == len(warnings) == 1
-
-    log_events = sorted([*errors, *warnings], key=lambda e: e.line_no)
-
     with color_when("always"):
-        output = make_log_context(log_events)
+        output = render(str(log_file), context=3)
 
     # The error line should be red (ANSI 91), the warning yellow (ANSI 93).
     assert "\x1b[0;91m> " in output and "something broke" in output
     assert "\x1b[0;93m> " in output and "something fishy" in output
 
 
+def test_severity_filter(tmp_path: pathlib.Path):
+    """Filtering by severity drops the other severity's matches and their context."""
+    lines = [f"line {i}\n" for i in range(1, 41)]
+    lines[4] = "error: something broke\n"  # line 5
+    lines[34] = "/tmp/foo.c:1: warning: something fishy\n"  # line 35
+
+    log_file = tmp_path / "log.txt"
+    log_file.write_text("".join(lines))
+
+    (block,) = CTestLogParser().scan(str(log_file), context=3, severities={Severity.WARNING})
+
+    assert (block.start, block.end) == (32, 38)
+    assert severities([block]) == [Severity.WARNING]
+
+
 def test_log_parser_non_utf8_bytes(tmp_path: pathlib.Path):
-    """parse() does not raise UnicodeDecodeError on non-UTF-8 log files."""
+    """scan() does not raise UnicodeDecodeError on non-UTF-8 log files."""
     log_file = tmp_path / "log.bin"
     log_file.write_bytes(b"checking things...\nerror: \x80\xff something broke\ndone\n")
-    parser = CTestLogParser()
-    errors, _, _ = parser.parse(str(log_file))
-    assert len(errors) == 1
+
+    (block,) = CTestLogParser().scan(str(log_file))
+
+    assert severities([block]) == [Severity.ERROR]
 
 
 def test_tail_renders_as_plain_context():
-    """A LogEvent should render all lines as plain context with no highlighting."""
-    lines = ["tail line 1", "tail line 2", "tail line 3"]
-    section = LogEvent(text=lines[-1], line_no=100, pre_context=lines[:-1])
+    """Tail lines with no match render as plain context with no highlighting."""
+    log = io.StringIO("".join(f"tail line {i}\n" for i in range(1, 4)))
 
     with color_when(False):
-        output = make_log_context([section])
+        output = render(log, tail=3)
 
-    assert "-- lines 98 to 100 --" in output
+    assert "-- lines 1 to 3 --" in output
     # All lines should be plain context (indented with two spaces, no "> " prefix)
     assert "  tail line 1\n" in output
     assert "  tail line 2\n" in output
@@ -150,32 +199,52 @@ def test_tail_renders_as_plain_context():
 def test_tail_overlapping_with_error():
     """Tail lines overlapping with an error's context should not be duplicated."""
     log = io.StringIO("line 1\nline 2\nline 3\nerror: something broke\nline 5\nline 6\nline 7\n")
-    parser = CTestLogParser()
-    errors, _, tail = parser.parse(log, context=2, tail=3)
-    assert len(errors) == 1
-    assert tail is not None
 
     with color_when(False):
-        output = make_log_context([*errors, tail])
+        output = render(log, context=2, tail=3)
 
     # "line 5" and "line 6" appear in both the error context and the tail,
     # but should only appear once in the output
     assert output.count("line 5") == 1
     assert output.count("line 6") == 1
     assert output.count("line 7") == 1
+    assert output.count("-- lines") == 1
+
+
+def test_tail_detached_from_error():
+    """A tail far away from the last match is a block of its own."""
+    lines = [f"line {i}\n" for i in range(1, 41)]
+    lines[4] = "error: something broke\n"  # line 5
+
+    first, second = CTestLogParser().scan(lines, context=2, tail=3)
+
+    assert (first.start, first.end) == (3, 7)
+    assert (second.start, second.end) == (38, 40)
 
 
 def test_tail_only():
-    """A LogEvent with no errors/warnings renders correctly."""
-    lines = ["final line 1", "final line 2"]
-    section = LogEvent(text=lines[-1], line_no=51, pre_context=lines[:-1])
+    """A log with no errors or warnings renders its tail."""
+    log = io.StringIO("final line 1\nfinal line 2\n")
 
     with color_when(False):
-        output = make_log_context([section])
+        output = render(log, tail=2)
 
-    assert "-- lines 50 to 51 --" in output
+    assert "-- lines 1 to 2 --" in output
     assert "  final line 1\n" in output
     assert "  final line 2\n" in output
+
+
+def test_empty_log():
+    """An empty log produces no blocks and no output."""
+    assert list(CTestLogParser().scan(io.StringIO(""), tail=20)) == []
+    assert render(io.StringIO(""), tail=20) == ""
+
+
+def test_negative_context_or_tail_raises():
+    with pytest.raises(ValueError, match="non-negative"):
+        list(CTestLogParser().scan(io.StringIO("error: nope\n"), context=-1))
+    with pytest.raises(ValueError, match="non-negative"):
+        list(CTestLogParser().scan(io.StringIO("error: nope\n"), tail=-1))
 
 
 class TestOptimizeRegexes:

--- a/lib/spack/spack/test/util/log_parser.py
+++ b/lib/spack/spack/test/util/log_parser.py
@@ -6,9 +6,25 @@ import io
 import pathlib
 import re
 
-from spack.util.ctest_log_parser import CTestLogParser, LogEvent, _optimize_regexes
-from spack.util.log_parse import make_log_context
+from spack.util.ctest_log_parser import CTestLogParser, Severity, _optimize_regexes
+from spack.util.log_parse import write_log_context
 from spack.util.tty.color import color_when
+
+
+def render(stream, **kwargs) -> str:
+    """Render a log the way the installer and spack log-parse do."""
+    out = io.StringIO()
+    write_log_context(out, stream, **kwargs)
+    return out.getvalue()
+
+
+def severities(blocks):
+    """All matched severities of a list of blocks, in line order."""
+    return [
+        match.severity
+        for block in blocks
+        for _, match in sorted(block.matches.items())  # noqa: B905
+    ]
 
 
 def test_log_parser(tmp_path: pathlib.Path):
@@ -32,29 +48,32 @@ configure: error: cannot run C compiled programs.                           E
         )
 
     parser = CTestLogParser()
-    errors, warnings, _ = parser.parse(str(log_file))
+    blocks = list(parser.scan(str(log_file)))
 
-    assert len(errors) == 4
-    assert all(e.text.endswith("E") for e in errors)
+    assert severities(blocks) == [
+        Severity.ERROR,
+        Severity.WARNING,
+        Severity.ERROR,
+        Severity.ERROR,
+        Severity.ERROR,
+    ]
 
-    assert len(warnings) == 1
-    assert all(w.text.endswith("W") for w in warnings)
+    # every matched line is the one the log marks with a trailing E or W
+    for block in blocks:
+        for line_no in block.matches:
+            assert block.lines[line_no - block.start].endswith(("E", "W"))
 
 
 def test_log_parser_stream():
-    """parse() accepts a file-like object."""
+    """scan() accepts a file-like object."""
     log = io.StringIO(
         "error: weird_error.c:145: something weird happened                 E\n"
         "checking for gcc... irrelevant line\n"
         "/var/tmp/build/foo.py:60: warning: some weird warning              W\n"
     )
-    parser = CTestLogParser()
-    errors, warnings, _ = parser.parse(log)
+    blocks = list(CTestLogParser().scan(log))
 
-    assert len(errors) == 1
-    assert errors[0].text.endswith("E")
-    assert len(warnings) == 1
-    assert warnings[0].text.endswith("W")
+    assert severities(blocks) == [Severity.ERROR, Severity.WARNING]
 
 
 def test_log_parser_preserves_leading_whitespace():
@@ -64,15 +83,25 @@ def test_log_parser_preserves_leading_whitespace():
         "    int y = x + 1;\n"
         "            ^\n"
     )
-    parser = CTestLogParser()
-    errors, _, _ = parser.parse(log, context=6)
+    (block,) = CTestLogParser().scan(log, context=6)
 
-    assert len(errors) == 1
-    assert errors[0].post_context[0] == "    int y = x + 1;"
-    assert errors[0].post_context[1] == "            ^"
+    assert block.lines == [
+        "/path/to/file.c:10: error: use of undeclared identifier 'x'",
+        "    int y = x + 1;",
+        "            ^",
+    ]
 
 
-def test_make_log_context_merges_overlapping_events(tmp_path: pathlib.Path):
+def test_source_file_of_match():
+    """A match records the file and line number the compiler pointed at."""
+    log = io.StringIO("/path/to/file.c:10: error: use of undeclared identifier 'x'\n")
+    (block,) = CTestLogParser().scan(log, context=0)
+
+    assert block.matches[1].source_file == "/path/to/file.c"
+    assert block.matches[1].source_line_no == "10"
+
+
+def test_merges_overlapping_events(tmp_path: pathlib.Path):
     """Overlapping or adjacent context windows should produce a single merged block."""
 
     # Two errors close together: lines 5 and 10 with context=3 means windows overlap.
@@ -83,20 +112,33 @@ def test_make_log_context_merges_overlapping_events(tmp_path: pathlib.Path):
     log_file = tmp_path / "log.txt"
     log_file.write_text("".join(lines))
 
-    parser = CTestLogParser()
-    errors, warnings, _ = parser.parse(str(log_file), context=3)
+    (block,) = CTestLogParser().scan(str(log_file), context=3)
 
-    log_events = sorted([*errors, *warnings], key=lambda e: e.line_no)
-    output = make_log_context(log_events)
+    assert (block.start, block.end) == (2, 13)
+    assert sorted(block.matches) == [5, 10]
 
     # Should be exactly one header for the merged block, not two.
+    output = render(str(log_file), context=3)
     assert output.count("-- lines") == 1
-
-    # The header should cover the full merged range.
     assert "-- lines 2 to 13 --" in output
 
 
-def test_make_log_context_warning_in_error_context_keeps_yellow(tmp_path: pathlib.Path):
+def test_separate_blocks_when_windows_do_not_touch(tmp_path: pathlib.Path):
+    """Errors far apart get one block each."""
+    lines = [f"line {i}\n" for i in range(1, 41)]
+    lines[4] = "error: first problem\n"  # line 5
+    lines[34] = "error: second problem\n"  # line 35
+
+    log_file = tmp_path / "log.txt"
+    log_file.write_text("".join(lines))
+
+    first, second = CTestLogParser().scan(str(log_file), context=3)
+
+    assert (first.start, first.end) == (2, 8)
+    assert (second.start, second.end) == (32, 38)
+
+
+def test_warning_in_error_context_keeps_yellow(tmp_path: pathlib.Path):
     """A warning line inside an error's context window must be highlighted yellow, not red."""
     # Line 5 = error, line 8 = warning, context=3 so error window covers lines 2-11
     # meaning the warning at line 8 falls inside the error's context.
@@ -107,39 +149,62 @@ def test_make_log_context_warning_in_error_context_keeps_yellow(tmp_path: pathli
     log_file = tmp_path / "log.txt"
     log_file.write_text("".join(lines))
 
-    parser = CTestLogParser()
-    errors, warnings, _ = parser.parse(str(log_file), context=3)
-
-    assert len(errors) == len(warnings) == 1
-
-    log_events = sorted([*errors, *warnings], key=lambda e: e.line_no)
-
     with color_when("always"):
-        output = make_log_context(log_events)
+        output = render(str(log_file), context=3)
 
     # The error line should be red (ANSI 91), the warning yellow (ANSI 93).
     assert "\x1b[0;91m> " in output and "something broke" in output
     assert "\x1b[0;93m> " in output and "something fishy" in output
 
 
+def test_severity_filter(tmp_path: pathlib.Path):
+    """Filtering by severity drops the other severity's matches and their context."""
+    lines = [f"line {i}\n" for i in range(1, 41)]
+    lines[4] = "error: something broke\n"  # line 5
+    lines[34] = "/tmp/foo.c:1: warning: something fishy\n"  # line 35
+
+    log_file = tmp_path / "log.txt"
+    log_file.write_text("".join(lines))
+
+    (block,) = CTestLogParser().scan(str(log_file), context=3, severities={Severity.WARNING})
+
+    assert (block.start, block.end) == (32, 38)
+    assert severities([block]) == [Severity.WARNING]
+
+
+def test_min_line_ignores_earlier_matches(tmp_path: pathlib.Path):
+    """min_line drops matches before it, but they can still show up as context."""
+    lines = [f"line {i}\n" for i in range(1, 41)]
+    lines[4] = "error: first problem\n"  # line 5
+    lines[34] = "error: second problem\n"  # line 35
+
+    log_file = tmp_path / "log.txt"
+    log_file.write_text("".join(lines))
+
+    (block,) = CTestLogParser().scan(str(log_file), context=3, min_line=35)
+
+    assert (block.start, block.end) == (32, 38)
+    assert sorted(block.matches) == [35]
+
+
 def test_log_parser_non_utf8_bytes(tmp_path: pathlib.Path):
-    """parse() does not raise UnicodeDecodeError on non-UTF-8 log files."""
+    """scan() does not raise UnicodeDecodeError on non-UTF-8 log files."""
     log_file = tmp_path / "log.bin"
     log_file.write_bytes(b"checking things...\nerror: \x80\xff something broke\ndone\n")
-    parser = CTestLogParser()
-    errors, _, _ = parser.parse(str(log_file))
-    assert len(errors) == 1
+
+    (block,) = CTestLogParser().scan(str(log_file))
+
+    assert severities([block]) == [Severity.ERROR]
 
 
 def test_tail_renders_as_plain_context():
-    """A LogEvent should render all lines as plain context with no highlighting."""
-    lines = ["tail line 1", "tail line 2", "tail line 3"]
-    section = LogEvent(text=lines[-1], line_no=100, pre_context=lines[:-1])
+    """Tail lines with no match render as plain context with no highlighting."""
+    log = io.StringIO("".join(f"tail line {i}\n" for i in range(1, 4)))
 
     with color_when(False):
-        output = make_log_context([section])
+        output = render(log, tail=3)
 
-    assert "-- lines 98 to 100 --" in output
+    assert "-- lines 1 to 3 --" in output
     # All lines should be plain context (indented with two spaces, no "> " prefix)
     assert "  tail line 1\n" in output
     assert "  tail line 2\n" in output
@@ -150,32 +215,71 @@ def test_tail_renders_as_plain_context():
 def test_tail_overlapping_with_error():
     """Tail lines overlapping with an error's context should not be duplicated."""
     log = io.StringIO("line 1\nline 2\nline 3\nerror: something broke\nline 5\nline 6\nline 7\n")
-    parser = CTestLogParser()
-    errors, _, tail = parser.parse(log, context=2, tail=3)
-    assert len(errors) == 1
-    assert tail is not None
 
     with color_when(False):
-        output = make_log_context([*errors, tail])
+        output = render(log, context=2, tail=3)
 
     # "line 5" and "line 6" appear in both the error context and the tail,
     # but should only appear once in the output
     assert output.count("line 5") == 1
     assert output.count("line 6") == 1
     assert output.count("line 7") == 1
+    assert output.count("-- lines") == 1
+
+
+def test_tail_detached_from_error():
+    """A tail far away from the last match is a block of its own."""
+    lines = [f"line {i}\n" for i in range(1, 41)]
+    lines[4] = "error: something broke\n"  # line 5
+
+    first, second = CTestLogParser().scan(lines, context=2, tail=3)
+
+    assert (first.start, first.end) == (3, 7)
+    assert (second.start, second.end) == (38, 40)
 
 
 def test_tail_only():
-    """A LogEvent with no errors/warnings renders correctly."""
-    lines = ["final line 1", "final line 2"]
-    section = LogEvent(text=lines[-1], line_no=51, pre_context=lines[:-1])
+    """A log with no errors or warnings renders its tail."""
+    log = io.StringIO("final line 1\nfinal line 2\n")
 
     with color_when(False):
-        output = make_log_context([section])
+        output = render(log, tail=2)
 
-    assert "-- lines 50 to 51 --" in output
+    assert "-- lines 1 to 2 --" in output
     assert "  final line 1\n" in output
     assert "  final line 2\n" in output
+
+
+def test_empty_log():
+    """An empty log produces no blocks and no output."""
+    assert list(CTestLogParser().scan(io.StringIO(""), tail=20)) == []
+    assert render(io.StringIO(""), tail=None) == ""
+
+
+def test_unbounded_tail_shows_whole_log():
+    """tail=None shows every line, even when nothing matched."""
+    log = io.StringIO("".join(f"line {i}\n" for i in range(1, 101)))
+
+    with color_when(False):
+        output = render(log, tail=None)
+
+    assert "-- lines 1 to 100 --" in output
+    for i in range(1, 101):
+        assert f"  line {i}\n" in output
+
+
+def test_unbounded_tail_highlights_matches():
+    """A match anywhere in an unbounded tail is still highlighted."""
+    lines = [f"line {i}\n" for i in range(1, 101)]
+    lines[4] = "error: something broke\n"  # line 5
+    lines[49] = "/tmp/foo.c:1: warning: something fishy\n"  # line 50
+
+    with color_when("always"):
+        output = render(lines, tail=None)
+
+    assert "\x1b[0;91m> " in output and "something broke" in output
+    assert "\x1b[0;93m> " in output and "something fishy" in output
+    assert "  line 100\n" in output
 
 
 class TestOptimizeRegexes:

--- a/lib/spack/spack/util/ctest_log_parser.py
+++ b/lib/spack/spack/util/ctest_log_parser.py
@@ -69,11 +69,11 @@ up to date with CTest, just make sure the ``*_matches`` and
 ``*_exceptions`` lists are kept up to date with CTest's build handler.
 """
 
-import io
+import enum
 import re
 import time
 from collections import deque
-from typing import Dict, Iterable, List, Optional, TextIO, Tuple, Union
+from typing import Container, Deque, Dict, Iterator, List, NamedTuple, Optional, TextIO, Union
 
 from spack.util.lang import PatternStr
 
@@ -210,69 +210,37 @@ _file_line_matches = [
 ]
 
 
-class LogEvent:
-    """Class representing interesting events (e.g., errors) in a build log."""
+class Severity(enum.Enum):
+    """Kind of a matched log line. The value is the color used to render it."""
 
-    #: color name when rendering in the terminal
-    color = ""
+    ERROR = "R"
+    WARNING = "Y"
 
-    def __init__(
-        self,
-        text: str,
-        line_no: int,
-        source_file: Optional[str] = None,
-        source_line_no: Optional[str] = None,
-        pre_context: Optional[List[str]] = None,
-        post_context: Optional[List[str]] = None,
-    ) -> None:
-        self.text = text
-        self.line_no = line_no
-        self.source_file = source_file
-        self.source_line_no = source_line_no
-        self.pre_context = pre_context if pre_context is not None else []
-        self.post_context = post_context if post_context is not None else []
-        self.repeat_count = 0
 
-    @property
-    def start(self) -> int:
-        """First line in the log with text for the event or its context."""
-        return self.line_no - len(self.pre_context)
+#: Both severities, the default for scans that do not filter.
+ALL_SEVERITIES = frozenset(Severity)
+
+
+class Match(NamedTuple):
+    """A log line that matched an error or warning regex."""
+
+    line_no: int  #: 1-based line number in the log
+    severity: Severity
+    source_file: Optional[str] = None
+    source_line_no: Optional[str] = None
+
+
+class Block(NamedTuple):
+    """A contiguous run of log lines worth showing."""
+
+    start: int  #: 1-based line number of lines[0]
+    lines: List[str]  #: the lines themselves, with trailing whitespace stripped
+    matches: Dict[int, Match]  #: the matched lines of this block, keyed by line number
 
     @property
     def end(self) -> int:
-        """Last line in the log with text for event or its context."""
-        return self.line_no + len(self.post_context) + 1
-
-    def __getitem__(self, line_no: int) -> str:
-        """Index event text and context by actual line number in file."""
-        if line_no == self.line_no:
-            return self.text
-        elif line_no < self.line_no:
-            return self.pre_context[line_no - self.line_no]
-        else:
-            return self.post_context[line_no - self.line_no - 1]
-
-    def __str__(self) -> str:
-        """Returns event lines and context."""
-        out = io.StringIO()
-        for i in range(self.start, self.end):
-            if i == self.line_no:
-                out.write("  >> %-6d%s" % (i, self[i]))
-            else:
-                out.write("     %-6d%s" % (i, self[i]))
-        return out.getvalue()
-
-
-class BuildError(LogEvent):
-    """LogEvent subclass for build errors."""
-
-    color = "R"
-
-
-class BuildWarning(LogEvent):
-    """LogEvent subclass for build warnings."""
-
-    color = "Y"
+        """1-based line number of the last line in the block."""
+        return self.start + len(self.lines) - 1
 
 
 def _optimize_regexes(regex_strings: List[str]) -> List[str]:
@@ -349,85 +317,6 @@ class _ProfileMatcher(_Matcher):
             print("%16.2f        %s" % (t * 1e6, pattern.pattern))
 
 
-def _parse(
-    stream: Iterable[str],
-    error_matcher: _Matcher,
-    warning_matcher: _Matcher,
-    file_line_matches: List[PatternStr],
-    context: int,
-    tail: int = 0,
-) -> Tuple[List[BuildError], List[BuildWarning], Optional[LogEvent]]:
-
-    errors: List[BuildError] = []
-    warnings: List[BuildWarning] = []
-    # rolling window of recent lines
-    pre_context: deque[str] = deque(maxlen=max(context, tail))
-    # list of (event, remaining_post_context_lines)
-    pending_events: List[Tuple[Union[BuildError, BuildWarning], int]] = []
-
-    last_line_no = 0
-    for i, line in enumerate(stream):
-        rstripped_line = line.rstrip()
-        last_line_no = i + 1
-
-        # feed this line into every event still collecting post_context
-        if pending_events:
-            active_events = []
-            for event, remaining in pending_events:
-                event.post_context.append(rstripped_line)
-                if remaining > 1:
-                    active_events.append((event, remaining - 1))
-                elif isinstance(event, BuildError):
-                    errors.append(event)
-                else:
-                    warnings.append(event)
-            pending_events = active_events
-
-        # use CTest's regular expressions to scrape the log for events
-        if error_matcher(line):
-            event = BuildError(rstripped_line, i + 1)
-        elif warning_matcher(line):
-            event = BuildWarning(rstripped_line, i + 1)
-        else:
-            pre_context.append(rstripped_line)
-            continue
-
-        event.pre_context = list(pre_context)[-context:] if context else []
-        event.post_context = []
-
-        # get file/line number for the event, if possible
-        for flm in file_line_matches:
-            match = flm.search(line)
-            if match:
-                event.source_file, event.source_line_no = match.groups()
-                break
-
-        if context > 0:
-            pending_events.append((event, context))
-        elif isinstance(event, BuildError):
-            errors.append(event)
-        else:
-            warnings.append(event)
-
-        pre_context.append(rstripped_line)
-
-    # flush events whose post_context window extends past EOF
-    for event, _ in pending_events:
-        if isinstance(event, BuildError):
-            errors.append(event)
-        else:
-            warnings.append(event)
-
-    # build tail section from the last N lines of the log, if requested
-    if tail > 0 and last_line_no > 0:
-        lines = list(pre_context)[-tail:]
-        tail_event = LogEvent(text=lines[-1], line_no=last_line_no, pre_context=lines[:-1])
-    else:
-        tail_event = None
-
-    return errors, warnings, tail_event
-
-
 class CTestLogParser:
     """Log file parser that extracts errors and warnings."""
 
@@ -449,29 +338,99 @@ class CTestLogParser:
         self._error_matcher.print_timings("error")
         self._warning_matcher.print_timings("warning")
 
-    def parse(
-        self, stream: Union[str, TextIO, List[str]], context: int = 6, tail: int = 0
-    ) -> Tuple[List[BuildError], List[BuildWarning], Optional[LogEvent]]:
-        """Parse a log file by searching each line for errors and warnings.
+    def _match(self, line: str, line_no: int, severities: Container[Severity]) -> Optional[Match]:
+        """Return a match for the line if it is an error or warning of interest."""
+        if self._error_matcher(line):
+            severity = Severity.ERROR
+        elif self._warning_matcher(line):
+            severity = Severity.WARNING
+        else:
+            return None
+
+        if severity not in severities:
+            return None
+
+        for flm in self._file_line_matches:
+            found = flm.search(line)
+            if found:
+                return Match(line_no, severity, *found.groups())
+
+        return Match(line_no, severity)
+
+    def scan(
+        self,
+        stream: Union[str, TextIO, List[str]],
+        context: int = 6,
+        tail: int = 0,
+        severities: Container[Severity] = ALL_SEVERITIES,
+    ) -> Iterator[Block]:
+        """Scan a log for errors and warnings and yield the blocks worth showing.
 
         Args:
             stream: filename or stream to read from
-            context: lines of context to extract around each log event
-            tail: if > 0, also return a :class:`LogEvent` with the last ``tail`` lines
+            context: lines of context to show around each matched line
+            tail: also show the last this many lines, whether or not anything matched
+            severities: only match lines of these severities
 
-        Returns:
-            two lists containing :class:`BuildError` and :class:`BuildWarning` objects,
-            plus an optional :class:`LogEvent` for the tail (None when ``tail=0``).
+        Yields:
+            :class:`Block` objects in increasing line order. Blocks never overlap: matches whose
+            context windows touch end up in a single block.
         """
+        if context < 0 or tail < 0:
+            raise ValueError("context and tail must be non-negative")
+
         if isinstance(stream, str):
             with open(stream, encoding="utf-8", errors="replace") as f:
-                return self.parse(f, context, tail)
+                yield from self.scan(f, context, tail, severities)
+            return
 
-        return _parse(
-            stream,
-            self._error_matcher,
-            self._warning_matcher,
-            self._file_line_matches,
-            context,
-            tail,
-        )
+        # lines after the current block, the lookbehind for the next match
+        recent: Deque[str] = deque(maxlen=max(context, tail))
+        start = 1  # 1-based line number of lines[0]
+        lines: List[str] = []
+        matches: Dict[int, Match] = {}
+        owed = 0  # lines of context still to add after the last match
+        line_no = 0
+
+        for line_no, line in enumerate(stream, 1):
+            text = line.rstrip()
+            match = self._match(line, line_no, severities)
+
+            if match is None:
+                if owed:
+                    lines.append(text)
+                    owed -= 1
+                else:
+                    recent.append(text)
+                continue
+
+            # Start a new block if this match does not touch the current one.
+            window_start = max(1, line_no - context)
+            if lines and window_start > start + len(lines):
+                yield Block(start, lines, matches)
+                lines, matches = [], {}
+
+            if not lines:
+                start = window_start
+
+            missing = line_no - start - len(lines)
+            if missing:
+                lines.extend(list(recent)[-missing:])
+            lines.append(text)
+            matches[line_no] = match
+            owed = context
+            recent.clear()
+
+        if tail and line_no:
+            tail_start = max(1, line_no - tail + 1)
+            if lines and tail_start > start + len(lines):
+                yield Block(start, lines, matches)
+                lines, matches = [], {}
+            if not lines:
+                start = tail_start
+            missing = line_no - start - len(lines) + 1
+            if missing > 0:
+                lines.extend(list(recent)[-missing:])
+
+        if lines:
+            yield Block(start, lines, matches)

--- a/lib/spack/spack/util/ctest_log_parser.py
+++ b/lib/spack/spack/util/ctest_log_parser.py
@@ -69,11 +69,11 @@ up to date with CTest, just make sure the ``*_matches`` and
 ``*_exceptions`` lists are kept up to date with CTest's build handler.
 """
 
-import io
+import enum
 import re
 import time
 from collections import deque
-from typing import Dict, Iterable, List, Optional, TextIO, Tuple, Union
+from typing import Container, Deque, Dict, Iterator, List, NamedTuple, Optional, TextIO, Union
 
 from spack.util.lang import PatternStr
 
@@ -210,69 +210,37 @@ _file_line_matches = [
 ]
 
 
-class LogEvent:
-    """Class representing interesting events (e.g., errors) in a build log."""
+class Severity(enum.Enum):
+    """Kind of a matched log line. The value is the color used to render it."""
 
-    #: color name when rendering in the terminal
-    color = ""
+    ERROR = "R"
+    WARNING = "Y"
 
-    def __init__(
-        self,
-        text: str,
-        line_no: int,
-        source_file: Optional[str] = None,
-        source_line_no: Optional[str] = None,
-        pre_context: Optional[List[str]] = None,
-        post_context: Optional[List[str]] = None,
-    ) -> None:
-        self.text = text
-        self.line_no = line_no
-        self.source_file = source_file
-        self.source_line_no = source_line_no
-        self.pre_context = pre_context if pre_context is not None else []
-        self.post_context = post_context if post_context is not None else []
-        self.repeat_count = 0
 
-    @property
-    def start(self) -> int:
-        """First line in the log with text for the event or its context."""
-        return self.line_no - len(self.pre_context)
+#: Both severities, the default for scans that do not filter.
+ALL_SEVERITIES = frozenset(Severity)
+
+
+class Match(NamedTuple):
+    """A log line that matched an error or warning regex."""
+
+    line_no: int  #: 1-based line number in the log
+    severity: Severity
+    source_file: Optional[str] = None
+    source_line_no: Optional[str] = None
+
+
+class Block(NamedTuple):
+    """A contiguous run of log lines worth showing."""
+
+    start: int  #: 1-based line number of lines[0]
+    lines: List[str]  #: the lines themselves, with trailing whitespace stripped
+    matches: Dict[int, Match]  #: the matched lines of this block, keyed by line number
 
     @property
     def end(self) -> int:
-        """Last line in the log with text for event or its context."""
-        return self.line_no + len(self.post_context) + 1
-
-    def __getitem__(self, line_no: int) -> str:
-        """Index event text and context by actual line number in file."""
-        if line_no == self.line_no:
-            return self.text
-        elif line_no < self.line_no:
-            return self.pre_context[line_no - self.line_no]
-        else:
-            return self.post_context[line_no - self.line_no - 1]
-
-    def __str__(self) -> str:
-        """Returns event lines and context."""
-        out = io.StringIO()
-        for i in range(self.start, self.end):
-            if i == self.line_no:
-                out.write("  >> %-6d%s" % (i, self[i]))
-            else:
-                out.write("     %-6d%s" % (i, self[i]))
-        return out.getvalue()
-
-
-class BuildError(LogEvent):
-    """LogEvent subclass for build errors."""
-
-    color = "R"
-
-
-class BuildWarning(LogEvent):
-    """LogEvent subclass for build warnings."""
-
-    color = "Y"
+        """1-based line number of the last line in the block."""
+        return self.start + len(self.lines) - 1
 
 
 def _optimize_regexes(regex_strings: List[str]) -> List[str]:
@@ -349,85 +317,6 @@ class _ProfileMatcher(_Matcher):
             print("%16.2f        %s" % (t * 1e6, pattern.pattern))
 
 
-def _parse(
-    stream: Iterable[str],
-    error_matcher: _Matcher,
-    warning_matcher: _Matcher,
-    file_line_matches: List[PatternStr],
-    context: int,
-    tail: int = 0,
-) -> Tuple[List[BuildError], List[BuildWarning], Optional[LogEvent]]:
-
-    errors: List[BuildError] = []
-    warnings: List[BuildWarning] = []
-    # rolling window of recent lines
-    pre_context: deque[str] = deque(maxlen=max(context, tail))
-    # list of (event, remaining_post_context_lines)
-    pending_events: List[Tuple[Union[BuildError, BuildWarning], int]] = []
-
-    last_line_no = 0
-    for i, line in enumerate(stream):
-        rstripped_line = line.rstrip()
-        last_line_no = i + 1
-
-        # feed this line into every event still collecting post_context
-        if pending_events:
-            active_events = []
-            for event, remaining in pending_events:
-                event.post_context.append(rstripped_line)
-                if remaining > 1:
-                    active_events.append((event, remaining - 1))
-                elif isinstance(event, BuildError):
-                    errors.append(event)
-                else:
-                    warnings.append(event)
-            pending_events = active_events
-
-        # use CTest's regular expressions to scrape the log for events
-        if error_matcher(line):
-            event = BuildError(rstripped_line, i + 1)
-        elif warning_matcher(line):
-            event = BuildWarning(rstripped_line, i + 1)
-        else:
-            pre_context.append(rstripped_line)
-            continue
-
-        event.pre_context = list(pre_context)[-context:] if context else []
-        event.post_context = []
-
-        # get file/line number for the event, if possible
-        for flm in file_line_matches:
-            match = flm.search(line)
-            if match:
-                event.source_file, event.source_line_no = match.groups()
-                break
-
-        if context > 0:
-            pending_events.append((event, context))
-        elif isinstance(event, BuildError):
-            errors.append(event)
-        else:
-            warnings.append(event)
-
-        pre_context.append(rstripped_line)
-
-    # flush events whose post_context window extends past EOF
-    for event, _ in pending_events:
-        if isinstance(event, BuildError):
-            errors.append(event)
-        else:
-            warnings.append(event)
-
-    # build tail section from the last N lines of the log, if requested
-    if tail > 0 and last_line_no > 0:
-        lines = list(pre_context)[-tail:]
-        tail_event = LogEvent(text=lines[-1], line_no=last_line_no, pre_context=lines[:-1])
-    else:
-        tail_event = None
-
-    return errors, warnings, tail_event
-
-
 class CTestLogParser:
     """Log file parser that extracts errors and warnings."""
 
@@ -449,29 +338,107 @@ class CTestLogParser:
         self._error_matcher.print_timings("error")
         self._warning_matcher.print_timings("warning")
 
-    def parse(
-        self, stream: Union[str, TextIO, List[str]], context: int = 6, tail: int = 0
-    ) -> Tuple[List[BuildError], List[BuildWarning], Optional[LogEvent]]:
-        """Parse a log file by searching each line for errors and warnings.
+    def _match(self, line: str, line_no: int, severities: Container[Severity]) -> Optional[Match]:
+        """Return a match for the line if it is an error or warning of interest."""
+        if self._error_matcher(line):
+            severity = Severity.ERROR
+        elif self._warning_matcher(line):
+            severity = Severity.WARNING
+        else:
+            return None
+
+        if severity not in severities:
+            return None
+
+        for flm in self._file_line_matches:
+            found = flm.search(line)
+            if found:
+                return Match(line_no, severity, *found.groups())
+
+        return Match(line_no, severity)
+
+    def scan(
+        self,
+        stream: Union[str, TextIO, List[str]],
+        context: int = 6,
+        tail: Optional[int] = 0,
+        severities: Container[Severity] = ALL_SEVERITIES,
+        min_line: int = 0,
+    ) -> Iterator[Block]:
+        """Scan a log for errors and warnings and yield the blocks worth showing.
 
         Args:
             stream: filename or stream to read from
-            context: lines of context to extract around each log event
-            tail: if > 0, also return a :class:`LogEvent` with the last ``tail`` lines
+            context: lines of context to show around each matched line
+            tail: also show the last this many lines, whether or not anything matched; None
+                shows the whole log
+            severities: only match lines of these severities
+            min_line: ignore matches before this line, though they can still appear as context
 
-        Returns:
-            two lists containing :class:`BuildError` and :class:`BuildWarning` objects,
-            plus an optional :class:`LogEvent` for the tail (None when ``tail=0``).
+        Yields:
+            :class:`Block` objects in increasing line order. Blocks never overlap: matches whose
+            context windows touch end up in a single block.
         """
         if isinstance(stream, str):
             with open(stream, encoding="utf-8", errors="replace") as f:
-                return self.parse(f, context, tail)
+                yield from self.scan(f, context, tail, severities, min_line)
+            return
 
-        return _parse(
-            stream,
-            self._error_matcher,
-            self._warning_matcher,
-            self._file_line_matches,
-            context,
-            tail,
-        )
+        keep_all = tail is None  # tail=None means keep every line, matched or not
+
+        # lines after the current block, the lookbehind for the next match
+        recent: Deque[str] = deque(maxlen=max(context, tail or 0))
+        start = 1  # 1-based line number of lines[0]
+        lines: List[str] = []
+        matches: Dict[int, Match] = {}
+        owed = 0  # lines of context still to add after the last match
+        line_no = 0
+
+        for line_no, line in enumerate(stream, 1):
+            text = line.rstrip()
+            match = self._match(line, line_no, severities) if line_no >= min_line else None
+
+            if keep_all:
+                lines.append(text)
+                if match is not None:
+                    matches[line_no] = match
+                continue
+
+            if match is None:
+                if owed:
+                    lines.append(text)
+                    owed -= 1
+                else:
+                    recent.append(text)
+                continue
+
+            # Start a new block if this match does not touch the current one.
+            window_start = max(1, line_no - context)
+            if lines and window_start > start + len(lines):
+                yield Block(start, lines, matches)
+                lines, matches = [], {}
+
+            if not lines:
+                start = window_start
+
+            missing = line_no - start - len(lines)
+            if missing:
+                lines.extend(list(recent)[-missing:])
+            lines.append(text)
+            matches[line_no] = match
+            owed = context
+            recent.clear()
+
+        if tail and line_no:
+            tail_start = max(1, line_no - tail + 1)
+            if lines and tail_start > start + len(lines):
+                yield Block(start, lines, matches)
+                lines, matches = [], {}
+            if not lines:
+                start = tail_start
+            missing = line_no - start - len(lines) + 1
+            if missing > 0:
+                lines.extend(list(recent)[-missing:])
+
+        if lines:
+            yield Block(start, lines, matches)

--- a/lib/spack/spack/util/log_parse.py
+++ b/lib/spack/spack/util/log_parse.py
@@ -2,33 +2,35 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-import io
-from typing import List, Optional, TextIO, Tuple, Union
+from typing import Container, Iterator, List, Optional, TextIO, Union
 
-from spack.util.ctest_log_parser import BuildError, BuildWarning, CTestLogParser, LogEvent
+from spack.util.ctest_log_parser import ALL_SEVERITIES, Block, CTestLogParser, Severity
 from spack.util.tty.color import cescape, colorize
 
-__all__ = ["parse_log_events", "make_log_context"]
+__all__ = ["scan_log", "write_block", "write_log_context"]
 
 
 _PARSER: Optional[CTestLogParser] = None
 
 
-def parse_log_events(
-    stream: Union[str, TextIO], context: int = 6, profile: bool = False, tail: int = 0
-) -> Tuple[List[BuildError], List[BuildWarning], Union[LogEvent, None]]:
-    """Extract interesting events from a log file.
+def scan_log(
+    stream: Union[str, TextIO, List[str]],
+    context: int = 6,
+    tail: int = 0,
+    severities: Container[Severity] = ALL_SEVERITIES,
+    profile: bool = False,
+) -> Iterator[Block]:
+    """Scan a build log for errors and warnings and yield the blocks worth showing.
 
     Args:
         stream: build log name or file object
-        context: lines of context to extract around each log event
+        context: lines of context to show around each matched line
+        tail: also show the last this many lines, whether or not anything matched
+        severities: only match lines of these severities
         profile: print out profile information for parsing
-        tail: if > 0, also return the last ``tail`` lines
 
-    Returns:
-        two lists containing :class:`~spack.util.ctest_log_parser.BuildError` and
-        :class:`~spack.util.ctest_log_parser.BuildWarning` objects, plus an optional
-        :class:`~spack.util.ctest_log_parser.LogEvent` for the tail (None when ``tail=0``).
+    Yields:
+        :class:`~spack.util.ctest_log_parser.Block` objects in increasing line order.
     """
     global _PARSER
     if profile:
@@ -37,59 +39,31 @@ def parse_log_events(
         _PARSER = parser = CTestLogParser()
     else:
         parser = _PARSER
-    result = parser.parse(stream, context, tail)
+
+    yield from parser.scan(stream, context, tail, severities)
+
     if profile:
         parser.print_timings()
-    return result
 
 
-def make_log_context(log_events: List[LogEvent]) -> str:
-    """Get error context from a log file.
+def write_block(out: TextIO, block: Block) -> None:
+    """Write a block of log lines to a stream, under a header giving its line range.
 
-    Args:
-        log_events: list of events created by ``ctest_log_parser.parse()``
-
-    Returns:
-        str: context from the build log with errors highlighted
-
-    Parses the log file for lines containing errors, and prints them out with context.
-    Errors are highlighted in red and warnings in yellow. Events are sorted by line number.
+    Matched lines are prefixed with a ``>``, red for errors and yellow for warnings; the lines of
+    context around them are indented instead.
     """
-    event_colors = {e.line_no: e.color for e in log_events if e.color}
-    log_events = sorted(log_events, key=lambda e: e.line_no)
+    out.write(colorize("@c{-- lines %d to %d --}\n" % (block.start, block.end)))
+    for line_no, text in enumerate(block.lines, block.start):
+        match = block.matches.get(line_no)
+        if match is None:
+            out.write("  %s\n" % text)
+        else:
+            out.write(colorize("@%s{> %s}\n" % (match.severity.value, cescape(text))))
 
-    out = io.StringIO()
-    next_line = 1
-    block_start = -1
-    block_lines: List[str] = []
 
-    def flush_block():
-        block_end = block_start + len(block_lines) - 1
-        out.write(colorize("@c{-- lines %d to %d --}\n" % (block_start, block_end)))
-        out.writelines(block_lines)
-        block_lines.clear()
-
-    for event in log_events:
-        start = event.start
-
-        if start < next_line:
-            start = next_line
-        elif block_lines:
-            flush_block()
-
-        if not block_lines:
-            block_start = start
-
-        for i in range(start, event.end):
-            if i in event_colors:
-                color = event_colors[i]
-                block_lines.append(colorize("@%s{> %s}\n" % (color, cescape(event[i]))))
-            else:
-                block_lines.append("  %s\n" % event[i])
-
-        next_line = event.end
-
-    if block_lines:
-        flush_block()
-
-    return out.getvalue()
+def write_log_context(
+    out: TextIO, stream: Union[str, TextIO, List[str]], context: int = 6, tail: int = 0
+) -> None:
+    """Write the interesting parts of a build log to a stream."""
+    for block in scan_log(stream, context, tail):
+        write_block(out, block)

--- a/lib/spack/spack/util/log_parse.py
+++ b/lib/spack/spack/util/log_parse.py
@@ -2,33 +2,38 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-import io
-from typing import List, Optional, TextIO, Tuple, Union
+from typing import Container, Iterator, List, Optional, TextIO, Union
 
-from spack.util.ctest_log_parser import BuildError, BuildWarning, CTestLogParser, LogEvent
+from spack.util.ctest_log_parser import ALL_SEVERITIES, Block, CTestLogParser, Severity
 from spack.util.tty.color import cescape, colorize
 
-__all__ = ["parse_log_events", "make_log_context"]
+__all__ = ["scan_log", "write_block", "write_log_context"]
 
 
 _PARSER: Optional[CTestLogParser] = None
 
 
-def parse_log_events(
-    stream: Union[str, TextIO], context: int = 6, profile: bool = False, tail: int = 0
-) -> Tuple[List[BuildError], List[BuildWarning], Union[LogEvent, None]]:
-    """Extract interesting events from a log file.
+def scan_log(
+    stream: Union[str, TextIO, List[str]],
+    context: int = 6,
+    tail: Optional[int] = 0,
+    severities: Container[Severity] = ALL_SEVERITIES,
+    profile: bool = False,
+    min_line: int = 0,
+) -> Iterator[Block]:
+    """Scan a build log for errors and warnings and yield the blocks worth showing.
 
     Args:
         stream: build log name or file object
-        context: lines of context to extract around each log event
+        context: lines of context to show around each matched line
+        tail: also show the last this many lines, whether or not anything matched; None shows
+            the whole log
+        severities: only match lines of these severities
         profile: print out profile information for parsing
-        tail: if > 0, also return the last ``tail`` lines
+        min_line: ignore matches before this line, though they can still appear as context
 
-    Returns:
-        two lists containing :class:`~spack.util.ctest_log_parser.BuildError` and
-        :class:`~spack.util.ctest_log_parser.BuildWarning` objects, plus an optional
-        :class:`~spack.util.ctest_log_parser.LogEvent` for the tail (None when ``tail=0``).
+    Yields:
+        :class:`~spack.util.ctest_log_parser.Block` objects in increasing line order.
     """
     global _PARSER
     if profile:
@@ -37,59 +42,39 @@ def parse_log_events(
         _PARSER = parser = CTestLogParser()
     else:
         parser = _PARSER
-    result = parser.parse(stream, context, tail)
+
+    yield from parser.scan(stream, context, tail, severities, min_line)
+
     if profile:
         parser.print_timings()
-    return result
 
 
-def make_log_context(log_events: List[LogEvent]) -> str:
-    """Get error context from a log file.
+def write_block(out: TextIO, block: Block) -> None:
+    """Write a block of log lines to a stream, under a header giving its line range.
 
-    Args:
-        log_events: list of events created by ``ctest_log_parser.parse()``
-
-    Returns:
-        str: context from the build log with errors highlighted
-
-    Parses the log file for lines containing errors, and prints them out with context.
-    Errors are highlighted in red and warnings in yellow. Events are sorted by line number.
+    Matched lines are prefixed with a ``>``, red for errors and yellow for warnings; the lines of
+    context around them are indented instead.
     """
-    event_colors = {e.line_no: e.color for e in log_events if e.color}
-    log_events = sorted(log_events, key=lambda e: e.line_no)
+    out.write(colorize("@c{-- lines %d to %d --}\n" % (block.start, block.end)))
+    for line_no, text in enumerate(block.lines, block.start):
+        match = block.matches.get(line_no)
+        if match is None:
+            out.write("  %s\n" % text)
+        else:
+            out.write(colorize("@%s{> %s}\n" % (match.severity.value, cescape(text))))
 
-    out = io.StringIO()
-    next_line = 1
-    block_start = -1
-    block_lines: List[str] = []
 
-    def flush_block():
-        block_end = block_start + len(block_lines) - 1
-        out.write(colorize("@c{-- lines %d to %d --}\n" % (block_start, block_end)))
-        out.writelines(block_lines)
-        block_lines.clear()
-
-    for event in log_events:
-        start = event.start
-
-        if start < next_line:
-            start = next_line
-        elif block_lines:
-            flush_block()
-
-        if not block_lines:
-            block_start = start
-
-        for i in range(start, event.end):
-            if i in event_colors:
-                color = event_colors[i]
-                block_lines.append(colorize("@%s{> %s}\n" % (color, cescape(event[i]))))
-            else:
-                block_lines.append("  %s\n" % event[i])
-
-        next_line = event.end
-
-    if block_lines:
-        flush_block()
-
-    return out.getvalue()
+def write_log_context(
+    out: TextIO,
+    stream: Union[str, TextIO, List[str]],
+    context: int = 6,
+    tail: Optional[int] = 0,
+    severities: Container[Severity] = ALL_SEVERITIES,
+    min_line: int = 0,
+) -> int:
+    """Write the interesting parts of a build log to a stream, and return the lines written."""
+    written = 0
+    for block in scan_log(stream, context, tail, severities, min_line=min_line):
+        write_block(out, block)
+        written += len(block.lines)
+    return written


### PR DESCRIPTION
Instead of producing a warning or error instance with a list of surrounding
lines, yield a single contiguous block of lines with a list of associated
warnings and errors.

This reduces complexity in the code and is a bit more efficient when there are
overlapping lines in the context around warnings and errors.

It also makes streaming possible in `spack log-parse`, like with `grep`.

A change from develop: the installer filtered warnings and errors separately,
and dropped warnings if there were errors. Now, it drops contiguous blocks
without errors if there are errors. The difference is that it can emit a block
with both errors and warnings, whereas previously the warning from that
block would not be shown. I think the new behavior is reasonable.