### PR TITLE
spec.py: constraining an edge merges the propagation policy

### DIFF
--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -4038,6 +4038,7 @@ class Spec:
                         edge.depflag,
                         edge.virtuals,
                         edge.direct,
+                        edge.propagation,
                         edge.when,
                     )
                 )
@@ -4049,7 +4050,7 @@ class Spec:
 
             # level 1 edges all start with zero
             for i, edge in enumerate(sorted_l1_edges, start=1):
-                yield (0, i, edge.depflag, edge.virtuals, edge.direct, edge.when)
+                yield (0, i, edge.depflag, edge.virtuals, edge.direct, edge.propagation, edge.when)
 
             # yield remaining edges in the order they were encountered during traversal
             if edge_list:

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -832,7 +832,6 @@ class DependencySpec:
         if not self.direct and other.direct:
             changed = True
             self.direct = True
-        # The stronger propagation policy is kept: promote, never demote.
         if self.propagation == PropagationPolicy.NONE and other.propagation != self.propagation:
             changed = True
             self.propagation = other.propagation

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -832,6 +832,10 @@ class DependencySpec:
         if not self.direct and other.direct:
             changed = True
             self.direct = True
+        # The stronger propagation policy is kept: promote, never demote.
+        if self.propagation == PropagationPolicy.NONE and other.propagation != self.propagation:
+            changed = True
+            self.propagation = other.propagation
         return changed
 
     def _cmp_iter(self):

--- a/lib/spack/spack/test/spec_semantics.py
+++ b/lib/spack/spack/test/spec_semantics.py
@@ -2061,6 +2061,18 @@ def test_constrain(factory, lhs_str, rhs_str, result, constrained_str, mock_pack
     assert rhs == factory(constrained_str)
 
 
+def test_constrain_promotes_edge_propagation(mock_packages):
+    """Constraining an edge with a propagated edge to the same package promotes the policy; the
+    reverse never demotes it."""
+    lhs = Spec("mpileaks %callpath")
+    assert lhs.constrain("mpileaks %%callpath")
+    assert lhs == Spec("mpileaks %%callpath")
+
+    lhs = Spec("mpileaks %%callpath")
+    assert not lhs.constrain("mpileaks %callpath")
+    assert lhs == Spec("mpileaks %%callpath")
+
+
 def test_constrain_dependencies_copies(mock_packages):
     """Tests that constraining a spec with new deps makes proper copies, and does not accidentally
     share dependency instances, leading to corruption of unrelated Spec instances."""

--- a/lib/spack/spack/test/spec_semantics.py
+++ b/lib/spack/spack/test/spec_semantics.py
@@ -2073,6 +2073,15 @@ def test_constrain_promotes_edge_propagation(mock_packages):
     assert lhs == Spec("mpileaks %%callpath")
 
 
+def test_edge_propagation_is_part_of_spec_identity(mock_packages):
+    """%callpath and %%callpath are different states even though they permit the same solutions,
+    so they are distinct set elements, in line with to_dict, which serializes the policy."""
+    plain, propagated = Spec("mpileaks %callpath"), Spec("mpileaks %%callpath")
+    assert plain != propagated
+    assert hash(plain) != hash(propagated)
+    assert len({plain, propagated}) == 2
+
+
 def test_constrain_dependencies_copies(mock_packages):
     """Tests that constraining a spec with new deps makes proper copies, and does not accidentally
     share dependency instances, leading to corruption of unrelated Spec instances."""
@@ -2277,7 +2286,7 @@ EMPTY_FLG = Spec().compiler_flags
                     ("a", None, EMPTY_VER, EMPTY_VAR, EMPTY_FLG, None, None, None),
                     ("b", None, EMPTY_VER, EMPTY_VAR, EMPTY_FLG, None, None, None),
                 ),
-                ((0, 1, 0, (), False, Spec()),),
+                ((0, 1, 0, (), False, PropagationPolicy.NONE, Spec()),),
             ),
         ],
         # root with multiple deps
@@ -2291,9 +2300,9 @@ EMPTY_FLG = Spec().compiler_flags
                     ("d", None, EMPTY_VER, EMPTY_VAR, EMPTY_FLG, None, None, None),
                 ),
                 (
-                    (0, 1, 0, (), False, Spec()),
-                    (0, 2, 0, (), False, Spec()),
-                    (0, 3, 0, (), False, Spec()),
+                    (0, 1, 0, (), False, PropagationPolicy.NONE, Spec()),
+                    (0, 2, 0, (), False, PropagationPolicy.NONE, Spec()),
+                    (0, 3, 0, (), False, PropagationPolicy.NONE, Spec()),
                 ),
             ),
         ],
@@ -2308,9 +2317,9 @@ EMPTY_FLG = Spec().compiler_flags
                     ("d", None, EMPTY_VER, EMPTY_VAR, EMPTY_FLG, None, None, None),
                 ),
                 (
-                    (0, 1, 0, (), True, Spec()),
-                    (0, 2, 0, (), True, Spec()),
-                    (0, 3, 0, (), True, Spec()),
+                    (0, 1, 0, (), True, PropagationPolicy.NONE, Spec()),
+                    (0, 2, 0, (), True, PropagationPolicy.NONE, Spec()),
+                    (0, 3, 0, (), True, PropagationPolicy.NONE, Spec()),
                 ),
             ),
         ],
@@ -2328,12 +2337,12 @@ EMPTY_FLG = Spec().compiler_flags
                     ("g", None, EMPTY_VER, EMPTY_VAR, EMPTY_FLG, None, None, None),
                 ),
                 (
-                    (0, 1, 0, (), False, Spec()),
-                    (0, 2, 0, (), False, Spec()),
-                    (1, 3, 0, (), True, Spec()),
-                    (1, 4, 0, (), True, Spec()),
-                    (2, 5, 0, (), True, Spec()),
-                    (2, 6, 0, (), True, Spec()),
+                    (0, 1, 0, (), False, PropagationPolicy.NONE, Spec()),
+                    (0, 2, 0, (), False, PropagationPolicy.NONE, Spec()),
+                    (1, 3, 0, (), True, PropagationPolicy.NONE, Spec()),
+                    (1, 4, 0, (), True, PropagationPolicy.NONE, Spec()),
+                    (2, 5, 0, (), True, PropagationPolicy.NONE, Spec()),
+                    (2, 6, 0, (), True, PropagationPolicy.NONE, Spec()),
                 ),
             ),
         ],


### PR DESCRIPTION
Fixes two bugs related to `%%`.

First, `DependencySpec._constrain` drops the propagation policy of the right-hand side, so a merge silently loses a propagated preference:

```python
>>> s = Spec("mpileaks %callpath")
>>> s.constrain("mpileaks %%callpath")
False
>>> s
mpileaks %callpath  # wrong: the %% preference is gone
```

Second bug is

```python
>>> Spec("mpileaks %callpath") == Spec("mpileaks %%callpath")
True
```

Satisfaction deliberately keeps ignoring the propagation policy: `%%callpath` is a preference the solver may override, so it does not narrow the set of concrete specs. This leads to a fun example where `x satisfies y` and `y satisfies x` but `x != y` by design.
