### PR TITLE
asp.py: set direct=True for solver-built edges

### DIFF
--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -3568,7 +3568,9 @@ class SpecBuilder:
     def depends_on(self, parent_node, dependency_node, type):
         dependency_spec = self._specs[dependency_node]
         depflag = dt.flag_from_string(type)
-        self._specs[parent_node].add_dependency_edge(dependency_spec, depflag=depflag, virtuals=())
+        self._specs[parent_node].add_dependency_edge(
+            dependency_spec, depflag=depflag, virtuals=(), direct=True
+        )
 
     def virtual_on_edge(self, parent_node, provider_node, virtual):
         dependencies = self._specs[parent_node].edges_to_dependencies(name=(provider_node.pkg))

--- a/lib/spack/spack/test/concretization/core.py
+++ b/lib/spack/spack/test/concretization/core.py
@@ -1478,6 +1478,16 @@ spack:
         spec = spack.concretize.concretize_one(spec)
         assert (uuidpatch, localpatch) == spec["libelf"].variants["patches"].value
 
+    def test_patch_condition_on_compiler_only(self):
+        """A patch's ``when=`` clause can constrain a direct dependency
+        (e.g. ``%gcc@10:``).
+        Regression test for a bug where such a patch was silently skipped.
+        """
+        fix_patch = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+        spec = spack.concretize.concretize_one("patch-when-compiler %gcc@10.2.1")
+        assert spec.satisfies("%gcc@10.2.1")
+        assert (fix_patch,) == spec.variants["patches"].value
+
     def test_dont_select_version_that_brings_more_variants_in(self):
         s = spack.concretize.concretize_one("dep-with-variants-if-develop-root")
         assert s["dep-with-variants-if-develop"].satisfies("@1.0")

--- a/var/spack/test_repos/spack_repo/builtin_mock/packages/patch_when_compiler/package.py
+++ b/var/spack/test_repos/spack_repo/builtin_mock/packages/patch_when_compiler/package.py
@@ -1,0 +1,21 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack_repo.builtin_mock.build_systems.generic import Package
+
+from spack.package import *
+
+
+class PatchWhenCompiler(Package):
+    """Package with a patch whose ``when=`` clause constrains a direct
+    dependency."""
+
+    homepage = "http://www.example.com"
+    url = "http://www.example.com/patch-when-compiler-1.0.tar.gz"
+
+    version("1.0", md5="0123456789abcdef0123456789abcdef")
+
+    depends_on("c", type="build")
+
+    patch("fix.patch", when="%gcc@10:")


### PR DESCRIPTION
PR #52860 made `_get_satisfying_edge` require a `direct` flag on edges to satisfy a direct dependency (`%`) for unfinalized specs.

`SpecBuilder.depends_on` did not set `direct=True` on the edges it builds, so any `when=` clause that constrains a direct dependency stopped matching.

Note that this flag still gets set back to False in `_finalize_concretization`, preserving the invariant #52860 relied on for concrete specs.