### PR TITLE
util/environment: quote file/arguments when sourcing files

### DIFF
--- a/lib/spack/spack/test/environment_modifications.py
+++ b/lib/spack/spack/test/environment_modifications.py
@@ -572,3 +572,18 @@ def test_exclude_modules_variables():
     assert not any(x.startswith("BASH_FUNC_ml") for x in modifications)
     assert not any(x.startswith("BASH_FUNC_module") for x in modifications)
     assert not any(x.startswith("BASH_FUNC__module_raw") for x in modifications)
+
+
+@pytest.mark.not_on_windows("Test relies on POSIX shell quoting rules")
+@pytest.mark.regression("14261")
+def test_sourcing_file_with_spaces(tmp_path):
+    """Sourcing a file works when its path, and the arguments passed to it, contain spaces."""
+    directory = tmp_path / "dir with space"
+    directory.mkdir()
+    script = directory / "sourceme.sh"
+    script.write_text('export FROM_SPACED_PATH=yes\nexport FROM_SPACED_ARG="$1"\n')
+
+    env = environment.environment_after_sourcing_files((str(script), "arg with space"))
+
+    assert env["FROM_SPACED_PATH"] == "yes"
+    assert env["FROM_SPACED_ARG"] == "arg with space"

--- a/lib/spack/spack/util/environment.py
+++ b/lib/spack/spack/util/environment.py
@@ -1181,12 +1181,24 @@ def environment_after_sourcing_files(
     def _source_single_file(file_and_args, environment):
         shell_options_list = shell_options.split()
 
+        # The command below is a single string handed to a shell, so the file to be sourced,
+        # its arguments, and the interpreter are quoted to survive word splitting. The shell
+        # operators around them (source_command, suppress_output, concatenate_on_success) are
+        # shell syntax, and must be left alone.
+        if sys.platform == "win32":
+            # cmd.exe does not follow POSIX quoting rules, so pass arguments through unchanged
+            quoted_args = [str(x) for x in file_and_args]
+            python_exe = sys.executable
+        else:
+            quoted_args = [shlex.quote(str(x)) for x in file_and_args]
+            python_exe = shlex.quote(sys.executable)
+
         source_file = [source_command]
-        source_file.extend(x for x in file_and_args)
+        source_file.extend(quoted_args)
         source_file = " ".join(source_file)
 
         dump_cmd = "import os, json; print(json.dumps(dict(os.environ)))"
-        dump_environment_cmd = sys.executable + f' -E -c "{dump_cmd}"'
+        dump_environment_cmd = python_exe + f' -E -c "{dump_cmd}"'
 
         # Try to source the file
         source_file_arguments = (


### PR DESCRIPTION
fixes #14261

`_source_single_file` builds a single string that is handed to a shell, but the file to be sourced, its arguments and the interpreter were interpolated unquoted.

Here we quote those three with `shlex.quote`. Windows keeps the previous behavior, as `cmd.exe` does not follow POSIX quoting rules.