### PR TITLE
Bugfix/oci redirect header and timer phases for oci update

### DIFF
--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -1598,69 +1598,78 @@ def _oci_config_from_tag(image_ref_and_tag: Tuple[ImageReference, str]) -> Optio
 
 
 def _oci_update_index(
-    image_ref: ImageReference, tmpdir: str, pool: concurrent.futures.Executor
+    image_ref: ImageReference,
+    tmpdir: str,
+    pool: concurrent.futures.Executor,
+    *,
+    timer=timer.NULL_TIMER,
 ) -> None:
-    tags = list_tags(image_ref)
+    with timer.measure("list"):
+        tags = list_tags(image_ref)
 
-    # Fetch all image config files in parallel
-    spec_dicts = pool.map(
-        _oci_config_from_tag, ((image_ref, tag) for tag in tags if tag_is_spec(tag))
-    )
+    with timer.measure("read"):
+        # Fetch all image config files in parallel
+        spec_dicts = pool.map(
+            _oci_config_from_tag, ((image_ref, tag) for tag in tags if tag_is_spec(tag))
+        )
 
-    # Populate the database
-    db_root_dir = os.path.join(tmpdir, "db_root")
-    db = BuildCacheDatabase(db_root_dir)
+        # Populate the database
+        db_root_dir = os.path.join(tmpdir, "db_root")
+        db = BuildCacheDatabase(db_root_dir)
 
-    for spec_dict in spec_dicts:
-        spec = spack.spec.Spec.from_dict(spec_dict)
-        db.add(spec)
-        db.mark(spec, "in_buildcache", True)
+        for spec_dict in spec_dicts:
+            spec = spack.spec.Spec.from_dict(spec_dict)
+            db.add(spec)
+            db.mark(spec, "in_buildcache", True)
 
-    # Create the index.json file
-    index_json_path = os.path.join(tmpdir, spack.database.INDEX_JSON_FILE)
-    with open(index_json_path, "w", encoding="utf-8") as f:
-        db._write_to_file(f)
+    with timer.measure("push"):
+        # Create the index.json file
+        index_json_path = os.path.join(tmpdir, spack.database.INDEX_JSON_FILE)
+        with open(index_json_path, "w", encoding="utf-8") as f:
+            db._write_to_file(f)
 
-    # Create an empty config.json file
-    empty_config_json_path = os.path.join(tmpdir, "config.json")
-    with open(empty_config_json_path, "wb") as f:
-        f.write(b"{}")
+        # Create an empty config.json file
+        empty_config_json_path = os.path.join(tmpdir, "config.json")
+        with open(empty_config_json_path, "wb") as f:
+            f.write(b"{}")
 
-    # Upload the index.json file
-    index_shasum = Digest.from_sha256(spack.util.crypto.checksum(hashlib.sha256, index_json_path))
-    upload_blob_with_retry(image_ref, file=index_json_path, digest=index_shasum)
+        # Upload the index.json file
+        index_shasum = Digest.from_sha256(
+            spack.util.crypto.checksum(hashlib.sha256, index_json_path)
+        )
+        upload_blob_with_retry(image_ref, file=index_json_path, digest=index_shasum)
 
-    # Upload the config.json file
-    empty_config_digest = Digest.from_sha256(
-        spack.util.crypto.checksum(hashlib.sha256, empty_config_json_path)
-    )
-    upload_blob_with_retry(image_ref, file=empty_config_json_path, digest=empty_config_digest)
+        # Upload the config.json file
+        empty_config_digest = Digest.from_sha256(
+            spack.util.crypto.checksum(hashlib.sha256, empty_config_json_path)
+        )
+        upload_blob_with_retry(image_ref, file=empty_config_json_path, digest=empty_config_digest)
 
-    # Push a manifest file that references the index.json file as a layer
-    # Notice that we push this as if it is an image, which it of course is not.
-    # When the ORAS spec becomes official, we can use that instead of a fake image.
-    # For now we just use the OCI image spec, so that we don't run into issues with
-    # automatic garbage collection of blobs that are not referenced by any image manifest.
-    oci_manifest = {
-        "mediaType": "application/vnd.oci.image.manifest.v1+json",
-        "schemaVersion": 2,
-        # Config is just an empty {} file for now, and irrelevant
-        "config": {
-            "mediaType": "application/vnd.oci.image.config.v1+json",
-            "digest": str(empty_config_digest),
-            "size": os.path.getsize(empty_config_json_path),
-        },
-        # The buildcache index is the only layer, and is not a tarball, we lie here.
-        "layers": [
-            {
-                "mediaType": "application/vnd.oci.image.layer.v1.tar+gzip",
-                "digest": str(index_shasum),
-                "size": os.path.getsize(index_json_path),
-            }
-        ],
-    }
+        # Push a manifest file that references the index.json file as a layer
+        # Notice that we push this as if it is an image, which it of course is not.
+        # When the ORAS spec becomes official, we can use that instead of a fake image.
+        # For now we just use the OCI image spec, so that we don't run into issues with
+        # automatic garbage collection of blobs that are not referenced by any image manifest.
+        oci_manifest = {
+            "mediaType": "application/vnd.oci.image.manifest.v1+json",
+            "schemaVersion": 2,
+            # Config is just an empty {} file for now, and irrelevant
+            "config": {
+                "mediaType": "application/vnd.oci.image.config.v1+json",
+                "digest": str(empty_config_digest),
+                "size": os.path.getsize(empty_config_json_path),
+            },
+            # The buildcache index is the only layer, and is not a tarball, we lie here.
+            "layers": [
+                {
+                    "mediaType": "application/vnd.oci.image.layer.v1.tar+gzip",
+                    "digest": str(index_shasum),
+                    "size": os.path.getsize(index_json_path),
+                }
+            ],
+        }
 
-    upload_manifest_with_retry(image_ref.with_tag(default_index_tag), oci_manifest)
+        upload_manifest_with_retry(image_ref.with_tag(default_index_tag), oci_manifest)
 
 
 def download_tarball(

--- a/lib/spack/spack/cmd/buildcache.py
+++ b/lib/spack/spack/cmd/buildcache.py
@@ -913,7 +913,7 @@ def update_index(
         with tempfile.TemporaryDirectory(
             dir=spack.stage.get_stage_root()
         ) as tmpdir, spack.util.parallel.make_concurrent_executor() as executor:
-            spack.binary_distribution._oci_update_index(image_ref, tmpdir, executor)
+            spack.binary_distribution._oci_update_index(image_ref, tmpdir, executor, timer=timer)
         return
 
     # Otherwise, assume a normal mirror.

--- a/lib/spack/spack/oci/opener.py
+++ b/lib/spack/spack/oci/opener.py
@@ -238,6 +238,21 @@ def _get_basic_challenge(challenges: List[Challenge]) -> Optional[str]:
     return challenge.get_param("realm")
 
 
+class PreserveRedirectHandler(urllib.request.HTTPRedirectHandler):
+    """Fixes a long-standing bug in ``urllib.request.HTTPRedirectHandler``: it never
+    forwards the original request's HTTP method, so any redirected ``HEAD`` request is
+    silently turned into a ``GET`` request. This breaks registries (e.g. GitLab backed
+    by GCS) that redirect blob requests to signed URLs whose signature covers the HTTP
+    method: a ``HEAD`` request redirected as ``GET`` no longer matches the signature,
+    and the storage backend responds with 403 Forbidden."""
+
+    def redirect_request(self, req: Request, fp, code, msg, headers, newurl):
+        new_req = super().redirect_request(req, fp, code, msg, headers, newurl)
+        if new_req is not None and req.get_method() == "HEAD":
+            new_req.method = "HEAD"
+        return new_req
+
+
 class OCIAuthHandler(urllib.request.BaseHandler):
     def __init__(self, credentials_provider: Callable[[str], Optional[UsernamePassword]]):
         """
@@ -413,7 +428,7 @@ def create_opener():
         urllib.request.HTTPHandler(),
         spack.util.web.SpackHTTPSHandler(context=spack.util.web.ssl_create_default_context()),
         spack.util.web.SpackHTTPDefaultErrorHandler(),
-        urllib.request.HTTPRedirectHandler(),
+        PreserveRedirectHandler(),
         urllib.request.HTTPErrorProcessor(),
         OCIAuthHandler(credentials_from_mirrors),
     ]:

--- a/lib/spack/spack/test/oci/urlopen.py
+++ b/lib/spack/spack/test/oci/urlopen.py
@@ -27,6 +27,7 @@ from spack.oci.oci import (
 )
 from spack.oci.opener import (
     Challenge,
+    PreserveRedirectHandler,
     RealmServiceScope,
     UsernamePassword,
     _get_basic_challenge,
@@ -46,6 +47,20 @@ from spack.test.oci.mock_registry import (
     MockBearerTokenServer,
     create_opener,
 )
+
+
+def test_head_request_preserves_method_on_redirect():
+    """Regression test: a HEAD request must remain a HEAD request after following a
+    redirect. The stdlib's HTTPRedirectHandler silently downgrades it to GET, which
+    breaks registries that redirect to signed URLs (e.g. GitLab's GCS-backed registry)
+    whose signature covers the HTTP method, resulting in a 403 Forbidden."""
+    handler = PreserveRedirectHandler()
+    req = Request(url="https://registry.example.com/v2/image/blobs/sha256:abc", method="HEAD")
+    new_req = handler.redirect_request(
+        req, None, 302, "Found", {}, "https://storage.example.com/signed-blob"
+    )
+    assert new_req is not None
+    assert new_req.get_method() == "HEAD"
 
 
 def test_parse_www_authenticate():


### PR DESCRIPTION
- Add Handler to preserve HTTP method across redirects through urllib
- Add timer phases during oci update. I had a crash because timer had no phases: times in `write_tty` was empty and `max` wasn't happy with empty arg