### PR TITLE
spec.py: make satisfies exhaustive

### DIFF
--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -1529,13 +1529,15 @@ def _satisfying_edges(
     compiler node, then a BFS over transitive link/run deps."""
     # First check direct deps of all types. There is a subtlety: only abstract specs distinguish
     # between direct and indirect edges, whereas concrete specs always have direct edges (without
-    # setting the direct flag).
+    # setting the direct flag). For performance, iterate the _dependencies edge map directly:
+    # edges_to_dependencies allocates an iterator chain and a result list per call.
     require_direct = rhs_edge.direct and not lhs_node.concrete
-    for lhs_edge in lhs_node.edges_to_dependencies():
-        if require_direct and not lhs_edge.direct:
-            continue
-        if _satisfies_edge(lhs_edge, rhs_edge, resolve_virtuals):
-            yield lhs_edge
+    for edges in lhs_node._dependencies.values():
+        for lhs_edge in edges:
+            if require_direct and not lhs_edge.direct:
+                continue
+            if _satisfies_edge(lhs_edge, rhs_edge, resolve_virtuals):
+                yield lhs_edge
 
     # Include the historical compiler node if available as an ad-hoc edge.
     compiler_spec = lhs_node.annotations.compiler_node_attribute
@@ -1554,9 +1556,17 @@ def _satisfying_edges(
         return
 
     # BFS through link/run transitive deps (skip depth 1, already checked). Nodes with multiple
-    # in-edges are expanded only once, but every in-edge is a candidate.
+    # in-edges are expanded only once, but every in-edge is a candidate. An edge with depflag 0
+    # is unconstrained and traversed too. For performance, iterate the _dependencies edge map
+    # directly instead of going through edges_to_dependencies.
     depflag = dt.LINK | dt.RUN
-    queue = collections.deque(lhs_node.edges_to_dependencies(depflag=depflag))
+    queue: "collections.deque[DependencySpec]" = collections.deque()
+    queue.extend(
+        e
+        for edges in lhs_node._dependencies.values()
+        for e in edges
+        if not e.depflag or e.depflag & depflag
+    )
     expanded = {id(lhs_node)}
     while queue:
         lhs_edge = queue.popleft()
@@ -1569,7 +1579,13 @@ def _satisfying_edges(
 
         if id(lhs_edge.spec) not in expanded:
             expanded.add(id(lhs_edge.spec))
-            queue.extend(lhs_edge.spec.edges_to_dependencies(depflag=depflag))
+            if lhs_edge.spec._dependencies:
+                queue.extend(
+                    e
+                    for edges in lhs_edge.spec._dependencies.values()
+                    for e in edges
+                    if not e.depflag or e.depflag & depflag
+                )
 
 
 def _edge_satisfies(lhs_node: "Spec", rhs_edge: DependencySpec, *, resolve_virtuals: bool) -> bool:

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -1536,7 +1536,7 @@ def _satisfying_edges(
         for lhs_edge in edges:
             if require_direct and not lhs_edge.direct:
                 continue
-            if _satisfies_edge(lhs_edge, rhs_edge, resolve_virtuals):
+            if _satisfies_edge_attributes(lhs_edge, rhs_edge, resolve_virtuals):
                 yield lhs_edge
 
     # Include the historical compiler node if available as an ad-hoc edge.
@@ -1549,7 +1549,7 @@ def _satisfying_edges(
             virtuals=("c", "cxx", "fortran"),
             direct=True,
         )
-        if _satisfies_edge(compiler_edge, rhs_edge, resolve_virtuals):
+        if _satisfies_edge_attributes(compiler_edge, rhs_edge, resolve_virtuals):
             yield compiler_edge
 
     if rhs_edge.direct:
@@ -1571,7 +1571,7 @@ def _satisfying_edges(
         lhs_edge = queue.popleft()
 
         # depth 1 was yielded by the loop over direct edges above
-        if lhs_edge.parent is not lhs_node and _satisfies_edge(
+        if lhs_edge.parent is not lhs_node and _satisfies_edge_attributes(
             lhs_edge, rhs_edge, resolve_virtuals
         ):
             yield lhs_edge
@@ -1599,7 +1599,7 @@ def _satisfies_dependencies(lhs: "Spec", rhs: "Spec", *, resolve_virtuals: bool)
             ):
                 continue
             edges = _satisfying_edges(lhs, rhs_edge, resolve_virtuals=resolve_virtuals)
-            # A concrete or leaf rhs child needs no recursion: _satisfies_edge compared the
+            # A concrete or leaf rhs child needs no recursion: _satisfies_edge_attributes compared the
             # child node already.
             if rhs_edge.spec.concrete or not rhs_edge.spec._dependencies:
                 if next(edges, None) is None:
@@ -1612,7 +1612,9 @@ def _satisfies_dependencies(lhs: "Spec", rhs: "Spec", *, resolve_virtuals: bool)
     return True
 
 
-def _satisfies_edge(lhs: "DependencySpec", rhs: "DependencySpec", resolve_virtuals: bool) -> bool:
+def _satisfies_edge_attributes(
+    lhs: "DependencySpec", rhs: "DependencySpec", resolve_virtuals: bool
+) -> bool:
     """Helper function for satisfaction tests, which checks edge attributes and the target node.
     It skips verification of the parent node."""
     name_mismatch = rhs.spec.name and lhs.spec.name != rhs.spec.name

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -49,7 +49,6 @@ line is a spec for a particular installation of the mpileaks package.
 
 import abc
 import collections
-import collections.abc
 import enum
 import io
 import itertools
@@ -65,6 +64,7 @@ from typing import (
     Any,
     Callable,
     ClassVar,
+    Deque,
     Dict,
     Iterable,
     Iterator,
@@ -1560,7 +1560,7 @@ def _satisfying_edges(
     # is unconstrained and traversed too. For performance, iterate the _dependencies edge map
     # directly instead of going through edges_to_dependencies.
     depflag = dt.LINK | dt.RUN
-    queue: "collections.deque[DependencySpec]" = collections.deque()
+    queue: Deque[DependencySpec] = collections.deque()
     queue.extend(
         e
         for edges in lhs_node._dependencies.values()

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -1587,19 +1587,7 @@ def _satisfying_edges(
                 )
 
 
-def _edge_satisfies(lhs_node: "Spec", rhs_edge: DependencySpec, *, resolve_virtuals: bool) -> bool:
-    """Whether some edge in ``lhs_node`` satisfies ``rhs_edge``, including ``rhs_edge``'s own
-    further dependencies."""
-    if rhs_edge.spec.concrete or not rhs_edge.spec._dependencies:
-        edges = _satisfying_edges(lhs_node, rhs_edge, resolve_virtuals=resolve_virtuals)
-        return next(edges, None) is not None
-    for lhs_edge in _satisfying_edges(lhs_node, rhs_edge, resolve_virtuals=resolve_virtuals):
-        if _node_satisfies(lhs_edge.spec, rhs_edge.spec, resolve_virtuals=resolve_virtuals):
-            return True
-    return False
-
-
-def _node_satisfies(lhs: "Spec", rhs: "Spec", *, resolve_virtuals: bool) -> bool:
+def _satisfies_dependencies(lhs: "Spec", rhs: "Spec", *, resolve_virtuals: bool) -> bool:
     """Whether every dependency edge of ``rhs`` is satisfied by some edge of ``lhs``."""
     for rhs_edge in rhs.edges_to_dependencies():
         # Skip rhs edges whose when condition doesn't apply to the lhs node.
@@ -1607,7 +1595,16 @@ def _node_satisfies(lhs: "Spec", rhs: "Spec", *, resolve_virtuals: bool) -> bool
             rhs_edge.when, resolve_virtuals=resolve_virtuals
         ):
             continue
-        if not _edge_satisfies(lhs, rhs_edge, resolve_virtuals=resolve_virtuals):
+        edges = _satisfying_edges(lhs, rhs_edge, resolve_virtuals=resolve_virtuals)
+        # A concrete or leaf rhs child needs no recursion: _satisfies_edge compared the child
+        # node already.
+        if rhs_edge.spec.concrete or not rhs_edge.spec._dependencies:
+            if next(edges, None) is None:
+                return False
+        elif not any(
+            _satisfies_dependencies(e.spec, rhs_edge.spec, resolve_virtuals=resolve_virtuals)
+            for e in edges
+        ):
             return False
     return True
 
@@ -3471,7 +3468,7 @@ class Spec:
         if not deps or not other._dependencies:
             return True
 
-        return _node_satisfies(self, other, resolve_virtuals=resolve_virtuals)
+        return _satisfies_dependencies(self, other, resolve_virtuals=resolve_virtuals)
 
     def _satisfies_node(self, other: "Spec", resolve_virtuals: bool) -> bool:
         """Compares self and other without looking at dependencies"""

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -67,6 +67,7 @@ from typing import (
     ClassVar,
     Dict,
     Iterable,
+    Iterator,
     List,
     Match,
     NamedTuple,
@@ -1520,10 +1521,12 @@ def _anonymous_star(dep: DependencySpec, dep_format: str) -> str:
     return "*" if dep.spec.architecture else ""
 
 
-def _get_satisfying_edge(
+def _satisfying_edges(
     lhs_node: "Spec", rhs_edge: DependencySpec, *, resolve_virtuals: bool
-) -> Optional[DependencySpec]:
-    """Search for an edge in ``lhs_node`` that satisfies ``rhs_edge``."""
+) -> Iterator[DependencySpec]:
+    """Yield every edge in ``lhs_node`` that satisfies ``rhs_edge`` structurally, ignoring the
+    target's own dependencies, in priority order: direct deps of all types, then the historical
+    compiler node, then a BFS over transitive link/run deps."""
     # First check direct deps of all types. There is a subtlety: only abstract specs distinguish
     # between direct and indirect edges, whereas concrete specs always have direct edges (without
     # setting the direct flag).
@@ -1532,7 +1535,7 @@ def _get_satisfying_edge(
         if require_direct and not lhs_edge.direct:
             continue
         if _satisfies_edge(lhs_edge, rhs_edge, resolve_virtuals):
-            return lhs_edge
+            yield lhs_edge
 
     # Include the historical compiler node if available as an ad-hoc edge.
     compiler_spec = lhs_node.annotations.compiler_node_attribute
@@ -1545,10 +1548,10 @@ def _get_satisfying_edge(
             direct=True,
         )
         if _satisfies_edge(compiler_edge, rhs_edge, resolve_virtuals):
-            return compiler_edge
+            yield compiler_edge
 
     if rhs_edge.direct:
-        return None
+        return
 
     # BFS through link/run transitive deps (skip depth 1, already checked).
     depflag = dt.LINK | dt.RUN
@@ -1557,15 +1560,41 @@ def _get_satisfying_edge(
     while queue:
         lhs_edge = queue.popleft()
 
-        if _satisfies_edge(lhs_edge, rhs_edge, resolve_virtuals):
-            return lhs_edge
+        # depth 1 was yielded by the loop over direct edges above
+        if lhs_edge.parent is not lhs_node and _satisfies_edge(
+            lhs_edge, rhs_edge, resolve_virtuals
+        ):
+            yield lhs_edge
 
         for lhs_edge in lhs_edge.spec.edges_to_dependencies(depflag=depflag):
             if id(lhs_edge.spec) not in seen:
                 seen.add(id(lhs_edge.spec))
                 queue.append(lhs_edge)
 
-    return None
+
+def _edge_satisfies(lhs_node: "Spec", rhs_edge: DependencySpec, *, resolve_virtuals: bool) -> bool:
+    """Whether some edge in ``lhs_node`` satisfies ``rhs_edge``, including ``rhs_edge``'s own
+    further dependencies."""
+    if rhs_edge.spec.concrete or not rhs_edge.spec._dependencies:
+        edges = _satisfying_edges(lhs_node, rhs_edge, resolve_virtuals=resolve_virtuals)
+        return next(edges, None) is not None
+    for lhs_edge in _satisfying_edges(lhs_node, rhs_edge, resolve_virtuals=resolve_virtuals):
+        if _node_satisfies(lhs_edge.spec, rhs_edge.spec, resolve_virtuals=resolve_virtuals):
+            return True
+    return False
+
+
+def _node_satisfies(lhs: "Spec", rhs: "Spec", *, resolve_virtuals: bool) -> bool:
+    """Whether every dependency edge of ``rhs`` is satisfied by some edge of ``lhs``."""
+    for rhs_edge in rhs.edges_to_dependencies():
+        # Skip rhs edges whose when condition doesn't apply to the lhs node.
+        if rhs_edge.when is not EMPTY_SPEC and not lhs._intersects(
+            rhs_edge.when, resolve_virtuals=resolve_virtuals
+        ):
+            continue
+        if not _edge_satisfies(lhs, rhs_edge, resolve_virtuals=resolve_virtuals):
+            return False
+    return True
 
 
 def _satisfies_edge(lhs: "DependencySpec", rhs: "DependencySpec", resolve_virtuals: bool) -> bool:
@@ -3427,28 +3456,7 @@ class Spec:
         if not deps or not other._dependencies:
             return True
 
-        stack = [(self, other)]
-
-        while stack:
-            lhs, rhs = stack.pop()
-
-            for rhs_edge in rhs.edges_to_dependencies():
-                # Skip rhs edges whose when condition doesn't apply to the lhs node.
-                if rhs_edge.when is not EMPTY_SPEC and not lhs._intersects(
-                    rhs_edge.when, resolve_virtuals=resolve_virtuals
-                ):
-                    continue
-
-                lhs_edge = _get_satisfying_edge(lhs, rhs_edge, resolve_virtuals=resolve_virtuals)
-
-                if not lhs_edge:
-                    return False
-
-                # Recursive case: `^zlib %gcc`
-                if not rhs_edge.spec.concrete and rhs_edge.spec._dependencies:
-                    stack.append((lhs_edge.spec, rhs_edge.spec))
-
-        return True
+        return _node_satisfies(self, other, resolve_virtuals=resolve_virtuals)
 
     def _satisfies_node(self, other: "Spec", resolve_virtuals: bool) -> bool:
         """Compares self and other without looking at dependencies"""

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -1556,16 +1556,15 @@ def _satisfying_edges(
         return
 
     # BFS through link/run transitive deps (skip depth 1, already checked). Nodes with multiple
-    # in-edges are expanded only once, but every in-edge is a candidate. An edge with depflag 0
-    # is unconstrained and traversed too. For performance, iterate the _dependencies edge map
-    # directly instead of going through edges_to_dependencies.
+    # in-edges are expanded only once, but every in-edge is a candidate. Deptype sets are lower
+    # bounds, so only an edge that overlaps link/run guarantees a link/run edge in every
+    # concretization; an edge with depflag 0 guarantees nothing and is not traversed. For
+    # performance, iterate the _dependencies edge map directly instead of going through
+    # edges_to_dependencies.
     depflag = dt.LINK | dt.RUN
     queue: Deque[DependencySpec] = collections.deque()
     queue.extend(
-        e
-        for edges in lhs_node._dependencies.values()
-        for e in edges
-        if not e.depflag or e.depflag & depflag
+        e for edges in lhs_node._dependencies.values() for e in edges if e.depflag & depflag
     )
     expanded = {id(lhs_node)}
     while queue:
@@ -1584,7 +1583,7 @@ def _satisfying_edges(
                     e
                     for edges in lhs_edge.spec._dependencies.values()
                     for e in edges
-                    if not e.depflag or e.depflag & depflag
+                    if e.depflag & depflag
                 )
 
 

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -1589,23 +1589,26 @@ def _satisfying_edges(
 
 def _satisfies_dependencies(lhs: "Spec", rhs: "Spec", *, resolve_virtuals: bool) -> bool:
     """Whether every dependency edge of ``rhs`` is satisfied by some edge of ``lhs``."""
-    for rhs_edge in rhs.edges_to_dependencies():
-        # Skip rhs edges whose when condition doesn't apply to the lhs node.
-        if rhs_edge.when is not EMPTY_SPEC and not lhs._intersects(
-            rhs_edge.when, resolve_virtuals=resolve_virtuals
-        ):
-            continue
-        edges = _satisfying_edges(lhs, rhs_edge, resolve_virtuals=resolve_virtuals)
-        # A concrete or leaf rhs child needs no recursion: _satisfies_edge compared the child
-        # node already.
-        if rhs_edge.spec.concrete or not rhs_edge.spec._dependencies:
-            if next(edges, None) is None:
+    # For performance, iterate the _dependencies edge map directly instead of going through
+    # edges_to_dependencies.
+    for rhs_edges in rhs._dependencies.values():
+        for rhs_edge in rhs_edges:
+            # Skip rhs edges whose when condition doesn't apply to the lhs node.
+            if rhs_edge.when is not EMPTY_SPEC and not lhs._intersects(
+                rhs_edge.when, resolve_virtuals=resolve_virtuals
+            ):
+                continue
+            edges = _satisfying_edges(lhs, rhs_edge, resolve_virtuals=resolve_virtuals)
+            # A concrete or leaf rhs child needs no recursion: _satisfies_edge compared the
+            # child node already.
+            if rhs_edge.spec.concrete or not rhs_edge.spec._dependencies:
+                if next(edges, None) is None:
+                    return False
+            elif not any(
+                _satisfies_dependencies(e.spec, rhs_edge.spec, resolve_virtuals=resolve_virtuals)
+                for e in edges
+            ):
                 return False
-        elif not any(
-            _satisfies_dependencies(e.spec, rhs_edge.spec, resolve_virtuals=resolve_virtuals)
-            for e in edges
-        ):
-            return False
     return True
 
 

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -1553,10 +1553,11 @@ def _satisfying_edges(
     if rhs_edge.direct:
         return
 
-    # BFS through link/run transitive deps (skip depth 1, already checked).
+    # BFS through link/run transitive deps (skip depth 1, already checked). Nodes with multiple
+    # in-edges are expanded only once, but every in-edge is a candidate.
     depflag = dt.LINK | dt.RUN
     queue = collections.deque(lhs_node.edges_to_dependencies(depflag=depflag))
-    seen = {id(lhs_edge.spec) for lhs_edge in queue}
+    expanded = {id(lhs_node)}
     while queue:
         lhs_edge = queue.popleft()
 
@@ -1566,10 +1567,9 @@ def _satisfying_edges(
         ):
             yield lhs_edge
 
-        for lhs_edge in lhs_edge.spec.edges_to_dependencies(depflag=depflag):
-            if id(lhs_edge.spec) not in seen:
-                seen.add(id(lhs_edge.spec))
-                queue.append(lhs_edge)
+        if id(lhs_edge.spec) not in expanded:
+            expanded.add(id(lhs_edge.spec))
+            queue.extend(lhs_edge.spec.edges_to_dependencies(depflag=depflag))
 
 
 def _edge_satisfies(lhs_node: "Spec", rhs_edge: DependencySpec, *, resolve_virtuals: bool) -> bool:

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -1599,8 +1599,6 @@ def _satisfies_dependencies(lhs: "Spec", rhs: "Spec", *, resolve_virtuals: bool)
             ):
                 continue
             edges = _satisfying_edges(lhs, rhs_edge, resolve_virtuals=resolve_virtuals)
-            # A concrete or leaf rhs child needs no recursion: _satisfies_edge_attributes compared the
-            # child node already.
             if rhs_edge.spec.concrete or not rhs_edge.spec._dependencies:
                 if next(edges, None) is None:
                     return False

--- a/lib/spack/spack/test/data/config/concretizer.yaml
+++ b/lib/spack/spack/test/data/config/concretizer.yaml
@@ -14,6 +14,7 @@ concretizer:
       fortran: 1
       # Regular packages
       cmake: 2
+      dupe-tool: 2
       gmake: 2
       python: 2
       python-venv: 2

--- a/lib/spack/spack/test/spec_semantics.py
+++ b/lib/spack/spack/test/spec_semantics.py
@@ -2655,23 +2655,29 @@ def test_satisfies_checks_all_in_edges_of_shared_node():
     root, a, b, c = Spec("pkg-a"), Spec("pkg-b"), Spec("pkg-c"), Spec("pkg-d")
     root.add_dependency_edge(a, depflag=dt.LINK, virtuals=())
     root.add_dependency_edge(b, depflag=dt.LINK, virtuals=())
-    a.add_dependency_edge(c, depflag=dt.RUN, virtuals=())
+    a.add_dependency_edge(c, depflag=dt.TEST | dt.RUN, virtuals=())
     b.add_dependency_edge(c, depflag=dt.BUILD | dt.RUN, virtuals=())
+    # each in-edge is the only match for one assertion, so either fails if satisfies stops at
+    # the first in-edge of pkg-d regardless of iteration order
+    assert root.satisfies("^[deptypes=test] pkg-d")  # only through pkg-b -> pkg-d
     assert root.satisfies("^[deptypes=build] pkg-d")  # only through pkg-c -> pkg-d
     assert root.satisfies("^[deptypes=run] pkg-d")  # through either in-edge
-    assert not root.satisfies("^[deptypes=test] pkg-d")
+    assert not root.satisfies("^[deptypes=build,test] pkg-d")  # no single in-edge has both
 
 
 def test_satisfies_tries_every_parallel_edge_of_a_concrete_spec(config, mock_packages):
     """Satisfies is exhaustive when there are duplicates on concrete specs."""
-    # dupe-tool-root --build--> dupe-tool@1.0
+    # dupe-tool-root --build--> dupe-tool@1.0 --build--> cmake
     #                --link-->  dupe-tool-user --link--> dupe-tool@2.0 --build--> gmake
     spec = spack.concretize.concretize_one("dupe-tool-root")
     assert spec.satisfies("^[deptypes=build] dupe-tool@1")
     assert spec.satisfies("^[deptypes=link] dupe-tool@2")
     assert spec.satisfies("^[deptypes=build] dupe-tool@1 ^[deptypes=link] dupe-tool@2 %gmake")
-    # only dupe-tool@2.0 depends on gmake, so an early bailout on dupe-tool@1.0 is wrong
-    assert spec.satisfies("^dupe-tool %gmake")
+    # each dupe-tool node is the only match for one assertion, so either fails if satisfies bails
+    # out on the first dupe-tool it visits regardless of iteration order
+    assert spec.satisfies("^dupe-tool %cmake")  # only dupe-tool@1.0
+    assert spec.satisfies("^dupe-tool %gmake")  # only dupe-tool@2.0
+    assert not spec.satisfies("^dupe-tool %cmake %gmake")  # no single node has both
 
 
 @pytest.mark.parametrize(

--- a/lib/spack/spack/test/spec_semantics.py
+++ b/lib/spack/spack/test/spec_semantics.py
@@ -2670,6 +2670,8 @@ def test_satisfies_tries_every_parallel_edge_of_a_concrete_spec(config, mock_pac
     assert spec.satisfies("^[deptypes=build] dupe-tool@1")
     assert spec.satisfies("^[deptypes=link] dupe-tool@2")
     assert spec.satisfies("^[deptypes=build] dupe-tool@1 ^[deptypes=link] dupe-tool@2 %gmake")
+    # only dupe-tool@2.0 depends on gmake, so an early bailout on dupe-tool@1.0 is wrong
+    assert spec.satisfies("^dupe-tool %gmake")
 
 
 @pytest.mark.parametrize(

--- a/lib/spack/spack/test/spec_semantics.py
+++ b/lib/spack/spack/test/spec_semantics.py
@@ -1475,10 +1475,29 @@ class TestSpecSemantics:
 
     @pytest.mark.regression("18527")
     def test_satisfies_dependencies_ordered(self):
-        d = Spec("zmpi ^fake")
+        d = Spec("zmpi")
+        d._add_dependency(Spec("fake"), depflag=dt.LINK, virtuals=())
         s = Spec("mpileaks")
-        s._add_dependency(d, depflag=0, virtuals=())
+        s._add_dependency(d, depflag=dt.LINK, virtuals=())
         assert s.satisfies("mpileaks ^zmpi ^fake")
+
+    def test_satisfies_transitive_dependencies_require_link_run_path(self):
+        """A transitive ^dep constraint is satisfied by a path of link/run edges; an edge
+        without deptype constraints does not guarantee a link/run edge in every
+        concretization."""
+
+        def chain(depflag1, depflag2):
+            root, mid, leaf = Spec("root"), Spec("mid"), Spec("leaf")
+            root._add_dependency(mid, depflag=depflag1, virtuals=())
+            mid._add_dependency(leaf, depflag=depflag2, virtuals=())
+            return root
+
+        assert not chain(0, 0).satisfies("^leaf")
+        assert not chain(dt.LINK, 0).satisfies("^leaf")
+        assert not chain(dt.LINK, dt.BUILD).satisfies("^leaf")
+        assert chain(dt.BUILD | dt.LINK, dt.LINK).satisfies("^leaf")
+        # a direct dependency of any type is satisfied without a link/run path
+        assert Spec("root ^leaf").satisfies("^leaf")
 
     @pytest.mark.parametrize("transitive", [True, False])
     def test_splice_swap_names(self, transitive):

--- a/lib/spack/spack/test/spec_semantics.py
+++ b/lib/spack/spack/test/spec_semantics.py
@@ -2651,8 +2651,12 @@ def test_satisfies_tries_every_parallel_edge(mock_packages):
 
 def test_satisfies_tries_every_parallel_edge_of_a_concrete_spec(config, mock_packages):
     """Satisfies is exhaustive when there are duplicates on concrete specs."""
+    # dupe-tool-root --build--> dupe-tool@1.0
+    #                --link-->  dupe-tool-user --link--> dupe-tool@2.0 --build--> gmake
     spec = spack.concretize.concretize_one("dupe-tool-root")
-    assert spec.satisfies("^dupe-tool@2.0 %gmake ^[deptypes=link] dupe-tool@2")
+    assert spec.satisfies("^[deptypes=build] dupe-tool@1")
+    assert spec.satisfies("^[deptypes=link] dupe-tool@2")
+    assert spec.satisfies("^[deptypes=build] dupe-tool@1 ^[deptypes=link] dupe-tool@2 %gmake")
 
 
 @pytest.mark.parametrize(

--- a/lib/spack/spack/test/spec_semantics.py
+++ b/lib/spack/spack/test/spec_semantics.py
@@ -1482,22 +1482,12 @@ class TestSpecSemantics:
         assert s.satisfies("mpileaks ^zmpi ^fake")
 
     def test_satisfies_transitive_dependencies_require_link_run_path(self):
-        """A transitive ^dep constraint is satisfied by a path of link/run edges; an edge
-        without deptype constraints does not guarantee a link/run edge in every
-        concretization."""
-
-        def chain(depflag1, depflag2):
-            root, mid, leaf = Spec("root"), Spec("mid"), Spec("leaf")
-            root._add_dependency(mid, depflag=depflag1, virtuals=())
-            mid._add_dependency(leaf, depflag=depflag2, virtuals=())
-            return root
-
-        assert not chain(0, 0).satisfies("^leaf")
-        assert not chain(dt.LINK, 0).satisfies("^leaf")
-        assert not chain(dt.LINK, dt.BUILD).satisfies("^leaf")
-        assert chain(dt.BUILD | dt.LINK, dt.LINK).satisfies("^leaf")
-        # a direct dependency of any type is satisfied without a link/run path
-        assert Spec("root ^leaf").satisfies("^leaf")
+        """A ^dep constraint is satisfied by a direct dependency of any type, or one in the
+        link/run closure. zmpi's gcc may concretize to a pure build dependency, which is
+        neither, so deptype-less edges are not traversed."""
+        assert Spec("mpileaks ^zmpi %gcc").satisfies("^zmpi")
+        assert not Spec("mpileaks ^zmpi %gcc").satisfies("^gcc")
+        assert not Spec("mpileaks ^[deptypes=link] zmpi %gcc").satisfies("^gcc")
 
     @pytest.mark.parametrize("transitive", [True, False])
     def test_splice_swap_names(self, transitive):

--- a/lib/spack/spack/test/spec_semantics.py
+++ b/lib/spack/spack/test/spec_semantics.py
@@ -2649,6 +2649,19 @@ def test_satisfies_tries_every_parallel_edge(mock_packages):
     assert not spec.satisfies("pkg-a ^pkg-b %pkg-c %pkg-e")
 
 
+def test_satisfies_checks_all_in_edges_of_shared_node():
+    """A node with multiple in-edges must be reachable through any of them; an in-edge that fails
+    on edge attributes must not shadow a parallel in-edge that matches."""
+    root, a, b, c = Spec("pkg-a"), Spec("pkg-b"), Spec("pkg-c"), Spec("pkg-d")
+    root.add_dependency_edge(a, depflag=dt.LINK, virtuals=())
+    root.add_dependency_edge(b, depflag=dt.LINK, virtuals=())
+    a.add_dependency_edge(c, depflag=dt.RUN, virtuals=())
+    b.add_dependency_edge(c, depflag=dt.BUILD | dt.RUN, virtuals=())
+    assert root.satisfies("^[deptypes=build] pkg-d")  # only through pkg-c -> pkg-d
+    assert root.satisfies("^[deptypes=run] pkg-d")  # through either in-edge
+    assert not root.satisfies("^[deptypes=test] pkg-d")
+
+
 def test_satisfies_tries_every_parallel_edge_of_a_concrete_spec(config, mock_packages):
     """Satisfies is exhaustive when there are duplicates on concrete specs."""
     # dupe-tool-root --build--> dupe-tool@1.0

--- a/lib/spack/spack/test/spec_semantics.py
+++ b/lib/spack/spack/test/spec_semantics.py
@@ -2641,6 +2641,20 @@ def test_parallel_edges_sort_with_differing_propagation(mock_packages):
     assert sorted(edges) == edges
 
 
+def test_satisfies_tries_every_parallel_edge(mock_packages):
+    """Satisfies is exhaustive when there are duplicates on abstract specs."""
+    spec = Spec("pkg-a ^[deptypes=link] pkg-b %pkg-c ^[deptypes=build] pkg-b %pkg-e")
+    assert spec.satisfies("pkg-a ^pkg-b %pkg-c")
+    assert spec.satisfies("pkg-a ^pkg-b %pkg-e")
+    assert not spec.satisfies("pkg-a ^pkg-b %pkg-c %pkg-e")
+
+
+def test_satisfies_tries_every_parallel_edge_of_a_concrete_spec(config, mock_packages):
+    """Satisfies is exhaustive when there are duplicates on concrete specs."""
+    spec = spack.concretize.concretize_one("dupe-tool-root")
+    assert spec.satisfies("^dupe-tool@2.0 %gmake ^[deptypes=link] dupe-tool@2")
+
+
 @pytest.mark.parametrize(
     "spec_str,assertions",
     [

--- a/var/spack/test_repos/spack_repo/builtin_mock/packages/dupe_tool/package.py
+++ b/var/spack/test_repos/spack_repo/builtin_mock/packages/dupe_tool/package.py
@@ -18,4 +18,5 @@ class DupeTool(Package):
     version("2.0", md5="0123456789abcdef0123456789abcdef")
     version("1.0", md5="fedcba9876543210fedcba9876543210")
 
+    depends_on("cmake", type="build", when="@1.0")
     depends_on("gmake", type="build", when="@2.0")

--- a/var/spack/test_repos/spack_repo/builtin_mock/packages/dupe_tool/package.py
+++ b/var/spack/test_repos/spack_repo/builtin_mock/packages/dupe_tool/package.py
@@ -1,0 +1,21 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack_repo.builtin_mock.build_systems.generic import Package
+
+from spack.package import *
+
+
+class DupeTool(Package):
+    """A package that appears twice in the dependency graph of dupe-tool-root."""
+
+    homepage = "http://www.example.com"
+    url = "http://www.example.com/dupe-tool-1.0.tar.gz"
+
+    tags = ["build-tools"]
+
+    version("2.0", md5="0123456789abcdef0123456789abcdef")
+    version("1.0", md5="fedcba9876543210fedcba9876543210")
+
+    depends_on("gmake", type="build", when="@2.0")

--- a/var/spack/test_repos/spack_repo/builtin_mock/packages/dupe_tool_root/package.py
+++ b/var/spack/test_repos/spack_repo/builtin_mock/packages/dupe_tool_root/package.py
@@ -1,0 +1,19 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack_repo.builtin_mock.build_systems.generic import Package
+
+from spack.package import *
+
+
+class DupeToolRoot(Package):
+    """Builds against an older dupe-tool than the one its runtime dependency links against."""
+
+    homepage = "http://www.example.com"
+    url = "http://www.example.com/dupe-tool-root-1.0.tar.gz"
+
+    version("1.0", md5="abcdefabcdefabcdefabcdefabcdefab")
+
+    depends_on("dupe-tool@1.0", type="build")
+    depends_on("dupe-tool-user", type=("link", "run"))

--- a/var/spack/test_repos/spack_repo/builtin_mock/packages/dupe_tool_user/package.py
+++ b/var/spack/test_repos/spack_repo/builtin_mock/packages/dupe_tool_user/package.py
@@ -1,0 +1,18 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack_repo.builtin_mock.build_systems.generic import Package
+
+from spack.package import *
+
+
+class DupeToolUser(Package):
+    """Links against the newer dupe-tool."""
+
+    homepage = "http://www.example.com"
+    url = "http://www.example.com/dupe-tool-user-1.0.tar.gz"
+
+    version("1.0", md5="11112222333344445555666677778888")
+
+    depends_on("dupe-tool@2.0", type=("link", "run"))


### PR DESCRIPTION
Fix a bug where satisfies does not consider other nodes with the same
package name:

```python
>>> s = Spec("pkg-a ^[deptypes=link] pkg-b %pkg-c ^[deptypes=build] pkg-b %pkg-e")
>>> s.satisfies("pkg-a ^pkg-b %pkg-c")
True
>>> s.satisfies("pkg-a ^pkg-b %pkg-e")
False  # wrong
```

(The example requires `deptypes=` to avoid merging parallel edges)

Also fix a depth >= 2 bug where satisfies traverses edges without deptype constraints:

```python
>>> Spec("mpileaks ^zmpi %gcc").satisfies("^gcc")
True  # wrong
```

`^gcc` looks at the closure of link/run deps and *direct* deps of any type. Deptypes has multi-valued variant semantics (so, "ast least" semantics), meaning that when deptypes are not specified on `%gcc`, it may concretize to a pure build dep of some `zmpi` in the link/run closure. That's a concrete spec that satisfies the lhs but not the rhs, because build deps of link/run deps are out of reach. Only an edge that overlaps link/run guarantees that the child is within the reach of `^` of the right-hand side.