### PR TITLE
spec_parser.py: keep commas in a when= edge attribute

### DIFF
--- a/lib/spack/spack/spec_parser.py
+++ b/lib/spack/spack/spec_parser.py
@@ -544,8 +544,10 @@ class EdgeAttributeParser:
                 name, value = self.ctx.current_token.value.split("=", maxsplit=1)
                 if name.endswith(":"):
                     name = name[:-1]
-                value = value.strip("'\" ").split(",")
-                attributes[name] = value
+                value = value.strip("'\" ")
+                # A when value is one spec string, where a comma is part of the syntax, e.g.
+                # when='@1,2'; deptypes and virtuals values are comma-separated lists.
+                attributes[name] = value if name == "when" else value.split(",")
                 if name not in ("deptypes", "virtuals", "when"):
                     msg = (
                         "the only edge attributes that are currently accepted "
@@ -569,7 +571,7 @@ class EdgeAttributeParser:
 
         # Turn "when" into a spec
         if "when" in attributes:
-            attributes["when"] = parse_one_or_raise(attributes["when"][0])
+            attributes["when"] = parse_one_or_raise(attributes["when"])
 
         return attributes
 

--- a/lib/spack/spack/test/spec_syntax.py
+++ b/lib/spack/spack/test/spec_syntax.py
@@ -1821,6 +1821,13 @@ def test_parse_multiple_edge_attributes(input_args, expected):
         assert s.satisfies(c)
 
 
+def test_when_edge_attribute_keeps_commas():
+    """A when value is one spec string, where a comma is part of the syntax, unlike the
+    comma-separated deptypes and virtuals lists."""
+    edge = spack.spec.Spec("foo ^[when='@1,2'] bar").edges_to_dependencies(name="bar")[0]
+    assert edge.when == spack.spec.Spec("@1,2")
+
+
 @pytest.mark.regression("52375")
 def test_external_spec_hash_can_be_looked_up(config, mock_packages):
     """Tests that the hash of an external can be successfully looked up."""


### PR DESCRIPTION
```python
>>> Spec("pkg-a ^[when='@1,2'] pkg-b")
pkg-a ^[when='@1'] pkg-b
```

The parser arbitrarily stopped parsing the when spec at `,`.