### PR TITLE
solver: don't reuse compiler dependencies unless reuse allows it

### DIFF
--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -1167,6 +1167,7 @@ class ConcreteSpecsByHash(collections.abc.Mapping):
     def __init__(self) -> None:
         self.data: Dict[str, spack.spec.Spec] = {}
         self.explicit: Set[str] = set()
+        self.selectable: Set[str] = set()
 
     def __getitem__(self, dag_hash: str) -> spack.spec.Spec:
         return self.data[dag_hash]
@@ -1180,7 +1181,14 @@ class ConcreteSpecsByHash(collections.abc.Mapping):
             if h in self.explicit or s.name == "gcc-runtime":
                 yield h, s
 
-    def add(self, spec: spack.spec.Spec) -> bool:
+    def is_selectable(self, dag_hash: str) -> bool:
+        """Returns True if any node can be matched against this hash, False if the hash is
+        known only because it belongs to the DAG of another selectable spec.
+        """
+        # Same exception as in explicit_items, gcc-runtime is never imposed by its own parent
+        return dag_hash in self.selectable or self.data[dag_hash].name == "gcc-runtime"
+
+    def add(self, spec: spack.spec.Spec, *, selectable: bool = True) -> bool:
         """Adds a new concrete spec to the mapping. Returns True if the spec was just added,
         False if the spec was already in the mapping.
 
@@ -1188,6 +1196,9 @@ class ConcreteSpecsByHash(collections.abc.Mapping):
 
         Args:
             spec: spec to be added
+            selectable: if True, any node in the solve can be matched against this spec. If
+                False, the spec can only be imposed by a parent that is being reused. Specs
+                added as selectable stay selectable, regardless of later additions.
 
         Raises:
             ValueError: if the spec is not concrete
@@ -1201,6 +1212,8 @@ class ConcreteSpecsByHash(collections.abc.Mapping):
 
         dag_hash = spec.dag_hash()
         self.explicit.add(dag_hash)
+        if selectable:
+            self.selectable.add(dag_hash)
         if dag_hash in self.data:
             return False
 
@@ -2795,7 +2808,7 @@ class SpackSolverSetup:
         for pkg_name, vid, value in sorted(def_info):
             self.gen.fact(fn.pkg_fact(pkg_name, fn.variant_possible_value(vid, value)))
 
-    def register_concrete_spec(self, spec, possible: set):
+    def register_concrete_spec(self, spec, possible: set, *, selectable: bool = True):
         # tell the solver about any installed packages that could
         # be dependencies (don't tell it about the others)
         if spec.name not in possible:
@@ -2808,13 +2821,17 @@ class SpackSolverSetup:
             tty.debug(f"[REUSE] Issues when trying to reuse {spec.short_spec}: {str(e)}")
             return
 
-        self.reusable_and_possible.add(spec)
+        self.reusable_and_possible.add(spec, selectable=selectable)
 
     def concrete_specs(self):
         """Emit facts for reusable specs"""
         for h, spec in self.reusable_and_possible.explicit_items():
-            # this indicates that there is a spec like this installed
-            self.gen.fact(fn.installed_hash(spec.name, h))
+            if self.reusable_and_possible.is_selectable(h):
+                # this indicates that there is a spec like this installed
+                self.gen.fact(fn.installed_hash(spec.name, h))
+            else:
+                # the hash is known, but only a parent being reused can impose it
+                self.gen.fact(fn.imposable_hash(spec.name, h))
             # indirection layer between hash constraints and imposition to allow for splicing
             for pred in self.spec_clauses(spec, body=True, required_from=None):
                 self.gen.fact(fn.hash_attr(h, *pred.args))
@@ -2967,11 +2984,20 @@ class SpackSolverSetup:
         candidate_compilers, self.rejected_compilers = possible_compilers(
             configuration=spack.config.CONFIG
         )
-        reuse_from_compilers = traverse.traverse_nodes(
-            [x for x in candidate_compilers if not x.external], deptype=("link", "run")
-        )
+        # Compilers installed by Spack are candidates for the solve, no matter what
+        # "concretizer:reuse" says. Their link and run dependencies are needed to impose a
+        # reused compiler, but they must not become reusable specs on their own: that is up
+        # to "concretizer:reuse", like for any other installed spec.
+        installed_compilers = [x for x in candidate_compilers if not x.external]
         reused_set = set(reuse)
-        reuse += [x for x in reuse_from_compilers if x not in reused_set]
+        reuse += [x for x in installed_compilers if x not in reused_set]
+        compiler_dependencies = [
+            x
+            for x in traverse.traverse_nodes(
+                installed_compilers, deptype=("link", "run"), root=False
+            )
+            if x not in reused_set
+        ]
 
         candidate_compilers.update(compilers_from_reuse)
         self.possible_compilers = list(candidate_compilers)
@@ -3031,6 +3057,10 @@ class SpackSolverSetup:
             self.gen.fact(fn.optimize_for_reuse())
             for reusable_spec in reuse:
                 self.register_concrete_spec(reusable_spec, self.pkgs)
+        # Registered after the reuse list, so that a dependency of an installed compiler that
+        # is also reusable on its own keeps being selectable.
+        for compiler_dependency in compiler_dependencies:
+            self.register_concrete_spec(compiler_dependency, self.pkgs, selectable=False)
         self.concrete_specs()
 
         self.gen.h1("Generic statements on possible packages")

--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -2052,8 +2052,17 @@ error(100, "Cannot set multiple {0} values for {1} from cli", FlagType, Package)
   attr("node", node(ID, PackageName)).
 % you can't choose an installed hash for a dev spec
 :- attr("hash", PackageNode, Hash), attr("variant_value", PackageNode, "dev_path", _).
-% You can't install a hash, if it is not installed
-:- attr("hash", node(ID, Package), Hash), not installed_hash(Package, Hash).
+% You can't install a hash, if it is not installed, or imposable by a spec being reused
+:- attr("hash", node(ID, Package), Hash),
+   not installed_hash(Package, Hash),
+   not imposable_hash(Package, Hash).
+
+% Hashes the solver knows about only because they belong to the DAG of a spec that can be
+% reused. Since they are not in the choice rule above, they cannot be selected by an arbitrary
+% node, but the spec owning them can still impose them. This is what keeps the dependencies of
+% a compiler available when "concretizer:reuse" excludes them: compilers installed by Spack are
+% always reusable, their dependencies are not reusable on their own.
+#defined imposable_hash/2.
 
 % hash_attrs are versions, but can_splice_attr are usually node_version_satisfies
 hash_attr(Hash, "node_version_satisfies", PackageName, Constraint) :-

--- a/lib/spack/spack/test/concretization/core.py
+++ b/lib/spack/spack/test/concretization/core.py
@@ -5610,3 +5610,65 @@ def test_terminal_ui_announces_pool_only_when_solving(total, announced, capsys):
     )
 
     assert ("Starting concretization" in capsys.readouterr().out) is announced
+
+
+@pytest.mark.parametrize("reuse,expected_reused", [(True, True), (False, False)])
+def test_reuse_of_compiler_dependencies_follows_reuse_config(
+    reuse, expected_reused, temporary_store, mutable_config: Configuration, mock_packages
+):
+    """Tests that we don't accidentally reuse compiler dependencies, for compilers installed
+    by Spack.
+    """
+    # Scenario: compiler-with-deps is installed with an old zlib in its subtree. An unrelated
+    # package is then concretized with gcc as its compiler, so the compiler owning that zlib is
+    # not part of the DAG. With reuse:true the old zlib is reused, with reuse:false a fresh
+    # zlib@1.2.11 must be built instead.
+    compiler = spack.concretize.concretize_one("compiler-with-deps ^zlib@1.2.8")
+    assert compiler["zlib"].satisfies("@1.2.8")
+    PackageInstaller([compiler.package], fake=True, explicit=True).install()
+
+    with mutable_config.override("concretizer:reuse", reuse):
+        s = spack.concretize.concretize_one("pkg-with-zlib-dep %c=gcc")
+
+    # The compiler that owns the old zlib is not part of the DAG at all
+    assert "compiler-with-deps" not in s, s.tree()
+    assert (s["zlib"].dag_hash() == compiler["zlib"].dag_hash()) is expected_reused, s.tree()
+    if not expected_reused:
+        assert s["zlib"].satisfies("@1.2.11"), s.tree()
+
+
+def test_compiler_with_dependencies_is_reused_when_reuse_is_false(
+    temporary_store, mutable_config: Configuration, mock_packages
+):
+    """Tests that a compiler installed by Spack can still be reused with reuse:false, together
+    with the dependencies it was installed with.
+    """
+    # The dependencies of a compiler are not selectable with reuse:false, but they must still be
+    # imposable by the compiler being reused, otherwise a compiler with dependencies could never
+    # be used without rebuilding it.
+    compiler = spack.concretize.concretize_one("compiler-with-deps ^zlib@1.2.8")
+    PackageInstaller([compiler.package], fake=True, explicit=True).install()
+
+    with mutable_config.override("concretizer:reuse", False):
+        s = spack.concretize.concretize_one("pkg-with-zlib-dep %c=compiler-with-deps")
+
+    assert s["compiler-with-deps"].dag_hash() == compiler.dag_hash(), s.tree()
+    assert s["compiler-with-deps"]["zlib"].dag_hash() == compiler["zlib"].dag_hash(), s.tree()
+
+
+def test_compiler_dependencies_can_be_excluded_from_reuse(
+    temporary_store, mutable_config: Configuration, mock_packages
+):
+    """Tests that the dependencies of a compiler installed by Spack are subject to the
+    include/exclude filters of the reuse sources, like any other installed spec.
+    """
+    compiler = spack.concretize.concretize_one("compiler-with-deps ^zlib@1.2.8")
+    PackageInstaller([compiler.package], fake=True, explicit=True).install()
+
+    with mutable_config.override(
+        "concretizer:reuse", {"from": [{"type": "local", "exclude": ["zlib"]}]}
+    ):
+        s = spack.concretize.concretize_one("pkg-with-zlib-dep %c=gcc")
+
+    assert s["zlib"].dag_hash() != compiler["zlib"].dag_hash(), s.tree()
+    assert s["zlib"].satisfies("@1.2.11"), s.tree()


### PR DESCRIPTION
Currently, we don't distinguish between a dependency that can be reused on its own and a dependency that can only be reused as part of another spec.

This matters for compilers, which are always reusable in a clingo solve (even when `reuse:false`). In that case we don't want to reuse a compiler dependency if the compiler itself is not being used.

Here we fix the issue by introducing a new `imposable_hash` fact that denotes a spec that can be reused only as a part of another spec.