### PR TITLE
Bugfix/ test non empty-ness not just existence

### DIFF
--- a/lib/spack/spack/config.py
+++ b/lib/spack/spack/config.py
@@ -1402,7 +1402,7 @@ class IncludePath(OptionalInclude):
 
         super().__init__(entry)
         path_override_env_var = entry.get("path_override_env_var", "")
-        if path_override_env_var and path_override_env_var in os.environ:
+        if path_override_env_var and os.environ.get(path_override_env_var):
             path = os.environ[path_override_env_var]
         else:
             path = entry.get("path", "")


### PR DESCRIPTION
If the variable exists but is empty, the pipeline fails.
If `SPACK_USER_CONFIG_PATH` or `SPACK_SYSTEM_CONFIG_PATH` is set but empty in the job environment (`SPACK_USER_CONFIG_PATH`=""), Spack uses this empty string as the path instead of falling back to path: "~/.spack" or path: "/etc/spack".