### PR TITLE
spec.py: a transitive edge does not satisfy a direct edge

### DIFF
--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -1538,8 +1538,13 @@ def _get_satisfying_edge(
     lhs_node: "Spec", rhs_edge: DependencySpec, *, resolve_virtuals: bool
 ) -> Optional[DependencySpec]:
     """Search for an edge in ``lhs_node`` that satisfies ``rhs_edge``."""
-    # First check direct deps of all types.
+    # First check direct deps of all types. There is a subtlety: only abstract specs distinguish
+    # between direct and indirect edges, whereas concrete specs always have direct edges (without
+    # setting the direct flag).
+    require_direct = rhs_edge.direct and not lhs_node.concrete
     for lhs_edge in lhs_node.edges_to_dependencies():
+        if require_direct and not lhs_edge.direct:
+            continue
         if _satisfies_edge(lhs_edge, rhs_edge, resolve_virtuals):
             return lhs_edge
 

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -2909,6 +2909,10 @@ class Spec:
     def _mark_root_concrete(self, value=True):
         """Mark just this spec (not dependencies) concrete."""
         self._concrete = value
+        # A direct dependency is a constraint written with %, so the flag belongs on abstract
+        # specs only; every edge of a materialized DAG is one anyway.
+        for edge in self.edges_to_dependencies():
+            edge.direct = not value
         self._validate_version()
         for variant in self.variants.values():
             variant.concrete = True

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -2913,14 +2913,17 @@ class Spec:
 
     def _mark_root_concrete(self, value=True):
         """Mark just this spec (not dependencies) concrete."""
+        if self._concrete == value:
+            return
         self._concrete = value
         # A direct dependency is a constraint written with %, so the flag belongs on abstract
         # specs only; every edge of a materialized DAG is one anyway.
         for edge in self.edges_to_dependencies():
             edge.direct = not value
-        self._validate_version()
-        for variant in self.variants.values():
-            variant.concrete = True
+        if value:
+            self._validate_version()
+            for variant in self.variants.values():
+                variant.concrete = True
 
     def _validate_version(self):
         # Specs that were concretized with just a git sha as version, without associated

--- a/lib/spack/spack/test/bootstrap.py
+++ b/lib/spack/spack/test/bootstrap.py
@@ -14,11 +14,16 @@ import spack.bootstrap.status
 import spack.compilers.config
 import spack.config
 import spack.environment
+import spack.spec
 import spack.store
 import spack.util.executable
 from spack.active_environment import active_environment
 
 from .conftest import _true
+
+PROTOTYPE_DIR = pathlib.Path(spack.bootstrap.clingo.__file__).parent / "prototypes"
+PROTOTYPES = sorted(x.name for x in PROTOTYPE_DIR.glob("*.json"))
+assert PROTOTYPES, f"no bootstrap prototypes in {PROTOTYPE_DIR}"
 
 
 @pytest.fixture
@@ -308,3 +313,19 @@ def test_use_store_does_not_try_writing_outside_root(
     with spack.store.use_store(user_store):
         assert spack.config.CONFIG.get("config:install_tree:root") == str(user_store)
     assert spack.config.CONFIG.get("config:install_tree:root") == initial_store
+
+
+@pytest.mark.parametrize("prototype", PROTOTYPES)
+def test_prototype_matches_a_constraint_on_its_compiler(prototype):
+    """The bootstrap concretizer edits a prototype with the concreteness flag cleared, picking
+    patches from conditions such as '%msvc@19.38:'. The compiler the prototype records has to
+    match such a condition."""
+    s = spack.spec.Spec.from_specfile(str(PROTOTYPE_DIR / prototype))
+    compilers = [x.spec for x in s.edges_to_dependencies() if "cxx" in x.virtuals]
+    assert compilers, f"{prototype} has no cxx provider"
+    compiler = compilers[0]
+
+    s._mark_concrete(False)
+
+    assert s.satisfies(f"%{compiler.name}")
+    assert s.satisfies(f"%{compiler.name}@{compiler.version}")

--- a/lib/spack/spack/test/spec_semantics.py
+++ b/lib/spack/spack/test/spec_semantics.py
@@ -2401,6 +2401,30 @@ def test_an_anonymous_spec_is_the_top_of_the_order_only(mock_packages):
     assert not Spec("").satisfies("pkg-b")
 
 
+def test_the_direct_flag_follows_concreteness(config, mock_packages):
+    """A direct dependency is a constraint written with %, so the flag is set when a spec stops
+    being concrete and cleared when it becomes concrete again."""
+    mpileaks = spack.concretize.concretize_one("mpileaks")
+    assert not any(edge.direct for edge in mpileaks.traverse_edges(root=False))
+
+    mpileaks._mark_concrete(False)
+    assert all(edge.direct for edge in mpileaks.traverse_edges(root=False))
+
+    mpileaks._mark_concrete(True)
+    assert not any(edge.direct for edge in mpileaks.traverse_edges(root=False))
+
+
+def test_a_spec_that_stopped_being_concrete_matches_a_direct_constraint(config, mock_packages):
+    """A spec that stops being concrete keeps every edge it had, so a direct dependency
+    constraint is matched by the package it depends on, and not by one further down."""
+    mpileaks = spack.concretize.concretize_one("mpileaks")
+    mpileaks._mark_concrete(False)
+
+    assert mpileaks.satisfies("mpileaks %callpath")
+    assert mpileaks.satisfies("mpileaks ^libelf")
+    assert not mpileaks.satisfies("mpileaks %libelf")
+
+
 @pytest.mark.parametrize(
     "spec_str,spec_fmt,expected",
     [

--- a/lib/spack/spack/test/spec_semantics.py
+++ b/lib/spack/spack/test/spec_semantics.py
@@ -2414,6 +2414,17 @@ def test_the_direct_flag_follows_concreteness(config, mock_packages):
     assert not any(edge.direct for edge in mpileaks.traverse_edges(root=False))
 
 
+def test_marking_an_abstract_spec_abstract_again_changes_nothing(mock_packages):
+    """The direct flag only flips when the concreteness actually changes, so marking an abstract
+    spec abstract leaves its transitive edges alone."""
+    spec = Spec("mpileaks ^callpath")
+    spec._mark_concrete(False)
+
+    assert not spec.edges_to_dependencies(name="callpath")[0].direct
+    assert not spec.satisfies("mpileaks %callpath")
+    assert spec.satisfies("mpileaks ^callpath")
+
+
 def test_a_spec_that_stopped_being_concrete_matches_a_direct_constraint(config, mock_packages):
     """A spec that stops being concrete keeps every edge it had, so a direct dependency
     constraint is matched by the package it depends on, and not by one further down."""

--- a/lib/spack/spack/test/spec_semantics.py
+++ b/lib/spack/spack/test/spec_semantics.py
@@ -2425,6 +2425,26 @@ def test_a_spec_that_stopped_being_concrete_matches_a_direct_constraint(config, 
     assert not mpileaks.satisfies("mpileaks %libelf")
 
 
+def test_a_direct_dependency_is_inside_a_transitive_one(mock_packages):
+    """'pkg-a ^pkg-b' means pkg-b is somewhere in the DAG and 'pkg-a %pkg-b' means it is a direct
+    dependency, so the second is inside the first and not the other way around."""
+    anywhere_in_dag = Spec("pkg-a ^pkg-b")
+    direct_dependency = Spec("pkg-a %pkg-b")
+    assert direct_dependency.satisfies(anywhere_in_dag)
+    assert not anywhere_in_dag.satisfies(direct_dependency)
+
+
+def test_every_edge_of_a_concrete_node_is_a_direct_dependency(mock_packages, config):
+    """A concrete spec records its edges without the direct flag, but each of them is a direct
+    dependency in fact, so it matches a direct constraint. A package further down does not."""
+    mpileaks = spack.concretize.concretize_one("mpileaks")
+    assert not mpileaks.edges_to_dependencies(name="callpath")[0].direct
+
+    assert mpileaks.satisfies("mpileaks %callpath")
+    assert mpileaks.satisfies("mpileaks ^libelf")
+    assert not mpileaks.satisfies("mpileaks %libelf")
+
+
 @pytest.mark.parametrize(
     "spec_str,spec_fmt,expected",
     [


### PR DESCRIPTION
Fix a bug where `^` satisfies `%`:

```python
>>> Spec("pkg-a ^pkg-b").satisfies("pkg-a %pkg-b")
True
```

`^` says the target is somewhere in the DAG and `%` says it is a direct dependency, so the second is inside the first and not the other way around. The search for a satisfying edge only descended past depth 1 for a `^` constraint, but at depth 1 it took any edge without checking its direct flag.

The first commit is a prerequisite. A concrete spec records its edges without the direct flag, since every edge of a materialized DAG is a direct dependency anyway, and the flag is meant to come back when the spec stops being concrete. It didn't, so enforcing `%` on its own breaks every clingo bootstrap prototype:

```python
>>> s = Spec.from_specfile(".../prototypes/clingo-linux-x86_64.json")
>>> s._mark_concrete(False)  # what the bootstrap does to adapt it to the host
>>> s.satisfies("%gcc")
False
```

That is how the conditions selecting patches for a compiler are written. Set the flag when a spec stops being concrete and clear it when it becomes concrete again, so no concrete spec has it and specfiles and hashes are unchanged.
