### PR TITLE
asp.py: set direct=True in post-processing

### DIFF
--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -3799,6 +3799,14 @@ def post_process_concretization_result(specs: SpecDict) -> None:
     This method updates the SpecDict in place.
 
     """
+    # The DAG is structurally complete, but still abstract. For node-local mutations that are
+    # conditional on (direct) dependencies, such as ``patch("...", when="%gcc")`` as well as
+    # ``dev_path``, we need to mark edges direct so that satisfies considers them as direct.
+    for s in specs.values():
+        if not s.concrete:
+            for edge in s.edges_to_dependencies():
+                edge.direct = True
+
     # inject patches -- note that we can't use set() to unique the
     # roots here, because the specs aren't complete, and the hash
     # function will loop forever.

--- a/lib/spack/spack/test/concretization/core.py
+++ b/lib/spack/spack/test/concretization/core.py
@@ -4759,6 +4759,17 @@ def test_concretization_cache_reapplies_patches_on_hit(
     assert initial_sha256s <= new_sha256s
 
 
+def test_patch_condition_on_direct_dependency(use_concretization_cache):
+    """A patch with a condition on a direct dependency (e.g. ``%gcc@10:``) is applied both on
+    a fresh solve and on a cache hit, where specs are rebuilt from serialized solver output."""
+    fix_patch = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    for _ in range(2):
+        spec = spack.concretize.concretize_one("patch-when-compiler %gcc@10.2.1")
+        assert (fix_patch,) == spec.variants["patches"].value
+        # concrete specs record every edge without the direct flag
+        assert not any(e.direct for s in spec.traverse() for e in s.edges_to_dependencies())
+
+
 def test_concretization_cache_count_cleanup(
     use_concretization_cache, mutable_config: Configuration
 ):

--- a/lib/spack/spack/test/spec_semantics.py
+++ b/lib/spack/spack/test/spec_semantics.py
@@ -2445,6 +2445,18 @@ def test_a_spec_that_stopped_being_concrete_matches_a_direct_constraint(config, 
     assert not mpileaks.satisfies("mpileaks %libelf")
 
 
+def test_direct_constraint_nested_below_a_concrete_dependency(config, mock_packages):
+    """A % constraint below ^ is checked on the node it applies to, so when that node is
+    concrete its edges match without the direct flag, even if the root spec is abstract."""
+    callpath = spack.concretize.concretize_one("callpath")
+    root = Spec("mpileaks")
+    root.add_dependency_edge(callpath, depflag=dt.BUILD | dt.LINK, virtuals=())
+
+    assert root.satisfies("mpileaks ^callpath %dyninst")
+    assert root.satisfies("mpileaks ^callpath ^libelf")
+    assert not root.satisfies("mpileaks ^callpath %libelf")
+
+
 def test_a_direct_dependency_is_inside_a_transitive_one(mock_packages):
     """'pkg-a ^pkg-b' means pkg-b is somewhere in the DAG and 'pkg-a %pkg-b' means it is a direct
     dependency, so the second is inside the first and not the other way around."""

--- a/var/spack/test_repos/spack_repo/builtin_mock/packages/patch_when_compiler/package.py
+++ b/var/spack/test_repos/spack_repo/builtin_mock/packages/patch_when_compiler/package.py
@@ -1,0 +1,21 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack_repo.builtin_mock.build_systems.generic import Package
+
+from spack.package import *
+
+
+class PatchWhenCompiler(Package):
+    """Package with a patch whose ``when=`` clause constrains a direct
+    dependency."""
+
+    homepage = "http://www.example.com"
+    url = "http://www.example.com/patch-when-compiler-1.0.tar.gz"
+
+    version("1.0", md5="0123456789abcdef0123456789abcdef")
+
+    depends_on("c", type="build")
+
+    patch("fix.patch", when="%gcc@10:")


### PR DESCRIPTION
Solver output is an abstract DAG that's practically concrete, but
undergoes a few conditional mutations on the node level while abstract,
such as assigning patches and `dev_path` variants.

Because satisfies requires an edge property `direct=True` for `%` on
abstract specs and we cannot mark the DAG that's about to undergo
mutation as concrete, the easiest solution to respect conditions for
mutations is to set `direct=True` on all edges from abstract specs.

Since there are various ways in which the almost-concrete DAG can be
created (concretization cache vs solver, and totally abstract vs
partially concrete due to reuse), I think the simplest way is to convert
edges to direct once the graph is structurally done (nodes and edges)
except for some conditional node-local mutations (patches, `dev_path`).

Notice that the `direct=True` attributes disappear again when the abstract
graph is finally made concrete.

