### PR TITLE
traverse.py: sort if >= 2 items

### DIFF
--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -3901,9 +3901,7 @@ class Spec:
             # Level 1: direct dependencies
             # we can yield these in sorted order without tracking visited nodes
             deps_have_deps = False
-            sorted_l1_edges = self.edges_to_dependencies(depflag=dt.ALL)
-            if len(sorted_l1_edges) > 1:
-                sorted_l1_edges = spack.traverse.sort_edges(sorted_l1_edges)
+            sorted_l1_edges = spack.traverse.sort_edges(self.edges_to_dependencies(depflag=dt.ALL))
 
             for edge in sorted_l1_edges:
                 yield edge.spec._cmp_node

--- a/lib/spack/spack/traverse.py
+++ b/lib/spack/spack/traverse.py
@@ -40,7 +40,8 @@ class EdgeAndDepth(NamedTuple):
 
 # Sort edges by name first, then abstract hash, then full edge comparison to break ties
 def sort_edges(edges):
-    edges.sort(key=lambda edge: (edge.spec.name or "", edge.spec.abstract_hash or "", edge))
+    if len(edges) > 1:
+        edges.sort(key=lambda edge: (edge.spec.name or "", edge.spec.abstract_hash or "", edge))
     return edges
 
 


### PR DESCRIPTION
`sort_edges` runs on every edge list during traversal. Leaf nodes have zero edges,
many abstract specs have no more than two edges. So avoid the allocation to do
nothing.

Previously just one call site did this.
