### PR TITLE
spec.py: edge queries distinguish name=None from name=""

### DIFF
--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -1121,8 +1121,8 @@ def _select_edges(
 
     Args:
         edge_map: map of edges to select from
-        parent: name of the parent package
-        child: name of the child package
+        parent: name of the parent package; ``""`` selects anonymous parents
+        child: name of the child package; ``""`` selects anonymous children
         depflag: allowed dependency types in flag form
         virtuals: list of virtuals or specific virtual on the edge
     """
@@ -1133,11 +1133,11 @@ def _select_edges(
     selected: Iterable[DependencySpec] = itertools.chain.from_iterable(edge_map.values())
 
     # Filter by parent name
-    if parent:
+    if parent is not None:
         selected = (d for d in selected if d.parent.name == parent)
 
     # Filter by child name
-    if child:
+    if child is not None:
         selected = (d for d in selected if d.spec.name == child)
 
     # Filter by allowed dependency types
@@ -1820,7 +1820,7 @@ class Spec:
         to parents.
 
         Args:
-            name: filter dependents by package name
+            name: filter dependents by package name; ``""`` selects anonymous dependents
             depflag: allowed dependency types
             virtuals: allowed virtuals
         """
@@ -1836,7 +1836,7 @@ class Spec:
         """Returns a list of edges connecting this node in the DAG to children.
 
         Args:
-            name: filter dependencies by package name
+            name: filter dependencies by package name; ``""`` selects anonymous dependencies
             depflag: allowed dependency types
             virtuals: allowed virtuals
         """
@@ -1882,7 +1882,7 @@ class Spec:
         """Returns a list of direct dependencies (nodes in the DAG)
 
         Args:
-            name: filter dependencies by package name
+            name: filter dependencies by package name; ``""`` selects anonymous dependencies
             deptype: allowed dependency types
             virtuals: allowed virtuals
         """
@@ -1898,7 +1898,7 @@ class Spec:
         """Return a list of direct dependents (nodes in the DAG).
 
         Args:
-            name: filter dependents by package name
+            name: filter dependents by package name; ``""`` selects anonymous dependents
             deptype: allowed dependency types
         """
         if not isinstance(deptype, dt.DepFlag):

--- a/lib/spack/spack/test/spec_dag.py
+++ b/lib/spack/spack/test/spec_dag.py
@@ -935,6 +935,25 @@ class TestSpecDag:
         assert len(mpileaks["libelf"].edges_from_dependents(depflag=dt.LINK)) == 2
 
 
+def test_query_edges_empty_name_selects_anonymous():
+    """name=None selects all edges, name="" selects edges to anonymous specs."""
+    spec = Spec("foo@1 ^*@2 ^bar@3")
+    assert len(spec.edges_to_dependencies()) == 2
+
+    anonymous = spec.edges_to_dependencies("")
+    assert len(anonymous) == 1
+    assert anonymous[0].spec.satisfies("@2")
+    assert spec[""] is anonymous[0].spec
+
+    bar = spec.edges_to_dependencies("bar")[0].spec
+    assert len(bar.edges_from_dependents("")) == 0
+    assert len(bar.edges_from_dependents("foo")) == 1
+
+    # the root of "^bar@3" is anonymous
+    bar = Spec("^bar@3").edges_to_dependencies("bar")[0].spec
+    assert len(bar.edges_from_dependents("")) == 1
+
+
 def test_tree_cover_nodes_reduce_deptype():
     """Test that tree output with deptypes sticks to the sub-dag of interest, instead of looking
     at in-edges from nodes not reachable from the root."""


### PR DESCRIPTION
The name filter of `edges_to_dependencies`, `edges_from_dependents`, `dependencies` and `dependents` tested truthiness, so passing `""` returned every edge and there was no way to select edges to anonymous specs.

Treat `None` as "no filter" and `""` as "edges to anonymous specs", matching the virtuals filter in `_select_edges`:

```python
>>> Spec("foo@1 ^*@2 ^bar@3").edges_to_dependencies("")
[DependencySpec('foo@1', '@2', depflag=0, virtuals=())]
```

Anonymous edges are stored under the `""` key of the edge map, so it's natural. It also shouldn't change `spec[""]` behavior, which already filtered `name == ""`.