### PR TITLE
Revert "Deprecate spack solve" (#52596)

### DIFF
--- a/.github/workflows/bootstrap.yml
+++ b/.github/workflows/bootstrap.yml
@@ -47,7 +47,7 @@ jobs:
           spack config add config:installer:new
           spack bootstrap disable github-actions-v2
           spack bootstrap disable github-actions-v0.6
-          spack spec --show opt,solutions zlib
+          spack solve zlib
           tree ~/.spack/bootstrap/store/
 
   clingo-sources:
@@ -74,7 +74,7 @@ jobs:
           spack bootstrap disable github-actions-v2
           spack bootstrap disable github-actions-v0.6
           export PATH="$(brew --prefix bison)/bin:$(brew --prefix cmake)/bin:$PATH"
-          spack spec --show opt,solutions zlib
+          spack solve zlib
           tree ~/.spack/bootstrap/store/
 
   gnupg-sources:
@@ -100,7 +100,7 @@ jobs:
         run: |
           . share/spack/setup-env.sh
           spack config add config:installer:new
-          spack spec --show opt,solutions zlib
+          spack solve zlib
           spack bootstrap disable github-actions-v2
           spack bootstrap disable github-actions-v0.6
           spack gpg list
@@ -150,7 +150,7 @@ jobs:
               echo "Python $ver not found"
               exit 1
             fi
-            spack spec --show opt,solutions zlib
+            spack solve zlib
           done
           tree ~/.spack/bootstrap/store
       - name: Bootstrap GnuPG
@@ -180,7 +180,7 @@ jobs:
           ./share/spack/setup-env.ps1
           spack bootstrap disable github-actions-v2
           spack bootstrap disable github-actions-v0.6
-          spack -d spec --show "opt,solutions" zlib
+          spack -d solve zlib
           ./share/spack/qa/validate_last_exit.ps1
           tree $env:userprofile/.spack/bootstrap/store/
       - name: Bootstrap GnuPG

--- a/lib/spack/docs/bootstrapping.rst
+++ b/lib/spack/docs/bootstrapping.rst
@@ -50,7 +50,7 @@ Running a command that concretizes a spec, like:
 
 .. code-block:: console
 
-   % spack spec zlib
+   % spack solve zlib
    ==> Installing "clingo-bootstrap@spack%apple-clang@12.0.0~docs~ipo+python build_type=Release arch=darwin-catalina-x86_64" from a buildcache
    [ ... ]
 

--- a/lib/spack/docs/config_yaml.rst
+++ b/lib/spack/docs/config_yaml.rst
@@ -295,7 +295,7 @@ When set to ``true``, Spack will utilize a cache of solver outputs from successf
 When enabled, Spack will check the concretization cache prior to running the solver.
 If a previous request to solve a given problem is present in the cache, Spack will load the concrete specs and other solver data from the cache rather than running the solver.
 Specs not previously concretized will be added to the cache on a successful solve.
-The cache additionally holds solver statistics, so commands like ``spack spec --show opt <spec>`` will still return information about the run that produced a given solver result.
+The cache additionally holds solver statistics, so commands like ``spack solve`` will still return information about the run that produced a given solver result.
 
 This cache is a subcache of the :ref:`Misc Cache` and as such will be cleaned when the Misc Cache is cleaned.
 

--- a/lib/spack/docs/developer_guide.rst
+++ b/lib/spack/docs/developer_guide.rst
@@ -771,11 +771,11 @@ When working on the ASP-based solver in ``lib/spack/spack/solver/``, it is often
 Generating ASP facts
 ^^^^^^^^^^^^^^^^^^^^
 
-The ``spack spec --show=asp`` flag dumps all ASP facts generated for a given spec to stdout:
+The ``spack solve --show=asp`` flag dumps all ASP facts generated for a given spec to stdout:
 
 .. code-block:: console
 
-   $ spack spec --show=asp zlib-ng > zlib.lp
+   $ spack solve --show=asp zlib-ng > zlib.lp
 
 The resulting file contains both the package facts (versions, variants, dependencies) and the problem-specific facts derived from the user's configuration.
 It can be fed directly to clingo alongside the solver rules.

--- a/lib/spack/docs/frequently_asked_questions.rst
+++ b/lib/spack/docs/frequently_asked_questions.rst
@@ -166,7 +166,7 @@ If it is not obvious *why* the solver made a particular decision -- for example,
 
 .. code-block:: console
 
-   $ spack spec --show opt,solutions <spec>
+   $ spack solve <spec>
 
 The output shows the optimization criteria and the weights assigned to each choice.
 This makes it possible to trace which preference or requirement is driving an unexpected result.

--- a/lib/spack/docs/packages_yaml.rst
+++ b/lib/spack/docs/packages_yaml.rst
@@ -516,7 +516,7 @@ In the example above, that means you could build ``mpich+cuda`` or ``mpich+rocm`
 .. note::
 
    When using a conditional requirement, Spack is allowed to actively avoid the triggering condition (the ``when=...`` spec) if that leads to a concrete spec with better scores in the optimization criteria.
-   To check the current optimization criteria and their priorities you can run ``spack spec --show opt,solutions zlib``.
+   To check the current optimization criteria and their priorities you can run ``spack solve zlib``.
 
 Setting default requirements
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/lib/spack/spack/cmd/solve.py
+++ b/lib/spack/spack/cmd/solve.py
@@ -1,25 +1,225 @@
 # Copyright Spack Project Developers. See COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
-import argparse
-import warnings
 
+import argparse
+import re
+import sys
+
+import spack
+import spack.binary_distribution
+import spack.cmd
 import spack.cmd.spec
+import spack.config
+import spack.hash_types as ht
+import spack.package_base
+import spack.spec
+from spack.active_environment import active_environment
+from spack.solver import asp
+from spack.util import tty
+from spack.util.tty import color
 
 description = "concretize a specs using an ASP solver"
 section = "developer"
 level = "long"
 
 
+#: output options
+show_options = ("asp", "opt", "output", "solutions")
+
+
 def setup_parser(subparser: argparse.ArgumentParser) -> None:
+    # Solver arguments
+    subparser.add_argument(
+        "--show",
+        action="store",
+        default="opt,solutions",
+        help="select outputs\n\ncomma-separated list of:\n"
+        "  asp          asp program text\n"
+        "  opt          optimization criteria for best model\n"
+        "  output       raw clingo output\n"
+        "  solutions    models found by asp program\n"
+        "  all          all of the above",
+    )
+    subparser.add_argument(
+        "--timers",
+        action="store_true",
+        default=False,
+        help="print out timers for different solve phases",
+    )
+    subparser.add_argument(
+        "--stats", action="store_true", default=False, help="print out statistics from clingo"
+    )
+
     spack.cmd.spec.setup_parser(subparser)
 
 
-def solve(parser, args):
-    msg = (
-        "The `spack solve` command is deprecated in favor of options added to the "
-        "`spack spec` command and will be removed in Spack v1.3"
-    )
-    warnings.warn(msg)
+def _process_result(result, show, required_format, kwargs):
+    opt, _, _ = min(result.answers)
+    if ("opt" in show) and (not required_format):
+        tty.msg("Best of %d considered solutions." % result.nmodels)
 
-    spack.cmd.spec.spec(parser, args)
+        print()
+        maxlen = max(len(s.name) for s in result.criteria)
+        color.cprint("@*{  Priority  Value  Criterion}")
+
+        # Width of a data row past its 2-space indent, matching the row format below:
+        # 8-wide priority + 2 gap + 5-wide value + 2 gap + maxlen-wide criterion name.
+        divider_width = 8 + 2 + 5 + 2 + maxlen
+        prev_band = None
+
+        for i, criterion in enumerate(result.criteria, 1):
+            # Criteria are grouped into priority bands; print a header when the band changes.
+            band = criterion.band
+            if band != prev_band:
+                label = f"-- {band}"
+                dashes = "-" * max(0, divider_width - len(label) - 1)
+                color.cprint(f"  @*{{{label}}} @K{{{dashes}}}")
+                prev_band = band
+
+            value = f"@K{{{criterion.value:>5}}}"
+            grey_out = True
+            if criterion.value > 0:
+                value = f"@*{{{criterion.value:>5}}}"
+                grey_out = False
+
+            if grey_out:
+                lc = "@K"
+            elif criterion.kind == asp.OptimizationKind.CONCRETE:
+                lc = "@b"
+            elif criterion.kind == asp.OptimizationKind.BUILD:
+                lc = "@g"
+            else:
+                lc = "@y"
+
+            color.cprint(f"  @K{{{i:8}}}  {value}  {lc}{{{criterion.name:<{maxlen}}}}")
+        print()
+        print()
+        color.cprint("  @*{Legend:}")
+        color.cprint("    @g{Specs to be built}")
+        color.cprint("    @b{Reused specs}")
+        color.cprint("    @y{Other criteria}")
+        print()
+
+    # dump the solutions as concretized specs
+    if "solutions" in show:
+        if required_format:
+            for spec in result.specs:
+                # With -y, just print YAML to output.
+                if required_format == "yaml":
+                    # use write because to_yaml already has a newline.
+                    sys.stdout.write(spec.to_yaml(hash=ht.dag_hash))
+                elif required_format == "json":
+                    sys.stdout.write(spec.to_json(hash=ht.dag_hash))
+                else:
+                    print(spec.format(required_format))
+        else:
+            tree_str = spack.spec.tree(
+                result.specs, color=color.get_color_when(sys.stdout), **kwargs
+            )
+            sys.stdout.write(tree_str)
+        print()
+
+    if result.unsolved_specs and "solutions" in show:
+        tty.msg(asp.Result.format_unsolved(result.unsolved_specs))
+
+
+def solve(parser, args):
+    # these are the same options as `spack spec`
+    fmt = spack.spec.DISPLAY_FORMAT
+    if args.namespaces:
+        fmt = "{namespace}." + fmt
+
+    show_status = args.install_status
+    if show_status:
+        spack.binary_distribution.load_buildcache_index()
+        status_fn = spack.cmd.buildcache_status_fn(spack.binary_distribution.BINARY_INDEX)
+    else:
+        status_fn = None
+
+    kwargs = {
+        "cover": args.cover,
+        "format": fmt,
+        "hashlen": None if args.very_long else 7,
+        "show_types": args.types,
+        "status_fn": status_fn,
+        "hashes": args.long or args.very_long,
+        "version_style_fn": (
+            spack.package_base.non_preferred_version if args.non_defaults else None
+        ),
+        "variant_style_fn": (
+            spack.package_base.non_default_variant if args.non_defaults else None
+        ),
+    }
+
+    # process output options
+    show = re.split(r"\s*,\s*", args.show)
+    if "all" in show:
+        show = show_options
+    for d in show:
+        if d not in show_options:
+            raise ValueError(
+                "Invalid option for '--show': '%s'\nchoose from: (%s)"
+                % (d, ", ".join(show_options + ("all",)))
+            )
+
+    # Format required for the output (JSON, YAML or None)
+    required_format = args.format
+
+    # If we have an active environment, pick the specs from there
+    env = active_environment()
+    if args.specs:
+        specs = spack.cmd.parse_specs(args.specs)
+    elif env:
+        specs = list(env.user_specs)
+    else:
+        args.subparser.error("requires at least one spec or an active environment")
+
+    solver = asp.Solver()
+    output = sys.stdout if "asp" in show else None
+    setup_only = set(show) == {"asp"}
+    unify = spack.config.CONFIG.get("concretizer:unify")
+    allow_deprecated = spack.config.CONFIG.get("config:deprecated", False)
+    if unify == "when_possible":
+        for idx, result in enumerate(
+            solver.solve_in_rounds(
+                specs,
+                out=output,
+                timers=args.timers,
+                stats=args.stats,
+                allow_deprecated=allow_deprecated,
+            )
+        ):
+            if "solutions" in show:
+                tty.msg("ROUND {0}".format(idx))
+                tty.msg("")
+            else:
+                print("% END ROUND {0}\n".format(idx))
+            if not setup_only:
+                _process_result(result, show, required_format, kwargs)
+    elif unify:
+        # set up solver parameters
+        # Note: reuse and other concretizer prefs are passed as configuration
+        result = solver.solve(
+            specs,
+            out=output,
+            timers=args.timers,
+            stats=args.stats,
+            setup_only=setup_only,
+            allow_deprecated=allow_deprecated,
+        )
+        if not setup_only:
+            _process_result(result, show, required_format, kwargs)
+    else:
+        for spec in specs:
+            tty.msg("SOLVING SPEC:", spec)
+            result = solver.solve(
+                [spec],
+                out=output,
+                timers=args.timers,
+                stats=args.stats,
+                setup_only=setup_only,
+                allow_deprecated=allow_deprecated,
+            )
+            if not setup_only:
+                _process_result(result, show, required_format, kwargs)

--- a/lib/spack/spack/cmd/solve.py
+++ b/lib/spack/spack/cmd/solve.py
@@ -18,7 +18,7 @@ def setup_parser(subparser: argparse.ArgumentParser) -> None:
 def solve(parser, args):
     msg = (
         "The `spack solve` command is deprecated in favor of options added to the "
-        "`spack spec` command and will be removed in Spack v1.4"
+        "`spack spec` command and will be removed in Spack v1.3"
     )
     warnings.warn(msg)
 

--- a/lib/spack/spack/cmd/spec.py
+++ b/lib/spack/spack/cmd/spec.py
@@ -3,28 +3,23 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 import argparse
-import re
 import sys
 
 import spack
 import spack.binary_distribution
 import spack.cmd
-import spack.config
 import spack.hash_types as ht
 import spack.package_base
 import spack.spec
+import spack.store
+import spack.traverse
 from spack.active_environment import active_environment
 from spack.cmd.common import arguments
-from spack.solver import asp
-from spack.util import tty
-from spack.util.tty import color
+from spack.util.lang import nullcontext
 
 description = "show what would be installed, given a spec"
 section = "build"
 level = "short"
-
-#: output options
-show_options = ("asp", "opt", "solutions")
 
 
 def setup_parser(subparser: argparse.ArgumentParser) -> None:
@@ -80,104 +75,21 @@ for further documentation regarding the spec syntax, see:
     arguments.add_common_arguments(subparser, ["specs"])
     arguments.add_concretizer_args(subparser)
 
-    # debugging arguments
-    subparser.add_argument(
-        "--show",
-        action="store",
-        default="solutions",
-        help="select outputs\n\ncomma-separated list of:\n"
-        "  asp          asp program text\n"
-        "  opt          optimization criteria for best model\n"
-        "  output       raw clingo output\n"
-        "  solutions    models found by asp program\n"
-        "  all          all of the above",
-    )
-    subparser.add_argument(
-        "--timers",
-        action="store_true",
-        default=False,
-        help="print out timers for different solve phases",
-    )
-    subparser.add_argument(
-        "--stats", action="store_true", default=False, help="print out statistics from clingo"
-    )
-
-
-def _process_result(result, show, required_format, kwargs):
-    opt, _, _ = min(result.answers)
-    if ("opt" in show) and (not required_format):
-        tty.msg("Best of %d considered solutions." % result.nmodels)
-
-        print()
-        maxlen = max(len(s.name) for s in result.criteria)
-        color.cprint("@*{  Priority  Value  Criterion}")
-
-        # Width of a data row past its 2-space indent, matching the row format below:
-        # 8-wide priority + 2 gap + 5-wide value + 2 gap + maxlen-wide criterion name.
-        divider_width = 8 + 2 + 5 + 2 + maxlen
-        prev_band = None
-
-        for i, criterion in enumerate(result.criteria, 1):
-            # Criteria are grouped into priority bands; print a header when the band changes.
-            band = criterion.band
-            if band != prev_band:
-                label = f"-- {band}"
-                dashes = "-" * max(0, divider_width - len(label) - 1)
-                color.cprint(f"  @*{{{label}}} @K{{{dashes}}}")
-                prev_band = band
-
-            value = f"@K{{{criterion.value:>5}}}"
-            grey_out = True
-            if criterion.value > 0:
-                value = f"@*{{{criterion.value:>5}}}"
-                grey_out = False
-
-            if grey_out:
-                lc = "@K"
-            elif criterion.kind == asp.OptimizationKind.CONCRETE:
-                lc = "@b"
-            elif criterion.kind == asp.OptimizationKind.BUILD:
-                lc = "@g"
-            else:
-                lc = "@y"
-
-            color.cprint(f"  @K{{{i:8}}}  {value}  {lc}{{{criterion.name:<{maxlen}}}}")
-        print()
-        print()
-        color.cprint("  @*{Legend:}")
-        color.cprint("    @g{Specs to be built}")
-        color.cprint("    @b{Reused specs}")
-        color.cprint("    @y{Other criteria}")
-        print()
-
-    # dump the solutions as concretized specs
-    if "solutions" in show:
-        if required_format:
-            for spec in result.specs:
-                # With -y, just print YAML to output.
-                if required_format == "yaml":
-                    # use write because to_yaml already has a newline.
-                    sys.stdout.write(spec.to_yaml(hash=ht.dag_hash))
-                elif required_format == "json":
-                    sys.stdout.write(spec.to_json(hash=ht.dag_hash))
-                else:
-                    print(spec.format(required_format))
-        else:
-            tree_str = spack.spec.tree(
-                result.specs, color=color.get_color_when(sys.stdout), **kwargs
-            )
-            sys.stdout.write(tree_str)
-        print()
-
-    if result.unsolved_specs and "solutions" in show:
-        tty.msg(asp.Result.format_unsolved(result.unsolved_specs))
-
 
 def spec(parser, args):
-    # these are the same options as `spack spec`
     fmt = spack.spec.DISPLAY_FORMAT
     if args.namespaces:
         fmt = "{namespace}." + fmt
+
+    env = active_environment()
+
+    if args.specs:
+        concrete_specs = spack.cmd.parse_specs(args.specs, concretize=True)
+    elif env:
+        env.concretize()
+        concrete_specs = env.concrete_roots()
+    else:
+        args.subparser.error("requires at least one spec or an active environment")
 
     show_status = args.install_status
     if show_status:
@@ -186,88 +98,38 @@ def spec(parser, args):
     else:
         status_fn = None
 
-    kwargs = {
-        "cover": args.cover,
-        "format": fmt,
-        "hashlen": None if args.very_long else 7,
-        "show_types": args.types,
-        "status_fn": status_fn,
-        "hashes": args.long or args.very_long,
-        "version_style_fn": (
-            spack.package_base.non_preferred_version if args.non_defaults else None
-        ),
-        "variant_style_fn": (
-            spack.package_base.non_default_variant if args.non_defaults else None
-        ),
-    }
+    # use a read transaction if we are getting install status for every
+    # spec in the DAG.  This avoids repeatedly querying the DB.
+    tree_context = spack.store.STORE.db.read_transaction if show_status else nullcontext
 
-    # process output options
-    show = re.split(r"\s*,\s*", args.show)
-    if "all" in show:
-        show = show_options
-    for d in show:
-        if d not in show_options:
-            raise ValueError(
-                "Invalid option for '--show': '%s'\nchoose from: (%s)"
-                % (d, ", ".join(show_options + ("all",)))
-            )
-
-    # Format required for the output (JSON, YAML or None)
-    required_format = args.format
-
-    # If we have an active environment, pick the specs from there
-    env = active_environment()
-    if args.specs:
-        specs = spack.cmd.parse_specs(args.specs)
-    elif env:
-        specs = list(env.user_specs)
-    else:
-        args.subparser.error("requires at least one spec or an active environment")
-
-    solver = asp.Solver()
-    output = sys.stdout if "asp" in show else None
-    setup_only = set(show) == {"asp"}
-    unify = spack.config.CONFIG.get("concretizer:unify")
-    allow_deprecated = spack.config.CONFIG.get("config:deprecated", False)
-    if unify == "when_possible":
-        for idx, result in enumerate(
-            solver.solve_in_rounds(
-                specs,
-                out=output,
-                timers=args.timers,
-                stats=args.stats,
-                allow_deprecated=allow_deprecated,
-            )
-        ):
-            if "solutions" in show:
-                tty.msg("ROUND {0}".format(idx))
-                tty.msg("")
+    # With --yaml, --json, or --format, just print the raw specs to output
+    if args.format:
+        for spec in concrete_specs:
+            if args.format == "yaml":
+                # use write because to_yaml already has a newline.
+                sys.stdout.write(spec.to_yaml(hash=ht.dag_hash))
+            elif args.format == "json":
+                print(spec.to_json(hash=ht.dag_hash))
             else:
-                print("% END ROUND {0}\n".format(idx))
-            if not setup_only:
-                _process_result(result, show, required_format, kwargs)
-    elif unify:
-        # set up solver parameters
-        # Note: reuse and other concretizer prefs are passed as configuration
-        result = solver.solve(
-            specs,
-            out=output,
-            timers=args.timers,
-            stats=args.stats,
-            setup_only=setup_only,
-            allow_deprecated=allow_deprecated,
-        )
-        if not setup_only:
-            _process_result(result, show, required_format, kwargs)
-    else:
-        for spec in specs:
-            result = solver.solve(
-                [spec],
-                out=output,
-                timers=args.timers,
-                stats=args.stats,
-                setup_only=setup_only,
-                allow_deprecated=allow_deprecated,
+                print(spec.format(args.format))
+        return
+
+    with tree_context():
+        print(
+            spack.spec.tree(
+                concrete_specs,
+                cover=args.cover,
+                format=fmt,
+                hashlen=None if args.very_long else 7,
+                show_types=args.types,
+                status_fn=status_fn,
+                hashes=args.long or args.very_long,
+                key=spack.traverse.by_dag_hash,
+                version_style_fn=(
+                    spack.package_base.non_preferred_version if args.non_defaults else None
+                ),
+                variant_style_fn=(
+                    spack.package_base.non_default_variant if args.non_defaults else None
+                ),
             )
-            if not setup_only:
-                _process_result(result, show, required_format, kwargs)
+        )

--- a/lib/spack/spack/test/cmd/spec.py
+++ b/lib/spack/spack/test/cmd/spec.py
@@ -107,7 +107,6 @@ def test_spec_json():
 
 def test_spec_format(mutable_database):
     output = spec("--format", "{name}-{^mpi.name}", "mpileaks^mpich")
-    print(output)
     assert output.rstrip("\n") == "mpileaks-mpich"
 
 
@@ -207,7 +206,7 @@ def test_spec_version_assigned_git_ref_as_version(name, version, error):
         (False, ["mpileaks_mpich", "dyninst"], "mpich", None),
         (False, ["mpileaks_zmpi", "dyninst"], "zmpi", None),
         # cases with unfiy:false
-        (True, ["mpileaks_mpich", "mpileaks_zmpi"], "mpileaks.*, mpileaks", spack.error.SpecError),
+        (True, ["mpileaks_mpich", "mpileaks_zmpi"], "callpath, mpileaks", spack.error.SpecError),
         (False, ["mpileaks_mpich", "mpileaks_zmpi"], "zmpi", None),
     ],
 )

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -1929,7 +1929,7 @@ _spack_restage() {
 _spack_solve() {
     if $list_options
     then
-        SPACK_COMPREPLY="-h --help -l --long -L --very-long -N --namespaces -I --install-status --no-install-status -y --yaml -j --json --format --non-defaults -c --cover -t --types -f --force -U --fresh --reuse --fresh-roots --reuse-deps --deprecated --show --timers --stats"
+        SPACK_COMPREPLY="-h --help --show --timers --stats -l --long -L --very-long -N --namespaces -I --install-status --no-install-status -y --yaml -j --json --format --non-defaults -c --cover -t --types -f --force -U --fresh --reuse --fresh-roots --reuse-deps --deprecated"
     else
         _all_packages
     fi
@@ -1938,7 +1938,7 @@ _spack_solve() {
 _spack_spec() {
     if $list_options
     then
-        SPACK_COMPREPLY="-h --help -l --long -L --very-long -N --namespaces -I --install-status --no-install-status -y --yaml -j --json --format --non-defaults -c --cover -t --types -f --force -U --fresh --reuse --fresh-roots --reuse-deps --deprecated --show --timers --stats"
+        SPACK_COMPREPLY="-h --help -l --long -L --very-long -N --namespaces -I --install-status --no-install-status -y --yaml -j --json --format --non-defaults -c --cover -t --types -f --force -U --fresh --reuse --fresh-roots --reuse-deps --deprecated"
     else
         _all_packages
     fi

--- a/share/spack/spack-completion.fish
+++ b/share/spack/spack-completion.fish
@@ -3013,10 +3013,16 @@ complete -c spack -n '__fish_spack_using_command restage' -s h -l help -f -a hel
 complete -c spack -n '__fish_spack_using_command restage' -s h -l help -d 'show this help message and exit'
 
 # spack solve
-set -g __fish_spack_optspecs_spack_solve h/help l/long L/very-long N/namespaces I/install-status no-install-status y/yaml j/json format= non-defaults c/cover= t/types f/force U/fresh reuse fresh-roots deprecated show= timers stats
+set -g __fish_spack_optspecs_spack_solve h/help show= timers stats l/long L/very-long N/namespaces I/install-status no-install-status y/yaml j/json format= non-defaults c/cover= t/types f/force U/fresh reuse fresh-roots deprecated
 complete -c spack -n '__fish_spack_using_command_pos_remainder 0 solve' -f -k -a '(__fish_spack_specs_or_id)'
 complete -c spack -n '__fish_spack_using_command solve' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command solve' -s h -l help -d 'show this help message and exit'
+complete -c spack -n '__fish_spack_using_command solve' -l show -r -f -a show
+complete -c spack -n '__fish_spack_using_command solve' -l show -r -d 'select outputs'
+complete -c spack -n '__fish_spack_using_command solve' -l timers -f -a timers
+complete -c spack -n '__fish_spack_using_command solve' -l timers -d 'print out timers for different solve phases'
+complete -c spack -n '__fish_spack_using_command solve' -l stats -f -a stats
+complete -c spack -n '__fish_spack_using_command solve' -l stats -d 'print out statistics from clingo'
 complete -c spack -n '__fish_spack_using_command solve' -s l -l long -f -a long
 complete -c spack -n '__fish_spack_using_command solve' -s l -l long -d 'show dependency hashes as well as versions'
 complete -c spack -n '__fish_spack_using_command solve' -s L -l very-long -f -a very_long
@@ -3049,15 +3055,9 @@ complete -c spack -n '__fish_spack_using_command solve' -l fresh-roots -l reuse-
 complete -c spack -n '__fish_spack_using_command solve' -l fresh-roots -l reuse-deps -d 'concretize with fresh roots and reused dependencies'
 complete -c spack -n '__fish_spack_using_command solve' -l deprecated -f -a config_deprecated
 complete -c spack -n '__fish_spack_using_command solve' -l deprecated -d 'allow concretizer to select deprecated versions'
-complete -c spack -n '__fish_spack_using_command solve' -l show -r -f -a show
-complete -c spack -n '__fish_spack_using_command solve' -l show -r -d 'select outputs'
-complete -c spack -n '__fish_spack_using_command solve' -l timers -f -a timers
-complete -c spack -n '__fish_spack_using_command solve' -l timers -d 'print out timers for different solve phases'
-complete -c spack -n '__fish_spack_using_command solve' -l stats -f -a stats
-complete -c spack -n '__fish_spack_using_command solve' -l stats -d 'print out statistics from clingo'
 
 # spack spec
-set -g __fish_spack_optspecs_spack_spec h/help l/long L/very-long N/namespaces I/install-status no-install-status y/yaml j/json format= non-defaults c/cover= t/types f/force U/fresh reuse fresh-roots deprecated show= timers stats
+set -g __fish_spack_optspecs_spack_spec h/help l/long L/very-long N/namespaces I/install-status no-install-status y/yaml j/json format= non-defaults c/cover= t/types f/force U/fresh reuse fresh-roots deprecated
 complete -c spack -n '__fish_spack_using_command_pos_remainder 0 spec' -f -k -a '(__fish_spack_specs_or_id)'
 complete -c spack -n '__fish_spack_using_command spec' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command spec' -s h -l help -d 'show this help message and exit'
@@ -3093,12 +3093,6 @@ complete -c spack -n '__fish_spack_using_command spec' -l fresh-roots -l reuse-d
 complete -c spack -n '__fish_spack_using_command spec' -l fresh-roots -l reuse-deps -d 'concretize with fresh roots and reused dependencies'
 complete -c spack -n '__fish_spack_using_command spec' -l deprecated -f -a config_deprecated
 complete -c spack -n '__fish_spack_using_command spec' -l deprecated -d 'allow concretizer to select deprecated versions'
-complete -c spack -n '__fish_spack_using_command spec' -l show -r -f -a show
-complete -c spack -n '__fish_spack_using_command spec' -l show -r -d 'select outputs'
-complete -c spack -n '__fish_spack_using_command spec' -l timers -f -a timers
-complete -c spack -n '__fish_spack_using_command spec' -l timers -d 'print out timers for different solve phases'
-complete -c spack -n '__fish_spack_using_command spec' -l stats -f -a stats
-complete -c spack -n '__fish_spack_using_command spec' -l stats -d 'print out statistics from clingo'
 
 # spack stage
 set -g __fish_spack_optspecs_spack_stage h/help n/no-checksum p/path= e/exclude= s/skip-installed f/force U/fresh reuse fresh-roots deprecated


### PR DESCRIPTION
Reverts #52596, #52597, #52655.

Merging `spack solve` into `spack spec` caused at least four regressions: `spack spec /hash` re-concretizes instead of doing a DB lookup; it re-concretizes in an active environment (somehow requires a +558/−111 diff in #52794, which is more than twice as large as the original diff); empty environments hit an internal solver error (#52832, open fix in #52841); the deprecated `spack solve` lost its `--show opt,solutions` default (https://github.com/spack/spack/pull/52596#discussion_r3474845734).

The revert conflicted with later refactors. To verify it: `git diff 965d02d8f2^ f229535891 -- lib/spack/spack/cmd/{spec,solve}.py` shows only hunks from those refactors (#52513, #52731, #52759, #52211, #52805, #52828):


