### PR TITLE
variant.py: apply the patch prefix rule to intersects too

### DIFF
--- a/lib/spack/spack/test/spec_semantics.py
+++ b/lib/spack/spack/test/spec_semantics.py
@@ -324,12 +324,7 @@ class TestSpecSemantics:
             (
                 "libelf patches=ba5e334fe247335f3a116decfb5284100791dc302b5571ff5e664d8f9a6806c2",
                 "libelf patches=ba5e3",  # constrain by a patch sha256 prefix
-                # TODO: the result below is not ideal. Prefix satisfies() works for patches, but
-                # constrain() isn't similarly special-cased to do the same thing
-                (
-                    "libelf patches=ba5e3,"
-                    "ba5e334fe247335f3a116decfb5284100791dc302b5571ff5e664d8f9a6806c2"
-                ),
+                "libelf patches=ba5e334fe247335f3a116decfb5284100791dc302b5571ff5e664d8f9a6806c2",
             ),
             # deptypes on direct deps
             (

--- a/lib/spack/spack/test/variant.py
+++ b/lib/spack/spack/test/variant.py
@@ -879,6 +879,23 @@ def test_patches_variant():
     assert not Spec("patches:=abcdef").satisfies("patches:=abcdefghi")
 
 
+def test_patches_variant_prefix_intersects_and_constrains():
+    """Prefix matching applies to intersection too, so a spec that satisfies a prefix also
+    overlaps it and can be constrained by it."""
+    assert Spec("patches:=abcdef").intersects("patches=ab")
+    assert Spec("patches=ab").intersects("patches:=abcdef")
+    assert not Spec("patches:=abcdef").intersects("patches=xyz")
+    assert not Spec("patches:=abcdef").intersects("patches=abcdefghi")
+
+    s = Spec("patches:=abcdef")
+    assert s.constrain("patches=ab") is False
+    assert s.variants["patches"].values == ("abcdef",)
+
+    s = Spec("patches=ab")
+    assert s.constrain("patches:=abcdef") is True
+    assert s.variants["patches"].values == ("abcdef",)
+
+
 def test_constrain_narrowing():
     s = Spec("foo=*")
     assert s.variants["foo"].type == spack.variant.VariantType.MULTI

--- a/lib/spack/spack/variant.py
+++ b/lib/spack/spack/variant.py
@@ -414,6 +414,29 @@ class VariantValue:
             self.type, self.name, self.values, propagate=self.propagate, concrete=self.concrete
         )
 
+    def _merged_values(self, other: "VariantValue") -> Tuple[Union[str, bool], ...]:
+        """The values of both sides. For patches a value identified by a checksum prefix and the
+        full checksum name the same patch, so only the longer one is kept."""
+        values = (*self.values, *other.values)
+        if self.name != "patches":
+            return values
+        return tuple(
+            v
+            for v in values
+            if not any(
+                w != v and isinstance(w, str) and isinstance(v, str) and w.startswith(v)
+                for w in values
+            )
+        )
+
+    def _contains(self, value: Union[str, bool]) -> bool:
+        """Whether this variant covers a single value of another one. A patch is identified by a
+        prefix of its checksum, so a shorter value is covered by any value starting with it.
+        """
+        if self.name == "patches" and isinstance(value, str):
+            return any(isinstance(w, str) and w.startswith(value) for w in self.values)
+        return value in self.values
+
     def satisfies(self, other: "VariantValue") -> bool:
         """The lhs satisfies the rhs if all possible concretizations of lhs are also
         possible concretizations of rhs."""
@@ -421,16 +444,7 @@ class VariantValue:
             return False
 
         if not other.concrete:
-            # rhs abstract means the lhs must at least contain its values.
-            # special-case patches with rhs abstract: their values may be prefixes of the lhs
-            # values.
-            if self.name == "patches":
-                return all(
-                    isinstance(v, str)
-                    and any(isinstance(w, str) and w.startswith(v) for w in self.values)
-                    for v in other.values
-                )
-            return all(v in self for v in other.values)
+            return all(self._contains(v) for v in other.values)
         if self.concrete:
             # both concrete: they must be equal
             return self.values == other.values
@@ -443,9 +457,9 @@ class VariantValue:
         if self.concrete:
             if other.concrete:
                 return self.values == other.values
-            return all(v in self for v in other.values)
+            return all(self._contains(v) for v in other.values)
         if other.concrete:
-            return all(v in other for v in self.values)
+            return all(other._contains(v) for v in self.values)
         # both abstract: the union is a valid concretization of both
         return True
 
@@ -454,7 +468,7 @@ class VariantValue:
         if not self.intersects(other):
             raise UnsatisfiableVariantSpecError(self, other)
         old_values = self.values
-        self.set(*self.values, *other.values)
+        self.set(*self._merged_values(other))
         changed = old_values != self.values
         if self.propagate and not other.propagate:
             self.propagate = False


### PR DESCRIPTION
Fix a bug where intersects is not aware of prefix semantics that satisfies implements. If x satisfies y then x is in the intersection.

```python
>>> Spec("libelf patches:=ba5e334f").satisfies("libelf patches=ba5e3")
True
>>> Spec("libelf patches:=ba5e334f").intersects("libelf patches=ba5e3")
False
```

The merge in `constrain` applies the same rule: a sha that is a prefix of another denotes the same patch, so the merge keeps the longer sha instead of listing both. This resolves a TODO in the tests, where constraining `patches=ba5e3...` by the full sha produced a two-element value.
