### PR TITLE
color: allow newline autoreturns on Windows

### DIFF
--- a/lib/spack/spack/util/tty/color.py
+++ b/lib/spack/spack/util/tty/color.py
@@ -173,9 +173,7 @@ def try_enable_terminal_color_on_windows() -> None:
                 con_handle = msvcrt.get_osfhandle(conout.fileno())
                 dw_orig_mode = wintypes.DWORD()
                 kernel32.GetConsoleMode(con_handle, ctypes.byref(dw_orig_mode))
-                dw_new_mode_request = (
-                    ENABLE_VIRTUAL_TERMINAL_PROCESSING | DISABLE_NEWLINE_AUTO_RETURN
-                )
+                dw_new_mode_request = ENABLE_VIRTUAL_TERMINAL_PROCESSING
                 dw_new_mode = dw_new_mode_request | dw_orig_mode.value
                 kernel32.SetConsoleMode(con_handle, wintypes.DWORD(dw_new_mode))
         except OSError:

--- a/lib/spack/spack/util/tty/color.py
+++ b/lib/spack/spack/util/tty/color.py
@@ -145,7 +145,6 @@ def try_enable_terminal_color_on_windows() -> None:
 
         try:
             ENABLE_VIRTUAL_TERMINAL_PROCESSING = 0x0004
-            DISABLE_NEWLINE_AUTO_RETURN = 0x0008
             kernel32 = ctypes.WinDLL("kernel32")
 
             def _err_check(result, func, args):


### PR DESCRIPTION
Previously we added terminal handling that removed Windows terminals default behavior of adding a carriage return post bare newlines by setting `DISABLE_NEWLINE_AUTO_RETURN` in the console settings. 

Restore it, we don't need to remove this behavior and it makes output stepped across the terminal.

The only reason it was there, as far as I can tell (and also as the person who added it), is because I naively (boneheaded-ly) followed some MSDN tutorial for setting terminal settings and as far as I can tell I assumed this was required for ANSI processing (it is not). 

Replaces #52824 