### PR TITLE
Windows: Sandboxing Support

### DIFF
--- a/lib/spack/docs/installing.rst
+++ b/lib/spack/docs/installing.rst
@@ -167,11 +167,10 @@ See :ref:`spack install <spack-install>` for the full set of flags related to de
 .. index::
    single: sandbox; configuring
 
-Build isolation and sandboxing (Linux)
+Build isolation and sandboxing
 --------------------------------------
 
 Spack can run builds in an unprivileged sandbox to restrict filesystem and network access.
-This opt-in feature requires Linux 5.13+ with Landlock support (network restrictions require Linux 6.7+).
 Sandboxing is meant for build reproducibility and bug containment rather than acting as a strict security boundary, as package recipes still execute outside the sandbox ahead of the build.
 
 When enabled, the stage directory, install prefix, system temp directory and ``/dev/null`` are implicitly writable.
@@ -183,7 +182,7 @@ All other paths must be explicitly allowed in configuration:
    config:
      sandbox:
        enable: true          # Enable for all builds
-       allow_network: false  # Disable TCP network access during the build phase
+       allow_network: false  # Disable network access during the build phase
        allow_read:           # Additional paths with read and execute permissions
        - /usr
        allow_write:          # Additional paths with write and execute permissions
@@ -194,4 +193,74 @@ Note that network restrictions only apply during the build phases, leaving Spack
 
 File system restrictions are complementary to existing file permissions and ACLs; they cannot grant access to files the user does not already have permission to read or write.
 
+The underlying isolation mechanism is platform-specific; see below for details.
+
+Linux (Landlock)
+^^^^^^^^^^^^^^^^
+
+On Linux, sandboxing uses the Landlock LSM and requires Linux 5.13+ (network restrictions require Linux 6.7+).
+
+Because Landlock lets a running process restrict itself in place, Spack applies the sandbox to
+the build process itself just before running the package's build phases: everything from that
+point on, including direct Python file I/O performed by the package recipe, is confined by the
+kernel.
+
 Spack's sandboxing complements external containerization tools like Podman or Bubblewrap: while a container must grant the main Spack process write access to the entire software store, Landlock dynamically confines each build subprocess strictly to its exact, package-specific install prefix.
+
+Windows (AppContainer)
+^^^^^^^^^^^^^^^^^^^^^^^
+
+On Windows, sandboxing uses `AppContainer isolation
+<https://learn.microsoft.com/en-us/windows/win32/secauthz/appcontainer-isolation>`_ and requires
+Windows 8 / Server 2012 or later.
+
+Unlike Landlock, a Windows AppContainer can only be established when a process is *created*;
+there is no supported way to confine an already-running process. Because of this, the Windows
+sandbox only confines the external build-tool subprocesses spawned during the build (compilers,
+``cmake``, ``make``, MSBuild, etc.); direct Python-level file I/O performed in-process by a
+package recipe (e.g. ``shutil.copy``, ``filter_file``, an in-process ``setup.py``) is **not**
+confined. This is an intentional, narrower guarantee than on Linux.
+
+Enforcement also works in the opposite direction from Landlock. Landlock removes access from a
+process that already has it, whereas an AppContainer starts with essentially nothing and is
+granted access one object at a time: a file is reachable only if its ACL names the container's
+own SID, one of its capabilities, or the built-in ``ALL APPLICATION PACKAGES`` group. Spack
+implements ``allow_read``/``allow_write`` by adding inheritable ACL entries for the container's
+SID to each allowed path, and removes them again when the build finishes.
+
+Two consequences follow from that model, and both usually need action:
+
+* **Build tools must be explicitly allowed.** ``C:\Windows`` and ``C:\Windows\System32`` grant
+  ``ALL APPLICATION PACKAGES`` read and execute by default, so they keep working, but most
+  installed software does not. In particular the MSVC toolchain and Windows SDK under
+  ``C:\Program Files (x86)\Microsoft Visual Studio`` and ``C:\Program Files (x86)\Windows Kits``
+  are **not** reachable from inside the sandbox unless you add them to ``allow_read``:
+
+  .. code-block:: yaml
+
+     config:
+       sandbox:
+         enable: true
+         allow_read:
+         - 'C:\Program Files\Microsoft Visual Studio'
+         - 'C:\Program Files (x86)\Windows Kits'
+
+* **Networking is opt-in, not opt-out.** An AppContainer has no network access at all by
+  default. ``allow_network: true`` therefore actively grants the ``internetClient``,
+  ``internetClientServer`` and ``privateNetworkClientServer`` capabilities (the last is what
+  makes a mirror on the local network reachable); ``allow_network: false`` simply grants none of
+  them. There is no kernel-version-style gating the way Landlock requires ABI v4+.
+
+Known limitations:
+
+* AppContainer processes cannot reach ``127.0.0.1``/localhost without a separate loopback
+  exemption, which Spack does not configure automatically. Builds or tests that rely on
+  contacting a local server will fail inside the sandbox, even with ``allow_network: true``.
+* Because access is granted by editing real ACLs, allowing a path with a large directory tree
+  costs an inheritance propagation pass over that tree, both when the sandbox is applied and
+  when it is torn down.
+* If a build is hard-killed mid-phase, the AppContainer profile and its granted ACL entries can
+  be left behind. This residue is inert (nothing can authenticate as the orphaned SID again) but
+  is not automatically reaped. After a clean build the granted entries are removed again; the
+  only lasting mark is the ``SE_DACL_AUTO_INHERITED`` control flag, which Windows sets on any
+  DACL it rewrites and which conveys no access.

--- a/lib/spack/spack/installer/build.py
+++ b/lib/spack/spack/installer/build.py
@@ -667,22 +667,27 @@ def _install(
 
         _enable_sandbox(spack.config.CONFIG.get("config:sandbox", {}), spec, stage.path)
 
-        for phase in builder:
-            if stop_before is not None and phase.name == stop_before:
-                send_state(f"stopped before {stop_before}", state_stream)
-                raise spack.error.StopPhase(f"Stopping before '{stop_before}'")
-            send_state(phase.name, state_stream)
-            spack.util.tty.msg(f"{pkg.name}: Executing phase: '{phase.name}'")
-            # Run the install phase with debug output enabled.
-            old_debug = spack.util.tty.debug_level()
-            spack.util.tty.set_debug(1)
-            try:
-                phase.execute()
-            finally:
-                spack.util.tty.set_debug(old_debug)
-            if stop_at is not None and phase.name == stop_at:
-                send_state(f"stopped after {stop_at}", state_stream)
-                raise spack.error.StopPhase(f"Stopping at '{stop_at}'")
+        try:
+            for phase in builder:
+                if stop_before is not None and phase.name == stop_before:
+                    send_state(f"stopped before {stop_before}", state_stream)
+                    raise spack.error.StopPhase(f"Stopping before '{stop_before}'")
+                send_state(phase.name, state_stream)
+                spack.util.tty.msg(f"{pkg.name}: Executing phase: '{phase.name}'")
+                # Run the install phase with debug output enabled.
+                old_debug = spack.util.tty.debug_level()
+                spack.util.tty.set_debug(1)
+                try:
+                    phase.execute()
+                finally:
+                    spack.util.tty.set_debug(old_debug)
+                if stop_at is not None and phase.name == stop_at:
+                    send_state(f"stopped after {stop_at}", state_stream)
+                    raise spack.error.StopPhase(f"Stopping at '{stop_at}'")
+        finally:
+            # No-op on Linux (Landlock restricts the process itself and needs no teardown) and
+            # when sandboxing is disabled; only WindowsAppContainerSandbox registers as active.
+            spack.sandbox.cleanup_active_sandbox()
 
         _archive_build_metadata(pkg)
         spack.hooks.post_install(spec, explicit)

--- a/lib/spack/spack/sandbox.py
+++ b/lib/spack/spack/sandbox.py
@@ -14,16 +14,18 @@ left unrestricted to ensure compatibility with compilers, terminal output, and
 build jobservers.
 """
 
+import atexit
 import ctypes
 import enum
 import os
 import platform
 import stat
 import sys
+import uuid
 import warnings
 from abc import ABC, abstractmethod
 from pathlib import Path
-from typing import Dict, Union
+from typing import Dict, List, Optional, Union
 
 # os.O_PATH is only defined on linux. Appease mypy with our own O_PATH.
 if sys.platform == "linux":
@@ -32,6 +34,7 @@ else:
     O_PATH = 0
 
 import spack.error
+import spack.util.executable
 
 # Linux landlock syscalls
 SYSCALL_LANDLOCK_CREATE_RULESET = 444
@@ -110,6 +113,14 @@ class Sandbox(ABC):
 
     @abstractmethod
     def apply(self, block_network: bool = False): ...
+
+    def cleanup(self) -> None:
+        """Release any resources held by the sandbox. No-op by default.
+
+        Landlock's restrictions live in the kernel and are torn down automatically when the
+        process exits, so LandlockSandbox does not need to override this. Backends that hold
+        external state (e.g. Windows AppContainer profiles and ACL grants) must override it.
+        """
 
 
 def _get_write_flags(abi_version: int) -> int:
@@ -263,13 +274,229 @@ class LandlockSandbox(Sandbox):
             os.close(ruleset_fd)
 
 
+#: Capabilities granted when ``allow_network`` is true. An AppContainer starts with *no* network
+#: access at all, so approximating Landlock's "unrestricted unless blocked" default takes all
+#: three: ``internetClient`` is outbound-internet only, ``internetClientServer`` adds inbound,
+#: and ``privateNetworkClientServer`` covers RFC1918/LAN hosts such as an internal Spack mirror.
+#: Loopback is not reachable via any capability; it needs a separate exemption Spack does not
+#: configure (see the Windows section of the sandboxing docs).
+NETWORK_CAPABILITIES = ["internetClient", "internetClientServer", "privateNetworkClientServer"]
+
+
+class WindowsAppContainerSandbox(Sandbox):
+    """Sandbox backend using Windows AppContainer isolation.
+
+    Unlike Landlock, an AppContainer can only be established at process-creation time: there
+    is no supported way to convert an already-running process into one. As a result, this
+    backend cannot self-restrict the current process the way LandlockSandbox does. Instead,
+    `apply()` finalizes a policy (a set of granted paths, plus capabilities) and installs
+    `_spawn_in_container` as `spack.util.executable`'s process spawner, so that every build
+    tool Spack runs from that point on starts inside the container. Direct in-process Python
+    file I/O performed by package recipes is therefore not confined on Windows.
+    """
+
+    def __init__(self) -> None:
+        # Imported lazily so non-Windows interpreters never touch ctypes.wintypes-based code.
+        import spack.util.win_acl as win_acl
+        import spack.util.win_appcontainer as win_appcontainer
+
+        self._win = win_appcontainer
+        # Side-effect-free probe: raises OSError if the required APIs aren't resolvable.
+        # installer_dispatch.py calls get_sandbox() eagerly just to fail fast, and discards
+        # the result, so no profile may be created here.
+        self._win.probe_support()
+
+        self.container_name = f"spack-{os.getpid()}-{uuid.uuid4().hex[:8]}"
+        self.path_rules: Dict[Path, int] = {}
+        # Read implies execute, matching Landlock, so that configure-time compile probes run.
+        self.read_mask = (
+            win_acl.FileAccessRights.FILE_GENERIC_READ
+            | win_acl.FileAccessRights.FILE_GENERIC_EXECUTE
+        )
+        self.write_mask = (
+            self.read_mask
+            | win_acl.FileAccessRights.FILE_GENERIC_WRITE
+            | win_acl.StandardAccessRights.DELETE
+        )
+
+        self.sid: Optional[int] = None
+        self.capabilities: List[int] = []
+        self._granted_paths: List[Path] = []
+        self._active = False
+        self._previous_spawner: Optional[spack.util.executable.ProcessSpawner] = None
+
+    @staticmethod
+    def _is_securable(resolved: Path) -> bool:
+        """Whether `resolved` is an object an ACL can actually be attached to.
+
+        Windows reserved device names (NUL, CON, ...) pass Path.exists() from any directory but
+        have no DACL, so trying to grant on them fails with ERROR_ACCESS_DENIED. NUL in
+        particular is always reachable from an AppContainer, and _enable_sandbox always asks for
+        os.devnull, so silently skipping devices avoids a warning on every single build.
+        """
+        return resolved.is_dir() or resolved.is_file()
+
+    def _allow_read(self, original: Path, resolved: Path):
+        if not self._is_securable(resolved):
+            return
+        current_mask = self.path_rules.get(resolved, 0)
+        self.path_rules[resolved] = current_mask | self.read_mask
+
+    def _allow_write(self, original: Path, resolved: Path):
+        if not self._is_securable(resolved):
+            return
+        current_mask = self.path_rules.get(resolved, 0)
+        self.path_rules[resolved] = current_mask | self.write_mask
+
+    # Each Win32 call below is wrapped in its own one-line method so tests can override it
+    # individually, the same way test/sandbox.py's SpyLandlockSandbox stubs out syscalls.
+
+    def _create_app_container(self) -> int:
+        return self._win.create_or_derive_app_container_sid(self.container_name)
+
+    def _derive_capabilities(self, names: List[str]) -> List[int]:
+        return self._win.derive_capability_sids(names)
+
+    def _grant(self, path: Path, sid: int) -> None:
+        self._win.grant_access(str(path), sid, self.path_rules[path])
+
+    def _revoke(self, path: Path, sid: int) -> None:
+        self._win.revoke_access(str(path), sid)
+
+    def _delete_profile(self) -> None:
+        self._win.delete_app_container_profile(self.container_name, self.sid)
+        self._win.release_capability_sids(self.capabilities)
+        self.capabilities = []
+
+    def _spawn_in_container(
+        self,
+        cmd: List[str],
+        *,
+        env: Dict[str, str],
+        stdin: spack.util.executable.StreamType,
+        stdout: spack.util.executable.StreamType,
+        stderr: spack.util.executable.StreamType,
+    ) -> spack.util.executable.SpawnedProcess:
+        """Start `cmd` inside this sandbox's AppContainer.
+
+        Installed as spack.util.executable's process spawner for as long as this sandbox is
+        applied, which is what confines the build tools Spack runs.
+        """
+        assert self.sid is not None, "the spawner is only installed between apply() and cleanup()"
+        return self._win.create_process(
+            cmd,
+            env=env,
+            stdin=stdin,
+            stdout=stdout,
+            stderr=stderr,
+            sid=self.sid,
+            capabilities=self.capabilities,
+        )
+
+    def apply(self, block_network: bool = False) -> None:
+        # An AppContainer has no network access at all unless a capability is granted, the
+        # opposite default of Landlock, which is unrestricted unless block_network=True.
+        capability_names = [] if block_network else list(NETWORK_CAPABILITIES)
+        try:
+            self.sid = self._create_app_container()
+            # From here on the profile exists in the OS, so any later failure has to go
+            # through cleanup() rather than leaving an orphaned container behind.
+            self._active = True
+            self.capabilities = self._derive_capabilities(capability_names)
+        except OSError as e:
+            self.cleanup()
+            raise SandboxError(f"Failed to apply build sandbox: {e}") from e
+
+        for path in self.path_rules:
+            try:
+                self._grant(path, self.sid)
+            except OSError as e:
+                warnings.warn(f"Cannot allow sandbox access to {path} due to: {e}")
+                continue
+            self._granted_paths.append(path)
+
+        # Route every subsequent Executable through the container. Done last, so a spawn can
+        # never observe a half-built policy.
+        self._previous_spawner = spack.util.executable.set_process_spawner(
+            self._spawn_in_container
+        )
+        _set_active_sandbox(self)
+        # Safety net for paths that bypass the installer's explicit cleanup (e.g. an
+        # exception escaping the build worker). cleanup() is idempotent, so running twice
+        # is harmless.
+        atexit.register(self.cleanup)
+
+    def cleanup(self) -> None:
+        if not self._active:
+            return
+        self._active = False
+        atexit.unregister(self.cleanup)
+
+        # Stop routing spawns into the container before dismantling it, so nothing can be
+        # launched against a container whose grants are already being revoked.
+        if self._previous_spawner is not None:
+            spack.util.executable.set_process_spawner(self._previous_spawner)
+            self._previous_spawner = None
+
+        # A path can only have been granted against a SID, so one exists whenever this is
+        # non-empty; apply() bails out before granting anything if the container never came up.
+        if self._granted_paths:
+            assert self.sid is not None, "granted paths always imply a live container SID"
+            for path in self._granted_paths:
+                try:
+                    self._revoke(path, self.sid)
+                except OSError as e:
+                    warnings.warn(f"Cannot revoke sandbox access to {path} due to: {e}")
+            self._granted_paths = []
+
+        try:
+            self._delete_profile()
+        except OSError as e:
+            warnings.warn(f"Cannot delete sandbox AppContainer profile due to: {e}")
+        # The SID memory is freed by _delete_profile; drop the now-dangling pointer so a
+        # stale use is a clean AttributeError-style failure rather than a wild pointer.
+        self.sid = None
+
+        if active_sandbox() is self:
+            _set_active_sandbox(None)
+
+
 def get_sandbox() -> Sandbox:
-    if platform.system() != "Linux":
-        raise SandboxError("Build sandboxing is only supported on Linux")
+    system = platform.system()
     try:
-        return LandlockSandbox()
+        if system == "Linux":
+            return LandlockSandbox()
+        elif system == "Windows":
+            return WindowsAppContainerSandbox()
+        else:
+            raise SandboxError(f"Build sandboxing is not supported on {system}")
     except OSError as e:
-        raise SandboxError(f"Landlock sandboxing is unavailable: {e}") from e
+        raise SandboxError(f"Sandboxing is unavailable: {e}") from e
+
+
+_active_sandbox: Optional[Sandbox] = None
+
+
+def active_sandbox() -> Optional[Sandbox]:
+    """Return the sandbox currently active for this process, if any.
+
+    Only backends holding resources that outlive `apply()` register here, so that the installer
+    can tear them down; today that means WindowsAppContainerSandbox. LandlockSandbox restricts
+    the process itself in place and its ruleset dies with the process, so it never registers.
+    """
+    return _active_sandbox
+
+
+def _set_active_sandbox(sandbox: Optional[Sandbox]) -> None:
+    global _active_sandbox
+    _active_sandbox = sandbox
+
+
+def cleanup_active_sandbox() -> None:
+    """Idempotent no-op if no sandbox is active."""
+    sandbox = active_sandbox()
+    if sandbox is not None:
+        sandbox.cleanup()
 
 
 class SandboxError(spack.error.SpackError):

--- a/lib/spack/spack/test/sandbox.py
+++ b/lib/spack/spack/test/sandbox.py
@@ -12,13 +12,9 @@ if sys.platform != "linux":
 
 import os
 import pathlib
-import tempfile
 from typing import List, Tuple
 
-import spack.concretize
 import spack.sandbox
-import spack.store
-from spack.installer.build import _enable_sandbox
 
 
 class SpyLandlockSandbox(spack.sandbox.LandlockSandbox):
@@ -118,81 +114,6 @@ def test_landlock_sandbox_network_args():
     assert net_flags & spack.sandbox.LANDLOCK_ACCESS_NET_CONNECT_TCP
     assert net_flags & spack.sandbox.LANDLOCK_ACCESS_NET_BIND_TCP
     assert sandbox.prctl_called
-
-
-class MockSandbox(spack.sandbox.Sandbox):
-    def __init__(self):
-        self.read_calls: List[Tuple[pathlib.Path, pathlib.Path]] = []
-        self.write_calls: List[Tuple[pathlib.Path, pathlib.Path]] = []
-        self.apply_calls: List[bool] = []
-
-    def _allow_read(self, original: pathlib.Path, resolved: pathlib.Path):
-        self.read_calls.append((original, resolved))
-
-    def _allow_write(self, original: pathlib.Path, resolved: pathlib.Path):
-        self.write_calls.append((original, resolved))
-
-    def apply(self, block_network=False):
-        self.apply_calls.append(block_network)
-
-
-def test_enable_sandbox_paths(
-    config, mock_packages, monkeypatch, temporary_store: spack.store.Store, tmp_path: pathlib.Path
-):
-    """Test that _enable_sandbox in the installer calls allow_read/allow_write correctly."""
-    mock_sandbox = MockSandbox()
-    monkeypatch.setattr(spack.sandbox, "get_sandbox", lambda: mock_sandbox)
-
-    spec = spack.concretize.concretize_one("dependent-install")
-
-    # Create prefix directories so resolved.exists() passes
-    pathlib.Path(spec.prefix).mkdir(parents=True, exist_ok=True)
-    for dep in spec.traverse(root=False):
-        pathlib.Path(dep.prefix).mkdir(parents=True, exist_ok=True)
-
-    stage_path = tmp_path / "stage"
-    stage_path.mkdir()
-
-    custom_write = tmp_path / "custom_write"
-    custom_write.mkdir()
-
-    # Create a symlink to verify original vs resolved path logic
-    custom_read_target = tmp_path / "custom_read_target"
-    custom_read_target.mkdir()
-    custom_read_link = tmp_path / "custom_read_link"
-    custom_read_link.symlink_to(custom_read_target)
-
-    # Ensure the sbang exists
-    temporary_store.install_sbang()
-    sbang_file = pathlib.Path(temporary_store.unpadded_root) / "bin" / "sbang"
-
-    config = {
-        "enable": True,
-        "allow_read": [str(custom_read_link)],
-        "allow_write": [str(custom_write)],
-        "allow_network": True,
-    }
-
-    _enable_sandbox(config, spec, str(stage_path))
-
-    allow_read_resolved = [c[1] for c in mock_sandbox.read_calls]
-    for dep in spec.traverse(root=False):
-        assert pathlib.Path(dep.prefix).resolve() in allow_read_resolved
-
-    # Verify symlink resolution in read_calls
-    assert custom_read_target.resolve() in allow_read_resolved
-    assert (custom_read_link.absolute(), custom_read_target.resolve()) in mock_sandbox.read_calls
-
-    # Verify sbang read
-    assert sbang_file.resolve() in allow_read_resolved
-
-    allow_write_resolved = [c[1] for c in mock_sandbox.write_calls]
-    assert stage_path.resolve() in allow_write_resolved
-    assert pathlib.Path(spec.prefix).resolve() in allow_write_resolved
-    assert custom_write.resolve() in allow_write_resolved
-    assert pathlib.Path(tempfile.gettempdir()).resolve() in allow_write_resolved
-
-    assert mock_sandbox.apply_calls == [False]
 
 
 def test_sandbox_network_blocking_requires_abi_v4():

--- a/lib/spack/spack/test/sandbox_common.py
+++ b/lib/spack/spack/test/sandbox_common.py
@@ -1,0 +1,109 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+"""Platform-agnostic unit tests for the abstract Sandbox interface and installer wiring."""
+
+import pathlib
+import sys
+import tempfile
+from typing import List, Tuple
+
+import pytest
+
+import spack.concretize
+import spack.sandbox
+import spack.store
+from spack.installer.build import _enable_sandbox
+
+
+class MockSandbox(spack.sandbox.Sandbox):
+    def __init__(self):
+        self.read_calls: List[Tuple[pathlib.Path, pathlib.Path]] = []
+        self.write_calls: List[Tuple[pathlib.Path, pathlib.Path]] = []
+        self.apply_calls: List[bool] = []
+
+    def _allow_read(self, original: pathlib.Path, resolved: pathlib.Path):
+        self.read_calls.append((original, resolved))
+
+    def _allow_write(self, original: pathlib.Path, resolved: pathlib.Path):
+        self.write_calls.append((original, resolved))
+
+    def apply(self, block_network=False):
+        self.apply_calls.append(block_network)
+
+
+def test_allow_read_reports_both_the_requested_and_resolved_path(tmp_path: pathlib.Path):
+    """Backends need the resolved path to apply a rule, and the original to report on it.
+
+    Rules are keyed by resolved path so that two names for one directory collapse to a single
+    rule instead of racing each other.
+    """
+    target = tmp_path / "target"
+    target.mkdir()
+    link = tmp_path / "link"
+    try:
+        link.symlink_to(target)
+    except OSError as e:
+        # Windows only permits this under Developer Mode or with elevation.
+        pytest.skip(f"cannot create symlinks on this host: {e}")
+
+    sandbox = MockSandbox()
+    sandbox.allow_read(link)
+
+    assert sandbox.read_calls == [(link.absolute(), target.resolve())]
+
+
+def test_enable_sandbox_paths(
+    config, mock_packages, monkeypatch, temporary_store: spack.store.Store, tmp_path: pathlib.Path
+):
+    """Test that _enable_sandbox in the installer calls allow_read/allow_write correctly."""
+    mock_sandbox = MockSandbox()
+    monkeypatch.setattr(spack.sandbox, "get_sandbox", lambda: mock_sandbox)
+
+    spec = spack.concretize.concretize_one("dependent-install")
+
+    # Create prefix directories so resolved.exists() passes
+    pathlib.Path(spec.prefix).mkdir(parents=True, exist_ok=True)
+    for dep in spec.traverse(root=False):
+        pathlib.Path(dep.prefix).mkdir(parents=True, exist_ok=True)
+
+    stage_path = tmp_path / "stage"
+    stage_path.mkdir()
+
+    custom_write = tmp_path / "custom_write"
+    custom_write.mkdir()
+
+    custom_read = tmp_path / "custom_read"
+    custom_read.mkdir()
+
+    # sbang (a shebang-length workaround) is a POSIX-only concept; install_sbang() is a no-op
+    # on Windows, so there is nothing to grant read access to on that platform.
+    temporary_store.install_sbang()
+    sbang_file = pathlib.Path(temporary_store.unpadded_root) / "bin" / "sbang"
+
+    config = {
+        "enable": True,
+        "allow_read": [str(custom_read)],
+        "allow_write": [str(custom_write)],
+        "allow_network": True,
+    }
+
+    _enable_sandbox(config, spec, str(stage_path))
+
+    allow_read_resolved = [c[1] for c in mock_sandbox.read_calls]
+    for dep in spec.traverse(root=False):
+        assert pathlib.Path(dep.prefix).resolve() in allow_read_resolved
+
+    assert custom_read.resolve() in allow_read_resolved
+
+    # Verify sbang read (sbang doesn't exist on Windows; see comment above)
+    if sys.platform != "win32":
+        assert sbang_file.resolve() in allow_read_resolved
+
+    allow_write_resolved = [c[1] for c in mock_sandbox.write_calls]
+    assert stage_path.resolve() in allow_write_resolved
+    assert pathlib.Path(spec.prefix).resolve() in allow_write_resolved
+    assert custom_write.resolve() in allow_write_resolved
+    assert pathlib.Path(tempfile.gettempdir()).resolve() in allow_write_resolved
+
+    assert mock_sandbox.apply_calls == [False]

--- a/lib/spack/spack/test/sandbox_windows.py
+++ b/lib/spack/spack/test/sandbox_windows.py
@@ -1,0 +1,367 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+"""Unit tests for Windows AppContainer sandboxing in the new installer.
+
+Most tests here spy on WindowsAppContainerSandbox's small overridable wrapper methods
+(_create_app_container, _derive_capabilities, _grant, _revoke, _delete_profile) rather than
+exercising the real Win32 APIs, mirroring how test/sandbox.py's SpyLandlockSandbox spies on
+Landlock syscalls.
+
+Spies alone cannot answer the only question that really matters -- whether the sandbox actually
+denies anything -- so the tests at the bottom of this module drive the real
+CreateAppContainerProfile/ACL/CreateProcessW path end to end and assert that reads, writes and
+network connections outside the policy are refused by the OS. Those tests do mutate system
+state (an AppContainer profile plus DACL entries under tmp_path), but they clean up after
+themselves and need no elevation.
+"""
+
+import os
+import pathlib
+import sys
+from typing import List, Set, Tuple
+
+import pytest
+
+if sys.platform != "win32":
+    pytest.skip("Windows-only tests", allow_module_level=True)
+
+import spack.sandbox
+import spack.util.executable as executable
+import spack.util.win_acl as win_acl
+from spack.util.executable import Executable
+
+
+class SpyWindowsAppContainerSandbox(spack.sandbox.WindowsAppContainerSandbox):
+    """WindowsAppContainerSandbox that records calls instead of touching the real OS."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.create_app_container_calls = 0
+        self.derive_capabilities_calls: List[List[str]] = []
+        self.grant_calls: List[Tuple[pathlib.Path, int]] = []
+        self.revoke_calls: List[Tuple[pathlib.Path, int]] = []
+        self.delete_profile_calls = 0
+        self.fail_grant_for: Set[pathlib.Path] = set()
+
+    def _create_app_container(self):
+        self.create_app_container_calls += 1
+        return 0xDEAD
+
+    def _derive_capabilities(self, names: List[str]):
+        self.derive_capabilities_calls.append(list(names))
+        return [0xCAFE + i for i in range(len(names))]
+
+    def _grant(self, path: pathlib.Path, sid) -> None:
+        if path in self.fail_grant_for:
+            raise OSError(f"synthetic grant failure for {path}")
+        self.grant_calls.append((path, sid))
+
+    def _revoke(self, path: pathlib.Path, sid) -> None:
+        self.revoke_calls.append((path, sid))
+
+    def _delete_profile(self) -> None:
+        self.delete_profile_calls += 1
+
+
+@pytest.fixture(autouse=True)
+def restore_process_globals():
+    """Applying a sandbox mutates process-wide state in two modules.
+
+    A test that fails between apply() and cleanup() would otherwise leak an installed spawner
+    into every later test in the session, so snapshot and restore both unconditionally.
+    """
+    spawner = executable._spawner
+    active = spack.sandbox.active_sandbox()
+    yield
+    executable.set_process_spawner(spawner)
+    spack.sandbox._set_active_sandbox(active)
+
+
+def test_rule_building_merges_overlapping_paths(tmp_path: pathlib.Path):
+    sandbox = SpyWindowsAppContainerSandbox()
+
+    d = tmp_path / "dir"
+    d.mkdir()
+    f = d / "file"
+    f.touch()
+
+    sandbox.allow_read(d)
+    sandbox.allow_write(f)
+    sandbox.allow_read(f)  # overlapping: merges with the write mask already set
+
+    assert sandbox.path_rules[d.resolve()] == sandbox.read_mask
+    merged = sandbox.path_rules[f.resolve()]
+    assert merged & sandbox.write_mask
+    assert merged & sandbox.read_mask
+
+
+def test_reserved_device_names_are_not_granted():
+    """os.devnull is requested by every build but has no DACL to attach an ACE to."""
+    sandbox = SpyWindowsAppContainerSandbox()
+    sandbox.allow_write(os.devnull)
+    assert sandbox.path_rules == {}
+
+
+def test_apply_grants_paths_and_registers_active_sandbox(tmp_path: pathlib.Path):
+    sandbox = SpyWindowsAppContainerSandbox()
+    d = tmp_path / "dir"
+    d.mkdir()
+    sandbox.allow_write(d)
+
+    assert spack.sandbox.active_sandbox() is None
+    sandbox.apply(block_network=False)
+    try:
+        assert spack.sandbox.active_sandbox() is sandbox
+        assert sandbox.create_app_container_calls == 1
+        assert sandbox.grant_calls == [(d.resolve(), sandbox.sid)]
+    finally:
+        sandbox.cleanup()
+    assert spack.sandbox.active_sandbox() is None
+
+
+def test_network_capability_mapping():
+    """allow_network requests the configured capabilities; blocking requests none at all.
+
+    An AppContainer is offline until a capability is granted, so blocking is the *absence* of
+    a request rather than an added restriction; getting this backwards would silently leave
+    builds online.
+    """
+    allow_net = SpyWindowsAppContainerSandbox()
+    allow_net.apply(block_network=False)
+    try:
+        assert allow_net.derive_capabilities_calls == [spack.sandbox.NETWORK_CAPABILITIES]
+    finally:
+        allow_net.cleanup()
+
+    block_net = SpyWindowsAppContainerSandbox()
+    block_net.apply(block_network=True)
+    try:
+        assert block_net.derive_capabilities_calls == [[]]
+        assert block_net.capabilities == []
+    finally:
+        block_net.cleanup()
+
+
+def test_cleanup_is_idempotent(tmp_path: pathlib.Path):
+    sandbox = SpyWindowsAppContainerSandbox()
+    d = tmp_path / "dir"
+    d.mkdir()
+    sandbox.allow_write(d)
+    sandbox.apply(block_network=True)
+
+    sandbox.cleanup()
+    sandbox.cleanup()  # must be a no-op the second time
+
+    assert len(sandbox.revoke_calls) == 1
+    assert sandbox.delete_profile_calls == 1
+    assert spack.sandbox.active_sandbox() is None
+
+
+def test_partial_grant_failure_does_not_raise(tmp_path: pathlib.Path):
+    sandbox = SpyWindowsAppContainerSandbox()
+    ok_dir = tmp_path / "ok"
+    ok_dir.mkdir()
+    bad_dir = tmp_path / "bad"
+    bad_dir.mkdir()
+    sandbox.allow_write(ok_dir)
+    sandbox.allow_write(bad_dir)
+    sandbox.fail_grant_for.add(bad_dir.resolve())
+
+    with pytest.warns(UserWarning, match="Cannot allow sandbox access"):
+        sandbox.apply(block_network=True)
+
+    try:
+        granted = {p for p, _ in sandbox.grant_calls}
+        assert ok_dir.resolve() in granted
+        assert bad_dir.resolve() not in granted
+        assert bad_dir.resolve() not in sandbox._granted_paths
+    finally:
+        sandbox.cleanup()
+
+    revoked = {p for p, _ in sandbox.revoke_calls}
+    assert bad_dir.resolve() not in revoked
+
+
+def test_apply_installs_spawner_and_cleanup_restores_it():
+    """The sandbox takes over process creation only for as long as it is applied.
+
+    Leaving the spawner installed past cleanup() would send later commands into a container
+    whose grants have already been revoked and whose profile is gone.
+    """
+    default_spawner = executable._spawner
+
+    sandbox = SpyWindowsAppContainerSandbox()
+    sandbox.apply(block_network=True)
+    try:
+        # Bound methods compare equal but are not identical, so `is` would never hold here.
+        assert executable._spawner == sandbox._spawn_in_container
+    finally:
+        sandbox.cleanup()
+
+    assert executable._spawner is default_spawner
+
+
+def test_executable_passes_resolved_command_and_environment_to_spawner(monkeypatch):
+    """Executable routes through the seam, handing over the fully assembled command and env."""
+    calls = []
+
+    class FakeProc:
+        returncode = 0
+
+        def communicate(self, timeout=None):
+            return b"", b""
+
+    def fake_spawner(cmd, *, env, stdin, stdout, stderr):
+        calls.append((cmd, env))
+        return FakeProc()
+
+    monkeypatch.setattr(executable, "_spawner", fake_spawner)
+
+    exe = Executable("cmd")
+    exe.add_default_arg("/c")
+    exe.add_default_env("FROM_DEFAULT", "default-value")
+    exe("echo hi", extra_env={"FROM_EXTRA": "extra-value"})
+
+    [(cmd, env)] = calls
+    assert cmd == ["cmd", "/c", "echo hi"]
+    # Default and per-call environment modifications are resolved before the spawner sees them,
+    # rather than being left for the child to inherit from os.environ.
+    assert env["FROM_DEFAULT"] == "default-value"
+    assert env["FROM_EXTRA"] == "extra-value"
+
+
+#
+# End-to-end tests against the real Win32 APIs.
+#
+
+CMD = "C:\\Windows\\System32\\cmd.exe"
+POWERSHELL = "C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe"
+
+#: Prints NET-OK if an outbound TCP connection succeeds, NET-BLOCKED if the OS refuses it.
+_CONNECT_SNIPPET = (
+    "$c = New-Object Net.Sockets.TcpClient; "
+    "try { $c.Connect('example.com', 80); 'NET-OK' } catch { 'NET-BLOCKED' }"
+)
+
+
+@pytest.fixture
+def live_sandbox(tmp_path: pathlib.Path):
+    """A real AppContainer sandbox with `tmp_path/allowed` writable and nothing else.
+
+    Yields ``(sandbox, allowed_dir, denied_dir)`` un-applied, so each test can choose whether
+    the network is blocked.
+    """
+    allowed = tmp_path / "allowed"
+    allowed.mkdir()
+    denied = tmp_path / "denied"
+    denied.mkdir()
+    (allowed / "readable.txt").write_text("ALLOWED-CONTENT", encoding="utf-8")
+    (denied / "secret.txt").write_text("DENIED-CONTENT", encoding="utf-8")
+
+    sandbox = spack.sandbox.WindowsAppContainerSandbox()
+    sandbox.allow_write(allowed)
+    try:
+        yield sandbox, allowed, denied
+    finally:
+        sandbox.cleanup()
+    assert spack.sandbox.active_sandbox() is None
+
+
+def _run(exe: str, *args: str) -> Tuple[int, str]:
+    cmd = Executable(exe)
+    out = cmd(*args, output=str, error=str, fail_on_error=False)
+    return cmd.returncode, out
+
+
+def test_live_sandbox_enforces_filesystem_policy(live_sandbox):
+    """The OS must actually refuse reads and writes outside the granted paths."""
+    sandbox, allowed, denied = live_sandbox
+    sandbox.apply(block_network=True)
+
+    rc, out = _run(CMD, "/c", "type", str(allowed / "readable.txt"))
+    assert rc == 0 and "ALLOWED-CONTENT" in out
+
+    rc, out = _run(CMD, "/c", "type", str(denied / "secret.txt"))
+    assert rc != 0, "reading outside the sandbox policy must fail"
+    assert "DENIED-CONTENT" not in out
+
+    rc, _ = _run(CMD, "/c", f"echo written > {allowed / 'new.txt'}")
+    assert rc == 0 and (allowed / "new.txt").exists()
+
+    rc, _ = _run(CMD, "/c", f"echo written > {denied / 'new.txt'}")
+    assert rc != 0, "writing outside the sandbox policy must fail"
+    assert not (denied / "new.txt").exists()
+
+
+def test_live_sandbox_restores_the_dacl_it_found(live_sandbox):
+    """Granting access edits real on-disk ACLs, so cleanup must put them back.
+
+    Compares ACE lists rather than raw SDDL: writing a DACL at all makes Windows set the
+    SE_DACL_AUTO_INHERITED (``AI``) control flag, which happens even for a no-op write and
+    conveys no access.
+    """
+    sandbox, allowed, _ = live_sandbox
+    nested = allowed / "child" / "nested.txt"
+    nested.parent.mkdir()
+    nested.write_text("nested", encoding="utf-8")
+    targets = [allowed, nested.parent, nested]
+
+    def ace_lists():
+        return [
+            [str(a) for a in win_acl.SecurityDescriptor.from_file(str(p)).dacl] for p in targets
+        ]
+
+    before = ace_lists()
+    sandbox.apply(block_network=True)
+    granted = ace_lists()
+    sandbox.cleanup()
+
+    # The grant has to actually reach the root and be inherited by pre-existing children,
+    # or the comparison after cleanup would pass vacuously.
+    assert granted != before
+    assert all(len(g) == len(b) + 1 for g, b in zip(granted, before))
+
+    assert ace_lists() == before
+
+
+def test_live_sandbox_blocks_network(live_sandbox):
+    sandbox, _, _ = live_sandbox
+    sandbox.apply(block_network=True)
+    assert sandbox.capabilities == []
+
+    # A zero-capability AppContainer is the case that regressed before: CreateProcessW rejects
+    # a non-NULL SECURITY_CAPABILITIES.Capabilities with CapabilityCount == 0, which failed
+    # every spawn rather than merely blocking the network.
+    rc, out = _run(POWERSHELL, "-NoProfile", "-Command", _CONNECT_SNIPPET)
+    assert rc == 0, f"the build tool itself must still launch: {out}"
+    assert "NET-OK" not in out
+
+
+def test_live_sandbox_allows_network_when_configured(live_sandbox):
+    sandbox, _, _ = live_sandbox
+    sandbox.apply(block_network=False)
+
+    rc, out = _run(POWERSHELL, "-NoProfile", "-Command", _CONNECT_SNIPPET)
+    assert rc == 0
+    if "NET-OK" not in out:
+        pytest.skip(f"host has no outbound network access: {out.strip()}")
+
+
+def test_live_sandbox_preserves_parent_std_handles(live_sandbox, capfd):
+    """Spawning must not close the parent's own stdio.
+
+    Redirecting only some streams used to hand the child the parent's real std handles and
+    then close them as if they were ours, silently destroying Spack's own console output.
+    """
+    sandbox, allowed, _ = live_sandbox
+    sandbox.apply(block_network=True)
+
+    # output is a pipe, error is left inherited: the mixed case that triggered the bug.
+    Executable(CMD)("/c", "type", str(allowed / "readable.txt"), output=str)
+
+    print("PARENT-STDOUT-ALIVE")
+    sys.stderr.write("PARENT-STDERR-ALIVE\n")
+    captured = capfd.readouterr()
+    assert "PARENT-STDOUT-ALIVE" in captured.out
+    assert "PARENT-STDERR-ALIVE" in captured.err

--- a/lib/spack/spack/util/executable.py
+++ b/lib/spack/spack/util/executable.py
@@ -11,7 +11,7 @@ import sys
 from pathlib import Path, PurePath
 from typing import BinaryIO, Callable, Dict, List, Optional, Sequence, Tuple, Type, Union, overload
 
-from spack.vendor.typing_extensions import Literal
+from spack.vendor.typing_extensions import Literal, Protocol
 
 import spack.error
 from spack.util import tty
@@ -20,6 +20,64 @@ from spack.util.environment import EnvironmentModifications
 __all__ = ["Executable", "which", "which_string", "ProcessError"]
 
 OutType = Union[Optional[BinaryIO], str, Type[str], Callable]
+
+StreamType = Union[None, int, BinaryIO]
+
+
+class SpawnedProcess(Protocol):
+    """The subset of ``subprocess.Popen`` that :meth:`Executable.__call__` relies on."""
+
+    returncode: Optional[int]
+
+    def communicate(self, *, timeout: Optional[float] = None) -> Tuple[bytes, bytes]: ...
+
+    def kill(self) -> None: ...
+
+
+class ProcessSpawner(Protocol):
+    """Starts a child process running ``cmd``, raising ``OSError`` if it cannot be started."""
+
+    def __call__(
+        self,
+        cmd: List[str],
+        *,
+        env: Dict[str, str],
+        stdin: StreamType,
+        stdout: StreamType,
+        stderr: StreamType,
+    ) -> SpawnedProcess: ...
+
+
+def _subprocess_spawner(
+    cmd: List[str],
+    *,
+    env: Dict[str, str],
+    stdin: StreamType,
+    stdout: StreamType,
+    stderr: StreamType,
+) -> SpawnedProcess:
+    # close_fds=False because Spack relies on children inheriting fds, e.g. the make jobserver.
+    return subprocess.Popen(
+        cmd, stdin=stdin, stderr=stderr, stdout=stdout, env=env, close_fds=False
+    )
+
+
+#: How Executable starts child processes. Swapped out by spack.sandbox to run build tools inside
+#: a Windows AppContainer, which can only be entered at process-creation time. Keeping this a
+#: seam rather than an import of spack.sandbox is what lets spack.util stay free of dependencies
+#: on top-level spack modules.
+_spawner: ProcessSpawner = _subprocess_spawner
+
+
+def set_process_spawner(spawner: Optional[ProcessSpawner]) -> ProcessSpawner:
+    """Install `spawner` process-wide, or restore the default when passed None.
+
+    Returns the spawner being replaced, so a caller can restore exactly what it found.
+    """
+    global _spawner
+    previous = _spawner
+    _spawner = _subprocess_spawner if spawner is None else spawner
+    return previous
 
 
 def _process_cmd_output(
@@ -46,7 +104,7 @@ def _process_cmd_output(
         return None
 
 
-def _streamify_output(arg: OutType, name: str) -> Tuple[Union[int, BinaryIO, None], bool]:
+def _streamify_output(arg: OutType, name: str) -> Tuple[StreamType, bool]:
     if isinstance(arg, str):
         return open(arg, "wb"), True
     elif arg is str or arg is str.split:
@@ -291,13 +349,8 @@ class Executable:
 
         result = None
         try:
-            proc = subprocess.Popen(
-                cmd,
-                stdin=istream,
-                stderr=estream,
-                stdout=ostream,
-                env=current_environment,
-                close_fds=False,
+            proc = _spawner(
+                cmd, env=current_environment, stdin=istream, stdout=ostream, stderr=estream
             )
         except OSError as e:
             message = "Command: " + cmd_line_string
@@ -309,6 +362,7 @@ class Executable:
         try:
             out, err = proc.communicate(timeout=timeout)
             result = _process_cmd_output(out, err, output, error)
+            assert proc.returncode is not None, "returncode is always set after communicate()"
             rc = self.returncode = proc.returncode
             if fail_on_error and rc != 0 and (rc not in ignore_errors):
                 long_msg = cmd_line_string

--- a/lib/spack/spack/util/win_acl.py
+++ b/lib/spack/spack/util/win_acl.py
@@ -17,6 +17,8 @@ Public API:
   passed to :meth:`SecurityDescriptor.add_ace`.
 - :func:`get_file_owner` -- return the account name of the owner of a file.
 - :func:`copy_file_permissions` -- copy the DACL from one file to another.
+- :func:`sid_to_string` -- convert a binary ``PSID`` from a Win32 API into the SDDL SID
+  string that :class:`AccessControlEntry` expects.
 - :func:`get_file_sddl` / :func:`set_file_sddl` -- low-level SDDL string read/write;
   intended primarily (but not exclusively) for testing and debugging rather than general use.
 
@@ -1135,6 +1137,21 @@ class SecurityDescriptor:
             if not _ConvertSidToStringSidW(sid_ptr, ctypes.byref(string_sid_ptr)):
                 raise _WinError(_get_last_error())
             return string_sid_ptr.value or ""
+
+
+def sid_to_string(psid: int) -> str:
+    """Convert a binary ``PSID`` pointer to its SDDL string form (e.g. ``S-1-15-2-...``).
+
+    Win32 APIs that mint or look up SIDs (``CreateAppContainerProfile``,
+    ``DeriveCapabilitySidsFromName``, ...) hand back a raw pointer, whereas
+    :class:`AccessControlEntry` identifies principals by SDDL string. This bridges the two.
+
+    The caller retains ownership of *psid*; nothing here frees it.
+    """
+    with _local_ptr(wintypes.LPWSTR) as string_sid_ptr:
+        if not _ConvertSidToStringSidW(psid, ctypes.byref(string_sid_ptr)):
+            raise _WinError(_get_last_error())
+        return string_sid_ptr.value or ""
 
 
 def get_file_owner(path: str) -> str:

--- a/lib/spack/spack/util/win_appcontainer.py
+++ b/lib/spack/spack/util/win_appcontainer.py
@@ -1,0 +1,671 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+"""
+Raw ctypes bindings for Windows AppContainer isolation, used by
+:class:`spack.sandbox.WindowsAppContainerSandbox`.
+
+This module is Windows-only and must only ever be imported lazily (never at module scope) by
+platform-neutral code, since it calls into ``ctypes.WinDLL`` at import time. Spack avoids pywin32
+and hand-rolls Windows interop via ``ctypes``/``ctypes.wintypes``, and this module follows the
+same style.
+
+Scope is limited to what is genuinely AppContainer-specific: creating and deleting container
+profiles, deriving capability SIDs, and spawning a process inside a container. Editing the
+DACLs that make a path reachable from inside the container is ordinary ACL work, so it is
+delegated to :mod:`spack.util.win_acl`.
+"""
+
+import ctypes
+import ctypes.wintypes as wintypes
+import subprocess
+import threading
+from typing import BinaryIO, Dict, List, NamedTuple, Optional, Tuple, Union
+
+import spack.util.win_acl as win_acl
+
+_kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+_advapi32 = ctypes.WinDLL("advapi32", use_last_error=True)
+_userenv = ctypes.WinDLL("userenv", use_last_error=True)
+_msvcrt = ctypes.WinDLL("msvcrt", use_last_error=True)
+
+# DeriveCapabilitySidsFromName is exported by KernelBase.dll, not kernel32/advapi32.
+_kernelbase = ctypes.WinDLL("kernelbase", use_last_error=True)
+
+SE_GROUP_ENABLED = 0x00000004
+
+ERROR_SUCCESS = 0
+ERROR_ALREADY_EXISTS = 183
+
+EXTENDED_STARTUPINFO_PRESENT = 0x00080000
+CREATE_UNICODE_ENVIRONMENT = 0x00000400
+STARTF_USESTDHANDLES = 0x00000100
+PROC_THREAD_ATTRIBUTE_SECURITY_CAPABILITIES = 0x00020009
+
+STD_INPUT_HANDLE = -10
+STD_OUTPUT_HANDLE = -11
+STD_ERROR_HANDLE = -12
+
+HANDLE_FLAG_INHERIT = 0x00000001
+DUPLICATE_SAME_ACCESS = 0x00000002
+
+INFINITE = 0xFFFFFFFF
+WAIT_TIMEOUT = 0x00000102
+
+
+class _SID_AND_ATTRIBUTES(ctypes.Structure):
+    _fields_ = [("Sid", ctypes.c_void_p), ("Attributes", wintypes.DWORD)]
+
+
+class _SECURITY_CAPABILITIES(ctypes.Structure):
+    _fields_ = [
+        ("AppContainerSid", ctypes.c_void_p),
+        ("Capabilities", ctypes.POINTER(_SID_AND_ATTRIBUTES)),
+        ("CapabilityCount", wintypes.DWORD),
+        ("Reserved", wintypes.DWORD),
+    ]
+
+
+class _STARTUPINFOW(ctypes.Structure):
+    _fields_ = [
+        ("cb", wintypes.DWORD),
+        ("lpReserved", wintypes.LPWSTR),
+        ("lpDesktop", wintypes.LPWSTR),
+        ("lpTitle", wintypes.LPWSTR),
+        ("dwX", wintypes.DWORD),
+        ("dwY", wintypes.DWORD),
+        ("dwXSize", wintypes.DWORD),
+        ("dwYSize", wintypes.DWORD),
+        ("dwXCountChars", wintypes.DWORD),
+        ("dwYCountChars", wintypes.DWORD),
+        ("dwFillAttribute", wintypes.DWORD),
+        ("dwFlags", wintypes.DWORD),
+        ("wShowWindow", wintypes.WORD),
+        ("cbReserved2", wintypes.WORD),
+        ("lpReserved2", ctypes.c_void_p),
+        ("hStdInput", wintypes.HANDLE),
+        ("hStdOutput", wintypes.HANDLE),
+        ("hStdError", wintypes.HANDLE),
+    ]
+
+
+class _STARTUPINFOEXW(ctypes.Structure):
+    _fields_ = [("StartupInfo", _STARTUPINFOW), ("lpAttributeList", ctypes.c_void_p)]
+
+
+class _PROCESS_INFORMATION(ctypes.Structure):
+    _fields_ = [
+        ("hProcess", wintypes.HANDLE),
+        ("hThread", wintypes.HANDLE),
+        ("dwProcessId", wintypes.DWORD),
+        ("dwThreadId", wintypes.DWORD),
+    ]
+
+
+# Explicit argtypes/restype for every API used below. This matters more than usual here: handles
+# and SIDs are pointer-sized, and ctypes silently truncates unprototyped calls to a 32-bit `int`
+# return/argument, which would produce a wrong-but-not-crashing security-relevant bug (e.g. a
+# corrupted pseudo-handle from GetCurrentProcess()).
+
+_userenv.CreateAppContainerProfile.restype = ctypes.c_long
+_userenv.CreateAppContainerProfile.argtypes = [
+    wintypes.LPCWSTR,
+    wintypes.LPCWSTR,
+    wintypes.LPCWSTR,
+    ctypes.POINTER(_SID_AND_ATTRIBUTES),
+    wintypes.DWORD,
+    ctypes.POINTER(ctypes.c_void_p),
+]
+
+_userenv.DeriveAppContainerSidFromAppContainerName.restype = ctypes.c_long
+_userenv.DeriveAppContainerSidFromAppContainerName.argtypes = [
+    wintypes.LPCWSTR,
+    ctypes.POINTER(ctypes.c_void_p),
+]
+
+_userenv.DeleteAppContainerProfile.restype = ctypes.c_long
+_userenv.DeleteAppContainerProfile.argtypes = [wintypes.LPCWSTR]
+
+_kernelbase.DeriveCapabilitySidsFromName.restype = wintypes.BOOL
+_kernelbase.DeriveCapabilitySidsFromName.argtypes = [
+    wintypes.LPCWSTR,
+    ctypes.POINTER(ctypes.POINTER(ctypes.c_void_p)),
+    ctypes.POINTER(wintypes.DWORD),
+    ctypes.POINTER(ctypes.POINTER(ctypes.c_void_p)),
+    ctypes.POINTER(wintypes.DWORD),
+]
+
+_advapi32.FreeSid.restype = ctypes.c_void_p
+_advapi32.FreeSid.argtypes = [ctypes.c_void_p]
+
+_kernel32.LocalFree.restype = wintypes.HLOCAL
+_kernel32.LocalFree.argtypes = [wintypes.HLOCAL]
+
+_kernel32.GetCurrentProcess.restype = wintypes.HANDLE
+_kernel32.GetCurrentProcess.argtypes = []
+
+_kernel32.GetStdHandle.restype = wintypes.HANDLE
+_kernel32.GetStdHandle.argtypes = [wintypes.DWORD]
+
+_kernel32.DuplicateHandle.restype = wintypes.BOOL
+_kernel32.DuplicateHandle.argtypes = [
+    wintypes.HANDLE,
+    wintypes.HANDLE,
+    wintypes.HANDLE,
+    ctypes.POINTER(wintypes.HANDLE),
+    wintypes.DWORD,
+    wintypes.BOOL,
+    wintypes.DWORD,
+]
+
+_kernel32.SetHandleInformation.restype = wintypes.BOOL
+_kernel32.SetHandleInformation.argtypes = [wintypes.HANDLE, wintypes.DWORD, wintypes.DWORD]
+
+_kernel32.CloseHandle.restype = wintypes.BOOL
+_kernel32.CloseHandle.argtypes = [wintypes.HANDLE]
+
+_kernel32.CreatePipe.restype = wintypes.BOOL
+_kernel32.CreatePipe.argtypes = [
+    ctypes.POINTER(wintypes.HANDLE),
+    ctypes.POINTER(wintypes.HANDLE),
+    ctypes.c_void_p,
+    wintypes.DWORD,
+]
+
+_kernel32.ReadFile.restype = wintypes.BOOL
+_kernel32.ReadFile.argtypes = [
+    wintypes.HANDLE,
+    ctypes.c_void_p,
+    wintypes.DWORD,
+    ctypes.POINTER(wintypes.DWORD),
+    ctypes.c_void_p,
+]
+
+_kernel32.WaitForSingleObject.restype = wintypes.DWORD
+_kernel32.WaitForSingleObject.argtypes = [wintypes.HANDLE, wintypes.DWORD]
+
+_kernel32.GetExitCodeProcess.restype = wintypes.BOOL
+_kernel32.GetExitCodeProcess.argtypes = [wintypes.HANDLE, ctypes.POINTER(wintypes.DWORD)]
+
+_kernel32.TerminateProcess.restype = wintypes.BOOL
+_kernel32.TerminateProcess.argtypes = [wintypes.HANDLE, wintypes.UINT]
+
+_kernel32.InitializeProcThreadAttributeList.restype = wintypes.BOOL
+_kernel32.InitializeProcThreadAttributeList.argtypes = [
+    ctypes.c_void_p,
+    wintypes.DWORD,
+    wintypes.DWORD,
+    ctypes.POINTER(ctypes.c_size_t),
+]
+
+_kernel32.UpdateProcThreadAttribute.restype = wintypes.BOOL
+_kernel32.UpdateProcThreadAttribute.argtypes = [
+    ctypes.c_void_p,
+    wintypes.DWORD,
+    ctypes.c_size_t,
+    ctypes.c_void_p,
+    ctypes.c_size_t,
+    ctypes.c_void_p,
+    ctypes.c_void_p,
+]
+
+_kernel32.DeleteProcThreadAttributeList.restype = None
+_kernel32.DeleteProcThreadAttributeList.argtypes = [ctypes.c_void_p]
+
+_kernel32.CreateProcessW.restype = wintypes.BOOL
+_kernel32.CreateProcessW.argtypes = [
+    wintypes.LPCWSTR,
+    wintypes.LPWSTR,
+    ctypes.c_void_p,
+    ctypes.c_void_p,
+    wintypes.BOOL,
+    wintypes.DWORD,
+    ctypes.c_void_p,
+    wintypes.LPCWSTR,
+    ctypes.c_void_p,  # LPSTARTUPINFOW; we actually pass &STARTUPINFOEXW (shares the same prefix)
+    ctypes.POINTER(_PROCESS_INFORMATION),
+]
+
+_msvcrt._get_osfhandle.restype = wintypes.HANDLE
+_msvcrt._get_osfhandle.argtypes = [ctypes.c_int]
+
+
+def _win_error(code: int, name: str) -> OSError:
+    """Build an OSError that keeps *both* the failing API and the system error text.
+
+    ``ctypes.WinError(code, descr)`` *replaces* the system message with ``descr``, so passing
+    the API name alone silently throws away the only useful part of the diagnostic.
+    """
+    return ctypes.WinError(code, f"{name}: {ctypes.FormatError(code).strip()}")
+
+
+def _check_bool(result, name: str):
+    if not result:
+        raise _win_error(ctypes.get_last_error(), name)
+    return result
+
+
+def _check_win32(code: int, name: str) -> int:
+    """Check a Win32 error code returned directly (not via SetLastError)."""
+    if code != ERROR_SUCCESS:
+        raise _win_error(code, name)
+    return code
+
+
+def _check_hresult(hr: int, name: str) -> int:
+    # HRESULTs from these APIs are 0 (S_OK) on success; negative on failure.
+    if hr < 0:
+        # Most failures here are HRESULT_FROM_WIN32(x), i.e. 0x8007xxxx; unwrap those back to
+        # the underlying Win32 code so FormatError produces a meaningful message.
+        code = hr & 0xFFFF if (hr & 0xFFFF0000) == 0x80070000 else hr & 0xFFFFFFFF
+        raise _win_error(code, name)
+    return hr
+
+
+def probe_support() -> None:
+    """Cheaply verify the required AppContainer APIs are resolvable. Side-effect-free."""
+    try:
+        _userenv.CreateAppContainerProfile
+        _userenv.DeriveAppContainerSidFromAppContainerName
+        _userenv.DeleteAppContainerProfile
+        _kernelbase.DeriveCapabilitySidsFromName
+        _advapi32.FreeSid
+        _kernel32.InitializeProcThreadAttributeList
+        _kernel32.UpdateProcThreadAttribute
+        _kernel32.CreateProcessW
+    except (AttributeError, OSError) as e:
+        raise OSError(f"Windows AppContainer APIs are unavailable: {e}") from e
+
+
+def create_or_derive_app_container_sid(name: str) -> int:
+    """Create (or derive, if already existing) an AppContainer profile and return its SID.
+
+    The returned SID is owned by the caller and must eventually be released via
+    :func:`delete_app_container_profile`.
+    """
+    sid = ctypes.c_void_p()
+    hr = _userenv.CreateAppContainerProfile(name, name, name, None, 0, ctypes.byref(sid))
+    if hr < 0 and (hr & 0xFFFF) == ERROR_ALREADY_EXISTS:
+        hr = _userenv.DeriveAppContainerSidFromAppContainerName(name, ctypes.byref(sid))
+    _check_hresult(hr, f"CreateAppContainerProfile({name})")
+    assert sid.value is not None
+    return sid.value
+
+
+def delete_app_container_profile(name: str, sid: Optional[int] = None) -> None:
+    """Best-effort teardown of an AppContainer profile and its associated SID memory.
+
+    The SID is released even if deleting the profile fails, so a failure here leaks at most
+    the (inert) profile registration, never process memory.
+    """
+    try:
+        hr = _userenv.DeleteAppContainerProfile(name)
+        _check_hresult(hr, f"DeleteAppContainerProfile({name})")
+    finally:
+        if sid is not None:
+            _advapi32.FreeSid(sid)
+
+
+def derive_capability_sids(names: List[str]) -> List[int]:
+    """Derive capability SIDs (e.g. "internetClient") for use in a SECURITY_CAPABILITIES struct.
+
+    Returned SID memory is owned by the caller (LocalAlloc'd by Windows) and must eventually be
+    released via :func:`release_capability_sids`.
+    """
+    result: List[int] = []
+    for name in names:
+        group_sids = ctypes.POINTER(ctypes.c_void_p)()
+        group_count = wintypes.DWORD(0)
+        cap_sids = ctypes.POINTER(ctypes.c_void_p)()
+        cap_count = wintypes.DWORD(0)
+
+        ok = _kernelbase.DeriveCapabilitySidsFromName(
+            name,
+            ctypes.byref(group_sids),
+            ctypes.byref(group_count),
+            ctypes.byref(cap_sids),
+            ctypes.byref(cap_count),
+        )
+        _check_bool(ok, f"DeriveCapabilitySidsFromName({name})")
+
+        try:
+            for i in range(group_count.value):
+                _kernel32.LocalFree(group_sids[i])
+        finally:
+            if group_sids:
+                _kernel32.LocalFree(ctypes.cast(group_sids, wintypes.HLOCAL))
+
+        for i in range(cap_count.value):
+            result.append(cap_sids[i])
+        if cap_sids:
+            _kernel32.LocalFree(ctypes.cast(cap_sids, wintypes.HLOCAL))
+
+    return result
+
+
+def release_capability_sids(sids: List[int]) -> None:
+    """Best-effort release of SIDs returned by :func:`derive_capability_sids`."""
+    for sid in sids:
+        _kernel32.LocalFree(sid)
+
+
+def grant_access(path: str, sid: int, mask: int) -> None:
+    """Add an ACE granting `mask` access to `sid` on `path`, inherited by child files/dirs."""
+    sd = win_acl.SecurityDescriptor.from_file(path)
+    sd.add_ace(
+        win_acl.AccessControlEntry(
+            win_acl.AceType.SDDL_ACCESS_ALLOWED,
+            flags=[win_acl.AceFlags.SDDL_OBJECT_INHERIT, win_acl.AceFlags.SDDL_CONTAINER_INHERIT],
+            rights=mask,
+            sid=win_acl.sid_to_string(sid),
+        )
+    )
+    sd.apply(path)
+
+
+def revoke_access(path: str, sid: int) -> None:
+    """Remove every ACE granted to `sid` on `path`. Safe to call even if none exist."""
+    sd = win_acl.SecurityDescriptor.from_file(path)
+    if sd.remove_ace(sid=win_acl.sid_to_string(sid), remove_all_matches=True):
+        sd.apply(path)
+
+
+def _duplicate_inheritable(handle: int) -> int:
+    proc = _kernel32.GetCurrentProcess()
+    out = wintypes.HANDLE()
+    _check_bool(
+        _kernel32.DuplicateHandle(
+            proc, handle, proc, ctypes.byref(out), 0, True, DUPLICATE_SAME_ACCESS
+        ),
+        "DuplicateHandle",
+    )
+    assert out.value is not None
+    return out.value
+
+
+def _create_pipe() -> Tuple[int, int]:
+    class _SECURITY_ATTRIBUTES(ctypes.Structure):
+        _fields_ = [
+            ("nLength", wintypes.DWORD),
+            ("lpSecurityDescriptor", ctypes.c_void_p),
+            ("bInheritHandle", wintypes.BOOL),
+        ]
+
+    sa = _SECURITY_ATTRIBUTES(
+        nLength=ctypes.sizeof(_SECURITY_ATTRIBUTES), lpSecurityDescriptor=None, bInheritHandle=True
+    )
+    read_h = wintypes.HANDLE()
+    write_h = wintypes.HANDLE()
+    _check_bool(
+        _kernel32.CreatePipe(ctypes.byref(read_h), ctypes.byref(write_h), ctypes.byref(sa), 0),
+        "CreatePipe",
+    )
+    assert read_h.value is not None and write_h.value is not None
+    return read_h.value, write_h.value
+
+
+class _ChildStream(NamedTuple):
+    """How one std stream is wired up for a spawn.
+
+    `handle` is the child's end, `parent_end` the parent's end of a pipe (set only when the
+    caller asked for ``subprocess.PIPE``), and `owned` says whether `handle` was created for
+    this spawn and must therefore be closed once the child has inherited it. Handles borrowed
+    from :func:`GetStdHandle` are the *parent's own* stdio and must never be closed -- doing so
+    tears down Spack's own console streams.
+    """
+
+    handle: Optional[int]
+    parent_end: Optional[int]
+    owned: bool
+
+
+def _resolve_std_handle(stream: Union[None, int, BinaryIO], std_handle_const: int) -> _ChildStream:
+    """Resolve an executable.py-style stream spec to an inheritable handle for the child."""
+    if stream is None:
+        h = _kernel32.GetStdHandle(std_handle_const)
+        return _ChildStream(h if h else None, None, owned=False)
+    if stream is subprocess.PIPE:
+        read_h, write_h = _create_pipe()
+        # Whichever end stays here must not be inheritable: a copy of it in the child would
+        # keep the pipe open forever and the parent's reader would never see EOF.
+        if std_handle_const == STD_INPUT_HANDLE:
+            # Not exercised by Executable.__call__ today (it never passes PIPE as input), but
+            # handled for completeness: the child reads stdin, the parent writes to it.
+            _kernel32.SetHandleInformation(write_h, HANDLE_FLAG_INHERIT, 0)
+            return _ChildStream(read_h, write_h, owned=True)
+        _kernel32.SetHandleInformation(read_h, HANDLE_FLAG_INHERIT, 0)
+        return _ChildStream(write_h, read_h, owned=True)
+    # A concrete file-like object (e.g. from open()).
+    assert not isinstance(stream, int)
+    raw = _msvcrt._get_osfhandle(stream.fileno())
+    return _ChildStream(_duplicate_inheritable(raw), None, owned=True)
+
+
+def _build_environment_block(env: Dict[str, str]) -> ctypes.Array:
+    # CreateProcess documents the environment block as sorted case-insensitively by name.
+    parts = [f"{k}={v}" for k, v in sorted(env.items(), key=lambda kv: kv[0].upper())]
+    block = "\0".join(parts) + "\0\0"
+    return ctypes.create_unicode_buffer(block)
+
+
+def _close_handles(*handles: Optional[int]) -> None:
+    """Release handles prepared for a spawn that never happened."""
+    for h in handles:
+        if h is not None:
+            _kernel32.CloseHandle(h)
+
+
+class AppContainerProcess:
+    """Minimal ``subprocess.Popen`` stand-in for a process launched inside an AppContainer.
+
+    Only the subset :meth:`spack.util.executable.Executable.__call__` actually uses is
+    implemented: ``communicate()``, ``kill()``, ``returncode`` and ``pid``.
+    """
+
+    def __init__(
+        self,
+        process_handle: int,
+        thread_handle: int,
+        pid: int,
+        cmd: List[str],
+        stdout_pipe: Optional[int],
+        stderr_pipe: Optional[int],
+        child_side_handles: List[int],
+    ) -> None:
+        self._process_handle: Optional[int] = process_handle
+        self.pid = pid
+        self._cmd = cmd
+        self.returncode: Optional[int] = None
+        self._results: Dict[str, bytes] = {}
+        self._communicated = False
+
+        _kernel32.CloseHandle(thread_handle)
+        # The parent's copies of the child's ends must go away before any read: an anonymous
+        # pipe only reports EOF once *every* write handle to it is closed.
+        for h in child_side_handles:
+            _kernel32.CloseHandle(h)
+
+        # Drain concurrently from the moment the child exists, so a child that fills the pipe
+        # buffer before communicate() is called cannot deadlock.
+        self._threads = [
+            self._start_drain(name, pipe)
+            for name, pipe in (("stdout", stdout_pipe), ("stderr", stderr_pipe))
+            if pipe is not None
+        ]
+
+    def _start_drain(self, name: str, handle: int) -> threading.Thread:
+        def _drain() -> None:
+            try:
+                self._results[name] = self._read_all(handle)
+            finally:
+                _kernel32.CloseHandle(handle)
+
+        t = threading.Thread(target=_drain, name=f"appcontainer-{name}", daemon=True)
+        t.start()
+        return t
+
+    @staticmethod
+    def _read_all(handle: int) -> bytes:
+        chunks = []
+        buf = ctypes.create_string_buffer(65536)
+        bytes_read = wintypes.DWORD(0)
+        while True:
+            ok = _kernel32.ReadFile(handle, buf, len(buf), ctypes.byref(bytes_read), None)
+            if not ok or bytes_read.value == 0:
+                break
+            chunks.append(buf.raw[: bytes_read.value])
+        return b"".join(chunks)
+
+    def communicate(self, timeout: Optional[float] = None) -> Tuple[bytes, bytes]:
+        # Callers may re-enter after a TimeoutExpired (Executable.__call__ does exactly that,
+        # via kill() then communicate()), so this must be safe to call more than once: the
+        # drain threads are started once in __init__ and simply re-joined here.
+        if self._communicated:
+            return self._results.get("stdout", b""), self._results.get("stderr", b"")
+
+        assert self._process_handle is not None, "process handle is only closed once reaped"
+        deadline_ms = INFINITE if timeout is None else int(timeout * 1000)
+        wait_result = _kernel32.WaitForSingleObject(self._process_handle, deadline_ms)
+
+        for t in self._threads:
+            t.join(timeout=0 if wait_result == WAIT_TIMEOUT else None)
+
+        if wait_result == WAIT_TIMEOUT or any(t.is_alive() for t in self._threads):
+            # Only reachable when a finite deadline was given: with timeout=None,
+            # deadline_ms is INFINITE and WaitForSingleObject never returns WAIT_TIMEOUT,
+            # and thread.join(timeout=None) blocks until the thread finishes.
+            assert timeout is not None
+            raise subprocess.TimeoutExpired(cmd=self._cmd, timeout=timeout)
+
+        exit_code = wintypes.DWORD(0)
+        _check_bool(
+            _kernel32.GetExitCodeProcess(self._process_handle, ctypes.byref(exit_code)),
+            "GetExitCodeProcess",
+        )
+        self.returncode = exit_code.value
+        self._communicated = True
+        _kernel32.CloseHandle(self._process_handle)
+        self._process_handle = None
+
+        return self._results.get("stdout", b""), self._results.get("stderr", b"")
+
+    def kill(self) -> None:
+        if self._process_handle is not None:
+            _kernel32.TerminateProcess(self._process_handle, 1)
+
+
+def create_process(
+    cmd: List[str],
+    *,
+    env: Dict[str, str],
+    cwd: Optional[str] = None,
+    stdin: Union[None, int, BinaryIO],
+    stdout: Union[None, int, BinaryIO],
+    stderr: Union[None, int, BinaryIO],
+    sid: int,
+    capabilities: List[int],
+) -> AppContainerProcess:
+    """Launch `cmd` inside the AppContainer identified by `sid`, granted `capabilities`."""
+    # SECURITY_CAPABILITIES.Capabilities MUST be NULL when CapabilityCount is 0. Handing
+    # CreateProcessW a valid pointer with a zero count fails the whole spawn with
+    # ERROR_INVALID_PARAMETER -- which is precisely the no-capabilities, network-blocked case.
+    cap_array = (_SID_AND_ATTRIBUTES * len(capabilities))()
+    for i, cap_sid in enumerate(capabilities):
+        cap_array[i].Sid = cap_sid
+        cap_array[i].Attributes = SE_GROUP_ENABLED
+
+    sec_cap = _SECURITY_CAPABILITIES(
+        AppContainerSid=sid,
+        Capabilities=(
+            ctypes.cast(cap_array, ctypes.POINTER(_SID_AND_ATTRIBUTES)) if capabilities else None
+        ),
+        CapabilityCount=len(capabilities),
+        Reserved=0,
+    )
+
+    startup_info = _STARTUPINFOEXW()
+    startup_info.StartupInfo.cb = ctypes.sizeof(startup_info)
+
+    child_side_handles: List[int] = []
+    stdout_pipe = stderr_pipe = None
+
+    any_redirect = stdin is not None or stdout is not None or stderr is not None
+    if any_redirect:
+        # STARTF_USESTDHANDLES is all-or-nothing, so streams the caller left as None are
+        # resolved to the parent's own std handles rather than being left unset.
+        in_stream = _resolve_std_handle(stdin, STD_INPUT_HANDLE)
+        out_stream = _resolve_std_handle(stdout, STD_OUTPUT_HANDLE)
+        err_stream = _resolve_std_handle(stderr, STD_ERROR_HANDLE)
+        stdout_pipe, stderr_pipe = out_stream.parent_end, err_stream.parent_end
+        startup_info.StartupInfo.dwFlags |= STARTF_USESTDHANDLES
+        startup_info.StartupInfo.hStdInput = in_stream.handle or 0
+        startup_info.StartupInfo.hStdOutput = out_stream.handle or 0
+        startup_info.StartupInfo.hStdError = err_stream.handle or 0
+        for stream in (in_stream, out_stream, err_stream):
+            if stream.owned and stream.handle:
+                child_side_handles.append(stream.handle)
+
+    try:
+        # First call is expected to fail with ERROR_INSUFFICIENT_BUFFER; it reports the size.
+        attr_list_size = ctypes.c_size_t(0)
+        _kernel32.InitializeProcThreadAttributeList(None, 1, 0, ctypes.byref(attr_list_size))
+        attr_list_buf = ctypes.create_string_buffer(attr_list_size.value)
+        startup_info.lpAttributeList = ctypes.cast(attr_list_buf, ctypes.c_void_p)
+        _check_bool(
+            _kernel32.InitializeProcThreadAttributeList(
+                startup_info.lpAttributeList, 1, 0, ctypes.byref(attr_list_size)
+            ),
+            "InitializeProcThreadAttributeList",
+        )
+        try:
+            # `sec_cap` and `cap_array` are only referenced by pointer from the attribute list,
+            # so both must stay alive (and unmoved) until CreateProcessW has consumed them.
+            _check_bool(
+                _kernel32.UpdateProcThreadAttribute(
+                    startup_info.lpAttributeList,
+                    0,
+                    ctypes.c_size_t(PROC_THREAD_ATTRIBUTE_SECURITY_CAPABILITIES),
+                    ctypes.byref(sec_cap),
+                    ctypes.sizeof(sec_cap),
+                    None,
+                    None,
+                ),
+                "UpdateProcThreadAttribute",
+            )
+
+            cmd_line = ctypes.create_unicode_buffer(subprocess.list2cmdline(cmd))
+            env_block = _build_environment_block(env)
+            process_info = _PROCESS_INFORMATION()
+
+            _check_bool(
+                _kernel32.CreateProcessW(
+                    None,
+                    cmd_line,
+                    None,
+                    None,
+                    True,
+                    EXTENDED_STARTUPINFO_PRESENT | CREATE_UNICODE_ENVIRONMENT,
+                    env_block,
+                    cwd,
+                    ctypes.cast(ctypes.byref(startup_info), ctypes.c_void_p),
+                    ctypes.byref(process_info),
+                ),
+                f"CreateProcessW({cmd[0]})",
+            )
+        finally:
+            _kernel32.DeleteProcThreadAttributeList(startup_info.lpAttributeList)
+    except OSError:
+        # No child exists to inherit these, so nothing else will ever close them.
+        _close_handles(*child_side_handles, stdout_pipe, stderr_pipe)
+        raise
+
+    return AppContainerProcess(
+        process_handle=process_info.hProcess,
+        thread_handle=process_info.hThread,
+        pid=process_info.dwProcessId,
+        cmd=cmd,
+        stdout_pipe=stdout_pipe,
+        stderr_pipe=stderr_pipe,
+        child_side_handles=child_side_handles,
+    )


### PR DESCRIPTION
**WIP**
* the structure and basic win32 api interactions are there, and I believe are correct, I just wanted to get eyes on this to make sure it's what Spack wants from a process sandbox while I do a bit more exploring and testing. 
* Module org needs a refactor for Windows (ad-hoc local imports, windows only cruft, etc all need fixing)
* Also the tests need updating as do the docs.

Implements support for process sandboxing, similar to Landlock on posix systems. Implements the process sandbox Spack interface by providing a sandbox implementation wrapping the Windows system AppContainer feature.

AppContainer, like landlock, offers process sandboxing, limiting filesystem and network access. AppContainer diverges from landlock in a few key ways, most importantly, it's grant system is the inverse of landlock (access is opt in vs opt out) and it only operates for _new_ processes so existing processes (i.e. top level Spack) cannot be sandboxed via this interface.

AppContainers are granted DACLs with limited permissions, and Spack grants further access via ACEs provided to the appcontainer ACL on creation.

AppContainers additionally require cleanup, this adds the requisite infra to affect that

Adds a "sid_to_string" method to our ACL module to support easier conversion.