### PR TITLE
bootstrap: install only the clingo binary matching the interpreter

### DIFF
--- a/lib/spack/spack/bootstrap/core.py
+++ b/lib/spack/spack/bootstrap/core.py
@@ -208,14 +208,8 @@ class BuildcacheBootstrapper(Bootstrapper):
                 raise RuntimeError("The binary index is empty")
 
             for item in bincache_data["verified"]:
-                candidate_spec = item["spec"]
-                # This will be None for things that don't depend on python
-                python_spec = item.get("python", None)
                 # Skip specs which are not compatible
-                if not abstract_spec.intersects(candidate_spec):
-                    continue
-
-                if python_spec is not None and not abstract_spec.intersects(f"^{python_spec}"):
+                if not spack.spec.Spec(item["spec"]).satisfies(abstract_spec):
                     continue
 
                 for _, pkg_hash, pkg_sha256 in item["binaries"]:

--- a/share/spack/bootstrap/github-actions-v0.6/clingo.json
+++ b/share/spack/bootstrap/github-actions-v0.6/clingo.json
@@ -8,7 +8,7 @@
           "ff7f45db1645d1d857a315bf8d63c31447330552528bdf1fccdcf50735e62166"
         ]
       ],
-      "spec": "clingo-bootstrap@spack platform=darwin target=aarch64 %apple-clang ^python@3.10"
+      "spec": "clingo-bootstrap@spack+python platform=darwin target=aarch64 %apple-clang ^python@3.10"
     },
     {
       "binaries": [
@@ -18,7 +18,7 @@
           "e7491ac297cbb3f45c80aaf4ca5102e2b655b731e7b6ce7682807d302cb61f1c"
         ]
       ],
-      "spec": "clingo-bootstrap@spack platform=darwin target=aarch64 %apple-clang ^python@3.11"
+      "spec": "clingo-bootstrap@spack+python platform=darwin target=aarch64 %apple-clang ^python@3.11"
     },
     {
       "binaries": [
@@ -28,7 +28,7 @@
           "91214626a86c21fc0d76918884ec819050d4d52b4f78df7cc9769a83fbee2f71"
         ]
       ],
-      "spec": "clingo-bootstrap@spack platform=darwin target=aarch64 %apple-clang ^python@3.12"
+      "spec": "clingo-bootstrap@spack+python platform=darwin target=aarch64 %apple-clang ^python@3.12"
     },
     {
       "binaries": [
@@ -38,7 +38,7 @@
           "db596d9e6d8970d659f4be4cb510f9ba5dc2ec4ea42ecf2aed1325ec5ad72b45"
         ]
       ],
-      "spec": "clingo-bootstrap@spack platform=darwin target=aarch64 %apple-clang ^python@3.13"
+      "spec": "clingo-bootstrap@spack+python platform=darwin target=aarch64 %apple-clang ^python@3.13"
     },
     {
       "binaries": [
@@ -48,7 +48,7 @@
           "a7ed91aee1f8d5cfe2ca5ef2e3e74215953ffd2d8b5c722a670f2c303610e90c"
         ]
       ],
-      "spec": "clingo-bootstrap@spack platform=darwin target=aarch64 %apple-clang ^python@3.8"
+      "spec": "clingo-bootstrap@spack+python platform=darwin target=aarch64 %apple-clang ^python@3.8"
     },
     {
       "binaries": [
@@ -58,7 +58,7 @@
           "c856a98f92b9fa218377cea9272dffa736e93251d987b6386e6abf40058333dc"
         ]
       ],
-      "spec": "clingo-bootstrap@spack platform=darwin target=aarch64 %apple-clang ^python@3.9"
+      "spec": "clingo-bootstrap@spack+python platform=darwin target=aarch64 %apple-clang ^python@3.9"
     },
     {
       "binaries": [
@@ -68,7 +68,7 @@
           "d74cc0b44faa69473816dca16a3806123790e6eb9a59f611b1d80da7843f474a"
         ]
       ],
-      "spec": "clingo-bootstrap@spack platform=darwin target=x86_64 %apple-clang ^python@3.10"
+      "spec": "clingo-bootstrap@spack+python platform=darwin target=x86_64 %apple-clang ^python@3.10"
     },
     {
       "binaries": [
@@ -78,7 +78,7 @@
           "2cb12477504ca8e112522b6d56325ce32024c9466de5b8427fd70a1a81b15020"
         ]
       ],
-      "spec": "clingo-bootstrap@spack platform=darwin target=x86_64 %apple-clang ^python@3.11"
+      "spec": "clingo-bootstrap@spack+python platform=darwin target=x86_64 %apple-clang ^python@3.11"
     },
     {
       "binaries": [
@@ -88,7 +88,7 @@
           "4e73426599fa61df1a4faceafa38ade170a3dec45b6d8f333e6c2b6bfe697724"
         ]
       ],
-      "spec": "clingo-bootstrap@spack platform=darwin target=x86_64 %apple-clang ^python@3.12"
+      "spec": "clingo-bootstrap@spack+python platform=darwin target=x86_64 %apple-clang ^python@3.12"
     },
     {
       "binaries": [
@@ -98,7 +98,7 @@
           "4309b42e5642bc5c83ede90759b1a0b5d66fffa8991b6213208577626b588cde"
         ]
       ],
-      "spec": "clingo-bootstrap@spack platform=darwin target=x86_64 %apple-clang ^python@3.13"
+      "spec": "clingo-bootstrap@spack+python platform=darwin target=x86_64 %apple-clang ^python@3.13"
     },
     {
       "binaries": [
@@ -108,7 +108,7 @@
           "1feeab9e1a81ca56de838ccc234d60957e9ab14da038e38b6687732b7bae1ff6"
         ]
       ],
-      "spec": "clingo-bootstrap@spack platform=darwin target=x86_64 %apple-clang ^python@3.6"
+      "spec": "clingo-bootstrap@spack+python platform=darwin target=x86_64 %apple-clang ^python@3.6"
     },
     {
       "binaries": [
@@ -118,7 +118,7 @@
           "1149ab7d5f1c82d8de53f048af8aa5c5dbf0d21da4e4780c06e54b8ee902085b"
         ]
       ],
-      "spec": "clingo-bootstrap@spack platform=darwin target=x86_64 %apple-clang ^python@3.7"
+      "spec": "clingo-bootstrap@spack+python platform=darwin target=x86_64 %apple-clang ^python@3.7"
     },
     {
       "binaries": [
@@ -128,7 +128,7 @@
           "d6aeae2dbd7fa3c1d1c62f840a5c01f8e71b64afe2bdc9c90d4087694f7d3443"
         ]
       ],
-      "spec": "clingo-bootstrap@spack platform=darwin target=x86_64 %apple-clang ^python@3.8"
+      "spec": "clingo-bootstrap@spack+python platform=darwin target=x86_64 %apple-clang ^python@3.8"
     },
     {
       "binaries": [
@@ -138,7 +138,7 @@
           "81ef2beef78f46979965e5e69cd92b68ff4d2a59dbae1331c648d18b6ded1444"
         ]
       ],
-      "spec": "clingo-bootstrap@spack platform=darwin target=x86_64 %apple-clang ^python@3.9"
+      "spec": "clingo-bootstrap@spack+python platform=darwin target=x86_64 %apple-clang ^python@3.9"
     },
     {
       "binaries": [
@@ -148,7 +148,7 @@
           "3d0830654f9e327fd7ec6dab214050295dbf0832f493937c0c133e516dd2a95a"
         ]
       ],
-      "spec": "clingo-bootstrap@spack platform=linux target=aarch64 %gcc ^python@3.10"
+      "spec": "clingo-bootstrap@spack+python platform=linux target=aarch64 %gcc ^python@3.10"
     },
     {
       "binaries": [
@@ -158,7 +158,7 @@
           "941b93cd89d5271c740d1b1c870e85f32e5970f9f7b842ad99870399215a93db"
         ]
       ],
-      "spec": "clingo-bootstrap@spack platform=linux target=aarch64 %gcc ^python@3.11"
+      "spec": "clingo-bootstrap@spack+python platform=linux target=aarch64 %gcc ^python@3.11"
     },
     {
       "binaries": [
@@ -168,7 +168,7 @@
           "8ca78e345da732643e3d1b077d8156ce89863c25095e4958d4ac6d1a458ae74b"
         ]
       ],
-      "spec": "clingo-bootstrap@spack platform=linux target=aarch64 %gcc ^python@3.12"
+      "spec": "clingo-bootstrap@spack+python platform=linux target=aarch64 %gcc ^python@3.12"
     },
     {
       "binaries": [
@@ -178,7 +178,7 @@
           "f6ced988b515494d86a1069f13ae9030caeb40fe951c2460f532123c80399154"
         ]
       ],
-      "spec": "clingo-bootstrap@spack platform=linux target=aarch64 %gcc ^python@3.13"
+      "spec": "clingo-bootstrap@spack+python platform=linux target=aarch64 %gcc ^python@3.13"
     },
     {
       "binaries": [
@@ -188,7 +188,7 @@
           "c00855b5cda99639b87c3912ee9c734c0b609dfe7d2c47ea947738c32bab6f03"
         ]
       ],
-      "spec": "clingo-bootstrap@spack platform=linux target=aarch64 %gcc ^python@3.6"
+      "spec": "clingo-bootstrap@spack+python platform=linux target=aarch64 %gcc ^python@3.6"
     },
     {
       "binaries": [
@@ -198,7 +198,7 @@
           "aa861cfdf6001fc2da6e83eecc9ad35df424d86d71f6d73e480818942405ce4e"
         ]
       ],
-      "spec": "clingo-bootstrap@spack platform=linux target=aarch64 %gcc ^python@3.7"
+      "spec": "clingo-bootstrap@spack+python platform=linux target=aarch64 %gcc ^python@3.7"
     },
     {
       "binaries": [
@@ -208,7 +208,7 @@
           "cb7807cd31fc5e0efe2acc1de1f74c7cef962bcadfc656b09ff853bc33c11bd0"
         ]
       ],
-      "spec": "clingo-bootstrap@spack platform=linux target=aarch64 %gcc ^python@3.8"
+      "spec": "clingo-bootstrap@spack+python platform=linux target=aarch64 %gcc ^python@3.8"
     },
     {
       "binaries": [
@@ -218,7 +218,7 @@
           "36e5efb6b15b431b661e9e272904ab3c29ae7b87bf6250c158d545ccefc2f424"
         ]
       ],
-      "spec": "clingo-bootstrap@spack platform=linux target=aarch64 %gcc ^python@3.9"
+      "spec": "clingo-bootstrap@spack+python platform=linux target=aarch64 %gcc ^python@3.9"
     },
     {
       "binaries": [
@@ -228,7 +228,7 @@
           "bd492c078b2cdaf327148eee5b0abd5b068dbb3ffa5dae0ec5d53257f471f7f7"
         ]
       ],
-      "spec": "clingo-bootstrap@spack platform=linux target=ppc64le %gcc ^python@3.10"
+      "spec": "clingo-bootstrap@spack+python platform=linux target=ppc64le %gcc ^python@3.10"
     },
     {
       "binaries": [
@@ -238,7 +238,7 @@
           "0ebe5e05246c33fc8529e90e21529b29742b5dd6756dbc07534577a90394c0e6"
         ]
       ],
-      "spec": "clingo-bootstrap@spack platform=linux target=ppc64le %gcc ^python@3.11"
+      "spec": "clingo-bootstrap@spack+python platform=linux target=ppc64le %gcc ^python@3.11"
     },
     {
       "binaries": [
@@ -248,7 +248,7 @@
           "9f97d3bf78b7642a775f12feb43781d46110793f58a7e69b0b68ac4fff47655c"
         ]
       ],
-      "spec": "clingo-bootstrap@spack platform=linux target=ppc64le %gcc ^python@3.12"
+      "spec": "clingo-bootstrap@spack+python platform=linux target=ppc64le %gcc ^python@3.12"
     },
     {
       "binaries": [
@@ -258,7 +258,7 @@
           "e7295bb4bcb11a936f39665632ce68c751c9f6cddc44904392a1b33a5290bbbe"
         ]
       ],
-      "spec": "clingo-bootstrap@spack platform=linux target=ppc64le %gcc ^python@3.13"
+      "spec": "clingo-bootstrap@spack+python platform=linux target=ppc64le %gcc ^python@3.13"
     },
     {
       "binaries": [
@@ -268,7 +268,7 @@
           "c44e7fbf721383aa8ee57d2305f41377e64a42ab8e02a9d3d6fc792d9b29ad08"
         ]
       ],
-      "spec": "clingo-bootstrap@spack platform=linux target=ppc64le %gcc ^python@3.6"
+      "spec": "clingo-bootstrap@spack+python platform=linux target=ppc64le %gcc ^python@3.6"
     },
     {
       "binaries": [
@@ -278,7 +278,7 @@
           "965ba5c1a42f436001162a3f3a0d1715424f2ec8f65c42d6b66efcd4f4566b77"
         ]
       ],
-      "spec": "clingo-bootstrap@spack platform=linux target=ppc64le %gcc ^python@3.7"
+      "spec": "clingo-bootstrap@spack+python platform=linux target=ppc64le %gcc ^python@3.7"
     },
     {
       "binaries": [
@@ -288,7 +288,7 @@
           "c8d31089d8f91718a5bde9c6b28cc67bdbadab401c8fdd07b296d588ece4ddfe"
         ]
       ],
-      "spec": "clingo-bootstrap@spack platform=linux target=ppc64le %gcc ^python@3.8"
+      "spec": "clingo-bootstrap@spack+python platform=linux target=ppc64le %gcc ^python@3.8"
     },
     {
       "binaries": [
@@ -298,7 +298,7 @@
           "ef3f05d30333a39fd18714b87ee22605679f52fda97f5e592764d1591527bbf3"
         ]
       ],
-      "spec": "clingo-bootstrap@spack platform=linux target=ppc64le %gcc ^python@3.9"
+      "spec": "clingo-bootstrap@spack+python platform=linux target=ppc64le %gcc ^python@3.9"
     },
     {
       "binaries": [
@@ -308,7 +308,7 @@
           "a4abec667660307ad5cff0a616d6651e187cc7b1386fd8cd4b6b288a01614076"
         ]
       ],
-      "spec": "clingo-bootstrap@spack platform=linux target=x86_64 %gcc ^python@3.10"
+      "spec": "clingo-bootstrap@spack+python platform=linux target=x86_64 %gcc ^python@3.10"
     },
     {
       "binaries": [
@@ -318,7 +318,7 @@
           "a572ab6db954f4a850d1292bb1ef6d6055916784a894d149d657996fa98d0367"
         ]
       ],
-      "spec": "clingo-bootstrap@spack platform=linux target=x86_64 %gcc ^python@3.11"
+      "spec": "clingo-bootstrap@spack+python platform=linux target=x86_64 %gcc ^python@3.11"
     },
     {
       "binaries": [
@@ -328,7 +328,7 @@
           "97f8ea17f3df3fb38904450114cbef9b4b0ea9c94da9de7a49b70b707012277a"
         ]
       ],
-      "spec": "clingo-bootstrap@spack platform=linux target=x86_64 %gcc ^python@3.12"
+      "spec": "clingo-bootstrap@spack+python platform=linux target=x86_64 %gcc ^python@3.12"
     },
     {
       "binaries": [
@@ -338,7 +338,7 @@
           "6599ac06ade0cb3e80695f36492ea94a306f8bde0537482521510076c5981aa0"
         ]
       ],
-      "spec": "clingo-bootstrap@spack platform=linux target=x86_64 %gcc ^python@3.13"
+      "spec": "clingo-bootstrap@spack+python platform=linux target=x86_64 %gcc ^python@3.13"
     },
     {
       "binaries": [
@@ -348,7 +348,7 @@
           "90b7cf4dd98e26c58578ad8604738cc32dfbb228cfb981bdfe103c99d0e7b5dd"
         ]
       ],
-      "spec": "clingo-bootstrap@spack platform=linux target=x86_64 %gcc ^python@3.6"
+      "spec": "clingo-bootstrap@spack+python platform=linux target=x86_64 %gcc ^python@3.6"
     },
     {
       "binaries": [
@@ -358,7 +358,7 @@
           "dc5dbfd9c05b43c4992bf6666638ae96cee5548921e94eb793ba85727b25ec59"
         ]
       ],
-      "spec": "clingo-bootstrap@spack platform=linux target=x86_64 %gcc ^python@3.7"
+      "spec": "clingo-bootstrap@spack+python platform=linux target=x86_64 %gcc ^python@3.7"
     },
     {
       "binaries": [
@@ -368,7 +368,7 @@
           "e8518de25baff7a74bdb42193e6e4b0496e7d0688434c42ce4bdc92fe4293a09"
         ]
       ],
-      "spec": "clingo-bootstrap@spack platform=linux target=x86_64 %gcc ^python@3.8"
+      "spec": "clingo-bootstrap@spack+python platform=linux target=x86_64 %gcc ^python@3.8"
     },
     {
       "binaries": [
@@ -378,7 +378,7 @@
           "0c5831932608e7b4084fc6ce60e2b67b77dab76e5515303a049d4d30cd772321"
         ]
       ],
-      "spec": "clingo-bootstrap@spack platform=linux target=x86_64 %gcc ^python@3.9"
+      "spec": "clingo-bootstrap@spack+python platform=linux target=x86_64 %gcc ^python@3.9"
     }
   ]
 }

--- a/share/spack/bootstrap/github-actions-v2/clingo.json
+++ b/share/spack/bootstrap/github-actions-v2/clingo.json
@@ -8,7 +8,7 @@
           "1d5b86c7b72caf39ae4288f14f10cd4172470f0a5a82091a19de832c8a9b8686"
         ]
       ],
-      "spec": "clingo-bootstrap@spack platform=darwin target=aarch64 %apple-clang ^python@3.10"
+      "spec": "clingo-bootstrap@spack+python platform=darwin target=aarch64 %apple-clang ^python@3.10"
     },
     {
       "binaries": [
@@ -18,7 +18,7 @@
           "08202efda0a9dde65625653e9a6c598d2c88330cddf8e7bdba4f41d45d614acc"
         ]
       ],
-      "spec": "clingo-bootstrap@spack platform=darwin target=aarch64 %apple-clang ^python@3.11"
+      "spec": "clingo-bootstrap@spack+python platform=darwin target=aarch64 %apple-clang ^python@3.11"
     },
     {
       "binaries": [
@@ -28,7 +28,7 @@
           "83d3b4021e3f1a76efc779530098b90495131b45494b865f0a9957f2e998b6fe"
         ]
       ],
-      "spec": "clingo-bootstrap@spack platform=darwin target=aarch64 %apple-clang ^python@3.12"
+      "spec": "clingo-bootstrap@spack+python platform=darwin target=aarch64 %apple-clang ^python@3.12"
     },
     {
       "binaries": [
@@ -38,7 +38,7 @@
           "99affb48dd65b7ac9c1fb128b8db22087a9af3b6d1b799b1faed753823b8cdfe"
         ]
       ],
-      "spec": "clingo-bootstrap@spack platform=darwin target=aarch64 %apple-clang ^python@3.13"
+      "spec": "clingo-bootstrap@spack+python platform=darwin target=aarch64 %apple-clang ^python@3.13"
     },
     {
       "binaries": [
@@ -48,7 +48,7 @@
           "8720111b230ced41bf77601ef3f54e085e3f53b080a24570992b71340ac5da49"
         ]
       ],
-      "spec": "clingo-bootstrap@spack platform=darwin target=aarch64 %apple-clang ^python@3.14"
+      "spec": "clingo-bootstrap@spack+python platform=darwin target=aarch64 %apple-clang ^python@3.14"
     },
     {
       "binaries": [
@@ -58,7 +58,7 @@
           "e9a22379dd9e66a778f4ebf38c3d50c6c896d3121039faf9619e4a2352f11b5c"
         ]
       ],
-      "spec": "clingo-bootstrap@spack platform=darwin target=aarch64 %apple-clang ^python@3.8"
+      "spec": "clingo-bootstrap@spack+python platform=darwin target=aarch64 %apple-clang ^python@3.8"
     },
     {
       "binaries": [
@@ -68,7 +68,7 @@
           "8277af1cbc941cc4907815e6175869fdba121fab579a6169e018777e7fa456d2"
         ]
       ],
-      "spec": "clingo-bootstrap@spack platform=darwin target=aarch64 %apple-clang ^python@3.9"
+      "spec": "clingo-bootstrap@spack+python platform=darwin target=aarch64 %apple-clang ^python@3.9"
     },
     {
       "binaries": [
@@ -78,7 +78,7 @@
           "4fd752d04e9bd30f318d792aabae68239366c653eae530ace0691f6cf9a8e4e6"
         ]
       ],
-      "spec": "clingo-bootstrap@spack platform=darwin target=x86_64 %apple-clang ^python@3.10"
+      "spec": "clingo-bootstrap@spack+python platform=darwin target=x86_64 %apple-clang ^python@3.10"
     },
     {
       "binaries": [
@@ -88,7 +88,7 @@
           "26ece3445157ae7846aba7ac07c5359bda8500607a6ca932a3a10de4d8523297"
         ]
       ],
-      "spec": "clingo-bootstrap@spack platform=darwin target=x86_64 %apple-clang ^python@3.11"
+      "spec": "clingo-bootstrap@spack+python platform=darwin target=x86_64 %apple-clang ^python@3.11"
     },
     {
       "binaries": [
@@ -98,7 +98,7 @@
           "df7b27379800fc56c277229c45c61e22d9855d7aadb5a189a976d39175c69007"
         ]
       ],
-      "spec": "clingo-bootstrap@spack platform=darwin target=x86_64 %apple-clang ^python@3.12"
+      "spec": "clingo-bootstrap@spack+python platform=darwin target=x86_64 %apple-clang ^python@3.12"
     },
     {
       "binaries": [
@@ -108,7 +108,7 @@
           "6e5abf247c13232d7b693c5b9e419c1252059f3d6a02351f7a8538d6971c5ca4"
         ]
       ],
-      "spec": "clingo-bootstrap@spack platform=darwin target=x86_64 %apple-clang ^python@3.13"
+      "spec": "clingo-bootstrap@spack+python platform=darwin target=x86_64 %apple-clang ^python@3.13"
     },
     {
       "binaries": [
@@ -118,7 +118,7 @@
           "ba8a4e37277b1f3506b825f08803bab258c693c539f2d4f8dfa75722eb95c45a"
         ]
       ],
-      "spec": "clingo-bootstrap@spack platform=darwin target=x86_64 %apple-clang ^python@3.14"
+      "spec": "clingo-bootstrap@spack+python platform=darwin target=x86_64 %apple-clang ^python@3.14"
     },
     {
       "binaries": [
@@ -128,7 +128,7 @@
           "553d8f08423191cfb52c729edf1ac419f3ed2d06a4332e3bb2598d2700e6176e"
         ]
       ],
-      "spec": "clingo-bootstrap@spack platform=darwin target=x86_64 %apple-clang ^python@3.8"
+      "spec": "clingo-bootstrap@spack+python platform=darwin target=x86_64 %apple-clang ^python@3.8"
     },
     {
       "binaries": [
@@ -138,7 +138,7 @@
           "66946cbe5b41440d18f29971ecf99d13cf29ecb0f0d24c485c5be3301e78a69a"
         ]
       ],
-      "spec": "clingo-bootstrap@spack platform=darwin target=x86_64 %apple-clang ^python@3.9"
+      "spec": "clingo-bootstrap@spack+python platform=darwin target=x86_64 %apple-clang ^python@3.9"
     },
     {
       "binaries": [
@@ -148,7 +148,7 @@
           "f38dbf6541cad89e16875d986e3765a36cb4f152eea641875001149c0b8db032"
         ]
       ],
-      "spec": "clingo-bootstrap@spack platform=linux target=aarch64 %gcc ^python@3.10"
+      "spec": "clingo-bootstrap@spack+python platform=linux target=aarch64 %gcc ^python@3.10"
     },
     {
       "binaries": [
@@ -158,7 +158,7 @@
           "cbbf79e1f4ce26095092ac47f18500e3cf647e10836b654e1f454b458543f135"
         ]
       ],
-      "spec": "clingo-bootstrap@spack platform=linux target=aarch64 %gcc ^python@3.11"
+      "spec": "clingo-bootstrap@spack+python platform=linux target=aarch64 %gcc ^python@3.11"
     },
     {
       "binaries": [
@@ -168,7 +168,7 @@
           "f84e5573c11138d709ce4d74245290e1ccea094ac7c2ed5742fc7f4becef0a13"
         ]
       ],
-      "spec": "clingo-bootstrap@spack platform=linux target=aarch64 %gcc ^python@3.12"
+      "spec": "clingo-bootstrap@spack+python platform=linux target=aarch64 %gcc ^python@3.12"
     },
     {
       "binaries": [
@@ -178,7 +178,7 @@
           "77a42d4a34ed2c9cce7a5d84335fad79adad8b0ea2fd045df954b8dce212b98c"
         ]
       ],
-      "spec": "clingo-bootstrap@spack platform=linux target=aarch64 %gcc ^python@3.13"
+      "spec": "clingo-bootstrap@spack+python platform=linux target=aarch64 %gcc ^python@3.13"
     },
     {
       "binaries": [
@@ -188,7 +188,7 @@
           "fb83a9312313b85b4c96abba421ead94081554e7ce8692388dc14fbeaf2f8c1a"
         ]
       ],
-      "spec": "clingo-bootstrap@spack platform=linux target=aarch64 %gcc ^python@3.14"
+      "spec": "clingo-bootstrap@spack+python platform=linux target=aarch64 %gcc ^python@3.14"
     },
     {
       "binaries": [
@@ -198,7 +198,7 @@
           "ab3d5b2cdf926a43f2fc63bd18a24f11f7a4a2c26d9572e27818104588d18808"
         ]
       ],
-      "spec": "clingo-bootstrap@spack platform=linux target=aarch64 %gcc ^python@3.6"
+      "spec": "clingo-bootstrap@spack+python platform=linux target=aarch64 %gcc ^python@3.6"
     },
     {
       "binaries": [
@@ -208,7 +208,7 @@
           "d8a20cc03e9a0137d8ab5de0e81cd87b57a15d4171ec5ad59fec4dc07c8673c6"
         ]
       ],
-      "spec": "clingo-bootstrap@spack platform=linux target=aarch64 %gcc ^python@3.7"
+      "spec": "clingo-bootstrap@spack+python platform=linux target=aarch64 %gcc ^python@3.7"
     },
     {
       "binaries": [
@@ -218,7 +218,7 @@
           "b9a3a9b990228374c479c398b61502a09818948829a8e9c9ae2038cbbaa6328f"
         ]
       ],
-      "spec": "clingo-bootstrap@spack platform=linux target=aarch64 %gcc ^python@3.8"
+      "spec": "clingo-bootstrap@spack+python platform=linux target=aarch64 %gcc ^python@3.8"
     },
     {
       "binaries": [
@@ -228,7 +228,7 @@
           "87ef77a2c2ef7cd880e47fa38abf96e8ef70a64645ba353ebe468e5ad9974595"
         ]
       ],
-      "spec": "clingo-bootstrap@spack platform=linux target=aarch64 %gcc ^python@3.9"
+      "spec": "clingo-bootstrap@spack+python platform=linux target=aarch64 %gcc ^python@3.9"
     },
     {
       "binaries": [
@@ -238,7 +238,7 @@
           "65281df2bd13df6ced19320ea6326474f75a15066e22bb934ecee7b20175aec9"
         ]
       ],
-      "spec": "clingo-bootstrap@spack platform=linux target=ppc64le %gcc ^python@3.10"
+      "spec": "clingo-bootstrap@spack+python platform=linux target=ppc64le %gcc ^python@3.10"
     },
     {
       "binaries": [
@@ -248,7 +248,7 @@
           "5bf5ac1121d36e62bef544940abd67e4f683dee760a20dfd5dd52b88ca8e947a"
         ]
       ],
-      "spec": "clingo-bootstrap@spack platform=linux target=ppc64le %gcc ^python@3.11"
+      "spec": "clingo-bootstrap@spack+python platform=linux target=ppc64le %gcc ^python@3.11"
     },
     {
       "binaries": [
@@ -258,7 +258,7 @@
           "297b399857de8bd0f248bd6f1ec16ea60956ccbfdfbef5cbfa5deec4e4d7301c"
         ]
       ],
-      "spec": "clingo-bootstrap@spack platform=linux target=ppc64le %gcc ^python@3.12"
+      "spec": "clingo-bootstrap@spack+python platform=linux target=ppc64le %gcc ^python@3.12"
     },
     {
       "binaries": [
@@ -268,7 +268,7 @@
           "0a7f6fd232a30248efe49fcc62ff9200778d33757cefb4c2559252f222b889a4"
         ]
       ],
-      "spec": "clingo-bootstrap@spack platform=linux target=ppc64le %gcc ^python@3.13"
+      "spec": "clingo-bootstrap@spack+python platform=linux target=ppc64le %gcc ^python@3.13"
     },
     {
       "binaries": [
@@ -278,7 +278,7 @@
           "58e718850872c45559973fa2674450bdde841b2ede6247274c209c7bf382b345"
         ]
       ],
-      "spec": "clingo-bootstrap@spack platform=linux target=ppc64le %gcc ^python@3.14"
+      "spec": "clingo-bootstrap@spack+python platform=linux target=ppc64le %gcc ^python@3.14"
     },
     {
       "binaries": [
@@ -288,7 +288,7 @@
           "b941a1d88d198e8427c80d25378d0c38e358eb44a370eecad8187d76e4062ac5"
         ]
       ],
-      "spec": "clingo-bootstrap@spack platform=linux target=ppc64le %gcc ^python@3.6"
+      "spec": "clingo-bootstrap@spack+python platform=linux target=ppc64le %gcc ^python@3.6"
     },
     {
       "binaries": [
@@ -298,7 +298,7 @@
           "1e871a754a620f922e5918ed25157b19bbc7ff48a46470bf6210398f35b05262"
         ]
       ],
-      "spec": "clingo-bootstrap@spack platform=linux target=ppc64le %gcc ^python@3.7"
+      "spec": "clingo-bootstrap@spack+python platform=linux target=ppc64le %gcc ^python@3.7"
     },
     {
       "binaries": [
@@ -308,7 +308,7 @@
           "ded0342e3c4e732162407dfd1c099b309d0852e1fcce3ccd8fd47f43caeba9b2"
         ]
       ],
-      "spec": "clingo-bootstrap@spack platform=linux target=ppc64le %gcc ^python@3.8"
+      "spec": "clingo-bootstrap@spack+python platform=linux target=ppc64le %gcc ^python@3.8"
     },
     {
       "binaries": [
@@ -318,7 +318,7 @@
           "fc3c53439fe2b1907fbe03e7610c905fc32d572af5b672831ebb1e81eff32cda"
         ]
       ],
-      "spec": "clingo-bootstrap@spack platform=linux target=ppc64le %gcc ^python@3.9"
+      "spec": "clingo-bootstrap@spack+python platform=linux target=ppc64le %gcc ^python@3.9"
     },
     {
       "binaries": [
@@ -328,7 +328,7 @@
           "2b97dc9cde3a94f933a4e7181cf9809836ed6e9d5a5784416758222e6fd2865f"
         ]
       ],
-      "spec": "clingo-bootstrap@spack platform=linux target=x86_64 %gcc ^python@3.10"
+      "spec": "clingo-bootstrap@spack+python platform=linux target=x86_64 %gcc ^python@3.10"
     },
     {
       "binaries": [
@@ -338,7 +338,7 @@
           "f2be487604f0b436ec982b38a7d931c5b4de4101c864cd63737b1c0463f3a8f1"
         ]
       ],
-      "spec": "clingo-bootstrap@spack platform=linux target=x86_64 %gcc ^python@3.11"
+      "spec": "clingo-bootstrap@spack+python platform=linux target=x86_64 %gcc ^python@3.11"
     },
     {
       "binaries": [
@@ -348,7 +348,7 @@
           "cc238348fb1a3b70351d784ec61f7843d0cc9ca5de745ce98e6bea7cd00787ea"
         ]
       ],
-      "spec": "clingo-bootstrap@spack platform=linux target=x86_64 %gcc ^python@3.12"
+      "spec": "clingo-bootstrap@spack+python platform=linux target=x86_64 %gcc ^python@3.12"
     },
     {
       "binaries": [
@@ -358,7 +358,7 @@
           "735b948738902a47aa91d6663168b0be5276d88ef5914e0a21c60ada20eefa26"
         ]
       ],
-      "spec": "clingo-bootstrap@spack platform=linux target=x86_64 %gcc ^python@3.13"
+      "spec": "clingo-bootstrap@spack+python platform=linux target=x86_64 %gcc ^python@3.13"
     },
     {
       "binaries": [
@@ -368,7 +368,7 @@
           "a4af59b800b9b2691c77a5ae09bffd0be5690451d50c123ad0dff984fa255b7f"
         ]
       ],
-      "spec": "clingo-bootstrap@spack platform=linux target=x86_64 %gcc ^python@3.14"
+      "spec": "clingo-bootstrap@spack+python platform=linux target=x86_64 %gcc ^python@3.14"
     },
     {
       "binaries": [
@@ -378,7 +378,7 @@
           "526d468db326aea1e36183b68a7f81cc5fa8094b03162baab76b9fbf88567f60"
         ]
       ],
-      "spec": "clingo-bootstrap@spack platform=linux target=x86_64 %gcc ^python@3.6"
+      "spec": "clingo-bootstrap@spack+python platform=linux target=x86_64 %gcc ^python@3.6"
     },
     {
       "binaries": [
@@ -388,7 +388,7 @@
           "c4bd0809a64a29a9c6d0b514b221f44222c3f610f66d81af0f9954cddae5e17c"
         ]
       ],
-      "spec": "clingo-bootstrap@spack platform=linux target=x86_64 %gcc ^python@3.7"
+      "spec": "clingo-bootstrap@spack+python platform=linux target=x86_64 %gcc ^python@3.7"
     },
     {
       "binaries": [
@@ -398,7 +398,7 @@
           "7a349c91530f7cd45e6a663cad1d3f352f59424c2d6780dccb6deb089dacc5c1"
         ]
       ],
-      "spec": "clingo-bootstrap@spack platform=linux target=x86_64 %gcc ^python@3.8"
+      "spec": "clingo-bootstrap@spack+python platform=linux target=x86_64 %gcc ^python@3.8"
     },
     {
       "binaries": [
@@ -408,7 +408,7 @@
           "31f1649728e2d58902eb62d1c2e37b1cfc73e007089322a17463b3cb5777cb98"
         ]
       ],
-      "spec": "clingo-bootstrap@spack platform=linux target=x86_64 %gcc ^python@3.9"
+      "spec": "clingo-bootstrap@spack+python platform=linux target=x86_64 %gcc ^python@3.9"
     }
   ]
 }


### PR DESCRIPTION
Bootstrapping used `Spec.intersects` to select a binary from the bootstrap metadata. Since #52893 transitive "^" constraints are treated as parallel edges that never conflict, so every clingo-bootstrap entry looked compatible with every interpreter. Fix is to use `Spec.satisfies`, which does discriminate transitive edges, and add the missing +python variant to the clingo metadata so the entries satisfy clingo_root_spec().

**Before**
```console
$ spack bootstrap now
==> Installing "gcc-runtime@=10.2.1 build_system=generic platform=linux os=centos7 target=x86_64" from a buildcache
==> Installing "patchelf@=0.17.2 build_system=autotools platform=linux os=centos7 target=x86_64" from a buildcache
==> Installing "clingo-bootstrap@=spack~apps~docs+ipo+optimized+python+static_libstdcpp build_system=cmake build_type=Release commit=2a025667090d71b2c9dce60fe924feb6bde8f667 generator=make patches:=bebb819,ec99431 platform=linux os=centos7 target=x86_64" from a buildcache
==> Installing "clingo-bootstrap@=spack~apps~docs+ipo+optimized+python+static_libstdcpp build_system=cmake build_type=Release commit=2a025667090d71b2c9dce60fe924feb6bde8f667 generator=make patches:=bebb819,ec99431 platform=linux os=centos7 target=x86_64" from a buildcache
==> Installing "clingo-bootstrap@=spack~apps~docs+ipo+optimized+python+static_libstdcpp build_system=cmake build_type=Release commit=2a025667090d71b2c9dce60fe924feb6bde8f667 generator=make patches:=bebb819,ec99431 platform=linux os=centos7 target=x86_64" from a buildcache
==> Installing "clingo-bootstrap@=spack~apps~docs+ipo+optimized+python+static_libstdcpp build_system=cmake build_type=Release commit=2a025667090d71b2c9dce60fe924feb6bde8f667 generator=make patches:=bebb819,ec99431 platform=linux os=centos7 target=x86_64" from a buildcache
==> Installing "clingo-bootstrap@=spack~apps~docs+ipo+optimized+python+static_libstdcpp build_system=cmake build_type=Release commit=2a025667090d71b2c9dce60fe924feb6bde8f667 generator=make patches:=bebb819,ec99431 platform=linux os=centos7 target=x86_64" from a buildcache
```

**After**
```console
$ spack bootstrap now
==> Installing "gcc-runtime@=10.2.1 build_system=generic platform=linux os=centos7 target=x86_64" from a buildcache
==> Installing "patchelf@=0.17.2 build_system=autotools platform=linux os=centos7 target=x86_64" from a buildcache
==> Installing "clingo-bootstrap@=spack~apps~docs+ipo+optimized+python+static_libstdcpp build_system=cmake build_type=Release commit=2a025667090d71b2c9dce60fe924feb6bde8f667 generator=make patches:=bebb819,ec99431 platform=linux os=centos7 target=x86_64" from a buildcache
```