### PR TITLE
Bugfix: Don't allow invalid package names from create

### DIFF
--- a/lib/spack/spack/cmd/create.py
+++ b/lib/spack/spack/cmd/create.py
@@ -23,7 +23,7 @@ from spack.util.editor import editor
 from spack.util.executable import which
 from spack.util.filesystem import mkdirp
 from spack.util.format import get_version_lines
-from spack.util.naming import pkg_name_to_class_name, simplify_name
+from spack.util.naming import is_valid_name, pkg_name_to_class_name, simplify_name
 
 description = "create a new package file"
 section = "packaging"
@@ -896,7 +896,7 @@ def get_name(name, url):
         # Use a user-supplied name if one is present
         result = name
         if len(name.strip()) > 0:
-            tty.msg("Using specified package name: '{0}'".format(result))
+            tty.msg("Found specified package name: '{0}'".format(result))
         else:
             tty.die("A package name must be provided when using the option.")
     elif url is not None:
@@ -915,10 +915,17 @@ def get_name(name, url):
                 "  `spack create --name <name> <url>`",
             )
 
+    if not is_valid_name(result):
+        tty.msg("Input name is malformed, name can only contain a-z, 0-9, and '-'")
+
+    orig = result
     result = simplify_name(result)
 
-    if not re.match(r"^[a-z0-9-]+$", result):
-        tty.die("Package name can only contain a-z, 0-9, and '-'")
+    if not is_valid_name(result):
+        tty.die(f"Failed to deduce a valid package name: {result}")
+
+    if orig != result:
+        tty.msg(f"Simplified name {orig} -> {result}")
 
     return result
 
@@ -1087,6 +1094,7 @@ def get_repository(args: argparse.Namespace, name: str) -> spack.repo.Repo:
 def create(parser, args):
     # Gather information about the package to be created
     name = get_name(args.name, args.url)
+
     url = get_url(args.url)
     versions, guesser = get_versions(args, name)
     build_system = get_build_system(args.template, url, guesser)

--- a/lib/spack/spack/test/namespace_trie.py
+++ b/lib/spack/spack/test/namespace_trie.py
@@ -91,3 +91,84 @@ def test_add_none_multiple(trie):
 
     assert not trie.is_prefix("foo.bar.baz")
     assert not trie.has_value("foo.bar.baz")
+
+
+@pytest.mark.parametrize(
+    ("name", "simplified"),
+    (
+        ("simple", "simple"),
+        ("with-hyphen", "with-hyphen"),
+        ("with_underscore", "with-underscore"),
+        ("MixEdCAsE", "mixedcase"),
+        ("0", "0"),
+        ("plus+", "plus-plus"),
+        ("tinkle++", "tinklepp"),
+        ("-leading-dash", "leading-dash"),
+        ("_leading_underscore", "leading-underscore"),
+        ("__leading_underscore", "leading-underscore"),
+        ("_0leading_underscore_num", "0leading-underscore-num"),
+        ("l_intel_download", "intel-download"),
+        ("luapkg", "lua-pkg"),
+        ("b++pkg", "bpp-pkg"),
+        ("bpppkg", "bpp-pkg"),
+    ),
+)
+def test_naming_simplify_name(name, simplified):
+    assert spack.util.naming.simplify_name(name) == simplified
+
+
+def test_naming_simplify_name_bad_char():
+    name = "mm"
+    # Assert the test base name good and already simplified
+    assert spack.util.naming.is_valid_name(name)
+    assert spack.util.naming.simplify_name(name) == name
+
+    for bad_char in (
+        "!",
+        "#",
+        "$",
+        "'",
+        "(",
+        ")",
+        "*",
+        ",",
+        "/",
+        ":",
+        ";",
+        "<",
+        "=",
+        ">",
+        "?",
+        "?",
+        "@",
+        '"',
+        "\\",
+        "^",
+        "`",
+        "{",
+        "|",
+        "}",
+        "~",
+    ):
+        # Bad character prefix
+        bad_name = bad_char + name
+        simplified_bad_name = spack.util.naming.simplify_name(bad_name)
+        assert not spack.util.naming.is_valid_name(bad_name)
+        assert simplified_bad_name == bad_name
+
+        # Bad character suffix
+        bad_name = bad_char + name
+        simplified_bad_name = spack.util.naming.simplify_name(bad_name)
+        assert not spack.util.naming.is_valid_name(bad_name)
+        assert simplified_bad_name == bad_name
+
+        # Bad character in the middle
+        bad_name = name[:1] + bad_char + name[1:]
+        simplified_bad_name = spack.util.naming.simplify_name(bad_name)
+        assert not spack.util.naming.is_valid_name(bad_name)
+        assert simplified_bad_name == bad_name
+
+
+def test_naming_simplify_name_empty_string():
+    assert not spack.util.naming.is_valid_name("")
+    assert not spack.util.naming.is_valid_name(spack.util.naming.simplify_name(""))

--- a/lib/spack/spack/util/naming.py
+++ b/lib/spack/spack/util/naming.py
@@ -61,6 +61,13 @@ _VALID_MODULE_RE_V1 = re.compile(r"^\w[\w-]*$")
 
 _VALID_MODULE_RE_V2 = re.compile(r"^[a-z_][a-z0-9_]*$")
 
+_VALID_PKG_NAME_RE = re.compile(r"^[a-z0-9]+(-[a-z0-9]+)*$")
+
+
+def is_valid_name(name: str) -> bool:
+    """Check if a pkg name is valid under the Spack naming rules"""
+    return _VALID_PKG_NAME_RE.match(name) is not None
+
 
 class NamingScheme:
     """Base class for package naming schemes."""
@@ -208,6 +215,11 @@ def simplify_name(name: str) -> str:
     # e.g. backports.ssl_match_hostname -> backports-ssl-match-hostname
     name = name.replace("_", "-")
     name = name.replace(".", "-")
+
+    # Strip preceeding dashes, these are not allowed
+    # NOTE: This must come after converting _ ->  -
+    # e.g. (_foo ->) -foo -> foo
+    name = name.lstrip("-")
 
     # Replace "++" with "pp" and "+" with "-plus"
     # e.g. gtk+   -> gtk-plus


### PR DESCRIPTION
- simplify_name no longer allows invalid package names with leading `-`
- `spack create` produces output to inform user of real package name
- `spack create` uses a correct regex for parsing whether a pacakge name is valid or not
- More unit tests around simplify_name to capture intended behavior

Conflicts with #52890 which also implements the same `spack.util.naming.is_valid_name` function.