### PR TITLE
Restore permissions in two more tests

### DIFF
--- a/lib/spack/spack/test/database.py
+++ b/lib/spack/spack/test/database.py
@@ -1042,21 +1042,21 @@ def test_prefix_write_lock_error(mutable_database_store: Store, monkeypatch):
 
 
 @pytest.mark.regression("26600")
-def test_database_works_with_empty_dir(tmp_path: pathlib.Path):
+def test_database_works_with_empty_dir(tmp_path: pathlib.Path, request):
     # Create the lockfile and failures directory otherwise
     # we'll get a permission error on Database creation
     db_dir = tmp_path / ".spack-db"
     db_dir.mkdir()
     (db_dir / spack.database._LOCK_FILE).touch()
     (db_dir / "failures").mkdir()
+    # Restore write permissions even if the test fails
+    request.addfinalizer(lambda: tmp_path.chmod(mode=0o755))
     tmp_path.chmod(mode=0o555)
     db = Database(str(tmp_path))
     with db.read_transaction():
         db.query()
     # Check that reading an empty directory didn't create a new index.json
     assert not os.path.exists(db._index_path)
-    # Restore write permissions, or pytest cannot remove the tmp dir.
-    tmp_path.chmod(mode=0o755)
 
 
 @pytest.mark.parametrize(

--- a/lib/spack/spack/test/old_installer.py
+++ b/lib/spack/spack/test/old_installer.py
@@ -516,7 +516,7 @@ def test_clear_failures_success(tmp_path: pathlib.Path):
 
 @pytest.mark.not_on_windows("chmod does not prevent removal on Win")
 @pytest.mark.skipif(fs.getuid() == 0, reason="user is root")
-def test_clear_failures_errs(tmp_path: pathlib.Path, capfd):
+def test_clear_failures_errs(tmp_path: pathlib.Path, capfd, request):
     """Test the clear_failures exception paths."""
     failures = spack.database.FailureTracker(
         str(tmp_path),
@@ -529,6 +529,7 @@ def test_clear_failures_errs(tmp_path: pathlib.Path, capfd):
     failures.mark(spec)
 
     # Make the file marker not writeable, so that clearing_failures fails
+    request.addfinalizer(lambda: failures.dir.chmod(0o750))
     failures.dir.chmod(0o000)
 
     # Clear failure tracking
@@ -537,7 +538,6 @@ def test_clear_failures_errs(tmp_path: pathlib.Path, capfd):
     # Ensure expected warning generated
     out = str(capfd.readouterr()[1])
     assert "Unable to remove failure" in out
-    failures.dir.chmod(0o750)
 
 
 def test_combine_phase_logs(tmp_path: pathlib.Path):


### PR DESCRIPTION
Similar to #52833, for a couple of tests that could still leave wrong permissions on tmpdir.