### PR TITLE
solver: fix syaml_* asp escaping

### DIFF
--- a/lib/spack/spack/solver/core.py
+++ b/lib/spack/spack/solver/core.py
@@ -62,11 +62,19 @@ class AspFunction:
     def __str__(self) -> str:
         parts = []
         for arg in self.args:
+            # exact type checks first, ordered by frequency
             if type(arg) is str:
                 arg = arg.replace("\\", r"\\").replace("\n", r"\n").replace('"', r"\"")
                 parts.append(f'"{arg}"')
             elif type(arg) is AspFunction or type(arg) is int or type(arg) is AspVar:
                 parts.append(str(arg))
+            # subclasses miss the checks above: config values are syaml_str / syaml_int. bool is
+            # an int subclass, but is not a number in ASP, so it is quoted below.
+            elif isinstance(arg, int) and not isinstance(arg, bool):
+                parts.append(str(arg))
+            elif isinstance(arg, str):
+                arg = arg.replace("\\", r"\\").replace("\n", r"\n").replace('"', r"\"")
+                parts.append(f'"{arg}"')
             else:
                 parts.append(f'"{arg}"')
         return f"{self.name}({','.join(parts)})"

--- a/lib/spack/spack/test/concretization/core.py
+++ b/lib/spack/spack/test/concretization/core.py
@@ -5684,3 +5684,14 @@ def test_parallel_edges_in_a_literal_reach_the_solver(mock_packages, config):
 
     with pytest.raises(spack.error.UnsatisfiableSpecError):
         spack.concretize.concretize_one("mpileaks ^mpich@3.0.3 ^mpich@3.0.4")
+
+
+@pytest.mark.regression("51829")
+def test_asp_facts_with_config_values():
+    """Config values are syaml_str / syaml_int subclasses of str / int, and have to be emitted
+    as ASP strings and numbers. Booleans are strings."""
+    fn = spack.solver.core.fn
+    assert str(fn.max_dupes("cmake", syaml.syaml_int(2))) == 'max_dupes("cmake",2)'
+    assert str(fn.max_dupes("cmake", 2)) == 'max_dupes("cmake",2)'
+    assert str(fn.os_compatible(syaml.syaml_str('a"b\\c'), "d")) == r'os_compatible("a\"b\\c","d")'
+    assert str(fn.variant_value("x", True)) == 'variant_value("x","True")'


### PR DESCRIPTION
Fix the following regression introduced in d567e1a5299ec8d0929e1b1bfbdd03825bb70fdb

```
$ spack -c concretizer:duplicates:max_dupes:cmake:2 solve cmake
concretize.lp:16:24-25: info: operation undefined: (X+-1)
```

which happens because `2` is a syaml_int instead of an int, so
solver/core.py should not assume builtin types and instead use
isinstance when escaping values for asp.

Similar for syaml_str:

```
$ spack -c 'concretizer:os_compatible:{"a\"b":["c"]}' solve --show asp zlib
os_compatible("a"b","c").
```

The idea is to preserve the original performance by manually ordering
the branches from most to least used when possible.
