### PR TITLE
spec.py: do not share arch and flags with the constraint

### DIFF
--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -951,22 +951,35 @@ class FlagMap(lang.HashableMap[str, List[CompilerFlag]]):
         changed = False
         for flag_type in other:
             if flag_type not in self:
-                self[flag_type] = other[flag_type]
+                # copy the list, so that self and other do not share it
+                self[flag_type] = list(other[flag_type])
                 changed = True
-            else:
-                extra_other = set(other[flag_type]) - set(self[flag_type])
-                if extra_other:
-                    self[flag_type] = list(self[flag_type]) + [
-                        x for x in other[flag_type] if x in extra_other
-                    ]
-                    changed = True
+                continue
 
-                # Next, if any flags in other propagate, we force them to propagate in our case
-                shared = list(sorted(set(other[flag_type]) - extra_other))
-                for x, y in _shared_subset_pair_iterate(shared, sorted(self[flag_type])):
-                    if y.propagate is True and x.propagate is False:
-                        changed = True
-                        y.propagate = False
+            extra_other = set(other[flag_type]) - set(self[flag_type])
+            if extra_other:
+                self[flag_type] = list(self[flag_type]) + [
+                    x for x in other[flag_type] if x in extra_other
+                ]
+                changed = True
+
+            # Next, if any flags in other propagate, we force them to propagate in our case.
+            # CompilerFlag objects can be shared with other specs, so they are replaced rather
+            # than modified in place.
+            shared = sorted(set(other[flag_type]) - extra_other)
+            demoted = {
+                id(y)
+                for x, y in _shared_subset_pair_iterate(shared, sorted(self[flag_type]))
+                if y.propagate is True and x.propagate is False
+            }
+            if demoted:
+                changed = True
+                self[flag_type] = [
+                    CompilerFlag(f, propagate=False, flag_group=f.flag_group, source=f.source)
+                    if id(f) in demoted
+                    else f
+                    for f in self[flag_type]
+                ]
 
         # TODO: what happens if flag groups with a partial (but not complete)
         # intersection specify different behaviors for flag propagation?
@@ -3089,7 +3102,8 @@ class Spec:
         if sarch is not None and oarch is not None:
             changed |= self.architecture.constrain(other.architecture)
         elif oarch is not None:
-            self.architecture = oarch
+            # copy, so that a later constrain on self does not write through into other
+            self.architecture = oarch.copy()
             changed = True
 
         if deps:

--- a/lib/spack/spack/test/spec_semantics.py
+++ b/lib/spack/spack/test/spec_semantics.py
@@ -2439,6 +2439,17 @@ def test_constrain_symbolically(constraints, expected):
     assert reverse_order == Spec(expected)
 
 
+def test_constrain_does_not_share_flags_or_architecture_with_the_rhs(mock_packages):
+    """A successful constrain copies what it takes from the right-hand side instead of aliasing
+    it, so narrowing the left-hand side further cannot reach a spec that was only ever read."""
+    lhs, rhs = Spec("pkg-a"), Spec("pkg-a cflags=-O2 target=x86_64:")
+    lhs.constrain(rhs)
+    before = rhs.to_dict()
+
+    lhs.constrain(Spec("pkg-a cflags=-g target=haswell"))
+    assert rhs.to_dict() == before
+
+
 @pytest.mark.parametrize(
     "parent_str,child_str,kwargs,expected_str,expected_repr",
     [


### PR DESCRIPTION
Fix two aliasing bugs that made constrain share mutable state from rhs with lhs.

```python
>>> lhs, rhs = Spec(""), Spec("pkg-a cflags==-O2")
>>> lhs.constrain(rhs)
True
>>> lhs.constrain("cflags=-O2")
True
>>> rhs  # was never modified
pkg-a cflags=-O2
```

```python
>>> lhs, rhs = Spec(""), Spec("pkg-a target=x86_64:")
>>> lhs.constrain(rhs)
True
>>> lhs.constrain("pkg-a target=haswell")
True
>>> rhs.target  # was never modified
Microarchitecture('haswell')
```
