### PR TITLE
spec.py: an anonymous spec is not inside a named one

### DIFF
--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -3438,6 +3438,9 @@ class Spec:
             # objects.
             return self.concrete and self.dag_hash() == other.dag_hash()
 
+        if other.name and not self.name:
+            return False
+
         if self.name != other.name and self.name and other.name:
             # Name mismatch can still be satisfiable if lhs provides the virtual mentioned by rhs.
             if not resolve_virtuals:

--- a/lib/spack/spack/test/spec_semantics.py
+++ b/lib/spack/spack/test/spec_semantics.py
@@ -2365,6 +2365,14 @@ def test_satisfies_and_subscript_with_compilers(config, mock_packages):
     assert s["pkg-a"].dependencies(name="gmake")[0] == s["pkg-a"]["gmake"]
 
 
+def test_an_anonymous_spec_is_the_top_of_the_order_only(mock_packages):
+    """A spec that leaves the name unset denotes every package, so everything is inside it and it
+    is inside nothing that names one. Being the bottom too would break transitivity."""
+    assert Spec("pkg-a").satisfies("")
+    assert Spec("").satisfies("")
+    assert not Spec("").satisfies("pkg-b")
+
+
 @pytest.mark.parametrize(
     "spec_str,spec_fmt,expected",
     [


### PR DESCRIPTION
Fix a bug where satisfies is not transitive:

```python
>>> Spec("pkg-a").satisfies("")
True
>>> Spec("").satisfies("pkg-b")
True
```

The name comparison was guarded on the left-hand side having a name, so a spec that leaves the name unset satisfied any name and was satisfied by any name too. A spec with no name denotes every package, so it is the top of the order only.