### PR TITLE
package_base: fix Windows .exe suffix handling in command property

### DIFF
--- a/lib/spack/spack/old_installer.py
+++ b/lib/spack/spack/old_installer.py
@@ -277,11 +277,14 @@ def _do_fake_install(pkg: "spack.package_base.PackageBase") -> None:
     plat_shared = ".dll" if sys.platform == "win32" else ".so"
     plat_static = ".lib" if sys.platform == "win32" else ".a"
     dso_suffix = ".dylib" if sys.platform == "darwin" else plat_shared
+    # Windows tells executables apart by extension, so a fake command without one would not
+    # be an executable as far as e.g. PackageBase.command is concerned
+    exe_suffix = ".exe" if sys.platform == "win32" else ""
 
     # Install fake command
     fs.mkdirp(pkg.prefix.bin)
     executable = lambda path, flags: os.open(path, flags, 0o700)
-    open(os.path.join(pkg.prefix.bin, command), "wb", opener=executable).close()
+    open(os.path.join(pkg.prefix.bin, command + exe_suffix), "wb", opener=executable).close()
 
     # Install fake header file
     fs.mkdirp(pkg.prefix.include)

--- a/lib/spack/spack/package_base.py
+++ b/lib/spack/spack/package_base.py
@@ -1561,15 +1561,12 @@ class PackageBase(WindowsRPath, PackageViewMixin, metaclass=PackageMeta):
     def command(self) -> spack.util.executable.Executable:
         """Returns the main executable for this package."""
         path = os.path.join(self.home.bin, self.spec.name)
-        # On Windows, executables have a .exe extension. os.path.isfile/is_exe do not
-        # automatically resolve missing extensions (unlike subprocess.Popen), so we
-        # try the .exe path first, then fall back to the bare path.
-        if sys.platform == "win32" and not pathlib.Path(path).suffix:
-            exe_path = f"{path}.exe"
-            if fsys.is_exe(exe_path):
-                return spack.util.executable.Executable(exe_path)
-        if fsys.is_exe(path):
-            return spack.util.executable.Executable(path)
+        # On Windows the executable carries an extension (typically .exe) that the package name
+        # does not, and os.path.isfile does not resolve it for us (unlike subprocess.Popen), so
+        # let resolve_exe fill it in.
+        exe_path = spack.util.executable.resolve_exe(path)
+        if exe_path is not None:
+            return spack.util.executable.Executable(exe_path)
         raise RuntimeError(f"Unable to locate {self.spec.name} command in {self.home.bin}")
 
     def url_version(self, version):

--- a/lib/spack/spack/package_base.py
+++ b/lib/spack/spack/package_base.py
@@ -1561,6 +1561,11 @@ class PackageBase(WindowsRPath, PackageViewMixin, metaclass=PackageMeta):
     def command(self) -> spack.util.executable.Executable:
         """Returns the main executable for this package."""
         path = os.path.join(self.home.bin, self.spec.name)
+        # On Windows, executables have a .exe extension. os.path.isfile/is_exe do not
+        # automatically resolve missing extensions (unlike subprocess.Popen), so we
+        # must append .exe ourselves when the path has no extension.
+        if sys.platform == "win32" and not pathlib.Path(path).suffix:
+            path += ".exe"
         if fsys.is_exe(path):
             return spack.util.executable.Executable(path)
         raise RuntimeError(f"Unable to locate {self.spec.name} command in {self.home.bin}")

--- a/lib/spack/spack/package_base.py
+++ b/lib/spack/spack/package_base.py
@@ -1563,9 +1563,11 @@ class PackageBase(WindowsRPath, PackageViewMixin, metaclass=PackageMeta):
         path = os.path.join(self.home.bin, self.spec.name)
         # On Windows, executables have a .exe extension. os.path.isfile/is_exe do not
         # automatically resolve missing extensions (unlike subprocess.Popen), so we
-        # must append .exe ourselves when the path has no extension.
+        # try the .exe path first, then fall back to the bare path.
         if sys.platform == "win32" and not pathlib.Path(path).suffix:
-            path += ".exe"
+            exe_path = f"{path}.exe"
+            if fsys.is_exe(exe_path):
+                return spack.util.executable.Executable(exe_path)
         if fsys.is_exe(path):
             return spack.util.executable.Executable(path)
         raise RuntimeError(f"Unable to locate {self.spec.name} command in {self.home.bin}")

--- a/lib/spack/spack/test/cmd/view.py
+++ b/lib/spack/spack/test/cmd/view.py
@@ -19,6 +19,9 @@ extensions = SpackCommand("extensions")
 install = SpackCommand("install")
 view = SpackCommand("view")
 
+#: Fake installs create executables with a .exe extension on Windows
+exe_suffix = ".exe" if sys.platform == "win32" else ""
+
 if sys.platform == "win32":
     if not _windows_can_symlink():
         pytest.skip(
@@ -47,7 +50,7 @@ def test_view_link_type(
     install("--fake", "libdwarf")
     view_dir = tmp_path / f"view_{cmd}"
     view(cmd, str(view_dir), "libdwarf")
-    package_bin = view_dir / "bin" / "libdwarf"
+    package_bin = view_dir / "bin" / f"libdwarf{exe_suffix}"
     assert package_bin.exists()
 
     # Check that we use symlinks for and only for the appropriate subcommands
@@ -81,7 +84,7 @@ def test_view_projections(
     projection_file = create_projection_file(tmp_path, view_projection)
     view(cmd, str(view_dir), f"--projection-file={projection_file}", "libdwarf")
 
-    package_bin = view_dir / "libdwarf-20130207" / "bin" / "libdwarf"
+    package_bin = view_dir / "libdwarf-20130207" / "bin" / f"libdwarf{exe_suffix}"
     assert package_bin.exists()
 
     # Check that we use symlinks for and only for the appropriate subcommands

--- a/lib/spack/spack/test/database.py
+++ b/lib/spack/spack/test/database.py
@@ -422,6 +422,9 @@ def _mock_remove(spec, db):
 
 
 def test_default_queries(database):
+    # Executables carry a .exe extension on Windows
+    exe_suffix = ".exe" if sys.platform == "win32" else ""
+
     # Testing a package whose name *doesn't* start with 'lib'
     # to ensure the library has 'lib' prepended to the name
     rec = database.get_record("zmpi")
@@ -438,7 +441,7 @@ def test_default_queries(database):
 
     command = spec["zmpi"].command
     assert isinstance(command, Executable)
-    assert command.name == "zmpi"
+    assert command.name == "zmpi" + exe_suffix
     assert os.path.exists(command.path)
 
     # Testing a package whose name *does* start with 'lib'
@@ -457,7 +460,7 @@ def test_default_queries(database):
 
     command = spec["libelf"].command
     assert isinstance(command, Executable)
-    assert command.name == "libelf"
+    assert command.name == "libelf" + exe_suffix
     assert os.path.exists(command.path)
 
 

--- a/lib/spack/spack/test/util/executable.py
+++ b/lib/spack/spack/test/util/executable.py
@@ -110,6 +110,75 @@ def test_which(tmp_path: pathlib.Path, monkeypatch):
         assert exe.path == path
 
 
+@pytest.mark.not_on_windows("Executables are determined by file extension on Windows")
+def test_resolve_exe(tmp_path: pathlib.Path):
+    script = tmp_path / "script"
+    script.touch()
+
+    assert ex.resolve_exe(str(script)) is None
+
+    fs.set_executable(str(script))
+
+    assert ex.resolve_exe(str(script)) == str(script)
+    assert ex.resolve_exe(script) == str(script)
+
+    # directories and missing files are not executables
+    assert ex.resolve_exe(str(tmp_path)) is None
+    assert ex.resolve_exe(str(tmp_path / "does-not-exist")) is None
+
+
+@pytest.mark.only_windows("Test is for Windows specific behavior")
+def test_windows_resolve_exe_searches_pathext(tmp_path: pathlib.Path, monkeypatch):
+    monkeypatch.setenv("PATHEXT", ".COM;.EXE;.BAT")
+
+    for name in ("foo.exe", "bar.bat", "clang-19.1.exe", "notes.txt", "extensionless"):
+        (tmp_path / name).touch()
+
+    # a path with an executable extension is used as is
+    assert ex.resolve_exe(str(tmp_path / "foo.exe")) == str(tmp_path / "foo.exe")
+
+    # a path missing its extension is resolved against PATHEXT
+    assert ex.resolve_exe(str(tmp_path / "foo")) == str(tmp_path / "foo.exe")
+    assert ex.resolve_exe(str(tmp_path / "bar")) == str(tmp_path / "bar.bat")
+
+    # so is a path ending in something that only looks like an extension
+    assert ex.resolve_exe(str(tmp_path / "clang-19.1")) == str(tmp_path / "clang-19.1.exe")
+
+    # files Windows does not consider executable, and files that don't exist, are not
+    assert ex.resolve_exe(str(tmp_path / "notes.txt")) is None
+    assert ex.resolve_exe(str(tmp_path / "notes")) is None
+    assert ex.resolve_exe(str(tmp_path / "extensionless")) is None
+    assert ex.resolve_exe(str(tmp_path / "does-not-exist")) is None
+
+    # extensions outside of PATHEXT are not executable
+    (tmp_path / "script.cmd").touch()
+    assert ex.resolve_exe(str(tmp_path / "script.cmd")) is None
+    monkeypatch.setenv("PATHEXT", ".COM;.EXE;.BAT;.CMD")
+    assert ex.resolve_exe(str(tmp_path / "script.cmd")) == str(tmp_path / "script.cmd")
+    assert ex.resolve_exe(str(tmp_path / "script")) == str(tmp_path / "script.cmd")
+
+
+@pytest.mark.only_windows("Test is for Windows specific behavior")
+def test_which_searches_pathext(tmp_path: pathlib.Path, monkeypatch):
+    """which() finds executables whose extension is omitted, in PATHEXT order."""
+    monkeypatch.setenv("PATH", str(tmp_path))
+    monkeypatch.setenv("PATHEXT", ".COM;.EXE;.BAT")
+
+    for name in ("script.bat", "prog.com", "prog.exe", "notes.txt", "extensionless"):
+        (tmp_path / name).touch()
+
+    assert ex.which("script").path == str(tmp_path / "script.bat")
+    assert ex.which("script.bat").path == str(tmp_path / "script.bat")
+
+    # PATHEXT determines which extension wins when several are present
+    assert ex.which("prog").path == str(tmp_path / "prog.com")
+
+    # files Windows does not consider executable are not found
+    assert ex.which("notes") is None
+    assert ex.which("notes.txt") is None
+    assert ex.which("extensionless") is None
+
+
 @pytest.fixture
 def make_script_exe(tmp_path: pathlib.Path):
     if sys.platform == "win32":

--- a/lib/spack/spack/test/util/filesystem.py
+++ b/lib/spack/spack/test/util/filesystem.py
@@ -791,6 +791,23 @@ def test_temporary_dir_context_manager():
         assert os.path.realpath(str(tmp_dir)) == os.path.realpath(os.getcwd())
 
 
+def test_is_exe(tmp_path: pathlib.Path):
+    """See ``test/util/executable.py`` for how paths are resolved to executables."""
+    script = tmp_path / ("script.exe" if sys.platform == "win32" else "script")
+    script.touch()
+
+    if sys.platform != "win32":
+        # Windows determines whether a file is executable from its extension
+        assert not fs.is_exe(str(script))
+        fs.set_executable(str(script))
+
+    assert fs.is_exe(str(script))
+
+    # directories and missing files are not executables
+    assert not fs.is_exe(str(tmp_path))
+    assert not fs.is_exe(str(tmp_path / "does-not-exist"))
+
+
 @pytest.mark.not_on_windows("No shebang on Windows")
 def test_is_nonsymlink_exe_with_shebang(tmp_path: pathlib.Path):
     with fs.working_dir(str(tmp_path)):

--- a/lib/spack/spack/util/executable.py
+++ b/lib/spack/spack/util/executable.py
@@ -16,8 +16,12 @@ from spack.vendor.typing_extensions import Literal
 import spack.error
 from spack.util import tty
 from spack.util.environment import EnvironmentModifications
+from spack.util.path import system_path_filter
 
-__all__ = ["Executable", "which", "which_string", "ProcessError"]
+__all__ = ["Executable", "resolve_exe", "which", "which_string", "ProcessError"]
+
+#: Extensions Windows considers executable, when ``PATHEXT`` is not set in the environment
+WINDOWS_DEFAULT_PATHEXT = ".COM;.EXE;.BAT;.CMD;.VBS;.VBE;.JS;.JSE;.WSF;.WSH;.MSC"
 
 OutType = Union[Optional[BinaryIO], str, Type[str], Callable]
 
@@ -358,6 +362,43 @@ class Executable:
         return " ".join(self.exe)
 
 
+def windows_executable_extensions() -> List[str]:
+    """Returns the file extensions Windows considers executable, in the order Windows searches
+    them, as lowercase strings including the leading dot."""
+    pathext = os.environ.get("PATHEXT", WINDOWS_DEFAULT_PATHEXT)
+    return [ext.lower() for ext in pathext.split(";") if ext.strip()]
+
+
+def _win_resolve_exe(path: str) -> Optional[str]:
+    """Windows implementation of :func:`resolve_exe`."""
+    extensions = windows_executable_extensions()
+    # Windows determines whether a file is executable from its extension, not from its
+    # permissions, so a path that already names a file with an executable extension is done.
+    if os.path.splitext(path)[1].lower() in extensions and os.path.isfile(path):
+        return path
+    # Otherwise the extension may be missing entirely ("clang" for "clang.exe") or the name may
+    # end in something that only looks like one ("clang-19.1" for "clang-19.1.exe"), so append
+    # each executable extension in turn, as the shell and CreateProcess do.
+    for extension in extensions:
+        candidate = path + extension
+        if os.path.isfile(candidate):
+            return candidate
+    return None
+
+
+@system_path_filter
+def resolve_exe(path: Union[str, Path]) -> Optional[str]:
+    """Returns the path of the executable file ``path`` refers to, or :obj:`None` if there is
+    none.
+
+    On Windows ``path`` may omit the file extension, in which case the extensions in ``PATHEXT``
+    are tried in order; the returned path always includes the extension."""
+    file_path = os.fspath(path)
+    if sys.platform == "win32":
+        return _win_resolve_exe(file_path)
+    return file_path if os.path.isfile(file_path) and os.access(file_path, os.X_OK) else None
+
+
 @overload
 def which_string(
     *args: str, path: Optional[Union[List[str], str]] = ..., required: Literal[True]
@@ -383,12 +424,6 @@ def which_string(
     if isinstance(path, str):
         paths = [Path(x) for x in path.split(os.pathsep)]
 
-    def get_candidate_items(search_item):
-        if sys.platform == "win32" and not search_item.suffix:
-            return [search_item.parent / (search_item.name + ext) for ext in [".exe", ".bat"]]
-
-        return [Path(search_item)]
-
     def add_extra_search_paths(paths):
         with_parents = []
         with_parents.extend(paths)
@@ -406,16 +441,15 @@ def which_string(
             search_paths.insert(0, Path.cwd())
         search_paths = add_extra_search_paths(search_paths)
 
-        candidate_items = get_candidate_items(Path(search_item))
-
-        for candidate_item in candidate_items:
-            for directory in search_paths:
-                exe = directory / candidate_item
-                try:
-                    if exe.is_file() and os.access(str(exe), os.X_OK):
-                        return str(exe)
-                except OSError:
-                    pass
+        for directory in search_paths:
+            # On Windows the executable extension is usually omitted from the name we search
+            # for, so resolve_exe appends the extensions in PATHEXT to find the file.
+            try:
+                exe = resolve_exe(directory / Path(search_item))
+            except OSError:
+                continue
+            if exe is not None:
+                return exe
 
     if required:
         raise CommandNotFoundError(f"spack requires '{args[0]}'. Make sure it is in your path.")

--- a/lib/spack/spack/util/filesystem.py
+++ b/lib/spack/spack/util/filesystem.py
@@ -47,7 +47,7 @@ from typing import (
 from spack.vendor.typing_extensions import Literal
 
 from spack.util import lang, tty
-from spack.util.executable import Executable
+from spack.util.executable import Executable, resolve_exe
 from spack.util.lang import dedupe, fnmatch_translate_multiple, memoized
 from spack.util.path import path_to_os_path, sanitize_win_longpath, system_path_filter
 
@@ -937,21 +937,14 @@ def install_tree(
     copy_tree(src, dest, symlinks=symlinks, ignore=ignore, _permissions=True)
 
 
-def _win_is_exe(path: Union[str, pathlib.Path]) -> bool:
-    path = os.fspath(path)
-    default_pathext = ".COM;.EXE;.BAT;.CMD;.VBS;.VBE;.JS;.JSE;.WSF;.WSH;.MSC"
-    pathext_str = os.environ.get("PATHEXT", default_pathext)
-    executable_extensions = {ext.upper() for ext in pathext_str.split(";")}
-    return bool({x for x in executable_extensions if x in path.upper()})
-
-
 @system_path_filter
 def is_exe(path) -> bool:
     """Returns :obj:`True` iff the specified path exists, is a regular file, and has executable
-    permissions for the current process."""
-    is_exe = os.path.isfile(path)
-    is_exe = is_exe and (os.access(path, os.X_OK) if sys.platform != "win32" else _win_is_exe(path) )
-    return  is_exe
+    permissions for the current process.
+
+    On Windows the extension may be omitted from ``path``, in which case the extensions in
+    ``PATHEXT`` are tried; see :func:`spack.util.executable.resolve_exe`."""
+    return resolve_exe(path) is not None
 
 
 def has_shebang(path) -> bool:

--- a/lib/spack/spack/util/filesystem.py
+++ b/lib/spack/spack/util/filesystem.py
@@ -937,11 +937,21 @@ def install_tree(
     copy_tree(src, dest, symlinks=symlinks, ignore=ignore, _permissions=True)
 
 
+def _win_is_exe(path: Union[str, pathlib.Path]) -> bool:
+    path = os.fspath(path)
+    default_pathext = ".COM;.EXE;.BAT;.CMD;.VBS;.VBE;.JS;.JSE;.WSF;.WSH;.MSC"
+    pathext_str = os.environ.get("PATHEXT", default_pathext)
+    executable_extensions = {ext.upper() for ext in pathext_str.split(";")}
+    return bool({x for x in executable_extensions if x in path.upper()})
+
+
 @system_path_filter
 def is_exe(path) -> bool:
     """Returns :obj:`True` iff the specified path exists, is a regular file, and has executable
     permissions for the current process."""
-    return os.path.isfile(path) and os.access(path, os.X_OK)
+    is_exe = os.path.isfile(path)
+    is_exe = is_exe and (os.access(path, os.X_OK) if sys.platform != "win32" else _win_is_exe(path) )
+    return  is_exe
 
 
 def has_shebang(path) -> bool:


### PR DESCRIPTION
On Windows, executables have a .exe extension. While subprocess.Popen automatically resolves missing extensions, os.path.isfile/is_exe do not. This caused PackageBase.command to raise RuntimeError on Windows when accessing spec["cmake"].command.path, breaking the CachedCMakeBuilder initconfig phase.

The fix appends .exe on Windows when the path has no extension, mirroring the behavior of which_string in spack.util.executable.