### PR TITLE
spec.py: a namespace is a constraint to satisfies

### DIFF
--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -3466,12 +3466,7 @@ class Spec:
             if not compare_hash or not compare_hash.startswith(other.abstract_hash):
                 return False
 
-        # namespaces either match, or other doesn't require one.
-        if (
-            other.namespace is not None
-            and self.namespace is not None
-            and self.namespace != other.namespace
-        ):
+        if other.namespace is not None and self.namespace != other.namespace:
             return False
 
         if not self.versions.satisfies(other.versions):

--- a/lib/spack/spack/test/spec_semantics.py
+++ b/lib/spack/spack/test/spec_semantics.py
@@ -735,6 +735,12 @@ class TestSpecSemantics:
         assert spec.satisfies("namespace=builtin_mock")
         assert not spec.satisfies("namespace=builtin")
 
+    def test_unset_namespace_does_not_satisfy_a_specified_one(self):
+        assert Spec("builtin_mock.pkg-a").satisfies("pkg-a")
+        assert not Spec("pkg-a").satisfies("builtin_mock.pkg-a")
+        assert Spec("pkg-a").intersects("builtin_mock.pkg-a")
+        assert Spec("builtin_mock.pkg-a").intersects("pkg-a")
+
     @pytest.mark.parametrize(
         "spec_string",
         [


### PR DESCRIPTION
Fix a bug where a spec without a namespace satisfies one that specifies it:

```python
>>> Spec("zlib").satisfies("builtin.zlib")
True  # wrong: lhs is less constrained
>>> Spec("builtin.zlib").satisfies("zlib")
True  # correct, unchanged
```

`intersects` and `constrain` were already correct.
