### PR TITLE
spec.py: fix absorption for virtual and anonymous edges

### DIFF
--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -2912,6 +2912,14 @@ class SpackSolverSetup:
         for root in specs:
             for s in root.traverse():
                 if repo.is_virtual(s.name):
+                    # Constraints beyond versions could refer to the virtual or its provider;
+                    # the solver supports neither interpretation.
+                    if not spack.spec.constrains_only_name_and_versions(s):
+                        start_str = f"'{root}'" if s == root else f"'{s}' in '{root}'"
+                        raise UnsatisfiableSpecError(
+                            f"cannot concretize {start_str}: the virtual package '{s.name}' "
+                            f"supports only version constraints"
+                        )
                     continue
 
                 try:

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -1605,7 +1605,7 @@ def _satisfies_dependencies(lhs: "Spec", rhs: "Spec", *, resolve_virtuals: bool)
     return True
 
 
-def _constrains_only_name_and_versions(spec: "Spec") -> bool:
+def constrains_only_name_and_versions(spec: "Spec") -> bool:
     """Whether the spec constrains nothing beyond its package name and versions."""
     return (
         not spec.variants
@@ -1644,7 +1644,7 @@ def _satisfies_edge_attributes(
     # Right-hand side is a virtual provided by the left-hand side. Virtuals currently support only
     # names and versions, so if anything else is set on the rhs we return false, which allows
     # future implementation to relax it once variants on virtuals become meaningful.
-    if not _constrains_only_name_and_versions(rhs.spec):
+    if not constrains_only_name_and_versions(rhs.spec):
         return False
 
     if rhs.spec.versions == spack.version.any_version:

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -1605,6 +1605,18 @@ def _satisfies_dependencies(lhs: "Spec", rhs: "Spec", *, resolve_virtuals: bool)
     return True
 
 
+def _constrains_only_name_and_versions(spec: "Spec") -> bool:
+    """Whether the spec constrains nothing beyond its package name and versions."""
+    return (
+        not spec.variants
+        and not spec.compiler_flags
+        and spec.architecture is None
+        and spec.namespace is None
+        and not spec.abstract_hash
+        and not spec._dependencies
+    )
+
+
 def _satisfies_edge_attributes(
     lhs: "DependencySpec", rhs: "DependencySpec", resolve_virtuals: bool
 ) -> bool:
@@ -1629,9 +1641,12 @@ def _satisfies_edge_attributes(
     if not name_mismatch:
         return lhs.spec._satisfies_node(rhs.spec, resolve_virtuals=resolve_virtuals)
 
-    # Right-hand side is virtual provided by left-hand side. The only node attribute supported is
-    # the version of the virtual. Avoid expensive lookups for provider metadata if there's no
-    # version constraint to check.
+    # Right-hand side is a virtual provided by the left-hand side. Virtuals currently support only
+    # names and versions, so if anything else is set on the rhs we return false, which allows
+    # future implementation to relax it once variants on virtuals become meaningful.
+    if not _constrains_only_name_and_versions(rhs.spec):
+        return False
+
     if rhs.spec.versions == spack.version.any_version:
         return True
 
@@ -1678,11 +1693,14 @@ def _satisfies_edge(lhs: DependencySpec, rhs: DependencySpec, resolve_virtuals: 
 def _edge_is_redundant(
     edge: DependencySpec, given: DependencySpec, resolve_virtuals: bool
 ) -> bool:
-    """Whether ``edge`` adds nothing to ``given``: ``given`` satisfies it, and it states no
-    propagation ``given`` does not. A propagated edge is an input to the solver's objective even
-    where it does not narrow the solution set, so satisfaction alone does not make it redundant."""
+    # %foo and %%foo satisfy each other in both directions; they do not restrict the solution space
+    # but only influence optimality. That means that edge redundancy cannot be based on satisfies
+    # only, hence the exception.
     if edge.propagation != PropagationPolicy.NONE and given.propagation != edge.propagation:
         return False
+    if edge.spec.name != given.spec.name:
+        # keep ^mpi@3 next to ^mpi=mpich@3: whether mpich@3 provides mpi@3 is package metadata
+        resolve_virtuals = False
     return _satisfies_edge(given, edge, resolve_virtuals)
 
 
@@ -2100,10 +2118,12 @@ class Spec:
         and is appended as a parallel edge: whether it ends up sharing a node with another edge
         to the same name is for concretization to decide.
 
-        All scans compare only edges to the same package name: a ``^virtual`` edge and a
-        ``^[virtuals=virtual] provider`` edge are independent requirements and stay apart.
-        Anonymous edges share the ``""`` bucket, where only the redundancy scans apply:
-        without a name, two direct deps can be distinct dependencies.
+        The ``_same_direct_dep`` scan compares pairs with identical package names only, because
+        anonymous specs can refer to different nodes. The redundancy scans compare every pair of
+        edges. Across different names the comparison does not resolve virtuals, so a ``^virtual``
+        edge is redundant only against an edge listing it in its ``virtuals`` attribute, and
+        only when it constrains nothing but the name. An anonymous edge is redundant when any edge
+        satisfies it; a named edge is never redundant against an anonymous one.
 
         Returns True if ``self`` changed.
 
@@ -2126,7 +2146,9 @@ class Spec:
                     break
 
         if merged_edge is None and any(
-            _edge_is_redundant(candidate, edge, resolve_virtuals) for edge in bucket
+            _edge_is_redundant(candidate, edge, resolve_virtuals)
+            for edges in self._dependencies.values()
+            for edge in edges
         ):
             return False
 
@@ -2135,7 +2157,8 @@ class Spec:
 
         for edge in [
             edge
-            for edge in bucket
+            for edges in self._dependencies.values()
+            for edge in edges
             if edge is not merged_edge and _edge_is_redundant(edge, candidate, resolve_virtuals)
         ]:
             self._detach_edge(edge)

--- a/lib/spack/spack/test/concretization/errors.py
+++ b/lib/spack/spack/test/concretization/errors.py
@@ -90,6 +90,27 @@ def test_nonexistent_version_error(spec, mock_packages, mutable_config):
         _ = spack.concretize.concretize_one(spec)
 
 
+@pytest.mark.parametrize(
+    "spec",
+    [
+        "mpileaks ^mpi target=x86_64",
+        "mpileaks %mpi target=x86_64",
+        "mpileaks ^mpi+debug",
+        "mpi cflags=-O2",
+    ],
+)
+def test_virtual_constrained_beyond_versions_error(spec, mock_packages, mutable_config):
+    # Virtual specs support only version constraints: anything else is reserved, since it could
+    # denote a property of the virtual or of its provider.
+    with pytest.raises(
+        spack.solver.asp.UnsatisfiableSpecError,
+        match="the virtual package 'mpi' supports only version constraints",
+    ) as e:
+        _ = spack.concretize.concretize_one(spec)
+
+    assert "cannot concretize" in str(e.value)
+
+
 def test_internal_error_handling_formatting(tmp_path: pathlib.Path):
     log = StringIO()
     input_to_output = [

--- a/lib/spack/spack/test/spec_semantics.py
+++ b/lib/spack/spack/test/spec_semantics.py
@@ -2935,6 +2935,94 @@ def test_two_providers_of_one_virtual_merge_as_parallel_edges(mock_packages):
     assert forward.to_dict() == backward.to_dict()
 
 
+def test_bare_virtual_edge_is_absorbed_by_a_provider_edge(mock_packages):
+    """A bare '^mpi' edge is satisfied by any '^[virtuals=mpi] provider' edge, so the merge
+    keeps only the provider edge, whichever side it comes from."""
+    provider = Spec("pkg-a ^[virtuals=mpi] mpich")
+    assert provider.satisfies("pkg-a ^mpi")
+
+    forward = provider.copy()
+    assert forward.constrain("pkg-a ^mpi") is False
+    assert forward.to_dict() == provider.to_dict()
+
+    backward = Spec("pkg-a ^mpi").constrained(provider)
+    assert backward.to_dict() == provider.to_dict()
+
+    assert Spec("pkg-a ^mpi ^mpi=mpich").to_dict() == provider.to_dict()
+    assert Spec("pkg-a ^mpi=mpich ^mpi").to_dict() == provider.to_dict()
+
+
+@pytest.mark.parametrize(
+    "spec_str",
+    [
+        "pkg-a ^mpi@3 ^mpi=mpich",
+        "pkg-a ^mpi@3 ^[virtuals=mpi] mpich@3",
+        "pkg-a ^mpi+debug ^mpi=mpich",
+    ],
+)
+def test_constrained_virtual_edge_stays_apart_from_a_provider_edge(mock_packages, spec_str):
+    """A virtual's version, variants and other attributes are unrelated to the provider's, so
+    only a bare virtual edge is absorbed; anything more constrained is its own requirement."""
+    assert len(Spec(spec_str).edges_to_dependencies()) == 2
+
+
+def test_bare_direct_virtual_edge_is_absorbed_by_a_provider_edge(mock_packages):
+    """The same rule for direct deps: '%c' adds nothing next to '%c=gcc'."""
+    provider = Spec("pkg-a %c=gcc")
+    assert Spec("pkg-a %c %c=gcc").to_dict() == provider.to_dict()
+    assert Spec("pkg-a %c=gcc %c").to_dict() == provider.to_dict()
+
+
+@pytest.mark.parametrize(
+    "lhs,rhs",
+    [
+        ("pkg-a ^mpi=mpich", "pkg-a ^mpi+debug"),
+        ("pkg-a ^mpi=mpich~debug", "pkg-a ^mpi+debug"),
+        ("pkg-a %mpi=mpich", "pkg-a %mpi+debug"),
+    ],
+)
+def test_provider_edge_does_not_satisfy_a_constrained_virtual(mock_packages, lhs, rhs):
+    """A virtual's variants and other non-version attributes have no defined meaning, so a
+    provider edge does not satisfy them, whatever the provider's own attributes say."""
+    assert not Spec(lhs).satisfies(rhs)
+
+
+def test_constrained_virtual_and_provider_edge_are_parallel_edges(mock_packages):
+    """The pairs above still intersect, and constrain keeps the two requirements side by
+    side."""
+    lhs = Spec("pkg-a ^mpi=mpich")
+    assert lhs.intersects("pkg-a ^mpi+debug")
+    assert len(lhs.constrained("pkg-a ^mpi+debug").edges_to_dependencies()) == 2
+
+
+def test_anonymous_edge_is_absorbed_by_a_satisfying_named_edge(mock_packages):
+    """An anonymous edge requires some dependency to match it, so a named edge satisfying it
+    makes it redundant, from either side of the merge."""
+    named = Spec("%bar+foo")
+    assert named.satisfies("%+foo")
+
+    forward = named.copy()
+    assert forward.constrain("%+foo") is False
+    assert forward.to_dict() == named.to_dict()
+
+    backward = Spec("%+foo").constrained(named)
+    assert backward.to_dict() == named.to_dict()
+
+    transitive = Spec("pkg-a ^pkg-b@2")
+    assert transitive.constrain("pkg-a ^*@2") is False
+
+
+def test_anonymous_edge_not_satisfied_by_a_named_edge_stays(mock_packages):
+    """A named edge that does not satisfy the anonymous requirement leaves it in place."""
+    assert len(Spec("pkg-a ^pkg-b@1 ^*@2").edges_to_dependencies()) == 2
+
+
+def test_propagated_bare_virtual_edge_is_not_absorbed(mock_packages):
+    """A propagated edge is an input to the solver's objective, so a non-propagating provider
+    edge does not make it redundant."""
+    assert len(Spec("pkg-a %%c %c=gcc").edges_to_dependencies()) == 2
+
+
 def test_two_providers_under_conditions_that_exclude_each_other_are_fine(mock_packages):
     """Only one provider can be the one at a time, so two of them named under conditions that
     cannot hold together are not in each other's way."""
@@ -3004,7 +3092,7 @@ def test_two_versions_of_one_provider_of_a_virtual_intersect(mock_packages):
 
 def test_an_anonymous_dependency_is_a_parallel_edge(mock_packages):
     """An edge with an anonymous target requires some dependency to match it. Constrain appends
-    it as a parallel edge, and discards it only when an existing anonymous edge satisfies it."""
+    it as a parallel edge, and discards it when an existing edge satisfies it."""
     # idempotency: the meet of a spec with itself is itself
     spec = Spec("pkg-a ^*@2")
     assert spec.satisfies(spec)

--- a/lib/spack/spack/test/spec_semantics.py
+++ b/lib/spack/spack/test/spec_semantics.py
@@ -2979,6 +2979,8 @@ def test_bare_direct_virtual_edge_is_absorbed_by_a_provider_edge(mock_packages):
         ("pkg-a ^mpi=mpich", "pkg-a ^mpi+debug"),
         ("pkg-a ^mpi=mpich~debug", "pkg-a ^mpi+debug"),
         ("pkg-a %mpi=mpich", "pkg-a %mpi+debug"),
+        ("pkg-a ^mpi=mpich", "pkg-a ^mpi %gcc"),
+        ("pkg-a ^mpi=mpich", "pkg-a ^mpi target=x86_64"),
     ],
 )
 def test_provider_edge_does_not_satisfy_a_constrained_virtual(mock_packages, lhs, rhs):
@@ -2990,9 +2992,11 @@ def test_provider_edge_does_not_satisfy_a_constrained_virtual(mock_packages, lhs
 def test_constrained_virtual_and_provider_edge_are_parallel_edges(mock_packages):
     """The pairs above still intersect, and constrain keeps the two requirements side by
     side."""
-    lhs = Spec("pkg-a ^mpi=mpich")
-    assert lhs.intersects("pkg-a ^mpi+debug")
-    assert len(lhs.constrained("pkg-a ^mpi+debug").edges_to_dependencies()) == 2
+    lhs, rhs = Spec("pkg-a ^mpi=mpich"), Spec("pkg-a ^mpi+debug")
+    assert lhs.intersects(rhs)
+    assert lhs.constrain(rhs)
+    assert len(lhs.edges_to_dependencies()) == 2
+    assert lhs.to_dict() == Spec("pkg-a ^mpi=mpich ^mpi+debug").to_dict()
 
 
 def test_anonymous_edge_is_absorbed_by_a_satisfying_named_edge(mock_packages):


### PR DESCRIPTION
`x.satisfies(y)` implies that `x.constrain(y)` is a no-op, or x ≤ y iff x = x ∧ y.

Three cases on develop break that it, two due to bugs in constrain, the third
due to a bug in satisfies.

Fix a bug where a bare `^virtual` edge next to a provider edge that satisfies
it is kept as a parallel edge:

```python
>>> s = Spec("pkg-a ^[virtuals=mpi] mpich")
>>> s.satisfies("pkg-a ^mpi")
True
>>> s.constrain("pkg-a ^mpi")
True  # wrong: the constraint was already satisfied
>>> s
pkg-a ^mpi ^mpi=mpich  # wrong: the bare edge is redundant
```

Fix a similar bug where an edge to an anonymous spec is kept even if already
implied by a spec with a name:

```python
>>> s = Spec("%bar+foo")
>>> s.satisfies("%+foo")
True
>>> s.constrain("%+foo")
True  # wrong
>>> s
%+foo %bar+foo  # wrong: the anonymous edge is redundant
```

Another bug is in satisfies, which returns true when the rhs is a virtual with
attributes other than name/version. That's inconsistent with constrain
producing parallel edges:

```python
>>> Spec("pkg-a ^mpi=mpich").satisfies("pkg-a ^mpi+debug")
True  # wrong: variants on a virtual have no defined meaning
>>> Spec("pkg-a ^mpi=mpich").constrained("pkg-a ^mpi+debug")
pkg-a ^mpi+debug ^mpi=mpich  # correct
```
