### PR TITLE
spec.py: make PropagationPolicy orderable

### DIFF
--- a/lib/spack/spack/enums.py
+++ b/lib/spack/spack/enums.py
@@ -27,7 +27,7 @@ class ConfigScopePriority(enum.IntEnum):
     ENVIRONMENT_SPEC_GROUPS = 5
 
 
-class PropagationPolicy(enum.Enum):
+class PropagationPolicy(enum.IntEnum):
     """Enum to specify the behavior of a propagated dependency"""
 
     NONE = enum.auto()

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -843,7 +843,7 @@ class DependencySpec:
             keywords.append(f"when={self.when}")
 
         if self.propagation != PropagationPolicy.NONE:
-            keywords.append(f"propagation={self.propagation}")
+            keywords.append(f"propagation=PropagationPolicy.{self.propagation.name}")
 
         keywords_str = ", ".join(keywords)
         return f"DependencySpec({self.parent.format()!r}, {self.spec.format()!r}, {keywords_str})"

--- a/lib/spack/spack/test/spec_semantics.py
+++ b/lib/spack/spack/test/spec_semantics.py
@@ -2502,6 +2502,23 @@ def test_edge_representation(parent_str, child_str, kwargs, expected_str, expect
     assert repr(edge) == expected_repr
 
 
+def test_parallel_edges_sort_with_differing_propagation(mock_packages):
+    """Two edges to one package that differ only in propagation are compared on that field, so
+    ``PropagationPolicy`` needs ``<`` and not just ``==``."""
+    edges = [
+        DependencySpec(Spec("pkg-a"), Spec("pkg-e"), depflag=0, virtuals=(), direct=True),
+        DependencySpec(
+            Spec("pkg-a"),
+            Spec("pkg-e"),
+            depflag=0,
+            virtuals=(),
+            direct=True,
+            propagation=PropagationPolicy.PREFERENCE,
+        ),
+    ]
+    assert sorted(edges) == edges
+
+
 @pytest.mark.parametrize(
     "spec_str,assertions",
     [


### PR DESCRIPTION
```python
from spack.spec import PropagationPolicy

sorted([PropagationPolicy.NONE, PropagationPolicy.PREFERENCE])  # TypeError: '<' not supported
```

`DependencySpec._cmp_iter` yields propagation, and `_add_edge_to_map`
sorts parallel edges to one package by the full edge tuple. Two edges
with different policies then fail to sort with a `TypeError`, since
plain `Enum` only supports equality. Make `PropagationPolicy` an
`IntEnum`, like `VariantType`, which is one for the same reason.

`DependencySpec.__repr__` now spells out `PropagationPolicy.<name>`, since
`str()` of an `IntEnum` member is the plain integer from Python 3.11 on.
