### PR TITLE
binary_distribution: show fingerprints in PickKeyException

### DIFF
--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -628,7 +628,7 @@ def select_signing_key() -> str:
     keys = spack.util.gpg.signing_keys()
     num = len(keys)
     if num > 1:
-        raise PickKeyException(str(keys))
+        raise PickKeyException(keys)
     elif num == 0:
         raise NoKeyException(
             "No default key available for signing.\n"
@@ -2913,8 +2913,10 @@ class PickKeyException(spack.error.SpackError):
     Raised when multiple keys can be used to sign.
     """
 
-    def __init__(self, keys):
-        err_msg = "Multiple keys available for signing\n%s\n" % keys
+    def __init__(self, keys: List[spack.util.gpg.GpgKey]):
+        err_msg = "Multiple keys available for signing\n%s\n" % "\n".join(
+            f"  {key}" for key in keys
+        )
         err_msg += "Use spack buildcache create -k <key hash> to pick a key."
         super().__init__(err_msg)
 

--- a/lib/spack/spack/test/binary_distribution.py
+++ b/lib/spack/spack/test/binary_distribution.py
@@ -1650,3 +1650,17 @@ def test_url_buildcache_hash_from_manifest_name(spec_manifest, result):
             result = URLBuildcacheEntry.hash_from_manifest_name(spec_manifest)
     else:
         assert result == URLBuildcacheEntry.hash_from_manifest_name(spec_manifest)
+
+
+def test_select_signing_key_shows_fingerprints(monkeypatch):
+    class Key:
+        def __init__(self, fpr):
+            self.fpr = fpr
+
+        def __str__(self):
+            return self.fpr
+
+    keys = [Key("AAAA"), Key("BBBB")]
+    monkeypatch.setattr(spack.util.gpg, "signing_keys", lambda *a: keys)
+    with pytest.raises(spack.binary_distribution.PickKeyException, match="AAAA\n  BBBB"):
+        spack.binary_distribution.select_signing_key()


### PR DESCRIPTION
Fix an issue in the presentation of an exception on `spack buildcache push`:

```
==> Error: Multiple keys available for signing
[<spack.util.gpg.GpgKey object at 0x10456ad00>, <spack.util.gpg.GpgKey object at 0x104a2d1f0>, <spack.util.gpg.GpgKey object at 0x104924a60>]
```

This regressed in #52430, which changed `signing_keys` from returning `List[str]` fingerprints to `List[GpgKey]`.