### PR TITLE
Skip spack prefixes for compilers

### DIFF
--- a/lib/spack/spack/detection/common.py
+++ b/lib/spack/spack/detection/common.py
@@ -44,8 +44,15 @@ def _externals_in_packages_yaml() -> Set[spack.spec.Spec]:
 
 
 def _installed_spec_prefixes() -> Set[str]:
-    """Returns the install prefixes of all specs currently in the Spack install database."""
-    return {spec.prefix for spec in spack.store.STORE.db.query()}
+    """Returns the real (symlink-resolved) install prefixes of all specs in the Spack DB."""
+    return {os.path.realpath(spec.prefix) for spec in spack.store.STORE.db.query()}
+
+
+def _is_subdir_of_installed_prefix(path: str, installed_prefixes: Set[str]) -> bool:
+    """Returns True if path (or any of its ancestors) is a Spack install prefix."""
+    real = os.path.realpath(path)
+    p = pathlib.Path(real)
+    return any(str(ancestor) in installed_prefixes for ancestor in (p, *p.parents))
 
 
 ExternalEntryType = Union[str, Dict[str, str]]
@@ -222,7 +229,7 @@ def update_configuration(
             s
             for s in entries
             if s not in predefined_external_specs
-            and s.external_path not in installed_prefixes
+            and not _is_subdir_of_installed_prefix(s.external_path, installed_prefixes)
         ]
 
         pkg_config = _pkg_config_dict(new_entries)

--- a/lib/spack/spack/detection/common.py
+++ b/lib/spack/spack/detection/common.py
@@ -225,12 +225,14 @@ def update_configuration(
     installed_prefixes = _installed_spec_prefixes()
     pkg_to_cfg, all_new_specs = {}, []
     for package_name, entries in detected_packages.items():
-        new_entries = [
-            s
-            for s in entries
-            if s not in predefined_external_specs
-            and not _is_subdir_of_installed_prefix(s.external_path, installed_prefixes)
-        ]
+        new_entries = []
+        for s in entries:
+            if s in predefined_external_specs:
+                continue
+            if _is_subdir_of_installed_prefix(s.external_path, installed_prefixes):
+                tty.debug(f"Skipping {s} (Spack-installed package at {s.external_path})")
+                continue
+            new_entries.append(s)
 
         pkg_config = _pkg_config_dict(new_entries)
         external_entries = pkg_config.get("externals", [])

--- a/lib/spack/spack/detection/common.py
+++ b/lib/spack/spack/detection/common.py
@@ -26,6 +26,7 @@ import spack.error
 import spack.operating_systems.windows_os as winOs
 import spack.schema
 import spack.spec
+import spack.store
 import spack.util.environment
 import spack.util.spack_yaml
 import spack.util.windows_registry
@@ -40,6 +41,11 @@ def _externals_in_packages_yaml() -> Set[spack.spec.Spec]:
         for item in package_configuration.get("externals", []):
             already_defined_specs.add(spack.spec.Spec(item["spec"]))
     return already_defined_specs
+
+
+def _installed_spec_prefixes() -> Set[str]:
+    """Returns the install prefixes of all specs currently in the Spack install database."""
+    return {spec.prefix for spec in spack.store.STORE.db.query()}
 
 
 ExternalEntryType = Union[str, Dict[str, str]]
@@ -209,9 +215,15 @@ def update_configuration(
         buildable: whether the detected packages are buildable or not
     """
     predefined_external_specs = _externals_in_packages_yaml()
+    installed_prefixes = _installed_spec_prefixes()
     pkg_to_cfg, all_new_specs = {}, []
     for package_name, entries in detected_packages.items():
-        new_entries = [s for s in entries if s not in predefined_external_specs]
+        new_entries = [
+            s
+            for s in entries
+            if s not in predefined_external_specs
+            and s.external_path not in installed_prefixes
+        ]
 
         pkg_config = _pkg_config_dict(new_entries)
         external_entries = pkg_config.get("externals", [])

--- a/lib/spack/spack/test/cmd/compiler.py
+++ b/lib/spack/spack/test/cmd/compiler.py
@@ -147,33 +147,42 @@ done
 
 
 @pytest.mark.not_on_windows("Cannot execute bash script on Windows")
-def test_compiler_find_skips_installed_packages(mutable_config, mock_executable, monkeypatch):
-    """Tests that 'spack compiler find' does not add a compiler already in the install DB."""
+@pytest.mark.parametrize("subdir", [False, True])
+def test_compiler_find_skips_installed_packages(mutable_config, monkeypatch, tmp_path, subdir):
+    """Tests that 'spack compiler find' does not add a compiler that lives inside a
+    Spack install prefix — whether the detected external_path is exactly the install
+    prefix (subdir=False) or a subdirectory of it (subdir=True, e.g. intel-oneapi-compilers
+    whose binaries live in <prefix>/compiler/<version>/bin/).
+    """
     expected_version = "4.5.3"
-    gcc_path = mock_executable(
-        "gcc",
-        output=f"""\
-for arg in "$@"; do
-    if [ "$arg" = -dumpversion ]; then
-        echo '{expected_version}'
-    fi
-done
-""",
-    )
-    root_dir = gcc_path.parent.parent
 
-    # Simulate the compiler's root being in the install DB by returning it as an installed prefix
+    # install_root is the Spack install prefix recorded in the DB.
+    # When subdir=True, the compiler binaries live in a subdirectory of it,
+    # simulating packages like intel-oneapi-compilers whose detected external_path
+    # is <install-prefix>/compiler rather than <install-prefix> itself.
+    install_root = tmp_path / "install_root"
+    bin_parent = (install_root / "compiler") if subdir else install_root
+    bin_dir = bin_parent / "bin"
+    bin_dir.mkdir(parents=True)
+
+    gcc = bin_dir / "gcc"
+    gcc.write_text(
+        f"#!/bin/sh\nfor arg in \"$@\"; do\n  if [ \"$arg\" = -dumpversion ];"
+        f" then echo '{expected_version}'; fi\ndone\n"
+    )
+    gcc.chmod(0o755)
+
     monkeypatch.setattr(
         spack.detection.common,
         "_installed_spec_prefixes",
-        lambda: {str(root_dir)},
+        lambda: {str(install_root)},
     )
 
     compilers_before_find = set(spack.compilers.config.all_compilers())
     args = spack.util.pattern.Bunch(
         all=None,
         compiler_spec=None,
-        add_paths=[str(root_dir)],
+        add_paths=[str(bin_parent)],
         scope=None,
         mixed_toolchain=False,
         jobs=1,

--- a/lib/spack/spack/test/cmd/compiler.py
+++ b/lib/spack/spack/test/cmd/compiler.py
@@ -6,10 +6,13 @@ import shutil
 
 import pytest
 
+import types
+
 import spack.cmd.compiler
 import spack.compilers.config
 import spack.detection.common
 import spack.main
+import spack.store
 import spack.util.pattern
 import spack.version
 from spack.config import Configuration
@@ -172,9 +175,10 @@ def test_compiler_find_skips_installed_packages(mutable_config, monkeypatch, tmp
     )
     gcc.chmod(0o755)
 
-    monkeypatch.setattr(
-        spack.detection.common, "_installed_spec_prefixes", lambda: {str(install_root)}
-    )
+    # _installed_spec_prefixes() calls db.query() and reads .prefix from each result.
+    # A simple namespace is enough — no need for a real concrete Spec.
+    mock_installed = types.SimpleNamespace(prefix=str(install_root))
+    monkeypatch.setattr(spack.store.STORE.db, "query", lambda *a, **kw: [mock_installed])
 
     compilers_before_find = set(spack.compilers.config.all_compilers())
     args = spack.util.pattern.Bunch(

--- a/lib/spack/spack/test/cmd/compiler.py
+++ b/lib/spack/spack/test/cmd/compiler.py
@@ -154,15 +154,12 @@ done
 def test_compiler_find_skips_installed_packages(mutable_config, monkeypatch, tmp_path, subdir):
     """Tests that 'spack compiler find' does not add a compiler that lives inside a
     Spack install prefix — whether the detected external_path is exactly the install
-    prefix (subdir=False) or a subdirectory of it (subdir=True, e.g. intel-oneapi-compilers
-    whose binaries live in <prefix>/compiler/<version>/bin/).
+    prefix (subdir=False) or a subdirectory of it (subdir=True).
     """
     expected_version = "4.5.3"
 
-    # install_root is the Spack install prefix recorded in the DB.
-    # When subdir=True, the compiler binaries live in a subdirectory of it,
-    # simulating packages like intel-oneapi-compilers whose detected external_path
-    # is <install-prefix>/compiler rather than <install-prefix> itself.
+    # We put a mock compiler executable in a prefix, and we will also mock
+    # db.query to report that as a spack installation prefix
     install_root = tmp_path / "install_root"
     bin_parent = (install_root / "compiler") if subdir else install_root
     bin_dir = bin_parent / "bin"
@@ -175,8 +172,6 @@ def test_compiler_find_skips_installed_packages(mutable_config, monkeypatch, tmp
     )
     gcc.chmod(0o755)
 
-    # _installed_spec_prefixes() calls db.query() and reads .prefix from each result.
-    # A simple namespace is enough — no need for a real concrete Spec.
     mock_installed = types.SimpleNamespace(prefix=str(install_root))
     monkeypatch.setattr(spack.store.STORE.db, "query", lambda *a, **kw: [mock_installed])
 

--- a/lib/spack/spack/test/cmd/compiler.py
+++ b/lib/spack/spack/test/cmd/compiler.py
@@ -6,13 +6,10 @@ import shutil
 
 import pytest
 
-import types
-
 import spack.cmd.compiler
 import spack.compilers.config
 import spack.detection.common
 import spack.main
-import spack.store
 import spack.util.pattern
 import spack.version
 from spack.config import Configuration
@@ -172,8 +169,9 @@ def test_compiler_find_skips_installed_packages(mutable_config, monkeypatch, tmp
     )
     gcc.chmod(0o755)
 
-    mock_installed = types.SimpleNamespace(prefix=str(install_root))
-    monkeypatch.setattr(spack.store.STORE.db, "query", lambda *a, **kw: [mock_installed])
+    monkeypatch.setattr(
+        spack.detection.common, "_installed_spec_prefixes", lambda: {str(install_root)}
+    )
 
     compilers_before_find = set(spack.compilers.config.all_compilers())
     args = spack.util.pattern.Bunch(

--- a/lib/spack/spack/test/cmd/compiler.py
+++ b/lib/spack/spack/test/cmd/compiler.py
@@ -167,15 +167,13 @@ def test_compiler_find_skips_installed_packages(mutable_config, monkeypatch, tmp
 
     gcc = bin_dir / "gcc"
     gcc.write_text(
-        f"#!/bin/sh\nfor arg in \"$@\"; do\n  if [ \"$arg\" = -dumpversion ];"
+        f'#!/bin/sh\nfor arg in "$@"; do\n  if [ "$arg" = -dumpversion ];'
         f" then echo '{expected_version}'; fi\ndone\n"
     )
     gcc.chmod(0o755)
 
     monkeypatch.setattr(
-        spack.detection.common,
-        "_installed_spec_prefixes",
-        lambda: {str(install_root)},
+        spack.detection.common, "_installed_spec_prefixes", lambda: {str(install_root)}
     )
 
     compilers_before_find = set(spack.compilers.config.all_compilers())

--- a/lib/spack/spack/test/cmd/compiler.py
+++ b/lib/spack/spack/test/cmd/compiler.py
@@ -8,6 +8,7 @@ import pytest
 
 import spack.cmd.compiler
 import spack.compilers.config
+import spack.detection.common
 import spack.main
 import spack.util.pattern
 import spack.version
@@ -143,6 +144,45 @@ done
     assert len(compilers_added_by_find) == 1
     new_compiler = compilers_added_by_find.pop()
     assert new_compiler.version == spack.version.Version(expected_version)
+
+
+@pytest.mark.not_on_windows("Cannot execute bash script on Windows")
+def test_compiler_find_skips_installed_packages(mutable_config, mock_executable, monkeypatch):
+    """Tests that 'spack compiler find' does not add a compiler already in the install DB."""
+    expected_version = "4.5.3"
+    gcc_path = mock_executable(
+        "gcc",
+        output=f"""\
+for arg in "$@"; do
+    if [ "$arg" = -dumpversion ]; then
+        echo '{expected_version}'
+    fi
+done
+""",
+    )
+    root_dir = gcc_path.parent.parent
+
+    # Simulate the compiler's root being in the install DB by returning it as an installed prefix
+    monkeypatch.setattr(
+        spack.detection.common,
+        "_installed_spec_prefixes",
+        lambda: {str(root_dir)},
+    )
+
+    compilers_before_find = set(spack.compilers.config.all_compilers())
+    args = spack.util.pattern.Bunch(
+        all=None,
+        compiler_spec=None,
+        add_paths=[str(root_dir)],
+        scope=None,
+        mixed_toolchain=False,
+        jobs=1,
+    )
+    spack.cmd.compiler.compiler_find(args)
+    compilers_after_find = set(spack.compilers.config.all_compilers())
+
+    compilers_added_by_find = compilers_after_find - compilers_before_find
+    assert len(compilers_added_by_find) == 0
 
 
 @pytest.mark.not_on_windows("Cannot execute bash script on Windows")


### PR DESCRIPTION
@douglasjacobsen noticed a strange behavior in Spack:

```
spack install intel-oneapi-compilers@2025.3.2            1
spack load intel-oneapi-compilers
spack compiler find                                      2
spack unload --all
spack install --fresh intel-oneapi-compilers@2025.3.2    3
```

After point 2, `spack compiler list` sees 2 compilers, and after point 3 `spack find intel-oneapi-compilers` detects two separate installs.

As of now, `spack external find`  (and `spack compiler find`) do not check whether detected specs are in the spack install database (i.e. whether Spack installed them): this PR skips any detected spec that is a subdir of a spack install prefix