### PR TITLE
Define `VIRTUAL_ENV_PROMPT` and simplify 

### DIFF
--- a/lib/spack/spack/cmd/env.py
+++ b/lib/spack/spack/cmd/env.py
@@ -332,7 +332,6 @@ def env_activate(args):
     elif args.temp:
         env = create_temp_env_directory()
         env_path = os.path.abspath(env)
-        short_name = os.path.basename(env_path)
         view = not args.without_view
         ev.create_in_dir(env, with_view=view).write(regenerate=False)
         _tty_info(f"Created and activated temporary environment in {env_path}")
@@ -340,12 +339,10 @@ def env_activate(args):
     # Managed environment
     elif ev.exists(args.env_name) and not args.dir:
         env_path = ev.root(args.env_name)
-        short_name = args.env_name
 
     # Environment directory
     elif ev.is_env_dir(args.env_name):
         env_path = os.path.abspath(args.env_name)
-        short_name = os.path.basename(env_path)
 
     # create if user requested, and then recall recursively
     elif args.create:
@@ -357,8 +354,6 @@ def env_activate(args):
 
     else:
         tty.die("No such environment: '%s'" % args.env_name)
-
-    env_prompt = "[%s]" % short_name
 
     # We only support one active environment at a time, so deactivate the current one.
     if active_environment() is None:
@@ -381,7 +376,7 @@ def env_activate(args):
         view = ev.default_view_name
 
     cmds += spack.environment.shell.activate_header(
-        env=active_env, shell=args.shell, prompt=env_prompt if args.prompt else None, view=view
+        env=active_env, shell=args.shell, prompt=args.prompt, view=view
     )
     env_mods.extend(spack.environment.shell.activate(env=active_env, view=view))
     cmds += env_mods.shell_modifications(args.shell)

--- a/lib/spack/spack/environment/shell.py
+++ b/lib/spack/spack/environment/shell.py
@@ -97,7 +97,11 @@ def activate_header(
 
 def deactivate_header(shell):
     shell_cmd = ShellCmdString(shell)
-    cmds: List[str] = [shell_cmd.unset("SPACK_ENV"), shell_cmd.unset("SPACK_ENV_VIEW")]
+    cmds: List[str] = [
+        shell_cmd.unset("SPACK_ENV"),
+        shell_cmd.unset("SPACK_ENV_VIEW"),
+        shell_cmd.unset("VIRTUAL_ENV_PROMPT"),
+    ]
 
     if shell == "csh":
         cmds.append(

--- a/lib/spack/spack/environment/shell.py
+++ b/lib/spack/spack/environment/shell.py
@@ -73,17 +73,22 @@ def _make_spack_prompt(shell: str, prompt: str) -> List[str]:
         ]
 
 
-def activate_header(env: ev.Environment, shell: str, prompt: bool = False, view: Optional[str] = None):
-    # Construct the commands to run
-    shell_cmd = ShellCmdString(shell)
-    cmds: List[str] = [shell_cmd.set("SPACK_ENV", env.path)]
-    if view:
-        cmds.append(shell_cmd.set("SPACK_ENV_VIEW", view))
-    cmds.extend(shell_cmd.alias("despacktivate", "spack env deactivate"))
-
+def activate_header(
+    env: ev.Environment, shell: str, prompt: bool = False, view: Optional[str] = None
+):
     short_name = env.name
     if short_name == env.path:
         short_name = os.path.basename(short_name)
+
+    # Construct the commands to run
+    shell_cmd = ShellCmdString(shell)
+    cmds: List[str] = [
+        shell_cmd.set("SPACK_ENV", env.path),
+        shell_cmd.set("VIRTUAL_ENV_PROMPT", short_name),
+    ]
+    if view:
+        cmds.append(shell_cmd.set("SPACK_ENV_VIEW", view))
+    cmds.extend(shell_cmd.alias("despacktivate", "spack env deactivate"))
 
     if prompt:
         cmds.extend(_make_spack_prompt(shell, f"[{short_name}]"))

--- a/lib/spack/spack/environment/shell.py
+++ b/lib/spack/spack/environment/shell.py
@@ -16,6 +16,63 @@ from spack.util.environment import EnvironmentModifications, ShellCmdString
 from spack.util.tty.color import colorize
 
 
+def _make_spack_prompt(shell: str, prompt: str) -> List[str]:
+    shell_cmd = ShellCmdString(shell)
+    if shell == "csh":
+        # TODO: figure out how to make color work for csh
+        return [
+            'if (! $?SPACK_OLD_PROMPT ) setenv SPACK_OLD_PROMPT "${prompt}"',
+            'set prompt="%s ${prompt}"' % prompt,
+        ]
+    elif shell == "fish":
+        # NOTE: We're not changing the fish_prompt function (which is fish's
+        # solution to the PS1 variable) here. This is a bit fiddly, and easy to
+        # screw up => spend time reasearching a solution. Feedback welcome.
+        return []
+    elif shell == "bat":
+        # TODO: Color
+        old_prompt = os.environ.get("SPACK_OLD_PROMPT")
+        if not old_prompt:
+            old_prompt = os.environ.get("PROMPT")
+        return [
+            shell_cmd.set("SPACK_OLD_PROMPT", str(old_prompt)),
+            shell_cmd.set("PROMPT", f"{prompt} $P$G"),
+        ]
+    elif shell == "pwsh":
+        return [
+            "function global:prompt { $pth = $(Convert-Path $(Get-Location))"
+            ' | Split-Path -leaf; if(!"$Env:SPACK_OLD_PROMPT") '
+            '{$Env:SPACK_OLD_PROMPT="[spack] PS $pth>"}; '
+            '"%s PS $pth>"}' % prompt
+        ]
+    else:
+        bash_color_prompt = colorize(f"@G{{{prompt}}}", color=True, enclose=True)
+        zsh_color_prompt = colorize(f"@G{{{prompt}}}", color=True, enclose=False, zsh=True)
+        return [
+            textwrap.dedent(
+                rf"""
+                if [ -z ${{SPACK_OLD_PS1+x}} ]; then
+                    if [ -z ${{PS1+x}} ]; then
+                        PS1='$$$$';
+                    fi;
+                    export SPACK_OLD_PS1="${{PS1}}";
+                fi;
+                if [ -n "${{TERM:-}}" ] && [ "${{TERM#*color}}" != "${{TERM}}" ] && \
+                    [ -n "${{BASH:-}}" ];
+                then
+                    export PS1="{bash_color_prompt} ${{PS1}}";
+                elif [ -n "${{TERM:-}}" ] && [ "${{TERM#*color}}" != "${{TERM}}" ] && \
+                        [ -n "${{ZSH_NAME:-}}" ];
+                then
+                    export PS1="{zsh_color_prompt} ${{PS1}}";
+                else
+                    export PS1="{prompt} ${{PS1}}";
+                fi
+                """
+            ).strip("\n")
+        ]
+
+
 def activate_header(env, shell, prompt=None, view: Optional[str] = None):
     # Construct the commands to run
     shell_cmd = ShellCmdString(shell)
@@ -25,55 +82,7 @@ def activate_header(env, shell, prompt=None, view: Optional[str] = None):
     cmds.extend(shell_cmd.alias("despacktivate", "spack env deactivate"))
 
     if prompt:
-        if shell == "csh":
-            # TODO: figure out how to make color work for csh
-            cmds.append('if (! $?SPACK_OLD_PROMPT ) setenv SPACK_OLD_PROMPT "${prompt}"')
-            cmds.append('set prompt="%s ${prompt}"' % prompt)
-        elif shell == "fish":
-            # NOTE: We're not changing the fish_prompt function (which is fish's
-            # solution to the PS1 variable) here. This is a bit fiddly, and easy to
-            # screw up => spend time reasearching a solution. Feedback welcome.
-            pass
-        elif shell == "bat":
-            # TODO: Color
-            old_prompt = os.environ.get("SPACK_OLD_PROMPT")
-            if not old_prompt:
-                old_prompt = os.environ.get("PROMPT")
-            cmds.append(shell_cmd.set("SPACK_OLD_PROMPT", str(old_prompt)))
-            cmds.append(shell_cmd.set("PROMPT", f"{prompt} $P$G"))
-        elif shell == "pwsh":
-            cmds.append(
-                "function global:prompt { $pth = $(Convert-Path $(Get-Location))"
-                ' | Split-Path -leaf; if(!"$Env:SPACK_OLD_PROMPT") '
-                '{$Env:SPACK_OLD_PROMPT="[spack] PS $pth>"}; '
-                '"%s PS $pth>"}' % prompt
-            )
-        else:
-            bash_color_prompt = colorize(f"@G{{{prompt}}}", color=True, enclose=True)
-            zsh_color_prompt = colorize(f"@G{{{prompt}}}", color=True, enclose=False, zsh=True)
-            cmds.append(
-                textwrap.dedent(
-                    rf"""
-                    if [ -z ${{SPACK_OLD_PS1+x}} ]; then
-                        if [ -z ${{PS1+x}} ]; then
-                            PS1='$$$$';
-                        fi;
-                        export SPACK_OLD_PS1="${{PS1}}";
-                    fi;
-                    if [ -n "${{TERM:-}}" ] && [ "${{TERM#*color}}" != "${{TERM}}" ] && \
-                       [ -n "${{BASH:-}}" ];
-                    then
-                        export PS1="{bash_color_prompt} ${{PS1}}";
-                    elif [ -n "${{TERM:-}}" ] && [ "${{TERM#*color}}" != "${{TERM}}" ] && \
-                         [ -n "${{ZSH_NAME:-}}" ];
-                    then
-                        export PS1="{zsh_color_prompt} ${{PS1}}";
-                    else
-                        export PS1="{prompt} ${{PS1}}";
-                    fi
-                    """
-                ).strip("\n")
-            )
+        cmds.extend(_make_spack_prompt(shell, prompt))
     return shell_cmd.join(cmds)
 
 

--- a/lib/spack/spack/environment/shell.py
+++ b/lib/spack/spack/environment/shell.py
@@ -73,7 +73,7 @@ def _make_spack_prompt(shell: str, prompt: str) -> List[str]:
         ]
 
 
-def activate_header(env, shell, prompt=None, view: Optional[str] = None):
+def activate_header(env: ev.Environment, shell: str, prompt: bool = False, view: Optional[str] = None):
     # Construct the commands to run
     shell_cmd = ShellCmdString(shell)
     cmds: List[str] = [shell_cmd.set("SPACK_ENV", env.path)]
@@ -81,8 +81,12 @@ def activate_header(env, shell, prompt=None, view: Optional[str] = None):
         cmds.append(shell_cmd.set("SPACK_ENV_VIEW", view))
     cmds.extend(shell_cmd.alias("despacktivate", "spack env deactivate"))
 
+    short_name = env.name
+    if short_name == env.path:
+        short_name = os.path.basename(short_name)
+
     if prompt:
-        cmds.extend(_make_spack_prompt(shell, prompt))
+        cmds.extend(_make_spack_prompt(shell, f"[{short_name}]"))
     return shell_cmd.join(cmds)
 
 

--- a/lib/spack/spack/environment/shell.py
+++ b/lib/spack/spack/environment/shell.py
@@ -22,47 +22,35 @@ def activate_header(env, shell, prompt=None, view: Optional[str] = None):
     cmds: List[str] = [shell_cmd.set("SPACK_ENV", env.path)]
     if view:
         cmds.append(shell_cmd.set("SPACK_ENV_VIEW", view))
+    cmds.extend(shell_cmd.alias("despacktivate", "spack env deactivate"))
 
-    if shell == "csh":
-        # TODO: figure out how to make color work for csh
-        cmds.append('alias despacktivate "spack env deactivate"')
-        if prompt:
+    if prompt:
+        if shell == "csh":
+            # TODO: figure out how to make color work for csh
             cmds.append('if (! $?SPACK_OLD_PROMPT ) setenv SPACK_OLD_PROMPT "${prompt}"')
             cmds.append('set prompt="%s ${prompt}"' % prompt)
-    elif shell == "fish":
-        if "color" in os.getenv("TERM", "") and prompt:
-            prompt = colorize("@G{%s} " % prompt, color=True)
-
-        cmds.append("function despacktivate")
-        cmds.append("   spack env deactivate")
-        cmds.append("end")
-        #
-        # NOTE: We're not changing the fish_prompt function (which is fish's
-        # solution to the PS1 variable) here. This is a bit fiddly, and easy to
-        # screw up => spend time reasearching a solution. Feedback welcome.
-        #
-    elif shell == "bat":
-        # TODO: Color
-        if prompt:
+        elif shell == "fish":
+            # NOTE: We're not changing the fish_prompt function (which is fish's
+            # solution to the PS1 variable) here. This is a bit fiddly, and easy to
+            # screw up => spend time reasearching a solution. Feedback welcome.
+            pass
+        elif shell == "bat":
+            # TODO: Color
             old_prompt = os.environ.get("SPACK_OLD_PROMPT")
             if not old_prompt:
                 old_prompt = os.environ.get("PROMPT")
             cmds.append(shell_cmd.set("SPACK_OLD_PROMPT", str(old_prompt)))
             cmds.append(shell_cmd.set("PROMPT", f"{prompt} $P$G"))
-    elif shell == "pwsh":
-        if prompt:
+        elif shell == "pwsh":
             cmds.append(
                 "function global:prompt { $pth = $(Convert-Path $(Get-Location))"
                 ' | Split-Path -leaf; if(!"$Env:SPACK_OLD_PROMPT") '
                 '{$Env:SPACK_OLD_PROMPT="[spack] PS $pth>"}; '
                 '"%s PS $pth>"}' % prompt
             )
-    else:
-        bash_color_prompt = colorize(f"@G{{{prompt}}}", color=True, enclose=True)
-        zsh_color_prompt = colorize(f"@G{{{prompt}}}", color=True, enclose=False, zsh=True)
-
-        cmds.append("alias despacktivate='spack env deactivate'")
-        if prompt:
+        else:
+            bash_color_prompt = colorize(f"@G{{{prompt}}}", color=True, enclose=True)
+            zsh_color_prompt = colorize(f"@G{{{prompt}}}", color=True, enclose=False, zsh=True)
             cmds.append(
                 textwrap.dedent(
                     rf"""

--- a/lib/spack/spack/test/util/environment.py
+++ b/lib/spack/spack/test/util/environment.py
@@ -175,19 +175,20 @@ def test_shell_modifications_are_properly_escaped():
 
 
 @pytest.mark.parametrize(
-    "shell,set_expected,unset_expected,join_sep",
+    "shell,set_expected,unset_expected,alias,join_sep",
     [
-        ("sh", "export FOO=bar", "unset FOO", ";\n"),
-        ("csh", "setenv FOO bar", "unsetenv FOO", ";\n"),
-        ("fish", "set -gx FOO bar", "set -e FOO", ";\n"),
-        ("bat", 'set "FOO=bar"', 'set "FOO="', "\n"),
-        ("pwsh", "$Env:FOO='bar'", "Set-Item -Path Env:FOO", "\n"),
+        ("sh", "export FOO=bar", "unset FOO", ["alias foo='spack bar'"], ";\n"),
+        ("csh", "setenv FOO bar", "unsetenv FOO", ['alias foo "spack bar"'], ";\n"),
+        ("fish", "set -gx FOO bar", "set -e FOO", ["function foo", "spack bar", "end"], ";\n"),
+        ("bat", 'set "FOO=bar"', 'set "FOO="', [], "\n"),
+        ("pwsh", "$Env:FOO='bar'", "Set-Item -Path Env:FOO", [], "\n"),
     ],
 )
-def test_shell_cmd_string(shell, set_expected, unset_expected, join_sep):
+def test_shell_cmd_string(shell, set_expected, unset_expected, alias, join_sep):
     shell_cmd = envutil.ShellCmdString(shell)
     assert shell_cmd.set("FOO", "bar") == set_expected
     assert shell_cmd.unset("FOO") == unset_expected
+    assert shell_cmd.alias("foo", "spack bar") == alias
     assert shell_cmd.join([]) == ""
     assert shell_cmd.join([set_expected]) == set_expected + join_sep
     assert (

--- a/lib/spack/spack/util/environment.py
+++ b/lib/spack/spack/util/environment.py
@@ -82,6 +82,18 @@ class ShellCmdString:
         """Returns the command to unset an environment variable."""
         return self._UNSET_STRINGS[self.shell].format(name)
 
+    def alias(self, name: str, code: str) -> List[str]:
+        if self.shell == "csh":
+            return [f'alias {name} "{code}"']
+        elif self.shell == "fish":
+            return [f"function {name}", code, "end"]
+        elif self.shell in ("bat", "pwsh"):
+            # Not implemented in Windows shells
+            return []
+        else:
+            # posix shell
+            return [f"alias {name}='{code}'"]
+
     def join(self, cmds: List[str]) -> str:
         """Joins a list of commands into a single, terminated script."""
         cmds = cmds + [""]


### PR DESCRIPTION
Following on to #52812: the `VIRTUAL_ENV_PROMPT` variable is commonly used (venv, uv, hatch, and 720k search results in github) to add decorators to PS1-formatting scripts .  This PR:
- Further simplifies the `activate_header` command to separate out all the complicated prompt-setting logic and alias setting
- Removes dead code
- Sets `VIRTUAL_ENV_PROMPT` based on the environment name (or basename if it's a non-managed env)