### PR TITLE
splicing: keep the package hash of automatically spliced specs

### DIFF
--- a/lib/spack/spack/solver/splicing.py
+++ b/lib/spack/spack/solver/splicing.py
@@ -5,6 +5,7 @@ from functools import cmp_to_key
 from typing import Dict, List, NamedTuple
 
 import spack.deptypes as dt
+import spack.hash_types as ht
 from spack.spec import Spec
 from spack.traverse import by_dag_hash, traverse_nodes
 
@@ -55,7 +56,7 @@ def _resolve_collected_splices(
             continue
 
         new_spec = spec.copy(deps=False)
-        new_spec.clear_caches(ignore=("package_hash",))
+        new_spec.clear_caches(ignore=(ht.package_hash.attr,))
 
         is_reused = spec.concrete
         if is_reused:

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -5031,6 +5031,10 @@ class Spec:
         """
         Clears all cached hashes in a Spec, while preserving other properties.
         """
+        assert all(
+            attr in ("_dunder_hash", "_prefix") or any(attr == h.attr for h in ht.HASHES)
+            for attr in ignore
+        ), f"unknown attribute in ignore: {ignore}"
         for h in ht.HASHES:
             if h.attr not in ignore:
                 if hasattr(self, h.attr):

--- a/lib/spack/spack/test/concretization/splicing.py
+++ b/lib/spack/spack/test/concretization/splicing.py
@@ -311,3 +311,24 @@ def test_fresh_ancestor_of_spliced_dep_is_not_spliced(install_specs, mutable_con
     # The leaf node is not spliced
     splice_z = concrete["splice-z"]
     assert splice_z.satisfies("@1.0.2") and not splice_z.spliced
+
+
+def test_spliced_spec_keeps_package_hash(install_specs, mutable_config):
+    """Tests that a spliced node keeps the package hash of the spec it was copied from"""
+    splice_t = install_specs("splice-t@1.0 ^splice-h@1.0.1 ^splice-z@1.0.0")[0]
+    mutable_config.set("packages", _make_specs_non_buildable(["splice-t"]))
+
+    _enable_splicing()
+    spliced = spack.concretize.concretize_one("splice-t@1.0 ^splice-h@1.0.2 ^splice-z@1.0.0")
+
+    # Spec has been spliced, and its package.py is the one it was built from
+    assert spliced.dag_hash() != splice_t.dag_hash()
+    assert spliced._package_hash == splice_t._package_hash
+    assert spliced.to_node_dict()["package_hash"] == splice_t._package_hash
+
+    # the dag hash must match a from-scratch recomputation that re-derives
+    # package hashes from the repo
+    recomputed = spliced.copy()
+    recomputed._mark_concrete(False)
+    recomputed._finalize_concretization()
+    assert recomputed.dag_hash() == spliced.dag_hash()


### PR DESCRIPTION
`Spec.clear_caches` matches its `ignore` argument against hash *attribute* names, which for the package hash is `_package_hash`. The call in `_resolve_collected_splices` passed `package_hash` without the leading underscore, so the ignore never matched and the package hash was cleared along with everything else. Compare `Spec._splice_detach_and_add_dependents`, which passes `ht.package_hash.attr`.

The spliced node stays concrete from the copy, and `_finalize_concretization` assigns package hashes only to non-concrete nodes, so the cleared hash was never restored. Its dag hash is then computed from a node dict that has no `package_hash` key at all.

This changes the dag hash of automatically spliced specs.

The first commit adds a failing test that demonstrates the bug. The second commit fixes the `ignore` value. The third commit makes `clear_caches` validate its `ignore` values to catch future typos.