### PR TITLE
level-opt format

### DIFF
--- a/lib/spack/spack/cmd/spec.py
+++ b/lib/spack/spack/cmd/spec.py
@@ -110,38 +110,85 @@ def _process_result(result, show, required_format, kwargs):
 
         print()
         maxlen = max(len(s.name) for s in result.criteria)
-        color.cprint("@*{  Priority  Value  Criterion}")
 
-        # Width of a data row past its 2-space indent, matching the row format below:
-        # 8-wide priority + 2 gap + 5-wide value + 2 gap + maxlen-wide criterion name.
-        divider_width = 8 + 2 + 5 + 2 + maxlen
+        # Build a 2D array: (name, band) => list of values by level
+        criteria_by_priority = sorted(result.criteria, key=lambda x: x.priority, reverse=True)
+        row_order = []
+        row_kinds = {}  # Store the kind for each (name, band)
+        seen = set()
+        for criterion in criteria_by_priority:
+            key = (criterion.name, criterion.band)
+            if key not in seen:
+                row_order.append(key)
+                row_kinds[key] = criterion.kind
+                seen.add(key)
+
+        max_level = max(criterion.level for criterion in result.criteria) if result.criteria else 0
+        num_levels = max_level + 1
+        rows = {key: [None] * num_levels for key in row_order}
+
+        for criterion in result.criteria:
+            key = (criterion.name, criterion.band)
+            rows[key][max_level - criterion.level] = criterion.value
+
+        # Remove prefix sum effect from criteria values
+        for key in rows:
+            row = rows[key]
+            prev_cumulative = 0
+            for i in range(len(row)):
+                if row[i] is not None:
+                    cumulative_value = row[i]
+                    row[i] = cumulative_value - prev_cumulative
+                    prev_cumulative = cumulative_value
+
+        # Print header with level labels (L0 for highest level, L1, L2... for lower)
+        level_headers = "  ".join(f"L{i}".rjust(5) for i in range(num_levels))
+        color.cprint(f"@*{{  {level_headers}  Criterion}}")
+
+        # Width of a data row:
+        # (5-wide value + 2 gap) * num_levels + maxlen-wide criterion name
+        divider_width = (5 + 2) * num_levels + maxlen
         prev_band = None
 
-        for i, criterion in enumerate(result.criteria, 1):
-            # Criteria are grouped into priority bands; print a header when the band changes.
-            band = criterion.band
+        # Print criteria using the 2D table
+        for name, band in row_order:
+            # Print band header when it changes
             if band != prev_band:
                 label = f"-- {band}"
                 dashes = "-" * max(0, divider_width - len(label) - 1)
                 color.cprint(f"  @*{{{label}}} @K{{{dashes}}}")
                 prev_band = band
 
-            value = f"@K{{{criterion.value:>5}}}"
-            grey_out = True
-            if criterion.value > 0:
-                value = f"@*{{{criterion.value:>5}}}"
-                grey_out = False
+            # Build the values string for all levels (highest level first, on the left)
+            row_data = rows[(name, band)]
+            values_parts = []
+            has_nonzero = False
+            # Iterate through the row
+            for value in row_data:
+                if value is not None:
+                    if value > 0:
+                        has_nonzero = True
+                        values_parts.append(f"@*{{{value:>5}}}")
+                    else:
+                        values_parts.append(f"@K{{{value:>5}}}")
+                else:
+                    values_parts.append(f"@K{{{'    -'}}}")
 
-            if grey_out:
-                lc = "@K"
-            elif criterion.kind == asp.OptimizationKind.CONCRETE:
-                lc = "@b"
-            elif criterion.kind == asp.OptimizationKind.BUILD:
-                lc = "@g"
+            values_str = "  ".join(values_parts)
+
+            # Determine color: only color if there's a non-zero value
+            kind = row_kinds[(name, band)]
+            if has_nonzero:
+                if kind == asp.OptimizationKind.CONCRETE:
+                    lc = "@b"
+                elif kind == asp.OptimizationKind.BUILD:
+                    lc = "@g"
+                else:
+                    lc = "@y"
             else:
-                lc = "@y"
+                lc = "@K"
 
-            color.cprint(f"  @K{{{i:8}}}  {value}  {lc}{{{criterion.name:<{maxlen}}}}")
+            color.cprint(f"  {values_str}  {lc}{{{name:<{maxlen}}}}")
         print()
         print()
         color.cprint("  @*{Legend:}")

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -137,6 +137,7 @@ class OptimizationCriteria(NamedTuple):
     value: int
     name: str
     band: str
+    level: int
     kind: OptimizationKind
 
 
@@ -155,17 +156,18 @@ def build_criteria_names(costs, arg_tuples):
     }
 
     for args in arg_tuples:
-        priority, band, name = args[0], band_names[args[2]].value, args[5]
+        priority, band, level, name = args[0], band_names[args[2]].value, args[4], args[5]
         priority = int(priority)
+        level = int(level)
 
         if band == OptimizationBand.REUSED.value:
             # Reused/concrete criterion
-            priorities_names.append((priority, name, band, OptimizationKind.CONCRETE))
+            priorities_names.append((priority, name, band, level, OptimizationKind.CONCRETE))
         elif band == OptimizationBand.BUILD.value:
             # Build criterion
-            priorities_names.append((priority, name, band, OptimizationKind.BUILD))
+            priorities_names.append((priority, name, band, level, OptimizationKind.BUILD))
         else:
-            priorities_names.append((priority, name, band, OptimizationKind.OTHER))
+            priorities_names.append((priority, name, band, level, OptimizationKind.OTHER))
 
     # sort the criteria by priority
     priorities_names = sorted(priorities_names, reverse=True)
@@ -176,8 +178,8 @@ def build_criteria_names(costs, arg_tuples):
     costs = costs[error_criteria:]
 
     return [
-        OptimizationCriteria(priority, value, name, band, status)
-        for (priority, name, band, status), value in zip(priorities_names, costs)
+        OptimizationCriteria(priority, value, name, band, level, status)
+        for (priority, name, band, level, status), value in zip(priorities_names, costs)
     ]
 
 

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -155,7 +155,7 @@ def build_criteria_names(costs, arg_tuples):
     }
 
     for args in arg_tuples:
-        priority, band, name = args[0], band_names[args[2]].value, args[4]
+        priority, band, name = args[0], band_names[args[2]].value, args[5]
         priority = int(priority)
 
         if band == OptimizationBand.REUSED.value:

--- a/lib/spack/spack/solver/compat.py
+++ b/lib/spack/spack/solver/compat.py
@@ -240,12 +240,18 @@ def default_clingo_control() -> Any:
     if clingo_flavor() is ClingoFlavor.V6:
         # clingo 6 has no `.configuration` API; pass equivalents as CLI options.
         return _ClingoV6Control(
-            ("--configuration=tweety", "--heuristic=Domain", "--opt-strategy=usc")
+            (
+                "--configuration=tweety",
+                "--heuristic=Domain",
+                "--opt-strategy=usc",
+                "--opt-heuristic=model",
+            )
         )
     control = clingo().Control()
     control.configuration.configuration = "tweety"
     control.configuration.solver.heuristic = "Domain"
     control.configuration.solver.opt_strategy = "usc"
+    control.configuration.solver.opt_heuristic = "model"
     return control
 
 

--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -2217,8 +2217,6 @@ build(PackageNode) :- attr("node", PackageNode), not concrete(PackageNode).
 #const built_offset = hinge_offset + indep_opt.
 #const high_offset  = built_offset + max_depth * level_opt.
 #const error_offset = high_offset + indep_opt.
-%   type
-#const fixed_offset = (max_depth - 1) * level_opt.
 
 % Build priority
 
@@ -2296,50 +2294,50 @@ level(Package, L-1) :-
 %-----------------------------------------------------------------------------
 % Optimization Criteria
 %-----------------------------------------------------------------------------
-% opt_criterion(Priority, Location, Type, Level (for fixed only), Description)
+% opt_criterion(Priority, Location, Type, Level, Description)
 
-opt_criterion(0, "high", "", 0, "requirement weight").
+opt_criterion(0, "high", "", max_depth-1, "requirement weight").
 
-opt_criterion(12, "built", "fixed", 0, "deprecated versions used").
-opt_criterion(11, "built", "fixed", 0, "version badness (roots)").
-opt_criterion(10, "built", "fixed", 0, "variant penalty (roots)").
-opt_criterion(9, "built", "fixed", 0, "default values of variants not being used (roots)").
-opt_criterion(8, "built", "fixed", 0, "preferred compilers").
-opt_criterion(7, "built", "fixed", 0, "compiler penalty from reuse").
-opt_criterion(6, "built", "level", 1, "variant penalty (non-roots)").
-opt_criterion(5, "built", "fixed", 1, "preferred providers (excluded compilers and language runtimes)").
-opt_criterion(4, "built", "fixed", 1, "number of compilers used on the same node").
-opt_criterion(3, "built", "fixed", 1, "non-preferred OS's").
-opt_criterion(2, "built", "level", 1, "version badness (non roots)").
-opt_criterion(1, "built", "level", 1, "default values of variants not being used (non-roots)").
-opt_criterion(0, "built", "fixed", 1, "preferred providers (language runtimes)").
+opt_criterion(12, "built", "fixed", max_depth-1, "deprecated versions used").
+opt_criterion(11, "built", "fixed", max_depth-1, "version badness (roots)").
+opt_criterion(10, "built", "fixed", max_depth-1, "variant penalty (roots)").
+opt_criterion(9, "built", "fixed", max_depth-1, "default values of variants not being used (roots)").
+opt_criterion(8, "built", "fixed", max_depth-1, "preferred compilers").
+opt_criterion(7, "built", "fixed", max_depth-1, "compiler penalty from reuse").
+opt_criterion(6, "built", "level", 0, "variant penalty (non-roots)").
+opt_criterion(5, "built", "fixed", 0, "preferred providers (excluded compilers and language runtimes)").
+opt_criterion(4, "built", "fixed", 0, "number of compilers used on the same node").
+opt_criterion(3, "built", "fixed", 0, "non-preferred OS's").
+opt_criterion(2, "built", "level", 0, "version badness (non roots)").
+opt_criterion(1, "built", "level", 0, "default values of variants not being used (non-roots)").
+opt_criterion(0, "built", "fixed", 0, "preferred providers (language runtimes)").
 
-opt_criterion(2, "hinge", "", 0, "number of packages to build (vs. reuse)").
-opt_criterion(1, "hinge", "", 0, "number of nodes from the same package").
-opt_criterion(0, "hinge", "", 0, "build unification sets").
+opt_criterion(2, "hinge", "", max_depth-1, "number of packages to build (vs. reuse)").
+opt_criterion(1, "hinge", "", max_depth-1, "number of nodes from the same package").
+opt_criterion(0, "hinge", "", max_depth-1, "build unification sets").
 
-opt_criterion(12, "concr", "fixed", 0, "deprecated versions used").
-opt_criterion(11, "concr", "fixed", 0, "version badness (roots)").
-opt_criterion(10, "concr", "fixed", 0, "variant penalty (roots)").
-opt_criterion(9, "concr", "fixed", 0, "default values of variants not being used (roots)").
-opt_criterion(8, "concr", "fixed", 0, "preferred compilers").
-opt_criterion(7, "concr", "fixed", 0, "compiler penalty from reuse").
-opt_criterion(6, "concr", "level", 1, "variant penalty (non-roots)").
-opt_criterion(5, "concr", "fixed", 1, "preferred providers (excluded compilers and language runtimes)").
-opt_criterion(4, "concr", "fixed", 1, "number of compilers used on the same node").
-opt_criterion(3, "concr", "fixed", 1, "non-preferred OS's").
-opt_criterion(2, "concr", "level", 1, "version badness (non roots)").
-opt_criterion(1, "concr", "level", 1, "default values of variants not being used (non-roots)").
-opt_criterion(0, "concr", "fixed", 1, "preferred providers (language runtimes)").
+opt_criterion(12, "concr", "fixed", max_depth-1, "deprecated versions used").
+opt_criterion(11, "concr", "fixed", max_depth-1, "version badness (roots)").
+opt_criterion(10, "concr", "fixed", max_depth-1, "variant penalty (roots)").
+opt_criterion(9, "concr", "fixed", max_depth-1, "default values of variants not being used (roots)").
+opt_criterion(8, "concr", "fixed", max_depth-1, "preferred compilers").
+opt_criterion(7, "concr", "fixed", max_depth-1, "compiler penalty from reuse").
+opt_criterion(6, "concr", "level", 0, "variant penalty (non-roots)").
+opt_criterion(5, "concr", "fixed", 0, "preferred providers (excluded compilers and language runtimes)").
+opt_criterion(4, "concr", "fixed", 0, "number of compilers used on the same node").
+opt_criterion(3, "concr", "fixed", 0, "non-preferred OS's").
+opt_criterion(2, "concr", "level", 0, "version badness (non roots)").
+opt_criterion(1, "concr", "level", 0, "default values of variants not being used (non-roots)").
+opt_criterion(0, "concr", "fixed", 0, "preferred providers (language runtimes)").
 
-opt_criterion(7, "low", "", 0, "target mismatches (built nodes)").
-opt_criterion(6, "low", "", 0, "non-preferred targets").
-opt_criterion(5, "low", "", 0, "target mismatches (reused nodes)").
-opt_criterion(4, "low", "", 0, "version badness (runtimes)").
-opt_criterion(3, "low", "", 0, "non-preferred targets (runtimes)").
-opt_criterion(2, "low", "", 0, "providers on edges").
-opt_criterion(1, "low", "", 0, "version badness on edges").
-opt_criterion(0, "low", "", 0, "penalty on symmetric duplicates").
+opt_criterion(7, "low", "", max_depth-1, "target mismatches (built nodes)").
+opt_criterion(6, "low", "", max_depth-1, "non-preferred targets").
+opt_criterion(5, "low", "", max_depth-1, "target mismatches (reused nodes)").
+opt_criterion(4, "low", "", max_depth-1, "version badness (runtimes)").
+opt_criterion(3, "low", "", max_depth-1, "non-preferred targets (runtimes)").
+opt_criterion(2, "low", "", max_depth-1, "providers on edges").
+opt_criterion(1, "low", "", max_depth-1, "version badness on edges").
+opt_criterion(0, "low", "", max_depth-1, "penalty on symmetric duplicates").
 
 %----------------------------------------------------------------------------
 % Show optimization criteria
@@ -2349,23 +2347,18 @@ opt_criterion(0, "low", "", 0, "penalty on symmetric duplicates").
 % be used when writing the actual minimization criteria
 
 % compute criteria priority
-
-% !!!-- TODO --!!!
-% levelized criteria are currently from 0 to max_depth-2 instead of max_depth-1
-% in order to match the output of develop branch
-
 opt_priority(Priority, high_offset, "high", "", Level, Description) :-
     opt_criterion(N, "high", _, Level, Description),
     Priority = N + high_offset.
 
 opt_priority(Priority, built_offset, "built", "fixed", Level, Description) :-
     opt_criterion(N, "built", "fixed", Level, Description),
-    Priority = N + built_offset + fixed_offset - (Level*level_opt).
+    Priority = N + built_offset + (Level*level_opt).
 
 opt_priority(Priority, built_offset, "built", "level", Level, Description) :-
     opt_criterion(N, "built", "level", _, Description),
     Priority = N + built_offset + (Level*level_opt),
-    Level = 0..(max_depth-2).
+    Level = 0..(max_depth-1).
 
 opt_priority(Priority, hinge_offset, "hinge", "", Level, Description) :-
     opt_criterion(N, "hinge", _, Level, Description),
@@ -2373,12 +2366,12 @@ opt_priority(Priority, hinge_offset, "hinge", "", Level, Description) :-
 
 opt_priority(Priority, concr_offset, "concr", "fixed", Level, Description) :-
     opt_criterion(N, "concr", "fixed", Level, Description),
-    Priority = N + concr_offset + fixed_offset - (Level*level_opt).
+    Priority = N + concr_offset + (Level*level_opt).
 
 opt_priority(Priority, concr_offset, "concr", "level", Level, Description) :-
     opt_criterion(N, "concr", "level", _, Description),
     Priority = N + concr_offset + (Level*level_opt),
-    Level = 0..(max_depth-2).
+    Level = 0..(max_depth-1).
 
 opt_priority(Priority, low_offset, "low", "", Level, Description) :-
     opt_criterion(N, "low", _, Level, Description),

--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -2208,7 +2208,6 @@ build(PackageNode) :- attr("node", PackageNode), not concrete(PackageNode).
 % Constants for calculating optimization criterion priority
 %   level_opt is level & fixed per level
 %   indep_opt is per high/hinge/low
-#const max_depth = 1.
 #const level_opt = 32.
 #const indep_opt = 16.
 %   location
@@ -2228,6 +2227,58 @@ treat_node_as_concrete(node(X, Package)) :- attr("node", node(X, Package)), runt
 build_priority(PackageNode, built_offset) :- build(PackageNode), attr("node", PackageNode), not treat_node_as_concrete(PackageNode).
 build_priority(PackageNode, concr_offset) :- build(PackageNode), attr("node", PackageNode), treat_node_as_concrete(PackageNode).
 build_priority(PackageNode, concr_offset) :- concrete(PackageNode), attr("node", PackageNode).
+
+%-----------------------------------------------------------------------------
+% DAG Node Level
+%-----------------------------------------------------------------------------
+% We define the "level" of a package node as its minimum depth in the DAG. For
+% convenience of optimization priority computation, level values are
+% reversed: roots are set to `max_depth` with level decreasing further into
+% the DAG.
+%
+% if max_depth = 6:
+%
+%       A       level = 5
+%      / \
+%     B   C     level = 4
+%     |  /
+%     D /       level = 3
+%     |/
+%     E         level = 3
+%
+% Computing exact depth for package nodes during search is costly and
+% inefficient for the solver. For all possible paths to a node, all edges must
+% be assigned for clingo to derive a depth. What we really want is a depth
+% value that can change when new packages nodes are created during the search.
+% First order logic is monotonic, so we cannot "disprove" a level with additional
+% facts.
+%
+% Since dependency paths cannot be deleted without backtracking, level is a
+% monotonically increasing property of package nodes. Thus we can treat level
+% facts as "level is at least N", written as `level(PackageNode, N)`. If shorter
+% paths are derived, we derive a new `level(PackageNode, M)` fact. We avoid
+% taking the minimum of these facts with the following trick.
+%
+% Package nodes can have multiple `level(PackageNode, _)` facts derived from
+% different paths, so we enforce that `level(PackageNode, N)` implies
+% `level(PackageNode, N-1)`. Because optimization criteria is lexicographically
+% optimized by priority, an optimal solution with a cost of [x_1, x_2, x_3, ...]
+% will also be the optimal solution if cost is "prefix summed":
+% [x_1, x_1 + x_2, x_1 + x_2 + x_3, ...]. This prefix sum effect is removed when
+% displaying optimization criteria to the user for clarity.
+%
+% Because all level(PackageNode, _) facts are derived easily by unit propagation,
+% it should be easier for clingo to find unsat cores for optimization.
+
+#const max_depth = 2.
+level(Package, max_depth-1) :- attr("root", Package).
+level(Package, 0)           :- attr("node", Package).
+level(Package, L-1)         :- level(Package, L), L > 1.
+level(Package, L-1) :-
+    attr("node", Package),
+    level(Dependent, L),
+    depends_on(Dependent, Package),
+    L > 1.
 
 %----------------------------------------------------------------------
 % Errors
@@ -2255,13 +2306,13 @@ opt_criterion(10, "built", "fixed", 0, "variant penalty (roots)").
 opt_criterion(9, "built", "fixed", 0, "default values of variants not being used (roots)").
 opt_criterion(8, "built", "fixed", 0, "preferred compilers").
 opt_criterion(7, "built", "fixed", 0, "compiler penalty from reuse").
-opt_criterion(6, "built", "fixed", 0, "variant penalty (non-roots)").
-opt_criterion(5, "built", "fixed", 0, "preferred providers (excluded compilers and language runtimes)").
-opt_criterion(4, "built", "fixed", 0, "number of compilers used on the same node").
-opt_criterion(3, "built", "fixed", 0, "non-preferred OS's").
-opt_criterion(2, "built", "fixed", 0, "version badness (non roots)").
-opt_criterion(1, "built", "fixed", 0, "default values of variants not being used (non-roots)").
-opt_criterion(0, "built", "fixed", 0, "preferred providers (language runtimes)").
+opt_criterion(6, "built", "level", 1, "variant penalty (non-roots)").
+opt_criterion(5, "built", "fixed", 1, "preferred providers (excluded compilers and language runtimes)").
+opt_criterion(4, "built", "fixed", 1, "number of compilers used on the same node").
+opt_criterion(3, "built", "fixed", 1, "non-preferred OS's").
+opt_criterion(2, "built", "level", 1, "version badness (non roots)").
+opt_criterion(1, "built", "level", 1, "default values of variants not being used (non-roots)").
+opt_criterion(0, "built", "fixed", 1, "preferred providers (language runtimes)").
 
 opt_criterion(2, "hinge", "", 0, "number of packages to build (vs. reuse)").
 opt_criterion(1, "hinge", "", 0, "number of nodes from the same package").
@@ -2273,13 +2324,13 @@ opt_criterion(10, "concr", "fixed", 0, "variant penalty (roots)").
 opt_criterion(9, "concr", "fixed", 0, "default values of variants not being used (roots)").
 opt_criterion(8, "concr", "fixed", 0, "preferred compilers").
 opt_criterion(7, "concr", "fixed", 0, "compiler penalty from reuse").
-opt_criterion(6, "concr", "fixed", 0, "variant penalty (non-roots)").
-opt_criterion(5, "concr", "fixed", 0, "preferred providers (excluded compilers and language runtimes)").
-opt_criterion(4, "concr", "fixed", 0, "number of compilers used on the same node").
-opt_criterion(3, "concr", "fixed", 0, "non-preferred OS's").
-opt_criterion(2, "concr", "fixed", 0, "version badness (non roots)").
-opt_criterion(1, "concr", "fixed", 0, "default values of variants not being used (non-roots)").
-opt_criterion(0, "concr", "fixed", 0, "preferred providers (language runtimes)").
+opt_criterion(6, "concr", "level", 1, "variant penalty (non-roots)").
+opt_criterion(5, "concr", "fixed", 1, "preferred providers (excluded compilers and language runtimes)").
+opt_criterion(4, "concr", "fixed", 1, "number of compilers used on the same node").
+opt_criterion(3, "concr", "fixed", 1, "non-preferred OS's").
+opt_criterion(2, "concr", "level", 1, "version badness (non roots)").
+opt_criterion(1, "concr", "level", 1, "default values of variants not being used (non-roots)").
+opt_criterion(0, "concr", "fixed", 1, "preferred providers (language runtimes)").
 
 opt_criterion(7, "low", "", 0, "target mismatches (built nodes)").
 opt_criterion(6, "low", "", 0, "non-preferred targets").
@@ -2298,28 +2349,43 @@ opt_criterion(0, "low", "", 0, "penalty on symmetric duplicates").
 % be used when writing the actual minimization criteria
 
 % compute criteria priority
-opt_priority(Priority, high_offset, "high", "", Description) :-
-    opt_criterion(N, "high", _, _, Description),
+
+% !!!-- TODO --!!!
+% levelized criteria are currently from 0 to max_depth-2 instead of max_depth-1
+% in order to match the output of develop branch
+
+opt_priority(Priority, high_offset, "high", "", Level, Description) :-
+    opt_criterion(N, "high", _, Level, Description),
     Priority = N + high_offset.
 
-opt_priority(Priority, built_offset, "built", "fixed", Description) :-
+opt_priority(Priority, built_offset, "built", "fixed", Level, Description) :-
     opt_criterion(N, "built", "fixed", Level, Description),
     Priority = N + built_offset + fixed_offset - (Level*level_opt).
 
-opt_priority(Priority, hinge_offset, "hinge", "", Description) :-
-    opt_criterion(N, "hinge", _, _, Description),
+opt_priority(Priority, built_offset, "built", "level", Level, Description) :-
+    opt_criterion(N, "built", "level", _, Description),
+    Priority = N + built_offset + (Level*level_opt),
+    Level = 0..(max_depth-2).
+
+opt_priority(Priority, hinge_offset, "hinge", "", Level, Description) :-
+    opt_criterion(N, "hinge", _, Level, Description),
     Priority = N + hinge_offset.
 
-opt_priority(Priority, concr_offset, "concr", "fixed", Description) :-
+opt_priority(Priority, concr_offset, "concr", "fixed", Level, Description) :-
     opt_criterion(N, "concr", "fixed", Level, Description),
     Priority = N + concr_offset + fixed_offset - (Level*level_opt).
 
-opt_priority(Priority, low_offset, "low", "", Description) :-
-    opt_criterion(N, "low", _, _, Description),
+opt_priority(Priority, concr_offset, "concr", "level", Level, Description) :-
+    opt_criterion(N, "concr", "level", _, Description),
+    Priority = N + concr_offset + (Level*level_opt),
+    Level = 0..(max_depth-2).
+
+opt_priority(Priority, low_offset, "low", "", Level, Description) :-
+    opt_criterion(N, "low", _, Level, Description),
     Priority = N + low_offset.
 
 % show criteria
-#minimize { 0@Priority: opt_priority(Priority, _, _, _, _) }.
+#minimize { 0@Priority: opt_priority(Priority, _, _, _, _, _) }.
 
 %-----------------------------------------------------------------------------
 % Optimization minimize blocks
@@ -2334,28 +2400,28 @@ opt_priority(Priority, low_offset, "low", "", Description) :-
 #minimize {
     Weight@Priority, PackageNode,Group
     : requirement_penalty(PackageNode, Group, Weight),
-      opt_priority(Priority, _, _, _, "requirement weight");
+      opt_priority(Priority, _, _, _, _, "requirement weight");
 
     Weight@Priority, PackageNode,Language,Group
     : requirement_penalty(PackageNode, Language, Group, Weight),
-      opt_priority(Priority, _, _, _, "requirement weight")
+      opt_priority(Priority, _, _, _, _, "requirement weight")
 }.
 
 % Try hard to reuse installed packages (i.e., minimize the number built)
 #minimize {
     1@Priority, PackageNode
     : build(PackageNode), not treat_node_as_concrete(PackageNode),
-      opt_priority(Priority, _, _, _, "number of packages to build (vs. reuse)")
+      opt_priority(Priority, _, _, _, _, "number of packages to build (vs. reuse)")
 }.
 
 % Minimize number of nodes from the same package
 #minimize {
     ID@Priority, Package
     : attr("node", node(ID, Package)), not is_self_build_req(node(ID, Package)),
-      opt_priority(Priority, _, _, _, "number of nodes from the same package");
+      opt_priority(Priority, _, _, _, _, "number of nodes from the same package");
     ID@Priority, Package
     : attr("virtual_node", node(ID, Package)),
-      opt_priority(Priority, _, _, _, "number of nodes from the same package")
+      opt_priority(Priority, _, _, _, _, "number of nodes from the same package")
 }.
 #defined optimize_for_reuse/0.
 
@@ -2364,7 +2430,7 @@ opt_priority(Priority, low_offset, "low", "", Description) :-
 #minimize{
     ID@Priority, ParentNode
     : build_set_id(ParentNode, ID),
-      opt_priority(Priority, _, _, _, "build unification sets")
+      opt_priority(Priority, _, _, _, _, "build unification sets")
 }.
 
 % Minimize the number of deprecated versions being used
@@ -2373,7 +2439,7 @@ opt_priority(Priority, low_offset, "low", "", Description) :-
     : attr("deprecated", PackageNode, _),
       not external(PackageNode),
       build_priority(PackageNode, BuildPriority),
-      opt_priority(Priority, BuildPriority, _, _, "deprecated versions used")
+      opt_priority(Priority, BuildPriority, _, _, _, "deprecated versions used")
 }.
 
 % Minimize the:
@@ -2385,13 +2451,13 @@ opt_priority(Priority, low_offset, "low", "", Description) :-
     : attr("root", PackageNode),
       version_weight(PackageNode, Weight),
       build_priority(PackageNode, BuildPriority),
-      opt_priority(Priority, BuildPriority, _, _, "version badness (roots)");
+      opt_priority(Priority, BuildPriority, _, _, _, "version badness (roots)");
     
     Penalty@Priority, PackageNode
     : attr("root", PackageNode),
       version_deprecation_penalty(PackageNode, Penalty),
       build_priority(PackageNode, BuildPriority),
-      opt_priority(Priority, BuildPriority, _, _, "version badness (roots)")
+      opt_priority(Priority, BuildPriority, _, _, _, "version badness (roots)")
 }.
 
 #minimize {
@@ -2399,7 +2465,7 @@ opt_priority(Priority, low_offset, "low", "", Description) :-
     : variant_penalty(PackageNode, Variant, Value, Penalty),
       attr("root", PackageNode),
       build_priority(PackageNode, BuildPriority),
-      opt_priority(Priority, BuildPriority, _, _, "variant penalty (roots)")
+      opt_priority(Priority, BuildPriority, _, _, _, "variant penalty (roots)")
 }.
 
 #minimize{
@@ -2407,7 +2473,7 @@ opt_priority(Priority, low_offset, "low", "", Description) :-
     : variant_default_not_used(PackageNode, Variant, Value),
       attr("root", PackageNode),
       build_priority(PackageNode, BuildPriority),
-      opt_priority(Priority, BuildPriority, _, _, "default values of variants not being used (roots)")
+      opt_priority(Priority, BuildPriority, _, _, _, "default values of variants not being used (roots)")
 }.
 
 % Choose the preferred compiler before penalizing variants, to avoid that a variant penalty
@@ -2417,13 +2483,13 @@ opt_priority(Priority, low_offset, "low", "", Description) :-
     : provider_weight(ProviderNode, node(X, Virtual), Weight),
       language(Virtual),
       build_priority(ProviderNode, BuildPriority),
-      opt_priority(Priority, BuildPriority, _, _, "preferred compilers")
+      opt_priority(Priority, BuildPriority, _, _, _, "preferred compilers")
 }.
 
 #minimize{
     1@Priority, Hash
     : compiler_penalty_from_reuse(Hash),
-      opt_priority(Priority, concr_offset, _, _, "compiler penalty from reuse")
+      opt_priority(Priority, concr_offset, _, _, _, "compiler penalty from reuse")
 }.
 
 % Try to use default variants or variants that have been set
@@ -2432,7 +2498,8 @@ opt_priority(Priority, low_offset, "low", "", Description) :-
     : variant_penalty(PackageNode, Variant, Value, Penalty),
       not attr("root", PackageNode),
       build_priority(PackageNode, BuildPriority),
-      opt_priority(Priority, BuildPriority, _, _, "variant penalty (non-roots)")
+      level(PackageNode, Level),
+      opt_priority(Priority, BuildPriority, _, _, Level, "variant penalty (non-roots)")
 }.
 
 % Minimize the weights of all the other providers (mpi, lapack, etc.)
@@ -2441,7 +2508,7 @@ opt_priority(Priority, low_offset, "low", "", Description) :-
     : provider_weight(ProviderNode, node(X, Virtual), Weight),
       not language(Virtual), not language_runtime(Virtual),
       build_priority(ProviderNode, BuildPriority),
-      opt_priority(Priority, BuildPriority, _, _, "preferred providers (excluded compilers and language runtimes)")
+      opt_priority(Priority, BuildPriority, _, _, _, "preferred providers (excluded compilers and language runtimes)")
 }.
 
 % Minimize the number of compilers used on nodes
@@ -2453,7 +2520,7 @@ compiler_penalty(PackageNode, C-1) :-
     Penalty@Priority, PackageNode
     : compiler_penalty(PackageNode, Penalty),
       build_priority(PackageNode, BuildPriority),
-      opt_priority(Priority, BuildPriority, _, _, "number of compilers used on the same node")
+      opt_priority(Priority, BuildPriority, _, _, _, "number of compilers used on the same node")
 }.
 
 % Minimize non-preferred OS's
@@ -2461,7 +2528,7 @@ compiler_penalty(PackageNode, C-1) :-
     Weight@Priority, PackageNode
     : node_os_weight(PackageNode, Weight),
       build_priority(PackageNode, BuildPriority),
-      opt_priority(Priority, BuildPriority, _, _, "non-preferred OS's")
+      opt_priority(Priority, BuildPriority, _, _, _, "non-preferred OS's")
 }.
 
 % Choose more recent versions for nodes
@@ -2471,14 +2538,16 @@ compiler_penalty(PackageNode, C-1) :-
       not attr("root", node(X, Package)),
       not runtime(Package),
       build_priority(node(X, Package), BuildPriority),
-      opt_priority(Priority, BuildPriority, _, _, "version badness (non roots)");
+      level(node(X, Package), Level),
+      opt_priority(Priority, BuildPriority, _, _, Level, "version badness (non roots)");
 
     Penalty@Priority, node(X, Package)
     : version_deprecation_penalty(node(X, Package), Penalty),
       not attr("root", node(X, Package)),
       not runtime(Package),
       build_priority(node(X, Package), BuildPriority),
-      opt_priority(Priority, BuildPriority, _, _, "version badness (non roots)")
+      level(node(X, Package), Level),
+      opt_priority(Priority, BuildPriority, _, _, Level, "version badness (non roots)")
 }.
 
 % Try to use all the default values of variants
@@ -2487,7 +2556,8 @@ compiler_penalty(PackageNode, C-1) :-
     : variant_default_not_used(PackageNode, Variant, Value),
       not attr("root", PackageNode),
       build_priority(PackageNode, BuildPriority),
-      opt_priority(Priority, BuildPriority, _, _, "default values of variants not being used (non-roots)")
+      level(PackageNode, Level),
+      opt_priority(Priority, BuildPriority, _, _, Level, "default values of variants not being used (non-roots)")
 }.
 
 % Prefer more optimal providers for language runtimes.
@@ -2496,7 +2566,7 @@ compiler_penalty(PackageNode, C-1) :-
     : provider_weight(ProviderNode, node(X, Virtual), Weight),
       language_runtime(Virtual),
       build_priority(ProviderNode, BuildPriority),
-      opt_priority(Priority, BuildPriority, _, _, "preferred providers (language runtimes)")
+      opt_priority(Priority, BuildPriority, _, _, _, "preferred providers (language runtimes)")
 }.
 
 % Build and concrete mismatches are sandwiched between node target penalty so that
@@ -2507,14 +2577,14 @@ compiler_penalty(PackageNode, C-1) :-
     : node_target_mismatch(PackageNode, node(ID, Dependency)),
       not runtime(Dependency),
       build_priority(node(ID, Dependency), built_offset),
-      opt_priority(Priority, _, _, _, "target mismatches (built nodes)")
+      opt_priority(Priority, _, _, _, _, "target mismatches (built nodes)")
 }.
 
 #minimize{
     Weight@Priority, node(X, Package)
     : node_target_weight(node(X, Package), Weight),
       not runtime(Package),
-      opt_priority(Priority, _, _, _, "non-preferred targets")
+      opt_priority(Priority, _, _, _, _, "non-preferred targets")
 }.
 
 #minimize{
@@ -2522,7 +2592,7 @@ compiler_penalty(PackageNode, C-1) :-
     : node_target_mismatch(PackageNode, node(ID, Dependency)),
       not runtime(Dependency),
       build_priority(node(ID, Dependency), concr_offset),
-      opt_priority(Priority, _, _, _, "target mismatches (reused nodes)")
+      opt_priority(Priority, _, _, _, _, "target mismatches (reused nodes)")
 }.
 
 % Choose more recent versions for runtimes
@@ -2530,7 +2600,7 @@ compiler_penalty(PackageNode, C-1) :-
     Weight@Priority, node(X, Package)
     : version_weight(node(X, Package), Weight),
       runtime(Package),
-      opt_priority(Priority, _, _, _, "version badness (runtimes)")
+      opt_priority(Priority, _, _, _, _, "version badness (runtimes)")
 }.
 
 % Choose best target for runtimes
@@ -2538,7 +2608,7 @@ compiler_penalty(PackageNode, C-1) :-
     Weight@Priority, node(X, Package)
     : node_target_weight(node(X, Package), Weight),
       runtime(Package),
-      opt_priority(Priority, _, _, _, "non-preferred targets (runtimes)")
+      opt_priority(Priority, _, _, _, _, "non-preferred targets (runtimes)")
 }.
 
 % Try to use the most optimal providers as much as possible
@@ -2549,7 +2619,7 @@ compiler_penalty(PackageNode, C-1) :-
       not attr("root", ProviderNode),
       language(Virtual),
       depends_on(ParentNode, ProviderNode),
-      opt_priority(Priority, _, _, _, "providers on edges")
+      opt_priority(Priority, _, _, _, _, "providers on edges")
 }.
 
 % Try to use latest versions of nodes as much as possible
@@ -2559,14 +2629,14 @@ compiler_penalty(PackageNode, C-1) :-
       multiple_unification_sets(Package),
       not attr("root", node(X, Package)),
       depends_on(ParentNode, node(X, Package)),
-      opt_priority(Priority, _, _, _, "version badness on edges")
+      opt_priority(Priority, _, _, _, _, "version badness on edges")
 }.
 
 % Reduce symmetry on duplicates
 #minimize{
     Weight@Priority, PackageNode,Reason
     : duplicate_penalty(PackageNode, Weight, Reason),
-      opt_priority(Priority, _, _, _, "penalty on symmetric duplicates")
+      opt_priority(Priority, _, _, _, _, "penalty on symmetric duplicates")
 }.
 
 

--- a/lib/spack/spack/solver/display.lp
+++ b/lib/spack/spack/solver/display.lp
@@ -15,7 +15,7 @@
 #show attr/5.
 #show attr/6.
 % names of optimization criteria
-#show opt_priority/5.
+#show opt_priority/6.
 
 % error types
 #show error/2.

--- a/lib/spack/spack/solver/when_possible.lp
+++ b/lib/spack/spack/solver/when_possible.lp
@@ -33,7 +33,7 @@ opt_criterion(1, "high", "", 0, "number of input specs not concretized").
 #minimize {
     1@Priority, ID
     : literal_not_solved(ID),
-    opt_priority(Priority, _, _, _, "number of input specs not concretized")
+    opt_priority(Priority, _, _, _, _, "number of input specs not concretized")
 }.
 
 #heuristic solve_literal(ID) : literal(ID). [1, sign]


### PR DESCRIPTION
Add formatting for level-optimization.

This PR also does a couple of small functionality changes:
- (non-roots) leveled optimization now optimizes at levels 0 and 1. This gives identical results since roots are optimized first anyway but gives a small (~2%) performance loss since there are just more criteria to optimize now.

The output now looks like (and works for higher values of max_depth):
```
     L0     L1  Criterion
  -- Highest priority --------------------------------------------------------
      0      -  requirement weight                                            
  -- Built nodes -------------------------------------------------------------
      0      -  deprecated versions used                                      
      0      -  version badness (roots)                                       
      0      -  variant penalty (roots)                                       
      0      -  default values of variants not being used (roots)             
      0      -  preferred compilers                                           
      0      -  compiler penalty from reuse                                   
      0      0  variant penalty (non-roots)                                   
      0      0  version badness (non roots)                                   
      0      0  default values of variants not being used (non-roots)         
      -      0  preferred providers (excluded compilers and language runtimes)
      -      1  number of compilers used on the same node                     
      -      0  non-preferred OS's                                            
      -      0  preferred providers (language runtimes)                       
  -- Fixed (reuse vs build) --------------------------------------------------
     22      -  number of packages to build (vs. reuse)                       
      0      -  number of nodes from the same package                         
      0      -  build unification sets                                        
  -- Reused nodes ------------------------------------------------------------
      0      -  deprecated versions used                                      
      0      -  version badness (roots)                                       
      0      -  variant penalty (roots)                                       
      0      -  default values of variants not being used (roots)             
      0      -  preferred compilers                                           
      0      -  compiler penalty from reuse                                   
      0      2  variant penalty (non-roots)                                   
      0      2  version badness (non roots)                                   
      0      0  default values of variants not being used (non-roots)         
      -      0  preferred providers (excluded compilers and language runtimes)
      -      0  number of compilers used on the same node                     
      -      0  non-preferred OS's                                            
      -      0  preferred providers (language runtimes)                       
  -- Lowest priority ---------------------------------------------------------
      0      -  target mismatches (built nodes)                               
     14      -  non-preferred targets                                         
      0      -  target mismatches (reused nodes)                              
      0      -  version badness (runtimes)                                    
      0      -  non-preferred targets (runtimes)                              
      0      -  providers on edges                                            
      4      -  version badness on edges                                      
      0      -  penalty on symmetric duplicates                               


  Legend:
    Specs to be built
    Reused specs
    Other criteria
```

Formatting was done with the help of Claude.