### PR TITLE
ArchSpec: a star means any value in intersects too

### DIFF
--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -230,6 +230,20 @@ def _make_microarchitecture(name: str) -> spack.vendor.archspec.cpu.Microarchite
     )
 
 
+def _attr_satisfies(lhs: Optional[str], rhs: Optional[str]) -> bool:
+    """Whether a platform or operating system on the lhs satisfies the one on the rhs."""
+    if not rhs:
+        return True
+    return bool(lhs) if rhs == "*" else lhs == rhs
+
+
+def _attr_intersects(lhs: Optional[str], rhs: Optional[str]) -> bool:
+    """Whether a platform or operating system on either side intersect."""
+    if not lhs or not rhs:
+        return True
+    return lhs == "*" or rhs == "*" or lhs == rhs
+
+
 @lang.lazy_lexicographic_ordering
 class ArchSpec:
     """Aggregate the target platform, the operating system and the target microarchitecture."""
@@ -405,16 +419,8 @@ class ArchSpec:
         """
         other = self._autospec(other)
 
-        # Check platform and os
         for attribute in ("platform", "os"):
-            other_attribute = getattr(other, attribute)
-            self_attribute = getattr(self, attribute)
-
-            # platform=* or os=*
-            if self_attribute and other_attribute == "*":
-                return True
-
-            if other_attribute and self_attribute != other_attribute:
+            if not _attr_satisfies(getattr(self, attribute), getattr(other, attribute)):
                 return False
 
         return self._target_satisfies(other, strict=True)
@@ -431,11 +437,8 @@ class ArchSpec:
         """
         other = self._autospec(other)
 
-        # Check platform and os
         for attribute in ("platform", "os"):
-            other_attribute = getattr(other, attribute)
-            self_attribute = getattr(self, attribute)
-            if other_attribute and self_attribute and self_attribute != other_attribute:
+            if not _attr_intersects(getattr(self, attribute), getattr(other, attribute)):
                 return False
 
         return self._target_satisfies(other, strict=False)
@@ -455,6 +458,10 @@ class ArchSpec:
 
         # self.target is not None, and other is target=*
         if other.target == ArchSpec.ANY_TARGET:
+            return True
+
+        # target=* on the lhs overlaps any target, but is too broad to satisfy a specific one
+        if not strict and self.target == ArchSpec.ANY_TARGET:
             return True
 
         return bool(self._target_intersection(other))
@@ -584,7 +591,9 @@ class ArchSpec:
         constrained = False
         for attr in ("platform", "os"):
             svalue, ovalue = getattr(self, attr), getattr(other, attr)
-            if svalue is None and ovalue is not None:
+            # a star constrains the value to be set, so it is kept when there is none yet and
+            # is replaced by a named value from the other side
+            if ovalue is not None and (svalue is None or (svalue == "*" and ovalue != "*")):
                 setattr(self, attr, ovalue)
                 constrained = True
 

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -230,25 +230,27 @@ def _make_microarchitecture(name: str) -> spack.vendor.archspec.cpu.Microarchite
     )
 
 
-def _attr_satisfies(lhs: Optional[str], rhs: Optional[str]) -> bool:
-    """Whether a platform or operating system on the lhs satisfies the one on the rhs."""
-    if not rhs:
-        return True
-    return bool(lhs) if rhs == "*" else lhs == rhs
-
-
-def _attr_intersects(lhs: Optional[str], rhs: Optional[str]) -> bool:
-    """Whether a platform or operating system on either side intersect."""
-    if not lhs or not rhs:
-        return True
-    return lhs == "*" or rhs == "*" or lhs == rhs
-
-
 @lang.lazy_lexicographic_ordering
 class ArchSpec:
     """Aggregate the target platform, the operating system and the target microarchitecture."""
 
     ANY_TARGET = _make_microarchitecture("*")
+
+    @staticmethod
+    def _attr_satisfies(lhs: Optional[str], rhs: Optional[str]) -> bool:
+        """Whether a platform or operating system on the lhs satisfies the one on the rhs."""
+        if not rhs:
+            return True
+        if rhs == "*":
+            return lhs is not None
+        return lhs == rhs
+
+    @staticmethod
+    def _attr_intersects(lhs: Optional[str], rhs: Optional[str]) -> bool:
+        """Whether a platform or operating system on either side intersect."""
+        if not lhs or not rhs:
+            return True
+        return lhs == "*" or rhs == "*" or lhs == rhs
 
     @staticmethod
     def default_arch():
@@ -420,7 +422,7 @@ class ArchSpec:
         other = self._autospec(other)
 
         for attribute in ("platform", "os"):
-            if not _attr_satisfies(getattr(self, attribute), getattr(other, attribute)):
+            if not self._attr_satisfies(getattr(self, attribute), getattr(other, attribute)):
                 return False
 
         return self._target_satisfies(other, strict=True)
@@ -438,7 +440,7 @@ class ArchSpec:
         other = self._autospec(other)
 
         for attribute in ("platform", "os"):
-            if not _attr_intersects(getattr(self, attribute), getattr(other, attribute)):
+            if not self._attr_intersects(getattr(self, attribute), getattr(other, attribute)):
                 return False
 
         return self._target_satisfies(other, strict=False)

--- a/lib/spack/spack/test/architecture.py
+++ b/lib/spack/spack/test/architecture.py
@@ -110,6 +110,42 @@ def test_satisfy_strict_constraint_when_not_concrete(architecture_tuple, constra
 
 
 @pytest.mark.parametrize(
+    "architecture_tuple,constraint_tuple",
+    [
+        (("linux", "ubuntu18.04", "x86_64"), ("*", None, None)),
+        (("linux", "ubuntu18.04", "x86_64"), (None, "*", None)),
+        (("linux", "ubuntu18.04", "x86_64"), (None, None, "*")),
+        (("linux", "ubuntu18.04", "x86_64"), ("*", "*", "*")),
+        (("linux", None, None), ("*", None, None)),
+    ],
+)
+def test_star_is_satisfied_and_intersected_and_does_not_constrain(
+    architecture_tuple, constraint_tuple
+):
+    """A star requires the attribute to be set, so a spec that sets it satisfies the star, the
+    two overlap in both directions, and merging changes nothing."""
+    architecture = ArchSpec(architecture_tuple)
+    constraint = ArchSpec(constraint_tuple)
+
+    assert architecture.satisfies(constraint)
+    assert architecture.intersects(constraint)
+    assert constraint.intersects(architecture)
+
+    merged = architecture.copy()
+    assert merged.constrain(constraint) is False
+    assert merged == architecture
+
+
+def test_star_does_not_short_circuit_the_other_attributes():
+    """A star on one attribute does not short-circuit satisfies or intersects: the remaining
+    attributes are still checked."""
+    architecture = ArchSpec(("linux", "ubuntu18.04", "x86_64"))
+    assert not architecture.satisfies(ArchSpec(("*", "rhel6", None)))
+    assert not architecture.satisfies(ArchSpec(("*", None, "aarch64")))
+    assert not architecture.intersects(ArchSpec(("*", "rhel6", None)))
+
+
+@pytest.mark.parametrize(
     "root_target_range,dep_target_range,result",
     [
         ("x86_64:nocona", "x86_64:core2", "nocona"),  # pref not in intersection


### PR DESCRIPTION
Fix a couple bugs, e.g.

```python
>>> Spec("pkg-a os=debian6").satisfies("pkg-a os=*")
True
>>> Spec("pkg-a os=debian6").intersects("pkg-a os=*")
False  #wrong
>>> Spec("pkg-a platform=test os=debian6").satisfies("pkg-a platform=* os=redhat6")
True  # wrong
>>> Spec("os=*").constrained("os=debian6")
spack.spec.UnsatisfiableArchitectureSpecError  # should be os=debian6
```

1. Satisfies supports `key=*` but intersects treats it as a literal string.
2. The star branch returned from `satisfies` straight away instead of moving on to the next attribute.
3. `target=*` on the left-hand side overlapped any target for `intersects`. The check only existed for a star on the right-hand side, so `intersects` disagreed with itself depending on which side the star was on.
4. `constrain` compared a star literally too, so constraining a star with a named value raised. A star constrains the value to be set without naming one, so the named value from the other side replaces it.
