### PR TITLE
spack solve: improve behavior for env groups

### DIFF
--- a/lib/spack/spack/cmd/solve.py
+++ b/lib/spack/spack/cmd/solve.py
@@ -176,19 +176,18 @@ def solve(parser, args):
         args.subparser.error("requires at least one spec or an active environment")
 
     solver = asp.Solver()
-    output = sys.stdout if "asp" in show else None
     setup_only = set(show) == {"asp"}
+    output = asp.OutputConfiguration(
+        timers=args.timers,
+        stats=args.stats,
+        out=sys.stdout if "asp" in show else None,
+        setup_only=setup_only,
+    )
     unify = spack.config.CONFIG.get("concretizer:unify")
     allow_deprecated = spack.config.CONFIG.get("config:deprecated", False)
     if unify == "when_possible":
         for idx, result in enumerate(
-            solver.solve_in_rounds(
-                specs,
-                out=output,
-                timers=args.timers,
-                stats=args.stats,
-                allow_deprecated=allow_deprecated,
-            )
+            solver.solve_in_rounds(specs, allow_deprecated=allow_deprecated, output=output)
         ):
             if "solutions" in show:
                 tty.msg("ROUND {0}".format(idx))
@@ -200,26 +199,12 @@ def solve(parser, args):
     elif unify:
         # set up solver parameters
         # Note: reuse and other concretizer prefs are passed as configuration
-        result = solver.solve(
-            specs,
-            out=output,
-            timers=args.timers,
-            stats=args.stats,
-            setup_only=setup_only,
-            allow_deprecated=allow_deprecated,
-        )
+        result = solver.solve(specs, allow_deprecated=allow_deprecated, output=output)
         if not setup_only:
             _process_result(result, show, required_format, kwargs)
     else:
         for spec in specs:
             tty.msg("SOLVING SPEC:", spec)
-            result = solver.solve(
-                [spec],
-                out=output,
-                timers=args.timers,
-                stats=args.stats,
-                setup_only=setup_only,
-                allow_deprecated=allow_deprecated,
-            )
+            result = solver.solve([spec], allow_deprecated=allow_deprecated, output=output)
             if not setup_only:
                 _process_result(result, show, required_format, kwargs)

--- a/lib/spack/spack/cmd/solve.py
+++ b/lib/spack/spack/cmd/solve.py
@@ -10,6 +10,7 @@ import spack
 import spack.binary_distribution
 import spack.cmd
 import spack.cmd.spec
+import spack.concretize
 import spack.config
 import spack.hash_types as ht
 import spack.package_base
@@ -54,74 +55,88 @@ def setup_parser(subparser: argparse.ArgumentParser) -> None:
     spack.cmd.spec.setup_parser(subparser)
 
 
-def _process_result(result, show, required_format, kwargs):
-    opt, _, _ = min(result.answers)
-    if ("opt" in show) and (not required_format):
-        tty.msg("Best of %d considered solutions." % result.nmodels)
+def _print_criteria(result):
+    tty.msg("Best of %d considered solutions." % result.nmodels)
 
-        print()
-        maxlen = max(len(s.name) for s in result.criteria)
-        color.cprint("@*{  Priority  Value  Criterion}")
+    print()
+    maxlen = max(len(s.name) for s in result.criteria)
+    color.cprint("@*{  Priority  Value  Criterion}")
 
-        # Width of a data row past its 2-space indent, matching the row format below:
-        # 8-wide priority + 2 gap + 5-wide value + 2 gap + maxlen-wide criterion name.
-        divider_width = 8 + 2 + 5 + 2 + maxlen
-        prev_band = None
+    # Width of a data row past its 2-space indent, matching the row format below:
+    # 8-wide priority + 2 gap + 5-wide value + 2 gap + maxlen-wide criterion name.
+    divider_width = 8 + 2 + 5 + 2 + maxlen
+    prev_band = None
 
-        for i, criterion in enumerate(result.criteria, 1):
-            # Criteria are grouped into priority bands; print a header when the band changes.
-            band = criterion.band
-            if band != prev_band:
-                label = f"-- {band}"
-                dashes = "-" * max(0, divider_width - len(label) - 1)
-                color.cprint(f"  @*{{{label}}} @K{{{dashes}}}")
-                prev_band = band
+    for i, criterion in enumerate(result.criteria, 1):
+        # Criteria are grouped into priority bands; print a header when the band changes.
+        band = criterion.band
+        if band != prev_band:
+            label = f"-- {band}"
+            dashes = "-" * max(0, divider_width - len(label) - 1)
+            color.cprint(f"  @*{{{label}}} @K{{{dashes}}}")
+            prev_band = band
 
-            value = f"@K{{{criterion.value:>5}}}"
-            grey_out = True
-            if criterion.value > 0:
-                value = f"@*{{{criterion.value:>5}}}"
-                grey_out = False
+        value = f"@K{{{criterion.value:>5}}}"
+        grey_out = True
+        if criterion.value > 0:
+            value = f"@*{{{criterion.value:>5}}}"
+            grey_out = False
 
-            if grey_out:
-                lc = "@K"
-            elif criterion.kind == asp.OptimizationKind.CONCRETE:
-                lc = "@b"
-            elif criterion.kind == asp.OptimizationKind.BUILD:
-                lc = "@g"
-            else:
-                lc = "@y"
-
-            color.cprint(f"  @K{{{i:8}}}  {value}  {lc}{{{criterion.name:<{maxlen}}}}")
-        print()
-        print()
-        color.cprint("  @*{Legend:}")
-        color.cprint("    @g{Specs to be built}")
-        color.cprint("    @b{Reused specs}")
-        color.cprint("    @y{Other criteria}")
-        print()
-
-    # dump the solutions as concretized specs
-    if "solutions" in show:
-        if required_format:
-            for spec in result.specs:
-                # With -y, just print YAML to output.
-                if required_format == "yaml":
-                    # use write because to_yaml already has a newline.
-                    sys.stdout.write(spec.to_yaml(hash=ht.dag_hash))
-                elif required_format == "json":
-                    sys.stdout.write(spec.to_json(hash=ht.dag_hash))
-                else:
-                    print(spec.format(required_format))
+        if grey_out:
+            lc = "@K"
+        elif criterion.kind == asp.OptimizationKind.CONCRETE:
+            lc = "@b"
+        elif criterion.kind == asp.OptimizationKind.BUILD:
+            lc = "@g"
         else:
-            tree_str = spack.spec.tree(
-                result.specs, color=color.get_color_when(sys.stdout), **kwargs
-            )
-            sys.stdout.write(tree_str)
-        print()
+            lc = "@y"
+
+        color.cprint(f"  @K{{{i:8}}}  {value}  {lc}{{{criterion.name:<{maxlen}}}}")
+    print()
+    print()
+    color.cprint("  @*{Legend:}")
+    color.cprint("    @g{Specs to be built}")
+    color.cprint("    @b{Reused specs}")
+    color.cprint("    @y{Other criteria}")
+    print()
+
+
+def _report_result(result, show, required_format, *, label_inputs=False):
+    """Prints what a single solve has to show, before any spec is reported.
+
+    An environment is solved in more than one round, so *label_inputs* says which specs the
+    criteria that follow belong to.
+    """
+    if label_inputs and not required_format:
+        tty.msg("SOLVING SPEC:", *result.abstract_specs)
+
+    if ("opt" in show) and (not required_format):
+        _print_criteria(result)
 
     if result.unsolved_specs and "solutions" in show:
         tty.msg(asp.Result.format_unsolved(result.unsolved_specs))
+
+
+def _print_specs(specs, show, required_format, kwargs):
+    """Dumps the concretized specs, in the format that was asked for."""
+    if "solutions" not in show or not specs:
+        return
+
+    if required_format:
+        for spec in specs:
+            # With -y, just print YAML to output.
+            if required_format == "yaml":
+                # use write because to_yaml already has a newline.
+                sys.stdout.write(spec.to_yaml(hash=ht.dag_hash))
+            elif required_format == "json":
+                # print, so that each spec stays a JSON document of its own
+                print(spec.to_json(hash=ht.dag_hash))
+            else:
+                print(spec.format(required_format))
+    else:
+        tree_str = spack.spec.tree(specs, color=color.get_color_when(sys.stdout), **kwargs)
+        sys.stdout.write(tree_str)
+    print()
 
 
 def solve(parser, args):
@@ -166,25 +181,48 @@ def solve(parser, args):
     # Format required for the output (JSON, YAML or None)
     required_format = args.format
 
-    # If we have an active environment, pick the specs from there
     env = active_environment()
-    if args.specs:
-        specs = spack.cmd.parse_specs(args.specs)
-    elif env:
-        specs = list(env.user_specs)
-    else:
+    specs = spack.cmd.parse_specs(args.specs)
+    if not specs and env is None:
         args.subparser.error("requires at least one spec or an active environment")
 
-    solver = asp.Solver()
-    setup_only = set(show) == {"asp"}
-    output = asp.OutputConfiguration(
+    if not specs and set(show) == {"asp"}:
+        args.subparser.error(
+            "'--show asp' needs specs to solve for, since an environment is solved one "
+            "group of specs at a time"
+        )
+
+    if specs:
+        _solve_specs(specs, args=args, show=show, required_format=required_format, kwargs=kwargs)
+    else:
+        _solve_environment(
+            env, args=args, show=show, required_format=required_format, kwargs=kwargs
+        )
+
+
+def _output_configuration(args, show, *, setup_only):
+    return asp.OutputConfiguration(
         timers=args.timers,
         stats=args.stats,
         out=sys.stdout if "asp" in show else None,
         setup_only=setup_only,
     )
+
+
+def _solve_specs(specs, *, args, show, required_format, kwargs):
+    """Solves the specs given on the command line, honoring concretizer:unify."""
+    solver = asp.Solver()
+    setup_only = set(show) == {"asp"}
+    output = _output_configuration(args, show, setup_only=setup_only)
     unify = spack.config.CONFIG.get("concretizer:unify")
     allow_deprecated = spack.config.CONFIG.get("config:deprecated", False)
+
+    def _report(result):
+        if setup_only:  # nothing was solved, so there is no result to look at
+            return
+        _report_result(result, show, required_format)
+        _print_specs(result.specs, show, required_format, kwargs)
+
     if unify == "when_possible":
         for idx, result in enumerate(
             solver.solve_in_rounds(specs, allow_deprecated=allow_deprecated, output=output)
@@ -194,17 +232,33 @@ def solve(parser, args):
                 tty.msg("")
             else:
                 print("% END ROUND {0}\n".format(idx))
-            if not setup_only:
-                _process_result(result, show, required_format, kwargs)
+            _report(result)
     elif unify:
         # set up solver parameters
         # Note: reuse and other concretizer prefs are passed as configuration
-        result = solver.solve(specs, allow_deprecated=allow_deprecated, output=output)
-        if not setup_only:
-            _process_result(result, show, required_format, kwargs)
+        _report(solver.solve(specs, allow_deprecated=allow_deprecated, output=output))
     else:
         for spec in specs:
             tty.msg("SOLVING SPEC:", spec)
-            result = solver.solve([spec], allow_deprecated=allow_deprecated, output=output)
-            if not setup_only:
-                _process_result(result, show, required_format, kwargs)
+            _report(solver.solve([spec], allow_deprecated=allow_deprecated, output=output))
+
+
+def _solve_environment(env, *, args, show, required_format, kwargs):
+    """Solves the active environment, one group of specs at a time."""
+    # An output configuration also states that the solving has to happen in this process, so
+    # ask for one only when something the reporter prints actually needs it
+    needs_in_process = args.timers or args.stats or "asp" in show or "opt" in show
+    reporter = spack.concretize.SolveReporter(
+        output=_output_configuration(args, show, setup_only=False) if needs_in_process else None,
+        on_result=lambda result: _report_result(result, show, required_format, label_inputs=True),
+    )
+
+    # Solving is forced, so that this command always shows a solve and never the lockfile.
+    # Nothing is written back, so the environment is left as it was for other commands.
+    env.concretize(force=True, reporter=reporter)
+
+    roots = list(env.concrete_roots())
+    if not roots and not required_format:
+        tty.msg("The environment has no input specs")
+
+    _print_specs(roots, show, required_format, kwargs)

--- a/lib/spack/spack/concretize.py
+++ b/lib/spack/spack/concretize.py
@@ -6,7 +6,18 @@
 import importlib
 import sys
 import time
-from typing import TYPE_CHECKING, Dict, Iterable, List, Optional, Sequence, Tuple, Union
+from typing import (
+    TYPE_CHECKING,
+    Callable,
+    Dict,
+    Iterable,
+    List,
+    NamedTuple,
+    Optional,
+    Sequence,
+    Tuple,
+    Union,
+)
 
 import spack.compilers
 import spack.compilers.config
@@ -23,7 +34,19 @@ SpecPair = Tuple[Spec, Spec]
 TestsType = Union[bool, Iterable[str]]
 
 if TYPE_CHECKING:
+    import spack.solver.asp
     from spack.solver.reuse import SpecFiltersFactory
+
+
+class SolveReporter(NamedTuple):
+    #: What the solve prints out, or None. Using None allows the solver to solve in parallel
+    output: Optional["spack.solver.asp.OutputConfiguration"]
+    #: Called once for every result produced in this process, in the order they are produced
+    on_result: Optional[Callable[["spack.solver.asp.Result"], None]]
+
+
+#: A solve that reports nothing, and only returns concrete specs
+DEFAULT_SOLVE_REPORTER = SolveReporter(output=None, on_result=None)
 
 
 def _concretize_specs_together(
@@ -31,6 +54,7 @@ def _concretize_specs_together(
     *,
     tests: TestsType = False,
     factory: Optional["SpecFiltersFactory"] = None,
+    reporter: SolveReporter = DEFAULT_SOLVE_REPORTER,
 ) -> List[Spec]:
     """Given a number of specs as input, tries to concretize them together.
 
@@ -39,13 +63,16 @@ def _concretize_specs_together(
         tests: list of package names for which to consider tests dependencies. If True, all nodes
             will have test dependencies. If False, test dependencies will be disregarded.
         factory: optional factory to produce a list of specs to be reused
+        reporter: what the solve reports, besides returning concrete specs
     """
     from spack.solver.asp import Solver
 
     allow_deprecated = spack.config.CONFIG.get("config:deprecated", False)
     result = Solver(specs_factory=factory).solve(
-        abstract_specs, tests=tests, allow_deprecated=allow_deprecated
+        abstract_specs, tests=tests, allow_deprecated=allow_deprecated, output=reporter.output
     )
+    if reporter.on_result is not None:
+        reporter.on_result(result)
     return [s.copy() for s in result.specs]
 
 
@@ -54,6 +81,7 @@ def concretize_together(
     *,
     tests: TestsType = False,
     factory: Optional["SpecFiltersFactory"] = None,
+    reporter: SolveReporter = DEFAULT_SOLVE_REPORTER,
 ) -> List[SpecPair]:
     """Given a number of specs as input, tries to concretize them together.
 
@@ -63,10 +91,13 @@ def concretize_together(
         tests: list of package names for which to consider tests dependencies. If True, all nodes
             will have test dependencies. If False, test dependencies will be disregarded.
         factory: optional factory to produce a list of specs to be reused
+        reporter: what the solve reports, besides returning concrete specs
     """
     to_concretize = [concrete if concrete else abstract for abstract, concrete in spec_list]
     abstract_specs = [abstract for abstract, _ in spec_list]
-    concrete_specs = _concretize_specs_together(to_concretize, tests=tests, factory=factory)
+    concrete_specs = _concretize_specs_together(
+        to_concretize, tests=tests, factory=factory, reporter=reporter
+    )
     return list(zip(abstract_specs, concrete_specs))
 
 
@@ -75,6 +106,7 @@ def concretize_together_when_possible(
     *,
     tests: TestsType = False,
     factory: Optional["SpecFiltersFactory"] = None,
+    reporter: SolveReporter = DEFAULT_SOLVE_REPORTER,
 ) -> List[SpecPair]:
     """Given a number of specs as input, tries to concretize them together to the extent possible.
 
@@ -87,6 +119,7 @@ def concretize_together_when_possible(
         tests: list of package names for which to consider tests dependencies. If True, all nodes
             will have test dependencies. If False, test dependencies will be disregarded.
         factory: optional factory to produce a list of specs to be reused
+        reporter: what the solve reports, besides returning concrete specs
     """
     from spack.solver.asp import Solver
 
@@ -100,8 +133,10 @@ def concretize_together_when_possible(
     j = 0
     start = time.monotonic()
     for result in Solver(specs_factory=factory).solve_in_rounds(
-        to_concretize, tests=tests, allow_deprecated=allow_deprecated
+        to_concretize, tests=tests, allow_deprecated=allow_deprecated, output=reporter.output
     ):
+        if reporter.on_result is not None:
+            reporter.on_result(result)
         now = time.monotonic()
         duration = now - start
         percentage = int((j + 1) / len(to_concretize) * 100)
@@ -128,6 +163,7 @@ def concretize_separately(
     *,
     tests: TestsType = False,
     factory: Optional["SpecFiltersFactory"] = None,
+    reporter: SolveReporter = DEFAULT_SOLVE_REPORTER,
 ) -> List[SpecPair]:
     """Concretizes the input specs separately from each other.
 
@@ -137,6 +173,8 @@ def concretize_separately(
         tests: list of package names for which to consider tests dependencies. If True, all nodes
             will have test dependencies. If False, test dependencies will be disregarded.
         factory: optional factory to produce a list of specs to be reused
+        reporter: what the solve reports, besides returning concrete specs. A reporter with
+            an output configuration forces an in-process solve.
     """
     from spack.bootstrap import (
         ensure_bootstrap_configuration,
@@ -181,17 +219,20 @@ def concretize_separately(
             (abstract, concrete) for abstract, concrete in spec_list if concrete
         ]
 
-    # Solve the environment in parallel on Linux
-    num_procs = min(len(args), spack.config.determine_number_of_jobs(parallel=True))
+    if reporter.output is not None:
+        # A reporter doesn't cross the process pool boundary. Solve in-process instead.
+        solved: Iterable[Tuple[int, Spec, float]] = _concretize_serially(args, reporter=reporter)
+    else:
+        # Solve the environment in parallel on Linux
+        num_procs = min(len(args), spack.config.determine_number_of_jobs(parallel=True))
 
-    msg = "Starting concretization"
-    # no parallel conc on Windows
-    if not sys.platform == "win32" and num_procs > 1:
-        msg += f" pool with {num_procs} processes"
-    tty.msg(msg)
+        msg = "Starting concretization"
+        # no parallel conc on Windows
+        if not sys.platform == "win32" and num_procs > 1:
+            msg += f" pool with {num_procs} processes"
+        tty.msg(msg)
 
-    for j, (i, concrete, duration) in enumerate(
-        spack.util.parallel.imap_unordered(
+        solved = spack.util.parallel.imap_unordered(
             _concretize_task,
             args,
             processes=num_procs,
@@ -199,7 +240,8 @@ def concretize_separately(
             maxtaskperchild=1,
             serialize_env=True,
         )
-    ):
+
+    for j, (i, concrete, duration) in enumerate(solved):
         ret.append((i, concrete))
         percentage = int((j + 1) / len(args) * 100)
         tty.verbose(
@@ -226,17 +268,31 @@ def _concretize_task(
         return index, spec, time.time() - start
 
 
+def _concretize_serially(
+    packed_arguments: Sequence[Tuple[int, str, TestsType, Optional["SpecFiltersFactory"]]],
+    *,
+    reporter: SolveReporter,
+) -> Iterable[Tuple[int, Spec, float]]:
+    for index, spec_str, tests, factory in packed_arguments:
+        start = time.time()
+        spec = concretize_one(Spec(spec_str), tests=tests, factory=factory, reporter=reporter)
+        yield index, spec, time.time() - start
+
+
 def concretize_one(
     spec: Union[str, Spec],
     *,
     tests: TestsType = False,
     factory: Optional["SpecFiltersFactory"] = None,
+    reporter: SolveReporter = DEFAULT_SOLVE_REPORTER,
 ) -> Spec:
     """Return a concretized copy of the given spec.
 
     Args:
         tests: if False disregard test dependencies, if a list of names activate them for
             the packages in the list, if True activate test dependencies for all packages.
+        factory: optional factory to produce a list of specs to be reused
+        reporter: what the solve reports, besides returning a concrete spec
     """
     from spack.solver.asp import Solver, SpecBuilder
 
@@ -255,8 +311,10 @@ def concretize_one(
 
     allow_deprecated = spack.config.CONFIG.get("config:deprecated", False)
     result = Solver(specs_factory=factory).solve(
-        [spec], tests=tests, allow_deprecated=allow_deprecated
+        [spec], tests=tests, allow_deprecated=allow_deprecated, output=reporter.output
     )
+    if reporter.on_result is not None:
+        reporter.on_result(result)
 
     # take the best answer
     opt, i, answer = min(result.answers)

--- a/lib/spack/spack/environment/environment.py
+++ b/lib/spack/spack/environment/environment.py
@@ -31,6 +31,7 @@ from typing import (
 
 import spack
 import spack.active_environment
+import spack.concretize
 import spack.config
 import spack.deptypes as dt
 import spack.error
@@ -1712,7 +1713,11 @@ class Environment:
             self.write()
 
     def concretize(
-        self, *, force: Optional[bool] = None, tests: Union[bool, Sequence[str]] = False
+        self,
+        *,
+        force: Optional[bool] = None,
+        tests: Union[bool, Sequence[str]] = False,
+        reporter: spack.concretize.SolveReporter = spack.concretize.DEFAULT_SOLVE_REPORTER,
     ) -> Sequence[SpecPair]:
         """Concretize user_specs in this environment.
 
@@ -1726,6 +1731,7 @@ class Environment:
                 defaults to ``spack.config.CONFIG.get("concretizer:force")``
             tests: False to run no tests, True to test all packages, or a list of
                 package names to run tests for some
+            reporter: what each solve reports, besides returning concrete specs
 
         Returns:
             List of specs that have been concretized. Each entry is a tuple of
@@ -1746,7 +1752,9 @@ class Environment:
         }
 
         try:
-            return EnvironmentConcretizer(self).concretize(force=force, tests=tests)
+            return EnvironmentConcretizer(self).concretize(
+                force=force, tests=tests, reporter=reporter
+            )
         except BaseException:
             self.concretized_roots = old_concretized_roots
             self.specs_by_hash = old_specs_by_hash
@@ -2706,7 +2714,11 @@ class EnvironmentConcretizer:
         self.env = env
 
     def concretize(
-        self, *, force: Optional[bool] = None, tests: Union[bool, Sequence[str]] = False
+        self,
+        *,
+        force: Optional[bool] = None,
+        tests: Union[bool, Sequence[str]] = False,
+        reporter: spack.concretize.SolveReporter = spack.concretize.DEFAULT_SOLVE_REPORTER,
     ) -> List[SpecPair]:
         if force is None:
             force = spack.config.CONFIG.get("concretizer:force")
@@ -2716,7 +2728,9 @@ class EnvironmentConcretizer:
         # Sort so that the ordering is deterministic, and "default" specs are first
         for current_group in self._order_groups():
             with self.env.config_override_for_group(group=current_group):
-                partial_result = self._concretize_single_group(group=current_group, tests=tests)
+                partial_result = self._concretize_single_group(
+                    group=current_group, tests=tests, reporter=reporter
+                )
                 result.extend(partial_result)
 
         # Unify the specs objects, so we get correct references to all parents
@@ -2725,7 +2739,11 @@ class EnvironmentConcretizer:
         return result
 
     def _concretize_single_group(
-        self, *, group: str, tests: Union[bool, Sequence[str]]
+        self,
+        *,
+        group: str,
+        tests: Union[bool, Sequence[str]],
+        reporter: spack.concretize.SolveReporter = spack.concretize.DEFAULT_SOLVE_REPORTER,
     ) -> List[SpecPair]:
         # Exit early if the set of concretized specs is the set of user specs
         new_user_specs, kept_user_specs = self._partition_user_specs(group=group)
@@ -2739,17 +2757,32 @@ class EnvironmentConcretizer:
         factory = ReusableSpecsFactory(env=self.env, group=group)
         if unify == "when_possible":
             partial_result = self._concretize_together_where_possible(
-                new_user_specs, kept_user_specs, tests=tests, group=group, factory=factory
+                new_user_specs,
+                kept_user_specs,
+                tests=tests,
+                group=group,
+                factory=factory,
+                reporter=reporter,
             )
 
         elif unify is True:
             partial_result = self._concretize_together(
-                new_user_specs, kept_user_specs, tests=tests, group=group, factory=factory
+                new_user_specs,
+                kept_user_specs,
+                tests=tests,
+                group=group,
+                factory=factory,
+                reporter=reporter,
             )
 
         elif unify is False:
             partial_result = self._concretize_separately(
-                new_user_specs, kept_user_specs, tests=tests, group=group, factory=factory
+                new_user_specs,
+                kept_user_specs,
+                tests=tests,
+                group=group,
+                factory=factory,
+                reporter=reporter,
             )
         else:
             raise SpackEnvironmentError(f"concretization strategy not implemented [{unify}]")
@@ -2832,12 +2865,11 @@ class EnvironmentConcretizer:
         group: Optional[str] = None,
         tests: Union[bool, Sequence] = False,
         factory: ReusableSpecsFactory,
+        reporter: spack.concretize.SolveReporter = spack.concretize.DEFAULT_SOLVE_REPORTER,
     ) -> List[SpecPair]:
-        import spack.concretize
-
         specs_to_concretize = self._user_spec_pairs(to_compute, to_keep)
         result = spack.concretize.concretize_together_when_possible(
-            specs_to_concretize, tests=tests, factory=factory
+            specs_to_concretize, tests=tests, factory=factory, reporter=reporter
         )
         result = [x for x in result if x[0] in to_compute]
         for abstract, concrete in result:
@@ -2853,13 +2885,12 @@ class EnvironmentConcretizer:
         group: Optional[str] = None,
         tests: Union[bool, Sequence] = False,
         factory: ReusableSpecsFactory,
+        reporter: spack.concretize.SolveReporter = spack.concretize.DEFAULT_SOLVE_REPORTER,
     ) -> List[SpecPair]:
-        import spack.concretize
-
         to_concretize = self._user_spec_pairs(to_compute, to_keep)
         try:
             concrete_pairs = spack.concretize.concretize_together(
-                to_concretize, tests=tests, factory=factory
+                to_concretize, tests=tests, factory=factory, reporter=reporter
             )
         except spack.error.UnsatisfiableSpecError as e:
             # "Enhance" the error message for multiple root specs, suggest a less strict
@@ -2891,13 +2922,12 @@ class EnvironmentConcretizer:
         group: Optional[str] = None,
         tests: Union[bool, Sequence] = False,
         factory: ReusableSpecsFactory,
+        reporter: spack.concretize.SolveReporter = spack.concretize.DEFAULT_SOLVE_REPORTER,
     ) -> List[SpecPair]:
         """Concretization strategy that concretizes separately one user spec after the other"""
-        import spack.concretize
-
         to_concretize = [(x, None) for x in to_compute]
         concrete_pairs = spack.concretize.concretize_separately(
-            to_concretize, tests=tests, factory=factory
+            to_concretize, tests=tests, factory=factory, reporter=reporter
         )
 
         for abstract, concrete in concrete_pairs:

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -4000,32 +4000,28 @@ class Solver:
     def solve_with_stats(
         self,
         specs: Sequence[spack.spec.Spec],
-        out: Optional[IO[str]] = None,
-        timers: bool = False,
-        stats: bool = False,
+        *,
         tests: spack.concretize.TestsType = False,
-        setup_only: bool = False,
         allow_deprecated: bool = False,
+        output: Optional[OutputConfiguration] = None,
     ) -> Tuple[Result, Optional[spack.util.timer.Timer], Optional[Dict]]:
         """
         Concretize a set of specs and track the timing and statistics for the solve
 
         Arguments:
           specs: List of ``Spec`` objects to solve for.
-          out: Optionally write the generate ASP program to a file-like object.
-          timers: Print out coarse timers for different solve phases.
-          stats: Print out detailed stats from clingo.
           tests: If True, concretize test dependencies for all packages.
             If a tuple of package names, concretize test dependencies for named
             packages (defaults to False: do not concretize test dependencies).
-          setup_only: if True, stop after setup and don't solve (default False).
           allow_deprecated: allow deprecated version in the solve
+          output: what the solve should print out, besides returning a result. Defaults to
+            ``DEFAULT_OUTPUT_CONFIGURATION``, which prints nothing.
         """
         specs = [spack.hash_lookup.lookup_hash(s) for s in specs]
         reusable_specs = self._extract_concrete_specs(specs)
         reusable_specs.extend(self.selector.reusable_specs(specs))
         setup = SpackSolverSetup(tests=tests)
-        output = OutputConfiguration(timers=timers, stats=stats, out=out, setup_only=setup_only)
+        output = output or DEFAULT_OUTPUT_CONFIGURATION
 
         result = self.driver.solve(
             setup,
@@ -4049,11 +4045,10 @@ class Solver:
     def solve_in_rounds(
         self,
         specs: Sequence[spack.spec.Spec],
-        out: Optional[IO[str]] = None,
-        timers: bool = False,
-        stats: bool = False,
+        *,
         tests: spack.concretize.TestsType = False,
         allow_deprecated: bool = False,
+        output: Optional[OutputConfiguration] = None,
     ) -> Generator[Result, None, None]:
         """Solve for a stable model of specs in multiple rounds.
 
@@ -4065,11 +4060,10 @@ class Solver:
 
         Arguments:
             specs (list): list of Specs to solve.
-            out: Optionally write the generate ASP program to a file-like object.
-            timers (bool): print timing if set to True
-            stats (bool): print internal statistics if set to True
             tests (bool): add test dependencies to the solve
             allow_deprecated (bool): allow deprecated version in the solve
+            output: what the solve should print out, besides yielding results. Defaults to
+                ``DEFAULT_OUTPUT_CONFIGURATION``, which prints nothing.
         """
         # "when_possible" requires at least one literal to be solved, so an empty input is unsat
         if not specs:
@@ -4084,7 +4078,8 @@ class Solver:
         setup.concretize_everything = False
 
         input_specs = specs
-        output = OutputConfiguration(timers=timers, stats=stats, out=out, setup_only=False)
+        # Rounds are driven by the specs left unsolved, so we can never stop after setup
+        output = (output or DEFAULT_OUTPUT_CONFIGURATION)._replace(setup_only=False)
         while True:
             result, _, _ = self.driver.solve(
                 setup,


### PR DESCRIPTION
depends on #52888

After this PR, the `spack solve` command will:
1. Report the specs of every group in an environment, instead of just the default one
2. Shows the input spec for `unify:false` solves