### PR TITLE
Separate UI from backend for concretization

### DIFF
--- a/lib/spack/spack/ci/__init__.py
+++ b/lib/spack/spack/ci/__init__.py
@@ -36,6 +36,7 @@ import spack.util.spack_yaml as syaml
 import spack.util.url as url_util
 import spack.util.web as web_util
 from spack import traverse
+from spack.concretize_ui import TerminalUI
 from spack.error import SpackError
 from spack.reporters.cdash import SPACK_CDASH_TIMEOUT
 from spack.util import tty
@@ -473,7 +474,7 @@ def generate_pipeline(env: ev.Environment, args) -> None:
             line.
     """
     with env.write_transaction():
-        env.concretize()
+        env.concretize(ui=TerminalUI())
         env.write()
 
     options = collect_pipeline_options(env, args)

--- a/lib/spack/spack/cmd/__init__.py
+++ b/lib/spack/spack/cmd/__init__.py
@@ -205,9 +205,6 @@ def _concretize_spec_pairs(
     Any spec with a concrete spec associated with it will concretize to that spec. Any spec
     with ``None`` for its concrete spec will be newly concretized. This method respects unification
     rules from config.
-
-    The command layer is the frontend, so progress is reported to a terminal frontend unless the
-    caller passes a different one.
     """
     ui = ui or TerminalUI()
     unify = spack.config.CONFIG.get("concretizer:unify", False)

--- a/lib/spack/spack/cmd/__init__.py
+++ b/lib/spack/spack/cmd/__init__.py
@@ -30,6 +30,7 @@ import spack.util.spack_yaml as syaml
 import spack.util.string
 from spack import traverse
 from spack.active_environment import active_environment
+from spack.concretize_ui import ConcretizerUI, TerminalUI
 from spack.util import tty
 from spack.util.filesystem import join_path
 from spack.util.lang import attr_setdefault, index_by
@@ -177,6 +178,7 @@ def parse_specs(
     args: Union[str, List[str]],
     concretize: bool = False,
     tests: spack.concretize.TestsType = False,
+    ui: Optional[ConcretizerUI] = None,
 ) -> List[spack.spec.Spec]:
     """Convenience function for parsing arguments from specs.  Handles common
     exceptions and dies if there are errors.
@@ -190,17 +192,24 @@ def parse_specs(
         return specs
 
     to_concretize: List[spack.concretize.SpecPairInput] = [(s, None) for s in specs]
-    return _concretize_spec_pairs(to_concretize, tests=tests)
+    return _concretize_spec_pairs(to_concretize, tests=tests, ui=ui)
 
 
 def _concretize_spec_pairs(
-    to_concretize: List[spack.concretize.SpecPairInput], tests: spack.concretize.TestsType = False
+    to_concretize: List[spack.concretize.SpecPairInput],
+    tests: spack.concretize.TestsType = False,
+    ui: Optional[ConcretizerUI] = None,
 ) -> List[spack.spec.Spec]:
     """Helper method that concretizes abstract specs from a list of abstract,concrete pairs.
 
     Any spec with a concrete spec associated with it will concretize to that spec. Any spec
     with ``None`` for its concrete spec will be newly concretized. This method respects unification
-    rules from config."""
+    rules from config.
+
+    The command layer is the frontend, so progress is reported to a terminal frontend unless the
+    caller passes a different one.
+    """
+    ui = ui or TerminalUI()
     unify = spack.config.CONFIG.get("concretizer:unify", False)
 
     # Special case for concretizing a single spec
@@ -247,7 +256,7 @@ def _concretize_spec_pairs(
     elif unify == "when_possible":
         concretize_method = spack.concretize.concretize_together_when_possible
 
-    concretized = concretize_method(to_concretize, tests=tests)
+    concretized = concretize_method(to_concretize, tests=tests, ui=ui)
     return [concrete for _, concrete in concretized]
 
 

--- a/lib/spack/spack/cmd/concretize.py
+++ b/lib/spack/spack/cmd/concretize.py
@@ -8,6 +8,7 @@ import spack.binary_distribution
 import spack.cmd
 import spack.cmd.common.arguments
 import spack.environment as ev
+from spack.concretize_ui import TerminalUI
 from spack.util import tty
 from spack.util.string import plural
 
@@ -42,7 +43,7 @@ def concretize(parser, args):
         tests = False
 
     with env.write_transaction():
-        concretized_specs = env.concretize(tests=tests)
+        concretized_specs = env.concretize(tests=tests, ui=TerminalUI())
         if not args.quiet:
             if concretized_specs:
                 tty.msg(f"Concretized {plural(len(concretized_specs), 'spec')}:")

--- a/lib/spack/spack/cmd/graph.py
+++ b/lib/spack/spack/cmd/graph.py
@@ -8,6 +8,7 @@ import spack.config
 import spack.store
 from spack.active_environment import active_environment
 from spack.cmd.common import arguments
+from spack.concretize_ui import HeadlessUI, TerminalUI
 from spack.graph import DAGWithDependencyTypes, SimpleDAG, graph_ascii, graph_dot, static_graph_dot
 from spack.util import tty
 
@@ -76,7 +77,9 @@ def graph(parser, args):
             specs = env.all_matching_specs(*args.specs)
 
     else:
-        specs = spack.cmd.parse_specs(args.specs, concretize=not args.static)
+        # Machine-readable output goes to stdout, so concretization must not print anything there
+        ui = HeadlessUI() if args.dot else TerminalUI()
+        specs = spack.cmd.parse_specs(args.specs, concretize=not args.static, ui=ui)
 
     if not specs:
         tty.die("no spec matching the query")

--- a/lib/spack/spack/cmd/install.py
+++ b/lib/spack/spack/cmd/install.py
@@ -19,6 +19,7 @@ import spack.store
 import spack.util.filesystem as fs
 from spack.active_environment import active_environment
 from spack.cmd.common import arguments
+from spack.concretize_ui import TerminalUI
 from spack.error import InstallError, SpackError
 from spack.old_installer import InstallPolicy
 from spack.util import tty
@@ -358,7 +359,7 @@ def _maybe_add_and_concretize(args, env, specs):
 
         # `spack concretize`
         tests = compute_tests_install_kwargs(env.user_specs, args.test)
-        concretized_specs = env.concretize(tests=tests)
+        concretized_specs = env.concretize(tests=tests, ui=TerminalUI())
         if concretized_specs:
             tty.msg(f"Concretized {plural(len(concretized_specs), 'spec')}")
             spack.binary_distribution.load_buildcache_index()

--- a/lib/spack/spack/cmd/spec.py
+++ b/lib/spack/spack/cmd/spec.py
@@ -15,7 +15,7 @@ import spack.store
 import spack.traverse
 from spack.active_environment import active_environment
 from spack.cmd.common import arguments
-from spack.concretize_ui import ConcretizerUI, TerminalUI
+from spack.concretize_ui import HeadlessUI, TerminalUI
 from spack.util.lang import nullcontext
 
 description = "show what would be installed, given a spec"
@@ -85,7 +85,7 @@ def spec(parser, args):
     env = active_environment()
 
     # Machine readable output goes to stdout, so concretization must not print anything there
-    ui = ConcretizerUI() if args.format else TerminalUI()
+    ui = HeadlessUI() if args.format else TerminalUI()
 
     if args.specs:
         concrete_specs = spack.cmd.parse_specs(args.specs, concretize=True, ui=ui)

--- a/lib/spack/spack/cmd/spec.py
+++ b/lib/spack/spack/cmd/spec.py
@@ -84,7 +84,7 @@ def spec(parser, args):
 
     env = active_environment()
 
-    # Machine readable output goes to stdout, so concretization must not print anything there
+    # Machine-readable output goes to stdout, so concretization must not print anything there
     ui = HeadlessUI() if args.format else TerminalUI()
 
     if args.specs:

--- a/lib/spack/spack/cmd/spec.py
+++ b/lib/spack/spack/cmd/spec.py
@@ -15,6 +15,7 @@ import spack.store
 import spack.traverse
 from spack.active_environment import active_environment
 from spack.cmd.common import arguments
+from spack.concretize_ui import ConcretizerUI, TerminalUI
 from spack.util.lang import nullcontext
 
 description = "show what would be installed, given a spec"
@@ -83,10 +84,13 @@ def spec(parser, args):
 
     env = active_environment()
 
+    # Machine readable output goes to stdout, so concretization must not print anything there
+    ui = ConcretizerUI() if args.format else TerminalUI()
+
     if args.specs:
-        concrete_specs = spack.cmd.parse_specs(args.specs, concretize=True)
+        concrete_specs = spack.cmd.parse_specs(args.specs, concretize=True, ui=ui)
     elif env:
-        env.concretize()
+        env.concretize(ui=ui)
         concrete_specs = env.concrete_roots()
     else:
         args.subparser.error("requires at least one spec or an active environment")

--- a/lib/spack/spack/concretize.py
+++ b/lib/spack/spack/concretize.py
@@ -15,7 +15,7 @@ import spack.error
 import spack.hash_lookup
 import spack.repo
 import spack.util.parallel
-from spack.concretize_ui import ConcretizerUI
+from spack.concretize_ui import ConcretizerUI, HeadlessUI
 from spack.spec import Spec
 from spack.util import tty
 
@@ -95,7 +95,7 @@ def concretize_together_when_possible(
     """
     from spack.solver.asp import Solver
 
-    ui = ui or ConcretizerUI()
+    ui = ui or HeadlessUI()
 
     to_concretize = [concrete if concrete else abstract for abstract, concrete in spec_list]
     old_concrete_to_abstract = {
@@ -150,7 +150,7 @@ def concretize_separately(
         ensure_winsdk_external_or_raise,
     )
 
-    ui = ui or ConcretizerUI()
+    ui = ui or HeadlessUI()
     to_concretize = [abstract for abstract, concrete in spec_list if not concrete]
     args = [
         (i, str(abstract), tests, factory)

--- a/lib/spack/spack/concretize.py
+++ b/lib/spack/spack/concretize.py
@@ -112,7 +112,9 @@ def concretize_together_when_possible(
         now = time.monotonic()
         duration = now - start
         for abstract, concrete in result.specs_by_input.items():
-            ui.on_spec_concretized(abstract, concrete, j, len(to_concretize), duration)
+            ui.on_spec_concretized(
+                abstract, concrete=concrete, index=j, total=len(to_concretize), duration=duration
+            )
             j += 1
         result_by_user_spec.update(result.specs_by_input)
         start = now
@@ -192,7 +194,7 @@ def concretize_separately(
     # imap_unordered falls back to a serial map when parallelism is disabled (e.g. Windows)
     if not spack.util.parallel.ENABLE_PARALLELISM:
         num_procs = 1
-    ui.on_batch_started(len(args), num_procs)
+    ui.on_batch_started(total=len(args), processes=num_procs)
 
     for j, (i, concrete, duration) in enumerate(
         spack.util.parallel.imap_unordered(
@@ -205,7 +207,9 @@ def concretize_separately(
         )
     ):
         ret.append((i, concrete))
-        ui.on_spec_concretized(to_concretize[i], concrete, j, len(args), duration)
+        ui.on_spec_concretized(
+            to_concretize[i], concrete=concrete, index=j, total=len(args), duration=duration
+        )
 
     # Add specs in original order
     ret.sort(key=lambda x: x[0])

--- a/lib/spack/spack/concretize.py
+++ b/lib/spack/spack/concretize.py
@@ -80,7 +80,7 @@ def concretize_together(
     # A single solve produced all the specs, so they all report the duration of that solve
     result = list(zip(abstract_specs, concrete_specs))
     for index, (abstract, concrete) in enumerate(result):
-        ui.on_spec_concretized(abstract, concrete=concrete, index=index, duration=duration)
+        ui.on_spec_concretized(abstract, concrete=concrete, count=index, duration=duration)
 
     return result
 
@@ -125,7 +125,7 @@ def concretize_together_when_possible(
         now = time.monotonic()
         duration = now - start
         for abstract, concrete in result.specs_by_input.items():
-            ui.on_spec_concretized(abstract, concrete=concrete, index=j, duration=duration)
+            ui.on_spec_concretized(abstract, concrete=concrete, count=j, duration=duration)
             j += 1
         result_by_user_spec.update(result.specs_by_input)
         start = now
@@ -218,7 +218,7 @@ def concretize_separately(
         )
     ):
         ret.append((i, concrete))
-        ui.on_spec_concretized(to_concretize[i], concrete=concrete, index=j, duration=duration)
+        ui.on_spec_concretized(to_concretize[i], concrete=concrete, count=j, duration=duration)
 
     # Add specs in original order
     ret.sort(key=lambda x: x[0])

--- a/lib/spack/spack/concretize.py
+++ b/lib/spack/spack/concretize.py
@@ -79,8 +79,8 @@ def concretize_together(
 
     # A single solve produced all the specs, so they all report the duration of that solve
     result = list(zip(abstract_specs, concrete_specs))
-    for index, (abstract, concrete) in enumerate(result):
-        ui.on_spec_concretized(abstract, concrete=concrete, count=index, duration=duration)
+    for count, (abstract, concrete) in enumerate(result, start=1):
+        ui.on_spec_concretized(abstract, concrete=concrete, count=count, duration=duration)
 
     return result
 
@@ -127,8 +127,8 @@ def concretize_together_when_possible(
         now = time.monotonic()
         duration = now - start
         for abstract, concrete in result.specs_by_input.items():
-            ui.on_spec_concretized(abstract, concrete=concrete, count=j, duration=duration)
             j += 1
+            ui.on_spec_concretized(abstract, concrete=concrete, count=j, duration=duration)
         result_by_user_spec.update(result.specs_by_input)
         start = now
 
@@ -216,7 +216,8 @@ def concretize_separately(
             debug=tty.is_debug(),
             maxtaskperchild=1,
             serialize_env=True,
-        )
+        ),
+        start=1,
     ):
         ret.append((i, concrete))
         ui.on_spec_concretized(to_concretize[i], concrete=concrete, count=j, duration=duration)

--- a/lib/spack/spack/concretize.py
+++ b/lib/spack/spack/concretize.py
@@ -15,7 +15,7 @@ import spack.error
 import spack.hash_lookup
 import spack.repo
 import spack.util.parallel
-from spack.concretize_ui import ConcretizerUI, HeadlessUI
+from spack.concretize_ui import ConcretizerUI, HeadlessUI, SolveKind
 from spack.spec import Spec
 from spack.util import tty
 
@@ -67,10 +67,22 @@ def concretize_together(
         factory: optional factory to produce a list of specs to be reused
         ui: frontend to report progress to. Defaults to a headless frontend.
     """
+    ui = ui or HeadlessUI()
+
     to_concretize = [concrete if concrete else abstract for abstract, concrete in spec_list]
     abstract_specs = [abstract for abstract, _ in spec_list]
+
+    ui.on_solve_started(kind=SolveKind.TOGETHER, total=len(to_concretize), processes=1)
+    start = time.monotonic()
     concrete_specs = _concretize_specs_together(to_concretize, tests=tests, factory=factory)
-    return list(zip(abstract_specs, concrete_specs))
+    duration = time.monotonic() - start
+
+    # A single solve produced all the specs, so they all report the duration of that solve
+    result = list(zip(abstract_specs, concrete_specs))
+    for index, (abstract, concrete) in enumerate(result):
+        ui.on_spec_concretized(abstract, concrete=concrete, index=index, duration=duration)
+
+    return result
 
 
 def concretize_together_when_possible(
@@ -105,6 +117,7 @@ def concretize_together_when_possible(
     result_by_user_spec: Dict[Spec, Spec] = {}
     allow_deprecated = spack.config.CONFIG.get("config:deprecated", False)
     j = 0
+    ui.on_solve_started(kind=SolveKind.WHEN_POSSIBLE, total=len(to_concretize), processes=1)
     start = time.monotonic()
     for result in Solver(specs_factory=factory).solve_in_rounds(
         to_concretize, tests=tests, allow_deprecated=allow_deprecated
@@ -112,9 +125,7 @@ def concretize_together_when_possible(
         now = time.monotonic()
         duration = now - start
         for abstract, concrete in result.specs_by_input.items():
-            ui.on_spec_concretized(
-                abstract, concrete=concrete, index=j, total=len(to_concretize), duration=duration
-            )
+            ui.on_spec_concretized(abstract, concrete=concrete, index=j, duration=duration)
             j += 1
         result_by_user_spec.update(result.specs_by_input)
         start = now
@@ -194,7 +205,7 @@ def concretize_separately(
     # imap_unordered falls back to a serial map when parallelism is disabled (e.g. Windows)
     if not spack.util.parallel.ENABLE_PARALLELISM:
         num_procs = 1
-    ui.on_batch_started(total=len(args), processes=num_procs)
+    ui.on_solve_started(kind=SolveKind.SEPARATELY, total=len(args), processes=num_procs)
 
     for j, (i, concrete, duration) in enumerate(
         spack.util.parallel.imap_unordered(
@@ -207,9 +218,7 @@ def concretize_separately(
         )
     ):
         ret.append((i, concrete))
-        ui.on_spec_concretized(
-            to_concretize[i], concrete=concrete, index=j, total=len(args), duration=duration
-        )
+        ui.on_spec_concretized(to_concretize[i], concrete=concrete, index=j, duration=duration)
 
     # Add specs in original order
     ret.sort(key=lambda x: x[0])

--- a/lib/spack/spack/concretize.py
+++ b/lib/spack/spack/concretize.py
@@ -193,6 +193,13 @@ def concretize_separately(
     # processes try to write the config file in parallel
     _ = spack.compilers.config.all_compilers()
 
+    # Solve the environment in parallel on Linux. imap_unordered falls back to a serial map when
+    # parallelism is disabled (e.g. Windows)
+    num_procs = 1
+    if args and spack.util.parallel.ENABLE_PARALLELISM:
+        num_procs = min(len(args), spack.config.determine_number_of_jobs(parallel=True))
+    ui.on_concretization_started(kind=SolveKind.SEPARATELY, total=len(args), processes=num_procs)
+
     # Early return if there is nothing to do
     if len(args) == 0:
         # Still have to combine the things that were passed in as abstract with the things
@@ -200,14 +207,6 @@ def concretize_separately(
         return [(abstract, concrete) for abstract, (_, concrete) in zip(to_concretize, ret)] + [
             (abstract, concrete) for abstract, concrete in spec_list if concrete
         ]
-
-    # Solve the environment in parallel on Linux
-    num_procs = min(len(args), spack.config.determine_number_of_jobs(parallel=True))
-
-    # imap_unordered falls back to a serial map when parallelism is disabled (e.g. Windows)
-    if not spack.util.parallel.ENABLE_PARALLELISM:
-        num_procs = 1
-    ui.on_concretization_started(kind=SolveKind.SEPARATELY, total=len(args), processes=num_procs)
 
     for j, (i, concrete, duration) in enumerate(
         spack.util.parallel.imap_unordered(

--- a/lib/spack/spack/concretize.py
+++ b/lib/spack/spack/concretize.py
@@ -72,7 +72,7 @@ def concretize_together(
     to_concretize = [concrete if concrete else abstract for abstract, concrete in spec_list]
     abstract_specs = [abstract for abstract, _ in spec_list]
 
-    ui.on_solve_started(kind=SolveKind.TOGETHER, total=len(to_concretize), processes=1)
+    ui.on_concretization_started(kind=SolveKind.TOGETHER, total=len(to_concretize), processes=1)
     start = time.monotonic()
     concrete_specs = _concretize_specs_together(to_concretize, tests=tests, factory=factory)
     duration = time.monotonic() - start
@@ -117,7 +117,9 @@ def concretize_together_when_possible(
     result_by_user_spec: Dict[Spec, Spec] = {}
     allow_deprecated = spack.config.CONFIG.get("config:deprecated", False)
     j = 0
-    ui.on_solve_started(kind=SolveKind.WHEN_POSSIBLE, total=len(to_concretize), processes=1)
+    ui.on_concretization_started(
+        kind=SolveKind.WHEN_POSSIBLE, total=len(to_concretize), processes=1
+    )
     start = time.monotonic()
     for result in Solver(specs_factory=factory).solve_in_rounds(
         to_concretize, tests=tests, allow_deprecated=allow_deprecated
@@ -205,7 +207,7 @@ def concretize_separately(
     # imap_unordered falls back to a serial map when parallelism is disabled (e.g. Windows)
     if not spack.util.parallel.ENABLE_PARALLELISM:
         num_procs = 1
-    ui.on_solve_started(kind=SolveKind.SEPARATELY, total=len(args), processes=num_procs)
+    ui.on_concretization_started(kind=SolveKind.SEPARATELY, total=len(args), processes=num_procs)
 
     for j, (i, concrete, duration) in enumerate(
         spack.util.parallel.imap_unordered(

--- a/lib/spack/spack/concretize.py
+++ b/lib/spack/spack/concretize.py
@@ -15,6 +15,7 @@ import spack.error
 import spack.hash_lookup
 import spack.repo
 import spack.util.parallel
+from spack.concretize_ui import ConcretizerUI
 from spack.spec import Spec
 from spack.util import tty
 
@@ -54,6 +55,7 @@ def concretize_together(
     *,
     tests: TestsType = False,
     factory: Optional["SpecFiltersFactory"] = None,
+    ui: Optional[ConcretizerUI] = None,
 ) -> List[SpecPair]:
     """Given a number of specs as input, tries to concretize them together.
 
@@ -63,6 +65,7 @@ def concretize_together(
         tests: list of package names for which to consider tests dependencies. If True, all nodes
             will have test dependencies. If False, test dependencies will be disregarded.
         factory: optional factory to produce a list of specs to be reused
+        ui: frontend to report progress to. Defaults to a headless frontend.
     """
     to_concretize = [concrete if concrete else abstract for abstract, concrete in spec_list]
     abstract_specs = [abstract for abstract, _ in spec_list]
@@ -75,6 +78,7 @@ def concretize_together_when_possible(
     *,
     tests: TestsType = False,
     factory: Optional["SpecFiltersFactory"] = None,
+    ui: Optional[ConcretizerUI] = None,
 ) -> List[SpecPair]:
     """Given a number of specs as input, tries to concretize them together to the extent possible.
 
@@ -87,8 +91,11 @@ def concretize_together_when_possible(
         tests: list of package names for which to consider tests dependencies. If True, all nodes
             will have test dependencies. If False, test dependencies will be disregarded.
         factory: optional factory to produce a list of specs to be reused
+        ui: frontend to report progress to. Defaults to a headless frontend.
     """
     from spack.solver.asp import Solver
+
+    ui = ui or ConcretizerUI()
 
     to_concretize = [concrete if concrete else abstract for abstract, concrete in spec_list]
     old_concrete_to_abstract = {
@@ -104,14 +111,9 @@ def concretize_together_when_possible(
     ):
         now = time.monotonic()
         duration = now - start
-        percentage = int((j + 1) / len(to_concretize) * 100)
         for abstract, concrete in result.specs_by_input.items():
-            tty.verbose(
-                f"{duration:6.1f}s [{percentage:3d}%] {concrete.cformat('{hash:7}')} "
-                f"{abstract.colored_str}"
-            )
+            ui.on_spec_concretized(abstract, concrete, j, len(to_concretize), duration)
             j += 1
-        sys.stdout.flush()
         result_by_user_spec.update(result.specs_by_input)
         start = now
 
@@ -128,6 +130,7 @@ def concretize_separately(
     *,
     tests: TestsType = False,
     factory: Optional["SpecFiltersFactory"] = None,
+    ui: Optional[ConcretizerUI] = None,
 ) -> List[SpecPair]:
     """Concretizes the input specs separately from each other.
 
@@ -137,6 +140,7 @@ def concretize_separately(
         tests: list of package names for which to consider tests dependencies. If True, all nodes
             will have test dependencies. If False, test dependencies will be disregarded.
         factory: optional factory to produce a list of specs to be reused
+        ui: frontend to report progress to. Defaults to a headless frontend.
     """
     from spack.bootstrap import (
         ensure_bootstrap_configuration,
@@ -144,6 +148,7 @@ def concretize_separately(
         ensure_winsdk_external_or_raise,
     )
 
+    ui = ui or ConcretizerUI()
     to_concretize = [abstract for abstract, concrete in spec_list if not concrete]
     args = [
         (i, str(abstract), tests, factory)
@@ -184,11 +189,10 @@ def concretize_separately(
     # Solve the environment in parallel on Linux
     num_procs = min(len(args), spack.config.determine_number_of_jobs(parallel=True))
 
-    msg = "Starting concretization"
-    # no parallel conc on Windows
-    if not sys.platform == "win32" and num_procs > 1:
-        msg += f" pool with {num_procs} processes"
-    tty.msg(msg)
+    # imap_unordered falls back to a serial map when parallelism is disabled (e.g. Windows)
+    if not spack.util.parallel.ENABLE_PARALLELISM:
+        num_procs = 1
+    ui.on_batch_started(len(args), num_procs)
 
     for j, (i, concrete, duration) in enumerate(
         spack.util.parallel.imap_unordered(
@@ -201,12 +205,7 @@ def concretize_separately(
         )
     ):
         ret.append((i, concrete))
-        percentage = int((j + 1) / len(args) * 100)
-        tty.verbose(
-            f"{duration:6.1f}s [{percentage:3d}%] {concrete.cformat('{hash:7}')} "
-            f"{to_concretize[i].colored_str}"
-        )
-        sys.stdout.flush()
+        ui.on_spec_concretized(to_concretize[i], concrete, j, len(args), duration)
 
     # Add specs in original order
     ret.sort(key=lambda x: x[0])

--- a/lib/spack/spack/concretize_ui.py
+++ b/lib/spack/spack/concretize_ui.py
@@ -46,9 +46,10 @@ class ConcretizerUI:
     def on_spec_concretized(
         self, abstract: Spec, *, concrete: Spec, count: int, duration: float
     ) -> None:
-        """A user spec has been concretized. ``count`` is the 0-based position of this event among
-        the ones reported for the group, and ``duration`` is the time spent in the solve that
-        produced this spec. Specs that come out of the same solve report the same duration.
+        """A user spec has been concretized. ``count`` is how many specs of the group have been
+        reported so far, including this one, and goes from 1 to the announced ``total``.
+        ``duration`` is the time spent in the solve that produced this spec, so specs that come
+        out of the same solve report the same duration.
         """
 
 
@@ -84,7 +85,7 @@ class TerminalUI(ConcretizerUI):
     ) -> None:
         if self.kind is SolveKind.TOGETHER:
             return
-        percentage = int((count + 1) / max(self.total, count + 1) * 100)
+        percentage = int(count / self.total * 100)
         tty.verbose(
             f"{duration:6.1f}s [{percentage:3d}%] {concrete.cformat('{hash:7}')} "
             f"{abstract.colored_str}",

--- a/lib/spack/spack/concretize_ui.py
+++ b/lib/spack/spack/concretize_ui.py
@@ -28,23 +28,27 @@ class SolveKind(enum.Enum):
 class ConcretizerUI:
     """Interface between concretization and a frontend. The methods are no-ops, which makes this
     class usable as a headless frontend.
+
+    Every event is emitted in the process that owns the frontend, and from a single thread.
+    Frontends therefore need no locking, and no capture of child output.
     """
 
     def on_group_started(self, *, group: str, is_default: bool) -> None:
         """A group of user specs is about to be concretized."""
 
-    def on_solve_started(self, *, kind: SolveKind, total: int, processes: int) -> None:
-        """Solving is about to start, using ``processes`` processes. Called once per
-        concretization, before any spec is reported, with ``total`` equal to the number of
-        ``on_spec_concretized`` calls that will follow.
+    def on_concretization_started(self, *, kind: SolveKind, total: int, processes: int) -> None:
+        """``total`` user specs are about to be concretized as ``kind`` prescribes, over
+        ``processes`` processes. Called once per group of user specs, before any spec of that
+        group is reported, with ``total`` equal to the number of ``on_spec_concretized`` calls
+        that will follow for it.
         """
 
     def on_spec_concretized(
         self, abstract: Spec, *, concrete: Spec, count: int, duration: float
     ) -> None:
-        """A user spec has been concretized. ``index`` is the 0-based completion order, and
-        ``duration`` is the time spent in the solve that produced this spec. Specs that come out
-        of the same solve report the same duration.
+        """A user spec has been concretized. ``count`` is the 0-based position of this event among
+        the ones reported for the group, and ``duration`` is the time spent in the solve that
+        produced this spec. Specs that come out of the same solve report the same duration.
         """
 
 
@@ -65,7 +69,7 @@ class TerminalUI(ConcretizerUI):
             return
         tty.msg(f"Concretizing the '{group}' group of specs")
 
-    def on_solve_started(self, *, kind: SolveKind, total: int, processes: int) -> None:
+    def on_concretization_started(self, *, kind: SolveKind, total: int, processes: int) -> None:
         self.kind = kind
         self.total = total
         if kind is not SolveKind.SEPARATELY:

--- a/lib/spack/spack/concretize_ui.py
+++ b/lib/spack/spack/concretize_ui.py
@@ -1,0 +1,61 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+"""Frontends for concretization.
+
+Defines the :class:`ConcretizerUI` contract (a headless no-op base) and the interactive
+:class:`TerminalUI` implementation. Concretization reports facts through this interface, and the
+frontend decides whether, where, and how to render them.
+"""
+
+import sys
+
+from spack.spec import Spec
+from spack.util import tty
+
+
+class ConcretizerUI:
+    """Interface between concretization and a frontend. The methods are no-ops, which makes this
+    class usable as a headless frontend.
+    """
+
+    def on_group_started(self, group: str, is_default: bool) -> None:
+        """A group of user specs is about to be concretized."""
+
+    def on_batch_started(self, total: int, processes: int) -> None:
+        """A batch of ``total`` independent solves is about to start, distributed over
+        ``processes`` processes.
+        """
+
+    def on_spec_concretized(
+        self, abstract: Spec, concrete: Spec, index: int, total: int, duration: float
+    ) -> None:
+        """A user spec has been concretized. ``index`` is the 0-based completion order, and
+        ``duration`` is the time spent solving, or the time spent in the current round for
+        ``unify: when_possible``.
+        """
+
+
+class TerminalUI(ConcretizerUI):
+    """Terminal frontend: announces groups and batches, and reports per-spec progress."""
+
+    def on_group_started(self, group: str, is_default: bool) -> None:
+        if is_default:
+            return
+        tty.msg(f"Concretizing the '{group}' group of specs")
+
+    def on_batch_started(self, total: int, processes: int) -> None:
+        msg = "Starting concretization"
+        if processes > 1:
+            msg += f" pool with {processes} processes"
+        tty.msg(msg)
+
+    def on_spec_concretized(
+        self, abstract: Spec, concrete: Spec, index: int, total: int, duration: float
+    ) -> None:
+        percentage = int((index + 1) / total * 100)
+        tty.verbose(
+            f"{duration:6.1f}s [{percentage:3d}%] {concrete.cformat('{hash:7}')} "
+            f"{abstract.colored_str}"
+        )
+        sys.stdout.flush()

--- a/lib/spack/spack/concretize_ui.py
+++ b/lib/spack/spack/concretize_ui.py
@@ -3,9 +3,8 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 """Frontends for concretization.
 
-Defines the :class:`ConcretizerUI` contract (a headless no-op base) and the interactive
-:class:`TerminalUI` implementation. Concretization reports facts through this interface, and the
-frontend decides whether, where, and how to render them.
+Defines the :class:`ConcretizerUI` contract (a headless no-op base) and the terminal
+:class:`TerminalUI` implementation.
 """
 
 import enum
@@ -41,7 +40,7 @@ class ConcretizerUI:
         """
 
     def on_spec_concretized(
-        self, abstract: Spec, *, concrete: Spec, index: int, duration: float
+        self, abstract: Spec, *, concrete: Spec, count: int, duration: float
     ) -> None:
         """A user spec has been concretized. ``index`` is the 0-based completion order, and
         ``duration`` is the time spent in the solve that produced this spec. Specs that come out
@@ -77,11 +76,11 @@ class TerminalUI(ConcretizerUI):
         tty.msg(msg)
 
     def on_spec_concretized(
-        self, abstract: Spec, *, concrete: Spec, index: int, duration: float
+        self, abstract: Spec, *, concrete: Spec, count: int, duration: float
     ) -> None:
         if self.kind is SolveKind.TOGETHER:
             return
-        percentage = int((index + 1) / max(self.total, index + 1) * 100)
+        percentage = int((count + 1) / max(self.total, count + 1) * 100)
         tty.verbose(
             f"{duration:6.1f}s [{percentage:3d}%] {concrete.cformat('{hash:7}')} "
             f"{abstract.colored_str}",

--- a/lib/spack/spack/concretize_ui.py
+++ b/lib/spack/spack/concretize_ui.py
@@ -8,10 +8,22 @@ Defines the :class:`ConcretizerUI` contract (a headless no-op base) and the inte
 frontend decides whether, where, and how to render them.
 """
 
+import enum
 import sys
 
 from spack.spec import Spec
 from spack.util import tty
+
+
+class SolveKind(enum.Enum):
+    """How the specs to be concretized are distributed over solves."""
+
+    #: A single solve produces every spec
+    TOGETHER = "together"
+    #: One solve per set of specs that can be unified
+    WHEN_POSSIBLE = "when_possible"
+    #: One solve per spec, possibly in parallel
+    SEPARATELY = "separately"
 
 
 class ConcretizerUI:
@@ -22,17 +34,18 @@ class ConcretizerUI:
     def on_group_started(self, *, group: str, is_default: bool) -> None:
         """A group of user specs is about to be concretized."""
 
-    def on_batch_started(self, *, total: int, processes: int) -> None:
-        """A batch of ``total`` independent solves is about to start, distributed over
-        ``processes`` processes.
+    def on_solve_started(self, *, kind: SolveKind, total: int, processes: int) -> None:
+        """Solving is about to start, using ``processes`` processes. Called once per
+        concretization, before any spec is reported, with ``total`` equal to the number of
+        ``on_spec_concretized`` calls that will follow.
         """
 
     def on_spec_concretized(
-        self, abstract: Spec, *, concrete: Spec, index: int, total: int, duration: float
+        self, abstract: Spec, *, concrete: Spec, index: int, duration: float
     ) -> None:
         """A user spec has been concretized. ``index`` is the 0-based completion order, and
-        ``duration`` is the time spent solving, or the time spent in the current round for
-        ``unify: when_possible``.
+        ``duration`` is the time spent in the solve that produced this spec. Specs that come out
+        of the same solve report the same duration.
         """
 
 
@@ -42,23 +55,33 @@ HeadlessUI = ConcretizerUI
 
 
 class TerminalUI(ConcretizerUI):
-    """Terminal frontend: announces groups and batches, and reports per-spec progress."""
+    """Terminal frontend: announces groups and solves, and reports per-spec progress."""
+
+    def __init__(self) -> None:
+        self.kind = SolveKind.TOGETHER
+        self.total = 0
 
     def on_group_started(self, *, group: str, is_default: bool) -> None:
         if is_default:
             return
         tty.msg(f"Concretizing the '{group}' group of specs")
 
-    def on_batch_started(self, *, total: int, processes: int) -> None:
+    def on_solve_started(self, *, kind: SolveKind, total: int, processes: int) -> None:
+        self.kind = kind
+        self.total = total
+        if kind is not SolveKind.SEPARATELY:
+            return
         msg = "Starting concretization"
         if processes > 1:
             msg += f" pool with {processes} processes"
         tty.msg(msg)
 
     def on_spec_concretized(
-        self, abstract: Spec, *, concrete: Spec, index: int, total: int, duration: float
+        self, abstract: Spec, *, concrete: Spec, index: int, duration: float
     ) -> None:
-        percentage = int((index + 1) / total * 100)
+        if self.kind is SolveKind.TOGETHER:
+            return
+        percentage = int((index + 1) / max(self.total, index + 1) * 100)
         tty.verbose(
             f"{duration:6.1f}s [{percentage:3d}%] {concrete.cformat('{hash:7}')} "
             f"{abstract.colored_str}",

--- a/lib/spack/spack/concretize_ui.py
+++ b/lib/spack/spack/concretize_ui.py
@@ -72,7 +72,7 @@ class TerminalUI(ConcretizerUI):
     def on_concretization_started(self, *, kind: SolveKind, total: int, processes: int) -> None:
         self.kind = kind
         self.total = total
-        if kind is not SolveKind.SEPARATELY:
+        if kind is not SolveKind.SEPARATELY or total == 0:
             return
         msg = "Starting concretization"
         if processes > 1:

--- a/lib/spack/spack/concretize_ui.py
+++ b/lib/spack/spack/concretize_ui.py
@@ -36,6 +36,11 @@ class ConcretizerUI:
         """
 
 
+#: Frontend that reports nothing. Same class as the contract it implements, aliased so that call
+#: sites can say which of the two roles they mean.
+HeadlessUI = ConcretizerUI
+
+
 class TerminalUI(ConcretizerUI):
     """Terminal frontend: announces groups and batches, and reports per-spec progress."""
 

--- a/lib/spack/spack/concretize_ui.py
+++ b/lib/spack/spack/concretize_ui.py
@@ -19,16 +19,16 @@ class ConcretizerUI:
     class usable as a headless frontend.
     """
 
-    def on_group_started(self, group: str, is_default: bool) -> None:
+    def on_group_started(self, *, group: str, is_default: bool) -> None:
         """A group of user specs is about to be concretized."""
 
-    def on_batch_started(self, total: int, processes: int) -> None:
+    def on_batch_started(self, *, total: int, processes: int) -> None:
         """A batch of ``total`` independent solves is about to start, distributed over
         ``processes`` processes.
         """
 
     def on_spec_concretized(
-        self, abstract: Spec, concrete: Spec, index: int, total: int, duration: float
+        self, abstract: Spec, *, concrete: Spec, index: int, total: int, duration: float
     ) -> None:
         """A user spec has been concretized. ``index`` is the 0-based completion order, and
         ``duration`` is the time spent solving, or the time spent in the current round for
@@ -39,23 +39,24 @@ class ConcretizerUI:
 class TerminalUI(ConcretizerUI):
     """Terminal frontend: announces groups and batches, and reports per-spec progress."""
 
-    def on_group_started(self, group: str, is_default: bool) -> None:
+    def on_group_started(self, *, group: str, is_default: bool) -> None:
         if is_default:
             return
         tty.msg(f"Concretizing the '{group}' group of specs")
 
-    def on_batch_started(self, total: int, processes: int) -> None:
+    def on_batch_started(self, *, total: int, processes: int) -> None:
         msg = "Starting concretization"
         if processes > 1:
             msg += f" pool with {processes} processes"
         tty.msg(msg)
 
     def on_spec_concretized(
-        self, abstract: Spec, concrete: Spec, index: int, total: int, duration: float
+        self, abstract: Spec, *, concrete: Spec, index: int, total: int, duration: float
     ) -> None:
         percentage = int((index + 1) / total * 100)
         tty.verbose(
             f"{duration:6.1f}s [{percentage:3d}%] {concrete.cformat('{hash:7}')} "
-            f"{abstract.colored_str}"
+            f"{abstract.colored_str}",
+            stream=sys.stdout,
         )
         sys.stdout.flush()

--- a/lib/spack/spack/environment/environment.py
+++ b/lib/spack/spack/environment/environment.py
@@ -55,6 +55,7 @@ import spack.util.tty.color as clr
 import spack.variant as vt
 from spack import traverse
 from spack.active_environment import active_environment
+from spack.concretize_ui import ConcretizerUI
 from spack.config import substitute_path_variables
 from spack.enums import ConfigScopePriority
 from spack.schema.env import TOP_LEVEL_KEY
@@ -1712,7 +1713,11 @@ class Environment:
             self.write()
 
     def concretize(
-        self, *, force: Optional[bool] = None, tests: Union[bool, Sequence[str]] = False
+        self,
+        *,
+        force: Optional[bool] = None,
+        tests: Union[bool, Sequence[str]] = False,
+        ui: Optional[ConcretizerUI] = None,
     ) -> Sequence[SpecPair]:
         """Concretize user_specs in this environment.
 
@@ -1726,6 +1731,7 @@ class Environment:
                 defaults to ``spack.config.CONFIG.get("concretizer:force")``
             tests: False to run no tests, True to test all packages, or a list of
                 package names to run tests for some
+            ui: frontend to report progress to. Defaults to a headless frontend.
 
         Returns:
             List of specs that have been concretized. Each entry is a tuple of
@@ -1746,7 +1752,7 @@ class Environment:
         }
 
         try:
-            return EnvironmentConcretizer(self).concretize(force=force, tests=tests)
+            return EnvironmentConcretizer(self, ui=ui).concretize(force=force, tests=tests)
         except BaseException:
             self.concretized_roots = old_concretized_roots
             self.specs_by_hash = old_specs_by_hash
@@ -2702,8 +2708,9 @@ class ReusableSpecsFactory:
 
 
 class EnvironmentConcretizer:
-    def __init__(self, env: Environment):
+    def __init__(self, env: Environment, *, ui: Optional[ConcretizerUI] = None):
         self.env = env
+        self.ui = ui or ConcretizerUI()
 
     def concretize(
         self, *, force: Optional[bool] = None, tests: Union[bool, Sequence[str]] = False
@@ -2733,8 +2740,7 @@ class EnvironmentConcretizer:
             return []
 
         # Pick the right concretization strategy
-        if group != DEFAULT_USER_SPEC_GROUP:
-            tty.msg(f"Concretizing the '{group}' group of specs")
+        self.ui.on_group_started(group, group == DEFAULT_USER_SPEC_GROUP)
         unify = spack.config.CONFIG.get_config("concretizer").get("unify", False)
         factory = ReusableSpecsFactory(env=self.env, group=group)
         if unify == "when_possible":
@@ -2837,7 +2843,7 @@ class EnvironmentConcretizer:
 
         specs_to_concretize = self._user_spec_pairs(to_compute, to_keep)
         result = spack.concretize.concretize_together_when_possible(
-            specs_to_concretize, tests=tests, factory=factory
+            specs_to_concretize, tests=tests, factory=factory, ui=self.ui
         )
         result = [x for x in result if x[0] in to_compute]
         for abstract, concrete in result:
@@ -2859,7 +2865,7 @@ class EnvironmentConcretizer:
         to_concretize = self._user_spec_pairs(to_compute, to_keep)
         try:
             concrete_pairs = spack.concretize.concretize_together(
-                to_concretize, tests=tests, factory=factory
+                to_concretize, tests=tests, factory=factory, ui=self.ui
             )
         except spack.error.UnsatisfiableSpecError as e:
             # "Enhance" the error message for multiple root specs, suggest a less strict
@@ -2897,7 +2903,7 @@ class EnvironmentConcretizer:
 
         to_concretize = [(x, None) for x in to_compute]
         concrete_pairs = spack.concretize.concretize_separately(
-            to_concretize, tests=tests, factory=factory
+            to_concretize, tests=tests, factory=factory, ui=self.ui
         )
 
         for abstract, concrete in concrete_pairs:

--- a/lib/spack/spack/environment/environment.py
+++ b/lib/spack/spack/environment/environment.py
@@ -2740,7 +2740,7 @@ class EnvironmentConcretizer:
             return []
 
         # Pick the right concretization strategy
-        self.ui.on_group_started(group, group == DEFAULT_USER_SPEC_GROUP)
+        self.ui.on_group_started(group=group, is_default=group == DEFAULT_USER_SPEC_GROUP)
         unify = spack.config.CONFIG.get_config("concretizer").get("unify", False)
         factory = ReusableSpecsFactory(env=self.env, group=group)
         if unify == "when_possible":

--- a/lib/spack/spack/environment/environment.py
+++ b/lib/spack/spack/environment/environment.py
@@ -55,7 +55,7 @@ import spack.util.tty.color as clr
 import spack.variant as vt
 from spack import traverse
 from spack.active_environment import active_environment
-from spack.concretize_ui import ConcretizerUI
+from spack.concretize_ui import ConcretizerUI, HeadlessUI
 from spack.config import substitute_path_variables
 from spack.enums import ConfigScopePriority
 from spack.schema.env import TOP_LEVEL_KEY
@@ -2710,7 +2710,7 @@ class ReusableSpecsFactory:
 class EnvironmentConcretizer:
     def __init__(self, env: Environment, *, ui: Optional[ConcretizerUI] = None):
         self.env = env
-        self.ui = ui or ConcretizerUI()
+        self.ui = ui or HeadlessUI()
 
     def concretize(
         self, *, force: Optional[bool] = None, tests: Union[bool, Sequence[str]] = False

--- a/lib/spack/spack/test/cmd/env.py
+++ b/lib/spack/spack/test/cmd/env.py
@@ -10,13 +10,12 @@ import pathlib
 import shutil
 import sys
 from argparse import Namespace
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, Optional
 
 import pytest
 
 import spack.cmd.env
 import spack.concretize
-import spack.concretize_ui
 import spack.config
 import spack.environment as ev
 import spack.error
@@ -44,6 +43,7 @@ from spack.spec import Spec
 from spack.stage import stage_prefix
 from spack.store import Store
 from spack.test.conftest import RepoBuilder
+from spack.test.utilities import RecordingUI
 from spack.traverse import traverse_nodes
 from spack.util import tty
 from spack.util.executable import Executable
@@ -5073,16 +5073,6 @@ def test_exists_consistent_with_all_environment_names(
 
     listed = "myenv" in ev.all_environment_names()
     assert ev.exists("myenv") == listed
-
-
-class RecordingUI(spack.concretize_ui.ConcretizerUI):
-    """Frontend that records the groups it is notified about, instead of announcing them."""
-
-    def __init__(self) -> None:
-        self.groups: List[Tuple[str, bool]] = []
-
-    def on_group_started(self, *, group: str, is_default: bool) -> None:
-        self.groups.append((group, is_default))
 
 
 def test_concretization_reports_groups(environment_from_manifest):

--- a/lib/spack/spack/test/cmd/env.py
+++ b/lib/spack/spack/test/cmd/env.py
@@ -10,12 +10,13 @@ import pathlib
 import shutil
 import sys
 from argparse import Namespace
-from typing import Any, Dict, Optional
+from typing import Any, Dict, List, Optional, Tuple
 
 import pytest
 
 import spack.cmd.env
 import spack.concretize
+import spack.concretize_ui
 import spack.config
 import spack.environment as ev
 import spack.error
@@ -5072,3 +5073,38 @@ def test_exists_consistent_with_all_environment_names(
 
     listed = "myenv" in ev.all_environment_names()
     assert ev.exists("myenv") == listed
+
+
+class RecordingUI(spack.concretize_ui.ConcretizerUI):
+    """Frontend that records the groups it is notified about, instead of announcing them."""
+
+    def __init__(self) -> None:
+        self.groups: List[Tuple[str, bool]] = []
+
+    def on_group_started(self, group: str, is_default: bool) -> None:
+        self.groups.append((group, is_default))
+
+
+def test_concretization_reports_groups(environment_from_manifest):
+    """Tests that each group of user specs is reported to the frontend, which is what decides
+    whether the default group is worth announcing."""
+    e = environment_from_manifest(
+        """\
+spack:
+  specs:
+  - libelf
+  - group: apps1
+    specs:
+    - pkg-a
+  - group: apps2
+    specs:
+    - pkg-b
+"""
+    )
+    ui = RecordingUI()
+    with e:
+        e.concretize(ui=ui)
+
+    # "default" is concretized first, the groups that don't need each other follow in any order
+    assert ui.groups[0] == ("default", True)
+    assert set(ui.groups[1:]) == {("apps1", False), ("apps2", False)}

--- a/lib/spack/spack/test/cmd/env.py
+++ b/lib/spack/spack/test/cmd/env.py
@@ -5081,15 +5081,13 @@ class RecordingUI(spack.concretize_ui.ConcretizerUI):
     def __init__(self) -> None:
         self.groups: List[Tuple[str, bool]] = []
 
-    def on_group_started(self, group: str, is_default: bool) -> None:
+    def on_group_started(self, *, group: str, is_default: bool) -> None:
         self.groups.append((group, is_default))
 
 
 def test_concretization_reports_groups(environment_from_manifest):
-    """Tests that each group of user specs is reported to the frontend, which is what decides
-    whether the default group is worth announcing."""
-    e = environment_from_manifest(
-        """\
+    """Tests that each group of user specs is reported to the frontend."""
+    e = environment_from_manifest("""
 spack:
   specs:
   - libelf
@@ -5099,8 +5097,7 @@ spack:
   - group: apps2
     specs:
     - pkg-b
-"""
-    )
+""")
     ui = RecordingUI()
     with e:
         e.concretize(ui=ui)

--- a/lib/spack/spack/test/concretization/core.py
+++ b/lib/spack/spack/test/concretization/core.py
@@ -5520,9 +5520,9 @@ class RecordingUI(spack.concretize_ui.ConcretizerUI):
         self.started.append((kind, total, processes))
 
     def on_spec_concretized(
-        self, abstract: Spec, *, concrete: Spec, index: int, duration: float
+        self, abstract: Spec, *, concrete: Spec, count: int, duration: float
     ) -> None:
-        self.concretized.append((abstract, concrete, index, duration))
+        self.concretized.append((abstract, concrete, count, duration))
 
 
 def test_concretize_separately_reports_progress(mutable_config, mock_packages):

--- a/lib/spack/spack/test/concretization/core.py
+++ b/lib/spack/spack/test/concretization/core.py
@@ -5511,43 +5511,50 @@ class RecordingUI(spack.concretize_ui.ConcretizerUI):
         self.batches: List[Tuple[int, int]] = []
         self.concretized: List[Tuple[Spec, Spec, int, int, float]] = []
 
-    def on_group_started(self, group: str, is_default: bool) -> None:
+    def on_group_started(self, *, group: str, is_default: bool) -> None:
         self.groups.append((group, is_default))
 
-    def on_batch_started(self, total: int, processes: int) -> None:
+    def on_batch_started(self, *, total: int, processes: int) -> None:
         self.batches.append((total, processes))
 
     def on_spec_concretized(
-        self, abstract: Spec, concrete: Spec, index: int, total: int, duration: float
+        self, abstract: Spec, *, concrete: Spec, index: int, total: int, duration: float
     ) -> None:
         self.concretized.append((abstract, concrete, index, total, duration))
 
 
 def test_concretize_separately_reports_progress(mutable_config, mock_packages):
     """Tests that concretizing separately reports one batch, and one event per spec, to the
-    injected frontend."""
+    injected frontend.
+    """
     ui = RecordingUI()
     spack.concretize.concretize_separately([(Spec("pkg-a"), None), (Spec("pkg-b"), None)], ui=ui)
 
-    # Parallelism is disabled in tests, so the batch runs in a single process
     assert ui.batches == [(2, 1)]
     assert [(index, total) for _, _, index, total, _ in ui.concretized] == [(0, 2), (1, 2)]
     assert {abstract.name for abstract, _, _, _, _ in ui.concretized} == {"pkg-a", "pkg-b"}
-    assert all(concrete.concrete for _, concrete, _, _, _ in ui.concretized)
     assert not ui.groups
+
+    for abstract, concrete, _, _, _ in ui.concretized:
+        assert concrete.concrete and concrete.satisfies(abstract)
 
 
 def test_concretize_together_when_possible_reports_progress(mutable_config, mock_packages):
-    """Tests that concretizing when possible reports one event per spec, and no batch, since it
-    is a single solve."""
+    """Tests that concretizing when possible reports one event per spec, and no batch. The two
+    specs cannot be unified, so they are solved in different rounds, and the completion order has
+    to keep increasing across rounds.
+    """
     ui = RecordingUI()
     spack.concretize.concretize_together_when_possible(
-        [(Spec("pkg-a"), None), (Spec("pkg-b"), None)], ui=ui
+        [(Spec("pkg-a@1.0"), None), (Spec("pkg-a@2.0"), None)], ui=ui
     )
 
     assert not ui.batches
     assert [(index, total) for _, _, index, total, _ in ui.concretized] == [(0, 2), (1, 2)]
-    assert {abstract.name for abstract, _, _, _, _ in ui.concretized} == {"pkg-a", "pkg-b"}
+    assert {str(abstract) for abstract, _, _, _, _ in ui.concretized} == {"pkg-a@1.0", "pkg-a@2.0"}
+
+    for abstract, concrete, _, _, _ in ui.concretized:
+        assert concrete.concrete and concrete.satisfies(abstract)
 
 
 def test_concretize_together_reports_nothing(mutable_config, mock_packages):

--- a/lib/spack/spack/test/concretization/core.py
+++ b/lib/spack/spack/test/concretization/core.py
@@ -5533,7 +5533,7 @@ def test_concretize_separately_reports_progress(mutable_config, mock_packages):
     spack.concretize.concretize_separately([(Spec("pkg-a"), None), (Spec("pkg-b"), None)], ui=ui)
 
     assert ui.started == [(spack.concretize_ui.SolveKind.SEPARATELY, 2, 1)]
-    assert [index for _, _, index, _ in ui.concretized] == [0, 1]
+    assert [count for _, _, count, _ in ui.concretized] == [1, 2]
     assert {abstract.name for abstract, _, _, _ in ui.concretized} == {"pkg-a", "pkg-b"}
     assert not ui.groups
 
@@ -5544,7 +5544,7 @@ def test_concretize_separately_reports_progress(mutable_config, mock_packages):
 def test_concretize_together_when_possible_reports_progress(mutable_config, mock_packages):
     """Tests that concretizing "when possible" reports the start of the concretization, and one
     event per spec. The two specs cannot be unified, so they are solved in different rounds, and
-    the index has to keep increasing across rounds.
+    the count has to keep increasing across rounds.
     """
     ui = RecordingUI()
     spack.concretize.concretize_together_when_possible(
@@ -5552,7 +5552,7 @@ def test_concretize_together_when_possible_reports_progress(mutable_config, mock
     )
 
     assert ui.started == [(spack.concretize_ui.SolveKind.WHEN_POSSIBLE, 2, 1)]
-    assert [index for _, _, index, _ in ui.concretized] == [0, 1]
+    assert [count for _, _, count, _ in ui.concretized] == [1, 2]
     assert {str(abstract) for abstract, _, _, _ in ui.concretized} == {"pkg-a@1.0", "pkg-a@2.0"}
 
     for abstract, concrete, _, _ in ui.concretized:
@@ -5567,7 +5567,7 @@ def test_concretize_together_reports_progress(mutable_config, mock_packages):
     spack.concretize.concretize_together([(Spec("pkg-a"), None), (Spec("pkg-b"), None)], ui=ui)
 
     assert ui.started == [(spack.concretize_ui.SolveKind.TOGETHER, 2, 1)]
-    assert [index for _, _, index, _ in ui.concretized] == [0, 1]
+    assert [count for _, _, count, _ in ui.concretized] == [1, 2]
     assert {abstract.name for abstract, _, _, _ in ui.concretized} == {"pkg-a", "pkg-b"}
     assert len({duration for _, _, _, duration in ui.concretized}) == 1
     assert not ui.groups
@@ -5586,7 +5586,8 @@ def test_concretize_together_reports_progress(mutable_config, mock_packages):
 )
 def test_reported_total_matches_number_of_specs(concretize_fn, mutable_config, mock_packages):
     """Tests that, whatever the concretization strategy, the total announced when concretization
-    starts is the number of specs that are reported as concretized afterwards.
+    starts is the number of specs that are reported as concretized afterwards, and that the counts
+    reported along the way run from 1 to that total. Frontends rely on this to show a percentage.
     """
     ui = RecordingUI()
     concretize_fn([(Spec("pkg-a"), None), (Spec("pkg-b"), None), (Spec("libelf"), None)], ui=ui)
@@ -5594,6 +5595,7 @@ def test_reported_total_matches_number_of_specs(concretize_fn, mutable_config, m
     assert len(ui.started) == 1
     _, total, _ = ui.started[0]
     assert total == len(ui.concretized) == 3
+    assert [count for _, _, count, _ in ui.concretized] == list(range(1, total + 1))
 
 
 def test_concretize_separately_reports_start_with_nothing_to_do(mutable_config, mock_packages):

--- a/lib/spack/spack/test/concretization/core.py
+++ b/lib/spack/spack/test/concretization/core.py
@@ -5594,3 +5594,27 @@ def test_reported_total_matches_number_of_specs(concretize_fn, mutable_config, m
     assert len(ui.started) == 1
     _, total, _ = ui.started[0]
     assert total == len(ui.concretized) == 3
+
+
+def test_concretize_separately_reports_start_with_nothing_to_do(mutable_config, mock_packages):
+    """Tests that concretization is announced even when every input spec is already concrete, so
+    that frontends always see a start event.
+    """
+    concrete = spack.concretize.concretize_one(Spec("pkg-a"))
+    ui = RecordingUI()
+    result = spack.concretize.concretize_separately([(Spec("pkg-a"), concrete)], ui=ui)
+
+    assert ui.started == [(spack.concretize_ui.SolveKind.SEPARATELY, 0, 1)]
+    assert not ui.concretized
+    assert [concrete for _, concrete in result] == [concrete]
+
+
+@pytest.mark.parametrize("total,announced", [(2, True), (0, False)])
+def test_terminal_ui_announces_pool_only_when_solving(total, announced, capsys):
+    """Tests that the terminal frontend stays silent when there is nothing to concretize."""
+    ui = spack.concretize_ui.TerminalUI()
+    ui.on_concretization_started(
+        kind=spack.concretize_ui.SolveKind.SEPARATELY, total=total, processes=1
+    )
+
+    assert ("Starting concretization" in capsys.readouterr().out) is announced

--- a/lib/spack/spack/test/concretization/core.py
+++ b/lib/spack/spack/test/concretization/core.py
@@ -5514,7 +5514,7 @@ class RecordingUI(spack.concretize_ui.ConcretizerUI):
     def on_group_started(self, *, group: str, is_default: bool) -> None:
         self.groups.append((group, is_default))
 
-    def on_solve_started(
+    def on_concretization_started(
         self, *, kind: spack.concretize_ui.SolveKind, total: int, processes: int
     ) -> None:
         self.started.append((kind, total, processes))
@@ -5526,8 +5526,8 @@ class RecordingUI(spack.concretize_ui.ConcretizerUI):
 
 
 def test_concretize_separately_reports_progress(mutable_config, mock_packages):
-    """Tests that concretizing separately reports the start of the solves, and one event per spec,
-    to the injected frontend.
+    """Tests that concretizing separately reports the start of the concretization, and one event
+    per spec, to the injected frontend.
     """
     ui = RecordingUI()
     spack.concretize.concretize_separately([(Spec("pkg-a"), None), (Spec("pkg-b"), None)], ui=ui)
@@ -5542,9 +5542,9 @@ def test_concretize_separately_reports_progress(mutable_config, mock_packages):
 
 
 def test_concretize_together_when_possible_reports_progress(mutable_config, mock_packages):
-    """Tests that concretizing "when possible" reports the start of the solves, and one event per
-    spec. The two specs cannot be unified, so they are solved in different rounds, and the
-    index has to keep increasing across rounds.
+    """Tests that concretizing "when possible" reports the start of the concretization, and one
+    event per spec. The two specs cannot be unified, so they are solved in different rounds, and
+    the index has to keep increasing across rounds.
     """
     ui = RecordingUI()
     spack.concretize.concretize_together_when_possible(
@@ -5560,7 +5560,9 @@ def test_concretize_together_when_possible_reports_progress(mutable_config, mock
 
 
 def test_concretize_together_reports_progress(mutable_config, mock_packages):
-    """Tests that concretizing together reports the start of the solve, and one event per spec."""
+    """Tests that concretizing together reports the start of the concretization, and one event
+    per spec.
+    """
     ui = RecordingUI()
     spack.concretize.concretize_together([(Spec("pkg-a"), None), (Spec("pkg-b"), None)], ui=ui)
 
@@ -5583,8 +5585,8 @@ def test_concretize_together_reports_progress(mutable_config, mock_packages):
     ],
 )
 def test_reported_total_matches_number_of_specs(concretize_fn, mutable_config, mock_packages):
-    """Tests that, whatever the concretization strategy, the total announced when the solves start
-    is the number of specs that are reported as concretized afterwards.
+    """Tests that, whatever the concretization strategy, the total announced when concretization
+    starts is the number of specs that are reported as concretized afterwards.
     """
     ui = RecordingUI()
     concretize_fn([(Spec("pkg-a"), None), (Spec("pkg-b"), None), (Spec("libelf"), None)], ui=ui)

--- a/lib/spack/spack/test/concretization/core.py
+++ b/lib/spack/spack/test/concretization/core.py
@@ -8,7 +8,7 @@ import pathlib
 import platform
 import re
 import sys
-from typing import Any, Dict
+from typing import Any, Dict, List, Tuple
 
 import pytest
 
@@ -21,6 +21,7 @@ import spack.cmd
 import spack.compilers.config
 import spack.compilers.libraries
 import spack.concretize
+import spack.concretize_ui
 import spack.config
 import spack.deptypes as dt
 import spack.environment as ev
@@ -5500,3 +5501,60 @@ def test_solve_in_rounds_with_no_specs(mock_packages, config):
     """Tests that solving no specs at all yields no result, instead of being unsatisfiable."""
     solver = spack.solver.asp.Solver()
     assert list(solver.solve_in_rounds([])) == []
+
+
+class RecordingUI(spack.concretize_ui.ConcretizerUI):
+    """Frontend that records the events it receives, instead of rendering them."""
+
+    def __init__(self) -> None:
+        self.groups: List[Tuple[str, bool]] = []
+        self.batches: List[Tuple[int, int]] = []
+        self.concretized: List[Tuple[Spec, Spec, int, int, float]] = []
+
+    def on_group_started(self, group: str, is_default: bool) -> None:
+        self.groups.append((group, is_default))
+
+    def on_batch_started(self, total: int, processes: int) -> None:
+        self.batches.append((total, processes))
+
+    def on_spec_concretized(
+        self, abstract: Spec, concrete: Spec, index: int, total: int, duration: float
+    ) -> None:
+        self.concretized.append((abstract, concrete, index, total, duration))
+
+
+def test_concretize_separately_reports_progress(mutable_config, mock_packages):
+    """Tests that concretizing separately reports one batch, and one event per spec, to the
+    injected frontend."""
+    ui = RecordingUI()
+    spack.concretize.concretize_separately([(Spec("pkg-a"), None), (Spec("pkg-b"), None)], ui=ui)
+
+    # Parallelism is disabled in tests, so the batch runs in a single process
+    assert ui.batches == [(2, 1)]
+    assert [(index, total) for _, _, index, total, _ in ui.concretized] == [(0, 2), (1, 2)]
+    assert {abstract.name for abstract, _, _, _, _ in ui.concretized} == {"pkg-a", "pkg-b"}
+    assert all(concrete.concrete for _, concrete, _, _, _ in ui.concretized)
+    assert not ui.groups
+
+
+def test_concretize_together_when_possible_reports_progress(mutable_config, mock_packages):
+    """Tests that concretizing when possible reports one event per spec, and no batch, since it
+    is a single solve."""
+    ui = RecordingUI()
+    spack.concretize.concretize_together_when_possible(
+        [(Spec("pkg-a"), None), (Spec("pkg-b"), None)], ui=ui
+    )
+
+    assert not ui.batches
+    assert [(index, total) for _, _, index, total, _ in ui.concretized] == [(0, 2), (1, 2)]
+    assert {abstract.name for abstract, _, _, _, _ in ui.concretized} == {"pkg-a", "pkg-b"}
+
+
+def test_concretize_together_reports_nothing(mutable_config, mock_packages):
+    """Tests that concretizing together is a single solve, and reports no progress at all."""
+    ui = RecordingUI()
+    spack.concretize.concretize_together([(Spec("pkg-a"), None), (Spec("pkg-b"), None)], ui=ui)
+
+    assert not ui.batches
+    assert not ui.concretized
+    assert not ui.groups

--- a/lib/spack/spack/test/concretization/core.py
+++ b/lib/spack/spack/test/concretization/core.py
@@ -8,7 +8,7 @@ import pathlib
 import platform
 import re
 import sys
-from typing import Any, Dict, List, Tuple
+from typing import Any, Dict
 
 import pytest
 
@@ -56,6 +56,7 @@ from spack.solver.reuse import spec_filter_from_packages_yaml
 from spack.spec import Spec
 from spack.store import Store
 from spack.test.conftest import RepoBuilder
+from spack.test.utilities import RecordingUI
 from spack.version import Version, VersionList, ver
 
 
@@ -5501,28 +5502,6 @@ def test_solve_in_rounds_with_no_specs(mock_packages, config):
     """Tests that solving no specs at all yields no result, instead of being unsatisfiable."""
     solver = spack.solver.asp.Solver()
     assert list(solver.solve_in_rounds([])) == []
-
-
-class RecordingUI(spack.concretize_ui.ConcretizerUI):
-    """Frontend that records the events it receives, instead of rendering them."""
-
-    def __init__(self) -> None:
-        self.groups: List[Tuple[str, bool]] = []
-        self.started: List[Tuple[spack.concretize_ui.SolveKind, int, int]] = []
-        self.concretized: List[Tuple[Spec, Spec, int, float]] = []
-
-    def on_group_started(self, *, group: str, is_default: bool) -> None:
-        self.groups.append((group, is_default))
-
-    def on_concretization_started(
-        self, *, kind: spack.concretize_ui.SolveKind, total: int, processes: int
-    ) -> None:
-        self.started.append((kind, total, processes))
-
-    def on_spec_concretized(
-        self, abstract: Spec, *, concrete: Spec, count: int, duration: float
-    ) -> None:
-        self.concretized.append((abstract, concrete, count, duration))
 
 
 def test_concretize_separately_reports_progress(mutable_config, mock_packages):

--- a/lib/spack/spack/test/concretization/core.py
+++ b/lib/spack/spack/test/concretization/core.py
@@ -5508,60 +5508,87 @@ class RecordingUI(spack.concretize_ui.ConcretizerUI):
 
     def __init__(self) -> None:
         self.groups: List[Tuple[str, bool]] = []
-        self.batches: List[Tuple[int, int]] = []
-        self.concretized: List[Tuple[Spec, Spec, int, int, float]] = []
+        self.started: List[Tuple[spack.concretize_ui.SolveKind, int, int]] = []
+        self.concretized: List[Tuple[Spec, Spec, int, float]] = []
 
     def on_group_started(self, *, group: str, is_default: bool) -> None:
         self.groups.append((group, is_default))
 
-    def on_batch_started(self, *, total: int, processes: int) -> None:
-        self.batches.append((total, processes))
+    def on_solve_started(
+        self, *, kind: spack.concretize_ui.SolveKind, total: int, processes: int
+    ) -> None:
+        self.started.append((kind, total, processes))
 
     def on_spec_concretized(
-        self, abstract: Spec, *, concrete: Spec, index: int, total: int, duration: float
+        self, abstract: Spec, *, concrete: Spec, index: int, duration: float
     ) -> None:
-        self.concretized.append((abstract, concrete, index, total, duration))
+        self.concretized.append((abstract, concrete, index, duration))
 
 
 def test_concretize_separately_reports_progress(mutable_config, mock_packages):
-    """Tests that concretizing separately reports one batch, and one event per spec, to the
-    injected frontend.
+    """Tests that concretizing separately reports the start of the solves, and one event per spec,
+    to the injected frontend.
     """
     ui = RecordingUI()
     spack.concretize.concretize_separately([(Spec("pkg-a"), None), (Spec("pkg-b"), None)], ui=ui)
 
-    assert ui.batches == [(2, 1)]
-    assert [(index, total) for _, _, index, total, _ in ui.concretized] == [(0, 2), (1, 2)]
-    assert {abstract.name for abstract, _, _, _, _ in ui.concretized} == {"pkg-a", "pkg-b"}
+    assert ui.started == [(spack.concretize_ui.SolveKind.SEPARATELY, 2, 1)]
+    assert [index for _, _, index, _ in ui.concretized] == [0, 1]
+    assert {abstract.name for abstract, _, _, _ in ui.concretized} == {"pkg-a", "pkg-b"}
     assert not ui.groups
 
-    for abstract, concrete, _, _, _ in ui.concretized:
+    for abstract, concrete, _, _ in ui.concretized:
         assert concrete.concrete and concrete.satisfies(abstract)
 
 
 def test_concretize_together_when_possible_reports_progress(mutable_config, mock_packages):
-    """Tests that concretizing when possible reports one event per spec, and no batch. The two
-    specs cannot be unified, so they are solved in different rounds, and the completion order has
-    to keep increasing across rounds.
+    """Tests that concretizing "when possible" reports the start of the solves, and one event per
+    spec. The two specs cannot be unified, so they are solved in different rounds, and the
+    index has to keep increasing across rounds.
     """
     ui = RecordingUI()
     spack.concretize.concretize_together_when_possible(
         [(Spec("pkg-a@1.0"), None), (Spec("pkg-a@2.0"), None)], ui=ui
     )
 
-    assert not ui.batches
-    assert [(index, total) for _, _, index, total, _ in ui.concretized] == [(0, 2), (1, 2)]
-    assert {str(abstract) for abstract, _, _, _, _ in ui.concretized} == {"pkg-a@1.0", "pkg-a@2.0"}
+    assert ui.started == [(spack.concretize_ui.SolveKind.WHEN_POSSIBLE, 2, 1)]
+    assert [index for _, _, index, _ in ui.concretized] == [0, 1]
+    assert {str(abstract) for abstract, _, _, _ in ui.concretized} == {"pkg-a@1.0", "pkg-a@2.0"}
 
-    for abstract, concrete, _, _, _ in ui.concretized:
+    for abstract, concrete, _, _ in ui.concretized:
         assert concrete.concrete and concrete.satisfies(abstract)
 
 
-def test_concretize_together_reports_nothing(mutable_config, mock_packages):
-    """Tests that concretizing together is a single solve, and reports no progress at all."""
+def test_concretize_together_reports_progress(mutable_config, mock_packages):
+    """Tests that concretizing together reports the start of the solve, and one event per spec."""
     ui = RecordingUI()
     spack.concretize.concretize_together([(Spec("pkg-a"), None), (Spec("pkg-b"), None)], ui=ui)
 
-    assert not ui.batches
-    assert not ui.concretized
+    assert ui.started == [(spack.concretize_ui.SolveKind.TOGETHER, 2, 1)]
+    assert [index for _, _, index, _ in ui.concretized] == [0, 1]
+    assert {abstract.name for abstract, _, _, _ in ui.concretized} == {"pkg-a", "pkg-b"}
+    assert len({duration for _, _, _, duration in ui.concretized}) == 1
     assert not ui.groups
+
+    for abstract, concrete, _, _ in ui.concretized:
+        assert concrete.concrete and concrete.satisfies(abstract)
+
+
+@pytest.mark.parametrize(
+    "concretize_fn",
+    [
+        spack.concretize.concretize_together,
+        spack.concretize.concretize_together_when_possible,
+        spack.concretize.concretize_separately,
+    ],
+)
+def test_reported_total_matches_number_of_specs(concretize_fn, mutable_config, mock_packages):
+    """Tests that, whatever the concretization strategy, the total announced when the solves start
+    is the number of specs that are reported as concretized afterwards.
+    """
+    ui = RecordingUI()
+    concretize_fn([(Spec("pkg-a"), None), (Spec("pkg-b"), None), (Spec("libelf"), None)], ui=ui)
+
+    assert len(ui.started) == 1
+    _, total, _ = ui.started[0]
+    assert total == len(ui.concretized) == 3

--- a/lib/spack/spack/test/utilities.py
+++ b/lib/spack/spack/test/utilities.py
@@ -4,7 +4,11 @@
 
 """Non-fixture utilities for test code. Must be imported."""
 
+from typing import List, Tuple
+
+from spack.concretize_ui import ConcretizerUI, SolveKind
 from spack.main import make_argument_parser
+from spack.spec import Spec
 
 
 class SpackCommandArgs:
@@ -28,3 +32,35 @@ class SpackCommandArgs:
         self.parser.add_command(self.command_name)
         args, unknown = self.parser.parse_known_args([self.command_name] + list(argv))
         return args
+
+
+class RecordingUI(ConcretizerUI):
+    """Concretizer frontend that records the events it receives, instead of rendering them.
+
+    Each list holds the arguments of the corresponding callback, in the order they were received.
+
+    Example usage::
+
+        ui = RecordingUI()
+        spack.concretize.concretize_separately([(Spec("pkg-a"), None)], ui=ui)
+        assert ui.started == [(SolveKind.SEPARATELY, 1, 1)]
+    """
+
+    def __init__(self) -> None:
+        #: (group, is_default) for each group that started
+        self.groups: List[Tuple[str, bool]] = []
+        #: (kind, total, processes) for each concretization that started
+        self.started: List[Tuple[SolveKind, int, int]] = []
+        #: (abstract, concrete, count, duration) for each spec that was concretized
+        self.concretized: List[Tuple[Spec, Spec, int, float]] = []
+
+    def on_group_started(self, *, group: str, is_default: bool) -> None:
+        self.groups.append((group, is_default))
+
+    def on_concretization_started(self, *, kind: SolveKind, total: int, processes: int) -> None:
+        self.started.append((kind, total, processes))
+
+    def on_spec_concretized(
+        self, abstract: Spec, *, concrete: Spec, count: int, duration: float
+    ) -> None:
+        self.concretized.append((abstract, concrete, count, duration))


### PR DESCRIPTION
On `develop` we have places where the core library decides how to "present" some part of the UI:
1. Progress when activating verbose mode
2. Headers when concretizing groups

This PR separates the UI concerns from the "backend" computation, by allowing the injection into concretization of `ui` components with methods that get called at various stages of concretization.

It also prevents spurious output to be printed when we call `spack spec [--json,--yaml,--format]`.