### PR TITLE
builder: resolve adapter base from package mro

### DIFF
--- a/lib/spack/spack/audit.py
+++ b/lib/spack/spack/audit.py
@@ -712,7 +712,9 @@ def _ensure_env_methods_are_ported_to_builders(pkgs, error_cls):
             for _, variant in pkg_cls.variant_definitions("build_system")
             for v in variant.values
         }
-        builder_cls_names = [spack.builder.BUILDER_CLS[x].__name__ for x in build_system_names]
+        builder_cls_names = [
+            spack.builder.default_builder_cls(pkg_cls, x).__name__ for x in build_system_names
+        ]
 
         has_builders_in_package_py = any(
             spack.builder.get_builder_class(pkg_cls, name) for name in builder_cls_names

--- a/lib/spack/spack/builder.py
+++ b/lib/spack/spack/builder.py
@@ -20,8 +20,10 @@ import spack.util.environment
 from spack.error import SpackError
 from spack.util.prefix import Prefix
 
-#: Builder classes, as registered by the ``builder`` decorator
-BUILDER_CLS: Dict[str, Type["Builder"]] = {}
+#: Builder classes, as registered by the ``register_builder`` decorator, keyed by
+#: (defining module, build system name) so that repos registering the same build system
+#: coexist.
+BUILDER_CLS: Dict[Tuple[str, str], Type["Builder"]] = {}
 
 #: Map id(pkg) to a builder, to avoid creating multiple
 #: builders for the same package object.
@@ -45,10 +47,22 @@ def register_builder(build_system_name: str):
 
     def _decorator(cls):
         cls.build_system = build_system_name
-        BUILDER_CLS[build_system_name] = cls
+        BUILDER_CLS[(cls.__module__, build_system_name)] = cls
         return cls
 
     return _decorator
+
+
+def default_builder_cls(
+    pkg_cls: Type[spack.package_base.PackageBase], build_system_name: str
+) -> Type["Builder"]:
+    """The builder for the given build system registered by the nearest module in the package
+    class's MRO"""
+    for base in pkg_cls.__mro__:
+        builder_cls = BUILDER_CLS.get((base.__module__, build_system_name))
+        if builder_cls is not None:
+            return builder_cls
+    raise KeyError(build_system_name)
 
 
 def create(pkg: spack.package_base.PackageBase) -> "Builder":
@@ -102,8 +116,8 @@ def _create(pkg: spack.package_base.PackageBase) -> "Builder":
         pkg: package object for which we need a builder
     """
     package_buildsystem = buildsystem_name(pkg)
-    default_builder_cls = BUILDER_CLS[package_buildsystem]
-    builder_cls_name = default_builder_cls.__name__
+    base_builder_cls = default_builder_cls(type(pkg), package_buildsystem)
+    builder_cls_name = base_builder_cls.__name__
     builder_class = get_builder_class(pkg, builder_cls_name)
 
     if builder_class:
@@ -113,7 +127,7 @@ def _create(pkg: spack.package_base.PackageBase) -> "Builder":
     # base classes and specialize certain phases or methods or attributes.
     # In that case they can store their builder class as a class level attribute.
     # See e.g. AspellDictPackage as an example.
-    base_cls = getattr(pkg, builder_cls_name, default_builder_cls)
+    base_cls = getattr(pkg, builder_cls_name, base_builder_cls)
 
     # From here on we define classes to construct a special builder that adapts to the
     # old, single class, package format. The adapter forwards any call or access to an

--- a/lib/spack/spack/test/builder.py
+++ b/lib/spack/spack/test/builder.py
@@ -237,3 +237,29 @@ def test_builder_when_inheriting_just_package(working_env):
     # The derived class doesn't redefine a builder, so we should
     # get the builder of the base class.
     assert type(base_builder) is type(derived_builder)
+
+
+def test_builder_resolution_survives_same_name_registration(mock_packages, config, monkeypatch):
+    """The adapter base for an old-style package comes from the module chain the package
+    inherits from: a registration for the same build system from another repo, however late
+    it is imported, does not affect resolution."""
+    from spack_repo.builtin_mock.build_systems.makefile import (  # type: ignore[import]
+        MakefileBuilder,
+    )
+
+    class PoisonBuilder(MakefileBuilder):
+        pass
+
+    PoisonBuilder.__module__ = "spack_repo.other.build_systems.makefile"
+
+    monkeypatch.setitem(
+        spack.builder.BUILDER_CLS,
+        ("spack_repo.other.build_systems.makefile", "makefile"),
+        PoisonBuilder,
+    )
+
+    spec = spack.concretize.concretize_one("printing-package")
+    builder = spack.builder._create(spec.package)
+
+    assert isinstance(builder, MakefileBuilder)
+    assert not isinstance(builder, PoisonBuilder)


### PR DESCRIPTION
Builder registrations were keyed by build system name alone, and
registered on module import as `@register_builder` runs in module
scope. The last import to run `register_builder` on the same name
wins.

I think that's already underspecified, but it has a practical annoying
consequence where tests can poison each other: if one test accidentally
imports `spack_repo.builtin.build_systems.*`, it will bind the wrong
`makefile` builder for the rest of the test suite, which is hard to catch.

So, register by `(module, name)` instead and walk the package MRO,
which allows multiple repos to register the same build system name.

