### PR TITLE
change docs to reflect new spack["cxx"] to replace spack.compiler

### DIFF
--- a/lib/spack/docs/build_systems/makefilepackage.rst
+++ b/lib/spack/docs/build_systems/makefilepackage.rst
@@ -208,7 +208,7 @@ The first two sections are `implicit variables <https://www.gnu.org/software/mak
   This includes variables like ``MPI``, ``OPENMP``, ``PIC``, and ``DEBUG``.
   These flags often require you to create a variant so that you can either build with or without MPI support, for example.
   These flags are often compiler-dependent.
-  You should replace them with the appropriate compiler flags, such as ``self['cxx'].openmp_flag`` or ``self["cxx"].pic_flag``.
+  You should replace them with the appropriate compiler flags, such as ``self["cxx"].openmp_flag`` or ``self["cxx"].pic_flag``.
 
 * **Platform flags**
 

--- a/lib/spack/docs/build_systems/makefilepackage.rst
+++ b/lib/spack/docs/build_systems/makefilepackage.rst
@@ -208,7 +208,7 @@ The first two sections are `implicit variables <https://www.gnu.org/software/mak
   This includes variables like ``MPI``, ``OPENMP``, ``PIC``, and ``DEBUG``.
   These flags often require you to create a variant so that you can either build with or without MPI support, for example.
   These flags are often compiler-dependent.
-  You should replace them with the appropriate compiler flags, such as ``self.compiler.openmp_flag`` or ``self.compiler.pic_flag``.
+  You should replace them with the appropriate compiler flags, such as ``self['cxx'].openmp_flag`` or ``self["cxx"].pic_flag``.
 
 * **Platform flags**
 

--- a/lib/spack/docs/build_systems/sconspackage.rst
+++ b/lib/spack/docs/build_systems/sconspackage.rst
@@ -270,7 +270,7 @@ If you pass them to the build and you see an error message like:
 
 
 you'll know that the package isn't compatible with Spack's compiler wrappers.
-In this case, you'll have to use the path to the actual compilers, which are stored in ``self.compiler.cc`` and friends.
+In this case, you'll have to use the path to the actual compilers, which are stored in ``self["c"].cc`` and friends.
 Note that this may involve passing additional flags to the build to locate dependencies, a task normally done by the compiler wrappers. serf is an example of a package with this limitation.
 
 External documentation

--- a/lib/spack/docs/packaging_guide_build.rst
+++ b/lib/spack/docs/packaging_guide_build.rst
@@ -733,8 +733,8 @@ File filtering functions
 
      .. code-block:: python
 
-        filter_file("CC='cc'", "CC='%s'" % self.compiler.cc, prefix.bin.mpicc)
-        filter_file("CXX='c++'", "CXX='%s'" % self.compiler.cxx, prefix.bin.mpicxx)
+        filter_file("CC='cc'", "CC='%s'" % self["c"].cc, prefix.bin.mpicc)
+        filter_file("CXX='c++'", "CXX='%s'" % self["cxx"].cxx, prefix.bin.mpicxx)
 
 :py:func:`change_sed_delimiter(old_delim, new_delim, *filenames) <spack.package.change_sed_delimiter>`
     Some packages, like TAU, have a build system that can't install into directories with, e.g. "@" in the name, because they use hard-coded ``sed`` commands in their build.


### PR DESCRIPTION
In preparation for larger change https://github.com/spack/spack-packages/pull/5978/changes

From previous discussions 

"You want 

self[“cxx”].cxx
self[“fortran”].fortran

self.compiler can return the wrong compiler when you’re combining different c/cxx and fortran compilers. We have it for backwards compatibility but you should avoid it in new code. "

I resisted the urge to make mass changes to all of the tutorials in spack, only changing the limited documentation files suggested by @bernhardkaindl 