### PR TITLE
tty: honor --color instead of checking isatty() directly

### DIFF
--- a/lib/spack/spack/cmd/spec.py
+++ b/lib/spack/spack/cmd/spec.py
@@ -163,7 +163,9 @@ def _process_result(result, show, required_format, kwargs):
                 else:
                     print(spec.format(required_format))
         else:
-            tree_str = spack.spec.tree(result.specs, color=sys.stdout.isatty(), **kwargs)
+            tree_str = spack.spec.tree(
+                result.specs, color=color.get_color_when(sys.stdout), **kwargs
+            )
             sys.stdout.write(tree_str)
         print()
 

--- a/lib/spack/spack/filesystem_view.py
+++ b/lib/spack/spack/filesystem_view.py
@@ -604,7 +604,7 @@ class YamlFilesystemView(FilesystemView):
     def print_conflict(self, spec_active, spec_specified, level="error"):
         "Singular print function for spec conflicts."
         cprint = getattr(tty, level)
-        color = sys.stdout.isatty()
+        color = tty.color.get_color_when()
         linked = tty.color.colorize("   (@gLinked@.)", color=color)
         specified = tty.color.colorize("(@rSpecified@.)", color=color)
         cprint(
@@ -844,14 +844,14 @@ def get_spec_from_file(filename) -> Optional[spack.spec.Spec]:
 
 
 def colorize_root(root):
-    colorize = ft.partial(tty.color.colorize, color=sys.stdout.isatty())
+    colorize = ft.partial(tty.color.colorize, color=tty.color.get_color_when())
     pre, post = map(colorize, "@M[@. @M]@.".split())
     return f"{pre}{root}{post}"
 
 
 def colorize_spec(spec):
-    "Colorize spec output if in TTY."
-    if sys.stdout.isatty():
+    "Colorize spec output unless colors are turned off."
+    if tty.color.get_color_when():
         return spec.cshort_spec
     else:
         return spec.short_spec

--- a/lib/spack/spack/graph.py
+++ b/lib/spack/spack/graph.py
@@ -309,15 +309,15 @@ class AsciiGraph:
         Arguments:
             spec: spec to graph.  This only handles one spec at a time.
             out: file object to write out to (default is sys.stdout)
-            color: whether to write in color.  Default is to autodetect
-               based on output file.
+            color: whether to write in color.  Default is to autodetect based on the ``--color``
+               setting and the output file.
 
         """
         if out is None:
             out = sys.stdout
 
         if color is None:
-            color = out.isatty()
+            color = spack.util.tty.color.get_color_when(out)
 
         self._out = spack.util.tty.color.ColorStream(out, color=color)
 

--- a/lib/spack/spack/test/util/tty/color.py
+++ b/lib/spack/spack/test/util/tty/color.py
@@ -2,13 +2,19 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+import io
 import re
+import sys
 import textwrap
 
 import pytest
 
 from spack.util.tty import color
 from spack.util.tty.color import cescape, colorize, csub
+
+#: "red" with and without ANSI codes, as written by ``cwrite("@r{red}")``
+RED = "\033[0;31mred\033[0m"
+PLAIN = "red"
 
 test_text = [
     "@r{The quick brown fox jumps over the lazy yellow dog.",
@@ -70,3 +76,47 @@ def test_colorize_top_level_consecutive_escaped_ats():
     """Consecutive @@ at the top level (outside braces) must each unescape independently."""
     assert colorize("@@@@", color=False) == "@@"
     assert colorize("@@@@@@", color=False) == "@@@"
+
+
+class MockStream(io.StringIO):
+    """A stream whose ``isatty()`` can be set independently of the underlying buffer."""
+
+    def __init__(self, isatty: bool) -> None:
+        super().__init__()
+        self._isatty = isatty
+
+    def isatty(self) -> bool:
+        return self._isatty
+
+
+@pytest.mark.parametrize("when,expected", [(True, RED), (False, PLAIN), (None, PLAIN)])
+def test_cwrite_follows_the_stream_it_writes_to(monkeypatch, when, expected):
+    """Tests that cwrite decides on color from its own stream, not from sys.stdout."""
+    monkeypatch.setattr(sys, "stdout", MockStream(isatty=True))
+    stream = MockStream(isatty=False)
+
+    with color.color_when(when):
+        color.cwrite("@r{red}", stream=stream)
+
+    assert stream.getvalue() == expected
+
+
+@pytest.mark.parametrize("when,expected", [(True, RED), (False, PLAIN), (None, RED)])
+def test_cwrite_color_setting_overrides_a_tty_stream(when, expected):
+    stream = MockStream(isatty=True)
+
+    with color.color_when(when):
+        color.cwrite("@r{red}", stream=stream)
+
+    assert stream.getvalue() == expected
+
+
+@pytest.mark.parametrize("when,expected", [(True, RED), (False, PLAIN), (None, PLAIN)])
+def test_color_stream_follows_the_stream_it_wraps(monkeypatch, when, expected):
+    monkeypatch.setattr(sys, "stdout", MockStream(isatty=True))
+    stream = MockStream(isatty=False)
+
+    with color.color_when(when):
+        color.ColorStream(stream).write("@r{red}")
+
+    assert stream.getvalue() == expected

--- a/lib/spack/spack/test/views.py
+++ b/lib/spack/spack/test/views.py
@@ -4,23 +4,15 @@
 
 import os
 import pathlib
-import sys
 
 import pytest
 
 import spack.concretize
 from spack.directory_layout import DirectoryLayout
-from spack.filesystem_view import (
-    SimpleFilesystemView,
-    YamlFilesystemView,
-    colorize_root,
-    colorize_spec,
-)
+from spack.filesystem_view import SimpleFilesystemView, YamlFilesystemView
 from spack.old_installer import PackageInstaller
 from spack.spec import Spec
 from spack.test.conftest import FsTree
-from spack.test.util.tty.color import MockStream
-from spack.util.tty.color import color_when, csub
 
 
 def test_remove_extensions_ordered(install_mockery, mock_fetch, tmp_path: pathlib.Path):
@@ -158,27 +150,3 @@ def test_view_no_dir_symlinks(mock_packages, tmp_path: pathlib.Path):
     # File should be a symlink.
     ah_path = os.path.join(include_dir, "a.h")
     assert os.path.islink(ah_path)
-
-
-@pytest.mark.regression("13387")
-@pytest.mark.parametrize("when,colored", [(True, True), (False, False)])
-def test_view_messages_respect_color_setting(
-    mock_packages, config, tmp_path: pathlib.Path, monkeypatch, when, colored
-):
-    """--color has to win over stdout being a terminal.
-
-    View messages used to check ``sys.stdout.isatty()`` directly, which made them ignore both
-    ``--color`` and ``SPACK_COLOR``.
-    """
-    monkeypatch.setattr(sys, "stdout", MockStream(isatty=True))
-    view_dir = str(tmp_path / "view")
-    spec = spack.concretize.concretize_one("pkg-a")
-
-    with color_when(when):
-        root_msg = colorize_root(view_dir)
-        spec_msg = colorize_spec(spec)
-
-    assert ("\033[" in root_msg) is colored
-    assert ("\033[" in spec_msg) is colored
-    assert csub(root_msg) == f"[{view_dir}]"
-    assert csub(spec_msg) == spec.short_spec

--- a/lib/spack/spack/test/views.py
+++ b/lib/spack/spack/test/views.py
@@ -4,15 +4,23 @@
 
 import os
 import pathlib
+import sys
 
 import pytest
 
 import spack.concretize
 from spack.directory_layout import DirectoryLayout
-from spack.filesystem_view import SimpleFilesystemView, YamlFilesystemView
+from spack.filesystem_view import (
+    SimpleFilesystemView,
+    YamlFilesystemView,
+    colorize_root,
+    colorize_spec,
+)
 from spack.old_installer import PackageInstaller
 from spack.spec import Spec
 from spack.test.conftest import FsTree
+from spack.test.util.tty.color import MockStream
+from spack.util.tty.color import color_when, csub
 
 
 def test_remove_extensions_ordered(install_mockery, mock_fetch, tmp_path: pathlib.Path):
@@ -150,3 +158,27 @@ def test_view_no_dir_symlinks(mock_packages, tmp_path: pathlib.Path):
     # File should be a symlink.
     ah_path = os.path.join(include_dir, "a.h")
     assert os.path.islink(ah_path)
+
+
+@pytest.mark.regression("13387")
+@pytest.mark.parametrize("when,colored", [(True, True), (False, False)])
+def test_view_messages_respect_color_setting(
+    mock_packages, tmp_path: pathlib.Path, monkeypatch, when, colored
+):
+    """--color has to win over stdout being a terminal.
+
+    View messages used to check ``sys.stdout.isatty()`` directly, which made them ignore both
+    ``--color`` and ``SPACK_COLOR``.
+    """
+    monkeypatch.setattr(sys, "stdout", MockStream(isatty=True))
+    view_dir = str(tmp_path / "view")
+    spec = spack.concretize.concretize_one("pkg-a")
+
+    with color_when(when):
+        root_msg = colorize_root(view_dir)
+        spec_msg = colorize_spec(spec)
+
+    assert ("\033[" in root_msg) is colored
+    assert ("\033[" in spec_msg) is colored
+    assert csub(root_msg) == f"[{view_dir}]"
+    assert csub(spec_msg) == spec.short_spec

--- a/lib/spack/spack/test/views.py
+++ b/lib/spack/spack/test/views.py
@@ -163,7 +163,7 @@ def test_view_no_dir_symlinks(mock_packages, tmp_path: pathlib.Path):
 @pytest.mark.regression("13387")
 @pytest.mark.parametrize("when,colored", [(True, True), (False, False)])
 def test_view_messages_respect_color_setting(
-    mock_packages, tmp_path: pathlib.Path, monkeypatch, when, colored
+    mock_packages, config, tmp_path: pathlib.Path, monkeypatch, when, colored
 ):
     """--color has to win over stdout being a terminal.
 

--- a/lib/spack/spack/util/tty/color.py
+++ b/lib/spack/spack/util/tty/color.py
@@ -186,22 +186,6 @@ def try_enable_terminal_color_on_windows() -> None:
             _force_color = False
 
 
-# Memoized ``sys.stdout.isatty()``, as a ``(stream, isatty)`` pair. The stream is part of the key,
-# so the entry is dropped as soon as ``sys.stdout`` is replaced (``log_output`` wraps it, pytest
-# captures it, ...).
-_STDOUT_ISATTY: Tuple[Optional[IO[str]], bool] = (None, False)
-
-
-def _isatty(stream) -> bool:
-    """Return ``stream.isatty()``, memoized for ``sys.stdout``"""
-    global _STDOUT_ISATTY
-    if stream is not sys.stdout:
-        return stream.isatty()
-    if _STDOUT_ISATTY[0] is not stream:
-        _STDOUT_ISATTY = (stream, stream.isatty())
-    return _STDOUT_ISATTY[1]
-
-
 def get_color_when(stream=None) -> bool:
     """Return whether output written to ``stream`` should be colored or not.
 
@@ -210,7 +194,9 @@ def get_color_when(stream=None) -> bool:
     """
     if _force_color is not None:
         return _force_color
-    return _isatty(sys.stdout if stream is None else stream)
+    if stream is None:
+        stream = sys.stdout
+    return stream.isatty()
 
 
 def set_color_when(when: Union[str, bool, None]) -> None:

--- a/lib/spack/spack/util/tty/color.py
+++ b/lib/spack/spack/util/tty/color.py
@@ -64,6 +64,7 @@ import os
 import re
 import sys
 import textwrap
+import weakref
 from contextlib import contextmanager
 from typing import IO, Iterator, List, NamedTuple, Optional, Tuple, Union
 
@@ -188,8 +189,10 @@ def try_enable_terminal_color_on_windows() -> None:
 
 # Memoized ``sys.stdout.isatty()``, as a ``(stream, isatty)`` pair. The stream is part of the key,
 # so the entry is dropped as soon as ``sys.stdout`` is replaced (``log_output`` wraps it, pytest
-# captures it, ...).
-_STDOUT_ISATTY: Tuple[Optional[IO[str]], bool] = (None, False)
+# captures it, ...). It is held weakly, so that caching does not keep a replaced stream alive; a
+# weak reference is also what makes the identity check sound, since the id of a dead object can be
+# reused by a new one.
+_STDOUT_ISATTY: Tuple[Optional["weakref.ref"], bool] = (None, False)
 
 
 def _isatty(stream) -> bool:
@@ -197,9 +200,14 @@ def _isatty(stream) -> bool:
     global _STDOUT_ISATTY
     if stream is not sys.stdout:
         return stream.isatty()
-    if _STDOUT_ISATTY[0] is not stream:
-        _STDOUT_ISATTY = (stream, stream.isatty())
-    return _STDOUT_ISATTY[1]
+    ref, is_a_tty = _STDOUT_ISATTY
+    if ref is None or ref() is not stream:
+        is_a_tty = stream.isatty()
+        try:
+            _STDOUT_ISATTY = (weakref.ref(stream), is_a_tty)
+        except TypeError:  # not weak-referenceable, don't memoize
+            _STDOUT_ISATTY = (None, is_a_tty)
+    return is_a_tty
 
 
 def get_color_when(stream=None) -> bool:

--- a/lib/spack/spack/util/tty/color.py
+++ b/lib/spack/spack/util/tty/color.py
@@ -64,7 +64,6 @@ import os
 import re
 import sys
 import textwrap
-import weakref
 from contextlib import contextmanager
 from typing import IO, Iterator, List, NamedTuple, Optional, Tuple, Union
 
@@ -189,10 +188,8 @@ def try_enable_terminal_color_on_windows() -> None:
 
 # Memoized ``sys.stdout.isatty()``, as a ``(stream, isatty)`` pair. The stream is part of the key,
 # so the entry is dropped as soon as ``sys.stdout`` is replaced (``log_output`` wraps it, pytest
-# captures it, ...). It is held weakly, so that caching does not keep a replaced stream alive; a
-# weak reference is also what makes the identity check sound, since the id of a dead object can be
-# reused by a new one.
-_STDOUT_ISATTY: Tuple[Optional["weakref.ref"], bool] = (None, False)
+# captures it, ...).
+_STDOUT_ISATTY: Tuple[Optional[IO[str]], bool] = (None, False)
 
 
 def _isatty(stream) -> bool:
@@ -200,14 +197,9 @@ def _isatty(stream) -> bool:
     global _STDOUT_ISATTY
     if stream is not sys.stdout:
         return stream.isatty()
-    ref, is_a_tty = _STDOUT_ISATTY
-    if ref is None or ref() is not stream:
-        is_a_tty = stream.isatty()
-        try:
-            _STDOUT_ISATTY = (weakref.ref(stream), is_a_tty)
-        except TypeError:  # not weak-referenceable, don't memoize
-            _STDOUT_ISATTY = (None, is_a_tty)
-    return is_a_tty
+    if _STDOUT_ISATTY[0] is not stream:
+        _STDOUT_ISATTY = (stream, stream.isatty())
+    return _STDOUT_ISATTY[1]
 
 
 def get_color_when(stream=None) -> bool:

--- a/lib/spack/spack/util/tty/color.py
+++ b/lib/spack/spack/util/tty/color.py
@@ -186,6 +186,22 @@ def try_enable_terminal_color_on_windows() -> None:
             _force_color = False
 
 
+# Memoized ``sys.stdout.isatty()``, as a ``(stream, isatty)`` pair. The stream is part of the key,
+# so the entry is dropped as soon as ``sys.stdout`` is replaced (``log_output`` wraps it, pytest
+# captures it, ...).
+_STDOUT_ISATTY: Tuple[Optional[IO[str]], bool] = (None, False)
+
+
+def _isatty(stream) -> bool:
+    """Return ``stream.isatty()``, memoized for ``sys.stdout``"""
+    global _STDOUT_ISATTY
+    if stream is not sys.stdout:
+        return stream.isatty()
+    if _STDOUT_ISATTY[0] is not stream:
+        _STDOUT_ISATTY = (stream, stream.isatty())
+    return _STDOUT_ISATTY[1]
+
+
 def get_color_when(stream=None) -> bool:
     """Return whether output written to ``stream`` should be colored or not.
 
@@ -194,9 +210,7 @@ def get_color_when(stream=None) -> bool:
     """
     if _force_color is not None:
         return _force_color
-    if stream is None:
-        stream = sys.stdout
-    return stream.isatty()
+    return _isatty(sys.stdout if stream is None else stream)
 
 
 def set_color_when(when: Union[str, bool, None]) -> None:

--- a/lib/spack/spack/util/tty/color.py
+++ b/lib/spack/spack/util/tty/color.py
@@ -186,13 +186,17 @@ def try_enable_terminal_color_on_windows() -> None:
             _force_color = False
 
 
-def get_color_when(stdout=None) -> bool:
-    """Return whether commands should print color or not."""
+def get_color_when(stream=None) -> bool:
+    """Return whether output written to ``stream`` should be colored or not.
+
+    ``--color`` and ``SPACK_COLOR`` take precedence over the stream being a tty. When no stream is
+    given, the decision is made for ``sys.stdout``.
+    """
     if _force_color is not None:
         return _force_color
-    if stdout is None:
-        stdout = sys.stdout
-    return stdout.isatty()
+    if stream is None:
+        stream = sys.stdout
+    return stream.isatty()
 
 
 def set_color_when(when: Union[str, bool, None]) -> None:
@@ -384,7 +388,7 @@ def cwrite(string: str, stream: Optional[IO[str]] = None, color: Optional[bool] 
     """
     stream = sys.stdout if stream is None else stream
     if color is None:
-        color = get_color_when()
+        color = get_color_when(stream)
     stream.write(colorize(string, color=color))
 
 
@@ -425,5 +429,5 @@ class ColorStream:
             if raw:
                 color = True
             else:
-                color = get_color_when()
+                color = get_color_when(self._stream)
         raw_write(colorize(string, color=color))


### PR DESCRIPTION
fixes #13387

Several call sites decided whether to colorize by calling sys.stdout.isatty() themselves and passing the result as an explicit `color` argument.

That bypasses get_color_when(), which is where `--color` and SPACK_COLOR are honored. Route all of them through get_color_when(), and let it take the stream the text is written to rather than always assuming sys.stdout.