### PR TITLE
Allow compilers to define hipflags: or specs to add hipflags=

### DIFF
--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -442,7 +442,7 @@ def set_wrapper_environment_variables_for_flags(pkg, env):
         else:
             handler = pkg.flag_handler.__func__
 
-        injf, envf, bsf = handler(pkg, flag, spec.compiler_flags[flag][:])
+        injf, envf, bsf = handler(pkg, flag, spec.compiler_flags.get(flag, [])[:])
         inject_flags[flag] = injf or []
         env_flags[flag] = envf or []
         build_system_flags[flag] = bsf or []

--- a/lib/spack/spack/schema/compilers.py
+++ b/lib/spack/spack/schema/compilers.py
@@ -41,6 +41,10 @@ flags: Dict[str, Any] = {
             "anyOf": [{"type": "string"}, {"type": "null"}],
             "description": "Flags for linker libraries, e.g. -lpthread",
         },
+        "hipflags": {
+            "anyOf": [{"type": "string"}, {"type": "null"}],
+            "description": "Flags for HIP compiler, e.g. --amdgpu-target=gfx90a",
+        },
     },
 }
 

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -908,7 +908,15 @@ class CompilerFlag(str):
         return obj
 
 
-_valid_compiler_flags = ["cflags", "cxxflags", "fflags", "ldflags", "ldlibs", "cppflags", "hipflags"]
+_valid_compiler_flags = [
+    "cflags",
+    "cxxflags",
+    "fflags",
+    "ldflags",
+    "ldlibs",
+    "cppflags",
+    "hipflags",
+]
 
 
 def _shared_subset_pair_iterate(container1, container2):

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -908,7 +908,7 @@ class CompilerFlag(str):
         return obj
 
 
-_valid_compiler_flags = ["cflags", "cxxflags", "fflags", "ldflags", "ldlibs", "cppflags"]
+_valid_compiler_flags = ["cflags", "cxxflags", "fflags", "ldflags", "ldlibs", "cppflags", "hipflags"]
 
 
 def _shared_subset_pair_iterate(container1, container2):


### PR DESCRIPTION
Only makes sense when combined with

https://github.com/spack/spack-packages/pull/4411 

and 

https://github.com/spack/compiler-wrapper/pull/20/

IMO this should merge last: hipflags is not essential to `hip-lang` support