### PR TITLE
sbom: catch all url_for_version() exceptions in get_download_location

### DIFF
--- a/lib/spack/spack/hooks/sbom_generate.py
+++ b/lib/spack/spack/hooks/sbom_generate.py
@@ -89,6 +89,14 @@ def get_download_location(spec):
         return str(pkg.url_for_version(spec.version))
     except spack.error.NoURLError:
         pass
+    except Exception:
+        # url_for_version() may raise arbitrary exceptions for versions resolved
+        # via a git ref (commit/tag/branch), where some packages' custom
+        # implementations assume purely numeric version components. Fall through
+        # to the git-URL fallback below.  See https://github.com/spack/spack/issues/52864.
+        tty.debug(
+            f"SBOM: url_for_version() failed for {spec}, falling back to git URL"
+        )
 
     git_url = pkg.version_or_package_attr("git", spec.version, default=None)
     if git_url and pkg.needs_commit(spec.version):

--- a/lib/spack/spack/test/hooks/sbom_generate.py
+++ b/lib/spack/spack/test/hooks/sbom_generate.py
@@ -239,6 +239,33 @@ def test_sbom_download_location_from_git_url(mock_packages, install_mockery):
     assert sbom["packages"][0]["downloadLocation"] == "https://a/really.com/big/repo.git"
 
 
+def test_sbom_download_location_fallback_on_url_for_version_exception(
+    mock_packages, install_mockery, monkeypatch
+):
+    """When url_for_version() raises an unexpected exception (e.g. TypeError for git-resolved
+    versions with numeric-only formatting), SBOM generation must not crash and should fall
+    back to the package's git URL. Regression test for
+    https://github.com/spack/spack/issues/52864.
+    """
+
+    spec = spack.concretize.concretize_one("git-sparsepaths-version@1.0")
+
+    def raising_url_for_version(version):
+        # Mimics the real crash: a package's custom url_for_version() doing
+        # arithmetic/formatting on version components that assumes they are all numeric.
+        major, minor = version[0], version[1]
+        return "v%02d-%02d.tar.gz" % (major, minor)
+
+    monkeypatch.setattr(spec.package, "url_for_version", raising_url_for_version)
+
+    generate_spdx_2_3(spec)
+
+    with open(sbom_path(spec), encoding="utf-8") as f:
+        sbom = json.load(f)
+
+    assert sbom["packages"][0]["downloadLocation"] == "https://a/really.com/big/repo.git"
+
+
 def test_sbom_download_location_from_package_url(mock_packages, install_mockery, monkeypatch):
     """Download location should come from the package-level URL."""
 


### PR DESCRIPTION
Fixes #52864

## Problem

`get_download_location()` in `lib/spack/spack/hooks/sbom_generate.py` calls `pkg.url_for_version(spec.version)` and only catches `spack.error.NoURLError`. But `url_for_version()` can raise arbitrary exceptions for versions resolved via a git ref (commit/tag/branch), where some packages' custom implementations assume purely numeric version components.

As reported in #52864, the `edm4hep` package's `url_for_version()` raises a `TypeError` when handed a git-resolved version, crashing SBOM generation (and thus the whole install).

## Fix

Catch all exceptions from `url_for_version()`, not just `NoURLError`, and fall through to the existing git-URL fallback. A `tty.debug()` log is emitted for troubleshooting.

This approach is more defensive than pre-checking `needs_commit()`: it handles not just git-resolved versions, but any case where `url_for_version()` fails unexpectedly (e.g. packages with broken version formatting logic, version types that don't match format specifiers).

## Approach comparison

There is an existing PR (#52902) that takes a pre-check approach (`if not pkg.needs_commit(spec.version)`). That approach is also valid. This PR's approach differs in that it:

1. Catches failures from `url_for_version()` regardless of root cause (not just git versions)
2. Avoids coupling SBOM logic to the internal `needs_commit()` API
3. Logs the failure for debugging rather than silently skipping

## Testing

- Added `test_sbom_download_location_fallback_on_url_for_version_exception`, which monkeypatches a mock package's `url_for_version()` to raise a `TypeError` (mirroring the real crash) for a git-resolved version, and asserts the download location correctly falls back to the git URL.
- Full existing suite for the hook passes.
- `black` and `flake8` clean on both changed files.