### PR TITLE
Windows: add QA scripts to install and reset the build prerequisites

### DIFF
--- a/lib/spack/docs/windows.rst
+++ b/lib/spack/docs/windows.rst
@@ -87,6 +87,39 @@ Spack requires the utilities vendored by this project.
 A tool for extracting ``.xz`` files is required for extracting source tarballs.
 The latest 7-Zip can be located at https://sourceforge.net/projects/sevenzip/.
 
+.. _windows_scripted_prerequisites:
+
+Scripted alternative
+^^^^^^^^^^^^^^^^^^^^
+
+Once you have a Spack checkout (Step 2 below), the Visual Studio components above can be
+installed without clicking through the installer UI:
+
+.. code-block:: console
+
+   $ powershell -ExecutionPolicy Bypass -File share\spack\qa\windows_install_msvc.ps1 -Apply -Elevate
+
+The script requests only the components Spack needs, so no IDE workload, ARM/ARM64 toolset or
+WDK is pulled in: the MSVC x64/x86 toolset, a Windows SDK, and "C++ CMake tools for Windows".
+It then installs the Intel oneAPI Fortran compiler, because MSVC provides none, and runs the
+``spack compiler find`` and ``spack external find`` commands described in Step 3 for you.
+
+Without ``-Apply`` the script only reports what it would do. ``-Elevate`` requests the
+administrator token the installers require. Because Build Tools installations expose no
+privacy UI, the script also opts out of the Visual Studio Customer Experience Improvement
+Program; pass ``-KeepTelemetry`` to leave that setting alone, and ``-SkipFortran`` to omit the
+Fortran compiler. Run ``Get-Help`` on the script for the full list of options.
+
+Every run finishes with a verification pass that checks for the files Spack actually consumes,
+such as ``cl.exe``, the bundled ``cmake.exe`` and ``ninja.exe``, and the SDK's
+``ucrt\x64\libucrt.lib`` and ``um\x64\OpenGL32.Lib``. The script exits non-zero if any of them
+are missing, so it can be used to check an existing machine as well as to set up a new one.
+
+A companion script, ``share\spack\qa\windows_reset_msvc.ps1``, removes a Visual Studio
+toolchain again along with the stale directories and registry keys it leaves behind. It exists
+to test Spack's Windows setup from a known-clean state, so do not run it on a machine whose
+toolchain you want to keep.
+
 Step 2: Install and setup Spack
 -------------------------------
 

--- a/share/spack/qa/windows_install_msvc.ps1
+++ b/share/spack/qa/windows_install_msvc.ps1
@@ -1,0 +1,843 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+<#
+.SYNOPSIS
+    Install the minimal Visual Studio Build Tools components that Spack needs on Windows.
+
+.DESCRIPTION
+    Spack on Windows requires an MSVC C/C++ toolset, a Windows SDK (which also provides WGL),
+    and the CMake/Ninja pair that ships with Visual Studio. This script installs exactly those
+    components and nothing else -- no IDE workload, no ARM/ARM64 toolsets, no WDK. Because MSVC
+    has no Fortran compiler, the Intel oneAPI Fortran compiler (ifx) is installed as well; pass
+    -SkipFortran to leave it out.
+
+    If a Visual Studio or Build Tools instance already exists, the missing components are added
+    to it with the Visual Studio Installer. If no instance exists, Build Tools is installed with
+    winget. Both paths are unattended and idempotent: re-running when everything is present is
+    a no-op.
+
+    The WDK is never installed, but an existing machine-wide WDK is registered as an external,
+    because Spack cannot build one: the Windows Kits family is a single shared installation.
+
+    After the toolchain is in place the script registers it with Spack ("spack compiler find",
+    "spack external find"), then verifies the result by checking for the specific files Spack
+    needs and reports anything missing.
+
+    Optional diagnostic data collection is turned off by default: no optional components are
+    requested, the VSCEIP OptIn registry value is set to 0, and VSCMD_SKIP_SENDTELEMETRY is set
+    machine-wide so VsDevCmd.bat does not report developer-shell usage. Pass -KeepTelemetry to
+    leave those settings untouched. Note that the MSVC telemetry helper VCTIP.EXE ships as part
+    of the compiler toolset and cannot be deselected at install time.
+
+.PARAMETER Apply
+    Perform the installation. Without this switch the script only reports what it would do.
+
+.PARAMETER Elevate
+    Relaunch the script with an administrator token (UAC prompt) and stream the elevated run's
+    output back to this console.
+
+.PARAMETER Components
+    Override the component IDs to install. Defaults to the MSVC x64/x86 toolset, a Windows 11
+    SDK, and C++ CMake tools for Windows.
+
+.PARAMETER WingetPackageId
+    winget package used when no Visual Studio instance exists.
+    Defaults to Microsoft.VisualStudio.2022.BuildTools.
+
+.PARAMETER SkipFortran
+    Do not install the Intel oneAPI Fortran compiler (ifx). MSVC provides no Fortran, so it is
+    installed by default for packages that contain Fortran sources. It comes from winget, so no
+    manual download is required; an already-downloaded offline installer is used only as a
+    fallback when winget is unavailable.
+
+.PARAMETER FortranInstaller
+    Path to an Intel Fortran offline installer to use instead of winget. When omitted and
+    winget is unavailable, the newest *fortran*offline*.exe in the Downloads folder is used.
+
+.PARAMETER FortranWingetId
+    winget package for the Intel Fortran compiler. Defaults to Intel.FortranCompiler.
+
+.PARAMETER SkipSpackConfig
+    Do not run "spack compiler find" / "spack external find" after installing.
+
+.PARAMETER KeepTelemetry
+    Leave the Visual Studio telemetry settings alone. By default this script opts out of the
+    Customer Experience Improvement Program by setting the documented OptIn=0 registry values,
+    because Build Tools installs have no UI for this, and sets VSCMD_SKIP_SENDTELEMETRY=1.
+    Opting out needs elevation; without it the step is reported as skipped.
+
+.PARAMETER SpackRoot
+    Path to the Spack checkout. Defaults to the checkout containing this script.
+
+.EXAMPLE
+    .\share\spack\qa\windows_install_msvc.ps1
+    Report what is missing and what would be installed, change nothing.
+
+.EXAMPLE
+    .\share\spack\qa\windows_install_msvc.ps1 -Apply -Elevate
+    Prompt for elevation and install the missing components.
+
+.LINK
+    https://learn.microsoft.com/visualstudio/install/workload-component-id-vs-build-tools
+
+.LINK
+    https://learn.microsoft.com/visualstudio/ide/visual-studio-experience-improvement-program
+
+.LINK
+    https://github.com/oneapi-src/oneapi-ci/blob/master/scripts/install_windows.bat
+#>
+
+#Requires -Version 5.1
+
+[CmdletBinding()]
+param(
+    [switch]$Apply,
+    [switch]$Elevate,
+    [string[]]$Components,
+    [string]$WingetPackageId = 'Microsoft.VisualStudio.2022.BuildTools',
+    [switch]$SkipFortran,
+    [string]$FortranInstaller,
+    [string]$FortranWingetId = 'Intel.FortranCompiler',
+    [switch]$SkipSpackConfig,
+    [switch]$KeepTelemetry,
+    [string]$SpackRoot
+)
+
+$ErrorActionPreference = 'Continue'
+$ProgressPreference = 'SilentlyContinue'
+
+# Minimal component set. See the .LINK reference for the authoritative ID list.
+#   VC.Tools.x86.x64      MSVC C/C++ build tools for x64/x86 (latest)
+#   Windows11SDK.26100    Windows SDK; also supplies WGL (um\x64\OpenGL32.Lib) and the UCRT libs
+#   VC.CMake.Project      "C++ CMake tools for Windows", which bundles CMake and Ninja
+$DefaultComponents = @(
+    'Microsoft.VisualStudio.Component.VC.Tools.x86.x64',
+    'Microsoft.VisualStudio.Component.Windows11SDK.26100',
+    'Microsoft.VisualStudio.Component.VC.CMake.Project'
+)
+if (-not $Components) { $Components = $DefaultComponents }
+
+$script:Actions = New-Object System.Collections.ArrayList
+$script:Checks = New-Object System.Collections.ArrayList
+
+function Add-Action {
+    param([string]$Step, [string]$Item, [string]$Status, [string]$Detail = '')
+    $null = $script:Actions.Add([pscustomobject]@{
+            Step = $Step; Item = $Item; Status = $Status; Detail = $Detail
+        })
+}
+
+function Add-Check {
+    param([string]$Check, [bool]$Passed, [string]$Detail = '')
+    $null = $script:Checks.Add([pscustomobject]@{
+            Check = $Check; Result = $(if ($Passed) { 'OK' } else { 'MISSING' }); Detail = $Detail
+        })
+}
+
+function Test-Elevated {
+    $identity = [Security.Principal.WindowsIdentity]::GetCurrent()
+    $principal = New-Object Security.Principal.WindowsPrincipal($identity)
+    return $principal.IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
+}
+
+function Get-ProgramFilesRoots {
+    $roots = @()
+    foreach ($var in 'ProgramFiles', 'ProgramFiles(x86)') {
+        $value = [Environment]::GetEnvironmentVariable($var)
+        if ($value -and ($roots -notcontains $value)) { $roots += $value }
+    }
+    return $roots
+}
+
+function Get-VsInstallerDirectory {
+    foreach ($root in Get-ProgramFilesRoots) {
+        $dir = Join-Path $root 'Microsoft Visual Studio\Installer'
+        if (Test-Path -LiteralPath $dir) { return $dir }
+    }
+    return $null
+}
+
+function Invoke-VsWhere {
+    param([string[]]$ArgumentList)
+    $installerDir = Get-VsInstallerDirectory
+    if (-not $installerDir) { return @() }
+    $vswhere = Join-Path $installerDir 'vswhere.exe'
+    if (-not (Test-Path -LiteralPath $vswhere)) { return @() }
+
+    $raw = & $vswhere @ArgumentList 2>&1
+    if ($LASTEXITCODE -ne 0) { return @() }
+    $text = ($raw | Out-String).Trim()
+    if (-not $text) { return @() }
+    try {
+        $parsed = $text | ConvertFrom-Json
+    } catch {
+        return @()
+    }
+    if ($null -eq $parsed) { return @() }
+    return @($parsed)
+}
+
+function Get-VsInstances {
+    return Invoke-VsWhere -ArgumentList @('-all', '-prerelease', '-products', '*', '-format', 'json')
+}
+
+function Test-VsComponent {
+    param([string]$ComponentId)
+    # @() is required: PowerShell unrolls a single-element return value, and .Count on a bare
+    # PSCustomObject is $null in Windows PowerShell 5.1.
+    $found = @(Invoke-VsWhere -ArgumentList @(
+            '-all', '-prerelease', '-products', '*', '-requires', $ComponentId, '-format', 'json'))
+    return $found.Count -gt 0
+}
+
+function Write-Step {
+    param([string]$Message)
+    Write-Host "  -> $Message" -ForegroundColor DarkGray
+}
+
+function Invoke-Tool {
+    param([string]$FilePath, [string[]]$ArgumentList, [switch]$Stream)
+
+    # -Stream echoes each line as it arrives; installers can run for many minutes and are
+    # indistinguishable from a hang when their output is only reported at the end.
+    $lines = New-Object System.Collections.ArrayList
+    & $FilePath @ArgumentList 2>&1 | ForEach-Object {
+        $line = "$_"
+        if ($Stream -and $line.Trim()) { Write-Host "     $line" }
+        $null = $lines.Add($line)
+    }
+    return @{ ExitCode = $LASTEXITCODE; Output = ($lines -join [Environment]::NewLine).Trim() }
+}
+
+function Get-SpackCommand {
+    if ($SpackRoot) {
+        $candidate = Join-Path $SpackRoot 'bin\spack.ps1'
+        if (Test-Path -LiteralPath $candidate) { return $candidate }
+        Write-Warning "no bin\spack.ps1 under -SpackRoot '$SpackRoot'"
+        return $null
+    }
+    $candidate = Join-Path $PSScriptRoot '..\..\..\bin\spack.ps1'
+    if (Test-Path -LiteralPath $candidate) { return (Resolve-Path -LiteralPath $candidate).Path }
+    if ($env:SPACK_ROOT) {
+        $candidate = Join-Path $env:SPACK_ROOT 'bin\spack.ps1'
+        if (Test-Path -LiteralPath $candidate) { return $candidate }
+    }
+    return $null
+}
+
+function Invoke-Spack {
+    param([string]$SpackCmd, [string[]]$ArgumentList)
+    $output = & $SpackCmd @ArgumentList 2>&1
+    return @{ ExitCode = $LASTEXITCODE; Output = ($output | Out-String).Trim() }
+}
+
+function Get-InstallerLogHint {
+    <# The VS bootstrapper and installer write dd_*.log files to %TEMP%. #>
+    $logs = Get-ChildItem -LiteralPath $env:TEMP -Filter 'dd_*.log' -File -ErrorAction SilentlyContinue |
+        Sort-Object LastWriteTime -Descending | Select-Object -First 3
+    if (-not $logs) { return "no dd_*.log found in $env:TEMP" }
+    return ($logs | ForEach-Object { $_.FullName }) -join '; '
+}
+
+function Get-InstallerExitDetail {
+    param([int]$ExitCode, [string]$Output)
+    switch ($ExitCode) {
+        0 { return 'installer reported success' }
+        3010 { return 'installer reported success, reboot required' }
+        1602 { return 'cancelled by the user (1602)' }
+        1603 { return "fatal installer error (1603). Logs: $(Get-InstallerLogHint)" }
+        default { return "exit $ExitCode. Logs: $(Get-InstallerLogHint). Output: $Output" }
+    }
+}
+
+# Process names used by the Visual Studio Installer and its bootstrapper. Only one may run at a
+# time; a second invocation fails without a distinguishing exit code.
+$VsInstallerProcessNames = @(
+    'vs_installer', 'vs_installershell', 'vs_installerservice', 'vs_bootstrapper',
+    'vs_setup_bootstrapper', 'vs_buildtools', 'VSIXInstaller', 'setup'
+)
+
+function Get-RunningVsInstallerProcesses {
+    return @(Get-Process -Name $VsInstallerProcessNames -ErrorAction SilentlyContinue)
+}
+
+function Confirm-ComponentsInstalled {
+    param([string[]]$Expected, [int]$TimeoutSeconds = 1800)
+
+    # The installer detaches, so poll vswhere rather than trusting the exit code: winget and the
+    # VS bootstrapper can both exit 0 without having installed anything.
+    $start = Get-Date
+    $deadline = $start.AddSeconds($TimeoutSeconds)
+    $nextHeartbeat = $start.AddSeconds(30)
+    Write-Step 'waiting for the Visual Studio Installer to register the components'
+    do {
+        $stillMissing = @($Expected | Where-Object { -not (Test-VsComponent -ComponentId $_) })
+        if ($stillMissing.Count -eq 0) {
+            Add-Action -Step 'confirm' -Item 'components' -Status 'Ok' -Detail 'all requested components are now present'
+            return
+        }
+        Start-Sleep -Seconds 5
+        if ((Get-Date) -ge $nextHeartbeat) {
+            Write-Step ('still waiting ({0:n0}s elapsed)' -f ((Get-Date) - $start).TotalSeconds)
+            $nextHeartbeat = (Get-Date).AddSeconds(30)
+        }
+    } while ((Get-Date) -lt $deadline)
+
+    Add-Action -Step 'confirm' -Item ($stillMissing -join ', ') -Status 'Failed' `
+        -Detail "still not installed after the installer reported success. Logs: $(Get-InstallerLogHint)"
+}
+
+# ---------------------------------------------------------------------------------------
+# Installation
+# ---------------------------------------------------------------------------------------
+
+function Get-MissingComponents {
+    $missing = @()
+    foreach ($component in $Components) {
+        if (Test-VsComponent -ComponentId $component) {
+            Add-Action -Step 'components' -Item $component -Status 'NotNeeded' -Detail 'already installed'
+        } else {
+            $missing += $component
+        }
+    }
+    return $missing
+}
+
+function Invoke-ModifyExistingInstance {
+    param([object]$Instance, [string[]]$MissingComponents)
+
+    $label = "$($Instance.displayName) [$($Instance.installationPath)]"
+    if (-not $Apply) {
+        Add-Action -Step 'vs-modify' -Item $label -Status 'DryRun' `
+            -Detail "would add: $($MissingComponents -join ', ')"
+        return
+    }
+    if (-not (Test-Elevated)) {
+        Add-Action -Step 'vs-modify' -Item $label -Status 'Skipped' -Detail 'needs elevation'
+        return
+    }
+
+    $installerDir = Get-VsInstallerDirectory
+    $vsInstaller = if ($installerDir) { Join-Path $installerDir 'vs_installer.exe' } else { $null }
+    if (-not $vsInstaller -or -not (Test-Path -LiteralPath $vsInstaller)) {
+        Add-Action -Step 'vs-modify' -Item $label -Status 'Failed' -Detail 'vs_installer.exe not found'
+        return
+    }
+
+    $toolArgs = @('modify', '--installPath', $Instance.installationPath)
+    foreach ($component in $MissingComponents) { $toolArgs += @('--add', $component) }
+    # No --wait: setup.exe rejects it for some verbs (exit 87) and detaches anyway, so
+    # Confirm-ComponentsInstalled polls vswhere for the result instead.
+    $toolArgs += @('--passive', '--norestart')
+
+    Write-Step "adding components to $($Instance.installationPath)"
+    $result = Invoke-Tool -FilePath $vsInstaller -ArgumentList $toolArgs -Stream
+    $detail = Get-InstallerExitDetail -ExitCode $result.ExitCode -Output $result.Output
+    $status = if ($result.ExitCode -eq 0 -or $result.ExitCode -eq 3010) { 'Ok' } else { 'Failed' }
+    Add-Action -Step 'vs-modify' -Item $label -Status $status -Detail $detail
+}
+
+function Invoke-InstallBuildTools {
+    param([string[]]$MissingComponents)
+
+    $overrideArgs = @('--passive', '--norestart', '--wait')
+    foreach ($component in $MissingComponents) { $overrideArgs += @('--add', $component) }
+    $override = $overrideArgs -join ' '
+
+    if (-not $Apply) {
+        Add-Action -Step 'winget-install' -Item $WingetPackageId -Status 'DryRun' -Detail $override
+        return
+    }
+    $winget = Get-Command winget -ErrorAction SilentlyContinue
+    if (-not $winget) {
+        Add-Action -Step 'winget-install' -Item $WingetPackageId -Status 'Failed' `
+            -Detail 'winget not found; install "App Installer" or run the Build Tools bootstrapper manually'
+        return
+    }
+    if (-not (Test-Elevated)) {
+        Add-Action -Step 'winget-install' -Item $WingetPackageId -Status 'Skipped' -Detail 'needs elevation'
+        return
+    }
+
+    Write-Step "installing $WingetPackageId with winget (several GB, this takes a while)"
+    $result = Invoke-Tool -Stream -FilePath $winget.Source -ArgumentList @(
+        'install', '--id', $WingetPackageId, '--exact', '--source', 'winget',
+        '--accept-package-agreements', '--accept-source-agreements', '--disable-interactivity',
+        '--override', $override)
+    $detail = Get-InstallerExitDetail -ExitCode $result.ExitCode -Output $result.Output
+    $status = if ($result.ExitCode -eq 0 -or $result.ExitCode -eq 3010) { 'Ok' } else { 'Failed' }
+    Add-Action -Step 'winget-install' -Item $WingetPackageId -Status $status -Detail $detail
+}
+
+# ---------------------------------------------------------------------------------------
+# Intel Fortran (optional)
+# ---------------------------------------------------------------------------------------
+
+function Get-OneApiRoots {
+    $roots = @()
+    if ($env:ONEAPI_ROOT) { $roots += $env:ONEAPI_ROOT }
+    foreach ($base in Get-ProgramFilesRoots) { $roots += (Join-Path $base 'Intel\oneAPI') }
+    return @($roots | Where-Object { Test-Path -LiteralPath $_ } | Select-Object -Unique)
+}
+
+function Find-IfxExecutable {
+    foreach ($root in Get-OneApiRoots) {
+        $found = @(Get-ChildItem -Path (Join-Path $root 'compiler\*\bin\ifx.exe') -ErrorAction SilentlyContinue |
+                Sort-Object FullName -Descending)
+        if ($found.Count -gt 0) { return $found[0].FullName }
+    }
+    return $null
+}
+
+function Find-FortranOfflineInstaller {
+    if ($FortranInstaller) {
+        if (Test-Path -LiteralPath $FortranInstaller) { return $FortranInstaller }
+        Write-Warning "no installer at -FortranInstaller '$FortranInstaller'"
+        return $null
+    }
+    $downloads = Join-Path $env:USERPROFILE 'Downloads'
+    if (-not (Test-Path -LiteralPath $downloads)) { return $null }
+    $candidates = @(Get-ChildItem -LiteralPath $downloads -Filter '*fortran*offline*.exe' -File -ErrorAction SilentlyContinue |
+            Sort-Object LastWriteTime -Descending)
+    if ($candidates.Count -eq 0) { return $null }
+    return $candidates[0].FullName
+}
+
+function Install-FortranFromOfflineInstaller {
+    param([string]$InstallerPath)
+
+    # Sequence and arguments follow Intel's own CI scripts; see the oneapi-ci .LINK reference.
+    $extractDir = Join-Path $env:TEMP ('oneapi-extract-{0}' -f (Get-Date -Format 'yyyyMMddHHmmss'))
+    Write-Step "extracting $InstallerPath"
+    $extract = Invoke-Tool -Stream -FilePath $InstallerPath -ArgumentList @(
+        '-s', '-x', '-f', $extractDir, '--log', 'extract.log')
+    $bootstrapper = Join-Path $extractDir 'bootstrapper.exe'
+    if ($extract.ExitCode -ne 0 -or -not (Test-Path -LiteralPath $bootstrapper)) {
+        Add-Action -Step 'fortran' -Item $InstallerPath -Status 'Failed' `
+            -Detail "extraction failed (exit $($extract.ExitCode)): $($extract.Output)"
+        return
+    }
+    try {
+        Write-Step 'running the Intel oneAPI bootstrapper'
+        $result = Invoke-Tool -Stream -FilePath $bootstrapper -ArgumentList @(
+            '-s', '--action', 'install', '--eula=accept',
+            '-p=NEED_VS2017_INTEGRATION=0', '-p=NEED_VS2019_INTEGRATION=0',
+            '-p=NEED_VS2022_INTEGRATION=0', "--log-dir=$extractDir")
+        $status = if ($result.ExitCode -eq 0 -or $result.ExitCode -eq 3010) { 'Ok' } else { 'Failed' }
+        Add-Action -Step 'fortran' -Item $InstallerPath -Status $status `
+            -Detail "bootstrapper exit $($result.ExitCode). Logs: $extractDir"
+    } finally {
+        Remove-Item -LiteralPath $extractDir -Recurse -Force -ErrorAction SilentlyContinue
+    }
+}
+
+function Invoke-InstallFortran {
+    $ifx = Find-IfxExecutable
+    if ($ifx) {
+        Add-Action -Step 'fortran' -Item 'ifx' -Status 'NotNeeded' -Detail $ifx
+        return
+    }
+    if (-not $Apply) {
+        Add-Action -Step 'fortran' -Item $FortranWingetId -Status 'DryRun' -Detail 'would install Intel Fortran (ifx)'
+        return
+    }
+    if (-not (Test-Elevated)) {
+        Add-Action -Step 'fortran' -Item $FortranWingetId -Status 'Skipped' -Detail 'needs elevation'
+        return
+    }
+
+    $winget = Get-Command winget -ErrorAction SilentlyContinue
+    if ($winget) {
+        Write-Step "installing $FortranWingetId with winget (this takes a while)"
+        $result = Invoke-Tool -Stream -FilePath $winget.Source -ArgumentList @(
+            'install', '--id', $FortranWingetId, '--exact', '--source', 'winget',
+            '--accept-package-agreements', '--accept-source-agreements', '--disable-interactivity')
+        if ($result.ExitCode -eq 0 -or $result.ExitCode -eq 3010) {
+            Add-Action -Step 'fortran' -Item $FortranWingetId -Status 'Ok' -Detail 'installed via winget'
+            return
+        }
+        Add-Action -Step 'fortran' -Item $FortranWingetId -Status 'Failed' `
+            -Detail "winget exit $($result.ExitCode): $($result.Output)"
+    }
+
+    $offline = Find-FortranOfflineInstaller
+    if (-not $offline) {
+        Add-Action -Step 'fortran' -Item 'offline installer' -Status 'Skipped' `
+            -Detail 'winget unavailable or failed and no *fortran*offline*.exe found; pass -FortranInstaller'
+        return
+    }
+    Install-FortranFromOfflineInstaller -InstallerPath $offline
+}
+
+# ---------------------------------------------------------------------------------------
+# Telemetry opt-out
+# ---------------------------------------------------------------------------------------
+
+function Get-VsceipKeys {
+    $keys = @('HKLM:\SOFTWARE\Policies\Microsoft\VisualStudio\SQM')
+    foreach ($instance in @(Get-VsInstances)) {
+        $major = ($instance.installationVersion -split '\.')[0]
+        if (-not $major) { continue }
+        $keys += if ([Environment]::Is64BitOperatingSystem) {
+            "HKLM:\SOFTWARE\Wow6432Node\Microsoft\VSCommon\$major.0\SQM"
+        } else {
+            "HKLM:\SOFTWARE\Microsoft\VSCommon\$major.0\SQM"
+        }
+    }
+    return @($keys | Select-Object -Unique)
+}
+
+function Invoke-DisableTelemetry {
+    $keys = Get-VsceipKeys
+
+    if (-not $Apply) {
+        foreach ($key in $keys) {
+            Add-Action -Step 'telemetry' -Item $key -Status 'DryRun' -Detail 'would set OptIn=0'
+        }
+        Add-Action -Step 'telemetry' -Item 'VSCMD_SKIP_SENDTELEMETRY' -Status 'DryRun' -Detail 'would set to 1 (machine)'
+        return
+    }
+    if (-not (Test-Elevated)) {
+        Add-Action -Step 'telemetry' -Item 'VSCEIP opt-out' -Status 'Skipped' -Detail 'needs elevation'
+        return
+    }
+    foreach ($key in $keys) {
+        try {
+            if (-not (Test-Path -LiteralPath $key)) {
+                New-Item -Path $key -Force -ErrorAction Stop | Out-Null
+            }
+            New-ItemProperty -LiteralPath $key -Name 'OptIn' -PropertyType DWord -Value 0 -Force -ErrorAction Stop | Out-Null
+            Add-Action -Step 'telemetry' -Item "$key\OptIn" -Status 'Ok' -Detail 'set to 0 (opted out)'
+        } catch {
+            Add-Action -Step 'telemetry' -Item $key -Status 'Failed' -Detail $_.Exception.Message
+        }
+    }
+
+    # VsDevCmd.bat sends developer-shell telemetry only while this variable is empty.
+    $existing = [Environment]::GetEnvironmentVariable('VSCMD_SKIP_SENDTELEMETRY', 'Machine')
+    if ($existing) {
+        Add-Action -Step 'telemetry' -Item 'VSCMD_SKIP_SENDTELEMETRY' -Status 'NotNeeded' -Detail "already set to '$existing'"
+        return
+    }
+    try {
+        [Environment]::SetEnvironmentVariable('VSCMD_SKIP_SENDTELEMETRY', '1', 'Machine')
+        Add-Action -Step 'telemetry' -Item 'VSCMD_SKIP_SENDTELEMETRY' -Status 'Ok' -Detail 'set to 1 (machine)'
+    } catch {
+        Add-Action -Step 'telemetry' -Item 'VSCMD_SKIP_SENDTELEMETRY' -Status 'Failed' -Detail $_.Exception.Message
+    }
+}
+
+# ---------------------------------------------------------------------------------------
+# Spack registration
+# ---------------------------------------------------------------------------------------
+
+function Get-SpackUserConfigPath {
+    param([string]$SpackCmd)
+    if ($SpackCmd) {
+        $result = Invoke-Spack -SpackCmd $SpackCmd -ArgumentList @(
+            'python', '-c', 'import spack.paths; print(spack.paths.user_config_path)')
+        if ($result.ExitCode -eq 0 -and $result.Output) {
+            $line = ($result.Output -split "`n" | Where-Object { $_.Trim() } | Select-Object -Last 1).Trim()
+            if ($line) { return $line }
+        }
+    }
+    if ($env:SPACK_USER_CONFIG_PATH) { return $env:SPACK_USER_CONFIG_PATH }
+    return (Join-Path $env:USERPROFILE '.spack')
+}
+
+function Test-MsvcFortranConfigured {
+    param([string]$PackagesYaml)
+
+    if (-not (Test-Path -LiteralPath $PackagesYaml)) { return $false }
+    $inMsvc = $false
+    foreach ($line in @(Get-Content -LiteralPath $PackagesYaml)) {
+        if ($line -match '^\s{2}msvc:\s*$') { $inMsvc = $true; continue }
+        if (-not $inMsvc) { continue }
+        if ($line -match '^\s{0,2}\S') { break }
+        if ($line -match '^\s+fortran:\s*\S') { return $true }
+    }
+    return $false
+}
+
+function Invoke-RegisterWithSpack {
+    param([string]$SpackCmd)
+
+    $commands = @(
+        @{ Label = 'spack compiler find'; Args = @('compiler', 'find') },
+        @{ Label = 'spack external find --not-buildable win-sdk wgl win-wdk'
+            Args  = @('external', 'find', '--not-buildable', 'win-sdk', 'wgl', 'win-wdk')
+        },
+        @{ Label = 'spack external find cmake ninja'; Args = @('external', 'find', 'cmake', 'ninja') }
+    )
+
+    # The msvc package provides Fortran and records the ifx/ifort path it finds during
+    # detection, but `spack compiler find` never refreshes an already-registered compiler.
+    # An msvc entry detected before Fortran existed would keep concretizing without one.
+    if (-not $SkipFortran -and $SpackCmd -and (Find-IfxExecutable)) {
+        $packagesYaml = Join-Path (Get-SpackUserConfigPath -SpackCmd $SpackCmd) 'packages.yaml'
+        if (-not (Test-MsvcFortranConfigured -PackagesYaml $packagesYaml)) {
+            if (-not $Apply) {
+                Add-Action -Step 'spack' -Item 'packages:msvc' -Status 'DryRun' `
+                    -Detail 'would re-detect msvc so it picks up the Fortran compiler'
+            } else {
+                $result = Invoke-Spack -SpackCmd $SpackCmd -ArgumentList @('config', 'rm', 'packages:msvc')
+                $status = if ($result.ExitCode -eq 0) { 'Ok' } else { 'Failed' }
+                Add-Action -Step 'spack' -Item 'packages:msvc' -Status $status `
+                    -Detail 'removed for re-detection with the Fortran compiler'
+            }
+        }
+    }
+
+    foreach ($command in $commands) {
+        if (-not $SpackCmd) {
+            Add-Action -Step 'spack' -Item $command.Label -Status 'Skipped' -Detail 'spack not found; pass -SpackRoot'
+            continue
+        }
+        if (-not $Apply) {
+            Add-Action -Step 'spack' -Item $command.Label -Status 'DryRun' -Detail 'would register externals'
+            continue
+        }
+        $result = Invoke-Spack -SpackCmd $SpackCmd -ArgumentList $command.Args
+        if ($result.ExitCode -eq 0) {
+            Add-Action -Step 'spack' -Item $command.Label -Status 'Ok' -Detail 'registered'
+        } else {
+            Add-Action -Step 'spack' -Item $command.Label -Status 'Failed' `
+                -Detail "exit $($result.ExitCode): $($result.Output)"
+        }
+    }
+}
+
+# ---------------------------------------------------------------------------------------
+# Verification: check for the exact files Spack needs, not just registry/installer metadata
+# ---------------------------------------------------------------------------------------
+
+function Get-WindowsKitLibDirectories {
+    $kitsRoot = Join-Path ${env:ProgramFiles(x86)} 'Windows Kits\10\Lib'
+    if (-not (Test-Path -LiteralPath $kitsRoot)) { return @() }
+    return @(Get-ChildItem -LiteralPath $kitsRoot -Directory -ErrorAction SilentlyContinue |
+            Where-Object { $_.Name -match '^\d+\.\d+\.\d+\.\d+$' } |
+            Sort-Object Name -Descending)
+}
+
+function Test-KitFile {
+    param([string]$RelativePath)
+    foreach ($version in Get-WindowsKitLibDirectories) {
+        $candidate = Join-Path $version.FullName $RelativePath
+        if (Test-Path -LiteralPath $candidate) { return $candidate }
+    }
+    return $null
+}
+
+function Invoke-Verification {
+    param([string]$SpackCmd)
+
+    $toolsetInstances = @(Invoke-VsWhere -ArgumentList @(
+            '-products', '*', '-requires', 'Microsoft.VisualStudio.Component.VC.Tools.x86.x64',
+            '-format', 'json'))
+    Add-Check -Check 'Visual Studio instance with the MSVC x64/x86 toolset' `
+        -Passed ($toolsetInstances.Count -gt 0) `
+        -Detail $(if ($toolsetInstances.Count -gt 0) { ($toolsetInstances | ForEach-Object { $_.installationPath }) -join '; ' } else { 'none' })
+
+    $clPaths = @()
+    $cmakePaths = @()
+    $ninjaPaths = @()
+    foreach ($instance in $toolsetInstances) {
+        $root = $instance.installationPath
+        $clPaths += @(Get-ChildItem -Path (Join-Path $root 'VC\Tools\MSVC\*\bin\Hostx64\x64\cl.exe') -ErrorAction SilentlyContinue |
+                Select-Object -ExpandProperty FullName)
+        $cmake = Join-Path $root 'Common7\IDE\CommonExtensions\Microsoft\CMake\CMake\bin\cmake.exe'
+        if (Test-Path -LiteralPath $cmake) { $cmakePaths += $cmake }
+        $ninja = Join-Path $root 'Common7\IDE\CommonExtensions\Microsoft\CMake\Ninja\ninja.exe'
+        if (Test-Path -LiteralPath $ninja) { $ninjaPaths += $ninja }
+    }
+
+    Add-Check -Check 'MSVC cl.exe (Hostx64\x64)' -Passed ($clPaths.Count -gt 0) `
+        -Detail $(if ($clPaths.Count -gt 0) { $clPaths[0] } else { 'not found' })
+    Add-Check -Check 'CMake bundled with Visual Studio' -Passed ($cmakePaths.Count -gt 0) `
+        -Detail $(if ($cmakePaths.Count -gt 0) { $cmakePaths[0] } else { 'not found' })
+    Add-Check -Check 'Ninja bundled with Visual Studio' -Passed ($ninjaPaths.Count -gt 0) `
+        -Detail $(if ($ninjaPaths.Count -gt 0) { $ninjaPaths[0] } else { 'not found' })
+
+    $ucrt = Test-KitFile -RelativePath 'ucrt\x64\libucrt.lib'
+    Add-Check -Check 'Windows SDK UCRT libs (x64)' -Passed ([bool]$ucrt) `
+        -Detail $(if ($ucrt) { $ucrt } else { 'no ucrt\x64\libucrt.lib under any Windows Kits\10\Lib version' })
+
+    $wgl = Test-KitFile -RelativePath 'um\x64\OpenGL32.Lib'
+    Add-Check -Check 'WGL (OpenGL32.Lib, x64)' -Passed ([bool]$wgl) `
+        -Detail $(if ($wgl) { $wgl } else { 'no um\x64\OpenGL32.Lib under any Windows Kits\10\Lib version' })
+
+    if ($SkipFortran) {
+        Add-Check -Check 'Intel Fortran (ifx)' -Passed $true -Detail 'not requested (-SkipFortran)'
+    } else {
+        $ifx = Find-IfxExecutable
+        Add-Check -Check 'Intel Fortran (ifx)' -Passed ([bool]$ifx) `
+            -Detail $(if ($ifx) { $ifx } else { 'no compiler\*\bin\ifx.exe under any oneAPI root' })
+    }
+
+    if ($SpackCmd) {
+        $result = Invoke-Spack -SpackCmd $SpackCmd -ArgumentList @(
+            'python', '-c',
+            'import spack.operating_systems.windows_os as w; print(len(w.WindowsOs().compiler_search_paths))')
+        if ($result.ExitCode -ne 0) {
+            Add-Check -Check 'Spack detects MSVC search paths' -Passed $false -Detail $result.Output
+        } else {
+            $line = ($result.Output -split "`n" | Where-Object { $_.Trim() } | Select-Object -Last 1).Trim()
+            $count = 0
+            [void][int]::TryParse($line, [ref]$count)
+            Add-Check -Check 'Spack detects MSVC search paths' -Passed ($count -gt 0) -Detail "$line path(s)"
+        }
+    } else {
+        Add-Check -Check 'Spack detects MSVC search paths' -Passed $false -Detail 'spack not found; pass -SpackRoot'
+    }
+}
+
+# ---------------------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------------------
+
+function Write-NewLogLines {
+    param([string]$Path, [int]$AlreadyShown)
+
+    if (-not (Test-Path -LiteralPath $Path)) { return $AlreadyShown }
+    $lines = @(Get-Content -LiteralPath $Path -ErrorAction SilentlyContinue)
+    if ($lines.Count -le $AlreadyShown) { return $AlreadyShown }
+    $lines[$AlreadyShown..($lines.Count - 1)] | ForEach-Object { Write-Host $_ }
+    return $lines.Count
+}
+
+function Invoke-SelfElevate {
+    $log = Join-Path $env:TEMP ('spack-windows-install-{0}.log' -f (Get-Date -Format 'yyyyMMdd-HHmmss'))
+    $inner = "& '$PSCommandPath'"
+    if ($Apply) { $inner += ' -Apply' }
+    if ($SkipSpackConfig) { $inner += ' -SkipSpackConfig' }
+    if ($KeepTelemetry) { $inner += ' -KeepTelemetry' }
+    if ($SkipFortran) { $inner += ' -SkipFortran' }
+    if ($FortranInstaller) { $inner += " -FortranInstaller '$FortranInstaller'" }
+    if ($PSBoundParameters.ContainsKey('FortranWingetId')) { $inner += " -FortranWingetId '$FortranWingetId'" }
+    if ($SpackRoot) { $inner += " -SpackRoot '$SpackRoot'" }
+    if ($PSBoundParameters.ContainsKey('WingetPackageId')) { $inner += " -WingetPackageId '$WingetPackageId'" }
+    if ($PSBoundParameters.ContainsKey('Components')) {
+        $quoted = ($Components | ForEach-Object { "'$_'" }) -join ','
+        $inner += " -Components $quoted"
+    }
+    $inner += " *> '$log'; exit `$LASTEXITCODE"
+
+    Write-Host "Relaunching elevated; output is captured in $log" -ForegroundColor Yellow
+    try {
+        $proc = Start-Process -FilePath 'powershell' -Verb RunAs -PassThru -ArgumentList @(
+            '-NoProfile', '-ExecutionPolicy', 'Bypass', '-Command', $inner)
+    } catch {
+        Write-Error "elevation failed: $($_.Exception.Message)"
+        exit 2
+    }
+
+    # Tail the child's log while it runs; otherwise long installer steps look like a hang.
+    $shown = 0
+    while (-not $proc.HasExited) {
+        Start-Sleep -Milliseconds 500
+        $shown = Write-NewLogLines -Path $log -AlreadyShown $shown
+    }
+    $proc.WaitForExit()
+    $shown = Write-NewLogLines -Path $log -AlreadyShown $shown
+    if ($shown -eq 0) { Write-Warning "elevated run produced no log at $log" }
+    exit $proc.ExitCode
+}
+
+if ($Elevate -and -not (Test-Elevated)) { Invoke-SelfElevate }
+
+$spackCmd = Get-SpackCommand
+
+Write-Host ''
+Write-Host '=== Spack Windows MSVC install ===' -ForegroundColor Cyan
+Write-Host ("  mode     : {0}" -f $(if ($Apply) { 'APPLY' } else { 'DRY RUN (pass -Apply to install)' }))
+Write-Host ("  elevated : {0}" -f (Test-Elevated))
+Write-Host ("  spack    : {0}" -f $(if ($spackCmd) { $spackCmd } else { '<not found>' }))
+Write-Host '  components:'
+foreach ($component in $Components) { Write-Host "    $component" }
+Write-Host ''
+
+if ($Apply -and -not (Test-Elevated)) {
+    Write-Warning 'Not running elevated. Installation steps will be skipped. Re-run with -Elevate or from an Administrator shell.'
+}
+
+$missing = @(Get-MissingComponents)
+if ($missing.Count -eq 0) {
+    Add-Action -Step 'install' -Item '(none)' -Status 'NotNeeded' -Detail 'all components already present'
+} else {
+    $busy = @(Get-RunningVsInstallerProcesses)
+    if ($Apply -and $busy.Count -gt 0) {
+        $names = ($busy | ForEach-Object { "$($_.ProcessName)($($_.Id))" }) -join ', '
+        Add-Action -Step 'preflight' -Item 'Visual Studio Installer' -Status 'Failed' `
+            -Detail "already running: $names. Close it and re-run; only one installer may run at a time."
+    } else {
+        $instances = @(Get-VsInstances)
+        if ($instances.Count -gt 0) {
+            Invoke-ModifyExistingInstance -Instance $instances[0] -MissingComponents $missing
+        } else {
+            Invoke-InstallBuildTools -MissingComponents $missing
+        }
+        if ($Apply) { Confirm-ComponentsInstalled -Expected $missing }
+    }
+}
+
+$installFailed = @($script:Actions | Where-Object { $_.Status -eq 'Failed' }).Count -gt 0
+if ($SkipFortran) {
+    Add-Action -Step 'fortran' -Item 'Intel Fortran' -Status 'Skipped' -Detail '-SkipFortran'
+} elseif (-not $installFailed) {
+    Invoke-InstallFortran
+}
+
+$installFailed = @($script:Actions | Where-Object { $_.Status -eq 'Failed' }).Count -gt 0
+if ($KeepTelemetry) {
+    Add-Action -Step 'telemetry' -Item 'VSCEIP opt-out' -Status 'Skipped' -Detail '-KeepTelemetry'
+} elseif (-not $installFailed) {
+    Invoke-DisableTelemetry
+}
+
+if ($SkipSpackConfig) {
+    Add-Action -Step 'spack' -Item 'compiler/external find' -Status 'Skipped' -Detail '-SkipSpackConfig'
+} elseif ($installFailed) {
+    Add-Action -Step 'spack' -Item 'compiler/external find' -Status 'Skipped' -Detail 'installation did not complete'
+} else {
+    Invoke-RegisterWithSpack -SpackCmd $spackCmd
+}
+
+Invoke-Verification -SpackCmd $spackCmd
+
+Write-Host ''
+Write-Host '=== Actions ===' -ForegroundColor Cyan
+$script:Actions | Format-Table -AutoSize -Wrap | Out-String -Width 200 | Write-Host
+
+Write-Host '=== Verification ===' -ForegroundColor Cyan
+$script:Checks | Format-Table -AutoSize -Wrap | Out-String -Width 200 | Write-Host
+
+$failed = @($script:Actions | Where-Object { $_.Status -eq 'Failed' })
+$skipped = @($script:Actions | Where-Object { $_.Status -eq 'Skipped' })
+$incomplete = @($script:Checks | Where-Object { $_.Result -eq 'MISSING' })
+
+Write-Host '=== Summary ===' -ForegroundColor Cyan
+Write-Host ("  actions failed  : {0}" -f $failed.Count)
+Write-Host ("  actions skipped : {0}" -f $skipped.Count)
+Write-Host ("  checks missing  : {0}" -f $incomplete.Count)
+
+foreach ($item in $failed) { Write-Host ("  FAILED  {0}: {1} -- {2}" -f $item.Step, $item.Item, $item.Detail) -ForegroundColor Red }
+foreach ($item in $skipped) { Write-Host ("  SKIPPED {0}: {1} -- {2}" -f $item.Step, $item.Item, $item.Detail) -ForegroundColor Yellow }
+foreach ($item in $incomplete) { Write-Host ("  MISSING {0} -- {1}" -f $item.Check, $item.Detail) -ForegroundColor Red }
+
+if (-not $Apply) {
+    Write-Host ''
+    Write-Host 'DRY RUN: nothing was installed. Re-run with -Apply -Elevate to install.' -ForegroundColor Yellow
+    exit 0
+}
+
+if ($failed.Count -eq 0 -and $incomplete.Count -eq 0) {
+    Write-Host ''
+    Write-Host 'PREREQUISITES SATISFIED' -ForegroundColor Green
+    exit 0
+}
+
+Write-Host ''
+Write-Host 'PREREQUISITES NOT SATISFIED' -ForegroundColor Red
+exit 1

--- a/share/spack/qa/windows_reset_msvc.ps1
+++ b/share/spack/qa/windows_reset_msvc.ps1
@@ -1,0 +1,830 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+<#
+.SYNOPSIS
+    Reset a Windows host to a pristine "no MSVC" state for Spack.
+
+.DESCRIPTION
+    Removes Visual Studio / Build Tools installations and the stale artifacts they leave
+    behind, so that Spack's Windows compiler detection and clingo bootstrap can be
+    validated from a known-clean starting point.
+
+    The script never guesses: every action is reported, and a verification pass re-checks
+    the host after the actions have run. It exits non-zero if the host is not clean or if
+    any step failed.
+
+    Cleanup targets, in order:
+      1. Visual Studio / Build Tools instances reported by vswhere (uninstalled via vs_installer,
+         -Force only).
+      2. Instances that survive step 1 (Microsoft's InstallCleanup.exe, -RunInstallCleanup only).
+      3. Leftover "Microsoft Visual Studio" directories under Program Files.
+      4. Visual Studio Installer instance metadata (_Instances).
+      5. Stale instance-suffixed VisualStudio registry keys whose install paths no longer exist.
+         These are read by spack.operating_systems.windows_os and cause phantom detections.
+      6. Stale msvc / win-sdk / wgl / win-wdk externals in Spack's user packages.yaml.
+      7. Spack's bootstrap store.
+
+    Not touched: Visual C++ redistributables (needed by unrelated software), the Visual Studio
+    Installer itself (needed to reinstall Build Tools), and Windows Kits. Use
+    -IncludeWindowsKits for a read-only report of the Windows Kits state.
+
+    Processes running from inside a directory that is about to be removed (for example
+    VCTIP.EXE, which cl.exe spawns) are stopped so they cannot hold files open.
+
+.PARAMETER Apply
+    Perform the cleanup. Without this switch the script only reports what it would do.
+
+.PARAMETER Force
+    Allow last-resort direct removal of leftover directories and registry keys when the
+    vendor uninstallers cannot or will not remove them, and allow uninstalling Visual Studio
+    instances that are still registered. Requires -Apply. Requires elevation for machine-wide
+    paths and HKLM keys.
+
+.PARAMETER RunInstallCleanup
+    Allow Microsoft's InstallCleanup.exe to run when an instance survives a failed uninstall.
+    Opt-in, because InstallCleanup removes an instance wholesale -- including a healthy one
+    that the uninstall step merely failed to talk to. Requires -Apply and -Force.
+
+.PARAMETER Elevate
+    Relaunch the script with an administrator token (UAC prompt) and stream the elevated
+    run's output back to this console. Assumes UAC elevates the same user account; if a
+    different administrator account is used, the Spack user config steps will act on that
+    account's profile.
+
+.PARAMETER KeepSpackConfig
+    Do not modify Spack's user packages.yaml.
+
+.PARAMETER CleanSpackCaches
+    Run "spack clean -a" instead of only clearing the bootstrap store.
+
+.PARAMETER IncludeWindowsKits
+    Additionally report the Windows Kits (SDK/WDK) state. Read-only: Windows Kits are never
+    removed by this script.
+
+.PARAMETER SpackRoot
+    Path to the Spack checkout. Defaults to the checkout containing this script.
+
+.EXAMPLE
+    .\share\spack\qa\windows_reset_msvc.ps1
+    Report what would be cleaned, change nothing.
+
+.EXAMPLE
+    .\share\spack\qa\windows_reset_msvc.ps1 -Apply -Force -Elevate
+    Prompt for elevation and fully reset the host.
+#>
+
+#Requires -Version 5.1
+
+[CmdletBinding()]
+param(
+    [switch]$Apply,
+    [switch]$Force,
+    [switch]$RunInstallCleanup,
+    [switch]$Elevate,
+    [switch]$KeepSpackConfig,
+    [switch]$CleanSpackCaches,
+    [switch]$IncludeWindowsKits,
+    [string]$SpackRoot
+)
+
+$ErrorActionPreference = 'Continue'
+$ProgressPreference = 'SilentlyContinue'
+
+# Package names whose externals become invalid once the toolchain is removed.
+$SpackStalePackages = @('msvc', 'win-sdk', 'wgl', 'win-wdk')
+
+# Instance-suffixed registry key names, e.g. "17.0_cc287979". Unsuffixed keys such as
+# "14.0" are shared/legacy and are never removed.
+$InstanceKeyPattern = '^\d+\.\d+_[0-9a-fA-F]+$'
+
+$script:Actions = New-Object System.Collections.ArrayList
+$script:Checks = New-Object System.Collections.ArrayList
+
+function Add-Action {
+    param([string]$Step, [string]$Item, [string]$Status, [string]$Detail = '')
+    $null = $script:Actions.Add([pscustomobject]@{
+            Step   = $Step
+            Item   = $Item
+            Status = $Status
+            Detail = $Detail
+        })
+}
+
+function Add-Check {
+    param([string]$Check, [bool]$Passed, [string]$Detail = '')
+    $null = $script:Checks.Add([pscustomobject]@{
+            Check  = $Check
+            Result = $(if ($Passed) { 'CLEAN' } else { 'DIRTY' })
+            Detail = $Detail
+        })
+}
+
+function Test-Elevated {
+    $identity = [Security.Principal.WindowsIdentity]::GetCurrent()
+    $principal = New-Object Security.Principal.WindowsPrincipal($identity)
+    return $principal.IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
+}
+
+function Get-ProgramFilesRoots {
+    $roots = @()
+    foreach ($var in 'ProgramFiles', 'ProgramFiles(x86)') {
+        $value = [Environment]::GetEnvironmentVariable($var)
+        if ($value -and ($roots -notcontains $value)) { $roots += $value }
+    }
+    return $roots
+}
+
+function Get-VsInstallerDirectory {
+    foreach ($root in Get-ProgramFilesRoots) {
+        $dir = Join-Path $root 'Microsoft Visual Studio\Installer'
+        if (Test-Path -LiteralPath $dir) { return $dir }
+    }
+    return $null
+}
+
+function Get-VsInstances {
+    $installerDir = Get-VsInstallerDirectory
+    if (-not $installerDir) { return @() }
+    $vswhere = Join-Path $installerDir 'vswhere.exe'
+    if (-not (Test-Path -LiteralPath $vswhere)) { return @() }
+
+    $raw = & $vswhere -all -prerelease -products '*' -format json 2>&1
+    if ($LASTEXITCODE -ne 0) {
+        Write-Warning "vswhere.exe exited with $LASTEXITCODE"
+        return @()
+    }
+    $text = ($raw | Out-String).Trim()
+    if (-not $text) { return @() }
+    try {
+        $parsed = $text | ConvertFrom-Json
+    } catch {
+        Write-Warning "could not parse vswhere output: $($_.Exception.Message)"
+        return @()
+    }
+    if ($null -eq $parsed) { return @() }
+    return @($parsed)
+}
+
+function Get-VsRootDirectories {
+    $dirs = @()
+    foreach ($root in Get-ProgramFilesRoots) {
+        $vsRoot = Join-Path $root 'Microsoft Visual Studio'
+        if (-not (Test-Path -LiteralPath $vsRoot)) { continue }
+        foreach ($child in Get-ChildItem -LiteralPath $vsRoot -Directory -ErrorAction SilentlyContinue) {
+            # The Installer directory hosts vswhere/vs_installer and must survive.
+            if ($child.Name -eq 'Installer') { continue }
+            $dirs += $child.FullName
+        }
+    }
+    return $dirs
+}
+
+function Get-ClExecutables {
+    $found = @()
+    foreach ($root in Get-ProgramFilesRoots) {
+        $vsRoot = Join-Path $root 'Microsoft Visual Studio'
+        if (-not (Test-Path -LiteralPath $vsRoot)) { continue }
+        $found += Get-ChildItem -LiteralPath $vsRoot -Filter 'cl.exe' -Recurse -File -ErrorAction SilentlyContinue |
+            Select-Object -ExpandProperty FullName
+    }
+    return $found
+}
+
+function Get-StaleVsRegistryKeys {
+    <#
+        Returns registry keys that describe a Visual Studio instance which is no longer on
+        disk. Two shapes are handled:
+          HKLM\SOFTWARE\[WOW6432Node\]Microsoft\VisualStudio_<hash>  (Capabilities/ApplicationDescription)
+          HKLM\SOFTWARE\[WOW6432Node\]Microsoft\VisualStudio\<ver>_<hash>  (InstallDir/ShellFolder/ProductDir)
+    #>
+    $stale = @()
+    $parents = @(
+        'HKLM:\SOFTWARE\Microsoft',
+        'HKLM:\SOFTWARE\WOW6432Node\Microsoft'
+    )
+
+    foreach ($parent in $parents) {
+        if (-not (Test-Path -LiteralPath $parent)) { continue }
+
+        foreach ($key in Get-ChildItem -LiteralPath $parent -ErrorAction SilentlyContinue) {
+            if ($key.PSChildName -notmatch '^VisualStudio_[0-9a-fA-F]+$') { continue }
+            $capabilities = Join-Path $key.PSPath 'Capabilities'
+            $target = $null
+            if (Test-Path -LiteralPath $capabilities) {
+                $props = Get-ItemProperty -LiteralPath $capabilities -ErrorAction SilentlyContinue
+                if ($props -and $props.PSObject.Properties.Name -contains 'ApplicationDescription') {
+                    # Value looks like "@C:\...\devenv.exe,-12345"
+                    $target = ($props.ApplicationDescription -split ',')[0].TrimStart('@')
+                }
+            }
+            if (-not $target -or -not (Test-Path -LiteralPath $target)) {
+                $detail = if ($target) { "target missing: $target" } else { 'no ApplicationDescription target' }
+                $stale += [pscustomobject]@{ Path = $key.PSPath; Name = $key.Name; Detail = $detail }
+            }
+        }
+
+        $vsKey = Join-Path $parent 'VisualStudio'
+        if (-not (Test-Path -LiteralPath $vsKey)) { continue }
+        foreach ($key in Get-ChildItem -LiteralPath $vsKey -ErrorAction SilentlyContinue) {
+            if ($key.PSChildName -notmatch $InstanceKeyPattern) { continue }
+            $props = Get-ItemProperty -LiteralPath $key.PSPath -ErrorAction SilentlyContinue
+            $target = $null
+            foreach ($name in 'InstallDir', 'ShellFolder', 'ProductDir') {
+                if ($props -and ($props.PSObject.Properties.Name -contains $name) -and $props.$name) {
+                    $target = $props.$name
+                    break
+                }
+            }
+            if (-not $target -or -not (Test-Path -LiteralPath $target)) {
+                $detail = if ($target) { "target missing: $target" } else { 'no install path value' }
+                $stale += [pscustomobject]@{ Path = $key.PSPath; Name = $key.Name; Detail = $detail }
+            }
+        }
+    }
+    return $stale
+}
+
+function Invoke-Tool {
+    param([string]$FilePath, [string[]]$ArgumentList, [switch]$Stream)
+
+    # -Stream echoes each line as it arrives; uninstallers can run for many minutes and are
+    # indistinguishable from a hang when their output is only reported at the end.
+    $lines = New-Object System.Collections.ArrayList
+    & $FilePath @ArgumentList 2>&1 | ForEach-Object {
+        $line = "$_"
+        if ($Stream -and $line.Trim()) { Write-Host "     $line" }
+        $null = $lines.Add($line)
+    }
+    return @{ ExitCode = $LASTEXITCODE; Output = ($lines -join [Environment]::NewLine).Trim() }
+}
+
+function Get-SpackCommand {
+    if ($SpackRoot) {
+        $candidate = Join-Path $SpackRoot 'bin\spack.ps1'
+        if (Test-Path -LiteralPath $candidate) { return $candidate }
+        Write-Warning "no bin\spack.ps1 under -SpackRoot '$SpackRoot'"
+        return $null
+    }
+    $candidate = Join-Path $PSScriptRoot '..\..\..\bin\spack.ps1'
+    if (Test-Path -LiteralPath $candidate) { return (Resolve-Path -LiteralPath $candidate).Path }
+    if ($env:SPACK_ROOT) {
+        $candidate = Join-Path $env:SPACK_ROOT 'bin\spack.ps1'
+        if (Test-Path -LiteralPath $candidate) { return $candidate }
+    }
+    return $null
+}
+
+function Invoke-Spack {
+    param([string]$SpackCmd, [string[]]$ArgumentList)
+    $output = & $SpackCmd @ArgumentList 2>&1
+    return @{ ExitCode = $LASTEXITCODE; Output = ($output | Out-String).Trim() }
+}
+
+function Get-SpackUserConfigPath {
+    param([string]$SpackCmd)
+    if ($SpackCmd) {
+        $result = Invoke-Spack -SpackCmd $SpackCmd -ArgumentList @(
+            'python', '-c', 'import spack.paths; print(spack.paths.user_config_path)')
+        if ($result.ExitCode -eq 0 -and $result.Output) {
+            $line = ($result.Output -split "`n" | Where-Object { $_.Trim() } | Select-Object -Last 1).Trim()
+            if ($line) { return $line }
+        }
+    }
+    if ($env:SPACK_USER_CONFIG_PATH) { return $env:SPACK_USER_CONFIG_PATH }
+    return (Join-Path $env:USERPROFILE '.spack')
+}
+
+function Stop-ProcessesUnderPath {
+    param([string]$Path)
+
+    # Toolchain helpers such as VCTIP.EXE (spawned by cl.exe) keep DLLs in the toolset directory
+    # mapped, which makes deletion fail with "Access is denied" even for administrators.
+    $prefix = $Path.TrimEnd('\') + '\'
+    $running = @(Get-Process -ErrorAction SilentlyContinue | Where-Object {
+            $_.Path -and $_.Path.StartsWith($prefix, [System.StringComparison]::OrdinalIgnoreCase)
+        })
+    foreach ($proc in $running) {
+        $label = "$($proc.ProcessName)($($proc.Id))"
+        try {
+            Stop-Process -Id $proc.Id -Force -ErrorAction Stop
+            Add-Action -Step 'stop-process' -Item $label -Status 'Ok' -Detail $proc.Path
+        } catch {
+            Add-Action -Step 'stop-process' -Item $label -Status 'Failed' -Detail $_.Exception.Message
+        }
+    }
+    if ($running.Count -gt 0) { Start-Sleep -Seconds 2 }
+    return $running.Count
+}
+
+function Remove-ItemReported {
+    param([string]$Step, [string]$Path, [string]$Reason, [bool]$RequireForce = $true)
+
+    if (-not (Test-Path -LiteralPath $Path)) {
+        Add-Action -Step $Step -Item $Path -Status 'NotNeeded' -Detail 'already absent'
+        return
+    }
+    if (-not $Apply) {
+        Add-Action -Step $Step -Item $Path -Status 'DryRun' -Detail $Reason
+        return
+    }
+    if ($RequireForce -and -not $Force) {
+        Add-Action -Step $Step -Item $Path -Status 'Skipped' -Detail 'needs -Force'
+        return
+    }
+    if (-not (Test-Elevated)) {
+        Add-Action -Step $Step -Item $Path -Status 'Skipped' -Detail 'needs elevation'
+        return
+    }
+    try {
+        Remove-Item -LiteralPath $Path -Recurse -Force -ErrorAction Stop
+        Add-Action -Step $Step -Item $Path -Status 'Ok' -Detail $Reason
+        return
+    } catch {
+        $failure = $_.Exception.Message
+    }
+    if ((Stop-ProcessesUnderPath -Path $Path) -gt 0) {
+        try {
+            Remove-Item -LiteralPath $Path -Recurse -Force -ErrorAction Stop
+            Add-Action -Step $Step -Item $Path -Status 'Ok' -Detail "$Reason (after releasing file locks)"
+            return
+        } catch {
+            $failure = $_.Exception.Message
+        }
+    }
+    Add-Action -Step $Step -Item $Path -Status 'Failed' -Detail $failure
+}
+
+# ---------------------------------------------------------------------------------------
+# Step 1: uninstall Visual Studio / Build Tools instances via the vendor installer
+# ---------------------------------------------------------------------------------------
+
+#: Set when an uninstall was attempted and the instance survived. InstallCleanup is only ever
+#: allowed after that, so a healthy instance can never be removed by the fallback.
+$script:UninstallLeftInstance = $false
+
+function Wait-ForVsInstanceRemoval {
+    param([string]$InstallPath, [int]$TimeoutSeconds = 1800)
+
+    $start = Get-Date
+    $deadline = $start.AddSeconds($TimeoutSeconds)
+    $nextHeartbeat = $start.AddSeconds(30)
+    while ((Get-Date) -lt $deadline) {
+        $remaining = @(Get-VsInstances | Where-Object { $_.installationPath -eq $InstallPath })
+        if ($remaining.Count -eq 0) { return $true }
+        Start-Sleep -Seconds 5
+        if ((Get-Date) -ge $nextHeartbeat) {
+            Write-Step ('still uninstalling ({0:n0}s elapsed)' -f ((Get-Date) - $start).TotalSeconds)
+            $nextHeartbeat = (Get-Date).AddSeconds(30)
+        }
+    }
+    return $false
+}
+
+function Invoke-UninstallVsInstances {
+    # @() is required: PowerShell unrolls a single-element return value, and .Count on a bare
+    # PSCustomObject is $null in Windows PowerShell 5.1.
+    $instances = @(Get-VsInstances)
+    if ($instances.Count -eq 0) {
+        Add-Action -Step 'vs-instances' -Item '(none)' -Status 'NotNeeded' -Detail 'vswhere reports no instances'
+        return
+    }
+
+    $installerDir = Get-VsInstallerDirectory
+    $vsInstaller = if ($installerDir) { Join-Path $installerDir 'vs_installer.exe' } else { $null }
+
+    foreach ($instance in $instances) {
+        $path = $instance.installationPath
+        $label = "$($instance.displayName) [$path]"
+
+        if (-not $Apply) {
+            Add-Action -Step 'vs-instances' -Item $label -Status 'DryRun' -Detail 'would uninstall'
+            continue
+        }
+        if (-not $Force) {
+            Add-Action -Step 'vs-instances' -Item $label -Status 'Skipped' `
+                -Detail 'needs -Force; refusing to uninstall a registered instance implicitly'
+            continue
+        }
+        if (-not $vsInstaller -or -not (Test-Path -LiteralPath $vsInstaller)) {
+            Add-Action -Step 'vs-instances' -Item $label -Status 'Failed' -Detail 'vs_installer.exe not found'
+            continue
+        }
+        if (-not (Test-Elevated)) {
+            Add-Action -Step 'vs-instances' -Item $label -Status 'Skipped' -Detail 'needs elevation'
+            continue
+        }
+
+        # No --wait: setup.exe rejects it for 'uninstall' (exit 87) and the installer detaches,
+        # so completion is observed through vswhere instead.
+        Write-Step "uninstalling $path (this takes a while)"
+        $result = Invoke-Tool -Stream -FilePath $vsInstaller -ArgumentList @(
+            'uninstall', '--installPath', $path, '--quiet', '--norestart')
+
+        if ($result.ExitCode -eq 87) {
+            $script:UninstallLeftInstance = $true
+            Add-Action -Step 'vs-instances' -Item $label -Status 'Failed' `
+                -Detail "installer rejected the command line (87): $($result.Output)"
+            continue
+        }
+        if ($result.ExitCode -eq 1602) {
+            $script:UninstallLeftInstance = $true
+            Add-Action -Step 'vs-instances' -Item $label -Status 'Failed' -Detail 'cancelled by user (1602)'
+            continue
+        }
+        if ($result.ExitCode -ne 0 -and $result.ExitCode -ne 3010) {
+            $script:UninstallLeftInstance = $true
+            Add-Action -Step 'vs-instances' -Item $label -Status 'Failed' `
+                -Detail "exit $($result.ExitCode): $($result.Output)"
+            continue
+        }
+
+        if (Wait-ForVsInstanceRemoval -InstallPath $path) {
+            Add-Action -Step 'vs-instances' -Item $label -Status 'Ok' -Detail 'uninstalled'
+        } else {
+            $script:UninstallLeftInstance = $true
+            Add-Action -Step 'vs-instances' -Item $label -Status 'Failed' `
+                -Detail 'still registered after the uninstall timeout'
+        }
+    }
+}
+
+# ---------------------------------------------------------------------------------------
+# Step 2: Microsoft's own last-resort cleanup for instances the uninstaller cannot remove
+# ---------------------------------------------------------------------------------------
+
+function Invoke-InstallCleanup {
+    $remaining = @(Get-VsInstances)
+    if ($remaining.Count -eq 0) {
+        Add-Action -Step 'install-cleanup' -Item 'InstallCleanup.exe' -Status 'NotNeeded' -Detail 'no instances remain'
+        return
+    }
+    if (-not $script:UninstallLeftInstance) {
+        Add-Action -Step 'install-cleanup' -Item 'InstallCleanup.exe' -Status 'Skipped' `
+            -Detail 'no uninstall attempt failed; the remaining instance is not known to be broken'
+        return
+    }
+
+    $installerDir = Get-VsInstallerDirectory
+    $cleanup = if ($installerDir) { Join-Path $installerDir 'InstallCleanup.exe' } else { $null }
+    if (-not $cleanup -or -not (Test-Path -LiteralPath $cleanup)) {
+        Add-Action -Step 'install-cleanup' -Item 'InstallCleanup.exe' -Status 'Skipped' -Detail 'not present'
+        return
+    }
+    if (-not $Apply) {
+        Add-Action -Step 'install-cleanup' -Item 'InstallCleanup.exe' -Status 'DryRun' `
+            -Detail "would run for $($remaining.Count) leftover instance(s)"
+        return
+    }
+    if (-not $Force -or -not $RunInstallCleanup) {
+        Add-Action -Step 'install-cleanup' -Item 'InstallCleanup.exe' -Status 'Skipped' `
+            -Detail 'needs -Force and -RunInstallCleanup'
+        return
+    }
+    if (-not (Test-Elevated)) {
+        Add-Action -Step 'install-cleanup' -Item 'InstallCleanup.exe' -Status 'Skipped' -Detail 'needs elevation'
+        return
+    }
+
+    Write-Step 'running InstallCleanup.exe'
+    $result = Invoke-Tool -Stream -FilePath $cleanup -ArgumentList @('-i')
+    if ($result.ExitCode -eq 0) {
+        Add-Action -Step 'install-cleanup' -Item 'InstallCleanup.exe' -Status 'Ok' -Detail 'instance data removed'
+    } else {
+        Add-Action -Step 'install-cleanup' -Item 'InstallCleanup.exe' -Status 'Failed' `
+            -Detail "exit $($result.ExitCode): $($result.Output)"
+    }
+}
+
+# ---------------------------------------------------------------------------------------
+# Step 3/4: leftover directories and installer metadata
+# ---------------------------------------------------------------------------------------
+
+function Invoke-RemoveLeftoverDirectories {
+    $dirs = @(Get-VsRootDirectories)
+    if ($dirs.Count -eq 0) {
+        Add-Action -Step 'leftover-dirs' -Item '(none)' -Status 'NotNeeded' -Detail 'no leftover VS directories'
+        return
+    }
+    foreach ($dir in $dirs) {
+        $entries = @(Get-ChildItem -LiteralPath $dir -Force -Recurse -ErrorAction SilentlyContinue)
+        $isEmpty = $entries.Count -eq 0
+        $reason = if ($isEmpty) { 'empty leftover directory' } else { "$($entries.Count) leftover entries" }
+        Remove-ItemReported -Step 'leftover-dirs' -Path $dir -Reason $reason -RequireForce (-not $isEmpty)
+    }
+}
+
+function Invoke-RemoveInstallerMetadata {
+    $instancesDir = Join-Path $env:ProgramData 'Microsoft\VisualStudio\Packages\_Instances'
+    Remove-ItemReported -Step 'installer-metadata' -Path $instancesDir -Reason 'stale instance metadata'
+}
+
+# ---------------------------------------------------------------------------------------
+# Step 5: stale registry keys that make Spack detect a phantom compiler
+# ---------------------------------------------------------------------------------------
+
+function Invoke-RemoveStaleRegistryKeys {
+    $stale = @(Get-StaleVsRegistryKeys)
+    if ($stale.Count -eq 0) {
+        Add-Action -Step 'registry' -Item '(none)' -Status 'NotNeeded' -Detail 'no stale VisualStudio keys'
+        return
+    }
+    foreach ($key in $stale) {
+        if (-not $Apply) {
+            Add-Action -Step 'registry' -Item $key.Name -Status 'DryRun' -Detail $key.Detail
+            continue
+        }
+        if (-not $Force) {
+            Add-Action -Step 'registry' -Item $key.Name -Status 'Skipped' -Detail 'needs -Force'
+            continue
+        }
+        if (-not (Test-Elevated)) {
+            Add-Action -Step 'registry' -Item $key.Name -Status 'Skipped' -Detail 'needs elevation'
+            continue
+        }
+        try {
+            Remove-Item -LiteralPath $key.Path -Recurse -Force -ErrorAction Stop
+            Add-Action -Step 'registry' -Item $key.Name -Status 'Ok' -Detail $key.Detail
+        } catch {
+            Add-Action -Step 'registry' -Item $key.Name -Status 'Failed' -Detail $_.Exception.Message
+        }
+    }
+}
+
+# ---------------------------------------------------------------------------------------
+# Step 6/7: Spack state
+# ---------------------------------------------------------------------------------------
+
+function Invoke-CleanSpackConfig {
+    param([string]$SpackCmd, [string]$UserConfigPath)
+
+    $packagesYaml = Join-Path $UserConfigPath 'packages.yaml'
+    if (-not (Test-Path -LiteralPath $packagesYaml)) {
+        Add-Action -Step 'spack-config' -Item $packagesYaml -Status 'NotNeeded' -Detail 'no user packages.yaml'
+        return
+    }
+
+    $content = Get-Content -LiteralPath $packagesYaml -Raw -ErrorAction SilentlyContinue
+    $present = @($SpackStalePackages | Where-Object { $content -match ('(?m)^\s{2}' + [regex]::Escape($_) + ':\s*$') })
+    if ($present.Count -eq 0) {
+        Add-Action -Step 'spack-config' -Item $packagesYaml -Status 'NotNeeded' -Detail 'no toolchain externals present'
+        return
+    }
+    if (-not $Apply) {
+        Add-Action -Step 'spack-config' -Item $packagesYaml -Status 'DryRun' `
+            -Detail "would remove: $($present -join ', ')"
+        return
+    }
+
+    $backup = "$packagesYaml.bak-" + (Get-Date -Format 'yyyyMMdd-HHmmss')
+    try {
+        Copy-Item -LiteralPath $packagesYaml -Destination $backup -ErrorAction Stop
+        Add-Action -Step 'spack-config' -Item $backup -Status 'Ok' -Detail 'backup written'
+    } catch {
+        Add-Action -Step 'spack-config' -Item $backup -Status 'Failed' -Detail $_.Exception.Message
+        return
+    }
+
+    if (-not $SpackCmd) {
+        Add-Action -Step 'spack-config' -Item 'spack config rm' -Status 'Skipped' `
+            -Detail 'spack not found; pass -SpackRoot'
+        return
+    }
+    foreach ($name in $present) {
+        $result = Invoke-Spack -SpackCmd $SpackCmd -ArgumentList @('config', 'rm', "packages:$name")
+        if ($result.ExitCode -eq 0) {
+            Add-Action -Step 'spack-config' -Item "packages:$name" -Status 'Ok' -Detail 'removed'
+        } else {
+            Add-Action -Step 'spack-config' -Item "packages:$name" -Status 'Failed' `
+                -Detail "exit $($result.ExitCode): $($result.Output)"
+        }
+    }
+}
+
+function Invoke-CleanSpackStore {
+    param([string]$SpackCmd)
+
+    $spackArgs = if ($CleanSpackCaches) { @('clean', '-a') } else { @('clean', '-b') }
+    $label = 'spack ' + ($spackArgs -join ' ')
+
+    if (-not $SpackCmd) {
+        Add-Action -Step 'spack-store' -Item $label -Status 'Skipped' -Detail 'spack not found; pass -SpackRoot'
+        return
+    }
+    if (-not $Apply) {
+        Add-Action -Step 'spack-store' -Item $label -Status 'DryRun' -Detail 'would clear bootstrap store'
+        return
+    }
+    $result = Invoke-Spack -SpackCmd $SpackCmd -ArgumentList $spackArgs
+    if ($result.ExitCode -eq 0) {
+        Add-Action -Step 'spack-store' -Item $label -Status 'Ok' -Detail 'cleared'
+    } else {
+        Add-Action -Step 'spack-store' -Item $label -Status 'Failed' `
+            -Detail "exit $($result.ExitCode): $($result.Output)"
+    }
+}
+
+# ---------------------------------------------------------------------------------------
+# Verification
+# ---------------------------------------------------------------------------------------
+
+function Invoke-Verification {
+    param([string]$SpackCmd, [string]$UserConfigPath)
+
+    $instances = @(Get-VsInstances)
+    Add-Check -Check 'no Visual Studio instances (vswhere)' -Passed ($instances.Count -eq 0) `
+        -Detail $(if ($instances.Count -eq 0) { 'none' } else { ($instances | ForEach-Object { $_.installationPath }) -join '; ' })
+
+    $cls = @(Get-ClExecutables)
+    Add-Check -Check 'no cl.exe under Program Files\Microsoft Visual Studio' -Passed ($cls.Count -eq 0) `
+        -Detail $(if ($cls.Count -eq 0) { 'none' } else { $cls -join '; ' })
+
+    $dirs = @(Get-VsRootDirectories)
+    Add-Check -Check 'no leftover Visual Studio directories' -Passed ($dirs.Count -eq 0) `
+        -Detail $(if ($dirs.Count -eq 0) { 'none' } else { $dirs -join '; ' })
+
+    $stale = @(Get-StaleVsRegistryKeys)
+    Add-Check -Check 'no stale VisualStudio registry keys' -Passed ($stale.Count -eq 0) `
+        -Detail $(if ($stale.Count -eq 0) { 'none' } else { ($stale | ForEach-Object { $_.Name }) -join '; ' })
+
+    $instancesDir = Join-Path $env:ProgramData 'Microsoft\VisualStudio\Packages\_Instances'
+    $instanceEntries = @()
+    if (Test-Path -LiteralPath $instancesDir) {
+        $instanceEntries = @(Get-ChildItem -LiteralPath $instancesDir -Force -ErrorAction SilentlyContinue)
+    }
+    Add-Check -Check 'no Visual Studio installer instance metadata' -Passed ($instanceEntries.Count -eq 0) `
+        -Detail $(if ($instanceEntries.Count -eq 0) { 'absent or empty' } else { "$($instanceEntries.Count) entries in $instancesDir" })
+
+    if (-not $KeepSpackConfig) {
+        $packagesYaml = Join-Path $UserConfigPath 'packages.yaml'
+        $present = @()
+        if (Test-Path -LiteralPath $packagesYaml) {
+            $content = Get-Content -LiteralPath $packagesYaml -Raw -ErrorAction SilentlyContinue
+            $present = @($SpackStalePackages | Where-Object { $content -match ('(?m)^\s{2}' + [regex]::Escape($_) + ':\s*$') })
+        }
+        Add-Check -Check 'no toolchain externals in user packages.yaml' -Passed ($present.Count -eq 0) `
+            -Detail $(if ($present.Count -eq 0) { 'none' } else { $present -join ', ' })
+    }
+
+    if ($SpackCmd) {
+        $result = Invoke-Spack -SpackCmd $SpackCmd -ArgumentList @(
+            'python', '-c',
+            'import spack.operating_systems.windows_os as w; print(w.WindowsOs().compiler_search_paths)')
+        if ($result.ExitCode -ne 0) {
+            Add-Check -Check 'Spack finds no MSVC search paths' -Passed $false `
+                -Detail "spack python failed: $($result.Output)"
+        } else {
+            $line = ($result.Output -split "`n" | Where-Object { $_.Trim() } | Select-Object -Last 1).Trim()
+            Add-Check -Check 'Spack finds no MSVC search paths' -Passed ($line -eq '[]') -Detail $line
+        }
+    } else {
+        Add-Check -Check 'Spack finds no MSVC search paths' -Passed $false -Detail 'spack not found; pass -SpackRoot'
+    }
+}
+
+function Write-WindowsKitsReport {
+    $kitsRoot = Join-Path ${env:ProgramFiles(x86)} 'Windows Kits\10'
+    Write-Host ''
+    Write-Host '=== Windows Kits (read-only report; never removed by this script) ===' -ForegroundColor Cyan
+    if (-not (Test-Path -LiteralPath $kitsRoot)) {
+        Write-Host "  not present: $kitsRoot"
+        return
+    }
+    Write-Host "  root: $kitsRoot"
+    $libRoot = Join-Path $kitsRoot 'Lib'
+    if (Test-Path -LiteralPath $libRoot) {
+        foreach ($version in Get-ChildItem -LiteralPath $libRoot -Directory -ErrorAction SilentlyContinue) {
+            $subs = @(Get-ChildItem -LiteralPath $version.FullName -Directory -ErrorAction SilentlyContinue |
+                    Select-Object -ExpandProperty Name)
+            $hasUcrtX64 = Test-Path -LiteralPath (Join-Path $version.FullName 'ucrt\x64')
+            $hasWglX64 = Test-Path -LiteralPath (Join-Path $version.FullName 'um\x64\OpenGL32.Lib')
+            Write-Host ("  {0}: [{1}] ucrt\x64={2} um\x64\OpenGL32.Lib={3}" -f `
+                    $version.Name, ($subs -join ','), $hasUcrtX64, $hasWglX64)
+        }
+    }
+    Write-Host '  To remove Windows Kits, use Settings > Apps > Installed apps (Windows SDK / WDK).'
+}
+
+# ---------------------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------------------
+
+function Write-Step {
+    param([string]$Message)
+    Write-Host "  -> $Message" -ForegroundColor DarkGray
+}
+
+function Write-NewLogLines {
+    param([string]$Path, [int]$AlreadyShown)
+
+    if (-not (Test-Path -LiteralPath $Path)) { return $AlreadyShown }
+    $lines = @(Get-Content -LiteralPath $Path -ErrorAction SilentlyContinue)
+    if ($lines.Count -le $AlreadyShown) { return $AlreadyShown }
+    $lines[$AlreadyShown..($lines.Count - 1)] | ForEach-Object { Write-Host $_ }
+    return $lines.Count
+}
+
+function Invoke-SelfElevate {
+    $log = Join-Path $env:TEMP ('spack-windows-reset-{0}.log' -f (Get-Date -Format 'yyyyMMdd-HHmmss'))
+    $switches = @('-Apply', '-Force', '-RunInstallCleanup', '-KeepSpackConfig', '-CleanSpackCaches', '-IncludeWindowsKits')
+    $values = @($Apply, $Force, $RunInstallCleanup, $KeepSpackConfig, $CleanSpackCaches, $IncludeWindowsKits)
+
+    $inner = "& '$PSCommandPath'"
+    for ($i = 0; $i -lt $switches.Count; $i++) {
+        if ($values[$i]) { $inner += ' ' + $switches[$i] }
+    }
+    if ($SpackRoot) { $inner += " -SpackRoot '$SpackRoot'" }
+    $inner += " *> '$log'; exit `$LASTEXITCODE"
+
+    Write-Host "Relaunching elevated; output is captured in $log" -ForegroundColor Yellow
+    try {
+        $proc = Start-Process -FilePath 'powershell' -Verb RunAs -PassThru -ArgumentList @(
+            '-NoProfile', '-ExecutionPolicy', 'Bypass', '-Command', $inner)
+    } catch {
+        Write-Error "elevation failed: $($_.Exception.Message)"
+        exit 2
+    }
+
+    # Tail the child's log while it runs; otherwise long uninstall steps look like a hang.
+    $shown = 0
+    while (-not $proc.HasExited) {
+        Start-Sleep -Milliseconds 500
+        $shown = Write-NewLogLines -Path $log -AlreadyShown $shown
+    }
+    $proc.WaitForExit()
+    $shown = Write-NewLogLines -Path $log -AlreadyShown $shown
+    if ($shown -eq 0) { Write-Warning "elevated run produced no log at $log" }
+    exit $proc.ExitCode
+}
+
+if ($Elevate -and -not (Test-Elevated)) { Invoke-SelfElevate }
+
+$spackCmd = Get-SpackCommand
+$userConfigPath = Get-SpackUserConfigPath -SpackCmd $spackCmd
+
+Write-Host ''
+Write-Host '=== Spack Windows MSVC reset ===' -ForegroundColor Cyan
+Write-Host ("  mode        : {0}" -f $(if ($Apply) { 'APPLY' } else { 'DRY RUN (pass -Apply to make changes)' }))
+Write-Host ("  force       : {0}" -f $Force)
+Write-Host ("  elevated    : {0}" -f (Test-Elevated))
+Write-Host ("  spack       : {0}" -f $(if ($spackCmd) { $spackCmd } else { '<not found>' }))
+Write-Host ("  user config : {0}" -f $userConfigPath)
+Write-Host ''
+
+if ($Apply -and -not (Test-Elevated)) {
+    Write-Warning 'Not running elevated. Machine-wide uninstall, directory and registry steps will be skipped. Re-run with -Elevate or from an Administrator shell.'
+}
+
+Invoke-UninstallVsInstances
+Invoke-InstallCleanup
+Invoke-RemoveLeftoverDirectories
+Invoke-RemoveInstallerMetadata
+Invoke-RemoveStaleRegistryKeys
+if (-not $KeepSpackConfig) {
+    Invoke-CleanSpackConfig -SpackCmd $spackCmd -UserConfigPath $userConfigPath
+} else {
+    Add-Action -Step 'spack-config' -Item 'packages.yaml' -Status 'Skipped' -Detail '-KeepSpackConfig'
+}
+Invoke-CleanSpackStore -SpackCmd $spackCmd
+
+Invoke-Verification -SpackCmd $spackCmd -UserConfigPath $userConfigPath
+
+Write-Host ''
+Write-Host '=== Actions ===' -ForegroundColor Cyan
+$script:Actions | Format-Table -AutoSize -Wrap | Out-String -Width 200 | Write-Host
+
+Write-Host '=== Verification ===' -ForegroundColor Cyan
+$script:Checks | Format-Table -AutoSize -Wrap | Out-String -Width 200 | Write-Host
+
+if ($IncludeWindowsKits) { Write-WindowsKitsReport }
+
+$failed = @($script:Actions | Where-Object { $_.Status -eq 'Failed' })
+$skipped = @($script:Actions | Where-Object { $_.Status -eq 'Skipped' })
+$dirty = @($script:Checks | Where-Object { $_.Result -eq 'DIRTY' })
+
+Write-Host ''
+Write-Host '=== Summary ===' -ForegroundColor Cyan
+Write-Host ("  actions failed  : {0}" -f $failed.Count)
+Write-Host ("  actions skipped : {0}" -f $skipped.Count)
+Write-Host ("  checks dirty    : {0}" -f $dirty.Count)
+
+foreach ($item in $failed) { Write-Host ("  FAILED  {0}: {1} -- {2}" -f $item.Step, $item.Item, $item.Detail) -ForegroundColor Red }
+foreach ($item in $skipped) { Write-Host ("  SKIPPED {0}: {1} -- {2}" -f $item.Step, $item.Item, $item.Detail) -ForegroundColor Yellow }
+foreach ($item in $dirty) { Write-Host ("  DIRTY   {0} -- {1}" -f $item.Check, $item.Detail) -ForegroundColor Red }
+
+if (-not $Apply) {
+    Write-Host ''
+    Write-Host 'DRY RUN: nothing was changed. Re-run elevated with -Apply -Force to clean the host.' -ForegroundColor Yellow
+    exit 0
+}
+
+if ($failed.Count -eq 0 -and $dirty.Count -eq 0) {
+    Write-Host ''
+    Write-Host 'HOST IS CLEAN' -ForegroundColor Green
+    exit 0
+}
+
+Write-Host ''
+Write-Host 'HOST IS NOT CLEAN' -ForegroundColor Red
+exit 1


### PR DESCRIPTION
Summary
-------

Add two PowerShell scripts under `share/spack/qa` that bring a Windows host into the documented Spack prerequisite state and back out of it again, and document them in `lib/spack/docs/windows.rst`:

- `windows_install_msvc.ps1` installs the minimal Visual Studio Build Tools components Spack needs, adds the Intel oneAPI Fortran compiler, and registers everything with Spack.
- `windows_reset_msvc.ps1` removes a Visual Studio toolchain and the stale artifacts it leaves behind, so that Windows compiler detection and the clingo bootstrap can be validated from a known-clean starting point.

Both scripts default to a dry run, report every action plus a verification pass, and exit non-zero when the host is not in the expected state.

Problem
-------

`lib/spack/docs/windows.rst` describes the required Visual Studio components in prose and tells the user to click through the Visual Studio Installer UI. There is no scripted way to put a Windows host into that state, and no way to check afterwards whether it worked.

Diagnosing it by hand is awkward, user actions might have left behind directories and instance-suffixed `VisualStudio*` registry keys that `spack.operating_systems.windows_os` still reads, which produces phantom compiler detections.

Solution
--------

`windows_install_msvc.ps1` requests exactly three required component IDs:

- `Microsoft.VisualStudio.Component.VC.Tools.x86.x64`
- `Microsoft.VisualStudio.Component.Windows11SDK.26100`
- `Microsoft.VisualStudio.Component.VC.CMake.Project`

It adds them to an existing instance with `vs_installer modify`, or installs Build Tools with winget when no instance exists. It then installs the Intel oneAPI Fortran compiler, because MSVC ships none, preferring winget so that no manual download is needed and falling back to an already-downloaded offline installer. Finally it runs `spack compiler find` and `spack external find` for the Windows SDK, WGL, an already-present WDK, CMake and Ninja.

Unless Fortran is disabled using `-SkipFortran`, the Intel Fortran Compiler is installed, which is not part of the Visual Studio Build Tools, so it is added through winget and an offline installer as fallback for air-gapped hosts.

To reset the host to the uninstalled state, `windows_reset_msvc.ps1` uninstalls the Components through the vendor installer, falls back to removing leftover directories, installer instance metadata and stale `VisualStudio*` registry keys whose recorded install path no longer exists. Visual C++ redistributables, the Visual Studio Installer itself and the Windows Kits are never touched.

Several details are load-bearing rather than cosmetic:

- Verification checks for the files Spack actually consumes, such as `cl.exe` under `Hostx64\x64`, the bundled `cmake.exe` and `ninja.exe`, `ucrt\x64\libucrt.lib`, `um\x64\OpenGL32.Lib` and `compiler\*\bin\ifx.exe`. Both winget and the Visual Studio bootstrapper can exit 0 without having installed anything, so installer exit codes alone are not trusted; component presence is re-polled through vswhere.

- `--wait` is not passed to `setup.exe`, which rejects it for some verbs with exit 87 and detaches regardless. Completion is observed by polling instead.

- The `msvc` package provides Fortran and records the `ifx`/`ifort` path it finds during detection, but `spack compiler find` never refreshes an already-registered compiler. An `msvc` entry detected before Fortran was installed would therefore keep concretizing without one, so the installer re-detects `msvc` when that state is found.

- Removal steps stop processes running from inside the directory being deleted. The MSVC telemetry helper `VCTIP.EXE`, which `cl.exe` spawns, otherwise keeps DLLs in the toolset directory mapped and makes deletion fail with an access denied error even for administrators.

- Every call returning `vswhere` or registry objects is wrapped in `@()`, because Windows PowerShell 5.1 unrolls a single-element array return and `.Count` on a bare `PSCustomObject` evaluates to `$null`.

Installer output is streamed line by line while the vendor tools run, the polling loops emit a heartbeat, and `-Elevate` tails the elevated child's log instead of printing it after the fact. Downloading and installing Build Tools takes minutes, which is otherwise indistinguishable from a hang.

Because Build Tools installs expose no privacy UI, the installer opts out of the Visual Studio Customer Experience Improvement Program ("Telemetry") through the documented `OptIn` registry values and sets `VSCMD_SKIP_SENDTELEMETRY`, which `VsDevCmd.bat` checks before reporting developer-shell usage. `-KeepTelemetry` leaves both untouched.

The status of the opt-out is also verified after installation, and the telemetry helper program is killed before removal to avoid leaving stale processes and directories behind.