### PR TITLE
stage: try all mirror layout paths when fetching from mirrors

### DIFF
--- a/lib/spack/spack/stage.py
+++ b/lib/spack/spack/stage.py
@@ -496,7 +496,7 @@ class Stage(AbstractStage):
             fnames.append(url_util.default_download_filename(self.default_fetcher.url))
 
         if self.mirror_layout:
-            fnames.append(os.path.basename(self.mirror_layout.path))
+            fnames.extend(os.path.basename(path) for path in self.mirror_layout)
 
         paths = [os.path.join(self.path, f) for f in fnames]
         if not expanded:
@@ -561,16 +561,19 @@ class Stage(AbstractStage):
         # TODO: CompositeFetchStrategy here.
         if not self.default_fetcher_only and self.mirror_layout and self.mirrors:
             # Add URL strategies for all the mirrors with the digest
-            # Insert fetchers in the order that the URLs are provided.
+            # Insert fetchers in the order that the URLs are provided. Try all paths of the
+            # mirror layout (e.g. both the digest-based storage path and the human-readable
+            # alias), since a mirror may only have the resource under one of them.
             fetchers[:0] = (
                 fs.from_url_scheme(
-                    url_util.join(mirror.fetch_url, *self.mirror_layout.path.split(os.sep)),
+                    url_util.join(mirror.fetch_url, *rel_path.split(os.sep)),
                     checksum=digest,
                     expand=expand,
                     extension=extension,
                 )
                 for mirror in self.mirrors
                 if not spack.oci.image.is_oci_url(mirror.fetch_url)  # no support for mirrors yet
+                for rel_path in self.mirror_layout
             )
 
         if not self.default_fetcher_only and self.mirror_layout and self.default_fetcher.cachable:

--- a/lib/spack/spack/test/stage.py
+++ b/lib/spack/spack/test/stage.py
@@ -18,6 +18,8 @@ import pytest
 import spack.config
 import spack.error
 import spack.fetch_strategy
+import spack.mirrors.layout
+import spack.mirrors.mirror
 import spack.stage
 import spack.util.executable
 import spack.util.url as url_util
@@ -533,6 +535,32 @@ class TestStage:
 
         check_destroy(stage, self.stage_name)
         assert search_fn.performed_search
+
+    def test_fetch_from_mirror_with_only_alias_path(self, mock_stage_archive, tmp_path):
+        """A mirror that only has the human-readable per-package alias (not the digest-based
+        ``_source-cache`` storage path) should still be usable."""
+        archive = mock_stage_archive()
+
+        # A layout whose primary (digest) path does not exist on the mirror; only the
+        # human-readable alias does.
+        layout = spack.mirrors.layout.DefaultLayout(
+            alias_path=os.path.join("test-files", _archive_fn),
+            digest_path=os.path.join("_source-cache", "archive", "ab", "abc123.tar.gz"),
+        )
+        mirror_root = tmp_path / "mirror"
+        (mirror_root / "test-files").mkdir(parents=True)
+        shutil.copy(str(archive.tmpdir / _archive_fn), str(mirror_root / layout.alias))
+
+        mirror = spack.mirrors.mirror.Mirror(url_util.path_to_file_url(str(mirror_root)))
+        stage = Stage(
+            FailingFetchStrategy(), name=self.stage_name, mirror_paths=layout, mirrors=[mirror]
+        )
+        with stage:
+            stage.fetch(mirror_only=True)
+            assert stage.archive_file is not None
+            stage.expand_archive()
+            assert stage.expanded
+        check_destroy(stage, self.stage_name)
 
     def test_ensure_one_stage_entry(self, mock_stage_archive):
         archive = mock_stage_archive()


### PR DESCRIPTION
Previously, Stage._generate_fetchers only tried the primary storage path of the mirror layout (MirrorLayout.path). For checksummed packages this is the content-addressed path, meaning the human-readable path (e.g. `zlib/zlib-1.2.13.tar.gz`) was never consulted, even if it was the only one that existed.

Iterate over all paths the layout advertises (content-addressed path first, then alias) when constructing mirror fetchers, and consider all layout basenames in expected_archive_files.

Assisted-by: Claude Fable 5 