### PR TITLE
spec.py: fix shared mutable state of CompilerFlag

### DIFF
--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -925,6 +925,11 @@ class CompilerFlag(str):
         obj.source = kwargs.pop("source", None)
         return obj
 
+    def copy(self) -> "CompilerFlag":
+        return CompilerFlag(
+            self, propagate=self.propagate, flag_group=self.flag_group, source=self.source
+        )
+
     def to_dict(self) -> Dict[str, Any]:
         """Value and propagation of this flag, unlike ``FlagMap.yaml_entry``, which is its value
         only. ``flag_group`` and ``source`` are not included: they are bookkeeping for a single
@@ -983,15 +988,15 @@ class FlagMap(lang.HashableMap[str, List[CompilerFlag]]):
         changed = False
         for flag_type in other:
             if flag_type not in self:
-                # copy the list, so that self and other do not share it
-                self[flag_type] = list(other[flag_type])
+                # copy the list and its flags, so that self and other share no mutable state
+                self[flag_type] = [f.copy() for f in other[flag_type]]
                 changed = True
                 continue
 
             extra_other = set(other[flag_type]) - set(self[flag_type])
             if extra_other:
                 self[flag_type] = list(self[flag_type]) + [
-                    x for x in other[flag_type] if x in extra_other
+                    x.copy() for x in other[flag_type] if x in extra_other
                 ]
                 changed = True
 
@@ -1039,8 +1044,8 @@ class FlagMap(lang.HashableMap[str, List[CompilerFlag]]):
 
     def copy(self):
         clone = FlagMap()
-        for name, compiler_flag in self.items():
-            clone[name] = compiler_flag
+        for flag_type, flags in self.items():
+            clone[flag_type] = [f.copy() for f in flags]
         return clone
 
     def add_flag(self, flag_type, value, propagation, flag_group=None, source=None):

--- a/lib/spack/spack/test/spec_semantics.py
+++ b/lib/spack/spack/test/spec_semantics.py
@@ -2538,7 +2538,7 @@ def test_constrain_does_not_share_flags_or_architecture_with_the_rhs(mock_packag
 
 
 def test_copy_does_not_share_flag_instances(mock_packages):
-    """CompilerFlag instances have mutable attributes; those should not be shared with copies."""
+    """CompilerFlag is a mutable string in FlagMap; it should not be shared on copy."""
     old = Spec("pkg-a cflags=-O2 cflags==-g")
     new = old.copy()
     assert len(new.compiler_flags["cflags"]) == len(old.compiler_flags["cflags"]) == 2

--- a/lib/spack/spack/test/spec_semantics.py
+++ b/lib/spack/spack/test/spec_semantics.py
@@ -2536,6 +2536,20 @@ def test_constrain_does_not_share_flags_or_architecture_with_the_rhs(mock_packag
     assert rhs.to_dict() == before
 
 
+def test_copy_does_not_share_mutable_state(mock_packages):
+    """Ensure that mutable operations on compiler flags do not mutate the original spec"""
+    lhs, rhs = Spec("pkg-a"), Spec("pkg-a cflags=-O2")
+    lhs.constrain(rhs)
+    before = rhs.to_dict()
+    lhs.constrain("pkg-a cflags==-O2")
+    assert rhs.to_dict() == before
+
+    original = Spec("pkg-a cflags=-O2")
+    before = original.to_dict()
+    original.copy().constrain("pkg-a cflags==-O2")
+    assert original.to_dict() == before
+
+
 @pytest.mark.parametrize(
     "parent_str,child_str,kwargs,expected_str,expected_repr",
     [

--- a/lib/spack/spack/test/spec_semantics.py
+++ b/lib/spack/spack/test/spec_semantics.py
@@ -2532,22 +2532,19 @@ def test_constrain_does_not_share_flags_or_architecture_with_the_rhs(mock_packag
     lhs.constrain(rhs)
     before = rhs.to_dict()
 
-    lhs.constrain(Spec("pkg-a cflags=-g target=haswell"))
+    # -g extends the flag list, ==-O2 constrains the propagation of -O2, haswell the range
+    lhs.constrain(Spec("pkg-a cflags==-O2 cflags=-g target=haswell"))
     assert rhs.to_dict() == before
 
 
-def test_copy_does_not_share_mutable_state(mock_packages):
-    """Ensure that mutable operations on compiler flags do not mutate the original spec"""
-    lhs, rhs = Spec("pkg-a"), Spec("pkg-a cflags=-O2")
-    lhs.constrain(rhs)
-    before = rhs.to_dict()
-    lhs.constrain("pkg-a cflags==-O2")
-    assert rhs.to_dict() == before
-
-    original = Spec("pkg-a cflags=-O2")
-    before = original.to_dict()
-    original.copy().constrain("pkg-a cflags==-O2")
-    assert original.to_dict() == before
+def test_copy_does_not_share_flag_instances(mock_packages):
+    """CompilerFlag instances have mutable attributes; those should not be shared with copies."""
+    old = Spec("pkg-a cflags=-O2 cflags==-g")
+    new = old.copy()
+    assert len(new.compiler_flags["cflags"]) == len(old.compiler_flags["cflags"]) == 2
+    for x, y in zip(old.compiler_flags["cflags"], new.compiler_flags["cflags"]):
+        assert x is not y
+        assert x == y and x.propagate == y.propagate and x.flag_group == y.flag_group
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
CompilerFlag is a mutable subclass of str and constrain is a mutable
operation, so not only do we have to copy the list of flags, but also
each individual CompilerFlag instance.
