### PR TITLE
spec: make parallel edges round-trip to_dict and make constrain commutative

### DIFF
--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -3697,14 +3697,20 @@ class Spec:
                 new_specs[spid(edge.spec)] = edge.spec.copy(deps=False)
 
             edge_propagation = edge.propagation if propagation is None else propagation
-            new_specs[spid(edge.parent)].add_dependency_edge(
-                new_specs[spid(edge.spec)],
+            new_parent = new_specs[spid(edge.parent)]
+            new_child = new_specs[spid(edge.spec)]
+            new_edge = DependencySpec(
+                new_parent,
+                new_child,
                 depflag=edge.depflag,
                 virtuals=edge.virtuals,
                 propagation=edge_propagation,
                 direct=edge.direct,
                 when=edge.when,
             )
+            # Don't use add_dependency_edge here, copy edges verbatim
+            _add_edge_to_map(new_parent._dependencies, new_child.name, new_edge)
+            _add_edge_to_map(new_child._dependents, new_parent.name, new_edge)
 
     def copy(self, deps: Union[bool, dt.DepTypes, dt.DepFlag] = True, **kwargs):
         """Make a copy of this spec.

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -726,7 +726,7 @@ class DeprecatedCompilerSpec(lang.DeprecatedProperty):
         raise AttributeError(f"{instance} has no C, C++, or Fortran compiler")
 
 
-@lang.lazy_lexicographic_ordering
+@lang.lazy_lexicographic_ordering(set_hash=False)
 class DependencySpec:
     """DependencySpecs represent an edge in the DAG, and contain dependency types
     and information on the virtuals being provided.
@@ -831,6 +831,21 @@ class DependencySpec:
         yield self.direct
         yield self.propagation
         yield self.when
+        yield self.spec  # tie-breaker for parallel edges: `^foo@1 ^foo+bar`
+
+    def __hash__(self):
+        # Hash edge properties, do not include the node.
+        return hash(
+            (
+                self.parent.name if self.parent else None,
+                self.spec.name if self.spec else None,
+                self.depflag,
+                self.virtuals,
+                self.direct,
+                self.propagation,
+                self.when,
+            )
+        )
 
     def __str__(self) -> str:
         return self.format()
@@ -1080,10 +1095,6 @@ class FlagMap(lang.HashableMap[str, List[CompilerFlag]]):
         return result
 
 
-def _sort_by_dep_types(dspec: DependencySpec):
-    return dspec.depflag
-
-
 EdgeMap = Dict[str, List[DependencySpec]]
 
 
@@ -1091,7 +1102,7 @@ def _add_edge_to_map(edge_map: EdgeMap, key: str, edge: DependencySpec) -> None:
     if key in edge_map:
         lst = edge_map[key]
         lst.append(edge)
-        lst.sort(key=_sort_by_dep_types)
+        lst.sort()  # type: ignore[call-arg,call-overload]
     else:
         edge_map[key] = [edge]
 
@@ -1855,11 +1866,11 @@ class Spec:
         Args:
             deptype: allowed dependency types
         """
-        _sort_fn = lambda x: (x.spec.name, _sort_by_dep_types(x))
         _group_fn = lambda x: x.spec.name
         selected_edges = _select_edges(self._dependencies, depflag=depflag)
+        edges = sorted(selected_edges)  # type: ignore[type-var]
         result = {}
-        for key, group in itertools.groupby(sorted(selected_edges, key=_sort_fn), key=_group_fn):
+        for key, group in itertools.groupby(edges, key=_group_fn):
             result[key] = list(group)
         return result
 

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -5496,14 +5496,18 @@ def wire_spec_nodes(
                 raise MissingSpecHashError(
                     f"node '{node['name']}' references missing dep hash {dep.name}/{dep.hash}"
                 )
-            node_spec._add_dependency(
+            # Add edges exactly as they are stored
+            edge = DependencySpec(
+                node_spec,
                 dep_spec,
                 depflag=dt.canonicalize(dep.deptypes),
                 virtuals=dep.virtuals,
                 direct=dep.direct,
-                when=Spec(dep.when) if dep.when else None,
+                when=Spec(dep.when) if dep.when else EMPTY_SPEC,
                 propagation=PropagationPolicy[dep.propagation],
             )
+            _add_edge_to_map(node_spec._dependencies, edge.spec.name, edge)
+            _add_edge_to_map(edge.spec._dependents, edge.parent.name, edge)
 
         if "build_spec" in node.keys():
             bname, bhash, _ = reader.extract_build_spec_info_from_node_dict(

--- a/lib/spack/spack/test/spec_dag.py
+++ b/lib/spack/spack/test/spec_dag.py
@@ -772,6 +772,18 @@ class TestSpecDag:
         s2 = s1.copy()
         self.check_diamond_deptypes(s2)
 
+    def test_copy_preserves_parallel_deptype_edges(self):
+        """Parallel edges to one shared child, as from_dict builds them, must not merge into one
+        edge on copy."""
+        original = Spec.from_dict(
+            Spec("pkg-a ^[deptypes=build] pkg-b ^[deptypes=link] pkg-b").to_dict()
+        )
+        copied = original.copy()
+        edges = copied.edges_to_dependencies("pkg-b")
+        assert len(edges) == 2
+        assert {e.depflag for e in edges} == {dt.BUILD, dt.LINK}
+        assert copied.to_dict() == original.to_dict()
+
     def test_getitem_query(self):
         s = spack.concretize.concretize_one("mpileaks")
 

--- a/lib/spack/spack/test/spec_yaml.py
+++ b/lib/spack/spack/test/spec_yaml.py
@@ -23,6 +23,7 @@ import spack.vendor.ruamel.yaml
 
 import spack.concretize
 import spack.config
+import spack.deptypes as dt
 import spack.error
 import spack.hash_types as ht
 import spack.paths
@@ -584,6 +585,16 @@ def test_direct_edges_and_round_tripping_to_dict(spec_str, config, mock_packages
             continue
         for dependency_data in node["dependencies"]:
             assert "direct" not in dependency_data["parameters"]
+
+
+def test_parallel_deptype_edges_survive_round_trip(mock_packages):
+    """Two parallel edges to one package, differing only in deptype, share one child node once
+    read back from JSON. Sharing the child must not merge them into one edge."""
+    original = Spec("pkg-a ^[deptypes=build] pkg-b ^[deptypes=link] pkg-b")
+    reconstructed = Spec.from_dict(original.to_dict())
+    edges = reconstructed.edges_to_dependencies("pkg-b")
+    assert len(edges) == 2
+    assert {e.depflag for e in edges} == {dt.BUILD, dt.LINK}
 
 
 def test_pickle_preserves_identity_and_prefix(config, mock_packages):

--- a/lib/spack/spack/test/spec_yaml.py
+++ b/lib/spack/spack/test/spec_yaml.py
@@ -597,6 +597,19 @@ def test_parallel_deptype_edges_survive_round_trip(mock_packages):
     assert {e.depflag for e in edges} == {dt.BUILD, dt.LINK}
 
 
+def test_parallel_edges_are_serialized_in_a_canonical_order(mock_packages):
+    """Two edges to one package with the same dependency types are told apart by their when
+    condition and their virtuals, so a meet producing both is one state with one hash."""
+    forward = Spec("%pkg-b").copy()
+    forward.constrain(Spec("pkg-a ^[when='+foo'] pkg-b@1"))
+    backward = Spec("pkg-a ^[when='+foo'] pkg-b@1").copy()
+    backward.constrain(Spec("%pkg-b"))
+
+    assert len(forward.edges_to_dependencies()) == 2
+    assert forward.to_dict() == backward.to_dict()
+    assert forward.dag_hash() == backward.dag_hash()
+
+
 def test_pickle_preserves_identity_and_prefix(config, mock_packages):
     """When pickling multiple specs that share dependencies, the identity of those dependencies
     should be preserved when unpickling."""


### PR DESCRIPTION
Fix three bugs related to parallel edges (i.e. abstract specs with distinct edges to the same package name).

`to_dict` does not round-trip

```python
>>> s = Spec("a ^[deptypes=build] foo ^[deptypes=link] foo")
>>> s
a ^[deptypes=link] foo ^[deptypes=build] foo
>>> Spec.from_dict(s.to_dict())
a ^[deptypes=build,link] foo
```

`constrain` is not commutative with parallel edges due to edge ordering

```python
>>> forward = Spec("%bar").constrained("a ^[when='+x'] bar@1")
>>> backward = Spec("a ^[when='+x'] bar@1").constrained("%bar")
>>> forward.to_dict() == backward.to_dict()
False
```

The third bug is not easy to reproduce on develop: it's the same edge merging bug that occurs when you do a `Spec.copy()` where two parallel edges point to the same Spec instance. It can occur after a round-trip `Spec.from_dict(s.to_dict())`, since Spack there constructs a unique instance for the two distinct `foo` instances in the top example.