### PR TITLE
spec.py: print compiler flags in the order they are stored

### DIFF
--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -1033,15 +1033,11 @@ class FlagMap(lang.HashableMap[str, List[CompilerFlag]]):
 
         result = ""
         for flag_type, flags in sorted_items:
-            normal = [f for f in flags if not f.propagate]
-            if normal:
-                value = spack.spec_parser.quote_if_needed(" ".join(normal))
-                result += f" {flag_type}={value}"
-
-            propagated = [f for f in flags if f.propagate]
-            if propagated:
-                value = spack.spec_parser.quote_if_needed(" ".join(propagated))
-                result += f" {flag_type}=={value}"
+            # Do not sort by propagation yes/no, but group by it, which preserves the order.
+            for propagate, group in itertools.groupby(flags, key=lambda flag: flag.propagate):
+                sigil = "==" if propagate else "="
+                value = spack.spec_parser.quote_if_needed(" ".join(group))
+                result += f" {flag_type}{sigil}{value}"
 
         # TODO: somehow add this space only if something follows in Spec.format()
         if sorted_items:

--- a/lib/spack/spack/test/spec_semantics.py
+++ b/lib/spack/spack/test/spec_semantics.py
@@ -2379,18 +2379,6 @@ def test_satisfies_and_subscript_with_compilers(config, mock_packages):
     assert s["pkg-a"].dependencies(name="gmake")[0] == s["pkg-a"]["gmake"]
 
 
-def test_the_default_format_leaves_out_the_namespace(mock_packages):
-    """The default format prints the namespace only for an anonymous spec, so a named spec loses
-    it when it goes through a string. An unset namespace is no constraint, so the two still denote
-    the same set."""
-    spec = Spec("builtin_mock.pkg-a")
-    round_tripped = Spec(str(spec))
-
-    assert spec.namespace == "builtin_mock"
-    assert round_tripped.namespace is None
-    assert round_tripped.satisfies(spec) and spec.satisfies(round_tripped)
-
-
 def test_flag_order_survives_formatting(mock_packages):
     """Compiler flags are printed in the order they are stored, grouped into runs that agree on
     whether they propagate. Flag order is significant to the build, so losing it changes the
@@ -2403,16 +2391,6 @@ def test_flag_order_survives_formatting(mock_packages):
     round_tripped = Spec(str(spec))
     assert [str(flag) for flag in round_tripped.compiler_flags["cflags"]] == ["-O2", "-g"]
     assert round_tripped.dag_hash() == spec.dag_hash()
-
-
-def test_concrete_patches_are_truncated_by_formatting(mock_packages):
-    """Patch checksums are abbreviated to seven characters when printed. A concrete patches value
-    takes exactly the values it lists, so the abbreviated spec is disjoint from the original."""
-    spec = Spec("pkg-a patches:=abcdef1234567890")
-    round_tripped = Spec(str(spec))
-
-    assert round_tripped.variants["patches"].value == ("abcdef1",)
-    assert not spec.intersects(round_tripped)
 
 
 def test_an_anonymous_spec_is_the_top_of_the_order_only(mock_packages):

--- a/lib/spack/spack/test/spec_semantics.py
+++ b/lib/spack/spack/test/spec_semantics.py
@@ -2365,6 +2365,42 @@ def test_satisfies_and_subscript_with_compilers(config, mock_packages):
     assert s["pkg-a"].dependencies(name="gmake")[0] == s["pkg-a"]["gmake"]
 
 
+def test_the_default_format_leaves_out_the_namespace(mock_packages):
+    """The default format prints the namespace only for an anonymous spec, so a named spec loses
+    it when it goes through a string. An unset namespace is no constraint, so the two still denote
+    the same set."""
+    spec = Spec("builtin_mock.pkg-a")
+    round_tripped = Spec(str(spec))
+
+    assert spec.namespace == "builtin_mock"
+    assert round_tripped.namespace is None
+    assert round_tripped.satisfies(spec) and spec.satisfies(round_tripped)
+
+
+def test_flag_order_survives_formatting(mock_packages):
+    """Compiler flags are printed in the order they are stored, grouped into runs that agree on
+    whether they propagate. Flag order is significant to the build, so losing it changes the
+    hash."""
+    spec = Spec("pkg-a cflags==-O2").copy()
+    spec.constrain(Spec("pkg-a cflags=-g"))
+    assert [str(flag) for flag in spec.compiler_flags["cflags"]] == ["-O2", "-g"]
+    assert str(spec) == "pkg-a cflags==-O2 cflags=-g"
+
+    round_tripped = Spec(str(spec))
+    assert [str(flag) for flag in round_tripped.compiler_flags["cflags"]] == ["-O2", "-g"]
+    assert round_tripped.dag_hash() == spec.dag_hash()
+
+
+def test_concrete_patches_are_truncated_by_formatting(mock_packages):
+    """Patch checksums are abbreviated to seven characters when printed. A concrete patches value
+    takes exactly the values it lists, so the abbreviated spec is disjoint from the original."""
+    spec = Spec("pkg-a patches:=abcdef1234567890")
+    round_tripped = Spec(str(spec))
+
+    assert round_tripped.variants["patches"].value == ("abcdef1",)
+    assert not spec.intersects(round_tripped)
+
+
 @pytest.mark.parametrize(
     "spec_str,spec_fmt,expected",
     [


### PR DESCRIPTION
Fix a round-trip bug:

```python
>>> Spec(str(Spec("pkg-a cflags==-O2 cflags=-g"))) == Spec("pkg-a cflags==-O2 cflags=-g")
False
```

Each flag was printed as non-propagating followed by the propagating ones, but the order matters and the parser ensures that.
