### PR TITLE
spec.py: constrain the abstract hash after the checks, and return true iff changed

### DIFF
--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -3147,12 +3147,6 @@ class Spec:
             self._dup(other)
             return True
 
-        if other.abstract_hash:
-            if not self.abstract_hash or other.abstract_hash.startswith(self.abstract_hash):
-                self.abstract_hash = other.abstract_hash
-            elif not self.abstract_hash.startswith(other.abstract_hash):
-                raise InvalidHashError(self, other.abstract_hash)
-
         if not (self.name == other.name or (not self.name) or (not other.name)):
             raise UnsatisfiableSpecNameError(self.name, other.name)
 
@@ -3179,6 +3173,13 @@ class Spec:
             raise UnsatisfiableArchitectureSpecError(sarch, oarch)
 
         changed = False
+
+        if other.abstract_hash:
+            if not self.abstract_hash or other.abstract_hash.startswith(self.abstract_hash):
+                changed |= self.abstract_hash != other.abstract_hash
+                self.abstract_hash = other.abstract_hash
+            elif not self.abstract_hash.startswith(other.abstract_hash):
+                raise InvalidHashError(self, other.abstract_hash)
 
         if not self.name and other.name:
             self.name = other.name

--- a/lib/spack/spack/test/spec_semantics.py
+++ b/lib/spack/spack/test/spec_semantics.py
@@ -451,8 +451,25 @@ class TestSpecSemantics:
         """Test that Specs specified only by their hashes can constrain each other."""
         mpich_dag_hash = "/" + database.query_one("mpich").dag_hash()
         spec = Spec(mpich_dag_hash[:7])
-        assert spec.constrain(Spec(mpich_dag_hash)) is False
+        assert spec.constrain(mpich_dag_hash) is True
         assert spec.abstract_hash == mpich_dag_hash[1:]
+        # the full hash is already there, so constraining with it again changes nothing
+        assert spec.constrain(mpich_dag_hash) is False
+
+    def test_constrain_extends_the_hash_on_an_edge(self, mock_packages):
+        """The changed flag covers the abstract hash of a dependency too."""
+        spec = Spec("%gcc")
+        assert spec.constrain("%gcc/abc") is True
+        assert spec.constrain("%gcc/abc") is False
+
+    def test_failed_constrain_does_not_extend_the_hash(self, mock_packages):
+        """The abstract hash merges after the compatibility checks, so a constraint that is
+        rejected in another dimension leaves no hash behind."""
+        lhs = Spec("pkg-b")
+        with pytest.raises(UnsatisfiableSpecError):
+            lhs.constrain("pkg-a/abcdef")
+        assert lhs.abstract_hash is None
+        assert lhs == Spec("pkg-b")
 
     def test_mismatched_constrain_spec_by_hash(self, database):
         """Test that Specs specified only by their incompatible hashes fail appropriately."""


### PR DESCRIPTION
Two `Spec.constrain` bugs around the abstract hash, found with the property tests of #52836.

The returned changed flag missed a hash extension:

```python
>>> s = Spec("pkg-a")
>>> s.constrain("pkg-a/abcdef")
False  # wrong: the hash extended
>>> s.abstract_hash
'abcdef'
```

And the hash was applied before any compatibility check ran, so constrain would mutate on error:

```python
>>> s = Spec("pkg-b")
>>> s.constrain("pkg-a/abcdef")
UnsatisfiableSpecNameError: pkg-b does not satisfy pkg-a
>>> s.abstract_hash
'abcdef'  # wrong: the rejected constraint stuck
```

