### PR TITLE
spec.py: round-trip str of abstract spec with namespace

### DIFF
--- a/lib/spack/spack/environment/environment.py
+++ b/lib/spack/spack/environment/environment.py
@@ -2304,11 +2304,10 @@ class Environment:
 
     def _concrete_roots_dict(self):
         if not self.has_groups():
-            return [{"hash": x.hash, "spec": x.root.long_spec} for x in self.concretized_roots]
+            return [{"hash": x.hash, "spec": str(x.root)} for x in self.concretized_roots]
 
         return [
-            {"hash": x.hash, "spec": x.root.long_spec, "group": x.group}
-            for x in self.concretized_roots
+            {"hash": x.hash, "spec": str(x.root), "group": x.group} for x in self.concretized_roots
         ]
 
     def has_groups(self) -> bool:

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -167,14 +167,6 @@ DEFAULT_FORMAT = (
     "{ /abstract_hash}"
 )
 
-#: Full format for Spec.format(). This format can be round-tripped without losing
-#: namespace information
-FULL_FORMAT = (
-    "{fullname}{@versions}{compiler_flags}{variants}"
-    "{ platform=architecture.platform}{ os=architecture.os}{ target=architecture.target}"
-    "{ /abstract_hash}"
-)
-
 #: Display format, which eliminates extra `@=` in the output, for readability.
 DISPLAY_FORMAT = (
     "{name}{@version}{compiler_flags}"
@@ -4517,16 +4509,11 @@ class Spec:
 
         return " ".join(parts).strip()
 
-    def _long_spec(self, format=None, color: Optional[bool] = False) -> str:
+    def _long_spec(self, color: Optional[bool] = False) -> str:
         """Helper for :attr:`long_spec` and :attr:`clong_spec`."""
-        if format is None:
-            format = DISPLAY_FORMAT if self.concrete else DEFAULT_FORMAT
         if self.concrete:
-            return self.tree(format=format, color=color)
-
-        node_format = self.format(format_string=format, color=color)
-        dep_format = self._format_dependencies(format_string=format, color=color)
-        return f"{node_format} {dep_format}".strip()
+            return self.tree(format=DISPLAY_FORMAT, color=color)
+        return f"{self.format(color=color)} {self._format_dependencies(color=color)}".strip()
 
     def _short_spec(self, color: Optional[bool] = False) -> str:
         """Helper for :attr:`short_spec` and :attr:`cshort_spec`."""
@@ -4554,12 +4541,12 @@ class Spec:
     @property
     def long_spec(self):
         """Long string of the spec, including dependencies."""
-        return self._long_spec(format=FULL_FORMAT, color=False)
+        return self._long_spec(color=False)
 
     @property
     def clong_spec(self):
         """Returns an auto-colorized version of :attr:`long_spec`."""
-        return self._long_spec(format=FULL_FORMAT, color=None)
+        return self._long_spec(color=None)
 
     @property
     def short_spec(self):

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -161,7 +161,7 @@ _STYLE_COLOR_MAP = {
 #: Default format for Spec.format(). This format can be round-tripped, so that:
 #:     Spec(Spec("string").format()) == Spec("string)"
 DEFAULT_FORMAT = (
-    "{name}{@versions}{compiler_flags}"
+    "{fullname_if_abstract}{@versions}{compiler_flags}"
     "{variants}{ namespace=namespace_if_anonymous}"
     "{ platform=architecture.platform}{ os=architecture.os}{ target=architecture.target}"
     "{ /abstract_hash}"
@@ -177,7 +177,7 @@ FULL_FORMAT = (
 
 #: Display format, which eliminates extra `@=` in the output, for readability.
 DISPLAY_FORMAT = (
-    "{name}{@version}{compiler_flags}"
+    "{fullname_if_abstract}{@version}{compiler_flags}"
     "{variants}{ namespace=namespace_if_anonymous}"
     "{ platform=architecture.platform}{ os=architecture.os}{ target=architecture.target}"
     "{ /abstract_hash}"
@@ -4058,6 +4058,12 @@ class Spec:
     def namespace_if_anonymous(self):
         return self.namespace if not self.name else None
 
+    @property
+    def fullname_if_abstract(self):
+        """The namespace-qualified name of an abstract spec. A concrete spec always has a
+        namespace, so its default format prints the plain name."""
+        return self.name if self.concrete else self.fullname
+
     def _format_default(self) -> str:
         """Fast path for formatting with DEFAULT_FORMAT and no color.
 
@@ -4067,7 +4073,10 @@ class Spec:
         parts = []
 
         if self.name:
-            parts.append(self.name)
+            if self.namespace and not self.concrete:
+                parts.append(f"{self.namespace}.{self.name}")
+            else:
+                parts.append(self.name)
 
         if self.versions:
             version_str = str(self.versions)

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -177,7 +177,7 @@ FULL_FORMAT = (
 
 #: Display format, which eliminates extra `@=` in the output, for readability.
 DISPLAY_FORMAT = (
-    "{fullname_if_abstract}{@version}{compiler_flags}"
+    "{name}{@version}{compiler_flags}"
     "{variants}{ namespace=namespace_if_anonymous}"
     "{ platform=architecture.platform}{ os=architecture.os}{ target=architecture.target}"
     "{ /abstract_hash}"

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -4052,9 +4052,10 @@ class Spec:
 
     @property
     def fullname_if_abstract(self):
-        """The namespace-qualified name of an abstract spec. A concrete spec always has a
-        namespace, so its default format prints the plain name."""
-        return self.name if self.concrete else self.fullname
+        """The namespace-qualified name of a named abstract spec. A concrete spec always has
+        a namespace, so its default format prints the plain name. An anonymous spec renders
+        its namespace as a separate ``namespace=`` token."""
+        return self.fullname if self.name and not self.concrete else self.name
 
     def _format_default(self) -> str:
         """Fast path for formatting with DEFAULT_FORMAT and no color.

--- a/lib/spack/spack/test/spec_format.py
+++ b/lib/spack/spack/test/spec_format.py
@@ -217,3 +217,14 @@ def test_abstract_spec_str_roundtrips_namespace(config, mock_packages):
     concrete = spack.concretize.concretize_one("mpileaks")
     assert concrete.namespace == "builtin_mock"
     assert str(concrete).startswith("mpileaks@")
+
+
+def test_namespace_of_anonymous_spec_on_slow_path():
+    """Colored output takes the slow format path instead of _format_default. The namespace
+    of an anonymous spec renders as a single namespace= token on both paths."""
+    anonymous = Spec("namespace=bar")
+    expected = colorize(f"{VARIANT_COLOR} namespace=bar@.", color=True)
+    assert anonymous.format(color=True) == expected
+
+    named = Spec("foo namespace=bar")
+    assert named.format(color=True) == "bar.foo"

--- a/lib/spack/spack/test/spec_format.py
+++ b/lib/spack/spack/test/spec_format.py
@@ -5,7 +5,7 @@
 
 import spack.concretize
 from spack.enums import PartStyle
-from spack.spec import DIM_COLOR, HIGHLIGHT_COLOR, VARIANT_COLOR, VERSION_COLOR
+from spack.spec import DIM_COLOR, HIGHLIGHT_COLOR, VARIANT_COLOR, VERSION_COLOR, Spec
 from spack.util.tty.color import colorize
 
 
@@ -199,3 +199,21 @@ def test_architecture_style_fn_receives_correct_part(config, mock_packages):
         architecture_style_fn=record_part,
     )
     assert received_parts == ["platform", "os", "target"]
+
+
+def test_abstract_spec_str_roundtrips_namespace(config, mock_packages):
+    """Ensure that abstract specs (anonymous or not) round-trip and canonicalize the namespace"""
+    named = Spec("foo namespace=bar")
+    assert str(named) == "bar.foo"
+    assert Spec(str(named)).namespace == "bar"
+
+    anonymous = Spec("namespace=bar")
+    assert str(anonymous) == "namespace=bar"
+    assert Spec(str(anonymous)).namespace == "bar"
+
+    dep = Spec("pkg-a ^builtin_mock.pkg-b")
+    assert str(dep) == "pkg-a ^builtin_mock.pkg-b"
+
+    concrete = spack.concretize.concretize_one("mpileaks")
+    assert concrete.namespace == "builtin_mock"
+    assert str(concrete).startswith("mpileaks@")

--- a/lib/spack/spack/test/spec_syntax.py
+++ b/lib/spack/spack/test/spec_syntax.py
@@ -263,7 +263,7 @@ def specfile_for(config, mock_packages):
                 Token(SpecTokens.DEPENDENCY, value="%"),
                 Token(SpecTokens.UNQUALIFIED_PACKAGE_NAME, value="gcc"),
             ],
-            "yaml-cpp %gcc",
+            "builtin.yaml-cpp %gcc",
         ),
         (
             r"testrepo.yaml-cpp%gcc",
@@ -272,7 +272,7 @@ def specfile_for(config, mock_packages):
                 Token(SpecTokens.DEPENDENCY, value="%"),
                 Token(SpecTokens.UNQUALIFIED_PACKAGE_NAME, value="gcc"),
             ],
-            "yaml-cpp %gcc",
+            "testrepo.yaml-cpp %gcc",
         ),
         (
             r"builtin.yaml-cpp@0.1.8%gcc@7.2.0 ^boost@3.1.4",
@@ -286,7 +286,7 @@ def specfile_for(config, mock_packages):
                 Token(SpecTokens.UNQUALIFIED_PACKAGE_NAME, value="boost"),
                 Token(SpecTokens.VERSION, value="@3.1.4"),
             ],
-            "yaml-cpp@0.1.8 %gcc@7.2.0 ^boost@3.1.4",
+            "builtin.yaml-cpp@0.1.8 %gcc@7.2.0 ^boost@3.1.4",
         ),
         (
             r"builtin.yaml-cpp ^testrepo.boost ^zlib",
@@ -297,7 +297,7 @@ def specfile_for(config, mock_packages):
                 Token(SpecTokens.DEPENDENCY, value="^"),
                 Token(SpecTokens.UNQUALIFIED_PACKAGE_NAME, value="zlib"),
             ],
-            "yaml-cpp ^boost ^zlib",
+            "builtin.yaml-cpp ^testrepo.boost ^zlib",
         ),
         # Canonicalization of the string representation
         (


### PR DESCRIPTION
An explicit namespace on an abstract spec is a constraint: `pkg-a` does not satisfy `builtin_mock.pkg-a`. The default format dropped it, so the printed spec read back as a strictly wider one:

```python
>>> s = Spec("builtin_mock.pkg-a")
>>> str(s)
'pkg-a'  # wrong: the namespace constraint is lost
>>> Spec(str(s)).satisfies(s)
False
```

With this change an abstract spec is converted to str as follows:

```python
>>> str(Spec("foo namespace=bar"))
'bar.foo'
>>> str(Spec("pkg-a ^builtin_mock.pkg-b"))
'pkg-a ^builtin_mock.pkg-b'
```

An anonymous spec keeps `namespace=bar`. A concrete spec always has a namespace and keeps printing its plain name, so `spack find` output does not change.

Further, remove `FULL_FORMAT` which only partially fixed a similar issue for abstract specs, but still had the following bug for anonymous abstract specs:

```python
>>> Spec("namespace=foo").long_spec
'foo.'
```
