### PR TITLE
Revert 52841

### DIFF
--- a/lib/spack/spack/cmd/concretize.py
+++ b/lib/spack/spack/cmd/concretize.py
@@ -38,7 +38,7 @@ def concretize(parser, args):
     if args.test == "all":
         tests = True
     elif args.test == "root":
-        tests = [spec.name for spec in env.all_user_specs]
+        tests = [spec.name for spec in env.user_specs]
     else:
         tests = False
 

--- a/lib/spack/spack/cmd/env.py
+++ b/lib/spack/spack/cmd/env.py
@@ -1053,7 +1053,7 @@ def env_depfile(args):
     # Warn in case we're generating a depfile for an empty environment. We don't automatically
     # concretize; the user should do that explicitly. Could be changed in the future if requested.
     if model.empty:
-        if not env.all_user_specs:
+        if not env.user_specs:
             tty.warn("no specs in the environment")
         elif filter_specs is not None:
             tty.warn("no concrete matching specs found in environment")

--- a/lib/spack/spack/cmd/install.py
+++ b/lib/spack/spack/cmd/install.py
@@ -358,7 +358,7 @@ def _maybe_add_and_concretize(args, env, specs):
                 env.add(spec)
 
         # `spack concretize`
-        tests = compute_tests_install_kwargs(env.all_user_specs, args.test)
+        tests = compute_tests_install_kwargs(env.user_specs, args.test)
         concretized_specs = env.concretize(tests=tests, ui=TerminalUI())
         if concretized_specs:
             tty.msg(f"Concretized {plural(len(concretized_specs), 'spec')}")

--- a/lib/spack/spack/cmd/spec.py
+++ b/lib/spack/spack/cmd/spec.py
@@ -90,11 +90,6 @@ def spec(parser, args):
     if args.specs:
         concrete_specs = spack.cmd.parse_specs(args.specs, concretize=True, ui=ui)
     elif env:
-        if not env.all_user_specs:
-            args.subparser.error(
-                "active environment has no root specs, please provide at least one spec"
-            )
-
         env.concretize(ui=ui)
         concrete_specs = env.concrete_roots()
     else:

--- a/lib/spack/spack/environment/environment.py
+++ b/lib/spack/spack/environment/environment.py
@@ -1309,15 +1309,6 @@ class Environment:
         key = self._user_specs_key(group=group)
         return self.spec_lists[key]
 
-    @property
-    def all_user_specs(self) -> SpecList:
-        """Returns all user specs from all groups in the environment."""
-        spec_list = SpecList()
-        for group in self.manifest.groups():
-            for spec in self.user_specs_by(group=group):
-                spec_list.add(spec)
-        return spec_list
-
     def explicit_roots(self):
         for x in self.concretized_roots:
             if self.manifest.is_explicit(group=x.group):

--- a/lib/spack/spack/environment/list.py
+++ b/lib/spack/spack/environment/list.py
@@ -105,10 +105,6 @@ class SpecList:
     def __len__(self):
         return len(self.specs)
 
-    def __bool__(self):
-        """Return True if the SpecList contains any specs, False if empty."""
-        return bool(self.yaml_list)
-
     def __getitem__(self, key):
         return self.specs[key]
 

--- a/lib/spack/spack/test/cmd/spec.py
+++ b/lib/spack/spack/test/cmd/spec.py
@@ -173,53 +173,6 @@ def test_env_aware_spec(mutable_mock_env_path):
         assert "mpich@3.0.4" in output
 
 
-def test_env_without_spec_error(mutable_mock_env_path):
-    """Verify that `spack spec` fails when the active environment has no root specs."""
-    env = ev.create("test")
-    with env:
-        with pytest.raises(SpackCommandError, match="Spack command failed with exit code 2") as e:
-            spec()
-        error_msg = "active environment has no root specs"
-        assert error_msg in e.value.output
-
-
-def test_spec_shows_specs_from_named_groups(mutable_mock_env_path):
-    """Test that spack spec shows specs from named groups, not just default group."""
-    env = ev.create("test")
-
-    # Add spec to a named group (not in default)
-    env.manifest.add_user_spec("mpileaks", group="software")
-    env.write()
-
-    # Reload environment to pick up the new group
-    env = ev.read("test")
-
-    with env:
-        output = spec()
-        assert "mpileaks" in output
-
-
-def test_spec_shows_specs_from_all_groups(mutable_mock_env_path):
-    """Test that spack spec shows specs from both default and named groups together."""
-    env = ev.create("test")
-
-    # Add spec to named group
-    env.manifest.add_user_spec("mpileaks", group="software")
-    env.write()
-
-    # Add spec to default group
-    env.add("cmake")
-    env.write()
-
-    # Reload environment
-    env = ev.read("test")
-
-    with env:
-        output = spec()
-        assert "cmake" in output
-        assert "mpileaks" in output
-
-
 @pytest.mark.parametrize(
     "name, version, error",
     [


### PR DESCRIPTION
reverts "Fix `spack spec` error handling and support for environment spec groups (#52841)"

This reverts commit 0980ba88bbc80008bee24972b84693edf660fa24.

