### PR TITLE
Clean up of `spack.bootstrap`

### DIFF
--- a/lib/spack/docs/conf.py
+++ b/lib/spack/docs/conf.py
@@ -365,7 +365,7 @@ nitpick_ignore = [
     # Spack classes that intersphinx is unable to resolve
     ("py:class", "BuildStatus"),
     ("py:class", "GitOrStandardVersion"),
-    ("py:class", "spack.bootstrap._common.QueryInfo"),
+    ("py:class", "spack.bootstrap._common.ExecutableInfo"),
     ("py:class", "spack.vendor.archspec.cpu.microarchitecture.Microarchitecture"),
     ("py:class", "spack.vendor.jinja2.Environment"),
     ("py:class", "SpecFiltersFactory"),

--- a/lib/spack/spack/bootstrap/_common.py
+++ b/lib/spack/spack/bootstrap/_common.py
@@ -193,22 +193,13 @@ def _executables_in_store(
     executables_str = ", ".join(executables)
     msg = "[BOOTSTRAP EXECUTABLES {0}] Try installed specs with query '{1}'"
     tty.debug(msg.format(executables_str, query_spec))
-    installed_specs = spack.store.STORE.db.query(query_spec, installed=True)
-    if installed_specs:
-        for concrete_spec in installed_specs:
-            bin_dir = concrete_spec.prefix.bin
-            # IF we have a "bin" directory and it contains
-            # the executables we are looking for
-            if (
-                os.path.exists(bin_dir)
-                and os.path.isdir(bin_dir)
-                and spack.util.executable.which_string(*executables, path=bin_dir)
-            ):
-                spack.util.environment.path_put_first("PATH", [bin_dir])
-                return ExecutableInfo(
-                    spec=concrete_spec,
-                    command=spack.util.executable.which(*executables, path=bin_dir, required=True),
-                )
+    for concrete_spec in spack.store.STORE.db.query(query_spec, installed=True):
+        bin_dir = concrete_spec.prefix.bin
+        command = spack.util.executable.which(*executables, path=bin_dir)
+        if command is None:
+            continue
+        spack.util.environment.path_put_first("PATH", [bin_dir])
+        return ExecutableInfo(spec=concrete_spec, command=command)
     return None
 
 

--- a/lib/spack/spack/bootstrap/_common.py
+++ b/lib/spack/spack/bootstrap/_common.py
@@ -11,10 +11,9 @@ import re
 import sys
 import sysconfig
 import warnings
-from typing import Optional, Sequence, Union
+from typing import NamedTuple, Optional, Sequence, Union
 
 import spack.vendor.archspec.cpu
-from spack.vendor.typing_extensions import TypedDict
 
 import spack.platforms
 import spack.spec
@@ -27,7 +26,9 @@ from spack.util import tty
 from .config import spec_for_current_python
 
 
-class QueryInfo(TypedDict, total=False):
+class ExecutableInfo(NamedTuple):
+    """An executable found in the bootstrap store, and the spec that provides it."""
+
     spec: spack.spec.Spec
     command: spack.util.executable.Executable
 
@@ -40,17 +41,13 @@ def _python_import(module: str) -> bool:
     return True
 
 
-def _try_import_from_store(
-    module: str, query_spec: Union[str, "spack.spec.Spec"], query_info: Optional[QueryInfo] = None
-) -> bool:
+def _try_import_from_store(module: str, query_spec: Union[str, "spack.spec.Spec"]) -> bool:
     """Return True if the module can be imported from an already
     installed spec, False otherwise.
 
     Args:
         module: Python module to be imported
         query_spec: spec that may provide the module
-        query_info (dict or None): if a dict is passed it is populated with the
-            command found and the concrete spec providing it
     """
     # If it is a string assume it's one of the root specs by this module
     if isinstance(query_spec, str):
@@ -96,8 +93,6 @@ def _try_import_from_store(
                         f'provides the "{module}" Python module'
                     )
                     tty.debug(msg)
-                    if query_info is not None:
-                        query_info["spec"] = candidate_spec
                     return True
             except Exception as exc:  # pylint: disable=broad-except
                 msg = (
@@ -183,22 +178,17 @@ def _fix_ext_suffix(candidate_spec: "spack.spec.Spec"):
 
 
 def _executables_in_store(
-    executables: Sequence[str],
-    query_spec: Union["spack.spec.Spec", str],
-    query_info: Optional[QueryInfo] = None,
-) -> bool:
-    """Return True if at least one of the executables can be retrieved from
-    a spec in store, False otherwise.
+    executables: Sequence[str], query_spec: Union["spack.spec.Spec", str]
+) -> Optional[ExecutableInfo]:
+    """Return the first of the executables that can be retrieved from a spec in the
+    store, together with the spec providing it, or None if there is no such spec.
 
     The different executables must provide the same functionality and are
-    "alternate" to each other, i.e. the function will exit True on the first
-    executable found.
+    "alternate" to each other, i.e. the function returns on the first one found.
 
     Args:
         executables: list of executables to be searched
         query_spec: spec that may provide the executable
-        query_info (dict or None): if a dict is passed it is populated with the
-            command found and the concrete spec providing it
     """
     executables_str = ", ".join(executables)
     msg = "[BOOTSTRAP EXECUTABLES {0}] Try installed specs with query '{1}'"
@@ -215,13 +205,11 @@ def _executables_in_store(
                 and spack.util.executable.which_string(*executables, path=bin_dir)
             ):
                 spack.util.environment.path_put_first("PATH", [bin_dir])
-                if query_info is not None:
-                    query_info["command"] = spack.util.executable.which(
-                        *executables, path=bin_dir, required=True
-                    )
-                    query_info["spec"] = concrete_spec
-                return True
-    return False
+                return ExecutableInfo(
+                    spec=concrete_spec,
+                    command=spack.util.executable.which(*executables, path=bin_dir, required=True),
+                )
+    return None
 
 
 def _root_spec(spec_str: str) -> str:

--- a/lib/spack/spack/bootstrap/_common.py
+++ b/lib/spack/spack/bootstrap/_common.py
@@ -225,12 +225,11 @@ def _executables_in_store(
 
 
 def _root_spec(spec_str: str) -> str:
-    """Add a proper compiler and target to a spec used during bootstrapping.
+    """Add the host platform and target to a spec used during bootstrapping.
 
     Args:
-        spec_str: spec to be bootstrapped. Must be without compiler and target.
+        spec_str: spec to be bootstrapped. Must be without platform and target.
     """
-    # Add a compiler and platform requirement to the root spec.
     platform = str(spack.platforms.host())
 
     spec_str += f" platform={platform}"

--- a/lib/spack/spack/bootstrap/core.py
+++ b/lib/spack/spack/bootstrap/core.py
@@ -27,7 +27,7 @@ import json
 import os
 import sys
 import uuid
-from typing import Any, Callable, Dict, List, Optional, Sequence, Type, TypeVar
+from typing import Any, Callable, Dict, Generic, List, Optional, Sequence, Type, TypeVar
 
 import spack.binary_distribution
 import spack.concretize
@@ -68,6 +68,59 @@ ConfigDictionary = Dict[str, Any]
 ResultT = TypeVar("ResultT")
 
 
+class BootstrapRequest(Generic[ResultT]):
+    """Software to be made available in the bootstrap store, and how to check for it.
+
+    The two kinds of request, a Python module and a set of executables, differ only in the
+    spec to be installed, in the probe that tests whether the software can be used, and in
+    the arguments to be passed to the installer when building from sources.
+    """
+
+    def __init__(
+        self,
+        abstract_spec: spack.spec.Spec,
+        metadata_name: str,
+        probe: Callable[[spack.spec.Spec], Optional[ResultT]],
+        installer_args: Dict[str, Any],
+    ) -> None:
+        #: Spec to be installed to satisfy this request
+        self.abstract_spec = abstract_spec
+        #: Name of the buildcache metadata file for this software
+        self.metadata_name = metadata_name
+        #: Returns the software from the store, or None if it is not usable from there
+        self.probe = probe
+        #: Extra arguments for the installer, when building from sources
+        self.installer_args = installer_args
+
+    @classmethod
+    def for_module(cls, module: str, abstract_spec_str: str) -> "BootstrapRequest[bool]":
+        """Return a request for a module importable in the interpreter running Spack."""
+        return BootstrapRequest(
+            abstract_spec=spack.spec.Spec(abstract_spec_str + " ^" + spec_for_current_python()),
+            metadata_name=module,
+            probe=functools.partial(_try_import_from_store, module),
+            # unlike the executables below, modules have always forced a source build here
+            installer_args={
+                "fail_fast": True,
+                "root_policy": "source_only",
+                "dependencies_policy": "source_only",
+            },
+        )
+
+    @classmethod
+    def for_executables(
+        cls, executables: Sequence[str], abstract_spec_str: str
+    ) -> "BootstrapRequest[ExecutableInfo]":
+        """Return a request for executables to be found in the PATH."""
+        abstract_spec = spack.spec.Spec(abstract_spec_str)
+        return BootstrapRequest(
+            abstract_spec=abstract_spec,
+            metadata_name=abstract_spec.name,
+            probe=functools.partial(_executables_in_store, executables),
+            installer_args={},
+        )
+
+
 class Bootstrapper:
     """Interface for "core" software bootstrappers"""
 
@@ -88,33 +141,16 @@ class Bootstrapper:
             f"bootstrap-{self.name}-{uuid.uuid4()}", {"mirrors:": {self.name: self.url}}
         )
 
-    def try_import(self, module: str, abstract_spec_str: str) -> bool:
-        """Try to import a Python module from a spec satisfying the abstract spec
-        passed as argument.
+    def try_to_bootstrap(self, request: BootstrapRequest[ResultT]) -> Optional[ResultT]:
+        """Try to make the requested software available, from this source.
 
         Args:
-            module: Python module name to try importing
-            abstract_spec_str: abstract spec that can provide the Python module
+            request: software to be bootstrapped, and the probe that tests for it
 
         Return:
-            True if the Python module could be imported, False otherwise
+            What the probe of the request returned, or None if bootstrapping failed
         """
-        raise NotImplementedError("subclasses must implement try_import")
-
-    def try_search_path(
-        self, executables: Sequence[str], abstract_spec_str: str
-    ) -> Optional[ExecutableInfo]:
-        """Try to search some executables in the prefix of specs satisfying the abstract
-        spec passed as argument.
-
-        Args:
-            executables: executables to be found
-            abstract_spec_str: abstract spec that can provide the executables
-
-        Return:
-            The executable and the spec providing it, or None if not found
-        """
-        raise NotImplementedError("subclasses must implement try_search_path")
+        raise NotImplementedError("subclasses must implement try_to_bootstrap")
 
 
 class BuildcacheBootstrapper(Bootstrapper):
@@ -146,10 +182,7 @@ class BuildcacheBootstrapper(Bootstrapper):
             )
 
     def _install_and_test(
-        self,
-        abstract_spec: spack.spec.Spec,
-        bincache_data,
-        test_fn: Callable[[spack.spec.Spec], ResultT],
+        self, request: BootstrapRequest[ResultT], bincache_data
     ) -> Optional[ResultT]:
         # Ensure we see only the buildcache being used to bootstrap
         with spack.config.CONFIG.override(self.mirror_scope):
@@ -163,81 +196,46 @@ class BuildcacheBootstrapper(Bootstrapper):
 
             for item in bincache_data["verified"]:
                 # Skip specs which are not compatible
-                if not spack.spec.Spec(item["spec"]).satisfies(abstract_spec):
+                if not spack.spec.Spec(item["spec"]).satisfies(request.abstract_spec):
                     continue
 
                 for _, pkg_hash, pkg_sha256 in item["binaries"]:
                     self._install_by_hash(pkg_hash, pkg_sha256)
 
-                result = test_fn(abstract_spec)
+                result = request.probe(request.abstract_spec)
                 if result:
                     return result
         return None
 
-    def try_import(self, module: str, abstract_spec_str: str) -> bool:
-        tty.debug(f"Bootstrapping {module} from pre-built binaries")
-        abstract_spec = spack.spec.Spec(abstract_spec_str + " ^" + spec_for_current_python())
-        data = self._read_metadata(module)
-        test_fn = functools.partial(_try_import_from_store, module)
-        return bool(self._install_and_test(abstract_spec, data, test_fn))
-
-    def try_search_path(
-        self, executables: Sequence[str], abstract_spec_str: str
-    ) -> Optional[ExecutableInfo]:
-        abstract_spec = spack.spec.Spec(abstract_spec_str)
-        tty.debug(f"Bootstrapping {abstract_spec.name} from pre-built binaries")
-        data = self._read_metadata(abstract_spec.name)
-        test_fn = functools.partial(_executables_in_store, executables)
-        return self._install_and_test(abstract_spec, data, test_fn)
+    def try_to_bootstrap(self, request: BootstrapRequest[ResultT]) -> Optional[ResultT]:
+        tty.debug(f"Bootstrapping {request.metadata_name} from pre-built binaries")
+        return self._install_and_test(request, self._read_metadata(request.metadata_name))
 
 
 class SourceBootstrapper(Bootstrapper):
     """Install the software needed during bootstrapping from sources."""
 
-    def try_import(self, module: str, abstract_spec_str: str) -> bool:
-        tty.debug(f"Bootstrapping {module} from sources")
+    def try_to_bootstrap(self, request: BootstrapRequest[ResultT]) -> Optional[ResultT]:
+        tty.debug(f"Bootstrapping {request.metadata_name} from sources")
 
         # If we compile code from sources detecting a few build tools
         # might reduce compilation time by a fair amount
         _add_externals_if_missing()
 
         # Try to build and install from sources
-        if module == "clingo":
+        if request.metadata_name == "clingo":
             bootstrapper = ClingoBootstrapConcretizer(configuration=spack.config.CONFIG)
             concrete_spec = bootstrapper.concretize()
         else:
-            abstract_spec = spack.spec.Spec(abstract_spec_str + " ^" + spec_for_current_python())
-            concrete_spec = spack.concretize.concretize_one(abstract_spec)
+            concrete_spec = spack.concretize.concretize_one(request.abstract_spec)
 
-        msg = "[BOOTSTRAP MODULE {0}] Try installing '{1}' from sources"
-        tty.debug(msg.format(module, abstract_spec_str))
-
-        # Install the spec that should make the module importable
+        tty.debug(f"[BOOTSTRAP] Try installing '{request.abstract_spec}' from sources")
         with spack.config.CONFIG.override(self.mirror_scope):
             spack.installer_dispatch.create_installer(
-                [concrete_spec.package],
-                fail_fast=True,
-                root_policy="source_only",
-                dependencies_policy="source_only",
+                [concrete_spec.package], **request.installer_args
             ).install()
 
-        return _try_import_from_store(module, query_spec=concrete_spec)
-
-    def try_search_path(
-        self, executables: Sequence[str], abstract_spec_str: str
-    ) -> Optional[ExecutableInfo]:
-        tty.debug(f"Bootstrapping {abstract_spec_str} from sources")
-
-        # If we compile code from sources detecting a few build tools
-        # might reduce compilation time by a fair amount
-        _add_externals_if_missing()
-
-        concrete_spec = spack.concretize.concretize_one(abstract_spec_str)
-        msg = "[BOOTSTRAP] Try installing '{0}' from sources"
-        tty.debug(msg.format(abstract_spec_str))
-        with spack.config.CONFIG.override(self.mirror_scope):
-            spack.installer_dispatch.create_installer([concrete_spec.package]).install()
-        return _executables_in_store(executables, concrete_spec)
+        return request.probe(concrete_spec)
 
 
 #: Map a bootstrapper type to the corresponding class
@@ -301,9 +299,10 @@ def ensure_module_importable_or_raise(module: str, abstract_spec: Optional[str] 
         return
 
     abstract_spec = abstract_spec or module
+    request = BootstrapRequest.for_module(module, abstract_spec)
 
     # Every source installs into the same store, so check it once for all of them
-    if _try_import_from_store(module, abstract_spec):
+    if request.probe(request.abstract_spec):
         return
 
     exception_handler = GroupedExceptionHandler()
@@ -313,7 +312,7 @@ def ensure_module_importable_or_raise(module: str, abstract_spec: Optional[str] 
             continue
 
         with exception_handler.forward(current_config["name"], Exception):
-            if create_bootstrapper(current_config).try_import(module, abstract_spec):
+            if create_bootstrapper(current_config).try_to_bootstrap(request):
                 return
 
     raise ImportError(
@@ -362,8 +361,10 @@ def ensure_executables_in_path_or_raise(
         if not cmd_check or cmd_check(cmd):
             return cmd
 
+    request = BootstrapRequest.for_executables(executables, abstract_spec)
+
     # Every source installs into the same store, so check it once for all of them
-    found = _executables_in_store(executables, abstract_spec)
+    found = request.probe(request.abstract_spec)
     if found is not None:
         return _command_with_default_envmod(found)
 
@@ -375,8 +376,7 @@ def ensure_executables_in_path_or_raise(
         if not source_is_enabled(current_config):
             continue
         with exception_handler.forward(current_config["name"], Exception):
-            current_bootstrapper = create_bootstrapper(current_config)
-            found = current_bootstrapper.try_search_path(executables, abstract_spec)
+            found = create_bootstrapper(current_config).try_to_bootstrap(request)
             if found is not None:
                 return _command_with_default_envmod(found)
 

--- a/lib/spack/spack/bootstrap/core.py
+++ b/lib/spack/spack/bootstrap/core.py
@@ -300,6 +300,27 @@ def source_is_enabled(conf: ConfigDictionary) -> bool:
     return spack.config.CONFIG.get("bootstrap:trusted").get(conf["name"], False)
 
 
+def _cannot_bootstrap_message(
+    what: str, abstract_spec: str, exception_handler: GroupedExceptionHandler
+) -> str:
+    """Return the error message to report when no bootstrapping source succeeded.
+
+    Args:
+        what: description of what could not be bootstrapped
+        abstract_spec: abstract spec that was supposed to provide it
+        exception_handler: handler that collected the failure of each source
+    """
+    msg = f'cannot bootstrap {what} from spec "{abstract_spec}" '
+    if not exception_handler:
+        msg += ": no bootstrapping sources are enabled"
+    elif spack.error.debug or spack.error.SHOW_BACKTRACE:
+        msg += exception_handler.grouped_message(with_tracebacks=True)
+    else:
+        msg += exception_handler.grouped_message(with_tracebacks=False)
+        msg += "\nRun `spack --backtrace ...` for more detailed errors"
+    return msg
+
+
 def ensure_module_importable_or_raise(module: str, abstract_spec: Optional[str] = None):
     """Make the requested module available for import, or raise.
 
@@ -334,18 +355,11 @@ def ensure_module_importable_or_raise(module: str, abstract_spec: Optional[str] 
             if create_bootstrapper(current_config).try_import(module, abstract_spec):
                 return
 
-    msg = f'cannot bootstrap the "{module}" Python module '
-    if abstract_spec:
-        msg += f'from spec "{abstract_spec}" '
-
-    if not exception_handler:
-        msg += ": no bootstrapping sources are enabled"
-    elif spack.error.debug or spack.error.SHOW_BACKTRACE:
-        msg += exception_handler.grouped_message(with_tracebacks=True)
-    else:
-        msg += exception_handler.grouped_message(with_tracebacks=False)
-        msg += "\nRun `spack --backtrace ...` for more detailed errors"
-    raise ImportError(msg)
+    raise ImportError(
+        _cannot_bootstrap_message(
+            f'the "{module}" Python module', abstract_spec, exception_handler
+        )
+    )
 
 
 def ensure_executables_in_path_or_raise(
@@ -400,18 +414,11 @@ def ensure_executables_in_path_or_raise(
                 )
                 return cmd
 
-    msg = f"cannot bootstrap any of the {executables_str} executables "
-    if abstract_spec:
-        msg += f'from spec "{abstract_spec}" '
-
-    if not exception_handler:
-        msg += ": no bootstrapping sources are enabled"
-    elif spack.error.debug or spack.error.SHOW_BACKTRACE:
-        msg += exception_handler.grouped_message(with_tracebacks=True)
-    else:
-        msg += exception_handler.grouped_message(with_tracebacks=False)
-        msg += "\nRun `spack --backtrace ...` for more detailed errors"
-    raise RuntimeError(msg)
+    raise RuntimeError(
+        _cannot_bootstrap_message(
+            f"any of the {executables_str} executables", abstract_spec, exception_handler
+        )
+    )
 
 
 def _add_externals_if_missing() -> None:

--- a/lib/spack/spack/bootstrap/core.py
+++ b/lib/spack/spack/bootstrap/core.py
@@ -111,7 +111,7 @@ class Bootstrapper:
 
         Args:
             executables: executables to be found
-            abstract_spec_str: abstract spec that can provide the Python module
+            abstract_spec_str: abstract spec that can provide the executables
 
         Return:
             True if the executables are found, False otherwise
@@ -280,7 +280,7 @@ def create_bootstrapper(conf: ConfigDictionary) -> Bootstrapper:
 
 
 def source_is_enabled(conf: ConfigDictionary) -> bool:
-    """Returns true if the source is not enabled for bootstrapping"""
+    """Returns True if the source is enabled for bootstrapping, False otherwise"""
     return spack.config.CONFIG.get("bootstrap:trusted").get(conf["name"], False)
 
 
@@ -347,28 +347,26 @@ def ensure_module_importable_or_raise(module: str, abstract_spec: Optional[str] 
 
 
 def ensure_executables_in_path_or_raise(
-    executables: list,
+    executables: Sequence[str],
     abstract_spec: str,
     cmd_check: Optional[Callable[[spack.util.executable.Executable], bool]] = None,
-):
+) -> spack.util.executable.Executable:
     """Ensure that some executables are in path or raise.
 
     Args:
-        executables (list): list of executables to be searched in the PATH,
-            in order. The function exits on the first one found.
-        abstract_spec (str): abstract spec that provides the executables
-        cmd_check (object): callable predicate that takes a
-            ``spack.util.executable.Executable`` command and validate it. Should return
-            ``True`` if the executable is acceptable, ``False`` otherwise.
-            Can be used to, e.g., ensure a suitable version of the command before
-            accepting for bootstrapping.
+        executables: executables to be searched in the PATH, in order. The function
+            exits on the first one found.
+        abstract_spec: abstract spec that provides the executables
+        cmd_check: callable predicate that takes a ``spack.util.executable.Executable``
+            command and validates it. Should return ``True`` if the executable is
+            acceptable, ``False`` otherwise. Can be used to, e.g., ensure a suitable
+            version of the command before accepting for bootstrapping.
 
     Raises:
         RuntimeError: if the executables cannot be ensured to be in PATH
 
     Return:
         Executable object
-
     """
     cmd = spack.util.executable.which(*executables)
     if cmd:
@@ -443,7 +441,7 @@ def gnupg_root_spec() -> str:
     return _root_spec(f"{root_spec_name}@2.3:")
 
 
-def ensure_gpg_in_path_or_raise() -> None:
+def ensure_gpg_in_path_or_raise() -> spack.util.executable.Executable:
     """Ensure gpg or gpg2 are in the PATH or raise."""
     return ensure_executables_in_path_or_raise(
         executables=["gpg2", "gpg"], abstract_spec=gnupg_root_spec()
@@ -479,9 +477,8 @@ def verify_patchelf(patchelf: "spack.util.executable.Executable") -> bool:
 
 def ensure_patchelf_in_path_or_raise() -> spack.util.executable.Executable:
     """Ensure patchelf is in the PATH or raise."""
-    # The old concretizer is not smart and we're doing its job: if the latest patchelf
-    # does not concretize because the compiler doesn't support C++17, we try to
-    # concretize again with an upperbound @:13.
+    # If the latest patchelf cannot be provided, e.g. because the compiler doesn't
+    # support C++17, retry with the newest version that does not require it.
     try:
         return ensure_executables_in_path_or_raise(
             executables=["patchelf"], abstract_spec=patchelf_root_spec(), cmd_check=verify_patchelf

--- a/lib/spack/spack/bootstrap/core.py
+++ b/lib/spack/spack/bootstrap/core.py
@@ -27,7 +27,7 @@ import json
 import os
 import sys
 import uuid
-from typing import Any, Callable, Dict, List, Optional, Tuple
+from typing import Any, Callable, Dict, List, Optional, Sequence, Type
 
 import spack.binary_distribution
 import spack.concretize
@@ -62,26 +62,7 @@ METADATA_YAML_FILENAME = "metadata.yaml"
 #: Whether the current platform is Windows
 IS_WINDOWS = sys.platform == "win32"
 
-#: Map a bootstrapper type to the corresponding class
-_bootstrap_methods = {}
-
-
 ConfigDictionary = Dict[str, Any]
-
-
-def bootstrapper(bootstrapper_type: str):
-    """Decorator to register classes implementing bootstrapping
-    methods.
-
-    Args:
-        bootstrapper_type: string identifying the class
-    """
-
-    def _register(cls):
-        _bootstrap_methods[bootstrapper_type] = cls
-        return cls
-
-    return _register
 
 
 class Bootstrapper:
@@ -92,6 +73,7 @@ class Bootstrapper:
     def __init__(self, conf: ConfigDictionary) -> None:
         self.conf = conf
         self.name = conf["name"]
+        self.last_search: Optional[QueryInfo] = None
         self.metadata_dir = spack.config.canonicalize_path(conf["metadata"])
 
         # Check for relative paths, and turn them into absolute paths
@@ -123,7 +105,7 @@ class Bootstrapper:
         """
         return False
 
-    def try_search_path(self, executables: Tuple[str], abstract_spec_str: str) -> bool:
+    def try_search_path(self, executables: Sequence[str], abstract_spec_str: str) -> bool:
         """Try to search some executables in the prefix of specs satisfying the abstract
         spec passed as argument.
 
@@ -137,13 +119,11 @@ class Bootstrapper:
         return False
 
 
-@bootstrapper(bootstrapper_type="buildcache")
 class BuildcacheBootstrapper(Bootstrapper):
     """Install the software needed during bootstrapping from a buildcache."""
 
     def __init__(self, conf) -> None:
         super().__init__(conf)
-        self.last_search: Optional[QueryInfo] = None
         self.config_scope_name = f"bootstrap_buildcache-{uuid.uuid4()}"
 
     def _read_metadata(self, package_name: str) -> Any:
@@ -207,7 +187,7 @@ class BuildcacheBootstrapper(Bootstrapper):
         data = self._read_metadata(module)
         return self._install_and_test(abstract_spec, data, test_fn)
 
-    def try_search_path(self, executables: Tuple[str], abstract_spec_str: str) -> bool:
+    def try_search_path(self, executables: Sequence[str], abstract_spec_str: str) -> bool:
         info: QueryInfo
         test_fn, info = functools.partial(_executables_in_store, executables), {}
         if test_fn(query_spec=abstract_spec_str, query_info=info):
@@ -220,13 +200,11 @@ class BuildcacheBootstrapper(Bootstrapper):
         return self._install_and_test(abstract_spec, data, test_fn)
 
 
-@bootstrapper(bootstrapper_type="install")
 class SourceBootstrapper(Bootstrapper):
     """Install the software needed during bootstrapping from sources."""
 
     def __init__(self, conf) -> None:
         super().__init__(conf)
-        self.last_search: Optional[QueryInfo] = None
         self.config_scope_name = f"bootstrap_source-{uuid.uuid4()}"
 
     def try_import(self, module: str, abstract_spec_str: str) -> bool:
@@ -266,7 +244,7 @@ class SourceBootstrapper(Bootstrapper):
             return True
         return False
 
-    def try_search_path(self, executables: Tuple[str], abstract_spec_str: str) -> bool:
+    def try_search_path(self, executables: Sequence[str], abstract_spec_str: str) -> bool:
         info: QueryInfo = {}
         if _executables_in_store(executables, abstract_spec_str, query_info=info):
             self.last_search = info
@@ -289,10 +267,16 @@ class SourceBootstrapper(Bootstrapper):
         return False
 
 
-def create_bootstrapper(conf: ConfigDictionary):
+#: Map a bootstrapper type to the corresponding class
+_bootstrap_methods: Dict[str, Type[Bootstrapper]] = {
+    "buildcache": BuildcacheBootstrapper,
+    "install": SourceBootstrapper,
+}
+
+
+def create_bootstrapper(conf: ConfigDictionary) -> Bootstrapper:
     """Return a bootstrap object built according to the configuration argument"""
-    btype = conf["type"]
-    return _bootstrap_methods[btype](conf)
+    return _bootstrap_methods[conf["type"]](conf)
 
 
 def source_is_enabled(conf: ConfigDictionary) -> bool:
@@ -401,12 +385,13 @@ def ensure_executables_in_path_or_raise(
         with exception_handler.forward(current_config["name"], Exception):
             current_bootstrapper = create_bootstrapper(current_config)
             if current_bootstrapper.try_search_path(executables, abstract_spec):
+                query_info = current_bootstrapper.last_search
+                if query_info is None:
+                    raise RuntimeError(
+                        f'"{current_bootstrapper.name}" reported success without a query result'
+                    )
                 # Additional environment variables needed
-                concrete_spec, cmd = (
-                    current_bootstrapper.last_search["spec"],
-                    current_bootstrapper.last_search["command"],
-                )
-                assert cmd is not None, "expected an Executable"
+                concrete_spec, cmd = query_info["spec"], query_info["command"]
                 cmd.add_default_envmod(
                     spack.user_environment.environment_modifications_for_specs(
                         concrete_spec, set_package_py_globals=False

--- a/lib/spack/spack/bootstrap/core.py
+++ b/lib/spack/spack/bootstrap/core.py
@@ -175,26 +175,19 @@ class BuildcacheBootstrapper(Bootstrapper):
         return None
 
     def try_import(self, module: str, abstract_spec_str: str) -> bool:
-        test_fn = functools.partial(_try_import_from_store, module)
-        if test_fn(abstract_spec_str):
-            return True
-
         tty.debug(f"Bootstrapping {module} from pre-built binaries")
         abstract_spec = spack.spec.Spec(abstract_spec_str + " ^" + spec_for_current_python())
         data = self._read_metadata(module)
+        test_fn = functools.partial(_try_import_from_store, module)
         return bool(self._install_and_test(abstract_spec, data, test_fn))
 
     def try_search_path(
         self, executables: Sequence[str], abstract_spec_str: str
     ) -> Optional[ExecutableInfo]:
-        test_fn = functools.partial(_executables_in_store, executables)
-        result = test_fn(abstract_spec_str)
-        if result is not None:
-            return result
-
         abstract_spec = spack.spec.Spec(abstract_spec_str)
         tty.debug(f"Bootstrapping {abstract_spec.name} from pre-built binaries")
         data = self._read_metadata(abstract_spec.name)
+        test_fn = functools.partial(_executables_in_store, executables)
         return self._install_and_test(abstract_spec, data, test_fn)
 
 
@@ -202,9 +195,6 @@ class SourceBootstrapper(Bootstrapper):
     """Install the software needed during bootstrapping from sources."""
 
     def try_import(self, module: str, abstract_spec_str: str) -> bool:
-        if _try_import_from_store(module, abstract_spec_str):
-            return True
-
         tty.debug(f"Bootstrapping {module} from sources")
 
         # If we compile code from sources detecting a few build tools
@@ -236,10 +226,6 @@ class SourceBootstrapper(Bootstrapper):
     def try_search_path(
         self, executables: Sequence[str], abstract_spec_str: str
     ) -> Optional[ExecutableInfo]:
-        result = _executables_in_store(executables, abstract_spec_str)
-        if result is not None:
-            return result
-
         tty.debug(f"Bootstrapping {abstract_spec_str} from sources")
 
         # If we compile code from sources detecting a few build tools
@@ -316,6 +302,10 @@ def ensure_module_importable_or_raise(module: str, abstract_spec: Optional[str] 
 
     abstract_spec = abstract_spec or module
 
+    # Every source installs into the same store, so check it once for all of them
+    if _try_import_from_store(module, abstract_spec):
+        return
+
     exception_handler = GroupedExceptionHandler()
 
     for current_config in bootstrapping_sources():
@@ -331,6 +321,18 @@ def ensure_module_importable_or_raise(module: str, abstract_spec: Optional[str] 
             f'the "{module}" Python module', abstract_spec, exception_handler
         )
     )
+
+
+def _command_with_default_envmod(found: ExecutableInfo) -> spack.util.executable.Executable:
+    """Return the command from a lookup result, with the environment modifications
+    needed to run it.
+    """
+    found.command.add_default_envmod(
+        spack.user_environment.environment_modifications_for_specs(
+            found.spec, set_package_py_globals=False
+        )
+    )
+    return found.command
 
 
 def ensure_executables_in_path_or_raise(
@@ -360,6 +362,11 @@ def ensure_executables_in_path_or_raise(
         if not cmd_check or cmd_check(cmd):
             return cmd
 
+    # Every source installs into the same store, so check it once for all of them
+    found = _executables_in_store(executables, abstract_spec)
+    if found is not None:
+        return _command_with_default_envmod(found)
+
     executables_str = ", ".join(executables)
 
     exception_handler = GroupedExceptionHandler()
@@ -371,13 +378,7 @@ def ensure_executables_in_path_or_raise(
             current_bootstrapper = create_bootstrapper(current_config)
             found = current_bootstrapper.try_search_path(executables, abstract_spec)
             if found is not None:
-                # Additional environment variables needed
-                found.command.add_default_envmod(
-                    spack.user_environment.environment_modifications_for_specs(
-                        found.spec, set_package_py_globals=False
-                    )
-                )
-                return found.command
+                return _command_with_default_envmod(found)
 
     raise RuntimeError(
         _cannot_bootstrap_message(

--- a/lib/spack/spack/bootstrap/core.py
+++ b/lib/spack/spack/bootstrap/core.py
@@ -36,7 +36,6 @@ import spack.detection
 import spack.error
 import spack.installer_dispatch
 import spack.mirrors.mirror
-import spack.platforms
 import spack.spec
 import spack.store
 import spack.user_environment
@@ -55,7 +54,7 @@ from ._common import (
     _try_import_from_store,
 )
 from .clingo import ClingoBootstrapConcretizer
-from .config import spack_python_interpreter, spec_for_current_python
+from .config import spec_for_current_python
 
 #: Name of the file containing metadata about the bootstrapping source
 METADATA_YAML_FILENAME = "metadata.yaml"
@@ -147,22 +146,6 @@ class BuildcacheBootstrapper(Bootstrapper):
         self.last_search: Optional[QueryInfo] = None
         self.config_scope_name = f"bootstrap_buildcache-{uuid.uuid4()}"
 
-    @staticmethod
-    def _spec_and_platform(
-        abstract_spec_str: str,
-    ) -> Tuple[spack.spec.Spec, spack.platforms.Platform]:
-        """Return the spec object and platform we need to use when
-        querying the buildcache.
-
-        Args:
-            abstract_spec_str: abstract spec string we are looking for
-        """
-        # Try to install from an unsigned binary cache
-        abstract_spec = spack.spec.Spec(abstract_spec_str)
-        # On Cray we want to use Linux binaries if available from mirrors
-        bincache_platform = spack.platforms.real_host()
-        return abstract_spec, bincache_platform
-
     def _read_metadata(self, package_name: str) -> Any:
         """Return metadata about the given package."""
         json_filename = f"{package_name}.json"
@@ -172,31 +155,23 @@ class BuildcacheBootstrapper(Bootstrapper):
             data = json.load(stream)
         return data
 
-    def _install_by_hash(
-        self, pkg_hash: str, pkg_sha256: str, bincache_platform: spack.platforms.Platform
-    ) -> None:
-        with spack.platforms.use_platform(bincache_platform):
-            query = spack.binary_distribution.BinaryCacheQuery(all_architectures=True)
-            for match in spack.store.find([f"/{pkg_hash}"], multiple=False, query_fn=query):
-                spack.binary_distribution.install_root_node(
-                    # allow_missing is true since when bootstrapping clingo we truncate runtime
-                    # deps such as gcc-runtime, since we link libstdc++ statically, and the other
-                    # further runtime deps are loaded by the Python interpreter. This just silences
-                    # warnings about missing dependencies.
-                    match,
-                    unsigned=True,
-                    force=True,
-                    sha256=pkg_sha256,
-                    allow_missing=True,
-                )
+    def _install_by_hash(self, pkg_hash: str, pkg_sha256: str) -> None:
+        # The caller is inside ensure_bootstrap_configuration, which already selects the platform
+        query = spack.binary_distribution.BinaryCacheQuery(all_architectures=True)
+        for match in spack.store.find([f"/{pkg_hash}"], multiple=False, query_fn=query):
+            spack.binary_distribution.install_root_node(
+                # allow_missing is true since when bootstrapping clingo we truncate runtime
+                # deps such as gcc-runtime, since we link libstdc++ statically, and the other
+                # further runtime deps are loaded by the Python interpreter. This just silences
+                # warnings about missing dependencies.
+                match,
+                unsigned=True,
+                force=True,
+                sha256=pkg_sha256,
+                allow_missing=True,
+            )
 
-    def _install_and_test(
-        self,
-        abstract_spec: spack.spec.Spec,
-        bincache_platform: spack.platforms.Platform,
-        bincache_data,
-        test_fn,
-    ) -> bool:
+    def _install_and_test(self, abstract_spec: spack.spec.Spec, bincache_data, test_fn) -> bool:
         # Ensure we see only the buildcache being used to bootstrap
         with spack.config.CONFIG.override(self.mirror_scope):
             # This index is currently needed to get the compiler used to build some
@@ -213,7 +188,7 @@ class BuildcacheBootstrapper(Bootstrapper):
                     continue
 
                 for _, pkg_hash, pkg_sha256 in item["binaries"]:
-                    self._install_by_hash(pkg_hash, pkg_sha256, bincache_platform)
+                    self._install_by_hash(pkg_hash, pkg_sha256)
 
                 info: QueryInfo = {}
                 if test_fn(query_spec=abstract_spec, query_info=info):
@@ -228,11 +203,9 @@ class BuildcacheBootstrapper(Bootstrapper):
             return True
 
         tty.debug(f"Bootstrapping {module} from pre-built binaries")
-        abstract_spec, bincache_platform = self._spec_and_platform(
-            abstract_spec_str + " ^" + spec_for_current_python()
-        )
+        abstract_spec = spack.spec.Spec(abstract_spec_str + " ^" + spec_for_current_python())
         data = self._read_metadata(module)
-        return self._install_and_test(abstract_spec, bincache_platform, data, test_fn)
+        return self._install_and_test(abstract_spec, data, test_fn)
 
     def try_search_path(self, executables: Tuple[str], abstract_spec_str: str) -> bool:
         info: QueryInfo
@@ -241,10 +214,10 @@ class BuildcacheBootstrapper(Bootstrapper):
             self.last_search = info
             return True
 
-        abstract_spec, bincache_platform = self._spec_and_platform(abstract_spec_str)
+        abstract_spec = spack.spec.Spec(abstract_spec_str)
         tty.debug(f"Bootstrapping {abstract_spec.name} from pre-built binaries")
         data = self._read_metadata(abstract_spec.name)
-        return self._install_and_test(abstract_spec, bincache_platform, data, test_fn)
+        return self._install_and_test(abstract_spec, data, test_fn)
 
 
 @bootstrapper(bootstrapper_type="install")
@@ -269,15 +242,12 @@ class SourceBootstrapper(Bootstrapper):
         _add_externals_if_missing()
 
         # Try to build and install from sources
-        with spack_python_interpreter():
-            if module == "clingo":
-                bootstrapper = ClingoBootstrapConcretizer(configuration=spack.config.CONFIG)
-                concrete_spec = bootstrapper.concretize()
-            else:
-                abstract_spec = spack.spec.Spec(
-                    abstract_spec_str + " ^" + spec_for_current_python()
-                )
-                concrete_spec = spack.concretize.concretize_one(abstract_spec)
+        if module == "clingo":
+            bootstrapper = ClingoBootstrapConcretizer(configuration=spack.config.CONFIG)
+            concrete_spec = bootstrapper.concretize()
+        else:
+            abstract_spec = spack.spec.Spec(abstract_spec_str + " ^" + spec_for_current_python())
+            concrete_spec = spack.concretize.concretize_one(abstract_spec)
 
         msg = "[BOOTSTRAP MODULE {0}] Try installing '{1}' from sources"
         tty.debug(msg.format(module, abstract_spec_str))

--- a/lib/spack/spack/bootstrap/core.py
+++ b/lib/spack/spack/bootstrap/core.py
@@ -71,7 +71,8 @@ ResultT = TypeVar("ResultT")
 class Bootstrapper:
     """Interface for "core" software bootstrappers"""
 
-    config_scope_name = ""
+    #: Prefix of the name of the configuration scope pushed by this bootstrapper
+    config_scope_prefix = "bootstrap"
 
     def __init__(self, conf: ConfigDictionary) -> None:
         self.conf = conf
@@ -85,13 +86,10 @@ class Bootstrapper:
             maybe_url = os.path.join(self.metadata_dir, maybe_url)
         self.url = spack.mirrors.mirror.Mirror(maybe_url).fetch_url
 
-    @property
-    def mirror_scope(self) -> spack.config.InternalConfigScope:
-        """Mirror scope to be pushed onto the bootstrapping configuration when using
-        this bootstrapper.
-        """
-        return spack.config.InternalConfigScope(
-            self.config_scope_name, {"mirrors:": {self.name: self.url}}
+        #: Mirror scope to be pushed onto the bootstrapping configuration when using
+        #: this bootstrapper
+        self.mirror_scope = spack.config.InternalConfigScope(
+            f"{self.config_scope_prefix}-{uuid.uuid4()}", {"mirrors:": {self.name: self.url}}
         )
 
     def try_import(self, module: str, abstract_spec_str: str) -> bool:
@@ -105,7 +103,7 @@ class Bootstrapper:
         Return:
             True if the Python module could be imported, False otherwise
         """
-        return False
+        raise NotImplementedError("subclasses must implement try_import")
 
     def try_search_path(
         self, executables: Sequence[str], abstract_spec_str: str
@@ -120,15 +118,13 @@ class Bootstrapper:
         Return:
             The executable and the spec providing it, or None if not found
         """
-        return None
+        raise NotImplementedError("subclasses must implement try_search_path")
 
 
 class BuildcacheBootstrapper(Bootstrapper):
     """Install the software needed during bootstrapping from a buildcache."""
 
-    def __init__(self, conf) -> None:
-        super().__init__(conf)
-        self.config_scope_name = f"bootstrap_buildcache-{uuid.uuid4()}"
+    config_scope_prefix = "bootstrap_buildcache"
 
     def _read_metadata(self, package_name: str) -> Any:
         """Return metadata about the given package."""
@@ -211,9 +207,7 @@ class BuildcacheBootstrapper(Bootstrapper):
 class SourceBootstrapper(Bootstrapper):
     """Install the software needed during bootstrapping from sources."""
 
-    def __init__(self, conf) -> None:
-        super().__init__(conf)
-        self.config_scope_name = f"bootstrap_source-{uuid.uuid4()}"
+    config_scope_prefix = "bootstrap_source"
 
     def try_import(self, module: str, abstract_spec_str: str) -> bool:
         if _try_import_from_store(module, abstract_spec_str):

--- a/lib/spack/spack/bootstrap/core.py
+++ b/lib/spack/spack/bootstrap/core.py
@@ -27,7 +27,7 @@ import json
 import os
 import sys
 import uuid
-from typing import Any, Callable, Dict, List, Optional, Sequence, Type
+from typing import Any, Callable, Dict, List, Optional, Sequence, Type, TypeVar
 
 import spack.binary_distribution
 import spack.concretize
@@ -47,7 +47,7 @@ from spack.util import tty
 from spack.util.lang import GroupedExceptionHandler
 
 from ._common import (
-    QueryInfo,
+    ExecutableInfo,
     _executables_in_store,
     _python_import,
     _root_spec,
@@ -64,6 +64,9 @@ IS_WINDOWS = sys.platform == "win32"
 
 ConfigDictionary = Dict[str, Any]
 
+#: Whatever a bootstrapper's store probe returns on success
+ResultT = TypeVar("ResultT")
+
 
 class Bootstrapper:
     """Interface for "core" software bootstrappers"""
@@ -73,7 +76,6 @@ class Bootstrapper:
     def __init__(self, conf: ConfigDictionary) -> None:
         self.conf = conf
         self.name = conf["name"]
-        self.last_search: Optional[QueryInfo] = None
         self.metadata_dir = spack.config.canonicalize_path(conf["metadata"])
 
         # Check for relative paths, and turn them into absolute paths
@@ -105,7 +107,9 @@ class Bootstrapper:
         """
         return False
 
-    def try_search_path(self, executables: Sequence[str], abstract_spec_str: str) -> bool:
+    def try_search_path(
+        self, executables: Sequence[str], abstract_spec_str: str
+    ) -> Optional[ExecutableInfo]:
         """Try to search some executables in the prefix of specs satisfying the abstract
         spec passed as argument.
 
@@ -114,9 +118,9 @@ class Bootstrapper:
             abstract_spec_str: abstract spec that can provide the executables
 
         Return:
-            True if the executables are found, False otherwise
+            The executable and the spec providing it, or None if not found
         """
-        return False
+        return None
 
 
 class BuildcacheBootstrapper(Bootstrapper):
@@ -151,7 +155,12 @@ class BuildcacheBootstrapper(Bootstrapper):
                 allow_missing=True,
             )
 
-    def _install_and_test(self, abstract_spec: spack.spec.Spec, bincache_data, test_fn) -> bool:
+    def _install_and_test(
+        self,
+        abstract_spec: spack.spec.Spec,
+        bincache_data,
+        test_fn: Callable[[spack.spec.Spec], ResultT],
+    ) -> Optional[ResultT]:
         # Ensure we see only the buildcache being used to bootstrap
         with spack.config.CONFIG.override(self.mirror_scope):
             # This index is currently needed to get the compiler used to build some
@@ -170,29 +179,28 @@ class BuildcacheBootstrapper(Bootstrapper):
                 for _, pkg_hash, pkg_sha256 in item["binaries"]:
                     self._install_by_hash(pkg_hash, pkg_sha256)
 
-                info: QueryInfo = {}
-                if test_fn(query_spec=abstract_spec, query_info=info):
-                    self.last_search = info
-                    return True
-        return False
+                result = test_fn(abstract_spec)
+                if result:
+                    return result
+        return None
 
     def try_import(self, module: str, abstract_spec_str: str) -> bool:
-        info: QueryInfo
-        test_fn, info = functools.partial(_try_import_from_store, module), {}
-        if test_fn(query_spec=abstract_spec_str, query_info=info):
+        test_fn = functools.partial(_try_import_from_store, module)
+        if test_fn(abstract_spec_str):
             return True
 
         tty.debug(f"Bootstrapping {module} from pre-built binaries")
         abstract_spec = spack.spec.Spec(abstract_spec_str + " ^" + spec_for_current_python())
         data = self._read_metadata(module)
-        return self._install_and_test(abstract_spec, data, test_fn)
+        return bool(self._install_and_test(abstract_spec, data, test_fn))
 
-    def try_search_path(self, executables: Sequence[str], abstract_spec_str: str) -> bool:
-        info: QueryInfo
-        test_fn, info = functools.partial(_executables_in_store, executables), {}
-        if test_fn(query_spec=abstract_spec_str, query_info=info):
-            self.last_search = info
-            return True
+    def try_search_path(
+        self, executables: Sequence[str], abstract_spec_str: str
+    ) -> Optional[ExecutableInfo]:
+        test_fn = functools.partial(_executables_in_store, executables)
+        result = test_fn(abstract_spec_str)
+        if result is not None:
+            return result
 
         abstract_spec = spack.spec.Spec(abstract_spec_str)
         tty.debug(f"Bootstrapping {abstract_spec.name} from pre-built binaries")
@@ -208,9 +216,7 @@ class SourceBootstrapper(Bootstrapper):
         self.config_scope_name = f"bootstrap_source-{uuid.uuid4()}"
 
     def try_import(self, module: str, abstract_spec_str: str) -> bool:
-        info: QueryInfo = {}
-        if _try_import_from_store(module, abstract_spec_str, query_info=info):
-            self.last_search = info
+        if _try_import_from_store(module, abstract_spec_str):
             return True
 
         tty.debug(f"Bootstrapping {module} from sources")
@@ -239,16 +245,14 @@ class SourceBootstrapper(Bootstrapper):
                 dependencies_policy="source_only",
             ).install()
 
-        if _try_import_from_store(module, query_spec=concrete_spec, query_info=info):
-            self.last_search = info
-            return True
-        return False
+        return _try_import_from_store(module, query_spec=concrete_spec)
 
-    def try_search_path(self, executables: Sequence[str], abstract_spec_str: str) -> bool:
-        info: QueryInfo = {}
-        if _executables_in_store(executables, abstract_spec_str, query_info=info):
-            self.last_search = info
-            return True
+    def try_search_path(
+        self, executables: Sequence[str], abstract_spec_str: str
+    ) -> Optional[ExecutableInfo]:
+        result = _executables_in_store(executables, abstract_spec_str)
+        if result is not None:
+            return result
 
         tty.debug(f"Bootstrapping {abstract_spec_str} from sources")
 
@@ -261,10 +265,7 @@ class SourceBootstrapper(Bootstrapper):
         tty.debug(msg.format(abstract_spec_str))
         with spack.config.CONFIG.override(self.mirror_scope):
             spack.installer_dispatch.create_installer([concrete_spec.package]).install()
-        if _executables_in_store(executables, concrete_spec, query_info=info):
-            self.last_search = info
-            return True
-        return False
+        return _executables_in_store(executables, concrete_spec)
 
 
 #: Map a bootstrapper type to the corresponding class
@@ -382,20 +383,15 @@ def ensure_executables_in_path_or_raise(
             continue
         with exception_handler.forward(current_config["name"], Exception):
             current_bootstrapper = create_bootstrapper(current_config)
-            if current_bootstrapper.try_search_path(executables, abstract_spec):
-                query_info = current_bootstrapper.last_search
-                if query_info is None:
-                    raise RuntimeError(
-                        f'"{current_bootstrapper.name}" reported success without a query result'
-                    )
+            found = current_bootstrapper.try_search_path(executables, abstract_spec)
+            if found is not None:
                 # Additional environment variables needed
-                concrete_spec, cmd = query_info["spec"], query_info["command"]
-                cmd.add_default_envmod(
+                found.command.add_default_envmod(
                     spack.user_environment.environment_modifications_for_specs(
-                        concrete_spec, set_package_py_globals=False
+                        found.spec, set_package_py_globals=False
                     )
                 )
-                return cmd
+                return found.command
 
     raise RuntimeError(
         _cannot_bootstrap_message(

--- a/lib/spack/spack/bootstrap/core.py
+++ b/lib/spack/spack/bootstrap/core.py
@@ -276,6 +276,42 @@ def _cannot_bootstrap_message(
     return msg
 
 
+def _bootstrap_or_raise(
+    request: BootstrapRequest[ResultT], what: str, abstract_spec: str, error_type: Type[Exception]
+) -> ResultT:
+    """Make the requested software available in the bootstrap store, or raise.
+
+    The enabled bootstrapping sources are tried in order, and the function exits on the
+    first success.
+
+    Args:
+        request: software to be bootstrapped, and the probe that tests for it
+        what: description of the software, to be used in the error message
+        abstract_spec: abstract spec that was supposed to provide it
+        error_type: exception to be raised if no source succeeds
+
+    Raises:
+        error_type: if the software could not be bootstrapped
+    """
+    # Every source installs into the same store, so check it once for all of them
+    result = request.probe(request.abstract_spec)
+    if result:
+        return result
+
+    exception_handler = GroupedExceptionHandler()
+
+    for current_config in bootstrapping_sources():
+        if not source_is_enabled(current_config):
+            continue
+
+        with exception_handler.forward(current_config["name"], Exception):
+            result = create_bootstrapper(current_config).try_to_bootstrap(request)
+            if result:
+                return result
+
+    raise error_type(_cannot_bootstrap_message(what, abstract_spec, exception_handler))
+
+
 def ensure_module_importable_or_raise(module: str, abstract_spec: Optional[str] = None):
     """Make the requested module available for import, or raise.
 
@@ -299,39 +335,12 @@ def ensure_module_importable_or_raise(module: str, abstract_spec: Optional[str] 
         return
 
     abstract_spec = abstract_spec or module
-    request = BootstrapRequest.for_module(module, abstract_spec)
-
-    # Every source installs into the same store, so check it once for all of them
-    if request.probe(request.abstract_spec):
-        return
-
-    exception_handler = GroupedExceptionHandler()
-
-    for current_config in bootstrapping_sources():
-        if not source_is_enabled(current_config):
-            continue
-
-        with exception_handler.forward(current_config["name"], Exception):
-            if create_bootstrapper(current_config).try_to_bootstrap(request):
-                return
-
-    raise ImportError(
-        _cannot_bootstrap_message(
-            f'the "{module}" Python module', abstract_spec, exception_handler
-        )
+    _bootstrap_or_raise(
+        BootstrapRequest.for_module(module, abstract_spec),
+        what=f'the "{module}" Python module',
+        abstract_spec=abstract_spec,
+        error_type=ImportError,
     )
-
-
-def _command_with_default_envmod(found: ExecutableInfo) -> spack.util.executable.Executable:
-    """Return the command from a lookup result, with the environment modifications
-    needed to run it.
-    """
-    found.command.add_default_envmod(
-        spack.user_environment.environment_modifications_for_specs(
-            found.spec, set_package_py_globals=False
-        )
-    )
-    return found.command
 
 
 def ensure_executables_in_path_or_raise(
@@ -361,30 +370,19 @@ def ensure_executables_in_path_or_raise(
         if not cmd_check or cmd_check(cmd):
             return cmd
 
-    request = BootstrapRequest.for_executables(executables, abstract_spec)
-
-    # Every source installs into the same store, so check it once for all of them
-    found = request.probe(request.abstract_spec)
-    if found is not None:
-        return _command_with_default_envmod(found)
-
-    executables_str = ", ".join(executables)
-
-    exception_handler = GroupedExceptionHandler()
-
-    for current_config in bootstrapping_sources():
-        if not source_is_enabled(current_config):
-            continue
-        with exception_handler.forward(current_config["name"], Exception):
-            found = create_bootstrapper(current_config).try_to_bootstrap(request)
-            if found is not None:
-                return _command_with_default_envmod(found)
-
-    raise RuntimeError(
-        _cannot_bootstrap_message(
-            f"any of the {executables_str} executables", abstract_spec, exception_handler
+    found = _bootstrap_or_raise(
+        BootstrapRequest.for_executables(executables, abstract_spec),
+        what=f"any of the {', '.join(executables)} executables",
+        abstract_spec=abstract_spec,
+        error_type=RuntimeError,
+    )
+    # Additional environment variables needed to run the command
+    found.command.add_default_envmod(
+        spack.user_environment.environment_modifications_for_specs(
+            found.spec, set_package_py_globals=False
         )
     )
+    return found.command
 
 
 def _add_externals_if_missing() -> None:

--- a/lib/spack/spack/bootstrap/core.py
+++ b/lib/spack/spack/bootstrap/core.py
@@ -71,11 +71,7 @@ ResultT = TypeVar("ResultT")
 class Bootstrapper:
     """Interface for "core" software bootstrappers"""
 
-    #: Prefix of the name of the configuration scope pushed by this bootstrapper
-    config_scope_prefix = "bootstrap"
-
     def __init__(self, conf: ConfigDictionary) -> None:
-        self.conf = conf
         self.name = conf["name"]
         self.metadata_dir = spack.config.canonicalize_path(conf["metadata"])
 
@@ -89,7 +85,7 @@ class Bootstrapper:
         #: Mirror scope to be pushed onto the bootstrapping configuration when using
         #: this bootstrapper
         self.mirror_scope = spack.config.InternalConfigScope(
-            f"{self.config_scope_prefix}-{uuid.uuid4()}", {"mirrors:": {self.name: self.url}}
+            f"bootstrap-{self.name}-{uuid.uuid4()}", {"mirrors:": {self.name: self.url}}
         )
 
     def try_import(self, module: str, abstract_spec_str: str) -> bool:
@@ -123,8 +119,6 @@ class Bootstrapper:
 
 class BuildcacheBootstrapper(Bootstrapper):
     """Install the software needed during bootstrapping from a buildcache."""
-
-    config_scope_prefix = "bootstrap_buildcache"
 
     def _read_metadata(self, package_name: str) -> Any:
         """Return metadata about the given package."""
@@ -206,8 +200,6 @@ class BuildcacheBootstrapper(Bootstrapper):
 
 class SourceBootstrapper(Bootstrapper):
     """Install the software needed during bootstrapping from sources."""
-
-    config_scope_prefix = "bootstrap_source"
 
     def try_import(self, module: str, abstract_spec_str: str) -> bool:
         if _try_import_from_store(module, abstract_spec_str):

--- a/lib/spack/spack/test/bootstrap.py
+++ b/lib/spack/spack/test/bootstrap.py
@@ -7,6 +7,7 @@ import pathlib
 import pytest
 
 import spack.bootstrap
+import spack.bootstrap._common
 import spack.bootstrap.clingo
 import spack.bootstrap.config
 import spack.bootstrap.core
@@ -252,15 +253,14 @@ def test_gpg_status_check(
         mock_executable("gpg2", "echo GPG 2.3.4")
 
     # Mock the bootstrap store function
-    def mock_executables_in_store(exes, query_spec, query_info=None):
+    def mock_executables_in_store(exes, query_spec):
         if not gpg_in_store:
-            return False
+            return None
 
         # Simulate found gpg in bootstrap store
-        if query_info is not None:
-            query_info["spec"] = "gnupg@2.5.12"
-            query_info["command"] = spack.util.executable.Executable("gpg")
-        return True
+        return spack.bootstrap._common.ExecutableInfo(
+            spec=spack.spec.Spec("gnupg@2.5.12"), command=spack.util.executable.Executable("gpg")
+        )
 
     monkeypatch.setattr(spack.bootstrap.status, "_executables_in_store", mock_executables_in_store)
 


### PR DESCRIPTION
Reviewing the `spack.bootstrap` module for #52922 it turned out that a fair amount of code was harmful or no longer doing anything. In particular:
- The bootstrapper was using nested `use_platform(real_host())` per installed binary, which was clearing the whole config cache twice per binary installed.
- Similarly it was using `spack_python_interpreter()` inside a context that had already entered it.
- The `bootstrapper` decorator machinery prevented mypy inspections. Removing that lead to fixing type-hints and simplifying the overall structure.
- Removed the `last_query`, `query_info` and `conf` attributes of the bootstrapper
- The bootstrap store was queried once per configured source before the first install attempt, now it's queried just oince.
- Created a single generic `BootstrapRequest` to deduplicate the code for executables and Python modules

The PR was tested manually with end-to-end scenarios, since the coverage from unit tests is poor for this part of Spack.