### PR TITLE
tty: cache isatty of the std file descriptors

### DIFF
--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -1190,6 +1190,7 @@ def _setup_pkg_and_run(
         if stderr_pipe is not None:
             os.dup2(stderr_pipe.fileno(), sys.stderr.fileno())
             stderr_pipe.close()
+        tty.clear_isatty_cache()
 
         pkg = serialized_pkg.restore()
 

--- a/lib/spack/spack/main.py
+++ b/lib/spack/spack/main.py
@@ -719,6 +719,7 @@ class SpackCommand:
             sys.stderr.flush()
             for fd in fds:
                 os.dup2(tmp_file.fileno(), fd)
+            tty.clear_isatty_cache()
             try:
                 yield self
             finally:
@@ -727,6 +728,7 @@ class SpackCommand:
                 for fd, saved_fd in saved_fds.items():
                     os.dup2(saved_fd, fd)
                     os.close(saved_fd)
+                tty.clear_isatty_cache()
                 tmp_file.seek(0)
                 self.binary_output = tmp_file.read()
 

--- a/lib/spack/spack/test/conftest.py
+++ b/lib/spack/spack/test/conftest.py
@@ -67,6 +67,7 @@ import spack.util.lock
 import spack.util.naming
 import spack.util.parallel
 import spack.util.spack_yaml as syaml
+import spack.util.tty
 import spack.util.tty.color
 import spack.util.url as url_util
 import spack.util.web
@@ -2397,6 +2398,10 @@ def nullify_globals(request, monkeypatch):
 
 
 def pytest_runtest_setup(item):
+    # Tests redirect std fds (capfd, dup2) without going through spack code, so cached isatty()
+    # results from a previous test may be stale.
+    spack.util.tty.clear_isatty_cache()
+
     # Skip test marked "not_on_windows" if they're run on Windows
     not_on_windows_marker = item.get_closest_marker(name="not_on_windows")
     if not_on_windows_marker and sys.platform == "win32":

--- a/lib/spack/spack/test/util/tty/color.py
+++ b/lib/spack/spack/test/util/tty/color.py
@@ -120,3 +120,61 @@ def test_color_stream_follows_the_stream_it_wraps(monkeypatch, when, expected):
         color.ColorStream(stream).write("@r{red}")
 
     assert stream.getvalue() == expected
+
+
+class MockFdStream(MockStream):
+    """A stream with a file descriptor number and a counting ``isatty()``."""
+
+    def __init__(self, isatty: bool, fd: int) -> None:
+        super().__init__(isatty)
+        self._fd = fd
+        self.isatty_calls = 0
+
+    def fileno(self) -> int:
+        return self._fd
+
+    def isatty(self) -> bool:
+        self.isatty_calls += 1
+        return self._isatty
+
+
+def test_get_color_when_caches_isatty_of_std_fds():
+    """isatty() of fds 0-2 is queried once and re-queried after invalidation."""
+    stream = MockFdStream(isatty=True, fd=1)
+    try:
+        with color.color_when(None):
+            assert color.get_color_when(stream) is True
+            assert color.get_color_when(stream) is True
+        assert stream.isatty_calls == 1
+
+        color.clear_isatty_cache()
+        with color.color_when(None):
+            assert color.get_color_when(stream) is True
+        assert stream.isatty_calls == 2
+    finally:
+        color.clear_isatty_cache()
+
+
+def test_get_color_when_does_not_cache_high_fds():
+    """Streams on fds above 2 are queried every time and stay out of the cache."""
+    stream = MockFdStream(isatty=True, fd=7)
+    try:
+        with color.color_when(None):
+            assert color.get_color_when(stream) is True
+            assert color.get_color_when(stream) is True
+        assert stream.isatty_calls == 2
+        assert 7 not in color._isatty_cache
+    finally:
+        color.clear_isatty_cache()
+
+
+def test_get_color_when_does_not_cache_fd_less_streams():
+    """Streams without a file descriptor (StringIO) are queried every time, not cached."""
+    stream = MockStream(isatty=True)
+    try:
+        with color.color_when(None):
+            assert color.get_color_when(stream) is True
+            assert color.get_color_when(stream) is True
+        assert not color._isatty_cache
+    finally:
+        color.clear_isatty_cache()

--- a/lib/spack/spack/test/util/tty/log.py
+++ b/lib/spack/spack/test/util/tty/log.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 import contextlib
+import os
 import pathlib
 import sys
 from types import ModuleType
@@ -12,7 +13,7 @@ import pytest
 
 from spack.util.executable import Executable
 from spack.util.filesystem import working_dir
-from spack.util.tty import log
+from spack.util.tty import color, log
 
 termios: Optional[ModuleType] = None
 try:
@@ -198,3 +199,21 @@ def test_nested_logging_contexts(capfd, tmp_path):
             log_captured_out = f.read()
             assert "inner\n" in log_captured_out
             assert "outer\n" not in log_captured_out
+
+
+def test_redirect_stdio_clears_isatty_cache():
+    """Both redirect_stdio and restore_stdio invalidate cached isatty() results."""
+    read_fd, write_fd = os.pipe()
+    try:
+        color._isatty_cache[1] = True
+        saved_fds = log.redirect_stdio(write_fd)
+        try:
+            assert not color._isatty_cache
+            color._isatty_cache[1] = True
+        finally:
+            log.restore_stdio(saved_fds)
+        assert not color._isatty_cache
+    finally:
+        color.clear_isatty_cache()
+        os.close(read_fd)
+        os.close(write_fd)

--- a/lib/spack/spack/util/tty/__init__.py
+++ b/lib/spack/spack/util/tty/__init__.py
@@ -14,6 +14,7 @@ from types import TracebackType
 from typing import IO, Callable, Iterator, NoReturn, Optional, Type, Union
 
 from .color import cescape, clen, cprint, cwrite
+from .color import clear_isatty_cache as clear_isatty_cache
 
 # Globals
 _debug = 0

--- a/lib/spack/spack/util/tty/colify.py
+++ b/lib/spack/spack/util/tty/colify.py
@@ -12,7 +12,7 @@ import shutil
 import sys
 from typing import IO, Any, List, Optional
 
-from spack.util.tty.color import cextra, clen
+from spack.util.tty.color import _cached_isatty, cextra, clen
 
 
 class ColumnConfig:
@@ -163,7 +163,7 @@ def colify(
 
     # Use only one column if not a tty, unless cols specified explicitly
     if not cols and not tty:
-        if tty is False or not output.isatty():
+        if tty is False or not _cached_isatty(output):
             cols = 1
 
     # Specify the number of character columns to use.

--- a/lib/spack/spack/util/tty/color.py
+++ b/lib/spack/spack/util/tty/color.py
@@ -65,7 +65,7 @@ import re
 import sys
 import textwrap
 from contextlib import contextmanager
-from typing import IO, Iterator, List, NamedTuple, Optional, Tuple, Union
+from typing import IO, Dict, Iterator, List, NamedTuple, Optional, Tuple, Union
 
 
 class ColorParseError(Exception):
@@ -186,6 +186,29 @@ def try_enable_terminal_color_on_windows() -> None:
             _force_color = False
 
 
+#: isatty cache for fd 0-2. Must be cleared when a std fd is redirected with dup2.
+_isatty_cache: Dict[int, bool] = {}
+
+
+def _cached_isatty(stream) -> bool:
+    """``stream.isatty()``, cached by file descriptor for the std fds 0-2."""
+    try:
+        fd = stream.fileno()
+    except (AttributeError, ValueError, OSError):
+        return stream.isatty()  # in-memory streams like StringIO: no syscall involved
+    if fd > 2:
+        return stream.isatty()  # short-lived fds: fd number reuse would leave stale entries
+    result = _isatty_cache.get(fd)
+    if result is None:
+        result = _isatty_cache[fd] = bool(stream.isatty())
+    return result
+
+
+def clear_isatty_cache() -> None:
+    """Forget cached isatty() results, after a std fd was redirected with dup2."""
+    _isatty_cache.clear()
+
+
 def get_color_when(stream=None) -> bool:
     """Return whether output written to ``stream`` should be colored or not.
 
@@ -196,7 +219,7 @@ def get_color_when(stream=None) -> bool:
         return _force_color
     if stream is None:
         stream = sys.stdout
-    return stream.isatty()
+    return _cached_isatty(stream)
 
 
 def set_color_when(when: Union[str, bool, None]) -> None:

--- a/lib/spack/spack/util/tty/log.py
+++ b/lib/spack/spack/util/tty/log.py
@@ -386,6 +386,7 @@ def redirect_stdio(write_fd: int) -> Dict[int, int]:
     for fd in {sys.stdout.fileno(), sys.stderr.fileno(), 1, 2}:
         saved_fds[fd] = os.dup(fd)
         os.dup2(write_fd, fd)
+    tty.clear_isatty_cache()
     return saved_fds
 
 
@@ -396,6 +397,7 @@ def restore_stdio(saved_fds: Dict[int, int]) -> None:
     for fd, saved_fd in saved_fds.items():
         os.dup2(saved_fd, fd)
         os.close(saved_fd)
+    tty.clear_isatty_cache()
 
 
 def _process_line(
@@ -792,6 +794,7 @@ def _writer_daemon(
     if stdout_fd:
         os.dup2(stdout_fd.fileno(), sys.stdout.fileno())
         stdout_fd.close()
+    tty.clear_isatty_cache()
 
     # list of streams to select from
     istreams = [read_file, stdin_file] if stdin_file else [read_file]


### PR DESCRIPTION
Functions like `Spec.cformat` check `get_color_when` for each component,
which means a single `cformat` call is multiple ioctl syscalls, which is
bizarre. Instead of fixing all call sites (e.g. `spack.installer` has a proper
implementation), add a global cache.

This commit caches the result per file descriptor in the range 0-2,
which should be safe (higher fds get reused on close/open, but you break
cpython if you close stdin, stdout, stderr). It is manually cleared wherever
a std fd is redirected through `redirect_stdio`/`restore_stdio`,
`SpackCommand.capture_output`, the forked build child, and the log
output daemon. pytest redirects fds without going through spack code,
so conftest clears the cache before each test.

Streams w/o fd like StringIO don't require a syscall, so for those
there's no point in caching, and they continue to call isatty.

The cache lives in the color module, even though colify benefits from it
too. I don't want to introduce a new sibling module just for this
function.

Before:

```
$ strace -e ioctl  spack find -l |& grep TCGETS | wc -l
5968
```

After:

```
$ strace -e ioctl  spack find -l |& grep TCGETS | wc -l
497
```

Number of syscalls for `spack find` reduces by 36% for me.
