### PR TITLE
Windows docs: remove "work is in early stage"

### DIFF
--- a/lib/spack/docs/windows.rst
+++ b/lib/spack/docs/windows.rst
@@ -12,8 +12,6 @@
 Spack On Windows
 ================
 
-Windows support for Spack is currently under development.
-While this work is still in an early stage, it is currently possible to set up Spack and perform a few operations on Windows.
 This section will guide you through the steps needed to install Spack and start running it on a fresh Windows machine.
 
 Step 1: Install prerequisites


### PR DESCRIPTION
Update docs to reflect current state of Spack on Windows by removing lines indicating its not quite ready.

I keep having LLMs tell me Spack on Windows is in its "early stages". I just realized this is probably why, so as an added bonus, LLMs should stop telling folks this isn't ready for use yet.