### PR TITLE
Windows: fix stair-stepped build log output by translating bare linefeeds

### DIFF
--- a/lib/spack/spack/installer/ui.py
+++ b/lib/spack/spack/installer/ui.py
@@ -10,6 +10,7 @@ for the overall design."""
 
 import io
 import os
+import re
 import sys
 import time
 from typing import Callable, Dict, Generator, List, NamedTuple, Optional, Union, cast
@@ -24,6 +25,9 @@ if sys.platform == "win32":
     from spack.installer.windows import WindowsTerminalState as TerminalState
 else:
     from spack.installer.posix import PosixTerminalState as TerminalState
+
+#: Matches a line feed that is not already preceded by a carriage return.
+_BARE_LINE_FEED = re.compile(rb"(?<!\r)\n")
 
 
 class SetEcho(NamedTuple):
@@ -208,7 +212,9 @@ class TerminalUI(InstallerUI):
         self.actual_jobs: int = 0
         self.target_jobs: int = 0
         self.blocked: bool = False
-
+        #: Whether the previous log chunk ended in a carriage return, so a line feed opening the
+        #: next chunk is not mistaken for a bare one.
+        self.log_ends_with_carriage_return = False
         self.stdout = stdout
         self.get_terminal_size = get_terminal_size
         self.terminal_size = os.terminal_size((0, 0))
@@ -226,6 +232,9 @@ class TerminalUI(InstallerUI):
         #: Verbose mode only applies to non-TTY where we want to track a single build log.
         self.verbose = verbose and not self.is_tty
         self.filter_padding = filter_padding
+        #: Windows consoles are put in VT processing mode, where a bare line feed does not return
+        #: the carriage, so forwarded log bytes need the translation that text-mode writes do.
+        self.translate_log_newlines = sys.platform == "win32" and self.is_tty
         #: When True, suppress all terminal output (process is in background).
         self.headless = False
         self.term_title = spack.config.CONFIG.get("config:install_status", True) and self.is_tty
@@ -276,7 +285,7 @@ class TerminalUI(InstallerUI):
             self.next()
         else:
             if not self.log_ends_with_newline:
-                self.stdout.buffer.write(b"\n")
+                self.stdout.buffer.write(b"\r\n" if self.translate_log_newlines else b"\n")
                 self.log_ends_with_newline = True
             self.active_area_rows = 0
             self.search_term = ""
@@ -610,6 +619,23 @@ class TerminalUI(InstallerUI):
         else:
             buffer.write("\033[0m\033[K\033[1B\r")  # reset, clear to EOL, move to next line
 
+    def _to_console_newlines(self, data: bytes) -> bytes:
+        """Turn bare line feeds in child output into carriage return + line feed.
+
+        Log bytes are forwarded verbatim, so they miss the newline translation that our own
+        text-mode writes to stdout get. The Windows console runs with
+        ENABLE_VIRTUAL_TERMINAL_PROCESSING, where a lone line feed moves down a row but leaves
+        the column untouched, so output from tools that emit bare line feeds (cmake does, ninja
+        does not) would stair-step across the screen.
+        """
+        if self.log_ends_with_carriage_return and data.startswith(b"\n"):
+            # The carriage return arrived in the previous chunk.
+            leading, data = b"\n", data[1:]
+        else:
+            leading = b""
+        self.log_ends_with_carriage_return = data.endswith(b"\r")
+        return leading + _BARE_LINE_FEED.sub(b"\r\n", data)
+
     def on_log_output(self, build_id: str, data: bytes) -> None:
         if self.headless:
             return
@@ -620,9 +646,11 @@ class TerminalUI(InstallerUI):
             return
         if self.filter_padding:
             data = padding_filter_bytes(data)
+        self.log_ends_with_newline = data.endswith(b"\n")
+        if self.translate_log_newlines:
+            data = self._to_console_newlines(data)
         self.stdout.buffer.write(data)
         self.stdout.flush()
-        self.log_ends_with_newline = data.endswith(b"\n")
 
     def _render_build(
         self, build_info: BuildInfo, buffer: io.StringIO, max_width: int = 0, now: float = 0.0

--- a/lib/spack/spack/test/installer/ui.py
+++ b/lib/spack/spack/test/installer/ui.py
@@ -772,6 +772,7 @@ class TestLogFollowing:
         # Switch to log-following mode
         tui.overview_mode = False
         tui.tracked_build_id = build_id
+        tui.translate_log_newlines = False
 
         # Send some log data
         log_data = b"Building package...\nRunning tests...\n"
@@ -779,6 +780,46 @@ class TestLogFollowing:
 
         # Check that logs were echoed to stdout
         assert fake_stdout._buffer.getvalue() == log_data
+
+    @pytest.mark.parametrize(
+        "chunks,expected",
+        [
+            # Bare line feeds, as cmake emits, gain a carriage return.
+            ([b"a\nb\n"], b"a\r\nb\r\n"),
+            # Output that already has them, as ninja emits, is left alone.
+            ([b"a\r\nb\r\n"], b"a\r\nb\r\n"),
+            # A lone carriage return, used for progress lines, is not a newline.
+            ([b"50%\r100%\r"], b"50%\r100%\r"),
+            # A carriage return and line feed split across chunks stay a single newline.
+            ([b"a\r", b"\nb"], b"a\r\nb"),
+            # A bare line feed opening a chunk still gains one.
+            ([b"a", b"\nb"], b"a\r\nb"),
+        ],
+    )
+    def test_log_newlines_translated_for_console(self, chunks, expected):
+        """Bare line feeds stair-step on a VT-enabled Windows console, so they are translated."""
+        tui, _, fake_stdout = create_tui()
+        [build_id] = add_mock_builds(tui, 1)
+        tui.overview_mode = False
+        tui.tracked_build_id = build_id
+        tui.translate_log_newlines = True
+
+        for chunk in chunks:
+            tui.on_log_output(build_id, chunk)
+
+        assert fake_stdout._buffer.getvalue() == expected
+
+    def test_log_newlines_untranslated_when_disabled(self):
+        """Log bytes are forwarded verbatim when the console needs no translation."""
+        tui, _, fake_stdout = create_tui()
+        [build_id] = add_mock_builds(tui, 1)
+        tui.overview_mode = False
+        tui.tracked_build_id = build_id
+        tui.translate_log_newlines = False
+
+        tui.on_log_output(build_id, b"a\nb\n")
+
+        assert fake_stdout._buffer.getvalue() == b"a\nb\n"
 
     def test_print_logs_discarded_when_in_overview_mode(self):
         """Test that logs are discarded when in overview mode"""
@@ -1048,6 +1089,7 @@ class TestToggle:
         """Ensure newline is inserted before mode transitions when log doesn't end with newline."""
         tui, _, fake_stdout = create_tui(total=2)
         build_a, build_b = add_mock_builds(tui, 2)
+        tui.translate_log_newlines = False
 
         # Follow a build, toggle back and forth between logs and overview mode, and receive logs
         # that may or may not end with newlines.


### PR DESCRIPTION
When we added native ANSI color support using the VT support of Windows
by adding `ENABLE_VIRTUAL_TERMINAL_PROCESSING` in multiple locations,
we also added `DISABLE_NEWLINE_AUTO_RETURN` on `CONOUT$` when following
the output of a build.

It means that the console will not automatically return the cursor to
the beginning of the line when a line feed is encountered.

For the output of programs which do not include carriage returns, this
results in stair-steps across the screen:

```py
-- The CXX compiler identification is MSVC ...
                                              -- The C compiler ...
```

As the git log does not show why it was added, I suggest to remove it
as not needed.

`DISABLE_NEWLINE_AUTO_RETURN` is documented as delaying end-of-line
wrapping, which the installer overview relies on because it renders
build lines truncated to the terminal width.

That behavior is unaffected: it comes from the pending-wrap state of
virtual terminal processing itself. Filling an 80 column buffer and
then emitting what `TerminalUI._println` writes gives the same result
either way.

AFAICS, the only behavior that changes is the one that was breaking
log output.

cc: @johnwparent