### PR TITLE
spec.py: print a blank before the abstract hash

### DIFF
--- a/lib/spack/spack/cmd/__init__.py
+++ b/lib/spack/spack/cmd/__init__.py
@@ -511,7 +511,7 @@ def display_specs(specs, args=None, **kwargs):
         if flags:
             ffmt += " {compiler_flags}"
         vfmt = "{variants}" if variants else ""
-        hfmt = "{/abstract_hash}"
+        hfmt = "{ /abstract_hash}"
         format_string = nfmt + "{@version}" + vfmt + ffmt + hfmt
 
     if specfile_format:

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -178,7 +178,7 @@ DEFAULT_FORMAT = (
     "{name}{@versions}{compiler_flags}"
     "{variants}{ namespace=namespace_if_anonymous}"
     "{ platform=architecture.platform}{ os=architecture.os}{ target=architecture.target}"
-    "{/abstract_hash}"
+    "{ /abstract_hash}"
 )
 
 #: Display format, which eliminates extra `@=` in the output, for readability.
@@ -186,7 +186,7 @@ DISPLAY_FORMAT = (
     "{name}{@version}{compiler_flags}"
     "{variants}{ namespace=namespace_if_anonymous}"
     "{ platform=architecture.platform}{ os=architecture.os}{ target=architecture.target}"
-    "{/abstract_hash}"
+    "{ /abstract_hash}"
     "{compilers}"
 )
 
@@ -4001,8 +4001,10 @@ class Spec:
             if self.architecture.target:
                 parts.append(f" target={self.architecture.target}")
 
+        # The blank is required for round-tripping: ``key=value /abc`` parses as variant and
+        # abstract hash, whereas ``key=value/abc`` is parsed as a variant with value ``value/abc``.
         if self.abstract_hash:
-            parts.append(f"/{self.abstract_hash}")
+            parts.append(f" /{self.abstract_hash}")
 
         return "".join(parts).strip()
 

--- a/lib/spack/spack/test/spec_semantics.py
+++ b/lib/spack/spack/test/spec_semantics.py
@@ -2093,6 +2093,20 @@ def test_abstract_hash_intersects_and_satisfies(config, mock_packages):
     assert_disjoint(abstract_none, abstract_5)
 
 
+def test_a_blank_sets_the_abstract_hash_off_from_any_value(mock_packages):
+    """str() prints a blank before the abstract hash, so a value that can absorb a slash, a
+    namespace, variant, flag or target, does not swallow it and the hash survives reparsing."""
+    for spec_str in (
+        "namespace=builtin_mock /abcdef",
+        "foo=bar /abcdef",
+        "pkg-a cflags=-O2 /abcdef",
+        "pkg-a target=haswell /abcdef",
+    ):
+        spec = Spec(spec_str)
+        round_tripped = Spec(str(spec))
+        assert round_tripped.abstract_hash == spec.abstract_hash, spec_str
+
+
 def test_edge_equality_does_not_depend_on_virtual_order():
     """Tests that two edges that are constructed with just a different order of the virtuals in
     the input parameters are equal to each other.


### PR DESCRIPTION
Fix the following str round-trip bug:

```python
>>> Spec("key=value /hash").variants["key"].values[0]
'value'
>>> Spec(str(Spec("key=value /hash"))).variants["key"].values[0]
'value/hash'
```

A space before `/hash` is required.
