### PR TITLE
Allow nmake and jom to be duplicated in the DAG

### DIFF
--- a/etc/spack/defaults/base/concretizer.yaml
+++ b/etc/spack/defaults/base/concretizer.yaml
@@ -51,9 +51,11 @@ concretizer:
       c: 2
       cxx: 2
       fortran: 1
+      nmake: 2
       # Regular packages
       cmake: 2
       gmake: 2
+      jom: 2
       python: 2
       python-venv: 2
       py-cython: 2


### PR DESCRIPTION
Allows for both building and utilizing these build tools in a single dag without overuse of the qt spec.

Needed for best use of JOM. Sibling to https://github.com/spack/spack-packages/pull/5772