### PR TITLE
spec.py: make anonymous dep constrain commutative and idempotent

### DIFF
--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -1118,8 +1118,8 @@ def _select_edges(
 
     Args:
         edge_map: map of edges to select from
-        parent: name of the parent package
-        child: name of the child package
+        parent: name of the parent package; ``""`` selects anonymous parents
+        child: name of the child package; ``""`` selects anonymous children
         depflag: allowed dependency types in flag form
         virtuals: list of virtuals or specific virtual on the edge
     """
@@ -1130,11 +1130,11 @@ def _select_edges(
     selected: Iterable[DependencySpec] = itertools.chain.from_iterable(edge_map.values())
 
     # Filter by parent name
-    if parent:
+    if parent is not None:
         selected = (d for d in selected if d.parent.name == parent)
 
     # Filter by child name
-    if child:
+    if child is not None:
         selected = (d for d in selected if d.spec.name == child)
 
     # Filter by allowed dependency types
@@ -1817,7 +1817,7 @@ class Spec:
         to parents.
 
         Args:
-            name: filter dependents by package name
+            name: filter dependents by package name; ``""`` selects anonymous dependents
             depflag: allowed dependency types
             virtuals: allowed virtuals
         """
@@ -1833,7 +1833,7 @@ class Spec:
         """Returns a list of edges connecting this node in the DAG to children.
 
         Args:
-            name: filter dependencies by package name
+            name: filter dependencies by package name; ``""`` selects anonymous dependencies
             depflag: allowed dependency types
             virtuals: allowed virtuals
         """
@@ -1879,7 +1879,7 @@ class Spec:
         """Returns a list of direct dependencies (nodes in the DAG)
 
         Args:
-            name: filter dependencies by package name
+            name: filter dependencies by package name; ``""`` selects anonymous dependencies
             deptype: allowed dependency types
             virtuals: allowed virtuals
         """
@@ -1895,7 +1895,7 @@ class Spec:
         """Return a list of direct dependents (nodes in the DAG).
 
         Args:
-            name: filter dependents by package name
+            name: filter dependents by package name; ``""`` selects anonymous dependents
             deptype: allowed dependency types
         """
         if not isinstance(deptype, dt.DepFlag):
@@ -3219,15 +3219,9 @@ class Spec:
 
         changed = False
         for other_edge in other.edges_to_dependencies():
-            # Find the first edge in self that matches other_edge by name and when clause. The
-            # name comparison is explicit: an empty name does not filter, so for an anonymous
-            # dependency the loop sees every edge, and an anonymous constraint merges only into
-            # an anonymous edge.
+            # Find the first edge in self that matches other_edge by name and when clause.
             for self_edge in self.edges_to_dependencies(other_edge.spec.name):
-                if (
-                    self_edge.spec.name == other_edge.spec.name
-                    and self_edge.when == other_edge.when
-                ):
+                if self_edge.when == other_edge.when:
                     changed |= self_edge._constrain(other_edge)
                     break
             else:

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -3217,14 +3217,17 @@ class Spec:
         if not other._intersects_dependencies(self, resolve_virtuals=resolve_virtuals):
             raise UnsatisfiableDependencySpecError(other, self)
 
-        for d in other.traverse(root=False):
-            if not d.name:
-                raise UnconstrainableDependencySpecError(other)
         changed = False
         for other_edge in other.edges_to_dependencies():
-            # Find the first edge in self that matches other_edge by name and when clause.
+            # Find the first edge in self that matches other_edge by name and when clause. The
+            # name comparison is explicit: an empty name does not filter, so for an anonymous
+            # dependency the loop sees every edge, and an anonymous constraint merges only into
+            # an anonymous edge.
             for self_edge in self.edges_to_dependencies(other_edge.spec.name):
-                if self_edge.when == other_edge.when:
+                if (
+                    self_edge.spec.name == other_edge.spec.name
+                    and self_edge.when == other_edge.when
+                ):
                     changed |= self_edge._constrain(other_edge)
                     break
             else:
@@ -6000,15 +6003,6 @@ class UnsatisfiableDependencySpecError(spack.error.UnsatisfiableSpecError):
 
     def __init__(self, provided, required):
         super().__init__(provided, required, "dependency")
-
-
-class UnconstrainableDependencySpecError(spack.error.SpecError):
-    """Raised when attempting to constrain by an anonymous dependency spec"""
-
-    def __init__(self, spec):
-        msg = "Cannot constrain by spec '%s'. Cannot constrain by a" % spec
-        msg += " spec containing anonymous dependencies"
-        super().__init__(msg)
 
 
 class AmbiguousHashError(spack.error.SpecError):

--- a/lib/spack/spack/test/spec_dag.py
+++ b/lib/spack/spack/test/spec_dag.py
@@ -935,6 +935,25 @@ class TestSpecDag:
         assert len(mpileaks["libelf"].edges_from_dependents(depflag=dt.LINK)) == 2
 
 
+def test_query_edges_empty_name_selects_anonymous():
+    """name=None selects all edges, name="" selects edges to anonymous specs."""
+    spec = Spec("foo@1 ^*@2 ^bar@3")
+    assert len(spec.edges_to_dependencies()) == 2
+
+    anonymous = spec.edges_to_dependencies("")
+    assert len(anonymous) == 1
+    assert anonymous[0].spec.satisfies("@2")
+    assert spec[""] is anonymous[0].spec
+
+    bar = spec.edges_to_dependencies("bar")[0].spec
+    assert len(bar.edges_from_dependents("")) == 0
+    assert len(bar.edges_from_dependents("foo")) == 1
+
+    # the root of "^bar@3" is anonymous
+    bar = Spec("^bar@3").edges_to_dependencies("bar")[0].spec
+    assert len(bar.edges_from_dependents("")) == 1
+
+
 def test_tree_cover_nodes_reduce_deptype():
     """Test that tree output with deptypes sticks to the sub-dag of interest, instead of looking
     at in-edges from nodes not reachable from the root."""

--- a/lib/spack/spack/test/spec_semantics.py
+++ b/lib/spack/spack/test/spec_semantics.py
@@ -2076,6 +2076,23 @@ def test_constrain_dependencies_copies(mock_packages):
     assert y == Spec("^foo")
 
 
+def test_constrain_with_anonymous_dependency(mock_packages):
+    """Edges to anonymous specs can be constrained."""
+    spec = Spec("pkg-a ^*@2")
+    assert spec.satisfies(spec)
+    assert spec.intersects(spec)
+    assert spec.constrain("pkg-a ^*@2") is False
+
+    forward, backward = Spec("").constrained(spec), spec.constrained("")
+    assert forward.to_dict() == backward.to_dict() == spec.to_dict()
+
+    # an anonymous dependency merges only into an anonymous edge, never into a named one
+    named, anonymous = Spec("pkg-a ^pkg-b@2"), Spec("pkg-a ^*@2")
+    forward, backward = named.constrained(anonymous), anonymous.constrained(named)
+    assert forward.to_dict() == backward.to_dict()
+    assert len(forward.edges_to_dependencies()) == 2
+
+
 def test_abstract_hash_intersects_and_satisfies(config, mock_packages):
     concrete: Spec = spack.concretize.concretize_one("pkg-a")
     hash = concrete.dag_hash()


### PR DESCRIPTION
`constrain` raises `UnconstrainableDependencySpecError` only if an anonymous dep is on the right-hand side, which leads to two bugs: constrain is not commutative nor idempotent.

```python
>>> Spec("^*+bvv").constrained("")
^+bvv
>>> Spec("").constrained("^*+bvv")
UnconstrainableDependencySpecError: Cannot constrain by spec '^+bvv'. Cannot constrain by a spec containing anonymous dependencies
>>> s = Spec("pkg-a ^*@2")
>>> s.constrained(s)
UnconstrainableDependencySpecError: Cannot constrain by spec 'pkg-a ^@2'. Cannot constrain by a spec containing anonymous dependencies
```

The solution in to treat `name == ""` as any other name, meaning that `%+foo` and `%+bar` merge as `%+foo+bar`. Pushing it further by leaving `%+foo %+bar` as separate constraints could work too, but requires more special casing, and it could be relaxed in the future. For now, keep it simple.