### PR TITLE
Improve error message from broken patch hash

### DIFF
--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -3553,9 +3553,11 @@ class Spec:
                     self._patches = spack.repo.PATH.get_patches_for_package(sha256s, pkg_cls)
                 except spack.error.PatchLookupError as e:
                     raise spack.error.SpecError(
-                        f"{e}. This usually means the patch was modified or removed. "
-                        "To fix this, either reconcretize or use the original package "
-                        "repository"
+                        f"{e}. This may mean the patch was modified or removed. "
+                        "To fix this, try: "
+                        "(1) reconcretizing, "
+                        "(2) clearing the cache with `spack clean -m`, or "
+                        "(3) resetting the package repository."
                     ) from e
 
         return self._patches


### PR DESCRIPTION
I can't reproduce exactly how this was caused, but recently Spack failed to concretize llvm with an error message:
```
Error: Couldn't find patch for package builtin.hwloc with sha256: b4db98b39733435273e57b8229ee834ce50d2785641d1587d8039598752b1a3d. This usually means the patch was modified or removed. To fix this, either reconcretize or use the original package repository
```
I think it may be related to changing my `config:source_cache`, but I couldn't reproduce it. However, running `spack clean -m` fixed the error, so it's worth adding to the "try this" instructions.

<details><summary>Original error with debug tracing</summary><pre>
lib/spack/spack/main.py:1146 ==> [2026-08-01-08:07:55.350706] SpecError: Couldn't find patch for package builtin.hwloc with sha256: b4db98b39733435273e57b8229ee834ce50d2785641d1587d8039598752b1a3d. This usually means the patch was modified or removed. To fix this, either reconcretize or use the original package repository
lib/spack/spack/error.py:58 ==> [2026-08-01-08:07:55.351131] Error: Couldn't find patch for package builtin.hwloc with sha256: b4db98b39733435273e57b8229ee834ce50d2785641d1587d8039598752b1a3d. This usually means the patch was modified or removed. To fix this, either reconcretize or use the original package repository
Traceback (most recent call last):
  File "/auto/projects/celeritas/spack/lib/spack/spack/spec.py", line 3553, in patches
    self._patches = spack.repo.PATH.get_patches_for_package(sha256s, pkg_cls)
                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^
  File "/auto/projects/celeritas/spack/lib/spack/spack/repo.py", line 902, in get_patches_for_package
    return [current_index.patch_for_package(sha256, pkg_cls) for sha256 in sha256s]
            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^
  File "/auto/projects/celeritas/spack/lib/spack/spack/patch.py", line 442, in patch_for_package
    raise spack.error.PatchLookupError(
        f"Couldn't find patch for package {pkg.fullname} with sha256: {sha256}"
    )
spack.error.PatchLookupError: Couldn't find patch for package builtin.hwloc with sha256: b4db98b39733435273e57b8229ee834ce50d2785641d1587d8039598752b1a3d

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/auto/projects/celeritas/spack/lib/spack/spack/main.py", line 1139, in main
    return _main(argv)
  File "/auto/projects/celeritas/spack/lib/spack/spack/main.py", line 1047, in _main
    return finish_parse_and_run(parser, cmd_name, args, env_format_error)
  File "/auto/projects/celeritas/spack/lib/spack/spack/main.py", line 1109, in finish_parse_and_run
    return _invoke_command(command, parser, args, unknown)
  File "/auto/projects/celeritas/spack/lib/spack/spack/main.py", line 633, in _invoke_command
    return_val = command(parser, args)
  File "/auto/projects/celeritas/spack/lib/spack/spack/cmd/spec.py", line 250, in spec
    result = solver.solve(
        specs,
    ...<4 lines>...
        allow_deprecated=allow_deprecated,
    )
  File "/auto/projects/celeritas/spack/lib/spack/spack/solver/asp.py", line 4047, in solve
    result, _, _ = self.solve_with_stats(specs, **kwargs)
                   ~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^
  File "/auto/projects/celeritas/spack/lib/spack/spack/solver/asp.py", line 4031, in solve_with_stats
    result = self.driver.solve(
        setup,
    ...<4 lines>...
        allow_deprecated=allow_deprecated,
    )
  File "/auto/projects/celeritas/spack/lib/spack/spack/solver/asp.py", line 1144, in solve
    post_process_concretization_result(spec_dict)
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^
  File "/auto/projects/celeritas/spack/lib/spack/spack/solver/asp.py", line 3821, in post_process_concretization_result
    root._finalize_concretization()
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^
  File "/auto/projects/celeritas/spack/lib/spack/spack/spec.py", line 2924, in _finalize_concretization
    spec._cached_hash(ht.package_hash, force=True)
    ~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/auto/projects/celeritas/spack/lib/spack/spack/spec.py", line 2282, in _cached_hash
    hash_string = self.spec_hash(hash)
  File "/auto/projects/celeritas/spack/lib/spack/spack/spec.py", line 2252, in spec_hash
    return hash.override(self)
           ~~~~~~~~~~~~~^^^^^^
  File "/auto/projects/celeritas/spack/lib/spack/spack/hash_types.py", line 61, in _content_hash_override
    return pkg.content_hash()
           ~~~~~~~~~~~~~~~~^^
  File "/auto/projects/celeritas/spack/lib/spack/spack/package_base.py", line 1885, in content_hash
    ":".join((p.sha256, str(p.level))).encode("utf-8") for p in self.spec.patches
                                                                ^^^^^^^^^^^^^^^^^
  File "/auto/projects/celeritas/spack/lib/spack/spack/spec.py", line 3555, in patches
    raise spack.error.SpecError(
    ...<3 lines>...
    ) from e
spack.error.SpecError: Couldn't find patch for package builtin.hwloc with sha256: b4db98b39733435273e57b8229ee834ce50d2785641d1587d8039598752b1a3d. This usually means the patch was modified or removed. To fix this, either reconcretize or use the original package repository
</pre></details>