### PR TITLE
Add --force option to spack repo update

### DIFF
--- a/lib/spack/spack/cmd/repo.py
+++ b/lib/spack/spack/cmd/repo.py
@@ -189,10 +189,7 @@ def setup_parser(subparser: argparse.ArgumentParser):
         "--branch", "-b", nargs="?", default=None, help="name of a branch to change to"
     )
     update_parser.add_argument(
-        "--force",
-        "-f",
-        action="store_true",
-        help="force an update of a divergent branch"
+        "--force", "-f", action="store_true", help="force an update of a divergent branch"
     )
     refspec = update_parser.add_mutually_exclusive_group(required=False)
     refspec.add_argument("--tag", "-t", nargs="?", default=None, help="name of a tag to change to")

--- a/lib/spack/spack/cmd/repo.py
+++ b/lib/spack/spack/cmd/repo.py
@@ -188,6 +188,12 @@ def setup_parser(subparser: argparse.ArgumentParser):
     update_parser.add_argument(
         "--branch", "-b", nargs="?", default=None, help="name of a branch to change to"
     )
+    update_parser.add_argument(
+        "--force",
+        "-f",
+        action="store_true",
+        help="force an update of a divergent branch"
+    )
     refspec = update_parser.add_mutually_exclusive_group(required=False)
     refspec.add_argument("--tag", "-t", nargs="?", default=None, help="name of a tag to change to")
     refspec.add_argument(
@@ -629,7 +635,7 @@ def repo_update(args):
         git = spack.util.git.git(required=True)
 
         previous_commit = descriptor.get_commit(git=git)
-        descriptor.update(git=git, remote=args.remote)
+        descriptor.update(git=git, remote=args.remote, force=args.force)
         new_commit = descriptor.get_commit(git=git)
 
         if previous_commit == new_commit:

--- a/lib/spack/spack/repo.py
+++ b/lib/spack/spack/repo.py
@@ -1716,7 +1716,9 @@ class RepoDescriptor:
     def initialize(self, fetch: bool = True, git: MaybeExecutable = None) -> None:
         return None
 
-    def update(self, git: MaybeExecutable = None, remote: str = "origin", force: bool = False) -> None:
+    def update(
+        self, git: MaybeExecutable = None, remote: str = "origin", force: bool = False
+    ) -> None:
         return None
 
     def construct(
@@ -1867,17 +1869,11 @@ class RemoteRepoDescriptor(RepoDescriptor):
                             pass
                         if force:
                             spack.util.git.force_checkout_branch(
-                                self.branch,
-                                remote=remote,
-                                depth=depth,
-                                git_exe=git,
+                                self.branch, remote=remote, depth=depth, git_exe=git
                             )
                         else:
                             spack.util.git.pull_checkout_branch(
-                                self.branch,
-                                remote=remote,
-                                depth=depth,
-                                git_exe=git,
+                                self.branch, remote=remote, depth=depth, git_exe=git
                             )
 
             except spack.util.executable.ProcessError:
@@ -1886,7 +1882,9 @@ class RemoteRepoDescriptor(RepoDescriptor):
 
             self.read_index_file()
 
-    def update(self, git: MaybeExecutable = None, remote: str = "origin", force: bool = False) -> None:
+    def update(
+        self, git: MaybeExecutable = None, remote: str = "origin", force: bool = False
+    ) -> None:
 
         if git is None:
             raise RepoError("Git executable not found")

--- a/lib/spack/spack/repo.py
+++ b/lib/spack/spack/repo.py
@@ -1716,7 +1716,7 @@ class RepoDescriptor:
     def initialize(self, fetch: bool = True, git: MaybeExecutable = None) -> None:
         return None
 
-    def update(self, git: MaybeExecutable = None, remote: str = "origin") -> None:
+    def update(self, git: MaybeExecutable = None, remote: str = "origin", force: bool = False) -> None:
         return None
 
     def construct(
@@ -1792,6 +1792,7 @@ class RemoteRepoDescriptor(RepoDescriptor):
         update: bool = False,
         remote: str = "origin",
         depth: Optional[int] = None,
+        force: bool = False,
     ) -> None:
         with self.write_transaction:
             try:
@@ -1864,9 +1865,20 @@ class RemoteRepoDescriptor(RepoDescriptor):
                             remote = output.strip()
                         except spack.util.executable.ProcessError:
                             pass
-                        spack.util.git.pull_checkout_branch(
-                            self.branch, remote=remote, depth=depth, git_exe=git
-                        )
+                        if force:
+                            spack.util.git.force_checkout_branch(
+                                self.branch,
+                                remote=remote,
+                                depth=depth,
+                                git_exe=git,
+                            )
+                        else:
+                            spack.util.git.pull_checkout_branch(
+                                self.branch,
+                                remote=remote,
+                                depth=depth,
+                                git_exe=git,
+                            )
 
             except spack.util.executable.ProcessError:
                 self.error = f"Failed to {'update' if update else 'clone'} repository {self.name}"
@@ -1874,11 +1886,12 @@ class RemoteRepoDescriptor(RepoDescriptor):
 
             self.read_index_file()
 
-    def update(self, git: MaybeExecutable = None, remote: str = "origin") -> None:
+    def update(self, git: MaybeExecutable = None, remote: str = "origin", force: bool = False) -> None:
+
         if git is None:
             raise RepoError("Git executable not found")
 
-        self._clone_or_pull(git, update=True, remote=remote)
+        self._clone_or_pull(git, update=True, remote=remote, force=force)
 
         if self.error:
             raise RepoError(self.error)

--- a/lib/spack/spack/test/cmd/repo.py
+++ b/lib/spack/spack/test/cmd/repo.py
@@ -303,7 +303,12 @@ class MockDescriptor(spack.repo.RepoDescriptor):
     def get_commit(self, git: Optional[Executable] = None):
         pass
 
-    def update(self, git: Optional[Executable] = None, remote: Optional[str] = "origin", force: bool = False) -> None:
+    def update(
+        self,
+        git: Optional[Executable] = None,
+        remote: Optional[str] = "origin",
+        force: bool = False,
+    ) -> None:
         pass
 
     def construct(self, cache, overrides=None):

--- a/lib/spack/spack/test/cmd/repo.py
+++ b/lib/spack/spack/test/cmd/repo.py
@@ -303,7 +303,7 @@ class MockDescriptor(spack.repo.RepoDescriptor):
     def get_commit(self, git: Optional[Executable] = None):
         pass
 
-    def update(self, git: Optional[Executable] = None, remote: Optional[str] = "origin") -> None:
+    def update(self, git: Optional[Executable] = None, remote: Optional[str] = "origin", force: bool = False) -> None:
         pass
 
     def construct(self, cache, overrides=None):

--- a/lib/spack/spack/util/git.py
+++ b/lib/spack/spack/util/git.py
@@ -230,6 +230,24 @@ def pull_checkout_branch(
         raise
 
 
+def force_checkout_branch(
+    branch: str,
+    remote: str = "origin",
+    depth: Optional[int] = None,
+    git_exe: Optional[exe.Executable] = None,
+):
+    """Fetch and checkout --force branch."""
+    git_exe = git_exe or git(required=True)
+    fetch_args = ["--progress"]
+    if depth:
+        if depth <= 0:
+            raise ValueError("depth must be a positive integer")
+        fetch_args.append(f"--depth={depth}")
+
+    git_exe("fetch", *fetch_args, remote, f"+refs/heads/{branch}:refs/remotes/{remote}/{branch}")
+    git_exe("checkout", "--force", "-B", branch, f"{remote}/{branch}")
+
+
 def get_modified_files(
     from_ref: str = "HEAD~1", to_ref: str = "HEAD", git_exe: Optional[exe.Executable] = None
 ) -> List[str]:

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -1880,7 +1880,7 @@ _spack_repo_migrate() {
 _spack_repo_update() {
     if $list_options
     then
-        SPACK_COMPREPLY="-h --help --remote -r --scope --branch -b --tag -t --commit -c"
+        SPACK_COMPREPLY="-h --help --remote -r --scope --branch -b --force -f --tag -t --commit -c"
     else
         SPACK_COMPREPLY=""
     fi

--- a/share/spack/spack-completion.fish
+++ b/share/spack/spack-completion.fish
@@ -2957,7 +2957,7 @@ complete -c spack -n '__fish_spack_using_command repo migrate' -l fix -f -a fix
 complete -c spack -n '__fish_spack_using_command repo migrate' -l fix -d 'automatically migrate the repository to the latest Package API'
 
 # spack repo update
-set -g __fish_spack_optspecs_spack_repo_update h/help r/remote= scope= b/branch= t/tag= c/commit=
+set -g __fish_spack_optspecs_spack_repo_update h/help r/remote= scope= b/branch= f/force t/tag= c/commit=
 
 complete -c spack -n '__fish_spack_using_command repo update' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command repo update' -s h -l help -d 'show this help message and exit'
@@ -2967,6 +2967,8 @@ complete -c spack -n '__fish_spack_using_command repo update' -l scope -r -f -a 
 complete -c spack -n '__fish_spack_using_command repo update' -l scope -r -d 'configuration scope to modify'
 complete -c spack -n '__fish_spack_using_command repo update' -l branch -s b -r -f -a branch
 complete -c spack -n '__fish_spack_using_command repo update' -l branch -s b -r -d 'name of a branch to change to'
+complete -c spack -n '__fish_spack_using_command repo update' -l force -s f -f -a force
+complete -c spack -n '__fish_spack_using_command repo update' -l force -s f -d 'force an update of a divergent branch'
 complete -c spack -n '__fish_spack_using_command repo update' -l tag -s t -r -f -a tag
 complete -c spack -n '__fish_spack_using_command repo update' -l tag -s t -r -d 'name of a tag to change to'
 complete -c spack -n '__fish_spack_using_command repo update' -l commit -s c -r -f -a commit


### PR DESCRIPTION
Closes: https://github.com/spack/spack/issues/52633

* This code is ported from Spack v1.1 (https://github.com/ACCESS-NRI/spack/commits/access/releases/v1.1-admin-add-force/)

### Design decisions

* I made the assumption that the behaviour of `pull_checkout_branch()` is intentional. Hence a separate function `force_checkout_branch()` was made. However, if the behaviour of `pull_checkout_branch()` is unintentional, then I can merge the two functions quite easily by adding a new `force` parameter to `pull_checkout_branch()`.
* My understanding is that ` fetch_args = ["--quiet", "--progress"]` results in git using `--progress` because the two switches are mutually exclusive.