### PR TITLE
Windows: make WindowsRegistryView.find_subkeys return a list when nothing matches

### DIFF
--- a/lib/spack/spack/test/util/windows_registry.py
+++ b/lib/spack/spack/test/util/windows_registry.py
@@ -1,0 +1,36 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+"""Tests for ``util/windows_registry.py``."""
+
+import sys
+
+import pytest
+
+if sys.platform != "win32":
+    pytest.skip("Windows-only tests", allow_module_level=True)
+
+from spack.util.windows_registry import HKEY, WindowsRegistryView
+
+
+@pytest.fixture
+def software_key():
+    """A registry key that is guaranteed to exist on any Windows host."""
+    return WindowsRegistryView("SOFTWARE\\Microsoft", root_key=HKEY.HKEY_LOCAL_MACHINE)
+
+
+def test_find_subkeys_returns_empty_list_when_nothing_matches(software_key):
+    """find_subkeys must return a list, not None, so callers can iterate unconditionally.
+
+    Regression test: a host without Visual Studio has no ``VisualStudio_*`` subkeys, which
+    made ``spack.operating_systems.windows_os`` raise ``TypeError: 'NoneType' object is not
+    iterable`` while detecting compilers.
+    """
+    assert software_key.find_subkeys("ThisSubkeyDoesNotExist_.*", recursive=False) == []
+
+
+def test_find_subkeys_returns_matches(software_key):
+    matches = software_key.find_subkeys("Window.*", recursive=False)
+    assert isinstance(matches, list)
+    assert all(key.name.startswith("Window") for key in matches)

--- a/lib/spack/spack/util/windows_registry.py
+++ b/lib/spack/spack/util/windows_registry.py
@@ -10,6 +10,7 @@ import os
 import re
 import sys
 from contextlib import contextmanager
+from typing import List
 
 from spack.util import tty
 
@@ -359,18 +360,21 @@ class WindowsRegistryView:
             WindowsRegistryView.KeyMatchConditions.regex_matcher(subkey_name), recursive=recursive
         )
 
-    def find_subkeys(self, subkey_name: str, recursive: bool = True):
+    def find_subkeys(self, subkey_name: str, recursive: bool = True) -> List["RegistryKey"]:
         """Exactly the same as find_subkey, except this function tries to match
         a regex to multiple keys
 
         Args:
             subkey_name: subkey to be searched for
         Return:
-            the desired subkeys as a list of RegistryKey object, or none
+            the desired subkeys as a list of RegistryKey objects, empty if there are no matches
         """
         kwargs = {"collect_all_matching": True, "recursive": recursive}
-        return self._traverse_subkeys(
-            WindowsRegistryView.KeyMatchConditions.regex_matcher(subkey_name), **kwargs
+        return (
+            self._traverse_subkeys(
+                WindowsRegistryView.KeyMatchConditions.regex_matcher(subkey_name), **kwargs
+            )
+            or []
         )
 
     def find_value(self, val_name: str, recursive: bool = True):


### PR DESCRIPTION
Summary
-------

`WindowsRegistryView.find_subkeys` returned `None` instead of an empty list when no subkey matched, which crashed Windows compiler detection on hosts that have no Visual Studio registry keys. Return an empty list, annotate the return type, and add a regression test.

Problem
-------

`find_subkeys` is the plural, list-returning member of the registry search API, and its docstring promised "a list of RegistryKey object". It delegates to `_traverse_subkeys`, which ends with:

```py
return collection if collection else None
```

That is correct for the singular `find_subkey` and `find_matching_subkey`, which return either a key or `None`, but it makes `find_subkeys` return `None` rather than `[]` when the regex matches nothing.

Its only caller iterates the result. On a Windows host with no `SOFTWARE\WOW6432Node\Microsoft\VisualStudio_*` keys, `spack compiler find` and every other path through `WindowsOs.compiler_search_paths` therefore aborts:

```py
  File "lib/spack/spack/operating_systems/windows_os.py", line 143, in compiler_search_paths
    for entry in vs_entries:
                 ^^^^^^^^^^
TypeError: 'NoneType' object is not iterable
```

The caller already guards for an empty result and retries the query once, because registry reads can be flaky, so the retry simply produces `None` a second time.

This reproduces on any Windows machine without Visual Studio, which is the situation where compiler detection needs to run and report that nothing was found. It does not reproduce once any Visual Studio instance has registered its keys, so it is invisible on a typical developer machine.

Solution
--------

Return `[]` from `find_subkeys` when the traversal finds nothing, so the documented contract of the plural API holds, and add a `List["RegistryKey"]` return annotation to state it. The singular finders are left alone: `None` remains meaningful for them.

Fixing the callee rather than the call site keeps the guarantee with the function that documents it, so any future caller can iterate the result unconditionally.