### PR TITLE
sbom: don't call url_for_version() for git-resolved versions

### DIFF
--- a/lib/spack/spack/hooks/sbom_generate.py
+++ b/lib/spack/spack/hooks/sbom_generate.py
@@ -85,10 +85,18 @@ def get_git_commit(spec):
 def get_download_location(spec):
     pkg = spec.package
 
-    try:
-        return str(pkg.url_for_version(spec.version))
-    except spack.error.NoURLError:
-        pass
+    # Versions resolved via a git ref (a plain git version, or a "normal" version pinned
+    # to a commit/tag/branch) don't have a URL that url_for_version() can compute: that
+    # method is only meaningful for versions with a package-supplied url/urls scheme, and
+    # some packages' custom url_for_version() implementations assume purely numeric version
+    # components and raise arbitrary exceptions (not just NoURLError) when handed one of
+    # these. Go straight to the git remote for those instead of calling url_for_version().
+    # See https://github.com/spack/spack/issues/52864.
+    if not pkg.needs_commit(spec.version):
+        try:
+            return str(pkg.url_for_version(spec.version))
+        except spack.error.NoURLError:
+            pass
 
     git_url = pkg.version_or_package_attr("git", spec.version, default=None)
     if git_url and pkg.needs_commit(spec.version):

--- a/lib/spack/spack/test/hooks/sbom_generate.py
+++ b/lib/spack/spack/test/hooks/sbom_generate.py
@@ -239,6 +239,34 @@ def test_sbom_download_location_from_git_url(mock_packages, install_mockery):
     assert sbom["packages"][0]["downloadLocation"] == "https://a/really.com/big/repo.git"
 
 
+def test_sbom_download_location_skips_broken_url_for_version_on_git_version(
+    mock_packages, install_mockery, monkeypatch
+):
+    """A package whose url_for_version() blows up on a git-resolved version (e.g. because it
+    assumes purely numeric version components) must not crash SBOM generation: for versions
+    that need a commit, url_for_version() should not be called at all, and the download
+    location should fall back to the package's git URL. Regression test for
+    https://github.com/spack/spack/issues/52864.
+    """
+
+    spec = spack.concretize.concretize_one("git-sparsepaths-version@1.0")
+
+    def broken_url_for_version(version):
+        # Mirrors the real-world crash: a package's custom url_for_version() doing
+        # arithmetic/formatting on version components that assumes they are all numeric.
+        major, minor = version[0], version[1]
+        return "v%02d-%02d.tar.gz" % (major, minor)
+
+    monkeypatch.setattr(spec.package, "url_for_version", broken_url_for_version)
+
+    generate_spdx_2_3(spec)
+
+    with open(sbom_path(spec), encoding="utf-8") as f:
+        sbom = json.load(f)
+
+    assert sbom["packages"][0]["downloadLocation"] == "https://a/really.com/big/repo.git"
+
+
 def test_sbom_download_location_from_package_url(mock_packages, install_mockery, monkeypatch):
     """Download location should come from the package-level URL."""
 


### PR DESCRIPTION
Fixes #52864

## Problem

`get_download_location()` in `lib/spack/spack/hooks/sbom_generate.py` unconditionally calls `pkg.url_for_version(spec.version)` and only catches `spack.error.NoURLError`. But `url_for_version()` is only meaningful for versions that follow a package's `url`/`urls` scheme; it has nothing sensible to compute for versions resolved via a git ref (a plain git version, or a "normal" version pinned to a `commit`/`tag`/`branch`).

As reported in #52864, some packages' custom `url_for_version()` implementations assume purely numeric version components (e.g. `"v%02d-%02d.tar.gz" % (major, minor)`) and raise arbitrary exceptions - not just `NoURLError` - when handed one of these, crashing SBOM generation (and thus the whole install) for an otherwise-unrelated reason. Even when a custom `url_for_version()` doesn't crash, calling it for a git-resolved version can silently produce a nonsensical download location.

The specific `TypeError` from the reporter's `edm4hep` package is fixed independently in spack-packages#5975, but as the issue notes, the general problem is that `get_download_location()` should not be calling `url_for_version()` for these versions in the first place.

## Fix

Skip the `url_for_version()` call entirely when `pkg.needs_commit(spec.version)` is `True`, and fall straight through to the existing git-URL fallback (which already exists for the `NoURLError` case).

## Testing

- Added `test_sbom_download_location_skips_broken_url_for_version_on_git_version`, which monkeypatches a mock package's `url_for_version()` to mirror the real crash (numeric formatting on version components) for a git-resolved version, and asserts the download location correctly falls back to the git URL instead.
- Revert-checked: with only the source fix reverted (test kept), the new test fails as expected (`get_download_location` returns the bogus `url_for_version()` output instead of the git URL); with the fix restored it passes.
- Full existing suite for the hook: `lib/spack/spack/test/hooks/sbom_generate.py` (26 tests) and `lib/spack/spack/test/hooks/` + `lib/spack/spack/test/cmd/install.py` (124 tests total) all pass.
- `black --line-length 99` and `flake8` clean on both changed files.

---
_Note: this PR was prepared with AI assistance (tests written and verified against real dependencies, revert-checked as described above). Happy to adjust the approach if maintainers prefer a different fix shape (e.g. catching a broader exception set instead of pre-checking `needs_commit`)._