### PR TITLE
compilers: retry failed compiler output detection

### DIFF
--- a/lib/spack/spack/compilers/libraries.py
+++ b/lib/spack/spack/compilers/libraries.py
@@ -423,7 +423,7 @@ class FileCompilerCache(CompilerCache):
                 self._data = {}
 
             # Use cache entry that may have been created by another process in the meantime.
-            entry = self._get_entry(key, allow_empty=True)
+            entry = self._get_entry(key, allow_empty=False)
 
             # Finally compute the cache entry
             if entry is None:

--- a/lib/spack/spack/test/compilers/libraries.py
+++ b/lib/spack/spack/test/compilers/libraries.py
@@ -10,6 +10,7 @@ import pytest
 import spack.compilers.config
 import spack.compilers.libraries
 import spack.util.executable
+import spack.util.file_cache
 import spack.util.filesystem as fs
 import spack.util.module_cmd
 
@@ -143,3 +144,24 @@ class TestCompilerPropertyDetector:
         with pytest.raises(spack.util.module_cmd.ModuleLoadError):
             with detector.compiler_environment():
                 pass
+
+
+class TestFileCompilerCache:
+    def test_failed_compiler_output_is_retried(self, mock_gcc, monkeypatch, tmp_path):
+        file_cache = spack.util.file_cache.FileCache(tmp_path)
+        cache = spack.compilers.libraries.FileCompilerCache(file_cache)
+
+        outputs = iter([None, "successful compiler output"])
+
+        def compiler_output(compiler):
+            return {"c_compiler_output": next(outputs)}
+
+        monkeypatch.setattr(cache, "value", compiler_output)
+
+        first = cache.get(mock_gcc)
+        second = cache.get(mock_gcc)
+        third = cache.get(mock_gcc)
+
+        assert first.c_compiler_output is None
+        assert second.c_compiler_output == "successful compiler output"
+        assert third.c_compiler_output == "successful compiler output"


### PR DESCRIPTION
Fixes #51075

### Summary

A failed compiler invocation produces an empty compiler-output cache entry. Although the initial cache lookup rejects empty entries, the lookup inside the write transaction currently accepts them. As a result, subsequent lookups reuse the failed result instead of retrying compiler detection.

This change treats empty entries as cache misses inside the write transaction. Non-empty entries created by another process are still reused.

### Testing

Added a regression test that verifies:

- a failed compiler-output lookup returns an empty result;
- the next lookup retries detection and succeeds;
- the successful result remains cached for subsequent lookups.

Local checks:

- `spack unit-test lib/spack/spack/test/compilers/libraries.py` — 4 passed, 8 Windows-specific tests skipped
- `spack style --skip mypy lib/spack/spack/compilers/libraries.py lib/spack/spack/test/compilers/libraries.py`