### PR TITLE
isolate: Adds warning about the interaction between `spack isolate` and `SPACK_DISABLE_LOCAL_CONFIG`

### DIFF
--- a/lib/spack/docs/configuration.rst
+++ b/lib/spack/docs/configuration.rst
@@ -731,6 +731,8 @@ Currently, ``spack isolate`` is a best-effort approach to isolation of a Spack i
 The default location Spack uses for cloning Git based package repositories can only be configured by the ``SPACK_USER_CACHE_PATH`` environment variable (see :ref:`automatic-repo-cloning`).
 ``spack isolate --path ISO_PATH`` will explicitly set the destination of repositories that it knows about when invoked to a subdirectory of ``ISO_PATH``; however, newly added repositories without an explicit destination will be cloned to ``~/.spack``.
 To avoid this, either explicitly set ``SPACK_USER_CACHE_PATH`` or explicitly set the destination of newly added repositories to a different location (see :ref:`customizing-clone-location`).
+Furthermore, since ``spack isolate`` uses the user scope for isolation, setting ``SPACK_DISABLE_LOCAL_CONFIG`` will prevent future configuration changes from taking place in the isolated scope.
+You should unset this variable when using ``spack isolate``. 
 
   .. warning::
 

--- a/lib/spack/docs/configuration.rst
+++ b/lib/spack/docs/configuration.rst
@@ -732,7 +732,7 @@ The default location Spack uses for cloning Git based package repositories can o
 ``spack isolate --path ISO_PATH`` will explicitly set the destination of repositories that it knows about when invoked to a subdirectory of ``ISO_PATH``; however, newly added repositories without an explicit destination will be cloned to ``~/.spack``.
 To avoid this, either explicitly set ``SPACK_USER_CACHE_PATH`` or explicitly set the destination of newly added repositories to a different location (see :ref:`customizing-clone-location`).
 Furthermore, since ``spack isolate`` uses the user scope for isolation, setting ``SPACK_DISABLE_LOCAL_CONFIG`` will prevent future configuration changes from taking place in the isolated scope.
-You should unset this variable when using ``spack isolate``. 
+You should unset this variable when using ``spack isolate``
 
   .. warning::
 

--- a/lib/spack/spack/cmd/isolate.py
+++ b/lib/spack/spack/cmd/isolate.py
@@ -206,3 +206,15 @@ def isolate(parser, args):
             )
         )
     )
+    if "SPACK_DISABLE_LOCAL_CONFIG" in os.environ:
+        tty.warn(
+            "\n".join(
+                textwrap.wrap(
+                    "SPACK_DISABLE_LOCAL_CONFIG is present in the current shell environment,"
+                    " which disables the user scope. spack isolate uses this scope for"
+                    " isolation. In order for future configuration changes to be added"
+                    " to the isolated scope, you will need to unset SPACK_DISABLE_LOCAL_CONFIG."
+                )
+            )
+        )
+        pass


### PR DESCRIPTION
Since `spack isolate` uses the user scope for isolation and `SPACK_DISABLE_LOCAL_CONFIG` tells the config system to ignore the user scope, `spack isolate` stops working when `SPACK_DISABLE_LOCAL_CONFIG` is set. This PR adds a warning to `spack isolate` if the environment variable is present and explains this interaction in the docs. 

This PR **does not** change any functionality in `spack isolate`.