### PR TITLE
ArchSpec: fix satisfies, intersects, constrain

### DIFF
--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -1462,6 +1462,10 @@ class SpackSolverSetup:
         assert name, "Internal Error: spec with no name occurred. Please file an issue."
         target = spec.architecture.target
 
+        # the unbounded range constrains nothing: every node gets a target anyway
+        if str(target) == ":":
+            return []
+
         # Check if the target is a concrete target
         if str(target) in spack.vendor.archspec.cpu.TARGETS:
             return [single_target_fn(name, target)]

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -1462,7 +1462,7 @@ class SpackSolverSetup:
         assert name, "Internal Error: spec with no name occurred. Please file an issue."
         target = spec.architecture.target
 
-        # the unbounded range constrains nothing: every node gets a target anyway
+        # target is unconstrained
         if str(target) == ":":
             return []
 

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -369,13 +369,14 @@ def _parse_target_range(
     )
 
 
+@lang.memoized
 def _minimal_upper_bounds(
     a: Optional[spack.vendor.archspec.cpu.Microarchitecture],
     b: Optional[spack.vendor.archspec.cpu.Microarchitecture],
 ) -> List[Optional[spack.vendor.archspec.cpu.Microarchitecture]]:
     """The minimal targets above both a and b. The target graph is not a lattice, so there is
     not always a unique least upper bound: incomparable bounds can have several minimal common
-    upper bounds."""
+    upper bounds. Memoized: the search below scans the whole target table."""
     if a is None:
         return [b]
     if b is None:
@@ -396,6 +397,7 @@ def _minimal_upper_bounds(
     return [t for t in above if not any(other < t for other in above)]
 
 
+@lang.memoized
 def _maximal_lower_bounds(
     a: Optional[spack.vendor.archspec.cpu.Microarchitecture],
     b: Optional[spack.vendor.archspec.cpu.Microarchitecture],
@@ -491,8 +493,18 @@ class ArchSpec:
             return results
 
         for l_element in str(lhs).split(","):
-            l_min, l_max = _parse_target_range(l_element)
             for r_element in str(rhs).split(","):
+                # a concrete element intersects another element iff contained in it, and the
+                # overlap is the concrete element itself
+                if ":" not in r_element:
+                    if _satisfies_target_range(l_element, r_element):
+                        results.append(r_element)
+                    continue
+                if ":" not in l_element:
+                    if _satisfies_target_range(r_element, l_element):
+                        results.append(l_element)
+                    continue
+                l_min, l_max = _parse_target_range(l_element)
                 r_min, r_max = _parse_target_range(r_element)
                 for n_min in _minimal_upper_bounds(l_min, r_min):
                     for n_max in _maximal_lower_bounds(l_max, r_max):

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -371,6 +371,76 @@ class ArchSpec:
         return lhs == "*" or rhs == "*" or lhs == rhs
 
     @staticmethod
+    def _target_satisfies(
+        lhs: Optional[spack.vendor.archspec.cpu.Microarchitecture],
+        rhs: Optional[spack.vendor.archspec.cpu.Microarchitecture],
+    ) -> bool:
+        """Whether every microarchitecture in the lhs target is also in the rhs one."""
+        if not rhs:
+            return True
+
+        if lhs is None:
+            return False
+
+        if rhs == ArchSpec.ANY_TARGET:
+            return True
+
+        # Subset test: every target the lhs ranges denote must be covered by one of the rhs ranges.
+        return all(
+            any(_satisfies_target_range(r_range, l_range) for r_range in str(rhs).split(","))
+            for l_range in str(lhs).split(",")
+        )
+
+    @staticmethod
+    def _target_intersects(
+        lhs: Optional[spack.vendor.archspec.cpu.Microarchitecture],
+        rhs: Optional[spack.vendor.archspec.cpu.Microarchitecture],
+    ) -> bool:
+        """Whether there is a microarchitecture in both targets."""
+        if not lhs or not rhs:
+            return True
+
+        # a star overlaps any target, but is too broad to satisfy a specific one
+        if ArchSpec.ANY_TARGET in (lhs, rhs):
+            return True
+
+        return bool(ArchSpec._target_intersection(lhs, rhs))
+
+    @staticmethod
+    def _target_intersection(
+        lhs: Optional[spack.vendor.archspec.cpu.Microarchitecture],
+        rhs: Optional[spack.vendor.archspec.cpu.Microarchitecture],
+    ) -> List[str]:
+        """The elements of the target list denoting the targets both sides contain. Every element
+        is an interval, so the overlap of two of them starts at a common upper bound of their
+        lower bounds and ends at a common lower bound of their upper bounds. Those bounds are not
+        always unique, so one pair of intervals can produce several intervals: one per
+        combination."""
+        results: List[str] = []
+
+        if not lhs or not rhs:
+            return results
+
+        for l_element in str(lhs).split(","):
+            l_min, l_max = _parse_target_range(l_element)
+            for r_element in str(rhs).split(","):
+                r_min, r_max = _parse_target_range(r_element)
+                for n_min in _minimal_upper_bounds(l_min, r_min):
+                    for n_max in _maximal_lower_bounds(l_max, r_max):
+                        if n_min is None and n_max is None:
+                            continue
+                        elif n_min is None:
+                            results.append(f":{n_max}")
+                        elif n_max is None:
+                            results.append(f"{n_min}:")
+                        elif n_min.name == n_max.name:
+                            results.append(n_min.name)
+                        elif n_min.family == n_max.family and n_min <= n_max:
+                            results.append(f"{n_min}:{n_max}")
+
+        return results
+
+    @staticmethod
     def default_arch():
         """Return the default architecture"""
         platform = spack.platforms.host()
@@ -539,11 +609,11 @@ class ArchSpec:
         """
         other = self._autospec(other)
 
-        for attribute in ("platform", "os"):
-            if not self._attr_satisfies(getattr(self, attribute), getattr(other, attribute)):
-                return False
-
-        return self._target_satisfies(other, strict=True)
+        return (
+            self._attr_satisfies(self.platform, other.platform)
+            and self._attr_satisfies(self.os, other.os)
+            and self._target_satisfies(self.target, other.target)
+        )
 
     def intersects(self, other: "ArchSpec") -> bool:
         """Return True if there exists at least one concrete spec that matches both
@@ -557,43 +627,10 @@ class ArchSpec:
         """
         other = self._autospec(other)
 
-        for attribute in ("platform", "os"):
-            if not self._attr_intersects(getattr(self, attribute), getattr(other, attribute)):
-                return False
-
-        return self._target_satisfies(other, strict=False)
-
-    def _target_satisfies(self, other: "ArchSpec", strict: bool) -> bool:
-        if strict is True:
-            need_to_check = bool(other.target)
-        else:
-            need_to_check = bool(other.target and self.target)
-
-        if not need_to_check:
-            return True
-
-        # other_target is there and strict=True
-        if self.target is None:
-            return False
-
-        # self.target is not None, and other is target=*
-        if other.target == ArchSpec.ANY_TARGET:
-            return True
-
-        # target=* on the lhs overlaps any target, but is too broad to satisfy a specific one
-        if not strict and self.target == ArchSpec.ANY_TARGET:
-            return True
-
-        if not strict:
-            return bool(self._target_intersection(other))
-
-        # Subset test: every target self's ranges denote must be covered by one of other's.
-        return all(
-            any(
-                _satisfies_target_range(o_range, s_range)
-                for o_range in str(other.target).split(",")
-            )
-            for s_range in str(self.target).split(",")
+        return (
+            self._attr_intersects(self.platform, other.platform)
+            and self._attr_intersects(self.os, other.os)
+            and self._target_intersects(self.target, other.target)
         )
 
     def _target_constrain(self, other: "ArchSpec") -> bool:
@@ -615,7 +652,7 @@ class ArchSpec:
             self.target = other.target
             return True
 
-        if not other._target_satisfies(self, strict=False):
+        if not self._target_intersects(self.target, other.target):
             raise UnsatisfiableArchitectureSpecError(self, other)
 
         if self.target is None:
@@ -630,12 +667,11 @@ class ArchSpec:
             return True
 
         # self already inside other: the intersection is self, so skip computing it.
-        if self._target_satisfies(other, strict=True):
+        if self._target_satisfies(self.target, other.target):
             return False
 
         # Compute the intersection of every combination of ranges in the lists
-        results = self._target_intersection(other)
-        attribute_str = ",".join(results)
+        attribute_str = ",".join(self._target_intersection(self.target, other.target))
 
         intersection_target = _make_microarchitecture(attribute_str)
         if self.target == intersection_target:
@@ -643,36 +679,6 @@ class ArchSpec:
 
         self.target = intersection_target
         return True
-
-    def _target_intersection(self, other: "ArchSpec") -> List[str]:
-        """The elements of the target list denoting the targets both sides contain. Every element
-        is an interval, so the overlap of two of them starts at a common upper bound of their
-        lower bounds and ends at a common lower bound of their upper bounds. Those bounds are not
-        always unique, so one pair of intervals can produce several intervals: one per
-        combination."""
-        results: List[str] = []
-
-        if not self.target or not other.target:
-            return results
-
-        for s_element in str(self.target).split(","):
-            s_min, s_max = _parse_target_range(s_element)
-            for o_element in str(other.target).split(","):
-                o_min, o_max = _parse_target_range(o_element)
-                for n_min in _minimal_upper_bounds(s_min, o_min):
-                    for n_max in _maximal_lower_bounds(s_max, o_max):
-                        if n_min is None and n_max is None:
-                            continue
-                        elif n_min is None:
-                            results.append(f":{n_max}")
-                        elif n_max is None:
-                            results.append(f"{n_min}:")
-                        elif n_min.name == n_max.name:
-                            results.append(n_min.name)
-                        elif n_min.family == n_max.family and n_min <= n_max:
-                            results.append(f"{n_min}:{n_max}")
-
-        return results
 
     def constrain(self, other: "ArchSpec") -> bool:
         """Projects all architecture fields that are specified in the given

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -268,10 +268,10 @@ def _canonical_target_range(name: str) -> str:
     for element in name.split(","):
         t_min, t_sep, t_max = element.partition(":")
         if t_sep and t_max:
-            upper = _make_microarchitecture(t_max)
-            if not t_min or _make_microarchitecture(t_min) == upper.family:
+            family = _make_microarchitecture(t_max).family.name
+            if not t_min or t_min == family:
                 # if the upperbound is a root, canonicalize to the singleton
-                element = t_max if upper.family == upper else f":{t_max}"
+                element = t_max if t_max == family else f":{t_max}"
             elif t_min == t_max:
                 element = t_min
         elements.add(element)
@@ -344,9 +344,7 @@ def _satisfies_target_range(lhs: str, rhs: str) -> bool:
         if not floor >= _make_microarchitecture(lhs_min):
             return False
     if lhs_max:
-        if not rhs_max or not _make_microarchitecture(rhs_max) <= _make_microarchitecture(
-            lhs_max
-        ):
+        if not rhs_max or not _make_microarchitecture(rhs_max) <= _make_microarchitecture(lhs_max):
             return False
     return True
 
@@ -733,28 +731,17 @@ class ArchSpec:
             self.target = other.target
             return True
 
-        if not self._target_intersects(self.target, other.target):
-            raise UnsatisfiableArchitectureSpecError(self, other)
-
         if self.target is None:
             self.target = other.target
             return True
 
-        if self.target_concrete:
-            return False
+        results = self._target_intersection(self.target, other.target)
+        if not results:
+            raise UnsatisfiableArchitectureSpecError(self, other)
 
-        elif other.target_concrete:
-            self.target = other.target
-            return True
-
-        # self already inside other: the intersection is self, so skip computing it.
-        if self._target_satisfies(self.target, other.target):
-            return False
-
-        # Compute the intersection of every combination of ranges in the lists
-        attribute_str = ",".join(self._target_intersection(self.target, other.target))
-
-        intersection_target = _make_microarchitecture(attribute_str)
+        # Targets are stored canonically, so the intersection equals self.target exactly when
+        # self is already inside other.
+        intersection_target = _make_microarchitecture(",".join(results))
         if self.target == intersection_target:
             return False
 

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -319,11 +319,14 @@ def _satisfies_target_range(lhs: str, rhs: str) -> bool:
     rhs_min, rhs_sep, rhs_max = rhs.partition(":")
 
     if not rhs_sep:
-        # rhs is concrete: contained iff it falls within lhs's bounds.
+        # rhs is concrete: contained iff it falls within lhs's bounds. Comparing with
+        # microarchitectures rather than names keeps bounds outside the table from raising.
         t = _make_microarchitecture(rhs_min)
         if not lhs_sep:
             return rhs_min == lhs_min
-        return (not lhs_min or t >= lhs_min) and (not lhs_max or t <= lhs_max)
+        return (not lhs_min or t >= _make_microarchitecture(lhs_min)) and (
+            not lhs_max or t <= _make_microarchitecture(lhs_max)
+        )
 
     if not lhs_sep:
         # lhs is concrete: a range is inside it only by denoting that point too.
@@ -338,10 +341,12 @@ def _satisfies_target_range(lhs: str, rhs: str) -> bool:
             if rhs_min
             else _make_microarchitecture(rhs_max).family
         )
-        if not floor >= lhs_min:
+        if not floor >= _make_microarchitecture(lhs_min):
             return False
     if lhs_max:
-        if not rhs_max or not _make_microarchitecture(rhs_max) <= lhs_max:
+        if not rhs_max or not _make_microarchitecture(rhs_max) <= _make_microarchitecture(
+            lhs_max
+        ):
             return False
     return True
 

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -211,7 +211,10 @@ def ensure_modern_format_string(fmt: str) -> None:
 def _make_microarchitecture(name: str) -> spack.vendor.archspec.cpu.Microarchitecture:
     if isinstance(name, spack.vendor.archspec.cpu.Microarchitecture):
         return name
-    if ":" in name or "," in name:
+    if name == "*":
+        # the universe of targets, canonically the doubly unbounded range, like @: for versions
+        name = ":"
+    elif ":" in name or "," in name:
         name = _canonical_target_range(name)
     return spack.vendor.archspec.cpu.TARGETS.get(
         name, spack.vendor.archspec.cpu.generic_microarchitecture(name)
@@ -266,6 +269,8 @@ def _canonical_target_range(name: str) -> str:
     are dropped, and the rest are fused per family."""
     elements = set()
     for element in name.split(","):
+        if element == "*":
+            element = ":"
         t_min, t_sep, t_max = element.partition(":")
         if t_sep and t_max:
             family = _make_microarchitecture(t_max).family.name
@@ -439,8 +444,6 @@ def _maximal_lower_bounds(
 class ArchSpec:
     """Aggregate the target platform, the operating system and the target microarchitecture."""
 
-    ANY_TARGET = _make_microarchitecture("*")
-
     @staticmethod
     def _attr_satisfies(lhs: Optional[str], rhs: Optional[str]) -> bool:
         """Whether a platform or operating system on the lhs satisfies the one on the rhs."""
@@ -469,9 +472,6 @@ class ArchSpec:
         if lhs is None:
             return False
 
-        if rhs == ArchSpec.ANY_TARGET:
-            return True
-
         # Subset test: every target the lhs ranges denote must be covered by the rhs ranges.
         rhs_elements = str(rhs).split(",")
         return all(
@@ -485,10 +485,6 @@ class ArchSpec:
     ) -> bool:
         """Whether there is a microarchitecture in both targets."""
         if not lhs or not rhs:
-            return True
-
-        # a star overlaps any target, but is too broad to satisfy a specific one
-        if ArchSpec.ANY_TARGET in (lhs, rhs):
             return True
 
         return bool(ArchSpec._target_intersection(lhs, rhs))
@@ -737,18 +733,6 @@ class ArchSpec:
         # the two has no target, which would turn into an empty target below.
         if other.target is None:
             return False
-
-        # target=* constrains a target to be set without naming one, so any target already
-        # satisfies it and a side without one becomes the star. It is concrete by the definition
-        # below, so it is handled here rather than overriding a named target further down.
-        if other.target == ArchSpec.ANY_TARGET:
-            if self.target is not None:
-                return False
-            self.target = other.target
-            return True
-        if self.target == ArchSpec.ANY_TARGET:
-            self.target = other.target
-            return True
 
         if self.target is None:
             self.target = other.target

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -507,7 +507,8 @@ class ArchSpec:
                 for n_min in _minimal_upper_bounds(l_min, r_min):
                     for n_max in _maximal_lower_bounds(l_max, r_max):
                         if n_min is None and n_max is None:
-                            continue
+                            # both elements are unbounded on both sides: the overlap is too
+                            results.append(":")
                         elif n_min is None:
                             results.append(f":{n_max}")
                         elif n_max is None:

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -211,9 +211,42 @@ def ensure_modern_format_string(fmt: str) -> None:
 def _make_microarchitecture(name: str) -> spack.vendor.archspec.cpu.Microarchitecture:
     if isinstance(name, spack.vendor.archspec.cpu.Microarchitecture):
         return name
+    if ":" in name or "," in name:
+        name = _canonical_target_range(name)
     return spack.vendor.archspec.cpu.TARGETS.get(
         name, spack.vendor.archspec.cpu.generic_microarchitecture(name)
     )
+
+
+def _canonical_target_range(name: str) -> str:
+    """The canonical string representation of a target. For example, `x86_64:icelake` is
+    canonicalized to `:icelake`, and redundant elements are dropped in case of a list."""
+    elements = set()
+    for element in name.split(","):
+        t_min, t_sep, t_max = element.partition(":")
+        if (
+            t_sep
+            and t_min
+            and t_max
+            and _make_microarchitecture(t_max).family == _make_microarchitecture(t_min)
+        ):
+            element = f":{t_max}"
+        elements.add(element)
+
+    ordered = sorted(elements)
+    kept = []
+    for i, element in enumerate(ordered):
+        subsumed = False
+        for j, container in enumerate(ordered):
+            if i == j or not _satisfies_target_range(container, element):
+                continue
+            # two elements that denote the same set contain each other, so keep the first of them
+            if j < i or not _satisfies_target_range(element, container):
+                subsumed = True
+                break
+        if not subsumed:
+            kept.append(element)
+    return ",".join(kept)
 
 
 def _satisfies_target_range(lhs: str, rhs: str) -> bool:

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -349,6 +349,24 @@ def _satisfies_target_range(lhs: str, rhs: str) -> bool:
     return True
 
 
+def _covered_by_target_list(element: str, rhs_elements: List[str]) -> bool:
+    """Whether every target the element denotes is in one of ``rhs_elements``. An element
+    inside a single rhs element is covered; a range with an upper bound in the table can also
+    be covered by several rhs elements jointly, so its targets are checked one by one. An open
+    element is only inside an open element, since it admits targets outside the table."""
+    if any(_satisfies_target_range(r, element) for r in rhs_elements):
+        return True
+    if len(rhs_elements) == 1:
+        return False
+    t_min, t_sep, t_max = element.partition(":")
+    table = spack.vendor.archspec.cpu.TARGETS
+    if not t_max or t_max not in table or (t_min and t_min not in table):
+        # a point is covered element-wise or not at all; so are unknown names
+        return False
+    members = _closed_interval_targets(table[t_min] if t_min else None, table[t_max])
+    return all(any(_satisfies_target_range(r, m.name) for r in rhs_elements) for m in members)
+
+
 def _parse_target_range(
     element: str,
 ) -> Tuple[
@@ -454,10 +472,10 @@ class ArchSpec:
         if rhs == ArchSpec.ANY_TARGET:
             return True
 
-        # Subset test: every target the lhs ranges denote must be covered by one of the rhs ranges.
+        # Subset test: every target the lhs ranges denote must be covered by the rhs ranges.
+        rhs_elements = str(rhs).split(",")
         return all(
-            any(_satisfies_target_range(r_range, l_range) for r_range in str(rhs).split(","))
-            for l_range in str(lhs).split(",")
+            _covered_by_target_list(l_range, rhs_elements) for l_range in str(lhs).split(",")
         )
 
     @staticmethod

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -224,13 +224,13 @@ def _canonical_target_range(name: str) -> str:
     elements = set()
     for element in name.split(","):
         t_min, t_sep, t_max = element.partition(":")
-        if (
-            t_sep
-            and t_min
-            and t_max
-            and _make_microarchitecture(t_max).family == _make_microarchitecture(t_min)
-        ):
-            element = f":{t_max}"
+        if t_sep and t_max:
+            upper = _make_microarchitecture(t_max)
+            if not t_min or _make_microarchitecture(t_min) == upper.family:
+                # if the upperbound is a root, canonicalize to the singleton
+                element = t_max if upper.family == upper else f":{t_max}"
+            elif t_min == t_max:
+                element = t_min
         elements.add(element)
 
     ordered = sorted(elements)

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -212,7 +212,7 @@ def _make_microarchitecture(name: str) -> spack.vendor.archspec.cpu.Microarchite
     if isinstance(name, spack.vendor.archspec.cpu.Microarchitecture):
         return name
     if name == "*":
-        # the universe of targets, canonically the doubly unbounded range, like @: for versions
+        # canonicalize target=* to target=: like @: in version lists
         name = ":"
     elif ":" in name or "," in name:
         name = _canonical_target_range(name)
@@ -472,7 +472,7 @@ class ArchSpec:
         if lhs is None:
             return False
 
-        # Subset test: every target the lhs ranges denote must be covered by the rhs ranges.
+        # Subset test: every target of the lhs must be covered by the rhs
         rhs_elements = str(rhs).split(",")
         return all(
             _covered_by_target_list(l_range, rhs_elements) for l_range in str(lhs).split(",")
@@ -521,7 +521,6 @@ class ArchSpec:
                 for n_min in _minimal_upper_bounds(l_min, r_min):
                     for n_max in _maximal_lower_bounds(l_max, r_max):
                         if n_min is None and n_max is None:
-                            # both elements are unbounded on both sides: the overlap is too
                             results.append(":")
                         elif n_min is None:
                             results.append(f":{n_max}")

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -282,6 +282,72 @@ def _satisfies_target_range(lhs: str, rhs: str) -> bool:
     return True
 
 
+def _parse_target_range(
+    element: str,
+) -> Tuple[
+    Optional[spack.vendor.archspec.cpu.Microarchitecture],
+    Optional[spack.vendor.archspec.cpu.Microarchitecture],
+]:
+    """Returns a tuple of (min, max) with None meaning unbounded. For concrete targets
+    min == max."""
+    t_min, t_sep, t_max = element.partition(":")
+    if not t_sep:
+        t = _make_microarchitecture(t_min)
+        return t, t
+    return (
+        _make_microarchitecture(t_min) if t_min else None,
+        _make_microarchitecture(t_max) if t_max else None,
+    )
+
+
+def _minimal_upper_bounds(
+    a: Optional[spack.vendor.archspec.cpu.Microarchitecture],
+    b: Optional[spack.vendor.archspec.cpu.Microarchitecture],
+) -> List[Optional[spack.vendor.archspec.cpu.Microarchitecture]]:
+    """The minimal targets above both a and b. The target graph is not a lattice, so there is
+    not always a unique least upper bound: incomparable bounds can have several minimal common
+    upper bounds."""
+    if a is None:
+        return [b]
+    if b is None:
+        return [a]
+    if a.name == b.name:
+        return [a]
+    if a.family != b.family:
+        return []
+    if a >= b:
+        return [a]
+    if b > a:
+        return [b]
+    above = [
+        t
+        for t in spack.vendor.archspec.cpu.TARGETS.values()
+        if t.family == a.family and t >= a and t >= b
+    ]
+    return [t for t in above if not any(other < t for other in above)]
+
+
+def _maximal_lower_bounds(
+    a: Optional[spack.vendor.archspec.cpu.Microarchitecture],
+    b: Optional[spack.vendor.archspec.cpu.Microarchitecture],
+) -> List[Optional[spack.vendor.archspec.cpu.Microarchitecture]]:
+    """The dual of ``_minimal_upper_bounds``: the maximal targets below both a and b."""
+    if a is None:
+        return [b]
+    if b is None:
+        return [a]
+    if a.name == b.name:
+        return [a]
+    if a.family != b.family:
+        return []
+    if a <= b:
+        return [a]
+    if b < a:
+        return [b]
+    below = set(a.ancestors) & set(b.ancestors)
+    return [t for t in below if not any(t < other for other in below)]
+
+
 @lang.lazy_lexicographic_ordering
 class ArchSpec:
     """Aggregate the target platform, the operating system and the target microarchitecture."""
@@ -531,11 +597,30 @@ class ArchSpec:
         )
 
     def _target_constrain(self, other: "ArchSpec") -> bool:
-        if self.target is None and other.target is None:
+        # An unconstrained target on either side means the other side is the intersection.
+        # _target_intersection cannot express that: it returns an empty list whenever one of
+        # the two has no target, which would turn into an empty target below.
+        if other.target is None:
             return False
+
+        # target=* constrains a target to be set without naming one, so any target already
+        # satisfies it and a side without one becomes the star. It is concrete by the definition
+        # below, so it is handled here rather than overriding a named target further down.
+        if other.target == ArchSpec.ANY_TARGET:
+            if self.target is not None:
+                return False
+            self.target = other.target
+            return True
+        if self.target == ArchSpec.ANY_TARGET:
+            self.target = other.target
+            return True
 
         if not other._target_satisfies(self, strict=False):
             raise UnsatisfiableArchitectureSpecError(self, other)
+
+        if self.target is None:
+            self.target = other.target
+            return True
 
         if self.target_concrete:
             return False
@@ -543,6 +628,10 @@ class ArchSpec:
         elif other.target_concrete:
             self.target = other.target
             return True
+
+        # self already inside other: the intersection is self, so skip computing it.
+        if self._target_satisfies(other, strict=True):
+            return False
 
         # Compute the intersection of every combination of ranges in the lists
         results = self._target_intersection(other)
@@ -555,82 +644,33 @@ class ArchSpec:
         self.target = intersection_target
         return True
 
-    def _target_intersection(self, other):
-        results = []
+    def _target_intersection(self, other: "ArchSpec") -> List[str]:
+        """The elements of the target list denoting the targets both sides contain. Every element
+        is an interval, so the overlap of two of them starts at a common upper bound of their
+        lower bounds and ends at a common lower bound of their upper bounds. Those bounds are not
+        always unique, so one pair of intervals can produce several intervals: one per
+        combination."""
+        results: List[str] = []
 
         if not self.target or not other.target:
             return results
 
-        for s_target_range in str(self.target).split(","):
-            s_min, s_sep, s_max = s_target_range.partition(":")
-            for o_target_range in str(other.target).split(","):
-                o_min, o_sep, o_max = o_target_range.partition(":")
-
-                if not s_sep:
-                    # s_target_range is a concrete target
-                    # get a microarchitecture reference for at least one side
-                    # of each comparison so we can use archspec comparators
-                    s_comp = _make_microarchitecture(s_min)
-                    if not o_sep:
-                        if s_min == o_min:
-                            results.append(s_min)
-                    elif (not o_min or s_comp >= o_min) and (not o_max or s_comp <= o_max):
-                        results.append(s_min)
-                elif not o_sep:
-                    # "cast" to microarchitecture
-                    o_comp = _make_microarchitecture(o_min)
-                    if (not s_min or o_comp >= s_min) and (not s_max or o_comp <= s_max):
-                        results.append(o_min)
-                else:
-                    # Take the "min" of the two max, if there is a partial ordering.
-                    n_max = ""
-                    if s_max and o_max:
-                        _s_max = _make_microarchitecture(s_max)
-                        _o_max = _make_microarchitecture(o_max)
-                        if _s_max.family != _o_max.family:
+        for s_element in str(self.target).split(","):
+            s_min, s_max = _parse_target_range(s_element)
+            for o_element in str(other.target).split(","):
+                o_min, o_max = _parse_target_range(o_element)
+                for n_min in _minimal_upper_bounds(s_min, o_min):
+                    for n_max in _maximal_lower_bounds(s_max, o_max):
+                        if n_min is None and n_max is None:
                             continue
-                        if _s_max <= _o_max:
-                            n_max = s_max
-                        elif _o_max < _s_max:
-                            n_max = o_max
-                        else:
-                            continue
-                    elif s_max:
-                        n_max = s_max
-                    elif o_max:
-                        n_max = o_max
-
-                    # Take the "max" of the two min.
-                    n_min = ""
-                    if s_min and o_min:
-                        _s_min = _make_microarchitecture(s_min)
-                        _o_min = _make_microarchitecture(o_min)
-                        if _s_min.family != _o_min.family:
-                            continue
-                        if _s_min >= _o_min:
-                            n_min = s_min
-                        elif _o_min > _s_min:
-                            n_min = o_min
-                        else:
-                            continue
-                    elif s_min:
-                        n_min = s_min
-                    elif o_min:
-                        n_min = o_min
-
-                    if n_min and n_max:
-                        _n_min = _make_microarchitecture(n_min)
-                        _n_max = _make_microarchitecture(n_max)
-                        if _n_min.family != _n_max.family or not _n_min <= _n_max:
-                            continue
-                        if n_min == n_max:
-                            results.append(n_min)
-                        else:
+                        elif n_min is None:
+                            results.append(f":{n_max}")
+                        elif n_max is None:
+                            results.append(f"{n_min}:")
+                        elif n_min.name == n_max.name:
+                            results.append(n_min.name)
+                        elif n_min.family == n_max.family and n_min <= n_max:
                             results.append(f"{n_min}:{n_max}")
-                    elif n_min:
-                        results.append(f"{n_min}:")
-                    elif n_max:
-                        results.append(f":{n_max}")
 
         return results
 

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -216,6 +216,39 @@ def _make_microarchitecture(name: str) -> spack.vendor.archspec.cpu.Microarchite
     )
 
 
+def _satisfies_target_range(lhs: str, rhs: str) -> bool:
+    """Whether every microarchitecture in ``rhs`` is also in ``lhs``."""
+    lhs_min, lhs_sep, lhs_max = lhs.partition(":")
+    rhs_min, rhs_sep, rhs_max = rhs.partition(":")
+
+    if not rhs_sep:
+        # rhs is concrete: contained iff it falls within lhs's bounds.
+        t = _make_microarchitecture(rhs_min)
+        if not lhs_sep:
+            return rhs_min == lhs_min
+        return (not lhs_min or t >= lhs_min) and (not lhs_max or t <= lhs_max)
+
+    if not lhs_sep:
+        # lhs is concrete: a range is inside it only by denoting that point too.
+        return rhs_min == rhs_max == lhs_min
+
+    # Both are ranges
+    if lhs_min:
+        if not rhs_min and not rhs_max:
+            return False
+        floor = (
+            _make_microarchitecture(rhs_min)
+            if rhs_min
+            else _make_microarchitecture(rhs_max).family
+        )
+        if not floor >= lhs_min:
+            return False
+    if lhs_max:
+        if not rhs_max or not _make_microarchitecture(rhs_max) <= lhs_max:
+            return False
+    return True
+
+
 @lang.lazy_lexicographic_ordering
 class ArchSpec:
     """Aggregate the target platform, the operating system and the target microarchitecture."""
@@ -452,7 +485,17 @@ class ArchSpec:
         if not strict and self.target == ArchSpec.ANY_TARGET:
             return True
 
-        return bool(self._target_intersection(other))
+        if not strict:
+            return bool(self._target_intersection(other))
+
+        # Subset test: every target self's ranges denote must be covered by one of other's.
+        return all(
+            any(
+                _satisfies_target_range(o_range, s_range)
+                for o_range in str(other.target).split(",")
+            )
+            for s_range in str(self.target).split(",")
+        )
 
     def _target_constrain(self, other: "ArchSpec") -> bool:
         if self.target is None and other.target is None:

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -218,9 +218,52 @@ def _make_microarchitecture(name: str) -> spack.vendor.archspec.cpu.Microarchite
     )
 
 
+def _closed_interval_targets(
+    lower: Optional[spack.vendor.archspec.cpu.Microarchitecture],
+    upper: spack.vendor.archspec.cpu.Microarchitecture,
+) -> Set[spack.vendor.archspec.cpu.Microarchitecture]:
+    """The targets in the closed interval between the bounds; a None lower bound means the
+    family root. The set is exact: a target below the upper bound is one of its ancestors, so
+    no target outside the table can enter the interval."""
+    candidates = set(upper.ancestors)
+    candidates.add(upper)
+    if lower is None:
+        return candidates
+    return {t for t in candidates if t >= lower}
+
+
+def _decompose_target_set(targets: Set[spack.vendor.archspec.cpu.Microarchitecture]) -> List[str]:
+    """A deterministic decomposition of a set of targets into interval elements: repeatedly
+    emit the largest interval that starts at a minimal remaining target and stays inside the
+    set. The result is a function of the set alone, so lists denoting the same targets
+    decompose identically; it is not always of minimal length."""
+    result = []
+    remaining = set(targets)
+    while remaining:
+        m = min((t for t in remaining if not any(s < t for s in remaining)), key=lambda t: t.name)
+        best, members = m, {m}
+        for u in sorted(remaining, key=lambda t: t.name):
+            if not u > m:
+                continue
+            candidates = _closed_interval_targets(m, u)
+            if len(candidates) > len(members) and candidates <= remaining:
+                best, members = u, candidates
+        if m == best:
+            result.append(m.name)
+        elif m == m.family:
+            result.append(f":{best.name}")
+        else:
+            result.append(f"{m.name}:{best.name}")
+        remaining -= members
+    return result
+
+
 def _canonical_target_range(name: str) -> str:
     """The canonical string representation of a target. For example, `x86_64:icelake` is
-    canonicalized to `:icelake`, and redundant elements are dropped in case of a list."""
+    canonicalized to `:icelake`. A list is rewritten as a decomposition of the set of targets
+    it denotes, so that lists denoting the same set, such as `nocona:haswell` and
+    `nocona:nehalem,nehalem:haswell`, have one canonical form: elements denoting no target
+    are dropped, and the rest are fused per family."""
     elements = set()
     for element in name.split(","):
         t_min, t_sep, t_max = element.partition(":")
@@ -233,20 +276,41 @@ def _canonical_target_range(name: str) -> str:
                 element = t_min
         elements.add(element)
 
-    ordered = sorted(elements)
-    kept = []
-    for i, element in enumerate(ordered):
-        subsumed = False
-        for j, container in enumerate(ordered):
-            if i == j or not _satisfies_target_range(container, element):
-                continue
-            # two elements that denote the same set contain each other, so keep the first of them
-            if j < i or not _satisfies_target_range(element, container):
-                subsumed = True
-                break
-        if not subsumed:
-            kept.append(element)
-    return ",".join(kept)
+    if len(elements) <= 1:
+        return ",".join(elements)
+
+    table = spack.vendor.archspec.cpu.TARGETS
+    opens: Set[str] = set()  # lower bounds of `x:` elements
+    union: Set[spack.vendor.archspec.cpu.Microarchitecture] = set()
+    verbatim = set()  # elements with bounds outside the table cannot be compared
+    for element in elements:
+        t_min, t_sep, t_max = element.partition(":")
+        if not t_min and not t_max:
+            if t_sep:
+                # ':' is unbounded on both sides, so it contains every other element
+                return ":"
+            verbatim.add(element)
+        elif (t_min and t_min not in table) or (t_max and t_max not in table):
+            verbatim.add(element)
+        elif t_sep and not t_max:
+            opens.add(t_min)
+        else:
+            union |= _closed_interval_targets(
+                table[t_min] if t_min else None, table[t_max or t_min]
+            )
+
+    if not opens and not union and not verbatim:
+        # every element denotes the empty set: keep them rather than returning an empty string
+        return ",".join(sorted(elements))
+
+    # keep the antichain of minimal lower bounds: `y:` contains `x:` whenever y is below x
+    opens = {x for x in opens if not any(table[y] < table[x] for y in opens)}
+    # an open element already denotes every target above its bound
+    union = {t for t in union if not any(t >= table[x] for x in opens)}
+
+    kept = {f"{x}:" for x in opens} | verbatim
+    kept.update(_decompose_target_set(union))
+    return ",".join(sorted(kept))
 
 
 def _satisfies_target_range(lhs: str, rhs: str) -> bool:

--- a/lib/spack/spack/test/architecture.py
+++ b/lib/spack/spack/test/architecture.py
@@ -8,6 +8,7 @@ import pytest
 import spack.vendor.archspec.cpu
 
 import spack.concretize
+import spack.error
 import spack.operating_systems
 import spack.platforms
 from spack.spec import ArchSpec, Spec
@@ -110,6 +111,30 @@ def test_satisfy_strict_constraint_when_not_concrete(architecture_tuple, constra
 
 
 @pytest.mark.parametrize(
+    "lhs_tuple,rhs_tuple,expected_target",
+    [
+        ((None, "debian6", None), (None, None, "x86_64:"), "x86_64:"),
+        ((None, None, "x86_64:"), (None, "debian6", None), "x86_64:"),
+        ((None, "debian6", None), (None, None, "haswell"), "haswell"),
+    ],
+)
+def test_constrain_target_when_only_one_side_has_one(lhs_tuple, rhs_tuple, expected_target):
+    """The side that has a target wins, ranges included."""
+    architecture = ArchSpec(lhs_tuple)
+    architecture.constrain(ArchSpec(rhs_tuple))
+    assert architecture.target == ArchSpec((None, None, expected_target)).target
+
+
+def test_constrain_is_atomic_when_targets_are_disjoint():
+    """platform and os are applied before the target, so the up-front intersection check is what
+    keeps a failed constrain from leaving them behind."""
+    architecture = ArchSpec(("linux", None, "haswell"))
+    with pytest.raises(spack.error.UnsatisfiableSpecError):
+        architecture.constrain(ArchSpec((None, "ubuntu18.04", "ppc64le")))
+    assert architecture == ArchSpec(("linux", None, "haswell"))
+
+
+@pytest.mark.parametrize(
     "architecture_tuple,constraint_tuple",
     [
         (("linux", "ubuntu18.04", "x86_64"), ("*", None, None)),
@@ -143,6 +168,15 @@ def test_star_does_not_short_circuit_the_other_attributes():
     assert not architecture.satisfies(ArchSpec(("*", "rhel6", None)))
     assert not architecture.satisfies(ArchSpec(("*", None, "aarch64")))
     assert not architecture.intersects(ArchSpec(("*", "rhel6", None)))
+
+
+def test_star_target_is_replaced_by_a_named_target_when_constrained():
+    """target=* names no target, so the other side is the intersection. It is concrete by the
+    definition in ArchSpec, so _target_constrain handles it before a named target could be
+    overridden."""
+    architecture = ArchSpec((None, None, "*"))
+    assert architecture.constrain(ArchSpec((None, None, "x86_64"))) is True
+    assert str(architecture.target) == "x86_64"
 
 
 @pytest.mark.parametrize(

--- a/lib/spack/spack/test/architecture.py
+++ b/lib/spack/spack/test/architecture.py
@@ -171,10 +171,10 @@ def test_star_does_not_short_circuit_the_other_attributes():
 
 
 def test_star_target_is_replaced_by_a_named_target_when_constrained():
-    """target=* names no target, so the other side is the intersection. It is concrete by the
-    definition in ArchSpec, so _target_constrain handles it before a named target could be
-    overridden."""
+    """target=* is stored as the unbounded range target=:, so the named side of the
+    intersection wins."""
     architecture = ArchSpec((None, None, "*"))
+    assert str(architecture.target) == ":"
     assert architecture.constrain(ArchSpec((None, None, "x86_64"))) is True
     assert str(architecture.target) == "x86_64"
 

--- a/lib/spack/spack/test/architecture.py
+++ b/lib/spack/spack/test/architecture.py
@@ -171,8 +171,7 @@ def test_star_does_not_short_circuit_the_other_attributes():
 
 
 def test_star_target_is_replaced_by_a_named_target_when_constrained():
-    """target=* is stored as the unbounded range target=:, so the named side of the
-    intersection wins."""
+    """target=* is stored as target=: like @: in version lists"""
     architecture = ArchSpec((None, None, "*"))
     assert str(architecture.target) == ":"
     assert architecture.constrain(ArchSpec((None, None, "x86_64"))) is True

--- a/lib/spack/spack/test/concretization/core.py
+++ b/lib/spack/spack/test/concretization/core.py
@@ -5695,3 +5695,10 @@ def test_asp_facts_with_config_values():
     assert str(fn.max_dupes("cmake", 2)) == 'max_dupes("cmake",2)'
     assert str(fn.os_compatible(syaml.syaml_str('a"b\\c'), "d")) == r'os_compatible("a\"b\\c","d")'
     assert str(fn.variant_value("x", True)) == 'variant_value("x","True")'
+
+
+def test_target_star_concretizes(mock_packages, config):
+    """target=* is the unbounded target range: it constrains nothing instead of failing the
+    lookup of a single target named *."""
+    concrete = spack.concretize.concretize_one("pkg-a target=*")
+    assert concrete.architecture.target_concrete

--- a/lib/spack/spack/test/concretization/core.py
+++ b/lib/spack/spack/test/concretization/core.py
@@ -5698,7 +5698,6 @@ def test_asp_facts_with_config_values():
 
 
 def test_target_star_concretizes(mock_packages, config):
-    """target=* is the unbounded target range: it constrains nothing instead of failing the
-    lookup of a single target named *."""
+    """target=* is not a literal unknown target '*' but rather an unconstrained target"""
     concrete = spack.concretize.concretize_one("pkg-a target=*")
     assert concrete.architecture.target_concrete

--- a/lib/spack/spack/test/spec_semantics.py
+++ b/lib/spack/spack/test/spec_semantics.py
@@ -1995,8 +1995,9 @@ def test_abstract_contains_semantic(lhs, rhs, expected, mock_packages):
         (Spec, "target=x86_64:", "target=:power9", (False, False, False)),
         (Spec, "target=:haswell", "target=:power9", (False, False, False)),
         (Spec, "target=:haswell", "target=ppc64le:", (False, False, False)),
-        # Intersection among target ranges for the same architecture
-        (Spec, "target=:haswell", "target=x86_64:", (True, True, True)),
+        # Target ranges in one family: ":haswell" is a strict subset of "x86_64:", since x86_64
+        # is the family root and broadwell and later are above haswell.
+        (Spec, "target=:haswell", "target=x86_64:", (True, True, False)),
         (Spec, "target=:haswell", "target=x86_64_v4:", (False, False, False)),
         # Edge case of uarch that split in a diamond structure, from a common ancestor
         (Spec, "target=:cascadelake", "target=:cannonlake", (False, False, False)),

--- a/lib/spack/spack/test/spec_semantics.py
+++ b/lib/spack/spack/test/spec_semantics.py
@@ -2008,6 +2008,11 @@ def test_abstract_contains_semantic(lhs, rhs, expected, mock_packages):
         (Spec, "target=:aarch64", "target=aarch64", (True, True, True)),
         (Spec, "target=aarch64:aarch64", "target=aarch64", (True, True, True)),
         (Spec, "target=icelake:icelake", "target=icelake", (True, True, True)),
+        # Bounds outside the microarchitecture table compare by name only, without raising
+        (Spec, "target=foo:", "target=foo:", (True, True, True)),
+        (Spec, "target=foo", "target=foo:", (True, True, False)),
+        (Spec, "target=x86_64:", "target=foo:", (False, False, False)),
+        (Spec, "target=haswell", "target=foo:", (False, False, False)),
         # Spec with compilers
         (Spec, "mpileaks %gcc@5", "mpileaks %gcc@6", (False, False, False)),
         # %gcc sits behind an unpinned ^callpath edge, so callpath need not be one node:

--- a/lib/spack/spack/test/spec_semantics.py
+++ b/lib/spack/spack/test/spec_semantics.py
@@ -2103,6 +2103,23 @@ def test_edge_propagation_is_part_of_spec_identity(mock_packages):
     assert len({plain, propagated}) == 2
 
 
+def test_one_target_range_is_one_canonical_state(mock_packages):
+    """':icelake' and 'x86_64:icelake' denote the same range, since x86_64 is the family root.
+    Ranges are stored canonicalized, so the two are one state with one hash."""
+    long, short = Spec("pkg-a target=x86_64:icelake"), Spec("pkg-a target=:icelake")
+    assert long.to_dict() == short.to_dict()
+    assert long.dag_hash() == short.dag_hash()
+
+
+def test_a_target_range_inside_another_one_is_dropped_from_the_list(mock_packages):
+    """A list of ranges denotes their union, so a range inside another adds nothing to it and is
+    dropped, leaving one canonical state for that union."""
+    assert (
+        Spec("pkg-a target=cannonlake:,icelake:").to_dict()
+        == Spec("pkg-a target=cannonlake:").to_dict()
+    )
+
+
 def test_constrain_dependencies_copies(mock_packages):
     """Tests that constraining a spec with new deps makes proper copies, and does not accidentally
     share dependency instances, leading to corruption of unrelated Spec instances."""

--- a/lib/spack/spack/test/spec_semantics.py
+++ b/lib/spack/spack/test/spec_semantics.py
@@ -1999,8 +1999,11 @@ def test_abstract_contains_semantic(lhs, rhs, expected, mock_packages):
         # is the family root and broadwell and later are above haswell.
         (Spec, "target=:haswell", "target=x86_64:", (True, True, False)),
         (Spec, "target=:haswell", "target=x86_64_v4:", (False, False, False)),
-        # Edge case of uarch that split in a diamond structure, from a common ancestor
-        (Spec, "target=:cascadelake", "target=:cannonlake", (False, False, False)),
+        # Microarchitectures splitting in a diamond: targets up to the common ancestor (skylake)
+        # are below both bounds, so the ranges intersect without either containing the other.
+        (Spec, "target=:cascadelake", "target=:cannonlake", (True, False, False)),
+        # The same diamond seen from below: targets from icelake up are above both bounds.
+        (Spec, "target=cascadelake:", "target=cannonlake:", (True, False, False)),
         # Spec with compilers
         (Spec, "mpileaks %gcc@5", "mpileaks %gcc@6", (False, False, False)),
         # %gcc sits behind an unpinned ^callpath edge, so callpath need not be one node:
@@ -2066,6 +2069,8 @@ def test_intersects_and_satisfies(mock_packages, factory, lhs_str, rhs_str, resu
             True,
             "target=x86_64_v2:haswell",
         ),
+        # a range already inside the other is the intersection, so there is nothing to narrow
+        (Spec, "target=:icelake", "target=x86_64:", False, "target=:icelake"),
     ],
 )
 def test_constrain(factory, lhs_str, rhs_str, result, constrained_str, mock_packages):
@@ -2118,6 +2123,38 @@ def test_a_target_range_inside_another_one_is_dropped_from_the_list(mock_package
         Spec("pkg-a target=cannonlake:,icelake:").to_dict()
         == Spec("pkg-a target=cannonlake:").to_dict()
     )
+
+
+def test_incomparable_target_bounds_meet_as_a_union_of_ranges(mock_packages):
+    """Microarchitectures are ordered by a DAG, not a lattice, so two ranges can have more than one
+    minimal common bound. The intersection is then a list of ranges."""
+    lhs, rhs = Spec("pkg-a target=cascadelake:"), Spec("pkg-a target=cannonlake:")
+    forward, backward = lhs.copy(), rhs.copy()
+    forward.constrain(rhs)
+    backward.constrain(lhs)
+    assert str(forward.architecture.target) == "icelake:"
+    assert forward.to_dict() == backward.to_dict()
+
+    # the intersection is the greatest lower bound, not merely some spec inside both
+    assert Spec("pkg-a target=icelake").satisfies(forward)
+
+    # armv8.6a and neoverse_n1 have two minimal common upper bounds, so the result is a list
+    lhs, rhs = Spec("pkg-a target=armv8.6a:"), Spec("pkg-a target=neoverse_n1:")
+    forward, backward = lhs.copy(), rhs.copy()
+    forward.constrain(rhs)
+    backward.constrain(lhs)
+    assert str(forward.architecture.target) == "ampere1:,ampere1a:"
+    assert forward.to_dict() == backward.to_dict()
+
+    # the most extreme case in the target graph: armv8.3a and cortex_a72 have five minimal
+    # common upper bounds, none of which contains another
+    lhs, rhs = Spec("pkg-a target=armv8.3a:"), Spec("pkg-a target=cortex_a72:")
+    forward, backward = lhs.copy(), rhs.copy()
+    forward.constrain(rhs)
+    backward.constrain(lhs)
+    expected = "ampere1:,ampere1a:,neoverse_n2:,neoverse_v1:,neoverse_v2:"
+    assert str(forward.architecture.target) == expected
+    assert forward.to_dict() == backward.to_dict()
 
 
 def test_constrain_dependencies_copies(mock_packages):

--- a/lib/spack/spack/test/spec_semantics.py
+++ b/lib/spack/spack/test/spec_semantics.py
@@ -2008,6 +2008,17 @@ def test_abstract_contains_semantic(lhs, rhs, expected, mock_packages):
         (Spec, "target=:aarch64", "target=aarch64", (True, True, True)),
         (Spec, "target=aarch64:aarch64", "target=aarch64", (True, True, True)),
         (Spec, "target=icelake:icelake", "target=icelake", (True, True, True)),
+        # A range covered only by the union of the rhs ranges, not by a single one of them
+        (Spec, "target=:alderlake", "target=:icelake,:arrowlake", (True, True, False)),
+        (
+            Spec,
+            "target=:x86_64_v3",
+            "target=x86_64_v3:x86_64_v4,:sandybridge",
+            (True, True, False),
+        ),
+        # The unbounded range is the universe of targets and target=* is an alias for it
+        (Spec, "target=:", "target=:", (True, True, True)),
+        (Spec, "target=*", "target=:", (True, True, True)),
         # Bounds outside the microarchitecture table compare by name only, without raising
         (Spec, "target=foo:", "target=foo:", (True, True, True)),
         (Spec, "target=foo", "target=foo:", (True, True, False)),
@@ -2083,6 +2094,18 @@ def test_intersects_and_satisfies(mock_packages, factory, lhs_str, rhs_str, resu
         # ":aarch64" contains only aarch64 and canonicalizes to the singleton instead of a range
         (Spec, "target=:aarch64", "target=aarch64:", False, "target=aarch64"),
         (Spec, "target=aarch64:", "target=:aarch64", True, "target=aarch64"),
+        # The unbounded range intersects itself and constrains nothing
+        (Spec, "target=:", "target=:", False, "target=:"),
+        # A range covered by the union of the rhs ranges is already the intersection
+        (
+            Spec,
+            "target=:x86_64_v3",
+            "target=x86_64_v3:x86_64_v4,:sandybridge",
+            False,
+            "target=:x86_64_v3",
+        ),
+        # target=* is an alias for the unbounded range, so a named target narrows it
+        (Spec, "target=*", "target=haswell", True, "target=haswell"),
     ],
 )
 def test_constrain(factory, lhs_str, rhs_str, result, constrained_str, mock_packages):

--- a/lib/spack/spack/test/spec_semantics.py
+++ b/lib/spack/spack/test/spec_semantics.py
@@ -2016,7 +2016,7 @@ def test_abstract_contains_semantic(lhs, rhs, expected, mock_packages):
             "target=x86_64_v3:x86_64_v4,:sandybridge",
             (True, True, False),
         ),
-        # The unbounded range is the universe of targets and target=* is an alias for it
+        # target=* is an alias for target=: and means the unbounded range
         (Spec, "target=:", "target=:", (True, True, True)),
         (Spec, "target=*", "target=:", (True, True, True)),
         # Bounds outside the microarchitecture table compare by name only, without raising
@@ -2094,7 +2094,7 @@ def test_intersects_and_satisfies(mock_packages, factory, lhs_str, rhs_str, resu
         # ":aarch64" contains only aarch64 and canonicalizes to the singleton instead of a range
         (Spec, "target=:aarch64", "target=aarch64:", False, "target=aarch64"),
         (Spec, "target=aarch64:", "target=:aarch64", True, "target=aarch64"),
-        # The unbounded range intersects itself and constrains nothing
+        # Constrain is idemptotent on the unbounded range
         (Spec, "target=:", "target=:", False, "target=:"),
         # A range covered by the union of the rhs ranges is already the intersection
         (
@@ -2104,7 +2104,7 @@ def test_intersects_and_satisfies(mock_packages, factory, lhs_str, rhs_str, resu
             False,
             "target=:x86_64_v3",
         ),
-        # target=* is an alias for the unbounded range, so a named target narrows it
+        # target=* can be constrained by a specific target
         (Spec, "target=*", "target=haswell", True, "target=haswell"),
     ],
 )

--- a/lib/spack/spack/test/spec_semantics.py
+++ b/lib/spack/spack/test/spec_semantics.py
@@ -2176,6 +2176,67 @@ def test_incomparable_target_bounds_meet_as_a_union_of_ranges(mock_packages):
     assert forward.to_dict() == backward.to_dict()
 
 
+def test_adjacent_target_ranges_fuse_into_one_canonical_state(mock_packages):
+    """Two ranges tiling one interval denote the same set as the interval itself, so they are
+    fused into it: the tiling and the interval are one state that satisfies both ways."""
+    tiling = Spec("pkg-a target=nocona:nehalem,nehalem:haswell")
+    interval = Spec("pkg-a target=nocona:haswell")
+    assert str(tiling.architecture.target) == "nocona:haswell"
+    assert tiling.to_dict() == interval.to_dict()
+    assert tiling.dag_hash() == interval.dag_hash()
+    assert tiling.satisfies(interval) and interval.satisfies(tiling)
+
+
+def test_consecutive_targets_fuse_into_a_range(mock_packages):
+    """A list of targets whose union is an interval is canonicalized to that interval."""
+    listed = Spec("pkg-a target=alderlake,arrowlake")
+    ranged = Spec("pkg-a target=alderlake:arrowlake")
+    assert listed.to_dict() == ranged.to_dict()
+    assert listed.dag_hash() == ranged.dag_hash()
+
+
+def test_the_meet_of_a_range_and_its_tiling_is_the_range(mock_packages):
+    """Constraining a range by a tiling of a subrange fuses the intersection back into one
+    element, so the meet is a state that satisfies both operands."""
+    lhs, rhs = Spec("pkg-a target=:haswell"), Spec("pkg-a target=nocona:nehalem,nehalem:haswell")
+    forward, backward = lhs.copy(), rhs.copy()
+    forward.constrain(rhs)
+    backward.constrain(lhs)
+    assert str(forward.architecture.target) == "nocona:haswell"
+    assert forward.to_dict() == backward.to_dict()
+    assert forward.satisfies(lhs) and forward.satisfies(rhs)
+
+
+@pytest.mark.parametrize(
+    "target_str,canonical",
+    [
+        ("nocona:nehalem,nehalem:haswell", "nocona:haswell"),
+        ("alderlake,arrowlake", "alderlake:arrowlake"),
+        # the open range covers every target above nocona, leaving only the family root
+        ("nocona:,x86_64:core2", "nocona:,x86_64"),
+        ("nocona:,x86_64:nocona", "nocona:,x86_64"),
+        # ranges with a gap between them are not fused
+        ("x86_64:nocona,haswell:broadwell", ":nocona,haswell:broadwell"),
+        ("nocona,haswell", "haswell,nocona"),
+        # a range with incomparable bounds denotes no target and is dropped from the list
+        ("zen:haswell,nocona", "nocona"),
+    ],
+)
+def test_target_lists_have_one_canonical_idempotent_form(mock_packages, target_str, canonical):
+    """A target list is stored as a canonical decomposition of the set it denotes: parsing the
+    canonical form gives the same state as the original list."""
+    spec = Spec(f"pkg-a target={target_str}")
+    assert str(spec.architecture.target) == canonical
+    assert spec.to_dict() == Spec(f"pkg-a target={canonical}").to_dict()
+
+
+def test_unknown_target_names_in_lists_are_kept_verbatim(mock_packages):
+    """Bounds outside the microarchitecture table cannot be compared, so their elements are kept
+    as they are instead of raising."""
+    spec = Spec("pkg-a target=nocona:,foo:")
+    assert str(spec.architecture.target) == "foo:,nocona:"
+
+
 def test_constrain_dependencies_copies(mock_packages):
     """Tests that constraining a spec with new deps makes proper copies, and does not accidentally
     share dependency instances, leading to corruption of unrelated Spec instances."""

--- a/lib/spack/spack/test/spec_semantics.py
+++ b/lib/spack/spack/test/spec_semantics.py
@@ -2004,6 +2004,10 @@ def test_abstract_contains_semantic(lhs, rhs, expected, mock_packages):
         (Spec, "target=:cascadelake", "target=:cannonlake", (True, False, False)),
         # The same diamond seen from below: targets from icelake up are above both bounds.
         (Spec, "target=cascadelake:", "target=cannonlake:", (True, False, False)),
+        # Ranges that are singletons are canonicalized to their only element
+        (Spec, "target=:aarch64", "target=aarch64", (True, True, True)),
+        (Spec, "target=aarch64:aarch64", "target=aarch64", (True, True, True)),
+        (Spec, "target=icelake:icelake", "target=icelake", (True, True, True)),
         # Spec with compilers
         (Spec, "mpileaks %gcc@5", "mpileaks %gcc@6", (False, False, False)),
         # %gcc sits behind an unpinned ^callpath edge, so callpath need not be one node:
@@ -2071,6 +2075,9 @@ def test_intersects_and_satisfies(mock_packages, factory, lhs_str, rhs_str, resu
         ),
         # a range already inside the other is the intersection, so there is nothing to narrow
         (Spec, "target=:icelake", "target=x86_64:", False, "target=:icelake"),
+        # ":aarch64" contains only aarch64 and canonicalizes to the singleton instead of a range
+        (Spec, "target=:aarch64", "target=aarch64:", False, "target=aarch64"),
+        (Spec, "target=aarch64:", "target=:aarch64", True, "target=aarch64"),
     ],
 )
 def test_constrain(factory, lhs_str, rhs_str, result, constrained_str, mock_packages):
@@ -2114,6 +2121,18 @@ def test_one_target_range_is_one_canonical_state(mock_packages):
     long, short = Spec("pkg-a target=x86_64:icelake"), Spec("pkg-a target=:icelake")
     assert long.to_dict() == short.to_dict()
     assert long.dag_hash() == short.dag_hash()
+
+
+@pytest.mark.parametrize(
+    "range_str,target_str",
+    [(":aarch64", "aarch64"), ("aarch64:aarch64", "aarch64"), ("icelake:icelake", "icelake")],
+)
+def test_a_singleton_target_range_is_the_concrete_target(mock_packages, range_str, target_str):
+    """A range denoting a singleton is canonicalized to that element."""
+    ranged, concrete = Spec(f"pkg-a target={range_str}"), Spec(f"pkg-a target={target_str}")
+    assert ranged.to_dict() == concrete.to_dict()
+    assert ranged.dag_hash() == concrete.dag_hash()
+    assert ranged.architecture.target_concrete
 
 
 def test_a_target_range_inside_another_one_is_dropped_from_the_list(mock_packages):

--- a/lib/spack/spack/test/spec_semantics.py
+++ b/lib/spack/spack/test/spec_semantics.py
@@ -2167,16 +2167,16 @@ def test_incomparable_target_bounds_meet_as_a_union_of_ranges(mock_packages):
     forward, backward = lhs.copy(), rhs.copy()
     forward.constrain(rhs)
     backward.constrain(lhs)
-    assert str(forward.architecture.target) == "ampere1:,ampere1a:"
+    assert str(forward.architecture.target) == "ampere1:,neoverse_v3ae:"
     assert forward.to_dict() == backward.to_dict()
 
-    # the most extreme case in the target graph: armv8.3a and cortex_a72 have five minimal
+    # the most extreme case in the target graph: armv8.3a and cortex_a72 have four minimal
     # common upper bounds, none of which contains another
     lhs, rhs = Spec("pkg-a target=armv8.3a:"), Spec("pkg-a target=cortex_a72:")
     forward, backward = lhs.copy(), rhs.copy()
     forward.constrain(rhs)
     backward.constrain(lhs)
-    expected = "ampere1:,ampere1a:,neoverse_n2:,neoverse_v1:,neoverse_v2:"
+    expected = "ampere1:,neoverse_n2:,neoverse_v1:,neoverse_v2:"
     assert str(forward.architecture.target) == expected
     assert forward.to_dict() == backward.to_dict()
 


### PR DESCRIPTION
Fix various bugs related to `target` in Spec.

Intersection was broken:

```python
>>> Spec("pkg-a target=x86_64").satisfies("pkg-a target=:zen2")
True
>>> Spec("pkg-a target=x86_64").satisfies("pkg-a target=:icelake")
True
>>> Spec("pkg-a target=:zen2").intersects("pkg-a target=:icelake")
False  # wrong
```

Constrain mutates even if the set of microarchs didn't change, which is a lack of normalization that we do have in version lists:

```python
>>> Spec("target=x86_64:").constrained("target=:zen2")
target=x86_64:zen2
>>> Spec("target=:zen2") == Spec("target=x86_64:zen2")  # same
False
>>> Spec("target=x86_64:,x86_64_v2:,x86_64_v3:")  # same as x86_64:, not reduced
target=x86_64:,x86_64_v2:,x86_64_v3:
```

`satisfies` checked overlap instead of containment:

```python
>>> Spec("pkg-a target=x86_64:").satisfies("pkg-a target=haswell")
True  # wrong
```

The implementation treats each entry as an interval, even if it contains a single concrete item. The overlap of two intervals starts at a common upper bound of their lower bounds and ends at a common lower bound of their upper bounds. The target graph is not a lattice, so instead of a unique join and meet there can be several minimal upper bounds and maximal lower bounds, and one pair of intervals can produce several intervals: one per combination. The most extreme case is on aarch64:

```python
>>> Spec("target=armv8.3a:").constrained("target=cortex_a72:")
target=ampere1:,ampere1a:,neoverse_n2:,neoverse_v1:,neoverse_v2:
```

The result is canonical: entries are sorted, an entry contained in another is dropped, and a lower bound at the family root is left implicit, so `x86_64:zen2` prints as `:zen2`.

Canonicalization also has to merge contiguous entries:

```python
>>> Spec("pkg-a target=nocona:nehalem,nehalem:haswell").satisfies("pkg-a target=nocona:haswell")
True
>>> Spec("pkg-a target=nocona:haswell").satisfies("pkg-a target=nocona:nehalem,nehalem:haswell")
False  # wrong: both denote the same seven targets
>>> Spec("pkg-a target=alderlake:arrowlake").satisfies("pkg-a target=alderlake,arrowlake")
False  # wrong: alderlake is arrowlake's only parent
>>> Spec("target=nocona:haswell").constrained("target=nocona:nehalem,nehalem:haswell")
target=nehalem:haswell,nocona:nehalem  # should be target=nocona:haswell
```

Two more failures in canonicalization fixed by the same rewrite:

```python
>>> Spec("target=zen:haswell,nocona")
target=nocona,zen:haswell  # zen:haswell has incomparable bounds and denotes no target;
                           # it is now dropped, leaving the concrete target=nocona
>>> Spec("pkg-a target=nocona:,foo:")
SpecParsingError: "foo" is not a valid target name  # entries with names outside the table
                                                    # cannot be compared; they are now kept
                                                    # verbatim: target=foo:,nocona:
```


Comparing against a range with a name outside the table raised instead of comparing:

```python
>>> Spec("pkg-a target=haswell").intersects("pkg-a target=foo:")
ValueError: "foo" is not a valid target name  # now False
>>> Spec("pkg-a target=foo").satisfies("pkg-a target=foo:")
ValueError: "foo" is not a valid target name  # now True: unknown names compare by name only
```


`target=*` and `target=:` both denote every target and mutually satisfy each other, but neither behaved as "all targets". The range form broke reflexivity:

```python
>>> Spec("target=:").satisfies("target=:")
False  # wrong
>>> Spec("target=:").intersects("target=:")
False  # wrong
>>> Spec("target=:").constrained("target=:")
UnsatisfiableArchitectureSpecError: None-None-: does not satisfy None-None-:
```

and the `*` qualified as "concrete target", meaning it was taken literally by the solver:

```python
>>> Spec("zlib target=*").architecture.target_concrete
True  # wrong: satisfied by every target, like a range
>>> spack.concretize.concretize_one("zlib target=*")
SpecError: the target '*' in 'zlib target=* is not a known target.
>>> Spec("pkg-a").constrained("pkg-a target=*")  # the meet of two solvable specs
pkg-a target=*                                   # did not solve
>>> Spec("target=icelake:alderlake").intersects("target=*")
True  # wrong: the lhs denotes no target
```

`target=*` is now canonicalized to `target=:` which is like `@:` for version lists. The solver treats `target=:` the same now as no target specified at all, which would need revision would we make `target` optional.