### PR TITLE
installer: partially support pipe based jobserver

### DIFF
--- a/lib/spack/spack/installer/base.py
+++ b/lib/spack/spack/installer/base.py
@@ -14,7 +14,7 @@ import socket
 import sys
 import threading
 from multiprocessing.connection import Connection
-from typing import Any, Callable, NamedTuple, Optional, Union
+from typing import Callable, MutableMapping, NamedTuple, Optional, Union
 
 from spack.vendor.typing_extensions import Literal
 
@@ -205,15 +205,25 @@ class FdInfo:
         self.name = name
 
 
-class JobserverInfo(NamedTuple):
-    """What a build process needs to participate in the jobserver, produced by
-    :meth:`JobServerBase.makeflags_and_data`."""
+class Makeflags(abc.ABC):
+    """Sets MAKEFLAGS for a build process, so that it participates in Spack's jobserver. It is
+    applied in the build process itself, since the value can depend on file descriptors that
+    process has to open."""
 
-    #: MAKEFLAGS value to set in the build process environment, or None if there is no jobserver.
-    makeflags: Optional[str]
-    #: Implementation specific data serialized to the build process (e.g. pipe-based jobserver
-    #: connections that the build process must inherit).
-    data: Any
+    __slots__ = ()
+
+    @abc.abstractmethod
+    def apply(self, env: MutableMapping[str, str]) -> None:
+        """Set MAKEFLAGS in the given environment, if there is anything to set."""
+
+
+class NoMakeflags(Makeflags):
+    """No jobserver, nothing to set."""
+
+    __slots__ = ()
+
+    def apply(self, env: MutableMapping[str, str]) -> None:
+        pass
 
 
 class ProcessExitNotifier(abc.ABC):
@@ -250,9 +260,9 @@ class JobServerBase(abc.ABC):
         return self.num_jobs == self.target_jobs
 
     @abc.abstractmethod
-    def makeflags_and_data(self, gmake: Optional[spack.spec.Spec]) -> JobserverInfo:
-        """Return the :class:`~spack.installer.base.JobserverInfo` to be passed to the child
-        process."""
+    def makeflags(self, gmake: Optional[spack.spec.Spec]) -> Makeflags:
+        """Return the :class:`~spack.installer.base.Makeflags` to be serialized to the build
+        process and applied there."""
 
     @abc.abstractmethod
     def update_selector(self, selector: selectors.BaseSelector, wake: bool) -> None:
@@ -287,8 +297,8 @@ class JobServerBase(abc.ABC):
 class NoopJobServer(JobServerBase):
     """Dummy jobserver for platforms lacking jobserver support."""
 
-    def makeflags_and_data(self, gmake: Optional[spack.spec.Spec]) -> JobserverInfo:
-        return JobserverInfo(None, None)
+    def makeflags(self, gmake: Optional[spack.spec.Spec]) -> Makeflags:
+        return NoMakeflags()
 
     def update_selector(self, selector: selectors.BaseSelector, wake: bool) -> None: ...
 

--- a/lib/spack/spack/installer/build.py
+++ b/lib/spack/spack/installer/build.py
@@ -46,7 +46,7 @@ from spack.installer.base import (
     InstallPolicy,
     IpcChannel,
     JobServerBase,
-    JobserverInfo,
+    Makeflags,
     ProcessExitNotifier,
 )
 from spack.old_installer import _do_fake_install, dump_packages
@@ -335,7 +335,7 @@ def worker_function(
     parent: IpcChannel,
     tee_control_r: IpcChannel,
     tee_control_w: Optional[IpcChannel],
-    jobserver_info: JobserverInfo,
+    makeflags: Makeflags,
     global_state: GlobalStateMarshaler,
 ) -> None:
     """
@@ -348,9 +348,7 @@ def worker_function(
         parent: Connection to send build output to
         tee_control_r: Read end of the control pipe; the parent sends echo on/off here
         tee_control_w: Write end of the control pipe; used to stop the tee thread on POSIX
-        jobserver_info: MAKEFLAGS to set, so that the build process uses the POSIX jobserver, and
-            opaque data only to be serialized (e.g. old style jobserver r/w pipes, only to be
-            inherited in the build process)
+        makeflags: Sets MAKEFLAGS in this process, so that the build uses Spack's jobserver
         global_state: Global state to restore
     """
     spec, log_path = request.spec, request.log_path
@@ -388,8 +386,7 @@ def worker_function(
 
     signal.signal(signal.SIGTERM, handle_sigterm)
 
-    if jobserver_info.makeflags is not None:
-        os.environ["MAKEFLAGS"] = jobserver_info.makeflags
+    makeflags.apply(os.environ)
 
     # Save encodings before the Tee redirects fds 1/2 to the pipe. We need them to create the
     # line-buffered wrappers after the Tee starts.
@@ -693,10 +690,9 @@ def start_build(request: BuildRequest, jobserver: JobServerBase) -> ChildInfo:
     spec = request.spec
     channels = create_build_channels()
 
-    # Obtain the MAKEFLAGS to be set in the child process, and determine whether it's necessary
-    # for the child process to inherit our jobserver fds.
+    # Obtain the MAKEFLAGS to be set in the child process, in a style the package's gmake accepts.
     gmake = next(iter(spec.dependencies("gmake")), None)
-    jobserver_details = jobserver.makeflags_and_data(gmake)
+    makeflags = jobserver.makeflags(gmake)
 
     # As a performance optimization, we do not serialize the environment which
     # is slow to serialize and not needed in the build job
@@ -708,7 +704,7 @@ def start_build(request: BuildRequest, jobserver: JobServerBase) -> ChildInfo:
             channels.output_w,
             channels.control_r,
             channels.tee_control_w,
-            jobserver_details,
+            makeflags,
             GlobalStateMarshaler(serialize_env=False),
         ),
     )

--- a/lib/spack/spack/installer/posix.py
+++ b/lib/spack/spack/installer/posix.py
@@ -23,7 +23,7 @@ import tty
 import warnings
 from multiprocessing import Pipe, Process
 from multiprocessing.connection import Connection
-from typing import Callable, Optional, Tuple, Union
+from typing import Callable, MutableMapping, Optional, Tuple
 
 import spack.spec
 import spack.util.tty
@@ -36,7 +36,7 @@ from spack.installer.base import (
     BaseTerminalState,
     BuildChannels,
     JobServerBase,
-    JobserverInfo,
+    Makeflags,
     ProcessExitNotifier,
     StdinReader,
     Tee,
@@ -251,61 +251,74 @@ class PosixTee(Tee):
             os.close(log_r)
 
 
+class FifoMakeflags(Makeflags):
+    """MAKEFLAGS in fifo style, which gmake 4.4 and later understand."""
+
+    __slots__ = ("fifo_path", "num_jobs")
+
+    def __init__(self, fifo_path: str, num_jobs: int) -> None:
+        self.fifo_path = fifo_path
+        self.num_jobs = num_jobs
+
+    def apply(self, env: MutableMapping[str, str]) -> None:
+        env["MAKEFLAGS"] = f" -j{self.num_jobs} --jobserver-auth=fifo:{self.fifo_path}"
+
+
+class PipeMakeflags(Makeflags):
+    """Compatibility wrapper for old gmake that requires a pipe-based jobserver.
+
+    Args:
+        fifo_path: path of the jobserver FIFO to open
+        flag: "--jobserver-auth" (gmake >= 4.0) or "--jobserver-fds" (gmake < 4.0)
+    """
+
+    __slots__ = ("fifo_path", "flag")
+
+    def __init__(self, fifo_path: str, flag: str) -> None:
+        self.fifo_path = fifo_path
+        self.flag = flag
+
+    def apply(self, env: MutableMapping[str, str]) -> None:
+        # O_NONBLOCK avoids block on open, but make needs blocking, so fcntl immediately clears it.
+        r = os.open(self.fifo_path, os.O_RDONLY | os.O_NONBLOCK)
+        w = os.open(self.fifo_path, os.O_WRONLY)
+        fcntl.fcntl(r, fcntl.F_SETFL, fcntl.fcntl(r, fcntl.F_GETFL) & ~os.O_NONBLOCK)
+        os.set_inheritable(r, True)
+        os.set_inheritable(w, True)
+        # passing -jN here would make old gmake ignore the jobserver
+        env["MAKEFLAGS"] = f" -j {self.flag}={r},{w}"
+
+
 class PosixJobServer(JobServerBase):
-    """Attach to an existing POSIX jobserver or create a FIFO-based one."""
+    """Attach to an existing POSIX FIFO-based jobserver or create one."""
 
     def __init__(self, num_jobs: int, makeflags: Optional[str] = None) -> None:
         super().__init__(num_jobs, makeflags)
         #: Keep track of how many tokens Spack itself has acquired, which is used to release them.
         self.tokens_acquired = 0
-        self.fifo_path: Optional[str] = None
         self.created = False
-        self._setup(makeflags)
-        # Ensure that Executable()(...) in build processes ultimately inherit jobserver fds.
-        os.set_inheritable(self.r, True)
-        os.set_inheritable(self.w, True)
-        # r_conn and w_conn are used to make build processes inherit the jobserver fds if needed.
-        # Connection objects close the fd as they are garbage collected, so store them.
-        self.r_conn = Connection(self.r)
-        self.w_conn = Connection(self.w)
+        self.r, self.w, self.fifo_path = self._setup(makeflags)
 
-    def _setup(self, makeflags: Optional[str] = None) -> None:
+    def _setup(self, makeflags: Optional[str] = None) -> Tuple[int, int, str]:
+        fifo_path = get_jobserver_config(makeflags)
 
-        fifo_config = get_jobserver_config(makeflags)
-
-        if isinstance(fifo_config, str):
-            # FIFO-based jobserver. Try to open the FIFO.
-            open_attempt = open_existing_jobserver_fifo(fifo_config)
+        if fifo_path is not None:
+            # Try to attach to the existing FIFO-based jobserver.
+            open_attempt = open_existing_jobserver_fifo(fifo_path)
             if open_attempt:
-                self.r, self.w = open_attempt
-                self.fifo_path = fifo_config
-                return
-        elif isinstance(fifo_config, tuple):
-            # Old style pipe-based jobserver. Validate the fds before using them.
-            r, w = fifo_config
-            try:
-                fcntl.fcntl(r, fcntl.F_GETFD)
-                fcntl.fcntl(w, fcntl.F_GETFD)
-                self.r, self.w = r, w
-                return
-            except OSError:  # raised if invalid
-                pass
+                r, w = open_attempt
+                return r, w, fifo_path
 
         # No existing jobserver we can connect to: create a FIFO-based one.
-        self.r, self.w, self.fifo_path = create_jobserver_fifo(self.num_jobs)
+        r, w, fifo_path = create_jobserver_fifo(self.num_jobs)
         self.created = True
+        return r, w, fifo_path
 
-    def makeflags_and_data(self, gmake: Optional[spack.spec.Spec]) -> JobserverInfo:
-        if self.fifo_path and (not gmake or gmake.satisfies("@4.4:")):
-            return JobserverInfo(
-                f" -j{self.num_jobs} --jobserver-auth=fifo:{self.fifo_path}", None
-            )
-        # For non-FIFO jobservers, ensure the pipes are inherited by the child process
-        pipes = (self.r_conn, self.w_conn)
-        if not gmake or gmake.satisfies("@4.0:"):
-            return JobserverInfo(f" -j{self.num_jobs} --jobserver-auth={self.r},{self.w}", pipes)
-        else:
-            return JobserverInfo(f" -j{self.num_jobs} --jobserver-fds={self.r},{self.w}", pipes)
+    def makeflags(self, gmake: Optional[spack.spec.Spec]) -> Makeflags:
+        if not gmake or gmake.satisfies("@4.4:"):
+            return FifoMakeflags(self.fifo_path, self.num_jobs)
+        flag = "--jobserver-auth" if gmake.satisfies("@4.0:") else "--jobserver-fds"
+        return PipeMakeflags(self.fifo_path, flag)
 
     def update_selector(self, selector: selectors.BaseSelector, wake: bool) -> None:
         if wake and self.r not in selector.get_map():
@@ -377,11 +390,11 @@ class PosixJobServer(JobServerBase):
                         stacklevel=2,
                     )
 
-        self.r_conn.close()
-        self.w_conn.close()
+        os.close(self.r)
+        os.close(self.w)
 
         # Remove the FIFO if we created it.
-        if self.created and self.fifo_path:
+        if self.created:
             try:
                 os.unlink(self.fifo_path)
             except OSError:
@@ -392,8 +405,9 @@ class PosixJobServer(JobServerBase):
                 pass
 
 
-def get_jobserver_config(makeflags: Optional[str] = None) -> Optional[Union[str, Tuple[int, int]]]:
-    """Parse MAKEFLAGS for jobserver. Either it's a FIFO or (r, w) pair of file descriptors.
+def get_jobserver_config(makeflags: Optional[str] = None) -> Optional[str]:
+    """Parse MAKEFLAGS for a FIFO-based jobserver, returning its path. Old-style pipe-based
+    jobservers are not recognized.
 
     Args:
         makeflags: MAKEFLAGS string to parse. If None, reads from os.environ.
@@ -401,23 +415,12 @@ def get_jobserver_config(makeflags: Optional[str] = None) -> Optional[Union[str,
     makeflags = os.environ.get("MAKEFLAGS", "") if makeflags is None else makeflags
     if not makeflags:
         return None
-    # We can have the following flags:
-    # --jobserver-fds=R,W (before GNU make 4.2)
-    # --jobserver-auth=fifo:PATH or --jobserver-auth=R,W (after GNU make 4.2)
-    # In case of multiple, the last one wins.
+    # In case of multiple --jobserver-* flags, the last one wins, regardless of its format.
     matches = re.findall(r" --jobserver-[^=]+=([^ ]+)", makeflags)
     if not matches:
         return None
     last_match = matches[-1]
-    if last_match.startswith("fifo:"):
-        return last_match[5:]
-    parts = last_match.split(",", 1)
-    if len(parts) != 2:
-        return None
-    try:
-        return int(parts[0]), int(parts[1])
-    except ValueError:
-        return None
+    return last_match[5:] if last_match.startswith("fifo:") else None
 
 
 def create_jobserver_fifo(num_jobs: int) -> Tuple[int, int, str]:

--- a/lib/spack/spack/test/installer/posix.py
+++ b/lib/spack/spack/test/installer/posix.py
@@ -15,7 +15,10 @@ import pathlib
 import selectors
 import stat
 
+from spack.installer.base import NoMakeflags
 from spack.installer.posix import (
+    FifoMakeflags,
+    PipeMakeflags,
     PosixJobServer,
     create_jobserver_fifo,
     get_jobserver_config,
@@ -39,18 +42,20 @@ class TestGetJobserverConfig:
         """Parse new FIFO format"""
         assert get_jobserver_config(" -j4 --jobserver-auth=fifo:/tmp/my_fifo") == "/tmp/my_fifo"
 
-    def test_pipe_format_new(self):
-        """Parse new pipe format"""
-        assert get_jobserver_config(" -j4 --jobserver-auth=3,4") == (3, 4)
+    def test_pipe_format_new_not_recognized(self):
+        """Pipe-based jobservers aren't recognized: there's no path to hand a build process."""
+        assert get_jobserver_config(" -j4 --jobserver-auth=3,4") is None
 
-    def test_pipe_format_old(self):
-        """Parse old pipe format (on old versions of gmake this was not publicized)"""
-        assert get_jobserver_config(" -j4 --jobserver-fds=5,6") == (5, 6)
+    def test_pipe_format_old_not_recognized(self):
+        """Old-style --jobserver-fds is likewise not recognized."""
+        assert get_jobserver_config(" -j4 --jobserver-fds=5,6") is None
 
     def test_multiple_flags_last_wins(self):
         """When multiple jobserver flags exist, last one wins."""
         makeflags = " --jobserver-fds=3,4 --jobserver-auth=fifo:/tmp/fifo --jobserver-auth=7,8"
-        assert get_jobserver_config(makeflags) == (7, 8)
+        assert get_jobserver_config(makeflags) is None
+        makeflags = " --jobserver-auth=7,8 --jobserver-auth=fifo:/tmp/fifo"
+        assert get_jobserver_config(makeflags) == "/tmp/fifo"
 
     def test_invalid_format(self):
         assert get_jobserver_config(" --jobserver-auth=3") is None
@@ -183,28 +188,20 @@ class TestJobServer:
             js2.close()
             js1.close()
 
-    def test_setup_attaches_to_pipe_from_makeflags(self):
-        """An old-style pipe jobserver advertised in MAKEFLAGS is validated and adopted."""
+    def test_setup_ignores_pipe_from_makeflags(self):
+        """Spack does not attach to an old pipe jobserver advertised in MAKEFLAGS."""
         r, w = os.pipe()
-        js = PosixJobServer(4, makeflags=f" -j4 --jobserver-auth={r},{w}")
         try:
-            assert js.created is False
-            assert js.fifo_path is None
-            assert (js.r, js.w) == (r, w)
+            js = PosixJobServer(4, makeflags=f" -j4 --jobserver-auth={r},{w}")
+            try:
+                assert js.created is True
+                assert js.fifo_path is not None
+                assert (js.r, js.w) != (r, w)
+            finally:
+                js.close()
         finally:
-            js.close()  # closes r and w through the Connection objects
-
-    def test_setup_invalid_pipe_fds_creates_fifo(self):
-        """Invalid jobserver file descriptors in MAKEFLAGS fall back to a new FIFO."""
-        r, w = os.pipe()
-        os.close(r)
-        os.close(w)
-        js = PosixJobServer(2, makeflags=f" -j2 --jobserver-auth={r},{w}")
-        try:
-            assert js.created is True
-            assert js.fifo_path is not None
-        finally:
-            js.close()
+            os.close(r)
+            os.close(w)
 
     def test_update_selector_registers_and_unregisters(self):
         """update_selector idempotently (un)registers the token fd based on the wake flag."""
@@ -268,46 +265,46 @@ class TestJobServer:
             js.close()
 
     def test_makeflags_fifo_gmake_44(self):
-        """Should return FIFO format for gmake >= 4.4."""
+        """Should use fifo style for gmake >= 4.4."""
         js = PosixJobServer(8, makeflags="")
 
         try:
-            flags, data = js.makeflags_and_data(Spec("gmake@=4.4"))
-            assert flags == f" -j8 --jobserver-auth=fifo:{js.fifo_path}"
-            assert data is None
+            makeflags = js.makeflags(Spec("gmake@=4.4"))
+            assert isinstance(makeflags, FifoMakeflags)
+            assert (makeflags.fifo_path, makeflags.num_jobs) == (js.fifo_path, 8)
         finally:
             js.close()
 
     def test_makeflags_pipe_gmake_40(self):
-        """Should return pipe format for gmake 4.0-4.3."""
+        """Should use pipe style for gmake 4.0-4.3."""
         js = PosixJobServer(8, makeflags="")
 
         try:
-            flags, data = js.makeflags_and_data(Spec("gmake@=4.0"))
-            assert flags == f" -j8 --jobserver-auth={js.r},{js.w}"
-            assert data == (js.r_conn, js.w_conn)
+            makeflags = js.makeflags(Spec("gmake@=4.0"))
+            assert isinstance(makeflags, PipeMakeflags)
+            assert (makeflags.fifo_path, makeflags.flag) == (js.fifo_path, "--jobserver-auth")
         finally:
             js.close()
 
-    def test_makeflags_old_format_gmake_3(self):
-        """Should return old --jobserver-fds format for gmake < 4.0."""
+    def test_makeflags_pipe_old_flag_gmake_3(self):
+        """Should use pipe style with the old --jobserver-fds flag name for gmake < 4.0."""
         js = PosixJobServer(8, makeflags="")
 
         try:
-            flags, data = js.makeflags_and_data(Spec("gmake@=3.9"))
-            assert flags == f" -j8 --jobserver-fds={js.r},{js.w}"
-            assert data == (js.r_conn, js.w_conn)
+            makeflags = js.makeflags(Spec("gmake@=3.9"))
+            assert isinstance(makeflags, PipeMakeflags)
+            assert (makeflags.fifo_path, makeflags.flag) == (js.fifo_path, "--jobserver-fds")
         finally:
             js.close()
 
     def test_makeflags_no_gmake(self):
-        """Should return FIFO format when no gmake (modern default)."""
+        """Should use fifo style when there is no gmake (modern default)."""
         js = PosixJobServer(6, makeflags="")
 
         try:
-            flags, data = js.makeflags_and_data(None)
-            assert flags == f" -j6 --jobserver-auth=fifo:{js.fifo_path}"
-            assert data is None
+            makeflags = js.makeflags(None)
+            assert isinstance(makeflags, FifoMakeflags)
+            assert (makeflags.fifo_path, makeflags.num_jobs) == (js.fifo_path, 6)
         finally:
             js.close()
 
@@ -318,26 +315,6 @@ class TestJobServer:
         assert fifo_path and os.path.exists(fifo_path)
         js.close()
         assert not os.path.exists(os.path.dirname(fifo_path))
-
-    def test_file_descriptors_are_inheritable(self):
-        """Should set file descriptors as inheritable for child processes."""
-        js = PosixJobServer(4, makeflags="")
-
-        try:
-            assert os.get_inheritable(js.r)
-            assert os.get_inheritable(js.w)
-        finally:
-            js.close()
-
-    def test_connection_objects_exist(self):
-        """Should create Connection objects for fd inheritance."""
-        js = PosixJobServer(4, makeflags="")
-
-        try:
-            assert js.r_conn is not None and js.r_conn.fileno() == js.r
-            assert js.w_conn is not None and js.w_conn.fileno() == js.w
-        finally:
-            js.close()
 
     def test_close_warns_when_spack_holds_tokens(self):
         """Should warn when Spack closes the jobserver while still holding acquired tokens."""
@@ -501,4 +478,47 @@ class TestJobServer:
         finally:
             # Restore drained tokens so close() can clean up cleanly.
             os.write(js.w, drained)
+            js.close()
+
+
+def parse_pipe_fds(makeflags: str):
+    """Return the (r, w) pair advertised in a pipe style MAKEFLAGS value."""
+    r, w = makeflags.rsplit("=", 1)[1].split(",")
+    return int(r), int(w)
+
+
+class TestApplyMakeflags:
+    """Test applying MAKEFLAGS to an environment, which happens in the build child process."""
+
+    def test_fifo_style(self):
+        """Fifo style points gmake at the FIFO by path."""
+        env = {}
+        FifoMakeflags("/tmp/x", 4).apply(env)
+        assert env["MAKEFLAGS"] == " -j4 --jobserver-auth=fifo:/tmp/x"
+
+    def test_no_makeflags(self):
+        """No jobserver: nothing to set."""
+        env = {}
+        NoMakeflags().apply(env)
+        assert env == {}
+
+    def test_pipe_style_uses_fresh_blocking_fds(self):
+        """Pipe style should make the build process open its own fds, distinct from Spack's, and
+        end up blocking rather than inheriting Spack's non-blocking read fd."""
+        js = PosixJobServer(4, makeflags="")
+        try:
+            env = {}
+            PipeMakeflags(js.fifo_path, "--jobserver-auth").apply(env)
+            # The -j flag has no number: a number makes old gmake ignore the jobserver.
+            assert env["MAKEFLAGS"].startswith(" -j --jobserver-auth=")
+            r, w = parse_pipe_fds(env["MAKEFLAGS"])
+            try:
+                assert (r, w) != (js.r, js.w)
+                assert not (fcntl.fcntl(r, fcntl.F_GETFL) & os.O_NONBLOCK)
+                os.write(js.w, b"+")
+                assert os.read(r, 1) == b"+"
+            finally:
+                os.close(r)
+                os.close(w)
+        finally:
             js.close()


### PR DESCRIPTION
Closes #52808

Old gmake uses a pipe based jobserver, and support for it existed on two
sides:

1. Spack running under an old style jobserver
2. Spack creating a fifo jobserver, but adding a compatibility layer to
   support builds with `%gmake@old`.

This commit drops support for (1) and fixes support for (2).

Item (2) was broken in three different ways:

1. Old gmake reads `MAKEFLAGS= -jN` the same as the command line
   override, uses `N` new jobs, and ignores Spack's jobserver;
2. Old gmake requires a blocking read fd for the jobserver, but Spack
   passed the same fd from the parent process, which is non-blocking;
3. Spack computed the `MAKEFLAGS=--jobserver-auth=R,W` in the parent
   process and passed it on to the build subprocess, which works under
   fork, but not under forkserver, where the kernel may assign different
   fd numbers.

The fix is to let Spack pass an action related to MAKEFLAGS to the build
subproces, which on POSIX is either to just set the variable to advertise the
fifo path, or open the fifo and advertise correct fds. So, move some logic
from parent process to build process.

