### PR TITLE
mirror: content addressed mirrors only

### DIFF
--- a/lib/spack/docs/mirrors.rst
+++ b/lib/spack/docs/mirrors.rst
@@ -25,33 +25,26 @@ Here's an example of a mirror's directory structure:
 .. code-block:: none
 
    mirror/
-       cmake/
-           cmake-2.8.10.2.tar.gz
-       dyninst/
-           dyninst-8.1.1.tgz
-           dyninst-8.1.2.tgz
-       libdwarf/
-           libdwarf-20130126.tar.gz
-           libdwarf-20130207.tar.gz
-           libdwarf-20130729.tar.gz
-       libelf/
-           libelf-0.8.12.tar.gz
-           libelf-0.8.13.tar.gz
-       libunwind/
-           libunwind-1.1.tar.gz
-       mpich/
-           mpich-3.0.4.tar.gz
-       mvapich2/
-           mvapich2-1.9.tgz
+       _source-cache/
+           archive/
+               2e/
+                   2e197bcb6fd44dbf82652e04968b307c73545e01d5c5df04a1f28eef1a081fe4.tar.gz
+               63/
+                   63074c85be23615383579176d891e9464244d4dcb44ca9a4bdadd7bd9d84a0d8.tar.gz
+               a6/
+                   a667318a44e3f749721cc630f2cb5541b0f542e934c188280b7075fd6f8e2ee1.tar.gz
+           git/
+               my-git-hosting.example.com/
+                   my-project.git/
+                       8d24b17801d9d78a45892e42a7169eb6f1d4c26d.tar.gz
 
-The structure is very simple.
-There is a top-level directory.
-The second level directories are named after packages, and the third level contains tarballs for each package, named after each package.
+Mirror entries are stored *content-addressed*: archives live under ``_source-cache/archive/`` in directories named after the first two characters of their checksum, and each archive is named after its full checksum.
+Archives of version control checkouts (e.g. git repositories at a specific commit) are stored under a directory named after the fetch method, repository URL, and revision.
 
 .. note::
 
-   Archives are **not** named exactly the way they were in the package's fetch URL.
-   They have the form ``<name>-<version>.<extension>``, where ``<name>`` is Spack's name for the package, ``<version>`` is the version of the tarball, and ``<extension>`` is whatever format the package's fetch URL contains.
+   Archives are **not** named the way they were in the package's fetch URL.
+   They have the form ``<checksum>.<extension>``, where ``<checksum>`` is the digest specified in the package recipe for that version (e.g. its ``sha256``), and ``<extension>`` is whatever format the package's fetch URL contains.
 
    In order to make mirror creation reasonably fast, we copy the tarball in its original format to the mirror directory, but we do not standardize on a particular compression algorithm, because this would potentially require expanding and recompressing each archive.
 
@@ -103,7 +96,7 @@ Here is what it looks like:
    ==> Trying to fetch from http://www.prevanders.net/libdwarf-20130729.tar.gz
    #############################################################             84.7%
    ==> Added libdwarf@20130729
-   ==> Added spack-mirror-2014-06-24/libdwarf/libdwarf-20130729.tar.gz to mirror
+   ==> Added spack-mirror-2014-06-24/_source-cache/archive/4c/4cc5e2f7b7bd6abf71d7c9c8eee6656b13c81ff8f507b3f1732fd8a00752b971.tar.gz to mirror
    ==> Added python@2.7.8.
    ==> Successfully updated mirror in spack-mirror-2015-02-24.
      Archive stats:

--- a/lib/spack/spack/cmd/mirror.py
+++ b/lib/spack/spack/cmd/mirror.py
@@ -3,6 +3,8 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 import argparse
+import hashlib
+import os
 import sys
 from concurrent.futures import as_completed
 
@@ -10,11 +12,15 @@ import spack.caches
 import spack.cmd
 import spack.concretize
 import spack.config
+import spack.fetch_strategy
 import spack.mirrors.mirror
 import spack.mirrors.utils
 import spack.repo
 import spack.spec
+import spack.stage
+import spack.util.crypto
 import spack.util.parallel
+import spack.util.url as url_util
 import spack.util.web as web_util
 from spack.active_environment import active_environment
 from spack.cmd.common import arguments
@@ -85,6 +91,13 @@ def setup_parser(subparser: argparse.ArgumentParser) -> None:
     )
     arguments.add_common_arguments(create_parser, ["specs"])
     arguments.add_concretizer_args(create_parser)
+
+    # Add-archive
+    add_archive_parser = sp.add_parser("add-archive", help=mirror_add_archive.__doc__)
+    add_archive_parser.add_argument(
+        "-d", "--directory", default=None, help="directory of the mirror to add the archive to"
+    )
+    add_archive_parser.add_argument("url", help="URL or path of the archive to add")
 
     # Destroy
     destroy_parser = sp.add_parser("destroy", help=mirror_destroy.__doc__)
@@ -368,6 +381,34 @@ def mirror_add(args):
     else:
         mirror = spack.mirrors.mirror.Mirror(args.url, name=args.name)
     spack.mirrors.utils.add(mirror, args.scope)
+
+
+def mirror_add_archive(args):
+    """add a single archive, from a URL or path, to a mirror"""
+    url = args.url
+    if os.path.exists(url):
+        url = url_util.path_to_file_url(os.path.abspath(url))
+
+    # When no directory is provided, the source cache is used, like `spack mirror create`
+    mirror_root = args.directory or spack.caches.fetch_cache_location()
+
+    fetcher = spack.fetch_strategy.URLFetchStrategy(url=url)
+    with spack.stage.Stage(fetcher) as stage:
+        stage.fetch()
+
+        # The archive is stored content-addressed, named after its sha256 checksum
+        fetcher.digest = spack.util.crypto.checksum(hashlib.sha256, stage.archive_file)
+        relative_dst = os.path.join("_source-cache", fetcher.mirror_id())
+        ext = url_util.determine_url_file_extension(url).lstrip(".")
+        if ext:
+            relative_dst += f".{ext}"
+
+        mirror_cache = spack.mirrors.utils.get_mirror_cache(mirror_root)
+        if os.path.exists(os.path.join(mirror_cache.root, relative_dst)):
+            tty.msg(f"Archive already present in mirror {mirror_root} at {relative_dst}")
+        else:
+            mirror_cache.store(fetcher, relative_dst)
+            tty.msg(f"Added archive to mirror {mirror_root} at {relative_dst}")
 
 
 def mirror_remove(args):
@@ -747,6 +788,7 @@ def mirror(parser, args):
         "create": mirror_create,
         "destroy": mirror_destroy,
         "add": mirror_add,
+        "add-archive": mirror_add_archive,
         "remove": mirror_remove,
         "rm": mirror_remove,
         "set-url": mirror_set_url,

--- a/lib/spack/spack/test/cmd/mirror.py
+++ b/lib/spack/spack/test/cmd/mirror.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+import hashlib
 import os
 import pathlib
 
@@ -14,6 +15,7 @@ import spack.environment as ev
 import spack.mirrors.utils
 import spack.package_base
 import spack.spec
+import spack.util.crypto
 import spack.util.git
 import spack.util.url as url_util
 import spack.version
@@ -500,6 +502,23 @@ def test_mirror_name_collision(mutable_config):
 
     with pytest.raises(SpackCommandError):
         mirror("add", "first", "1")
+
+
+def test_mirror_add_archive(mock_archive, mutable_config, tmp_path: pathlib.Path):
+    """An archive is stored content-addressed in the mirror, whether it is
+    passed as a path or as a URL, and re-adding it is a no-op."""
+    mirror_dir = str(tmp_path / "mirror")
+    sha256 = spack.util.crypto.checksum(hashlib.sha256, mock_archive.archive_file)
+    expected = os.path.join(mirror_dir, "_source-cache", "archive", sha256[:2], f"{sha256}.tar.gz")
+
+    # Add by path
+    output = mirror("add-archive", "-d", mirror_dir, mock_archive.archive_file)
+    assert "Added archive" in output
+    assert os.path.isfile(expected)
+
+    # Adding the same archive again (by URL this time) is a no-op
+    output = mirror("add-archive", "-d", mirror_dir, mock_archive.url)
+    assert "already present" in output
 
 
 # Unit tests should not be affected by the user's managed environments

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -1471,7 +1471,7 @@ _spack_mirror() {
     then
         SPACK_COMPREPLY="-h --help -n --no-checksum"
     else
-        SPACK_COMPREPLY="create destroy add remove rm set-url set list ls"
+        SPACK_COMPREPLY="create add-archive destroy add remove rm set-url set list ls"
     fi
 }
 
@@ -1481,6 +1481,15 @@ _spack_mirror_create() {
         SPACK_COMPREPLY="-h --help -d --directory -a --all -j --jobs --file --exclude-file --exclude-specs --skip-unstable-versions -D --dependencies -n --versions-per-spec --private -f --force -U --fresh --reuse --fresh-roots --reuse-deps --deprecated"
     else
         _all_packages
+    fi
+}
+
+_spack_mirror_add_archive() {
+    if $list_options
+    then
+        SPACK_COMPREPLY="-h --help -d --directory"
+    else
+        SPACK_COMPREPLY=""
     fi
 }
 

--- a/share/spack/spack-completion.fish
+++ b/share/spack/spack-completion.fish
@@ -2367,6 +2367,7 @@ complete -c spack -n '__fish_spack_using_command mark' -s i -l implicit -d 'mark
 # spack mirror
 set -g __fish_spack_optspecs_spack_mirror h/help n/no-checksum
 complete -c spack -n '__fish_spack_using_command_pos 0 mirror' -f -a create -d 'create a directory to be used as a spack mirror, and fill it with package archives'
+complete -c spack -n '__fish_spack_using_command_pos 0 mirror' -f -a add-archive -d 'add a single archive, from a URL or path, to a mirror'
 complete -c spack -n '__fish_spack_using_command_pos 0 mirror' -f -a destroy -d 'given a url, recursively delete everything under it'
 complete -c spack -n '__fish_spack_using_command_pos 0 mirror' -f -a add -d 'add a mirror to Spack'
 complete -c spack -n '__fish_spack_using_command_pos 0 mirror' -f -a remove -d 'remove a mirror by name'
@@ -2415,6 +2416,14 @@ complete -c spack -n '__fish_spack_using_command mirror create' -l fresh-roots -
 complete -c spack -n '__fish_spack_using_command mirror create' -l fresh-roots -l reuse-deps -d 'concretize with fresh roots and reused dependencies'
 complete -c spack -n '__fish_spack_using_command mirror create' -l deprecated -f -a config_deprecated
 complete -c spack -n '__fish_spack_using_command mirror create' -l deprecated -d 'allow concretizer to select deprecated versions'
+
+# spack mirror add-archive
+set -g __fish_spack_optspecs_spack_mirror_add_archive h/help d/directory=
+
+complete -c spack -n '__fish_spack_using_command mirror add-archive' -s h -l help -f -a help
+complete -c spack -n '__fish_spack_using_command mirror add-archive' -s h -l help -d 'show this help message and exit'
+complete -c spack -n '__fish_spack_using_command mirror add-archive' -s d -l directory -r -f -a directory
+complete -c spack -n '__fish_spack_using_command mirror add-archive' -s d -l directory -r -d 'directory of the mirror to add the archive to'
 
 # spack mirror destroy
 set -g __fish_spack_optspecs_spack_mirror_destroy h/help m/mirror-name= mirror-url=


### PR DESCRIPTION
In #45809 we removed the ability to install from the human-readable layout of a mirror. This PR does the following to catch up with that decision:

1. Remove all docs references to the old mirror layout in favor of the content-addressed layout
2. Add a `spack mirror add-archive` command to add individual manually-downloaded tarballs to a mirror
3. Remove the human-readable mirror layout entirely

The rationale for (3) is that if the human-readable layout is not reliable, we should not be exposing it anyway.