### PR TITLE
spec.py: keep flag propagation in constrain

### DIFF
--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -943,29 +943,6 @@ class CompilerFlag(str):
 _valid_compiler_flags = ["cflags", "cxxflags", "fflags", "ldflags", "ldlibs", "cppflags"]
 
 
-def _shared_subset_pair_iterate(container1, container2):
-    """
-    [0, a, c, d, f]
-    [a, d, e, f]
-
-    yields [(a, a), (d, d), (f, f)]
-
-    no repeated elements
-    """
-    a_idx, b_idx = 0, 0
-    max_a, max_b = len(container1), len(container2)
-    while a_idx < max_a and b_idx < max_b:
-        if container1[a_idx] == container2[b_idx]:
-            yield (container1[a_idx], container2[b_idx])
-            a_idx += 1
-            b_idx += 1
-        else:
-            while container1[a_idx] < container2[b_idx]:
-                a_idx += 1
-            while container1[a_idx] > container2[b_idx]:
-                b_idx += 1
-
-
 class FlagMap(lang.HashableMap[str, List[CompilerFlag]]):
     __slots__ = ()
 
@@ -996,22 +973,11 @@ class FlagMap(lang.HashableMap[str, List[CompilerFlag]]):
                 changed = True
 
             # Next, if any flags in other propagate, we force them to propagate in our case.
-            # CompilerFlag objects can be shared with other specs, so they are replaced rather
-            # than modified in place.
-            shared = sorted(set(other[flag_type]) - extra_other)
-            demoted = {
-                id(y)
-                for x, y in _shared_subset_pair_iterate(shared, sorted(self[flag_type]))
-                if y.propagate is True and x.propagate is False
-            }
-            if demoted:
-                changed = True
-                self[flag_type] = [
-                    CompilerFlag(f, propagate=False, flag_group=f.flag_group, source=f.source)
-                    if id(f) in demoted
-                    else f
-                    for f in self[flag_type]
-                ]
+            other_propagate = {f for f in other[flag_type] if f.propagate}
+            for f in self[flag_type]:
+                if not f.propagate and f in other_propagate:
+                    f.propagate = True
+                    changed = True
 
         # TODO: what happens if flag groups with a partial (but not complete)
         # intersection specify different behaviors for flag propagation?

--- a/lib/spack/spack/test/spec_semantics.py
+++ b/lib/spack/spack/test/spec_semantics.py
@@ -389,10 +389,10 @@ class TestSpecSemantics:
             (
                 'mpich cflags="-O3 -g"',
                 'mpich cflags=="-O3"',
-                'mpich cflags="-O3 -g"',
-                'mpich cflags="-O3 -g"',
-                [],
-                [],
+                'mpich cflags=="-O3" cflags="-g"',
+                'mpich cflags=="-O3" cflags="-g"',
+                [("cflags", "-O3")],
+                [("cflags", "-O3")],
             ),
             (
                 'mpich cflags=="-O3 -g"',
@@ -401,6 +401,14 @@ class TestSpecSemantics:
                 'mpich cflags=="-O3 -g"',
                 [("cflags", "-O3"), ("cflags", "-g")],
                 [("cflags", "-O3"), ("cflags", "-g")],
+            ),
+            (
+                "mpich cflags=-O2 cflags=-g cflags=-fPIC cflags==-pipe",
+                "mpich cflags==-O2 cflags=-g cflags==-fPIC cflags=-pipe",
+                "mpich cflags==-O2 cflags=-g cflags==-fPIC cflags==-pipe",
+                "mpich cflags==-O2 cflags=-g cflags==-fPIC cflags==-pipe",
+                [("cflags", "-O2"), ("cflags", "-fPIC"), ("cflags", "-pipe")],
+                [("cflags", "-O2"), ("cflags", "-fPIC"), ("cflags", "-pipe")],
             ),
         ],
     )


### PR DESCRIPTION
Fix a bug where the meet of a propagating flag and a plain one drops the propagation.

```python
>>> lhs = Spec("pkg-a cflags=-O2")
>>> lhs.constrain("pkg-a cflags==-O2")
False
>>> lhs
pkg-a cflags=-O2
```

`FlagMap.constrain` says it forces a flag that propagates on the rhs to propagate on the lhs too, but the code sets `propagate = False`. A propagating flag applies to a package and to the packages built against it, so it is more constrained.

This is the right intersection because every node takes compiler flags: `cflags==-O2` emits `node_flag_set` on the node itself as well as `propagate`, so it is strictly narrower than `cflags=-O2`. Variants are not like that. `foo==bar` emits `variant_set` only where the package declares the variant, so it does not require `foo` to exist on this node and `foo=bar` does. Those two are incomparable, and the same rule would be wrong there.

