### PR TITLE
Optimize sorting in _dependencies_dict

### DIFF
--- a/lib/spack/spack/database.py
+++ b/lib/spack/spack/database.py
@@ -1864,7 +1864,7 @@ class Database:
             # Sort by name first so the full sort runs on nearly sorted input and compares specs
             # far fewer times.
             results.sort(key=lambda s: s.name)
-            results.sort()  # type: ignore[call-arg,call-overload]
+            results.sort()
         return results
 
     def query_one(

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -1815,7 +1815,7 @@ class SpackSolverSetup:
             self.gen.fact(fn.pkg_fact(pkg.name, fn.possible_provider(vpkg_name)))
 
         for when, provided in pkg.provided.items():
-            for vpkg in sorted(provided):  # type: ignore[type-var]
+            for vpkg in sorted(provided):
                 if vpkg.name not in self.possible_virtuals:
                     continue
 
@@ -2976,8 +2976,7 @@ class SpackSolverSetup:
         candidate_compilers.update(compilers_from_reuse)
         self.possible_compilers = list(candidate_compilers)
 
-        # TODO: warning is because mypy doesn't know Spec supports rich comparison via decorator
-        self.possible_compilers.sort()  # type: ignore[call-arg,call-overload]
+        self.possible_compilers.sort()
 
         self.compiler_mixing()
 
@@ -2991,7 +2990,7 @@ class SpackSolverSetup:
         )
         self.possible_virtuals = node_counter.possible_virtuals()
         self.pkgs = node_counter.possible_dependencies()
-        self.libcs = sorted(all_libcs())  # type: ignore[type-var]
+        self.libcs = sorted(all_libcs())
 
         for node in traverse.traverse_nodes(specs):
             if node.namespace is not None:

--- a/lib/spack/spack/solver/reuse.py
+++ b/lib/spack/spack/solver/reuse.py
@@ -259,7 +259,7 @@ class ReusableSpecsSelector:
                     has_external_source = True
                     if include:
                         # Since libcs are implicit externals, we need to implicitly include them
-                        include = include + sorted(all_libcs())  # type: ignore[type-var]
+                        include = include + sorted(all_libcs())
                     self.reuse_sources.append(
                         spec_filter_from_packages_yaml(
                             external_parser=external_parser,

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -1866,12 +1866,18 @@ class Spec:
         Args:
             deptype: allowed dependency types
         """
-        _group_fn = lambda x: x.spec.name
-        selected_edges = _select_edges(self._dependencies, depflag=depflag)
-        edges = sorted(selected_edges)  # type: ignore[type-var]
-        result = {}
-        for key, group in itertools.groupby(edges, key=_group_fn):
-            result[key] = list(group)
+        result: Dict[str, List[DependencySpec]] = {}
+        for edge in _select_edges(self._dependencies, depflag=depflag):
+            result.setdefault(edge.spec.name, []).append(edge)
+
+        # Comparing two DependencySpec is expensive, since it falls back on comparing the
+        # child specs to tell parallel edges apart. Only edges to the same package name can
+        # be parallel, and callers sort the groups by name themselves, so we can restrict
+        # the comparison sort to groups with more than one edge, which are rare.
+        for edges in result.values():
+            if len(edges) > 1:
+                edges.sort()  # type: ignore[call-arg,call-overload]
+
         return result
 
     def _add_flag(

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -61,6 +61,7 @@ import re
 import socket
 import warnings
 from typing import (
+    TYPE_CHECKING,
     Any,
     Callable,
     ClassVar,
@@ -746,6 +747,13 @@ class DependencySpec:
 
     __slots__ = "parent", "spec", "depflag", "virtuals", "direct", "when", "propagation"
 
+    if TYPE_CHECKING:
+        # lazy_lexicographic_ordering installs these with setattr, unseen by type checkers
+        def __lt__(self, other: Any) -> bool: ...
+        def __le__(self, other: Any) -> bool: ...
+        def __gt__(self, other: Any) -> bool: ...
+        def __ge__(self, other: Any) -> bool: ...
+
     def __init__(
         self,
         parent: "Spec",
@@ -1102,7 +1110,7 @@ def _add_edge_to_map(edge_map: EdgeMap, key: str, edge: DependencySpec) -> None:
     if key in edge_map:
         lst = edge_map[key]
         lst.append(edge)
-        lst.sort()  # type: ignore[call-arg,call-overload]
+        lst.sort()
     else:
         edge_map[key] = [edge]
 
@@ -1419,8 +1427,7 @@ def tree(
         ):
             deptype_lookup[edge.spec.dag_hash()] |= edge.depflag
 
-    # SupportsRichComparisonT issue with List[Spec]
-    sorted_specs: List["Spec"] = sorted(specs)  # type: ignore[type-var]
+    sorted_specs: List["Spec"] = sorted(specs)
 
     for d, dep_spec in spack.traverse.traverse_tree(
         sorted_specs, cover=cover, deptype=deptypes, depth_first=depth_first, key=key
@@ -1611,6 +1618,13 @@ def _satisfies_edge(lhs: "DependencySpec", rhs: "DependencySpec", resolve_virtua
 @lang.lazy_lexicographic_ordering(set_hash=False)
 class Spec:
     compiler = DeprecatedCompilerSpec()
+
+    if TYPE_CHECKING:
+        # lazy_lexicographic_ordering installs these with setattr, unseen by type checkers
+        def __lt__(self, other: Any) -> bool: ...
+        def __le__(self, other: Any) -> bool: ...
+        def __gt__(self, other: Any) -> bool: ...
+        def __ge__(self, other: Any) -> bool: ...
 
     @staticmethod
     def default_arch():
@@ -1857,7 +1871,7 @@ class Spec:
             deptype = dt.canonicalize(deptype)
         return [d.parent for d in self.edges_from_dependents(name, depflag=deptype)]
 
-    def _dependencies_dict(self, depflag: dt.DepFlag = dt.ALL):
+    def _dependencies_dict(self, depflag: dt.DepFlag = dt.ALL) -> EdgeMap:
         """Return a dictionary, keyed by package name, of the direct
         dependencies.
 
@@ -1866,13 +1880,13 @@ class Spec:
         Args:
             deptype: allowed dependency types
         """
-        result: Dict[str, List[DependencySpec]] = {}
+        result: EdgeMap = {}
         for edge in _select_edges(self._dependencies, depflag=depflag):
             result.setdefault(edge.spec.name, []).append(edge)
 
         for edges in result.values():
             if len(edges) > 1:
-                edges.sort()  # type: ignore[call-arg,call-overload]
+                edges.sort()
 
         return result
 
@@ -2478,7 +2492,7 @@ class Spec:
             dependencies = []
             for name, edges_for_name in sorted(deps.items()):
                 for dspec in edges_for_name:
-                    dep_attrs = {
+                    dep_attrs: Dict[str, Any] = {
                         "name": name,
                         hash.name: dspec.spec._cached_hash(hash),
                         "parameters": {

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -1870,8 +1870,6 @@ class Spec:
         for edge in _select_edges(self._dependencies, depflag=depflag):
             result.setdefault(edge.spec.name, []).append(edge)
 
-        # Only edges to the same package name can be parallel, and callers sort the groups by name
-        # themselves, so we can restrict the comparison sort to groups with more than one edge
         for edges in result.values():
             if len(edges) > 1:
                 edges.sort()  # type: ignore[call-arg,call-overload]

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -1870,10 +1870,8 @@ class Spec:
         for edge in _select_edges(self._dependencies, depflag=depflag):
             result.setdefault(edge.spec.name, []).append(edge)
 
-        # Comparing two DependencySpec is expensive, since it falls back on comparing the
-        # child specs to tell parallel edges apart. Only edges to the same package name can
-        # be parallel, and callers sort the groups by name themselves, so we can restrict
-        # the comparison sort to groups with more than one edge, which are rare.
+        # Only edges to the same package name can be parallel, and callers sort the groups by name
+        # themselves, so we can restrict the comparison sort to groups with more than one edge
         for edges in result.values():
             if len(edges) > 1:
                 edges.sort()  # type: ignore[call-arg,call-overload]


### PR DESCRIPTION
The statement:
```
sorted(selected_edges)
```
does a global sort over edges, while the only thing that matters is a by-name sort, since `to_node_dict` already sorts by name.

This speeds-up the function call noticeably for the happy path by dropping the unneeded sort.