### PR TITLE
audit: fix two issues

### DIFF
--- a/lib/spack/spack/audit.py
+++ b/lib/spack/spack/audit.py
@@ -612,21 +612,38 @@ def _ensure_all_versions_can_produce_a_fetcher(pkgs, error_cls):
     return errors
 
 
+def _declared_build_systems(pkg_cls) -> Set[str]:
+    """Return the names of the build systems declared by a package class."""
+    # values are either ConditionalValue objects or the values themselves
+    return set(
+        v.value if isinstance(v, spack.variant.ConditionalValue) else v
+        for _, variant in pkg_cls.variant_definitions("build_system")
+        for v in variant.values
+    )
+
+
 @package_properties
 def _ensure_package_builders(pkgs, error_cls):
-    """Ensure all packages can produce a builder"""
+    """Ensure all packages can produce a builder for each build system they declare"""
     errors = []
     for pkg_name in pkgs:
         pkg_cls = spack.repo.PATH.get_pkg_class(pkg_name)
-        pkg = pkg_cls(spack.spec.Spec(pkg_name))
-        try:
-            b = spack.builder.buildsystem_name(pkg)
-            if not isinstance(b, str):
-                raise TypeError("invalid builder type {!s}".format(type(b)))
-        except Exception as e:
-            errors.append(
-                error_cls("The package '{pkg_name}' does not have a build system", [str(e)])
-            )
+
+        build_system_names = _declared_build_systems(pkg_cls)
+        if not build_system_names:
+            errors.append(error_cls(f"The package '{pkg_name}' does not have a build system", []))
+            continue
+
+        for build_system_name in sorted(build_system_names):
+            if build_system_name not in spack.builder.BUILDER_CLS:
+                errors.append(
+                    error_cls(
+                        f"The package '{pkg_name}' declares the build system "
+                        f"'{build_system_name}', which has no builder",
+                        [],
+                    )
+                )
+
     return errors
 
 
@@ -706,12 +723,7 @@ def _ensure_env_methods_are_ported_to_builders(pkgs, error_cls):
     for pkg_name in pkgs:
         pkg_cls = spack.repo.PATH.get_pkg_class(pkg_name)
 
-        # values are either ConditionalValue objects or the values themselves
-        build_system_names = {
-            v.value if isinstance(v, spack.variant.ConditionalValue) else v
-            for _, variant in pkg_cls.variant_definitions("build_system")
-            for v in variant.values
-        }
+        build_system_names = _declared_build_systems(pkg_cls)
         builder_cls_names = [spack.builder.BUILDER_CLS[x].__name__ for x in build_system_names]
 
         has_builders_in_package_py = any(

--- a/lib/spack/spack/builder.py
+++ b/lib/spack/spack/builder.py
@@ -71,11 +71,7 @@ class _PhaseAdapter:
 def get_builder_class(
     pkg: Union["spack.package_base.PackageBase", Type["spack.package_base.PackageBase"]], name: str
 ) -> Optional[Type["Builder"]]:
-    """Return the builder class if a package module defines it.
-
-    Accepts either a package object or a package class, since the audits inspect
-    classes while the builder machinery works on objects.
-    """
+    """Return the builder class if a package module defines it."""
     pkg_cls = pkg if isinstance(pkg, type) else type(pkg)
     for current_cls in pkg_cls.__mro__:
         if not hasattr(current_cls, "module"):

--- a/lib/spack/spack/builder.py
+++ b/lib/spack/spack/builder.py
@@ -6,7 +6,7 @@ import collections.abc
 import copy
 import functools
 import os
-from typing import Callable, Dict, List, Optional, Tuple, Type
+from typing import Callable, Dict, List, Optional, Tuple, Type, Union
 
 import spack.directives
 import spack.error
@@ -68,9 +68,16 @@ class _PhaseAdapter:
         return self.phase_fn(self.builder.pkg, spec, prefix)
 
 
-def get_builder_class(pkg, name: str) -> Optional[Type["Builder"]]:
-    """Return the builder class if a package module defines it."""
-    for current_cls in type(pkg).__mro__:
+def get_builder_class(
+    pkg: Union["spack.package_base.PackageBase", Type["spack.package_base.PackageBase"]], name: str
+) -> Optional[Type["Builder"]]:
+    """Return the builder class if a package module defines it.
+
+    Accepts either a package object or a package class, since the audits inspect
+    classes while the builder machinery works on objects.
+    """
+    pkg_cls = pkg if isinstance(pkg, type) else type(pkg)
+    for current_cls in pkg_cls.__mro__:
         if not hasattr(current_cls, "module"):
             continue
         maybe_builder = getattr(current_cls.module, name, None)

--- a/lib/spack/spack/test/builder.py
+++ b/lib/spack/spack/test/builder.py
@@ -241,11 +241,7 @@ def test_builder_when_inheriting_just_package(working_env):
 
 @pytest.mark.usefixtures("builder_test_repository", "config")
 def test_get_builder_class_accepts_objects_and_classes():
-    """Tests that get_builder_class works on both package objects and package classes.
-
-    The package audits inspect classes, while the builder machinery works on objects,
-    so walking the MRO must start from the package class in either case.
-    """
+    """Tests that get_builder_class works on both package objects and package classes."""
     pkg_cls = spack.repo.PATH.get_pkg_class("callbacks")
     builder_cls = spack.builder.get_builder_class(pkg_cls, "GenericBuilder")
 

--- a/lib/spack/spack/test/builder.py
+++ b/lib/spack/spack/test/builder.py
@@ -237,3 +237,29 @@ def test_builder_when_inheriting_just_package(working_env):
     # The derived class doesn't redefine a builder, so we should
     # get the builder of the base class.
     assert type(base_builder) is type(derived_builder)
+
+
+@pytest.mark.usefixtures("builder_test_repository", "config")
+def test_get_builder_class_accepts_objects_and_classes():
+    """Tests that get_builder_class works on both package objects and package classes.
+
+    The package audits inspect classes, while the builder machinery works on objects,
+    so walking the MRO must start from the package class in either case.
+    """
+    pkg_cls = spack.repo.PATH.get_pkg_class("callbacks")
+    builder_cls = spack.builder.get_builder_class(pkg_cls, "GenericBuilder")
+
+    # The builder is defined in the package module, so it is found from the class
+    assert builder_cls is not None
+    assert spack.repo.is_package_module(builder_cls.__module__)
+
+    # ... and an object of that class gives the same answer
+    pkg = spack.concretize.concretize_one("callbacks").package
+    assert spack.builder.get_builder_class(pkg, "GenericBuilder") is builder_cls
+
+    # Derived packages that don't redefine a builder get it from the base package module
+    derived_cls = spack.repo.PATH.get_pkg_class("inheritance-only-package")
+    assert spack.builder.get_builder_class(derived_cls, "GenericBuilder") is builder_cls
+
+    # Names that are not defined in any package module are not builders
+    assert spack.builder.get_builder_class(pkg_cls, "UnknownBuilder") is None


### PR DESCRIPTION
https://github.com/spack/spack-packages/pull/5949 uncovered a few issues in `spack audit`

## Make get_builder_class accept a package class too

This fixes a regression in `spack audit` over checking builder related issues:

* **Spack:** 1.3.0.dev0 (66ff222)
* **Builtin repo:** https://github.com/spack/spack-packages (8103ad3)
* **Python:** 3.14.5
* **Platform:** linux-ubuntu24.04-skylake

**Before**

```python
$ spack audit packages samrai
PKG-DIRECTIVES: passed
PKG-ATTRIBUTES: passed
PKG-PROPERTIES: passed
```

**After**

```python
$ spack audit packages samrai
PKG-DIRECTIVES: passed
PKG-ATTRIBUTES: passed
PKG-PROPERTIES: 1 issue found
1. Package 'samrai' need to move the 'setup_build_environment' method from the package class to the appropriate builder class
```

## Fix issues introduced by new builders check

The new builders check introduced in #52577 is flawed, as it tries to check builders with an API expecting a concrete spec. Also, the error message was supposed to be an f-string, but it is not :slightly_smiling_face:  This PR fixes that check (which currently makes the audit fail on `spack-packages` develop) by using the package class metadata instead.