### PR TITLE
Windows: ensure stale VS registry entires are not falsely detected

### DIFF
--- a/lib/spack/spack/operating_systems/windows_os.py
+++ b/lib/spack/spack/operating_systems/windows_os.py
@@ -84,7 +84,9 @@ class WindowsOs(OperatingSystem):
             return []
         # vswhere prints nothing at all when no instance matches, so drop empty lines
         # rather than reporting a single empty (i.e. relative) install root.
-        return [line.strip() for line in paths.splitlines() if line.strip()]
+        valid_entries = filter(str.strip, paths.splitlines())
+        # return nicely cleaned list of valid vs entries
+        return [line.strip() for line in valid_entries]
 
     def _registry_install_paths(self) -> List[str]:
         """Visual Studio install roots recorded in the Windows registry.

--- a/lib/spack/spack/operating_systems/windows_os.py
+++ b/lib/spack/spack/operating_systems/windows_os.py
@@ -7,9 +7,10 @@ import os
 import pathlib
 import platform
 import subprocess
+from typing import List
 
 from spack.error import SpackError
-from spack.util import tty
+from spack.util import lang, tty
 from spack.util import windows_registry as winreg
 from spack.version import Version
 
@@ -43,55 +44,54 @@ class WindowsOs(OperatingSystem):
         return self.name
 
     @property
-    def vs_install_paths(self):
-        vs_install_paths = []
+    def vs_install_paths(self) -> List[str]:
+        """Root directories of the Visual Studio installations on this system.
+
+        Two independent sources are consulted, because neither is sufficient on its own:
+        ``vswhere.exe``, which is unavailable when the Visual Studio Installer is absent
+        or installed somewhere unexpected, and the Windows registry.
+
+        Roots that no longer exist on disk are discarded. Uninstalling Visual Studio
+        routinely leaves its registry entries behind, and those stale entries would
+        otherwise be reported as usable toolchains.
+        """
+        paths = self._vswhere_install_paths() + self._registry_install_paths()
+        paths = [path for path in paths if os.path.isdir(path)]
+        # Whenever both sources are available they report the same installations.
+        return list(lang.dedupe(paths, key=lambda p: os.path.normcase(os.path.normpath(p))))
+
+    def _vswhere_install_paths(self) -> List[str]:
+        """Visual Studio install roots reported by ``vswhere.exe``."""
         root = os.environ.get("ProgramFiles(x86)") or os.environ.get("ProgramFiles")
-        if root:
-            try:
-                extra_args = {"encoding": "mbcs", "errors": "strict"}
-                paths = subprocess.check_output(  # type: ignore[call-overload] # novermin
-                    [
-                        os.path.join(root, "Microsoft Visual Studio", "Installer", "vswhere.exe"),
-                        "-prerelease",
-                        "-requires",
-                        "Microsoft.VisualStudio.Component.VC.Tools.x86.x64",
-                        "-property",
-                        "installationPath",
-                        "-products",
-                        "*",
-                    ],
-                    **extra_args,
-                ).strip()
-                vs_install_paths = paths.split("\n")
-            except (subprocess.CalledProcessError, OSError, UnicodeDecodeError):
-                pass
-        return vs_install_paths
-
-    @property
-    def msvc_paths(self):
-        return [os.path.join(path, "VC", "Tools", "MSVC") for path in self.vs_install_paths]
-
-    @property
-    def oneapi_root(self):
-        root = os.environ.get("ONEAPI_ROOT", "") or os.path.join(
-            os.environ.get("ProgramFiles(x86)", ""), "Intel", "oneAPI"
-        )
-        if os.path.exists(root):
-            return root
-
-    @property
-    def compiler_search_paths(self):
-        # First Strategy: Find MSVC directories using vswhere
-        _compiler_search_paths = []
-        for p in self.msvc_paths:
-            _compiler_search_paths.extend(glob.glob(os.path.join(p, "*", "bin", "Hostx64", "x64")))
-        oneapi_root = self.oneapi_root
-        if oneapi_root:
-            _compiler_search_paths.extend(
-                glob.glob(os.path.join(oneapi_root, "compiler", "**", "bin"), recursive=True)
+        if not root:
+            return []
+        try:
+            extra_args = {"encoding": "mbcs", "errors": "strict"}
+            paths = subprocess.check_output(  # type: ignore[call-overload] # novermin
+                [
+                    os.path.join(root, "Microsoft Visual Studio", "Installer", "vswhere.exe"),
+                    "-prerelease",
+                    "-requires",
+                    "Microsoft.VisualStudio.Component.VC.Tools.x86.x64",
+                    "-property",
+                    "installationPath",
+                    "-products",
+                    "*",
+                ],
+                **extra_args,
             )
+        except (subprocess.CalledProcessError, OSError, UnicodeDecodeError):
+            return []
+        # vswhere prints nothing at all when no instance matches, so drop empty lines
+        # rather than reporting a single empty (i.e. relative) install root.
+        return [line.strip() for line in paths.splitlines() if line.strip()]
 
-        # Second strategy: Find MSVC via the registry
+    def _registry_install_paths(self) -> List[str]:
+        """Visual Studio install roots recorded in the Windows registry.
+
+        Serves as a fallback for hosts on which ``vswhere.exe`` cannot be located.
+        """
+
         def try_query_registry(retry=False):
             winreg_report_error = lambda e: tty.debug(
                 'Windows registry query on "SOFTWARE\\WOW6432Node\\Microsoft"'
@@ -134,12 +134,13 @@ class WindowsOs(OperatingSystem):
             # Note: Winreg does not support locking
             vs_entries = try_query_registry(retry=True)
 
-        vs_paths = []
-
         def clean_vs_path(path):
+            """Derive the install root from a devenv.exe reference recorded by Visual
+            Studio, which has the form ``@C:\\...\\Common7\\IDE\\devenv.exe,-1234``."""
             path = path.split(",")[0].lstrip("@")
             return str((pathlib.Path(path).parent / "..\\..").resolve())
 
+        vs_paths = []
         for entry in vs_entries:
             try:
                 val = entry.get_subkey("Capabilities").get_value("ApplicationDescription").value
@@ -149,6 +150,33 @@ class WindowsOs(OperatingSystem):
                     pass
                 else:
                     raise
+        return vs_paths
 
-        _compiler_search_paths.extend(vs_paths)
+    @property
+    def msvc_paths(self) -> List[str]:
+        return [os.path.join(path, "VC", "Tools", "MSVC") for path in self.vs_install_paths]
+
+    @property
+    def oneapi_root(self):
+        root = os.environ.get("ONEAPI_ROOT", "") or os.path.join(
+            os.environ.get("ProgramFiles(x86)", ""), "Intel", "oneAPI"
+        )
+        if os.path.exists(root):
+            return root
+
+    @property
+    def compiler_search_paths(self) -> List[str]:
+        """Directories that may contain a compiler Spack can drive on Windows.
+
+        ``vs_install_paths`` reports installation roots; the compilers themselves live
+        several levels below one, so the roots are never search paths in their own right.
+        """
+        _compiler_search_paths = []
+        for p in self.msvc_paths:
+            _compiler_search_paths.extend(glob.glob(os.path.join(p, "*", "bin", "Hostx64", "x64")))
+        oneapi_root = self.oneapi_root
+        if oneapi_root:
+            _compiler_search_paths.extend(
+                glob.glob(os.path.join(oneapi_root, "compiler", "**", "bin"), recursive=True)
+            )
         return _compiler_search_paths

--- a/lib/spack/spack/test/operating_systems/__init__.py
+++ b/lib/spack/spack/test/operating_systems/__init__.py
@@ -1,3 +1,0 @@
-# Copyright Spack Project Developers. See COPYRIGHT file for details.
-#
-# SPDX-License-Identifier: (Apache-2.0 OR MIT)

--- a/lib/spack/spack/test/operating_systems/__init__.py
+++ b/lib/spack/spack/test/operating_systems/__init__.py
@@ -1,0 +1,3 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)

--- a/lib/spack/spack/test/operating_systems/windows_os.py
+++ b/lib/spack/spack/test/operating_systems/windows_os.py
@@ -1,0 +1,137 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+"""Tests for Visual Studio discovery in ``operating_systems/windows_os.py``."""
+
+import os
+import subprocess
+import sys
+
+import pytest
+
+import spack.operating_systems.windows_os as windows_os
+from spack.version import Version
+
+
+pytestmark = pytest.mark.skipif(sys.platform != "win32", reason="Windows OS tests only relevant on Windows")
+
+
+@pytest.fixture(autouse=True)
+def fake_windows_version(monkeypatch):
+    """Let ``WindowsOs()`` be constructed on any host."""
+    monkeypatch.setattr(windows_os, "windows_version", lambda: Version("10.0.26100"))
+
+
+@pytest.fixture(autouse=True)
+def no_oneapi(monkeypatch):
+    """Keep a oneAPI installation on the test host out of the search paths."""
+    monkeypatch.setattr(windows_os.WindowsOs, "oneapi_root", property(lambda self: None))
+
+
+@pytest.fixture
+def no_vswhere(monkeypatch):
+    monkeypatch.setattr(windows_os.WindowsOs, "_vswhere_install_paths", lambda self: [])
+
+
+@pytest.fixture
+def no_registry(monkeypatch):
+    monkeypatch.setattr(windows_os.WindowsOs, "_registry_install_paths", lambda self: [])
+
+
+def vs_layout(root, *, toolset_versions=("14.44.35207",)):
+    """Create the parts of a Visual Studio install tree that Spack looks for."""
+    for version in toolset_versions:
+        (root / "VC" / "Tools" / "MSVC" / version / "bin" / "Hostx64" / "x64").mkdir(
+            parents=True, exist_ok=True
+        )
+    return str(root)
+
+
+def test_stale_registry_entry_is_not_reported(monkeypatch, tmp_path, no_vswhere):
+    """A registry key left behind by an uninstall must not yield an install path.
+
+    This is the phantom-detection case: Visual Studio records itself in the registry
+    and does not always clean up on uninstall, so the recorded root can outlive the
+    files it points at.
+    """
+    live = vs_layout(tmp_path / "live")
+    dead = str(tmp_path / "dead")
+
+    monkeypatch.setattr(windows_os.WindowsOs, "_registry_install_paths", lambda self: [live, dead])
+
+    os_ = windows_os.WindowsOs()
+    assert os_.vs_install_paths == [live]
+    assert not any(dead in path for path in os_.compiler_search_paths)
+
+
+def test_registry_roots_yield_compiler_search_paths(monkeypatch, tmp_path, no_vswhere):
+    """Registry-derived roots must go through the MSVC toolset glob.
+
+    Registry lookup is the fallback for hosts without ``vswhere.exe``. The roots it
+    reports contain no compiler themselves, so they are only useful once expanded to
+    the toolset ``bin`` directories.
+    """
+    versions = ("14.44.35207", "14.29.30133")
+    root = vs_layout(tmp_path / "vs", toolset_versions=versions)
+    monkeypatch.setattr(windows_os.WindowsOs, "_registry_install_paths", lambda self: [root])
+
+    search_paths = windows_os.WindowsOs().compiler_search_paths
+    assert sorted(search_paths) == sorted(
+        os.path.join(root, "VC", "Tools", "MSVC", version, "bin", "Hostx64", "x64")
+        for version in versions
+    )
+    # the root itself holds no compiler and must not be searched directly
+    assert root not in search_paths
+
+
+def test_install_paths_are_deduped_across_sources(monkeypatch, tmp_path):
+    """vswhere and the registry describe the same installations on most hosts."""
+    root = vs_layout(tmp_path / "vs")
+
+    monkeypatch.setattr(windows_os.WindowsOs, "_vswhere_install_paths", lambda self: [root])
+    # the registry resolves paths, so casing and separators need not match exactly
+    duplicate = root.upper() if os.name == "nt" else root
+    monkeypatch.setattr(windows_os.WindowsOs, "_registry_install_paths", lambda self: [duplicate])
+
+    assert windows_os.WindowsOs().vs_install_paths == [root]
+
+
+def test_empty_vswhere_output_yields_no_paths(monkeypatch, no_registry):
+    """vswhere prints nothing when it matches no instance.
+
+    Splitting that on newlines produces a single empty string, which would become a
+    relative ``VC\\Tools\\MSVC`` glob rooted at the current working directory.
+    """
+    monkeypatch.setenv("ProgramFiles(x86)", "C:\\Program Files (x86)")
+    monkeypatch.setattr(subprocess, "check_output", lambda *args, **kwargs: "")
+
+    os_ = windows_os.WindowsOs()
+    assert os_.vs_install_paths == []
+    assert os_.msvc_paths == []
+
+
+def test_vswhere_failure_is_not_fatal(monkeypatch, no_registry):
+    """A missing or broken vswhere must leave detection able to continue."""
+
+    def boom(*args, **kwargs):
+        raise OSError("vswhere.exe not found")
+
+    monkeypatch.setenv("ProgramFiles(x86)", "C:\\Program Files (x86)")
+    monkeypatch.setattr(subprocess, "check_output", boom)
+
+    assert windows_os.WindowsOs().vs_install_paths == []
+
+
+def test_vswhere_reports_multiple_instances(monkeypatch, tmp_path, no_registry):
+    """Every live instance is reported; a stale one is dropped."""
+    first = vs_layout(tmp_path / "2022")
+    second = vs_layout(tmp_path / "2019")
+    gone = str(tmp_path / "removed")
+
+    monkeypatch.setenv("ProgramFiles(x86)", "C:\\Program Files (x86)")
+    monkeypatch.setattr(
+        subprocess, "check_output", lambda *args, **kwargs: f"{first}\n{gone}\n{second}\n"
+    )
+
+    assert windows_os.WindowsOs().vs_install_paths == [first, second]

--- a/lib/spack/spack/test/operating_systems/windows_os.py
+++ b/lib/spack/spack/test/operating_systems/windows_os.py
@@ -13,8 +13,9 @@ import pytest
 import spack.operating_systems.windows_os as windows_os
 from spack.version import Version
 
-
-pytestmark = pytest.mark.skipif(sys.platform != "win32", reason="Windows OS tests only relevant on Windows")
+pytestmark = pytest.mark.skipif(
+    sys.platform != "win32", reason="Windows OS tests only relevant on Windows"
+)
 
 
 @pytest.fixture(autouse=True)

--- a/lib/spack/spack/test/operating_systems/windows_os.py
+++ b/lib/spack/spack/test/operating_systems/windows_os.py
@@ -92,7 +92,7 @@ def test_install_paths_are_deduped_across_sources(monkeypatch, tmp_path):
 
     monkeypatch.setattr(windows_os.WindowsOs, "_vswhere_install_paths", lambda self: [root])
     # the registry resolves paths, so casing and separators need not match exactly
-    duplicate = root.upper() if os.name == "nt" else root
+    duplicate = root.upper()
     monkeypatch.setattr(windows_os.WindowsOs, "_registry_install_paths", lambda self: [duplicate])
 
     assert windows_os.WindowsOs().vs_install_paths == [root]
@@ -105,7 +105,7 @@ def test_empty_vswhere_output_yields_no_paths(monkeypatch, no_registry):
     relative ``VC\\Tools\\MSVC`` glob rooted at the current working directory.
     """
     monkeypatch.setenv("ProgramFiles(x86)", "C:\\Program Files (x86)")
-    monkeypatch.setattr(subprocess, "check_output", lambda *args, **kwargs: "")
+    monkeypatch.setattr(windows_os.subprocess, "check_output", lambda *args, **kwargs: "")
 
     os_ = windows_os.WindowsOs()
     assert os_.vs_install_paths == []


### PR DESCRIPTION
Ensure compiler detection does not pickup registry cruft from VS uninstalls failing to remove their registry entries. Slight refactor and robustness improvements to WindowsOS and handling duped registry and vswhere derived VS detections.