### PR TITLE
spec.py: duplicate ^dep clauses are parallel edges

### DIFF
--- a/lib/spack/spack/deptypes.py
+++ b/lib/spack/spack/deptypes.py
@@ -44,34 +44,6 @@ NONE: DepFlag = 0
 ALL_FLAGS: Tuple[DepFlag, DepFlag, DepFlag, DepFlag] = (BUILD, LINK, RUN, TEST)
 
 
-def compatible(flag1: DepFlag, flag2: DepFlag) -> bool:
-    """Returns True if two depflags can be dependencies from a Spec to deps of the same name.
-
-    The only allowable separated dependencies are a build-only dependency, combined with a
-    non-build dependency. This separates our two process spaces, build time and run time.
-
-    These dependency combinations are allowed:
-
-    * single dep on name: ``[b]``, ``[l]``, ``[r]``, ``[bl]``, ``[br]``, ``[blr]``
-    * two deps on name: ``[b, l]``, ``[b, r]``, ``[b, lr]``
-
-    but none of these make any sense:
-
-    * two build deps: ``[b, b]``, ``[b, br]``, ``[b, bl]``, ``[b, blr]``
-    * any two deps that both have an ``l`` or an ``r``, i.e. ``[l, l]``, ``[r, r]``, ``[l, r]``,
-      ``[bl, l]``, ``[bl, r]``"""
-    # Cannot have overlapping build types to two different dependencies
-    if flag1 & flag2:
-        return False
-
-    # Cannot have two different link/run dependencies for the same name
-    link_run = LINK | RUN
-    if flag1 & link_run and flag2 & link_run:
-        return False
-
-    return True
-
-
 def flag_from_string(s: str) -> DepFlag:
     if s == "build":
         return BUILD

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -2159,16 +2159,24 @@ class Spec:
         return True
 
     def _detach_edge(self, edge: DependencySpec) -> None:
-        """Remove an edge from this spec and from the dependents of the node it points at."""
-        self._dependencies[edge.spec.name] = [
-            e for e in self._dependencies[edge.spec.name] if e is not edge
-        ]
+        """Remove an edge from this spec and from the dependents of the node it points at.
+        A bucket that runs empty is deleted: consumers distinguish "no dependents" by the
+        absence of the key, not by an empty list."""
+        remaining = [e for e in self._dependencies[edge.spec.name] if e is not edge]
+        if remaining:
+            self._dependencies[edge.spec.name] = remaining
+        else:
+            del self._dependencies[edge.spec.name]
         # Not a keyed lookup: self may have been anonymous when the edge was added and named only
         # later by a merge, leaving edge.spec._dependents keyed by the stale (possibly empty)
         # name rather than self.name as it is now.
         for name, dependents in edge.spec._dependents.items():
             if any(e is edge for e in dependents):
-                edge.spec._dependents[name] = [e for e in dependents if e is not edge]
+                remaining = [e for e in dependents if e is not edge]
+                if remaining:
+                    edge.spec._dependents[name] = remaining
+                else:
+                    del edge.spec._dependents[name]
                 break
 
     #

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -3427,6 +3427,17 @@ class Spec:
         for edges in groups.values():
             if len(edges) < 2:
                 continue
+            # A concrete node admits no further constraining: the group merges iff the concrete
+            # spec satisfies every other edge, so no copy of its subdag is needed.
+            concrete = next((e.spec for e in edges if e.spec.concrete), None)
+            if concrete is not None:
+                if all(
+                    concrete._satisfies(e.spec, resolve_virtuals=resolve_virtuals)
+                    for e in edges
+                    if e.spec is not concrete
+                ):
+                    continue
+                return False
             merged = edges[0].spec.copy(deps=True)
             try:
                 for edge in edges[1:]:

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -1649,6 +1649,51 @@ def _satisfies_edge_attributes(
     return lhs.spec._provides_virtual(rhs.spec)
 
 
+def _same_direct_dep(lhs: DependencySpec, rhs: DependencySpec) -> bool:
+    """Two edges of one parent refer to the same dependency when they are direct deps, refer to the
+    same package name, and have the same when condition.
+
+    Note that concrete specs exist that can have two distinct providers for a single virtual, so
+    we do not combine ``^virtual=x ^virtual=y``; we only enforce uniqueness on direct deps."""
+    return (
+        lhs.direct
+        and rhs.direct
+        and bool(lhs.spec.name)
+        and lhs.spec.name == rhs.spec.name
+        and lhs.when == rhs.when
+    )
+
+
+def _satisfies_edge(lhs: DependencySpec, rhs: DependencySpec, resolve_virtuals: bool) -> bool:
+    """Whether every DAG satisfying ``lhs`` satisfies ``rhs``."""
+    # Only a direct dependency can satisfy a direct dependency. _satisfies_edge_attributes does
+    # not compare this itself: its other caller, _satisfying_edges, filters on it externally,
+    # on fully built specs, unlike _add_or_merge_edge, whose parent node can still be under
+    # construction.
+    if rhs.direct and not lhs.direct:
+        return False
+    if not _satisfies_edge_attributes(lhs, rhs, resolve_virtuals):
+        return False
+    # A concrete or leaf rhs child needs no recursion: _satisfies_edge_attributes compared the
+    # child node already. A dependency of rhs's child that lhs's child lacks has to be checked:
+    # the two are independent requirements that a concretization can satisfy with two distinct
+    # nodes, and a single edge requiring both would exclude those DAGs.
+    if rhs.spec.concrete or not rhs.spec._dependencies:
+        return True
+    return _satisfies_dependencies(lhs.spec, rhs.spec, resolve_virtuals=resolve_virtuals)
+
+
+def _edge_is_redundant(
+    edge: DependencySpec, given: DependencySpec, resolve_virtuals: bool
+) -> bool:
+    """Whether ``edge`` adds nothing to ``given``: ``given`` satisfies it, and it states no
+    propagation ``given`` does not. A propagated edge is an input to the solver's objective even
+    where it does not narrow the solution set, so satisfaction alone does not make it redundant."""
+    if edge.propagation != PropagationPolicy.NONE and given.propagation != edge.propagation:
+        return False
+    return _satisfies_edge(given, edge, resolve_virtuals)
+
+
 @lang.lazy_lexicographic_ordering(set_hash=False)
 class Spec:
     compiler = DeprecatedCompilerSpec()
@@ -1996,56 +2041,14 @@ class Spec:
             propagation: propagation policy for this edge
             when: optional condition under which dependency holds
         """
-        if when is None:
-            when = EMPTY_SPEC
-
-        if spec.name not in self._dependencies or not spec.name:
-            self.add_dependency_edge(
-                spec,
-                depflag=depflag,
-                virtuals=virtuals,
-                direct=direct,
-                when=when,
-                propagation=propagation,
-            )
-            return
-
-        # Keep the intersection of constraints when a dependency is added multiple times with
-        # the same deptype. Add a new dependency if it is added with a compatible deptype
-        # (for example, a build-only dependency is compatible with a link-only dependency).
-        # The only restrictions, currently, are that we cannot add edges with overlapping
-        # dependency types and we cannot add multiple edges that have link/run dependency types.
-        # See ``spack.deptypes.compatible``.
-        orig = self._dependencies[spec.name]
-        try:
-            dspec = next(
-                dspec for dspec in orig if depflag == dspec.depflag and when == dspec.when
-            )
-        except StopIteration:
-            # Error if we have overlapping or incompatible deptypes
-            if any(not dt.compatible(dspec.depflag, depflag) for dspec in orig) and all(
-                dspec.when == when for dspec in orig
-            ):
-                edge_attrs = f"deptypes={dt.flag_to_chars(depflag).strip()}"
-                required_dep_str = f"^[{edge_attrs}] {str(spec)}"
-
-                raise DuplicateDependencyError(
-                    f"{spec.name} is a duplicate dependency, with conflicting dependency types\n"
-                    f"\t'{str(self)}' cannot depend on '{required_dep_str}'"
-                )
-
-            self.add_dependency_edge(
-                spec, depflag=depflag, virtuals=virtuals, direct=direct, when=when
-            )
-            return
-
-        try:
-            dspec.spec.constrain(spec)
-            dspec.update_virtuals(virtuals=virtuals)
-        except spack.error.UnsatisfiableSpecError:
-            raise DuplicateDependencyError(
-                f"Cannot depend on incompatible specs '{dspec.spec}' and '{spec}'"
-            )
+        self.add_dependency_edge(
+            spec,
+            depflag=depflag,
+            virtuals=virtuals,
+            direct=direct,
+            when=when,
+            propagation=propagation,
+        )
 
     def add_dependency_edge(
         self,
@@ -2070,47 +2073,16 @@ class Spec:
         if when is None:
             when = EMPTY_SPEC
 
-        # Check if we need to update edges that are already present
-        selected = self._dependencies.get(dependency_spec.name, [])
-        for edge in selected:
-            has_errors, details = False, []
-            msg = f"cannot update the edge from {edge.parent.name} to {edge.spec.name}"
-
-            if edge.when != when:
-                continue
-
-            # If the dependency is to an existing spec, we can update dependency
-            # types. If it is to a new object, check deptype compatibility.
-            if id(edge.spec) != id(dependency_spec) and not dt.compatible(edge.depflag, depflag):
-                has_errors = True
-                details.append(
-                    (
-                        f"{edge.parent.name} has already an edge matching any"
-                        f" of these types {depflag}"
-                    )
-                )
-
-                if any(v in edge.virtuals for v in virtuals):
-                    details.append(
-                        (
-                            f"{edge.parent.name} has already an edge matching any"
-                            f" of these virtuals {virtuals}"
-                        )
-                    )
-
-            if has_errors:
-                raise spack.error.SpecError(msg, "\n".join(details))
-
-        for edge in selected:
+        # An edge object already registered on both the parent and the child is updated in place,
+        # rather than treated as a second, competing constraint: both sides have to see the same
+        # modification.
+        for edge in self._dependencies.get(dependency_spec.name, []):
             if id(dependency_spec) == id(edge.spec) and edge.when == when:
-                # If we are here, it means the edge object was previously added to
-                # both the parent and the child. When we update this object they'll
-                # both see the deptype modification.
                 edge.update_deptypes(depflag=depflag)
                 edge.update_virtuals(virtuals=virtuals)
                 return
 
-        edge = DependencySpec(
+        candidate = DependencySpec(
             self,
             dependency_spec,
             depflag=depflag,
@@ -2119,8 +2091,83 @@ class Spec:
             propagation=propagation,
             when=when,
         )
-        _add_edge_to_map(self._dependencies, edge.spec.name, edge)
-        _add_edge_to_map(dependency_spec._dependents, edge.parent.name, edge)
+        self._add_or_merge_edge(candidate)
+
+    def _add_or_merge_edge(
+        self, candidate: DependencySpec, owned: bool = True, resolve_virtuals: bool = False
+    ) -> bool:
+        """Add ``candidate`` as a dependency edge.
+
+        With ``owned`` False the candidate's child still belongs to another DAG: a merge only
+        reads it, and an append replaces it with a copy first.
+
+        The candidate is merged into an existing edge when no concretization can satisfy the
+        two with separate dependencies (``_same_direct_dep``). A candidate that adds nothing to
+        an existing edge (``_edge_is_redundant``) is discarded, and existing edges made
+        redundant by the candidate are detached in its favor. Anything else is a new constraint
+        and is appended as a parallel edge: whether it ends up sharing a node with another edge
+        to the same name is for concretization to decide.
+
+        All scans compare only edges to the same package name: a ``^virtual`` edge and a
+        ``^[virtuals=virtual] provider`` edge are independent requirements and stay apart.
+
+        Returns True if ``self`` changed.
+
+        Raises:
+            spack.error.UnsatisfiableSpecError: if two direct dependencies that can only be a
+                single dependency have children that do not intersect.
+        """
+        name = candidate.spec.name
+
+        bucket = self._dependencies.get(name, []) if name else []
+
+        # A package has at most one direct dependency per name, so an unconditional direct dep
+        # is merged into an existing one (_same_direct_dep) by constraining, the only merge
+        # that can raise.
+        merged_edge: Optional[DependencySpec] = None
+        if name and candidate.when is EMPTY_SPEC:
+            for edge in bucket:
+                if _same_direct_dep(edge, candidate):
+                    merged_edge = edge
+                    break
+
+        if merged_edge is None and any(
+            _edge_is_redundant(candidate, edge, resolve_virtuals) for edge in bucket
+        ):
+            return False
+
+        # Constrain before detaching: a failed merge raises with self unchanged.
+        changed = merged_edge._constrain(candidate) if merged_edge is not None else False
+
+        for edge in [
+            edge
+            for edge in bucket
+            if edge is not merged_edge and _edge_is_redundant(edge, candidate, resolve_virtuals)
+        ]:
+            self._detach_edge(edge)
+            changed = True
+
+        if merged_edge is not None:
+            return changed
+
+        if not owned:
+            candidate.spec = candidate.spec.copy(deps=True)
+        _add_edge_to_map(self._dependencies, candidate.spec.name, candidate)
+        _add_edge_to_map(candidate.spec._dependents, self.name, candidate)
+        return True
+
+    def _detach_edge(self, edge: DependencySpec) -> None:
+        """Remove an edge from this spec and from the dependents of the node it points at."""
+        self._dependencies[edge.spec.name] = [
+            e for e in self._dependencies[edge.spec.name] if e is not edge
+        ]
+        # Not a keyed lookup: self may have been anonymous when the edge was added and named only
+        # later by a merge, leaving edge.spec._dependents keyed by the stale (possibly empty)
+        # name rather than self.name as it is now.
+        for name, dependents in edge.spec._dependents.items():
+            if any(e is edge for e in dependents):
+                edge.spec._dependents[name] = [e for e in dependents if e is not edge]
+                break
 
     #
     # Public interface
@@ -3226,22 +3273,18 @@ class Spec:
                 raise UnconstrainableDependencySpecError(other)
         changed = False
         for other_edge in other.edges_to_dependencies():
-            # Find the first edge in self that matches other_edge by name and when clause.
-            for self_edge in self.edges_to_dependencies(other_edge.spec.name):
-                if self_edge.when == other_edge.when:
-                    changed |= self_edge._constrain(other_edge)
-                    break
-            else:
-                # Otherwise, a copy of the edge is added as a constraint to self.
-                changed = True
-                self.add_dependency_edge(
-                    other_edge.spec.copy(deps=True),
-                    depflag=other_edge.depflag,
-                    virtuals=other_edge.virtuals,
-                    direct=other_edge.direct,
-                    propagation=other_edge.propagation,
-                    when=other_edge.when,  # no need to copy; when conditions are immutable
-                )
+            candidate = DependencySpec(
+                self,
+                other_edge.spec,
+                depflag=other_edge.depflag,
+                virtuals=other_edge.virtuals,
+                direct=other_edge.direct,
+                propagation=other_edge.propagation,
+                when=other_edge.when,  # no need to copy; when conditions are immutable
+            )
+            changed |= self._add_or_merge_edge(
+                candidate, owned=False, resolve_virtuals=resolve_virtuals
+            )
         return changed
 
     def constrained(self, other, deps=True):
@@ -3366,13 +3409,22 @@ class Spec:
             # one spec *could* eventually satisfy the other
             return True
 
-        # Handle first-order constraints directly
-        common_dependencies = {x.name for x in self.dependencies()}
-        common_dependencies &= {x.name for x in other.dependencies()}
-        for name in common_dependencies:
-            if not self[name]._intersects(
-                other[name], deps=True, resolve_virtuals=resolve_virtuals
-            ):
+        # A package has at most one direct dependency per name, so a concretization satisfies
+        # all unconditional direct edges to one name with a single node. Transitive constraints
+        # to one name never conflict with each other: a DAG can hold two nodes of the same name.
+        groups: Dict[str, List[DependencySpec]] = {}
+        for edge in itertools.chain(self.edges_to_dependencies(), other.edges_to_dependencies()):
+            if edge.direct and edge.spec.name and edge.when is EMPTY_SPEC:
+                groups.setdefault(edge.spec.name, []).append(edge)
+
+        for edges in groups.values():
+            if len(edges) < 2:
+                continue
+            merged = edges[0].spec.copy(deps=True)
+            try:
+                for edge in edges[1:]:
+                    merged._constrain(edge.spec, resolve_virtuals=resolve_virtuals)
+            except spack.error.SpecError:
                 return False
 
         if not resolve_virtuals:
@@ -5952,10 +6004,6 @@ class InvalidVariantForSpecError(spack.error.SpecError):
 
 class UnsupportedPropagationError(spack.error.SpecError):
     """Raised when propagation (==) is used with reserved variant names."""
-
-
-class DuplicateDependencyError(spack.error.SpecError):
-    """Raised when the same dependency occurs in a spec twice."""
 
 
 class UnsupportedCompilerError(spack.error.SpecError):

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -2167,17 +2167,12 @@ class Spec:
             self._dependencies[edge.spec.name] = remaining
         else:
             del self._dependencies[edge.spec.name]
-        # Not a keyed lookup: self may have been anonymous when the edge was added and named only
-        # later by a merge, leaving edge.spec._dependents keyed by the stale (possibly empty)
-        # name rather than self.name as it is now.
-        for name, dependents in edge.spec._dependents.items():
-            if any(e is edge for e in dependents):
-                remaining = [e for e in dependents if e is not edge]
-                if remaining:
-                    edge.spec._dependents[name] = remaining
-                else:
-                    del edge.spec._dependents[name]
-                break
+        dependents = edge.spec._dependents
+        remaining = [e for e in dependents[self.name] if e is not edge]
+        if remaining:
+            dependents[self.name] = remaining
+        else:
+            del dependents[self.name]
 
     #
     # Public interface
@@ -3244,6 +3239,16 @@ class Spec:
         if not self.name and other.name:
             self.name = other.name
             changed = True
+            # The children's dependent edges are filed under the name self had when they were
+            # added, the anonymous one: move them to the new name.
+            for edge in self.edges_to_dependencies():
+                dependents = edge.spec._dependents
+                remaining = [e for e in dependents[""] if e is not edge]
+                if remaining:
+                    dependents[""] = remaining
+                else:
+                    del dependents[""]
+                _add_edge_to_map(dependents, self.name, edge)
 
         if not self.namespace and other.namespace:
             self.namespace = other.namespace

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -2110,6 +2110,8 @@ class Spec:
 
         All scans compare only edges to the same package name: a ``^virtual`` edge and a
         ``^[virtuals=virtual] provider`` edge are independent requirements and stay apart.
+        Anonymous edges share the ``""`` bucket, where only the redundancy scans apply:
+        without a name, two direct deps can be distinct dependencies.
 
         Returns True if ``self`` changed.
 
@@ -2119,7 +2121,7 @@ class Spec:
         """
         name = candidate.spec.name
 
-        bucket = self._dependencies.get(name, []) if name else []
+        bucket = self._dependencies.get(name) or []
 
         # A package has at most one direct dependency per name, so an unconditional direct dep
         # is merged into an existing one (_same_direct_dep) by constraining, the only merge
@@ -3268,9 +3270,6 @@ class Spec:
         if not other._intersects_dependencies(self, resolve_virtuals=resolve_virtuals):
             raise UnsatisfiableDependencySpecError(other, self)
 
-        for d in other.traverse(root=False):
-            if not d.name:
-                raise UnconstrainableDependencySpecError(other)
         changed = False
         for other_edge in other.edges_to_dependencies():
             candidate = DependencySpec(
@@ -6053,15 +6052,6 @@ class UnsatisfiableDependencySpecError(spack.error.UnsatisfiableSpecError):
 
     def __init__(self, provided, required):
         super().__init__(provided, required, "dependency")
-
-
-class UnconstrainableDependencySpecError(spack.error.SpecError):
-    """Raised when attempting to constrain by an anonymous dependency spec"""
-
-    def __init__(self, spec):
-        msg = "Cannot constrain by spec '%s'. Cannot constrain by a" % spec
-        msg += " spec containing anonymous dependencies"
-        super().__init__(msg)
 
 
 class AmbiguousHashError(spack.error.SpecError):

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -3199,7 +3199,11 @@ class Spec:
 
         other = self._autospec(other)
         if other.concrete and other._satisfies(self, resolve_virtuals=resolve_virtuals):
+            # _dup makes self a detached copy without in-edges; self stays a node in its
+            # dependents' edge maps, so keep them
+            dependents = self._dependents
             self._dup(other)
+            self._dependents = dependents
             return True
 
         if not (self.name == other.name or (not self.name) or (not other.name)):

--- a/lib/spack/spack/test/concretization/core.py
+++ b/lib/spack/spack/test/concretization/core.py
@@ -5672,3 +5672,15 @@ def test_compiler_dependencies_can_be_excluded_from_reuse(
 
     assert s["zlib"].dag_hash() != compiler["zlib"].dag_hash(), s.tree()
     assert s["zlib"].satisfies("@1.2.11"), s.tree()
+
+
+def test_parallel_edges_in_a_literal_reach_the_solver(mock_packages, config):
+    """A duplicate ^dep clause parses as parallel edges rather than one merged node. The solver
+    still builds one node per name from a literal: compatible constraints are merged onto that
+    node, conflicting ones are unsatisfiable there instead of a parse error."""
+    spec = spack.concretize.concretize_one("mpileaks ^mpich@3.0.4 ^mpich+debug")
+    assert len(spec.dependencies(name="mpich")) == 1
+    assert spec["mpich"].satisfies("@3.0.4+debug")
+
+    with pytest.raises(spack.error.UnsatisfiableSpecError):
+        spack.concretize.concretize_one("mpileaks ^mpich@3.0.3 ^mpich@3.0.4")

--- a/lib/spack/spack/test/directives.py
+++ b/lib/spack/spack/test/directives.py
@@ -57,7 +57,10 @@ def test_constraints_from_context_are_merged(mock_packages: RepoPath):
     pkg_cls = mock_packages.get_pkg_class("with-constraint-met")
 
     assert pkg_cls.dependencies
-    assert "pkg-c" in pkg_cls.dependencies[spack.spec.Spec("@0.14:15 ^pkg-b@3.8:4.0")]
+    # The two ^pkg-b edges (one from the outer `when` context, one from depends_on's own when)
+    # are both indirect, so nothing says they are one node, and they stay parallel instead of
+    # being forced into a single @3.8:4.0 edge.
+    assert "pkg-c" in pkg_cls.dependencies[spack.spec.Spec("@0.14:15 ^pkg-b@:4.0 ^pkg-b@3.8:")]
 
 
 @pytest.mark.regression("27754")
@@ -220,9 +223,11 @@ def test_direct_dependencies_from_when_context_are_retained(mock_packages: RepoP
 
 
 def test_directives_meta_combine_when():
+    # The ^dep edges are indirect, so nothing says they are one node: combining two
+    # when-conditions that each constrain it keeps them parallel instead of fusing them.
     x, y, z = "+x ^dep +a", "+y ^dep +b", "+z"
-    assert _make_when_spec((x, y, z)) == Spec("+x +y +z ^dep +a +b")
-    assert _make_when_spec((x, y)) == Spec("+x +y ^dep +a +b")
+    assert _make_when_spec((x, y, z)) == Spec("+x +y +z ^dep+a ^dep+b")
+    assert _make_when_spec((x, y)) == Spec("+x +y ^dep+a ^dep+b")
     assert _make_when_spec((x,)) == Spec("+x ^dep +a")
 
 

--- a/lib/spack/spack/test/spec_dag.py
+++ b/lib/spack/spack/test/spec_dag.py
@@ -1144,6 +1144,24 @@ def test_detached_dependency_node_keeps_no_empty_dependent_bucket(mock_packages)
     assert not child._dependents
 
 
+def test_assigning_a_name_to_an_anonymous_spec_rekeys_dependents(mock_packages):
+    """Assigning a name to an anonymous spec moves its children's dependent edges from the
+    anonymous bucket to the new name, so keyed lookups on the edge maps return them."""
+    s = Spec("^pkg-b@1")
+    child = s.edges_to_dependencies(name="pkg-b")[0].spec
+    assert s.constrain(Spec("pkg-a"))
+    assert list(child._dependents.keys()) == ["pkg-a"]
+
+    # naming and edge replacement in one constrain: the detached child is unhooked cleanly
+    # and the surviving child is keyed by the new name
+    t = Spec("^pkg-b")
+    old_child = t.edges_to_dependencies(name="pkg-b")[0].spec
+    assert t.constrain(Spec("pkg-a ^pkg-b@1"))
+    assert t == Spec("pkg-a ^pkg-b@1")
+    assert not old_child._dependents
+    assert list(t["pkg-b"]._dependents.keys()) == ["pkg-a"]
+
+
 def test_constraining_and_intersecting_concrete_dep_of_abstract_root(mock_packages, config):
     """Constraining a concrete dep of an abstract spec is either a no-op or an error."""
     abstract = Spec("pkg-a")

--- a/lib/spack/spack/test/spec_dag.py
+++ b/lib/spack/spack/test/spec_dag.py
@@ -1167,6 +1167,23 @@ def test_assigning_a_name_to_an_anonymous_spec_rekeys_dependents(mock_packages):
     assert list(t["pkg-b"]._dependents.keys()) == ["pkg-a"]
 
 
+def test_merging_a_concrete_direct_dep_keeps_its_dependent_edges(mock_packages, config):
+    """A concrete node merged into an abstract direct dep replaces it in place; the node
+    keeps its dependent edges, so a later name assignment on the parent rekeys them."""
+    s = Spec("%pkg-b")
+    t = Spec("")
+    concrete = spack.concretize.concretize_one("pkg-b@=1.0")
+    t.add_dependency_edge(concrete, depflag=dt.BUILD, virtuals=(), direct=True)
+    assert s.constrain(t)
+    child = s.edges_to_dependencies(name="pkg-b")[0].spec
+    assert child.concrete
+    assert list(child._dependents.keys()) == [""]
+    check_links(s)
+    assert s.constrain("pkg-a")
+    assert list(child._dependents.keys()) == ["pkg-a"]
+    check_links(s)
+
+
 def test_constraining_and_intersecting_concrete_dep_of_abstract_root(mock_packages, config):
     """Constraining a concrete dep of an abstract spec is either a no-op or an error."""
     abstract = Spec("pkg-a")

--- a/lib/spack/spack/test/spec_dag.py
+++ b/lib/spack/spack/test/spec_dag.py
@@ -1053,12 +1053,9 @@ def test_adding_overlapping_deptypes_to_different_versions_stays_parallel(
     p.add_dependency_edge(c1, depflag=c1_depflag, virtuals=())
     p.add_dependency_edge(c2, depflag=c2_depflag, virtuals=())
 
-    edges = p.edges_to_dependencies(name="pkg-b")
-    assert len(edges) == 2
-    assert {e.spec.version for e in edges} == {
-        spack.version.Version("1.0"),
-        spack.version.Version("2.0"),
-    }
+    # no single node is both versions, so both parallel edges must be present
+    assert p.satisfies("^pkg-b@=1.0 ^pkg-b@=2.0")
+    assert len(p.dependencies(name="pkg-b")) == 2
 
 
 @pytest.mark.regression("33499")
@@ -1145,8 +1142,5 @@ def test_copy_preserves_parallel_edges_with_identical_attributes(mock_packages):
     assert len(root.edges_to_dependencies()) == 2
 
     copy = root.copy()
-    assert len(copy.edges_to_dependencies()) == 2
-    subdep_counts = sorted(
-        len(e.spec.edges_to_dependencies()) for e in copy.edges_to_dependencies()
-    )
-    assert subdep_counts == [0, 1]
+    assert copy == root
+    assert copy.to_dict() == root.to_dict()

--- a/lib/spack/spack/test/spec_dag.py
+++ b/lib/spack/spack/test/spec_dag.py
@@ -22,12 +22,17 @@ from spack.test.conftest import RepoBuilder
 
 
 def check_links(spec_to_check):
-    for spec in spec_to_check.traverse():
-        for dependent in spec.dependents():
-            assert dependent.edges_to_dependencies(name=spec.name)
-
-        for dependency in spec.dependencies():
-            assert dependency.edges_from_dependents(name=spec.name)
+    """Check edge-map symmetry on every node reachable by forward traversal: an edge in one
+    node's map is filed in the map at its other end, under the right name."""
+    for node in spec_to_check.traverse():
+        for name, edges in node._dependencies.items():
+            for edge in edges:
+                assert edge.parent is node and name == edge.spec.name
+                assert any(e is edge for e in edge.spec._dependents.get(node.name) or [])
+        for name, edges in node._dependents.items():
+            for edge in edges:
+                assert edge.spec is node and name == edge.parent.name
+                assert any(e is edge for e in edge.parent._dependencies.get(node.name) or [])
 
 
 @pytest.fixture()

--- a/lib/spack/spack/test/spec_dag.py
+++ b/lib/spack/spack/test/spec_dag.py
@@ -17,7 +17,7 @@ import spack.solver.asp
 import spack.util.hash as hashutil
 import spack.version
 from spack.dependency import Dependency
-from spack.spec import DependencySpec, Spec, _add_edge_to_map
+from spack.spec import Spec
 from spack.test.conftest import RepoBuilder
 
 
@@ -1121,26 +1121,14 @@ def test_getitem_finds_transitive_virtual():
 
 
 def test_copy_preserves_parallel_edges_with_identical_attributes(mock_packages):
-    """Two parallel edges to one name that agree on every attribute _satisfies_edge()
-    compares, and differ only in what their children depend on, are a legitimate state. A copy
-    reproduces both."""
+    """Two parallel edges to one name that agree on every attribute an edge carries, and differ
+    only in what their children depend on, are a legitimate state. A copy reproduces both."""
     # _dup_deps copies edge by edge in traversal order, attaching each node to its parent before
-    # that node's own children are visited, so the second edge is still childless when it is
-    # attached and can look redundant against the first
-    root = Spec("pkg-a")
-    bare = Spec("pkg-b")
-    with_dep = Spec("pkg-b")
-    with_dep._add_dependency(Spec("pkg-e"), depflag=dt.LINK, virtuals=())
+    # that node's own children are visited, so the two ^pkg-b edges are indistinguishable when
+    # the second is attached, and it can look redundant against the first
+    original = Spec("pkg-a ^pkg-b %pkg-c ^pkg-b %pkg-e")
+    assert len(original.edges_to_dependencies(name="pkg-b")) == 2
 
-    # built without add_dependency_edge, so this does not depend on what _satisfies_edge()
-    # compares today
-    for child in (bare, with_dep):
-        edge = DependencySpec(root, child, depflag=dt.NONE, virtuals=())
-        _add_edge_to_map(root._dependencies, child.name, edge)
-        _add_edge_to_map(child._dependents, root.name, edge)
-
-    assert len(root.edges_to_dependencies()) == 2
-
-    copy = root.copy()
-    assert copy == root
-    assert copy.to_dict() == root.to_dict()
+    copy = original.copy()
+    assert copy == original
+    assert copy.to_dict() == original.to_dict()

--- a/lib/spack/spack/test/spec_dag.py
+++ b/lib/spack/spack/test/spec_dag.py
@@ -17,7 +17,7 @@ import spack.solver.asp
 import spack.util.hash as hashutil
 import spack.version
 from spack.dependency import Dependency
-from spack.spec import Spec
+from spack.spec import DependencySpec, Spec, _add_edge_to_map
 from spack.test.conftest import RepoBuilder
 
 
@@ -1041,16 +1041,24 @@ def test_addition_of_different_deptypes_in_multiple_calls(mock_packages, config)
     "c1_depflag,c2_depflag",
     [(dt.LINK, dt.BUILD | dt.LINK), (dt.LINK | dt.RUN, dt.BUILD | dt.LINK)],
 )
-def test_adding_same_deptype_with_the_same_name_raises(
+def test_adding_overlapping_deptypes_to_different_versions_stays_parallel(
     mock_packages, config, c1_depflag, c2_depflag
 ):
+    """c1 and c2 are different concrete versions of one package, so neither edge satisfies the
+    other even though their depflags overlap, and both stay as parallel edges to pkg-b."""
     p = spack.concretize.concretize_one("pkg-b@=2.0")
     c1 = spack.concretize.concretize_one("pkg-b@=1.0")
     c2 = spack.concretize.concretize_one("pkg-b@=2.0")
 
     p.add_dependency_edge(c1, depflag=c1_depflag, virtuals=())
-    with pytest.raises(spack.error.SpackError):
-        p.add_dependency_edge(c2, depflag=c2_depflag, virtuals=())
+    p.add_dependency_edge(c2, depflag=c2_depflag, virtuals=())
+
+    edges = p.edges_to_dependencies(name="pkg-b")
+    assert len(edges) == 2
+    assert {e.spec.version for e in edges} == {
+        spack.version.Version("1.0"),
+        spack.version.Version("2.0"),
+    }
 
 
 @pytest.mark.regression("33499")
@@ -1113,3 +1121,32 @@ def test_getitem_finds_transitive_virtual():
     x.add_dependency_edge(y, depflag=dt.LINK, virtuals=())
     y.add_dependency_edge(z, depflag=dt.LINK, virtuals=("virtual",))
     assert x["virtual"].name == "z"
+
+
+def test_copy_preserves_parallel_edges_with_identical_attributes(mock_packages):
+    """Two parallel edges to one name that agree on every attribute _satisfies_edge()
+    compares, and differ only in what their children depend on, are a legitimate state. A copy
+    reproduces both."""
+    # _dup_deps copies edge by edge in traversal order, attaching each node to its parent before
+    # that node's own children are visited, so the second edge is still childless when it is
+    # attached and can look redundant against the first
+    root = Spec("pkg-a")
+    bare = Spec("pkg-b")
+    with_dep = Spec("pkg-b")
+    with_dep._add_dependency(Spec("pkg-e"), depflag=dt.LINK, virtuals=())
+
+    # built without add_dependency_edge, so this does not depend on what _satisfies_edge()
+    # compares today
+    for child in (bare, with_dep):
+        edge = DependencySpec(root, child, depflag=dt.NONE, virtuals=())
+        _add_edge_to_map(root._dependencies, child.name, edge)
+        _add_edge_to_map(child._dependents, root.name, edge)
+
+    assert len(root.edges_to_dependencies()) == 2
+
+    copy = root.copy()
+    assert len(copy.edges_to_dependencies()) == 2
+    subdep_counts = sorted(
+        len(e.spec.edges_to_dependencies()) for e in copy.edges_to_dependencies()
+    )
+    assert subdep_counts == [0, 1]

--- a/lib/spack/spack/test/spec_dag.py
+++ b/lib/spack/spack/test/spec_dag.py
@@ -1139,6 +1139,20 @@ def test_detached_dependency_node_keeps_no_empty_dependent_bucket(mock_packages)
     left behind."""
     s = Spec("pkg-a ^pkg-b")
     child = s["pkg-b"]
-    assert s.constrain(Spec("pkg-a ^pkg-b@1"))
+    assert s.constrain("pkg-a ^pkg-b@1")
     assert s == Spec("pkg-a ^pkg-b@1")
     assert not child._dependents
+
+
+def test_constraining_and_intersecting_concrete_dep_of_abstract_root(mock_packages, config):
+    """Constraining a concrete dep of an abstract spec is either a no-op or an error."""
+    abstract = Spec("pkg-a")
+    concrete = spack.concretize.concretize_one("pkg-b@=1.0")
+    abstract.add_dependency_edge(concrete, depflag=dt.BUILD, virtuals=(), direct=True)
+    compatible, conflicting = Spec("pkg-a %pkg-b@1"), Spec("pkg-a %pkg-b@2")
+    assert abstract.intersects(compatible) and compatible.intersects(abstract)
+    assert not abstract.intersects(conflicting) and not conflicting.intersects(abstract)
+
+    assert abstract.constrain(compatible) is False
+    with pytest.raises(spack.error.UnsatisfiableSpecError):
+        abstract.constrain(conflicting)

--- a/lib/spack/spack/test/spec_dag.py
+++ b/lib/spack/spack/test/spec_dag.py
@@ -1132,3 +1132,13 @@ def test_copy_preserves_parallel_edges_with_identical_attributes(mock_packages):
     copy = original.copy()
     assert copy == original
     assert copy.to_dict() == original.to_dict()
+
+
+def test_detached_dependency_node_keeps_no_empty_dependent_bucket(mock_packages):
+    """Replacing an edge detaches the old child completely: no empty dependent bucket is
+    left behind."""
+    s = Spec("pkg-a ^pkg-b")
+    child = s["pkg-b"]
+    assert s.constrain(Spec("pkg-a ^pkg-b@1"))
+    assert s == Spec("pkg-a ^pkg-b@1")
+    assert not child._dependents

--- a/lib/spack/spack/test/spec_semantics.py
+++ b/lib/spack/spack/test/spec_semantics.py
@@ -2855,9 +2855,9 @@ def test_edge_already_matched_is_not_copied_in(mock_packages):
 
 
 def test_edges_differing_in_namespace_stay_parallel(mock_packages):
-    """`^pkg-b@1` does not satisfy `^builtin_mock.pkg-b` and vice versa: a concretization can
-    hold a builtin_mock node next to a pkg-b@1 node from another repo, so the merge keeps both
-    edges. An edge that does carry the namespace absorbs the one it satisfies."""
+    """`^pkg-b@1` does not satisfy `^builtin_mock.pkg-b` and vice versa: a concrete spec can have
+    a builtin_mock node next to a pkg-b@1 node from another repo, so the merge keeps both edges.
+    An edge that does have the namespace absorbs the one it satisfies."""
     lhs, rhs = Spec("pkg-a ^pkg-b@1"), Spec("pkg-a ^builtin_mock.pkg-b")
     forward, backward = lhs.constrained(rhs), rhs.constrained(lhs)
     assert forward.to_dict() == backward.to_dict()
@@ -2891,16 +2891,15 @@ def test_edge_propagation_is_merged_at_parse_time(mock_packages):
 
 def test_satisfies_ignores_edge_propagation(mock_packages):
     """%% expresses a preference the solver may override, so it does not narrow the set of DAGs:
-    satisfaction ignores it in both directions. In particular concrete specs, whose edges record
-    no propagation, satisfy a %% input."""
+    satisfaction ignores it in both directions. This is one factor that makes the set of Spec
+    objects a preorder under satisfies instead of a partial order."""
     assert Spec("mpileaks %%callpath").satisfies("mpileaks %callpath")
     assert Spec("mpileaks %callpath").satisfies("mpileaks %%callpath")
 
 
 def test_conditional_propagated_edge_is_not_redundant(mock_packages):
-    """A conditionally propagated edge is satisfied by an unconditional plain one, but it states
-    a preference the plain edge does not, so the two stay parallel instead of the propagated edge
-    being discarded."""
+    """Satisfaction ignores edge propagation, but the edge redundancy check does not ignore it when
+    merging edges."""
     s = Spec("mpileaks %callpath %%[when='+foo'] callpath")
     assert s == Spec("mpileaks %%[when='+foo'] callpath %callpath")
     assert len(s.edges_to_dependencies(name="callpath")) == 2
@@ -2908,6 +2907,10 @@ def test_conditional_propagated_edge_is_not_redundant(mock_packages):
     t = Spec("mpileaks %%[when='+foo'] callpath")
     assert t.constrain("mpileaks %callpath")
     assert t == s
+
+    # with equal propagation on both edges, the conditional edge is redundant and discarded
+    assert Spec("mpileaks %%callpath %%[when='+foo'] callpath") == Spec("mpileaks %%callpath")
+    assert Spec("mpileaks %callpath %[when='+foo'] callpath") == Spec("mpileaks %callpath")
 
 
 def test_direct_and_indirect_provider_of_one_virtual_stay_apart(mock_packages):
@@ -2935,8 +2938,8 @@ def test_two_providers_of_one_virtual_merge_as_parallel_edges(mock_packages):
 def test_two_providers_under_conditions_that_exclude_each_other_are_fine(mock_packages):
     """Only one provider can be the one at a time, so two of them named under conditions that
     cannot hold together are not in each other's way."""
-    lhs = Spec("pkg-a ^[when='+foo' virtuals=mpi] mpich")
-    rhs = Spec("pkg-a ^[when='~foo' virtuals=mpi] zmpi")
+    lhs = Spec("pkg-a %[when='+foo' virtuals=mpi] mpich")
+    rhs = Spec("pkg-a %[when='~foo' virtuals=mpi] zmpi")
     assert lhs.intersects(rhs)
     assert rhs.intersects(lhs)
 
@@ -2987,13 +2990,16 @@ def test_direct_edges_to_one_name_merge_their_virtuals(mock_packages):
 
 
 def test_two_versions_of_one_provider_of_a_virtual_intersect(mock_packages):
-    """Two edges naming the same provider for one virtual at versions that do not intersect are
-    still two existential requirements, each matched by its own node."""
+    """Two edges referring to the same provider for one virtual at versions that do not intersect
+    can be matched by a concrete spec with duplicate nodes, cause ^ can refer to two distinct
+    unification sets in which virtuals are unified: link/run closure and pure build deps."""
     lhs, rhs = Spec("pkg-a ^mpi=mpich@3"), Spec("pkg-a ^mpi=mpich@4")
     assert lhs.intersects(rhs)
     assert rhs.intersects(lhs)
     result = lhs.constrained(rhs)
     assert result == Spec("pkg-a ^mpi=mpich@3 ^mpi=mpich@4")
+    example = Spec("pkg-a %[deptypes=build] mpi=mpich@3 ^[deptypes=link] mpi=mpich@4")
+    assert example.satisfies(result)
 
 
 def test_an_anonymous_dependency_is_a_parallel_edge(mock_packages):
@@ -3009,23 +3015,24 @@ def test_an_anonymous_dependency_is_a_parallel_edge(mock_packages):
     forward, backward = Spec("").constrained(spec), spec.constrained("")
     assert forward.to_dict() == backward.to_dict() == spec.to_dict()
 
-    # two anonymous constraints can each be matched by a different dependency, so they stay two
-    # edges, transitive or direct. The single edge "^+foo+bar" also satisfies both operands, but
-    # the meet is the greatest lower bound: the witness with two distinct deps satisfies both
-    # operands, so it must satisfy the result, and only the parallel pair admits it.
-    result = Spec("pkg-a ^+foo").constrained("pkg-a ^+bar")
-    assert result.to_dict() == Spec("pkg-a ^+foo ^+bar").to_dict()
-    assert result.satisfies("pkg-a ^+foo") and result.satisfies("pkg-a ^+bar")
-    witness = Spec("pkg-a ^pkg-b+foo ^pkg-c+bar")
-    assert witness.satisfies(result)
-    assert not witness.satisfies("pkg-a ^+foo+bar")
+    # Two anonymous constraints can each be matched by a different dependency, so they remain
+    # parallel edges under intersection. The test asserts that under the preorder of satisfies
+    # both `parallel <= {lhs, rhs}` and `merged <= {lhs, rhs}`, but also that `merged <= parallel`
+    # while `parallel <= merged` is not the case. Constrain should pick the greatest lower bound,
+    # meaning that `merged` is the incorrect choice.
+    lhs, rhs = Spec("pkg-a ^+foo"), Spec("pkg-a ^+bar")
+    parallel, merged = Spec("pkg-a ^+foo ^+bar"), Spec("pkg-a ^+foo+bar")
+    assert parallel.satisfies(lhs) and parallel.satisfies(rhs)
+    assert merged.satisfies(lhs) and merged.satisfies(rhs)
+    assert merged.satisfies(parallel) and not parallel.satisfies(merged)
+    assert lhs.constrained(rhs) == parallel
 
-    result = Spec("pkg-a %+foo").constrained("pkg-a %+bar")
-    assert result == Spec("pkg-a %+foo %+bar")
-    assert result.satisfies("pkg-a %+foo") and result.satisfies("pkg-a %+bar")
-    witness = Spec("pkg-a %pkg-b+foo %pkg-c+bar")
-    assert witness.satisfies(result)
-    assert not witness.satisfies("pkg-a %+foo+bar")
+    lhs, rhs = Spec("pkg-a %+foo"), Spec("pkg-a %+bar")
+    parallel, merged = Spec("pkg-a %+foo %+bar"), Spec("pkg-a %+foo+bar")
+    assert parallel.satisfies(lhs) and parallel.satisfies(rhs)
+    assert merged.satisfies(lhs) and merged.satisfies(rhs)
+    assert merged.satisfies(parallel) and not parallel.satisfies(merged)
+    assert lhs.constrained(rhs) == parallel
 
     # direct deps are written before the first ^ so %+bar binds to the root
     result = Spec("pkg-a ^+foo").constrained("pkg-a %+bar")
@@ -3059,9 +3066,8 @@ def test_an_anonymous_dependency_is_a_parallel_edge(mock_packages):
     assert forward.satisfies(named) and named.satisfies(forward)
 
 
-def test_an_edge_bridging_two_parallel_edges_relates_nothing(mock_packages):
-    """One edge listing two virtuals does not weld the edges listing them separately into one
-    node: all three are existential requirements, each matched by its own node."""
+def test_an_edge_bridging_two_parallel_edges(mock_packages):
+    """Edges to distinct virtuals of the same provider package stay parallel."""
     spec = Spec("mpileaks ^mpi=mpich ^lapack=mpich ^mpi,lapack=zmpi")
     assert spec == Spec("mpileaks ^mpi,lapack=zmpi ^mpi=mpich ^lapack=mpich")
     assert len(spec.edges_to_dependencies()) == 3
@@ -3080,30 +3086,29 @@ def test_an_edge_bridging_two_parallel_edges_relates_nothing(mock_packages):
 
 
 def test_edges_under_different_conditions_stay_parallel(mock_packages):
-    """Two direct edges to one name are one node only where both conditions hold, and an edge
-    records exactly one condition, so no single edge says that. A merge that fused them would
-    exclude concretizations that satisfy the pair."""
+    """Two direct edges to the same package name are one node only where both conditions hold, so
+    they stay parallel."""
     lhs = Spec("pkg-a %[when='+bvv' virtuals=c] gcc")
     rhs = Spec("pkg-a %[when='~bvv' virtuals=cxx] gcc")
     result = lhs.constrained(rhs)
     assert result == Spec("pkg-a %[when='+bvv' virtuals=c] gcc %[when='~bvv' virtuals=cxx] gcc")
 
-    # with bvv off neither conditional edge asks for anything, so a fused merge loses this spec
-    witness = Spec("pkg-a ~bvv %cxx=gcc")
-    assert witness.satisfies(lhs) and witness.satisfies(rhs)
-    assert witness.satisfies(result)
+    # this instance would fail if virtuals=c,cxx were merged
+    example = Spec("pkg-a ~bvv %cxx=gcc")
+    assert example.satisfies(lhs) and example.satisfies(rhs)
+    assert example.satisfies(result)
 
 
 def test_conflicting_deps_under_one_unforced_condition_intersect(mock_packages):
     """Both edges bind only where +foo holds, and pkg-a~foo satisfies both operands, so the
     conflicting conditional deps do not make the pair disjoint."""
     lhs, rhs = Spec("pkg-a %[when='+foo'] pkg-b@1"), Spec("pkg-a %[when='+foo'] pkg-b@2")
-    witness = Spec("pkg-a ~foo")
-    assert witness.satisfies(lhs) and witness.satisfies(rhs)
+    example = Spec("pkg-a ~foo")
+    assert example.satisfies(lhs) and example.satisfies(rhs)
     assert lhs.intersects(rhs) and rhs.intersects(lhs)
     result = lhs.constrained(rhs)
     assert result == Spec("pkg-a %[when='+foo'] pkg-b@1 %[when='+foo'] pkg-b@2")
-    assert witness.satisfies(result)
+    assert example.satisfies(result)
     assert result.to_dict() == rhs.constrained(lhs).to_dict()
 
 

--- a/lib/spack/spack/test/spec_semantics.py
+++ b/lib/spack/spack/test/spec_semantics.py
@@ -2861,15 +2861,13 @@ def test_edges_differing_in_namespace_stay_parallel(mock_packages):
     lhs, rhs = Spec("pkg-a ^pkg-b@1"), Spec("pkg-a ^builtin_mock.pkg-b")
     forward, backward = lhs.constrained(rhs), rhs.constrained(lhs)
     assert forward.to_dict() == backward.to_dict()
+    assert forward == Spec("pkg-a ^pkg-b@1 ^builtin_mock.pkg-b")
     assert len(forward.edges_to_dependencies(name="pkg-b")) == 2
 
     lhs, rhs = Spec("pkg-a ^pkg-b@1"), Spec("pkg-a ^builtin_mock.pkg-b@1")
     forward, backward = lhs.constrained(rhs), rhs.constrained(lhs)
     assert forward.to_dict() == backward.to_dict()
-    edges = forward.edges_to_dependencies(name="pkg-b")
-    assert len(edges) == 1
-    assert edges[0].spec.namespace == "builtin_mock"
-    assert edges[0].spec.satisfies("@1")
+    assert forward == Spec("pkg-a ^builtin_mock.pkg-b@1")
 
 
 def test_edge_propagation_is_merged(mock_packages):
@@ -2881,7 +2879,7 @@ def test_edge_propagation_is_merged(mock_packages):
     backward = rhs.copy()
     backward.constrain(lhs)
     assert forward.to_dict() == backward.to_dict()
-    assert forward.edges_to_dependencies()[0].propagation == PropagationPolicy.PREFERENCE
+    assert forward == Spec("pkg-a %%pkg-b")
 
 
 def test_edge_propagation_is_merged_at_parse_time(mock_packages):
@@ -2904,32 +2902,33 @@ def test_conditional_propagated_edge_is_not_redundant(mock_packages):
     a preference the plain edge does not, so the two stay parallel instead of the propagated edge
     being discarded."""
     s = Spec("mpileaks %callpath %%[when='+foo'] callpath")
+    assert s == Spec("mpileaks %%[when='+foo'] callpath %callpath")
     assert len(s.edges_to_dependencies(name="callpath")) == 2
 
     t = Spec("mpileaks %%[when='+foo'] callpath")
     assert t.constrain("mpileaks %callpath")
-    assert len(t.edges_to_dependencies(name="callpath")) == 2
+    assert t == s
 
 
 def test_direct_and_indirect_provider_of_one_virtual_stay_apart(mock_packages):
     """A direct provider and an indirect one need not be the same node: '%c=llvm ^c=gcc' is
     built with llvm but uses gcc somewhere at runtime."""
-    spec = Spec("mpileaks %[virtuals=c] llvm ^[virtuals=c] gcc")
-    edges = spec.edges_to_dependencies()
-    assert len(edges) == 2
-    assert {edge.spec.name for edge in edges} == {"llvm", "gcc"}
+    spec = Spec("mpileaks %c=llvm ^c=gcc")
+    assert spec.satisfies("%c=llvm")
+    assert spec.satisfies("^c=gcc")
+    assert len(spec.edges_to_dependencies()) == 2
 
 
 def test_two_providers_of_one_virtual_merge_as_parallel_edges(mock_packages):
     """Two edges naming different providers of one virtual are two requirements, each matched
     anywhere in the DAG. The parser and constrain keep them side by side."""
-    spec = Spec("mpileaks ^[virtuals=mpi] mpich ^[virtuals=mpi] zmpi")
-    assert len(spec.edges_to_dependencies()) == 2
+    spec = Spec("mpileaks ^mpi=mpich ^mpi=zmpi")
+    assert spec == Spec("mpileaks ^mpi=zmpi ^mpi=mpich")
 
-    lhs, rhs = Spec("pkg-a ^[virtuals=mpi] mpich"), Spec("pkg-a ^[virtuals=mpi] zmpi")
+    lhs, rhs = Spec("pkg-a ^mpi=mpich"), Spec("pkg-a ^mpi=zmpi")
     assert lhs.intersects(rhs) and rhs.intersects(lhs)
     forward, backward = lhs.constrained(rhs), rhs.constrained(lhs)
-    assert len(forward.edges_to_dependencies()) == 2
+    assert forward == Spec("pkg-a ^mpi=mpich ^mpi=zmpi")
     assert forward.to_dict() == backward.to_dict()
 
 
@@ -2948,8 +2947,8 @@ def test_parallel_build_and_link_edges_merge_cleanly(mock_packages):
     result = Spec("pkg-a ^[deptypes=build] pkg-b").constrained(
         Spec("pkg-a ^[deptypes=build] pkg-b ^[deptypes=link] pkg-b")
     )
-    depflags = sorted(dt.flag_to_chars(e.depflag).strip() for e in result.edges_to_dependencies())
-    assert depflags == ["b", "l"]
+    assert result == Spec("pkg-a ^[deptypes=build] pkg-b ^[deptypes=link] pkg-b")
+    assert len(result.edges_to_dependencies(name="pkg-b")) == 2
 
     # round-trips cleanly: copy, str()/reparse and to_dict/from_dict all agree
     assert result.copy().to_dict() == result.to_dict()
@@ -2968,40 +2967,33 @@ def test_parallel_direct_edges_are_always_the_same_edge(mock_packages):
     name are always merged into one, whatever their deptypes."""
     lhs, rhs = Spec("pkg-a %[deptypes=run] pkg-e"), Spec("pkg-a %[deptypes=link] pkg-e")
     result = lhs.constrained(rhs)
-    depflags = sorted(dt.flag_to_chars(e.depflag).strip() for e in result.edges_to_dependencies())
-    assert depflags == ["lr"]
+    assert result == Spec("pkg-a %[deptypes=link,run] pkg-e")
 
     # idempotent: re-applying the same constraint does not change anything further
     assert result.constrain(rhs) is False
-    depflags = sorted(dt.flag_to_chars(e.depflag).strip() for e in result.edges_to_dependencies())
-    assert depflags == ["lr"]
+    assert result == Spec("pkg-a %[deptypes=link,run] pkg-e")
 
 
 def test_direct_edges_to_one_name_merge_their_virtuals(mock_packages):
     """A package has at most one direct dependency on a name. Two direct edges to it are one
     dependency, merging their virtuals as they merge their deptypes."""
-    edges = Spec("mpileaks %[virtuals=c] gcc %[virtuals=cxx] gcc").edges_to_dependencies()
-    assert len(edges) == 1
-    assert edges[0].virtuals == ("c", "cxx")
+    spec = Spec("mpileaks %c=gcc %cxx=gcc")
+    assert spec == Spec("mpileaks %c,cxx=gcc")
 
-    lhs, rhs = Spec("pkg-a %[virtuals=c] gcc@5"), Spec("pkg-a %[virtuals=cxx] gcc")
+    lhs, rhs = Spec("pkg-a %c=gcc@5"), Spec("pkg-a %cxx=gcc")
     forward, backward = lhs.constrained(rhs), rhs.constrained(lhs)
     assert forward.to_dict() == backward.to_dict()
-
-    edges = forward.edges_to_dependencies()
-    assert len(edges) == 1
-    assert edges[0].virtuals == ("c", "cxx")
-    assert edges[0].spec.satisfies("gcc@5")
+    assert forward == Spec("pkg-a %c,cxx=gcc@5")
 
 
 def test_two_versions_of_one_provider_of_a_virtual_intersect(mock_packages):
     """Two edges naming the same provider for one virtual at versions that do not intersect are
     still two existential requirements, each matched by its own node."""
-    lhs, rhs = Spec("pkg-a ^[virtuals=mpi] mpich@3"), Spec("pkg-a ^[virtuals=mpi] mpich@4")
+    lhs, rhs = Spec("pkg-a ^mpi=mpich@3"), Spec("pkg-a ^mpi=mpich@4")
     assert lhs.intersects(rhs)
     assert rhs.intersects(lhs)
     result = lhs.constrained(rhs)
-    assert len(result.edges_to_dependencies()) == 2
+    assert result == Spec("pkg-a ^mpi=mpich@3 ^mpi=mpich@4")
 
 
 def test_an_anonymous_dependency_is_a_parallel_edge(mock_packages):
@@ -3029,18 +3021,20 @@ def test_an_anonymous_dependency_is_a_parallel_edge(mock_packages):
     assert not witness.satisfies("pkg-a ^+foo+bar")
 
     result = Spec("pkg-a %+foo").constrained("pkg-a %+bar")
-    assert len(result.edges_to_dependencies()) == 2
+    assert result == Spec("pkg-a %+foo %+bar")
     assert result.satisfies("pkg-a %+foo") and result.satisfies("pkg-a %+bar")
     witness = Spec("pkg-a %pkg-b+foo %pkg-c+bar")
     assert witness.satisfies(result)
     assert not witness.satisfies("pkg-a %+foo+bar")
 
+    # direct deps are written before the first ^ so %+bar binds to the root
     result = Spec("pkg-a ^+foo").constrained("pkg-a %+bar")
-    assert sorted(e.direct for e in result.edges_to_dependencies()) == [False, True]
+    assert result == Spec("pkg-a %+bar ^+foo")
+    assert len(result.edges_to_dependencies()) == 2
 
     lhs, rhs = Spec("pkg-a ^*@1"), Spec("pkg-a ^*@2")
     assert lhs.intersects(rhs) and rhs.intersects(lhs)
-    assert len(lhs.constrained(rhs).edges_to_dependencies()) == 2
+    assert lhs.constrained(rhs) == Spec("pkg-a ^*@1 ^*@2")
 
     # idempotency again, with several anonymous edges
     spec = Spec("pkg-a ^+foo ^+bar")
@@ -3068,19 +3062,20 @@ def test_an_anonymous_dependency_is_a_parallel_edge(mock_packages):
 def test_an_edge_bridging_two_parallel_edges_relates_nothing(mock_packages):
     """One edge listing two virtuals does not weld the edges listing them separately into one
     node: all three are existential requirements, each matched by its own node."""
-    spec = Spec(
-        "mpileaks ^[virtuals=mpi] mpich ^[virtuals=lapack] mpich ^[virtuals=mpi,lapack] zmpi"
-    )
+    spec = Spec("mpileaks ^mpi=mpich ^lapack=mpich ^mpi,lapack=zmpi")
+    assert spec == Spec("mpileaks ^mpi,lapack=zmpi ^mpi=mpich ^lapack=mpich")
     assert len(spec.edges_to_dependencies()) == 3
 
-    lhs = Spec(
-        "pkg-a ^[virtuals=blas] openblas-with-lapack@1 ^[virtuals=lapack] openblas-with-lapack@2"
-    )
+    lhs = Spec("pkg-a ^blas=openblas-with-lapack@1 ^lapack=openblas-with-lapack@2")
     rhs = Spec("pkg-a ^blas,lapack=openblas-with-lapack")
     assert lhs.intersects(rhs)
     assert rhs.intersects(lhs)
     forward, backward = lhs.constrained(rhs), rhs.constrained(lhs)
     assert forward.to_dict() == backward.to_dict()
+    assert forward == Spec(
+        "pkg-a ^blas=openblas-with-lapack@1 ^lapack=openblas-with-lapack@2"
+        " ^blas,lapack=openblas-with-lapack"
+    )
     assert len(forward.edges_to_dependencies()) == 3
 
 
@@ -3091,10 +3086,10 @@ def test_edges_under_different_conditions_stay_parallel(mock_packages):
     lhs = Spec("pkg-a %[when='+bvv' virtuals=c] gcc")
     rhs = Spec("pkg-a %[when='~bvv' virtuals=cxx] gcc")
     result = lhs.constrained(rhs)
-    assert len(result.edges_to_dependencies()) == 2
+    assert result == Spec("pkg-a %[when='+bvv' virtuals=c] gcc %[when='~bvv' virtuals=cxx] gcc")
 
     # with bvv off neither conditional edge asks for anything, so a fused merge loses this spec
-    witness = Spec("pkg-a ~bvv %[virtuals=cxx] gcc")
+    witness = Spec("pkg-a ~bvv %cxx=gcc")
     assert witness.satisfies(lhs) and witness.satisfies(rhs)
     assert witness.satisfies(result)
 
@@ -3107,7 +3102,7 @@ def test_conflicting_deps_under_one_unforced_condition_intersect(mock_packages):
     assert witness.satisfies(lhs) and witness.satisfies(rhs)
     assert lhs.intersects(rhs) and rhs.intersects(lhs)
     result = lhs.constrained(rhs)
-    assert len(result.edges_to_dependencies(name="pkg-b")) == 2
+    assert result == Spec("pkg-a %[when='+foo'] pkg-b@1 %[when='+foo'] pkg-b@2")
     assert witness.satisfies(result)
     assert result.to_dict() == rhs.constrained(lhs).to_dict()
 
@@ -3116,6 +3111,7 @@ def test_self_constrain_of_parallel_deptype_edges_is_idempotent(mock_packages):
     """Two parallel edges constrained with an equal pair stay themselves. Pairing them by name
     alone would merge build into the link edge and produce an edge neither spec required."""
     s = Spec("pkg-a ^[deptypes=build] pkg-e ^[deptypes=link] pkg-e")
+    assert len(s.edges_to_dependencies(name="pkg-e")) == 2
     changed = s.constrain(Spec("pkg-a ^[deptypes=build] pkg-e ^[deptypes=link] pkg-e"))
     assert not changed
     assert s.to_dict() == Spec("pkg-a ^[deptypes=build] pkg-e ^[deptypes=link] pkg-e").to_dict()
@@ -3132,6 +3128,5 @@ def test_copy_keeps_a_redundant_parallel_edge_and_its_subtree(mock_packages):
 
     copy = original.copy()
 
-    assert len(copy.edges_to_dependencies(name="pkg-b")) == 2
-    assert any(s.name == "pkg-e" for s in copy.traverse())
+    assert copy == original
     assert copy.to_dict() == original.to_dict()

--- a/lib/spack/spack/test/spec_semantics.py
+++ b/lib/spack/spack/test/spec_semantics.py
@@ -3004,6 +3004,67 @@ def test_two_versions_of_one_provider_of_a_virtual_intersect(mock_packages):
     assert len(result.edges_to_dependencies()) == 2
 
 
+def test_an_anonymous_dependency_is_a_parallel_edge(mock_packages):
+    """An edge with an anonymous target requires some dependency to match it. Constrain appends
+    it as a parallel edge, and discards it only when an existing anonymous edge satisfies it."""
+    # idempotency: the meet of a spec with itself is itself
+    spec = Spec("pkg-a ^*@2")
+    assert spec.satisfies(spec)
+    assert spec.intersects(spec)
+    assert spec.constrain("pkg-a ^*@2") is False
+
+    # commutativity: the meet is the same from either side
+    forward, backward = Spec("").constrained(spec), spec.constrained("")
+    assert forward.to_dict() == backward.to_dict() == spec.to_dict()
+
+    # two anonymous constraints can each be matched by a different dependency, so they stay two
+    # edges, transitive or direct. The single edge "^+foo+bar" also satisfies both operands, but
+    # the meet is the greatest lower bound: the witness with two distinct deps satisfies both
+    # operands, so it must satisfy the result, and only the parallel pair admits it.
+    result = Spec("pkg-a ^+foo").constrained("pkg-a ^+bar")
+    assert result.to_dict() == Spec("pkg-a ^+foo ^+bar").to_dict()
+    assert result.satisfies("pkg-a ^+foo") and result.satisfies("pkg-a ^+bar")
+    witness = Spec("pkg-a ^pkg-b+foo ^pkg-c+bar")
+    assert witness.satisfies(result)
+    assert not witness.satisfies("pkg-a ^+foo+bar")
+
+    result = Spec("pkg-a %+foo").constrained("pkg-a %+bar")
+    assert len(result.edges_to_dependencies()) == 2
+    assert result.satisfies("pkg-a %+foo") and result.satisfies("pkg-a %+bar")
+    witness = Spec("pkg-a %pkg-b+foo %pkg-c+bar")
+    assert witness.satisfies(result)
+    assert not witness.satisfies("pkg-a %+foo+bar")
+
+    result = Spec("pkg-a ^+foo").constrained("pkg-a %+bar")
+    assert sorted(e.direct for e in result.edges_to_dependencies()) == [False, True]
+
+    lhs, rhs = Spec("pkg-a ^*@1"), Spec("pkg-a ^*@2")
+    assert lhs.intersects(rhs) and rhs.intersects(lhs)
+    assert len(lhs.constrained(rhs).edges_to_dependencies()) == 2
+
+    # idempotency again, with several anonymous edges
+    spec = Spec("pkg-a ^+foo ^+bar")
+    before = spec.to_dict()
+    assert spec.constrain("pkg-a ^+foo ^+bar") is False
+    assert spec.to_dict() == before
+
+    # associativity: parallel edges accumulate the same way in any grouping
+    a, b, c = Spec("pkg-a ^+foo"), Spec("pkg-a ^+bar"), Spec("pkg-a ^+baz")
+    left, right = a.constrained(b).constrained(c), a.constrained(b.constrained(c))
+    assert left.to_dict() == right.to_dict()
+
+    # an anonymous edge satisfied by another anonymous edge is redundant, from either side
+    lhs, rhs = Spec("pkg-a ^*+foo"), Spec("pkg-a ^*+foo+bar")
+    forward, backward = lhs.constrained(rhs), rhs.constrained(lhs)
+    assert forward.to_dict() == backward.to_dict() == rhs.to_dict()
+
+    # a named edge alone satisfies both requirements of a named/anonymous pair
+    named, anonymous = Spec("pkg-a ^pkg-b@2"), Spec("pkg-a ^*@2")
+    forward, backward = named.constrained(anonymous), anonymous.constrained(named)
+    assert forward.to_dict() == backward.to_dict()
+    assert forward.satisfies(named) and named.satisfies(forward)
+
+
 def test_an_edge_bridging_two_parallel_edges_relates_nothing(mock_packages):
     """One edge listing two virtuals does not weld the edges listing them separately into one
     node: all three are existential requirements, each matched by its own node."""

--- a/lib/spack/spack/test/spec_semantics.py
+++ b/lib/spack/spack/test/spec_semantics.py
@@ -358,6 +358,13 @@ class TestSpecSemantics:
                 "%[when='%c' virtuals=c]gcc@10.3.1",
                 "libelf %[when='+c' virtuals=c]gcc %[when='%c' virtuals=c]gcc@10.3.1",
             ),
+            # Edges under different when conditions are never in effect at the same time, so
+            # they are two separate constraints even when they cannot both be met at once.
+            (
+                "libelf ^[when='+foo'] mpich@3.0",
+                "^[when='+bar'] mpich@4.0",
+                "libelf ^[when='+foo'] mpich@3.0 ^[when='+bar'] mpich@4.0",
+            ),
         ],
     )
     def test_abstract_specs_can_constrain_each_other(self, lhs, rhs, expected):
@@ -512,12 +519,6 @@ class TestSpecSemantics:
             ("foo@4.0%gcc", "@1:3%gcc"),
             ("foo@4.0%gcc@4.5", "@1:3%gcc@4.4:4.6"),
             ("builtin.mock.mpich", "builtin.mpich"),
-            ("mpileaks ^builtin.mock.mpich", "^builtin.mpich"),
-            ("mpileaks^mpich@1.2", "^mpich@2.0"),
-            ("mpileaks^mpich@4.0^callpath@1.5", "^mpich@1:3^callpath@1.4:1.6"),
-            ("mpileaks^mpich@2.0^callpath@1.7", "^mpich@1:3^callpath@1.4:1.6"),
-            ("mpileaks^mpich@4.0^callpath@1.7", "^mpich@1:3^callpath@1.4:1.6"),
-            ("mpileaks^mpi@3", "^mpi@1.2:1.6"),
             ("mpileaks^mpi@3:", "^mpich2@1.4"),
             ("mpileaks^mpi@3:", "^mpich2"),
             ("mpileaks^mpi@3:", "^mpich@1.0"),
@@ -2001,7 +2002,9 @@ def test_abstract_contains_semantic(lhs, rhs, expected, mock_packages):
         (Spec, "target=:cascadelake", "target=:cannonlake", (False, False, False)),
         # Spec with compilers
         (Spec, "mpileaks %gcc@5", "mpileaks %gcc@6", (False, False, False)),
-        (Spec, "mpileaks ^callpath %gcc@5", "mpileaks ^callpath %gcc@6", (False, False, False)),
+        # %gcc sits behind an unpinned ^callpath edge, so callpath need not be one node:
+        # an mpileaks with two callpath nodes, one per compiler, satisfies both sides.
+        (Spec, "mpileaks ^callpath %gcc@5", "mpileaks ^callpath %gcc@6", (True, False, False)),
         (Spec, "mpileaks ^callpath %gcc@5", "mpileaks ^callpath %gcc@5.4", (True, False, True)),
     ],
 )
@@ -2575,7 +2578,7 @@ def test_long_spec():
         (["+baz", "+bar"], "+baz+bar"),
         (["@2.0:", "@:5.1", "+bar"], "@2.0:5.1 +bar"),
         # Anonymous specs with dependencies
-        (["^mpich@3.2", "^mpich@:4.0+foo"], "^mpich@3.2 +foo"),
+        (["^mpich@3.2", "^mpich@:4.0+foo"], "^mpich@3.2 ^mpich@:4.0+foo"),
         # Mix a real package with a virtual one. This test
         # should fail if we start using the repository
         (["^mpich@3.2", "^mpi+foo"], "^mpich@3.2 ^mpi+foo"),
@@ -2834,3 +2837,240 @@ def test_mark_concrete_roundtrip_preserves_hashes(spec_str, config, mock_package
     s._finalize_concretization()
     roundtrip = {node.name: node.dag_hash() for node in s.traverse()}
     assert roundtrip == original
+
+
+def test_edge_already_matched_is_not_copied_in(mock_packages):
+    """An unconditional edge already covers a conditional edge to the same child, so constraining
+    with it adds nothing: the conditional edge is paired with the one matching it, whichever spec
+    it comes from."""
+    unconditional, conditional = Spec("%pkg-e"), Spec("%[when='+bvv'] pkg-e")
+    assert unconditional.intersects(conditional)
+    assert conditional.intersects(unconditional)
+
+    forward = unconditional.constrained(conditional)
+    backward = conditional.constrained(unconditional)
+    assert forward == unconditional
+    assert backward == unconditional
+    assert forward.to_dict() == backward.to_dict()
+
+
+def test_edges_differing_in_namespace_stay_parallel(mock_packages):
+    """`^pkg-b@1` does not satisfy `^builtin_mock.pkg-b` and vice versa: a concretization can
+    hold a builtin_mock node next to a pkg-b@1 node from another repo, so the merge keeps both
+    edges. An edge that does carry the namespace absorbs the one it satisfies."""
+    lhs, rhs = Spec("pkg-a ^pkg-b@1"), Spec("pkg-a ^builtin_mock.pkg-b")
+    forward, backward = lhs.constrained(rhs), rhs.constrained(lhs)
+    assert forward.to_dict() == backward.to_dict()
+    assert len(forward.edges_to_dependencies(name="pkg-b")) == 2
+
+    lhs, rhs = Spec("pkg-a ^pkg-b@1"), Spec("pkg-a ^builtin_mock.pkg-b@1")
+    forward, backward = lhs.constrained(rhs), rhs.constrained(lhs)
+    assert forward.to_dict() == backward.to_dict()
+    edges = forward.edges_to_dependencies(name="pkg-b")
+    assert len(edges) == 1
+    assert edges[0].spec.namespace == "builtin_mock"
+    assert edges[0].spec.satisfies("@1")
+
+
+def test_edge_propagation_is_merged(mock_packages):
+    """A propagated edge constrains the whole DAG, so it satisfies its unpropagated counterpart,
+    and constrain keeps the propagated policy from whichever spec has it."""
+    lhs, rhs = Spec("pkg-a ^pkg-b"), Spec("pkg-a %%pkg-b")
+    forward = lhs.copy()
+    forward.constrain(rhs)
+    backward = rhs.copy()
+    backward.constrain(lhs)
+    assert forward.to_dict() == backward.to_dict()
+    assert forward.edges_to_dependencies()[0].propagation == PropagationPolicy.PREFERENCE
+
+
+def test_edge_propagation_is_merged_at_parse_time(mock_packages):
+    """Duplicate % clauses to one name merge into a single direct edge that keeps the propagated
+    policy, whichever clause states it."""
+    assert Spec("mpileaks %callpath %%callpath") == Spec("mpileaks %%callpath")
+    assert Spec("mpileaks %%callpath %callpath") == Spec("mpileaks %%callpath")
+
+
+def test_satisfies_ignores_edge_propagation(mock_packages):
+    """%% expresses a preference the solver may override, so it does not narrow the set of DAGs:
+    satisfaction ignores it in both directions. In particular concrete specs, whose edges record
+    no propagation, satisfy a %% input."""
+    assert Spec("mpileaks %%callpath").satisfies("mpileaks %callpath")
+    assert Spec("mpileaks %callpath").satisfies("mpileaks %%callpath")
+
+
+def test_conditional_propagated_edge_is_not_redundant(mock_packages):
+    """A conditionally propagated edge is satisfied by an unconditional plain one, but it states
+    a preference the plain edge does not, so the two stay parallel instead of the propagated edge
+    being discarded."""
+    s = Spec("mpileaks %callpath %%[when='+foo'] callpath")
+    assert len(s.edges_to_dependencies(name="callpath")) == 2
+
+    t = Spec("mpileaks %%[when='+foo'] callpath")
+    assert t.constrain("mpileaks %callpath")
+    assert len(t.edges_to_dependencies(name="callpath")) == 2
+
+
+def test_direct_and_indirect_provider_of_one_virtual_stay_apart(mock_packages):
+    """A direct provider and an indirect one need not be the same node: '%c=llvm ^c=gcc' is
+    built with llvm but uses gcc somewhere at runtime."""
+    spec = Spec("mpileaks %[virtuals=c] llvm ^[virtuals=c] gcc")
+    edges = spec.edges_to_dependencies()
+    assert len(edges) == 2
+    assert {edge.spec.name for edge in edges} == {"llvm", "gcc"}
+
+
+def test_two_providers_of_one_virtual_merge_as_parallel_edges(mock_packages):
+    """Two edges naming different providers of one virtual are two requirements, each matched
+    anywhere in the DAG. The parser and constrain keep them side by side."""
+    spec = Spec("mpileaks ^[virtuals=mpi] mpich ^[virtuals=mpi] zmpi")
+    assert len(spec.edges_to_dependencies()) == 2
+
+    lhs, rhs = Spec("pkg-a ^[virtuals=mpi] mpich"), Spec("pkg-a ^[virtuals=mpi] zmpi")
+    assert lhs.intersects(rhs) and rhs.intersects(lhs)
+    forward, backward = lhs.constrained(rhs), rhs.constrained(lhs)
+    assert len(forward.edges_to_dependencies()) == 2
+    assert forward.to_dict() == backward.to_dict()
+
+
+def test_two_providers_under_conditions_that_exclude_each_other_are_fine(mock_packages):
+    """Only one provider can be the one at a time, so two of them named under conditions that
+    cannot hold together are not in each other's way."""
+    lhs = Spec("pkg-a ^[when='+foo' virtuals=mpi] mpich")
+    rhs = Spec("pkg-a ^[when='~foo' virtuals=mpi] zmpi")
+    assert lhs.intersects(rhs)
+    assert rhs.intersects(lhs)
+
+
+def test_parallel_build_and_link_edges_merge_cleanly(mock_packages):
+    """A build-only and a link-only edge to one package are two nodes that stay apart. The merge
+    unions the two edge lists and drops the edges satisfied by another."""
+    result = Spec("pkg-a ^[deptypes=build] pkg-b").constrained(
+        Spec("pkg-a ^[deptypes=build] pkg-b ^[deptypes=link] pkg-b")
+    )
+    depflags = sorted(dt.flag_to_chars(e.depflag).strip() for e in result.edges_to_dependencies())
+    assert depflags == ["b", "l"]
+
+    # round-trips cleanly: copy, str()/reparse and to_dict/from_dict all agree
+    assert result.copy().to_dict() == result.to_dict()
+    assert Spec(str(result)).to_dict() == result.to_dict()
+    assert Spec.from_dict(result.to_dict()).to_dict() == result.to_dict()
+
+    # the same union from the other side: the pair absorbs the lone build edge
+    backward = Spec("pkg-a ^[deptypes=build] pkg-b ^[deptypes=link] pkg-b").constrained(
+        Spec("pkg-a ^[deptypes=build] pkg-b")
+    )
+    assert backward.to_dict() == result.to_dict()
+
+
+def test_parallel_direct_edges_are_always_the_same_edge(mock_packages):
+    """A package has at most one direct dependency on a given name, so two direct edges to one
+    name are always merged into one, whatever their deptypes."""
+    lhs, rhs = Spec("pkg-a %[deptypes=run] pkg-e"), Spec("pkg-a %[deptypes=link] pkg-e")
+    result = lhs.constrained(rhs)
+    depflags = sorted(dt.flag_to_chars(e.depflag).strip() for e in result.edges_to_dependencies())
+    assert depflags == ["lr"]
+
+    # idempotent: re-applying the same constraint does not change anything further
+    assert result.constrain(rhs) is False
+    depflags = sorted(dt.flag_to_chars(e.depflag).strip() for e in result.edges_to_dependencies())
+    assert depflags == ["lr"]
+
+
+def test_direct_edges_to_one_name_merge_their_virtuals(mock_packages):
+    """A package has at most one direct dependency on a name. Two direct edges to it are one
+    dependency, merging their virtuals as they merge their deptypes."""
+    edges = Spec("mpileaks %[virtuals=c] gcc %[virtuals=cxx] gcc").edges_to_dependencies()
+    assert len(edges) == 1
+    assert edges[0].virtuals == ("c", "cxx")
+
+    lhs, rhs = Spec("pkg-a %[virtuals=c] gcc@5"), Spec("pkg-a %[virtuals=cxx] gcc")
+    forward, backward = lhs.constrained(rhs), rhs.constrained(lhs)
+    assert forward.to_dict() == backward.to_dict()
+
+    edges = forward.edges_to_dependencies()
+    assert len(edges) == 1
+    assert edges[0].virtuals == ("c", "cxx")
+    assert edges[0].spec.satisfies("gcc@5")
+
+
+def test_two_versions_of_one_provider_of_a_virtual_intersect(mock_packages):
+    """Two edges naming the same provider for one virtual at versions that do not intersect are
+    still two existential requirements, each matched by its own node."""
+    lhs, rhs = Spec("pkg-a ^[virtuals=mpi] mpich@3"), Spec("pkg-a ^[virtuals=mpi] mpich@4")
+    assert lhs.intersects(rhs)
+    assert rhs.intersects(lhs)
+    result = lhs.constrained(rhs)
+    assert len(result.edges_to_dependencies()) == 2
+
+
+def test_an_edge_bridging_two_parallel_edges_relates_nothing(mock_packages):
+    """One edge listing two virtuals does not weld the edges listing them separately into one
+    node: all three are existential requirements, each matched by its own node."""
+    spec = Spec(
+        "mpileaks ^[virtuals=mpi] mpich ^[virtuals=lapack] mpich ^[virtuals=mpi,lapack] zmpi"
+    )
+    assert len(spec.edges_to_dependencies()) == 3
+
+    lhs = Spec(
+        "pkg-a ^[virtuals=blas] openblas-with-lapack@1 ^[virtuals=lapack] openblas-with-lapack@2"
+    )
+    rhs = Spec("pkg-a ^blas,lapack=openblas-with-lapack")
+    assert lhs.intersects(rhs)
+    assert rhs.intersects(lhs)
+    forward, backward = lhs.constrained(rhs), rhs.constrained(lhs)
+    assert forward.to_dict() == backward.to_dict()
+    assert len(forward.edges_to_dependencies()) == 3
+
+
+def test_edges_under_different_conditions_stay_parallel(mock_packages):
+    """Two direct edges to one name are one node only where both conditions hold, and an edge
+    records exactly one condition, so no single edge says that. A merge that fused them would
+    exclude concretizations that satisfy the pair."""
+    lhs = Spec("pkg-a %[when='+bvv' virtuals=c] gcc")
+    rhs = Spec("pkg-a %[when='~bvv' virtuals=cxx] gcc")
+    result = lhs.constrained(rhs)
+    assert len(result.edges_to_dependencies()) == 2
+
+    # with bvv off neither conditional edge asks for anything, so a fused merge loses this spec
+    witness = Spec("pkg-a ~bvv %[virtuals=cxx] gcc")
+    assert witness.satisfies(lhs) and witness.satisfies(rhs)
+    assert witness.satisfies(result)
+
+
+def test_conflicting_deps_under_one_unforced_condition_intersect(mock_packages):
+    """Both edges bind only where +foo holds, and pkg-a~foo satisfies both operands, so the
+    conflicting conditional deps do not make the pair disjoint."""
+    lhs, rhs = Spec("pkg-a %[when='+foo'] pkg-b@1"), Spec("pkg-a %[when='+foo'] pkg-b@2")
+    witness = Spec("pkg-a ~foo")
+    assert witness.satisfies(lhs) and witness.satisfies(rhs)
+    assert lhs.intersects(rhs) and rhs.intersects(lhs)
+    result = lhs.constrained(rhs)
+    assert len(result.edges_to_dependencies(name="pkg-b")) == 2
+    assert witness.satisfies(result)
+    assert result.to_dict() == rhs.constrained(lhs).to_dict()
+
+
+def test_self_constrain_of_parallel_deptype_edges_is_idempotent(mock_packages):
+    """Two parallel edges constrained with an equal pair stay themselves. Pairing them by name
+    alone would merge build into the link edge and produce an edge neither spec required."""
+    s = Spec("pkg-a ^[deptypes=build] pkg-e ^[deptypes=link] pkg-e")
+    changed = s.constrain(Spec("pkg-a ^[deptypes=build] pkg-e ^[deptypes=link] pkg-e"))
+    assert not changed
+    assert s.to_dict() == Spec("pkg-a ^[deptypes=build] pkg-e ^[deptypes=link] pkg-e").to_dict()
+
+
+def test_copy_keeps_a_redundant_parallel_edge_and_its_subtree(mock_packages):
+    """A structural copy reproduces every edge as it is. ``_dup_deps`` builds each edge directly,
+    since replaying them through ``add_dependency_edge`` would discard the pkg-b@1: edge before its
+    child pkg-e is attached."""
+    original = Spec("pkg-a ^[deptypes=link] pkg-b@1")
+    dep = Spec("pkg-b@1:")
+    dep._add_dependency(Spec("pkg-e"), depflag=dt.LINK, virtuals=())
+    original._add_dependency(dep, depflag=dt.LINK, virtuals=())
+
+    copy = original.copy()
+
+    assert len(copy.edges_to_dependencies(name="pkg-b")) == 2
+    assert any(s.name == "pkg-e" for s in copy.traverse())
+    assert copy.to_dict() == original.to_dict()

--- a/lib/spack/spack/test/spec_syntax.py
+++ b/lib/spack/spack/test/spec_syntax.py
@@ -455,7 +455,7 @@ def specfile_for(config, mock_packages):
                 Token(SpecTokens.UNQUALIFIED_PACKAGE_NAME, value="y"),
                 Token(SpecTokens.BOOL_VARIANT, value="+bar"),
             ],
-            r"x ^y@foo+bar",
+            r"x ^y+bar ^y@foo",
         ),
         (
             r"x ^y@foo +bar ^y@foo",
@@ -675,7 +675,8 @@ def specfile_for(config, mock_packages):
             ],
             "^mpi=openmpi",
         ),
-        # Allow merging attributes, if deptypes match
+        # Neither edge is direct, and the virtuals they declare are different, so the two share
+        # no role and stay parallel, like the plain ^y@foo ^y+bar case above.
         (
             "^[virtuals=mpi] openmpi+foo ^[virtuals=lapack] openmpi+bar",
             [
@@ -690,7 +691,7 @@ def specfile_for(config, mock_packages):
                 Token(SpecTokens.UNQUALIFIED_PACKAGE_NAME, value="openmpi"),
                 Token(SpecTokens.BOOL_VARIANT, value="+bar"),
             ],
-            "^lapack,mpi=openmpi+bar+foo",
+            "^lapack=openmpi+bar ^mpi=openmpi+foo",
         ),
         (
             "^lapack,mpi=openmpi+foo+bar",
@@ -711,6 +712,52 @@ def specfile_for(config, mock_packages):
             [
                 Token(SpecTokens.START_EDGE_PROPERTIES, value="^["),
                 Token(SpecTokens.KEY_VALUE_PAIR, value="deptypes=link,build"),
+                Token(SpecTokens.END_EDGE_PROPERTIES, value="]"),
+                Token(SpecTokens.UNQUALIFIED_PACKAGE_NAME, value="zlib"),
+            ],
+            "^[deptypes=build,link] zlib",
+        ),
+        (
+            "^[deptypes=link] zlib ^[deptypes=build] zlib",
+            [
+                Token(SpecTokens.START_EDGE_PROPERTIES, value="^["),
+                Token(SpecTokens.KEY_VALUE_PAIR, value="deptypes=link"),
+                Token(SpecTokens.END_EDGE_PROPERTIES, value="]"),
+                Token(SpecTokens.UNQUALIFIED_PACKAGE_NAME, value="zlib"),
+                Token(SpecTokens.START_EDGE_PROPERTIES, value="^["),
+                Token(SpecTokens.KEY_VALUE_PAIR, value="deptypes=build"),
+                Token(SpecTokens.END_EDGE_PROPERTIES, value="]"),
+                Token(SpecTokens.UNQUALIFIED_PACKAGE_NAME, value="zlib"),
+            ],
+            "^[deptypes=link] zlib ^[deptypes=build] zlib",
+        ),
+        # Neither depflag is a superset of the other, so the edges stay parallel, as in the
+        # link/build case above. Indirect edges to one name are never one node on deptypes
+        # alone; a shared virtual, or being direct, is what fuses them.
+        (
+            "^[deptypes=link] zlib ^[deptypes=run] zlib",
+            [
+                Token(SpecTokens.START_EDGE_PROPERTIES, value="^["),
+                Token(SpecTokens.KEY_VALUE_PAIR, value="deptypes=link"),
+                Token(SpecTokens.END_EDGE_PROPERTIES, value="]"),
+                Token(SpecTokens.UNQUALIFIED_PACKAGE_NAME, value="zlib"),
+                Token(SpecTokens.START_EDGE_PROPERTIES, value="^["),
+                Token(SpecTokens.KEY_VALUE_PAIR, value="deptypes=run"),
+                Token(SpecTokens.END_EDGE_PROPERTIES, value="]"),
+                Token(SpecTokens.UNQUALIFIED_PACKAGE_NAME, value="zlib"),
+            ],
+            "^[deptypes=link] zlib ^[deptypes=run] zlib",
+        ),
+        # [build,link] already satisfies [link], so the second edge is redundant and is discarded.
+        (
+            "^[deptypes=build,link] zlib ^[deptypes=link] zlib",
+            [
+                Token(SpecTokens.START_EDGE_PROPERTIES, value="^["),
+                Token(SpecTokens.KEY_VALUE_PAIR, value="deptypes=build,link"),
+                Token(SpecTokens.END_EDGE_PROPERTIES, value="]"),
+                Token(SpecTokens.UNQUALIFIED_PACKAGE_NAME, value="zlib"),
+                Token(SpecTokens.START_EDGE_PROPERTIES, value="^["),
+                Token(SpecTokens.KEY_VALUE_PAIR, value="deptypes=link"),
                 Token(SpecTokens.END_EDGE_PROPERTIES, value="]"),
                 Token(SpecTokens.UNQUALIFIED_PACKAGE_NAME, value="zlib"),
             ],
@@ -759,6 +806,8 @@ def specfile_for(config, mock_packages):
             ],
             "pkg-a ^pkg-b@1 %pkg-c",
         ),
+        # With the % sub-dag included, neither ^pkg-b edge satisfies the other, so they
+        # stay parallel.
         (
             "pkg-a ^pkg-b@1 ^pkg-b %pkg-c",
             [
@@ -771,21 +820,7 @@ def specfile_for(config, mock_packages):
                 Token(SpecTokens.DEPENDENCY, value="%"),
                 Token(SpecTokens.UNQUALIFIED_PACKAGE_NAME, value="pkg-c"),
             ],
-            "pkg-a ^pkg-b@1 %pkg-c",
-        ),
-        (
-            "^[deptypes=link] zlib ^[deptypes=build] zlib",
-            [
-                Token(SpecTokens.START_EDGE_PROPERTIES, value="^["),
-                Token(SpecTokens.KEY_VALUE_PAIR, value="deptypes=link"),
-                Token(SpecTokens.END_EDGE_PROPERTIES, value="]"),
-                Token(SpecTokens.UNQUALIFIED_PACKAGE_NAME, value="zlib"),
-                Token(SpecTokens.START_EDGE_PROPERTIES, value="^["),
-                Token(SpecTokens.KEY_VALUE_PAIR, value="deptypes=build"),
-                Token(SpecTokens.END_EDGE_PROPERTIES, value="]"),
-                Token(SpecTokens.UNQUALIFIED_PACKAGE_NAME, value="zlib"),
-            ],
-            "^[deptypes=link] zlib ^[deptypes=build] zlib",
+            "pkg-a ^pkg-b %pkg-c ^pkg-b@1",
         ),
         (
             "git-test@git.foo/bar",
@@ -1534,8 +1569,6 @@ def test_disambiguate_hash_by_spec(spec1, spec2, constraint, mock_packages, monk
         ("x@1.2@2.3,2.4", "version"),
         ("x@1.2 +foo~bar @2.3", "version"),
         ("x@1.2%y@1.2@2.3:2.4", "version"),
-        # Duplicate dependency
-        ("x ^y@1 ^y@2", "Cannot depend on incompatible specs"),
         # Duplicate Architectures
         ("x arch=linux-rhel7-x86_64 arch=linux-rhel7-x86_64", "two architectures"),
         ("x arch=linux-rhel7-x86_64 arch=linux-rhel7-ppc64le", "two architectures"),
@@ -1552,8 +1585,6 @@ def test_disambiguate_hash_by_spec(spec1, spec2, constraint, mock_packages, monk
         ("x target=default_target platform=test os=redhat6 os=debian6", "'platform'"),
         # Dependencies
         ("^[@foo] zlib", "edge attributes"),
-        ("x ^[deptypes=link]foo ^[deptypes=run]foo", "conflicting dependency types"),
-        ("x ^[deptypes=build,link]foo ^[deptypes=link]foo", "conflicting dependency types"),
         # TODO: Remove this as soon as use variants are added and we can parse custom attributes
         ("^[foo=bar] zlib", "edge attributes"),
         # Propagating reserved names generates a parse error

--- a/lib/spack/spack/test/spec_syntax.py
+++ b/lib/spack/spack/test/spec_syntax.py
@@ -717,6 +717,9 @@ def specfile_for(config, mock_packages):
             ],
             "^[deptypes=build,link] zlib",
         ),
+        # Indirect edges to one name are never one node on deptypes alone; a shared virtual, or
+        # being direct, is what fuses them. When neither depflag is a superset of the other, the
+        # edges stay parallel.
         (
             "^[deptypes=link] zlib ^[deptypes=build] zlib",
             [
@@ -730,23 +733,6 @@ def specfile_for(config, mock_packages):
                 Token(SpecTokens.UNQUALIFIED_PACKAGE_NAME, value="zlib"),
             ],
             "^[deptypes=link] zlib ^[deptypes=build] zlib",
-        ),
-        # Neither depflag is a superset of the other, so the edges stay parallel, as in the
-        # link/build case above. Indirect edges to one name are never one node on deptypes
-        # alone; a shared virtual, or being direct, is what fuses them.
-        (
-            "^[deptypes=link] zlib ^[deptypes=run] zlib",
-            [
-                Token(SpecTokens.START_EDGE_PROPERTIES, value="^["),
-                Token(SpecTokens.KEY_VALUE_PAIR, value="deptypes=link"),
-                Token(SpecTokens.END_EDGE_PROPERTIES, value="]"),
-                Token(SpecTokens.UNQUALIFIED_PACKAGE_NAME, value="zlib"),
-                Token(SpecTokens.START_EDGE_PROPERTIES, value="^["),
-                Token(SpecTokens.KEY_VALUE_PAIR, value="deptypes=run"),
-                Token(SpecTokens.END_EDGE_PROPERTIES, value="]"),
-                Token(SpecTokens.UNQUALIFIED_PACKAGE_NAME, value="zlib"),
-            ],
-            "^[deptypes=link] zlib ^[deptypes=run] zlib",
         ),
         # [build,link] already satisfies [link], so the second edge is redundant and is discarded.
         (


### PR DESCRIPTION
A concrete spec can have two nodes with identical package name thanks to `max_dupes`, so `mpileaks ^foo@1 ^foo+bar` should express two separate requirements, not one node `foo@1+bar`. From the solver's perspective, `^` can reach into two distinct unification sets: the link/run closure and direct build deps. Both package names and virtual names are unique to their unification set, meaning that for `^` neither package names nor virtuals are unique.

On develop the two clauses are merged into one node, which breaks the identities of the meet-semilattice that specs form under `satisfies`: the meet `x ∧ y` is reported empty for pairs with a common lower bound, `x ∧ x ≠ x`, `x ∧ y ≠ y ∧ x`, and the meet that is produced can be strictly below the greatest lower bound or fail to parse back. Found with the property tests of #52836.

Fix a bug where two `^` constraints on one package name are reported disjoint although a spec with two nodes satisfies both:

```python
>>> Spec("pkg-a ^foo@1.2").intersects("pkg-a ^foo@2.0")
False  # wrong
>>> Spec("pkg-a ^pkg-b %gcc@5").intersects("pkg-a ^pkg-b %gcc@6")
False  # wrong
>>> Spec("pkg-a ^foo@1").constrained("pkg-a ^foo@2")
UnsatisfiableDependencySpecError: pkg-a ^foo@2 does not satisfy pkg-a ^foo@1
```

Fix a bug where the parser merges duplicate `^dep` clauses into a single node, and rejects them when their constraints or dependency types conflict:

```python
>>> Spec("pkg-a ^foo@1 ^foo+bar")
pkg-a ^foo@1+bar  # wrong: forces one node
>>> Spec("pkg-a ^foo@1 ^foo@2")
SpecParsingError: Cannot depend on incompatible specs 'foo@1' and 'foo@2'
>>> Spec("pkg-a ^[deptypes=link] foo ^[deptypes=run] foo")
SpecParsingError: foo is a duplicate dependency, with conflicting dependency types
```

Fix a bug where merging a single edge into a build/link pair of parallel edges invents a `build,link` edge neither operand required, and the result does not parse back:

```python
>>> s = Spec("pkg-a ^[deptypes=build] pkg-b ^[deptypes=link] pkg-b")
>>> r = s.constrained("pkg-a ^[deptypes=build] pkg-b")
>>> r
pkg-a ^[deptypes=build,link] pkg-b ^[deptypes=build] pkg-b  # wrong: nothing asked for build,link
>>> Spec(str(r))
SpecParsingError: pkg-b is a duplicate dependency, with conflicting dependency types
```

Fix a bug where constrain is not idempotent, x ∧ x ≠ x:

```python
>>> s = Spec("pkg-a ^[deptypes=build] pkg-e ^[deptypes=link] pkg-e")
>>> s.constrain("pkg-a ^[deptypes=build] pkg-e ^[deptypes=link] pkg-e")
True  # wrong: nothing changed
>>> s
pkg-a ^[deptypes=build,link] pkg-e ^[deptypes=build] pkg-e
```

Fix a bug where a conditional edge is kept beside the unconditional edge that implies it:

```python
>>> Spec("%pkg-e").constrained("%[when='+bvv'] pkg-e")
%pkg-e %[when='+bvv'] pkg-e  # wrong: the unconditional edge already requires more
```

Fix a bug where two conflicting deps under one unforced condition are reported disjoint:

```python
>>> lhs, rhs = Spec("pkg-a %[when='+foo'] pkg-b@1"), Spec("pkg-a %[when='+foo'] pkg-b@2")
>>> Spec("pkg-a ~foo").satisfies(lhs) and Spec("pkg-a ~foo").satisfies(rhs)
True
>>> lhs.intersects(rhs)
False  # wrong
>>> lhs.constrained(rhs)
UnsatisfiableDependencySpecError: pkg-a %[when='+foo'] pkg-b@2 does not satisfy pkg-a %[when='+foo'] pkg-b@1
```

Fix a bug where an anonymous dependency is rejected by `constrain`, but only on the right-hand side, and two anonymous constraints are reported disjoint although a dependency per constraint satisfies both:

```python
>>> Spec("^*@2").constrained("")
^@2
>>> Spec("").constrained("^*@2")
UnconstrainableDependencySpecError: Cannot constrain by a spec containing anonymous dependencies
>>> Spec("pkg-a ^*@1").intersects("pkg-a ^*@2")
False  # wrong
```

With this change the `^` clauses stay parallel edges, and an edge merges into another only when one satisfies the other:

```python
>>> Spec("pkg-a ^foo@1 ^foo+bar")
pkg-a ^foo+bar ^foo@1
>>> Spec("pkg-a ^foo@1").constrained("pkg-a ^foo@2")
pkg-a ^foo@1 ^foo@2
>>> Spec("%pkg-e").constrained("%[when='+bvv'] pkg-e")
%pkg-e
>>> Spec("pkg-a %[when='+foo'] pkg-b@1").intersects("pkg-a %[when='+foo'] pkg-b@2")
True
```

Unconditional `%` constraints to one package name still merge, since a package has at most one direct dependency per name. Edges under `when` conditions are one node only where both conditions hold, and an edge records exactly one condition, so they stay apart. An edge implied by another edge to the same name is still merged away, so `pkg-a ^foo@1 ^foo` remains a single edge.

An anonymous constraint requires some dependency to match it, and without a name nothing forces it onto one node with another edge, so it is a parallel edge too, direct or transitive. These cases pin down that the meet is the greatest lower bound, not just any lower bound: `%+foo+bar` satisfies both `%+foo` and `%+bar`, but so does `%+foo %+bar` with a different dependency for each, so the parallel pair is the meet and the fused edge is strictly below it:

```python
>>> Spec("pkg-a %+foo").constrained("pkg-a %+bar")
pkg-a %+bar %+foo
```

Independent of edge merging, fix a bug where `constrain` assigns a name to an anonymous spec but leaves the dependent edges of its children keyed by the anonymous name:

```python
>>> s = Spec("^bar@3")
>>> bar = s.edges_to_dependencies("bar")[0].spec
>>> s.constrain(Spec("foo"))
True
>>> bar._dependents.keys()
dict_keys([''])  # wrong: the parent's name is now foo
```

When the name is assigned, those edges are now rekeyed.

Also independent of edge merging, fix a bug where `constrain` with a concrete right-hand side detaches the spec from its dependents. The concrete spec is copied over the node with `_dup`, which prunes in-edges: correct for a detached copy, wrong for a node still filed in its dependents' edge maps.

```python
>>> s = Spec("pkg-a ^pkg-b")
>>> child = s.edges_to_dependencies("pkg-b")[0].spec
>>> child.constrain(concretize_one("pkg-b"))
True
>>> child.dependents()
[]  # wrong: pkg-a still depends on it
```

The in-edges are now kept when the node's contents are replaced.
