### PR TITLE
spec.py: merge the propagation policy of an edge

### DIFF
--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -820,6 +820,11 @@ class DependencySpec:
         if not self.direct and other.direct:
             changed = True
             self.direct = True
+        # A propagated edge constrains the whole DAG, so it is the narrower of the two policies.
+        # It is also always direct, which the assignment above has already taken care of.
+        if self.propagation == PropagationPolicy.NONE and other.propagation != self.propagation:
+            changed = True
+            self.propagation = other.propagation
         return changed
 
     def _cmp_iter(self):

--- a/lib/spack/spack/test/spec_semantics.py
+++ b/lib/spack/spack/test/spec_semantics.py
@@ -2058,6 +2058,17 @@ def test_constrain_dependencies_copies(mock_packages):
     assert y == Spec("^foo")
 
 
+def test_edge_propagation_is_merged(mock_packages):
+    """A propagated edge constrains the whole DAG, so it is the narrower of the two policies and
+    the meet takes it from whichever spec has it."""
+    lhs, rhs = Spec("pkg-a ^pkg-b"), Spec("pkg-a %%pkg-b")
+    forward, backward = lhs.copy(), rhs.copy()
+    forward.constrain(rhs)
+    backward.constrain(lhs)
+    assert forward.edges_to_dependencies()[0].propagation == PropagationPolicy.PREFERENCE
+    assert backward.edges_to_dependencies()[0].propagation == PropagationPolicy.PREFERENCE
+
+
 def test_abstract_hash_intersects_and_satisfies(config, mock_packages):
     concrete: Spec = spack.concretize.concretize_one("pkg-a")
     hash = concrete.dag_hash()


### PR DESCRIPTION
```python
import spack.repo, spack.paths
from spack.spec import Spec

with spack.repo.use_repositories(spack.paths.mock_packages_path):
    # propagation ('%%') is only picked up when it is on the left-hand side
    forward = Spec("pkg-a ^pkg-b").constrained(Spec("pkg-a %%pkg-b"))
    backward = Spec("pkg-a %%pkg-b").constrained(Spec("pkg-a ^pkg-b"))
    print(forward.edges_to_dependencies(name="pkg-b")[0].propagation)   # NONE, lost
    print(backward.edges_to_dependencies(name="pkg-b")[0].propagation)  # PREFERENCE, kept
```

Merging two edges took the deptypes, the virtuals and the direct flag
from both sides. It kept the propagation policy of the left-hand edge.
The intersection of a plain edge and a propagated one then depended on
which side the propagated edge was on. A propagated edge constrains the
whole DAG. It is the narrower of the two, and the merge takes it.

