### PR TITLE
test_function_calls: make the bootstrap root absolute

### DIFF
--- a/lib/spack/spack/test/cmd/clean.py
+++ b/lib/spack/spack/test/cmd/clean.py
@@ -59,8 +59,12 @@ all_effects = ["stages", "downloads", "caches", "failures", "python_cache", "boo
         ("", []),
     ],
 )
-def test_function_calls(command_line, effects, mock_calls_for_clean, mutable_config):
-    mutable_config.set("bootstrap", {"root": "fake"})
+def test_function_calls(
+    command_line, effects, mock_calls_for_clean, mutable_config, tmp_path: pathlib.Path
+):
+    # Redirect only where it is read, so the other cases keep the store clingo is bootstrapped in
+    if "bootstrap" in effects:
+        mutable_config.set("bootstrap:root", str(tmp_path / "bootstrap"))
 
     # Call the command with the supplied command line
     clean(command_line)


### PR DESCRIPTION
The test repointed `bootstrap:root` at a relative `fake` directory for every case, so the bootstrapped clingo became invisible and the mpileaks case only passed when an earlier test in the same process had already imported it.

It also left an untracked `fake` directory around, due to the relative path in the config.