### PR TITLE
Update requirements.txt package versions in github workflows to fix CVEs

### DIFF
--- a/.github/workflows/requirements/style/requirements.txt
+++ b/.github/workflows/requirements/style/requirements.txt
@@ -1,4 +1,4 @@
-black==25.12.0
+black==26.3.1
 clingo==5.8.0
 flake8==7.3.0
 isort==7.0.0

--- a/.github/workflows/requirements/unit_tests/requirements.txt
+++ b/.github/workflows/requirements/unit_tests/requirements.txt
@@ -2,3 +2,4 @@ pytest==9.0.3
 pytest-cov==7.1.0
 pytest-xdist==3.8.0
 coverage[toml]<=7.11.0
+pygments==2.20.0

--- a/lib/spack/docs/requirements.txt
+++ b/lib/spack/docs/requirements.txt
@@ -8,3 +8,4 @@ furo==2025.12.19
 docutils==0.22.4
 pygments==2.20.0
 pytest==9.1.1
+idna==3.15


### PR DESCRIPTION
These were discovered using osv-scanner.

Update idna to 3.15
  
  idna@3.0.0 has a medium-severity vulnerability CVE-2026-45409
  (PYSEC-2026-215) fixed in 3.15.

  This appears to be a transitive dependency.

Update pygments to 2.20.0
  
  pygments@2.9.0 has a medium-severity vulnerability CVE-2022-40896
  (PYSEC-2023-117) fixed in 2.15.1.
  
  pygments@2.9.0 has a low-severity vulnerability CVE-2026-4539
  (PYSEC-2026-2987) fixed in 2.20.0.

Update black to 26.3.1
    
  black@25.12.0 has a critical vulnerability CVE-2026-31900
  (PYSEC-2026-2120) fixed in 26.3.0.
  
  black@25.12.0 has a high-severity vulnerability CVE-2026-32274
  (PYSEC-2026-2121) fixed in 26.3.1.

  This appears to be a transitive dependency.