### PR TITLE
solver: use `warnings` instead of `tty` in the solver

### DIFF
--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -456,7 +456,7 @@ class Result:
                 self._concrete_specs.append(answer[node])
                 self._concrete_specs_by_input[input_spec] = answer[node]
             elif candidate and candidate.build_spec.satisfies(input_spec):
-                tty.warn(
+                warnings.warn(
                     "explicit splice configuration has caused the concretized spec"
                     f" {candidate} not to satisfy the input spec {input_spec}"
                 )
@@ -3578,7 +3578,7 @@ class SpecBuilder:
         dependencies[0].update_virtuals(virtual)
 
     def deprecated(self, node: NodeId, version: str) -> None:
-        tty.warn(f'using "{node.pkg}@{version}" which is a deprecated version')
+        warnings.warn(f'using "{node.pkg}@{version}" which is a deprecated version')
 
     def splice_at_hash(
         self, parent_node: NodeId, splice_node: NodeId, child_name: str, child_hash: str
@@ -3894,7 +3894,7 @@ def _specs_with_commits(spec):
 
     if "commit" not in spec.variants:
         if not spec.is_develop:
-            tty.warn(
+            warnings.warn(
                 f"Unable to resolve the git commit for {spec.name}. "
                 "An installation of this binary won't have complete binary provenance."
             )

--- a/lib/spack/spack/test/concretization/core.py
+++ b/lib/spack/spack/test/concretization/core.py
@@ -2589,7 +2589,6 @@ packages:
         database_mutable_config: Database,
         mock_packages,
         transitive,
-        capfd,
     ):
         mpich_spec = database_mutable_config.query("mpich")[0]
         splice_info = {
@@ -2599,7 +2598,10 @@ packages:
         }
         mutable_config.set("concretizer", {"splice": {"explicit": [splice_info]}})
 
-        spec = spack.concretize.concretize_one("hdf5 ^zmpi")
+        with pytest.warns(
+            UserWarning, match="explicit splice configuration has caused"
+        ) as recorded:
+            spec = spack.concretize.concretize_one("hdf5 ^zmpi")
 
         assert spec.satisfies(f"^mpich@{mpich_spec.version}")
         assert spec.build_spec.dependencies(name="zmpi", deptype="link")
@@ -2607,10 +2609,9 @@ packages:
         assert not spec.build_spec.satisfies(f"^mpich/{mpich_spec.dag_hash()}")
         assert not spec.dependencies(name="zmpi", deptype="link")
 
-        captured = capfd.readouterr()
-        assert "Warning: explicit splice configuration has caused" in captured.err
-        assert "hdf5 ^zmpi" in captured.err
-        assert str(spec) in captured.err
+        warned = "\n".join(str(x.message) for x in recorded)
+        assert "hdf5 ^zmpi" in warned
+        assert str(spec) in warned
 
     def test_explicit_splice_fails_nonexistent(
         self, mutable_config: Configuration, mock_packages, mock_store

--- a/lib/spack/spack/test/package_class.py
+++ b/lib/spack/spack/test/package_class.py
@@ -388,7 +388,7 @@ def test_git_provenance_find_commit_ls_remote(
 @pytest.mark.require_provenance
 @pytest.mark.disable_clean_stage_check
 def test_git_provenance_cant_resolve_commit(
-    mock_packages: RepoPath, monkeypatch, config, capfd, tmp_path
+    mock_packages: RepoPath, monkeypatch, config, tmp_path
 ):
     """Fail all attempts to resolve git commits"""
     repo_path = str(tmp_path / "non_existent")
@@ -397,10 +397,9 @@ def test_git_provenance_cant_resolve_commit(
     monkeypatch.setattr(spack.package_base.PackageBase, "git", repo_path, raising=False)
     monkeypatch.setattr(mock_packages.get_pkg_class("git-ref-package"), "git", repo_path)
     monkeypatch.setattr(spack.package_base.PackageBase, "do_fetch", lambda *args, **kwargs: None)
-    spec = spack.concretize.concretize_one("git-ref-package@develop")
-    captured = capfd.readouterr()
+    with pytest.warns(UserWarning, match="Unable to resolve the git commit"):
+        spec = spack.concretize.concretize_one("git-ref-package@develop")
     assert "commit" not in spec.variants
-    assert "Warning: Unable to resolve the git commit" in captured.err
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Extracted from #52891

We already route `warnings` to `tty` in `main`, so in core libraries stick to emit warnings instead of calling a tty directly.