### PR TITLE
spec_parser.py: attach a ^dep only when its sub-dag is complete

### DIFF
--- a/lib/spack/spack/spec_parser.py
+++ b/lib/spack/spack/spec_parser.py
@@ -317,12 +317,9 @@ class SpecParser:
         if not self.ctx.next_token:
             return initial_spec
 
-        def add_dependency(dep, **edge_properties):
-            """wrapper around root_spec._add_dependency"""
-            try:
-                target_spec._add_dependency(dep, **edge_properties)
-            except spack.error.SpecError as e:
-                raise SpecParsingError(str(e), self.ctx.current_token, self.literal_str) from e
+        # A ^ dependency is attached to the root only once its trailing % edges are parsed:
+        # merging it earlier would compare an incomplete sub-dag against the existing edges.
+        pending: Optional[Tuple["spack.spec.Spec", dict, Token]] = None
 
         if not initial_spec:
             from spack.spec import Spec
@@ -357,16 +354,41 @@ class SpecParser:
             dependency = self._parse_node(root_spec)
 
             if is_direct:
-                target_spec = current_spec
                 if dependency.name in LEGACY_COMPILER_TO_BUILTIN:
                     dependency.name = LEGACY_COMPILER_TO_BUILTIN[dependency.name]
+                self._attach_dependency(
+                    current_spec, dependency, self.ctx.current_token, **edge_properties
+                )
             else:
+                self._attach_pending(root_spec, pending)
                 current_spec = dependency
-                target_spec = root_spec
+                pending = (dependency, edge_properties, self.ctx.current_token)
 
-            add_dependency(dependency, **edge_properties)
+        self._attach_pending(root_spec, pending)
 
         return root_spec
+
+    def _attach_pending(
+        self,
+        root_spec: "spack.spec.Spec",
+        pending: Optional[Tuple["spack.spec.Spec", dict, Token]],
+    ) -> None:
+        """Attach the pending ^ dependency, whose sub-dag is complete now."""
+        if pending is not None:
+            dependency, edge_properties, token = pending
+            self._attach_dependency(root_spec, dependency, token, **edge_properties)
+
+    def _attach_dependency(
+        self,
+        target_spec: "spack.spec.Spec",
+        dependency: "spack.spec.Spec",
+        token: Token,
+        **edge_properties,
+    ) -> None:
+        try:
+            target_spec._add_dependency(dependency, **edge_properties)
+        except spack.error.SpecError as e:
+            raise SpecParsingError(str(e), token, self.literal_str) from e
 
     def _parse_node(self, root_spec: "spack.spec.Spec", root: bool = True):
         dependency = SpecNodeParser(self.ctx, self.literal_str).parse(root=root)

--- a/lib/spack/spack/test/spec_syntax.py
+++ b/lib/spack/spack/test/spec_syntax.py
@@ -716,6 +716,63 @@ def specfile_for(config, mock_packages):
             ],
             "^[deptypes=build,link] zlib",
         ),
+        # A bare duplicate ^pkg-b is redundant, on either side of the % edge.
+        (
+            "pkg-a ^pkg-b %pkg-c ^pkg-b",
+            [
+                Token(SpecTokens.UNQUALIFIED_PACKAGE_NAME, value="pkg-a"),
+                Token(SpecTokens.DEPENDENCY, value="^"),
+                Token(SpecTokens.UNQUALIFIED_PACKAGE_NAME, value="pkg-b"),
+                Token(SpecTokens.DEPENDENCY, value="%"),
+                Token(SpecTokens.UNQUALIFIED_PACKAGE_NAME, value="pkg-c"),
+                Token(SpecTokens.DEPENDENCY, value="^"),
+                Token(SpecTokens.UNQUALIFIED_PACKAGE_NAME, value="pkg-b"),
+            ],
+            "pkg-a ^pkg-b %pkg-c",
+        ),
+        # A ^ dependency is merged only once its trailing % edges are parsed: the % edge
+        # survives on the merged node.
+        (
+            "pkg-a ^pkg-b ^pkg-b %pkg-c",
+            [
+                Token(SpecTokens.UNQUALIFIED_PACKAGE_NAME, value="pkg-a"),
+                Token(SpecTokens.DEPENDENCY, value="^"),
+                Token(SpecTokens.UNQUALIFIED_PACKAGE_NAME, value="pkg-b"),
+                Token(SpecTokens.DEPENDENCY, value="^"),
+                Token(SpecTokens.UNQUALIFIED_PACKAGE_NAME, value="pkg-b"),
+                Token(SpecTokens.DEPENDENCY, value="%"),
+                Token(SpecTokens.UNQUALIFIED_PACKAGE_NAME, value="pkg-c"),
+            ],
+            "pkg-a ^pkg-b %pkg-c",
+        ),
+        (
+            "pkg-a ^pkg-b ^pkg-b@1 %pkg-c",
+            [
+                Token(SpecTokens.UNQUALIFIED_PACKAGE_NAME, value="pkg-a"),
+                Token(SpecTokens.DEPENDENCY, value="^"),
+                Token(SpecTokens.UNQUALIFIED_PACKAGE_NAME, value="pkg-b"),
+                Token(SpecTokens.DEPENDENCY, value="^"),
+                Token(SpecTokens.UNQUALIFIED_PACKAGE_NAME, value="pkg-b"),
+                Token(SpecTokens.VERSION, value="@1"),
+                Token(SpecTokens.DEPENDENCY, value="%"),
+                Token(SpecTokens.UNQUALIFIED_PACKAGE_NAME, value="pkg-c"),
+            ],
+            "pkg-a ^pkg-b@1 %pkg-c",
+        ),
+        (
+            "pkg-a ^pkg-b@1 ^pkg-b %pkg-c",
+            [
+                Token(SpecTokens.UNQUALIFIED_PACKAGE_NAME, value="pkg-a"),
+                Token(SpecTokens.DEPENDENCY, value="^"),
+                Token(SpecTokens.UNQUALIFIED_PACKAGE_NAME, value="pkg-b"),
+                Token(SpecTokens.VERSION, value="@1"),
+                Token(SpecTokens.DEPENDENCY, value="^"),
+                Token(SpecTokens.UNQUALIFIED_PACKAGE_NAME, value="pkg-b"),
+                Token(SpecTokens.DEPENDENCY, value="%"),
+                Token(SpecTokens.UNQUALIFIED_PACKAGE_NAME, value="pkg-c"),
+            ],
+            "pkg-a ^pkg-b@1 %pkg-c",
+        ),
         (
             "^[deptypes=link] zlib ^[deptypes=build] zlib",
             [


### PR DESCRIPTION
Fix a bug where a trailing `%` edge is dropped after a duplicate `^dep`:

```python
>>> Spec("pkg-a ^pkg-b %pkg-c ^pkg-b")
pkg-a ^pkg-b %pkg-c
>>> Spec("pkg-a ^pkg-b ^pkg-b %pkg-c")
pkg-a ^pkg-b
```

The parser attached each `^dep` to the root as soon as the node itself was parsed. When the new edge merged into an existing one, the parsed node was discarded, yet the parser kept targeting it, so the following `%` edges landed on a node unreachable from the root. Hold the last `^dep` pending and attach it when the next `^dep` arrives or the spec ends.