### PR TITLE
envs: record namespaces with abstract concretized roots

### DIFF
--- a/lib/spack/spack/cmd/info.py
+++ b/lib/spack/spack/cmd/info.py
@@ -325,9 +325,7 @@ def print_tests(pkg: PackageBase, args: Namespace) -> None:
 
 
 def _fmt_when(when: "spack.spec.Spec", indent: int) -> str:
-    return color.colorize(
-        f"{indent * ' '}@B{{when}} {color.cescape(when.clong_spec)}"
-    )
+    return color.colorize(f"{indent * ' '}@B{{when}} {color.cescape(when.clong_spec)}")
 
 
 def _fmt_variant_value(v: Any) -> str:

--- a/lib/spack/spack/cmd/info.py
+++ b/lib/spack/spack/cmd/info.py
@@ -158,7 +158,7 @@ def format_deptype(depflag: int) -> str:
 
 class DependencyFormatter(Formatter):
     def format_name(self, dep: spack.dependency.Dependency) -> str:
-        return dep.spec._long_spec(color=color.get_color_when())
+        return dep.spec.clong_spec
 
     def format_values(self, dep: spack.dependency.Dependency) -> str:
         return str(format_deptype(dep.depflag))
@@ -326,7 +326,7 @@ def print_tests(pkg: PackageBase, args: Namespace) -> None:
 
 def _fmt_when(when: "spack.spec.Spec", indent: int) -> str:
     return color.colorize(
-        f"{indent * ' '}@B{{when}} {color.cescape(when._long_spec(color=color.get_color_when()))}"
+        f"{indent * ' '}@B{{when}} {color.cescape(when.clong_spec)}"
     )
 
 

--- a/lib/spack/spack/environment/__init__.py
+++ b/lib/spack/spack/environment/__init__.py
@@ -36,6 +36,8 @@ contents have.  Lockfiles are JSON-formatted and their top-level sections are:
 5. ``include_concrete`` (dictionary): an optional dictionary that includes the roots
    and concrete specs from the included environments, keyed by the path to that
    environment
+8. The ``spec`` field in each element of the ``roots`` field changed from a string representation
+   to a dict representation of the abstract spec.
 
 Compatibility
 -------------
@@ -55,8 +57,10 @@ upgrade Spack to use them.
      - ``v5``
      - ``v6``
      - ``v7``
+     - ``v8``
    * - ``v0.12:0.14``
      - ✅
+     -
      -
      -
      -
@@ -71,10 +75,12 @@ upgrade Spack to use them.
      -
      -
      -
+     -
    * - ``v0.17``
      - ✅
      - ✅
      - ✅
+     -
      -
      -
      -
@@ -87,12 +93,14 @@ upgrade Spack to use them.
      -
      -
      -
+     -
    * - ``v0.22:v0.23``
      - ✅
      - ✅
      - ✅
      - ✅
      - ✅
+     -
      -
      -
    * - ``v1.0:1.1``
@@ -103,7 +111,18 @@ upgrade Spack to use them.
      - ✅
      - ✅
      -
+     -
    * - ``v1.2:``
+     - ✅
+     - ✅
+     - ✅
+     - ✅
+     - ✅
+     - ✅
+     - ✅
+     -
+   * - ``v1.3:``
+     - ✅
      - ✅
      - ✅
      - ✅
@@ -593,6 +612,13 @@ corresponding group.
       }
     }
 
+Version 8
+---------
+
+Version 8 changes the representation of the abstract roots from a string to a dict.
+
+This change is needed to capture spec information that can be represented on the root
+but is not printed in the default string represenatation (like namespaces of dependencies).
 """
 
 from .environment import (

--- a/lib/spack/spack/environment/__init__.py
+++ b/lib/spack/spack/environment/__init__.py
@@ -36,8 +36,6 @@ contents have.  Lockfiles are JSON-formatted and their top-level sections are:
 5. ``include_concrete`` (dictionary): an optional dictionary that includes the roots
    and concrete specs from the included environments, keyed by the path to that
    environment
-8. The ``spec`` field in each element of the ``roots`` field changed from a string representation
-   to a dict representation of the abstract spec.
 
 Compatibility
 -------------
@@ -57,10 +55,8 @@ upgrade Spack to use them.
      - ``v5``
      - ``v6``
      - ``v7``
-     - ``v8``
    * - ``v0.12:0.14``
      - ✅
-     -
      -
      -
      -
@@ -75,12 +71,10 @@ upgrade Spack to use them.
      -
      -
      -
-     -
    * - ``v0.17``
      - ✅
      - ✅
      - ✅
-     -
      -
      -
      -
@@ -93,14 +87,12 @@ upgrade Spack to use them.
      -
      -
      -
-     -
    * - ``v0.22:v0.23``
      - ✅
      - ✅
      - ✅
      - ✅
      - ✅
-     -
      -
      -
    * - ``v1.0:1.1``
@@ -111,18 +103,7 @@ upgrade Spack to use them.
      - ✅
      - ✅
      -
-     -
    * - ``v1.2:``
-     - ✅
-     - ✅
-     - ✅
-     - ✅
-     - ✅
-     - ✅
-     - ✅
-     -
-   * - ``v1.3:``
-     - ✅
      - ✅
      - ✅
      - ✅
@@ -612,13 +593,6 @@ corresponding group.
       }
     }
 
-Version 8
----------
-
-Version 8 changes the representation of the abstract roots from a string to a dict.
-
-This change is needed to capture spec information that can be represented on the root
-but is not printed in the default string represenatation (like namespaces of dependencies).
 """
 
 from .environment import (

--- a/lib/spack/spack/environment/environment.py
+++ b/lib/spack/spack/environment/environment.py
@@ -2309,7 +2309,8 @@ class Environment:
             return [{"hash": x.hash, "spec": x.root.to_dict()} for x in self.concretized_roots]
 
         return [
-            {"hash": x.hash, "spec": x.root.to_dict(), "group": x.group} for x in self.concretized_roots
+            {"hash": x.hash, "spec": x.root.to_dict(), "group": x.group}
+            for x in self.concretized_roots
         ]
 
     def has_groups(self) -> bool:

--- a/lib/spack/spack/environment/environment.py
+++ b/lib/spack/spack/environment/environment.py
@@ -1047,9 +1047,17 @@ class ConcretizedRootInfo:
 
     @staticmethod
     def from_info_dict(info_dict: Dict[str, str]) -> "ConcretizedRootInfo":
+        # Lockfile versions < 8 have strings for root specs
+        # versions >= 8 have dicts
+        spec = info_dict["spec"]
+        if isinstance(spec, str):
+            root = Spec(spec)
+        else:
+            root = Spec.from_dict(spec)
+
         # Lockfile versions < 7 don't have the "group" attribute
         return ConcretizedRootInfo(
-            root_spec=Spec(info_dict["spec"]),
+            root_spec=root,
             root_hash=info_dict["hash"],
             new=False,
             group=info_dict.get("group", DEFAULT_USER_SPEC_GROUP),
@@ -2298,10 +2306,10 @@ class Environment:
 
     def _concrete_roots_dict(self):
         if not self.has_groups():
-            return [{"hash": x.hash, "spec": str(x.root)} for x in self.concretized_roots]
+            return [{"hash": x.hash, "spec": x.root.to_dict()} for x in self.concretized_roots]
 
         return [
-            {"hash": x.hash, "spec": str(x.root), "group": x.group} for x in self.concretized_roots
+            {"hash": x.hash, "spec": x.root.to_dict(), "group": x.group} for x in self.concretized_roots
         ]
 
     def has_groups(self) -> bool:

--- a/lib/spack/spack/environment/environment.py
+++ b/lib/spack/spack/environment/environment.py
@@ -1047,17 +1047,9 @@ class ConcretizedRootInfo:
 
     @staticmethod
     def from_info_dict(info_dict: Dict[str, str]) -> "ConcretizedRootInfo":
-        # Lockfile versions < 8 have strings for root specs
-        # versions >= 8 have dicts
-        spec = info_dict["spec"]
-        if isinstance(spec, str):
-            root = Spec(spec)
-        else:
-            root = Spec.from_dict(spec)
-
         # Lockfile versions < 7 don't have the "group" attribute
         return ConcretizedRootInfo(
-            root_spec=root,
+            root_spec=Spec(info_dict["spec"]),
             root_hash=info_dict["hash"],
             new=False,
             group=info_dict.get("group", DEFAULT_USER_SPEC_GROUP),
@@ -2306,10 +2298,10 @@ class Environment:
 
     def _concrete_roots_dict(self):
         if not self.has_groups():
-            return [{"hash": x.hash, "spec": x.root.to_dict()} for x in self.concretized_roots]
+            return [{"hash": x.hash, "spec": x.root.long_spec} for x in self.concretized_roots]
 
         return [
-            {"hash": x.hash, "spec": x.root.to_dict(), "group": x.group}
+            {"hash": x.hash, "spec": x.root.long_spec, "group": x.group}
             for x in self.concretized_roots
         ]
 

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -166,6 +166,14 @@ DEFAULT_FORMAT = (
     "{ /abstract_hash}"
 )
 
+#: Full format for Spec.format(). This format can be round-tripped without losing
+#: namespace information
+FULL_FORMAT = (
+    "{fullname}{@versions}{compiler_flags}{variants}"
+    "{ platform=architecture.platform}{ os=architecture.os}{ target=architecture.target}"
+    "{ /abstract_hash}"
+)
+
 #: Display format, which eliminates extra `@=` in the output, for readability.
 DISPLAY_FORMAT = (
     "{name}{@version}{compiler_flags}"
@@ -4482,11 +4490,16 @@ class Spec:
 
         return " ".join(parts).strip()
 
-    def _long_spec(self, color: Optional[bool] = False) -> str:
+    def _long_spec(self, format=None, color: Optional[bool] = False) -> str:
         """Helper for :attr:`long_spec` and :attr:`clong_spec`."""
+        if format is None:
+            format = DISPLAY_FORMAT if self.concrete else DEFAULT_FORMAT
         if self.concrete:
-            return self.tree(format=DISPLAY_FORMAT, color=color)
-        return f"{self.format(color=color)} {self._format_dependencies(color=color)}".strip()
+            return self.tree(format=format, color=color)
+
+        node_format = self.format(format_string=format, color=color)
+        dep_format = self._format_dependencies(format_string=format, color=color)
+        return f"{node_format} {dep_format}".strip()
 
     def _short_spec(self, color: Optional[bool] = False) -> str:
         """Helper for :attr:`short_spec` and :attr:`cshort_spec`."""
@@ -4514,12 +4527,12 @@ class Spec:
     @property
     def long_spec(self):
         """Long string of the spec, including dependencies."""
-        return self._long_spec(color=False)
+        return self._long_spec(format=FULL_FORMAT, color=False)
 
     @property
     def clong_spec(self):
         """Returns an auto-colorized version of :attr:`long_spec`."""
-        return self._long_spec(color=None)
+        return self._long_spec(format=FULL_FORMAT, color=None)
 
     @property
     def short_spec(self):

--- a/lib/spack/spack/test/env.py
+++ b/lib/spack/spack/test/env.py
@@ -820,6 +820,43 @@ def test_deconcretize_then_concretize_does_not_error(mutable_mock_env_path, unif
     assert len(all_root_hashes) == 2
 
 
+def test_concretize_is_noop_for_concretized_namespaced_root(mutable_mock_env_path):
+    """Tests that a root spec with an explicit namespace is not reconcretized by a
+    repeated concretization.
+
+    The lockfile used to store roots in their default string format, which omits the
+    namespace. On re-read, the stored root no longer compared equal to the namespaced
+    user spec, so the spec was considered new and was reconcretized every time.
+    """
+    mutable_mock_env_path.mkdir()
+    spack_yaml = mutable_mock_env_path / ev.manifest_name
+    spack_yaml.write_text(
+        """spack:
+      specs:
+      - builtin_mock.pkg-a
+    """
+    )
+    env = ev.Environment(mutable_mock_env_path)
+    with env:
+        env.concretize()
+        env.write()
+    original_hashes = {x.hash for x in env.concretized_roots}
+
+    # Re-read the environment from the lockfile and concretize again
+    reread = ev.Environment(mutable_mock_env_path)
+    with reread:
+        newly_concretized = reread.concretize()
+
+    # The root was already concretized, so repeated concretization is a no-op
+    assert newly_concretized == []
+    assert len(reread.concretized_roots) == 1
+    assert not any(x.new for x in reread.concretized_roots)
+    assert {x.hash for x in reread.concretized_roots} == original_hashes
+
+    # The abstract root read from the lockfile retains its namespace
+    assert reread.concretized_roots[0].root == spack.spec.Spec("builtin_mock.pkg-a")
+
+
 @pytest.mark.regression("44216")
 def test_root_version_weights_for_old_versions(mutable_mock_env_path):
     """Tests that, when we select two old versions of root specs that have the same version


### PR DESCRIPTION
Fixes a bug reported on slack by @psakievich 

Spack currently drops namespace information for abstract specs when recording them as concrete roots. This causes Spack to re-concretize repeatedly for abstract specs with explicit namespaces, as it will always recognize the abstract spec from the manifest as different than the one from the lockfile.

Resolved by modifying the `Spec.long_spec` property to include namespaces in the string, and using that for the lockfile representation.