### PR TITLE
Raise coverage of the `spack.bootstrap` module

### DIFF
--- a/lib/spack/spack/bootstrap/_common.py
+++ b/lib/spack/spack/bootstrap/_common.py
@@ -203,17 +203,20 @@ def _executables_in_store(
     return None
 
 
-def _root_spec(spec_str: str) -> str:
-    """Add the host platform and target to a spec used during bootstrapping.
+def _root_spec(spec_str: str, platform: Optional[str] = None, target: Optional[str] = None) -> str:
+    """Add the platform and target to a spec used during bootstrapping.
 
     Args:
         spec_str: spec to be bootstrapped. Must be without platform and target.
+        platform: platform the software will run on. Defaults to the host platform.
+        target: target family the software will run on. Defaults to the host target family.
     """
-    platform = str(spack.platforms.host())
+    if platform is None:
+        platform = str(spack.platforms.host())
+    if target is None:
+        target = str(spack.vendor.archspec.cpu.host().family)
 
-    spec_str += f" platform={platform}"
-    target = spack.vendor.archspec.cpu.host().family
-    spec_str += f" target={target}"
+    spec_str += f" platform={platform} target={target}"
 
     tty.debug(f"[BOOTSTRAP ROOT SPEC] {spec_str}")
     return spec_str

--- a/lib/spack/spack/bootstrap/config.py
+++ b/lib/spack/spack/bootstrap/config.py
@@ -57,7 +57,7 @@ def store_path() -> str:
 
 
 @contextlib.contextmanager
-def spack_python_interpreter() -> Generator:
+def _spack_python_interpreter() -> Generator:
     """Override the current configuration to set the interpreter under
     which Spack is currently running as the only Python external spec
     available.
@@ -150,5 +150,5 @@ def _ensure_bootstrap_configuration() -> Generator:
         spack.config.CONFIG.set("bootstrap", user_configuration["bootstrap"])
         spack.config.CONFIG.set("config", user_configuration["config"])
         spack.config.CONFIG.set("repos", user_configuration["repos"])
-        with spack.modules.disable_modules(), spack_python_interpreter():
+        with spack.modules.disable_modules(), _spack_python_interpreter():
             yield

--- a/lib/spack/spack/bootstrap/core.py
+++ b/lib/spack/spack/bootstrap/core.py
@@ -153,6 +153,20 @@ class Bootstrapper:
         raise NotImplementedError("subclasses must implement try_to_bootstrap")
 
 
+def _matching_entries(bincache_data, abstract_spec: spack.spec.Spec) -> List[Any]:
+    """Return the metadata entries whose spec provides the abstract spec, in metadata order.
+
+    Args:
+        bincache_data: content of a buildcache metadata file
+        abstract_spec: spec to be bootstrapped
+    """
+    return [
+        entry
+        for entry in bincache_data["verified"]
+        if spack.spec.Spec(entry["spec"]).satisfies(abstract_spec)
+    ]
+
+
 class BuildcacheBootstrapper(Bootstrapper):
     """Install the software needed during bootstrapping from a buildcache."""
 
@@ -194,11 +208,7 @@ class BuildcacheBootstrapper(Bootstrapper):
             if not index:
                 raise RuntimeError("The binary index is empty")
 
-            for item in bincache_data["verified"]:
-                # Skip specs which are not compatible
-                if not spack.spec.Spec(item["spec"]).satisfies(request.abstract_spec):
-                    continue
-
+            for item in _matching_entries(bincache_data, request.abstract_spec):
                 for _, pkg_hash, pkg_sha256 in item["binaries"]:
                     self._install_by_hash(pkg_hash, pkg_sha256)
 

--- a/lib/spack/spack/bootstrap/core.py
+++ b/lib/spack/spack/bootstrap/core.py
@@ -72,8 +72,9 @@ class BootstrapRequest(Generic[ResultT]):
     """Software to be made available in the bootstrap store, and how to check for it.
 
     The two kinds of request, a Python module and a set of executables, differ only in the
-    spec to be installed, in the probe that tests whether the software can be used, and in
-    the arguments to be passed to the installer when building from sources.
+    spec to be installed, in the probe that tests whether the software can be used, in the
+    arguments to be passed to the installer when building from sources, and in how the spec
+    is concretized.
     """
 
     def __init__(
@@ -82,6 +83,7 @@ class BootstrapRequest(Generic[ResultT]):
         metadata_name: str,
         probe: Callable[[spack.spec.Spec], Optional[ResultT]],
         installer_args: Dict[str, Any],
+        concretize: Callable[[spack.spec.Spec], spack.spec.Spec],
     ) -> None:
         #: Spec to be installed to satisfy this request
         self.abstract_spec = abstract_spec
@@ -91,20 +93,34 @@ class BootstrapRequest(Generic[ResultT]):
         self.probe = probe
         #: Extra arguments for the installer, when building from sources
         self.installer_args = installer_args
+        #: Turns the abstract spec into the concrete one to be built from sources
+        self.concretize = concretize
 
     @classmethod
-    def for_module(cls, module: str, abstract_spec_str: str) -> "BootstrapRequest[bool]":
-        """Return a request for a module importable in the interpreter running Spack."""
+    def for_module(
+        cls,
+        module: str,
+        abstract_spec_str: str,
+        concretize: Optional[Callable[[spack.spec.Spec], spack.spec.Spec]] = None,
+    ) -> "BootstrapRequest[bool]":
+        """Return a request for a module importable in the interpreter running Spack.
+
+        Args:
+            module: module to be imported in the interpreter running Spack
+            abstract_spec_str: abstract spec that provides the module
+            concretize: how to concretize the spec, when building from sources. Defaults to
+                the regular concretizer.
+        """
         return BootstrapRequest(
             abstract_spec=spack.spec.Spec(abstract_spec_str + " ^" + spec_for_current_python()),
             metadata_name=module,
             probe=functools.partial(_try_import_from_store, module),
-            # unlike the executables below, modules have always forced a source build here
             installer_args={
                 "fail_fast": True,
                 "root_policy": "source_only",
                 "dependencies_policy": "source_only",
             },
+            concretize=concretize or spack.concretize.concretize_one,
         )
 
     @classmethod
@@ -118,6 +134,7 @@ class BootstrapRequest(Generic[ResultT]):
             metadata_name=abstract_spec.name,
             probe=functools.partial(_executables_in_store, executables),
             installer_args={},
+            concretize=spack.concretize.concretize_one,
         )
 
 
@@ -233,11 +250,7 @@ class SourceBootstrapper(Bootstrapper):
         _add_externals_if_missing()
 
         # Try to build and install from sources
-        if request.metadata_name == "clingo":
-            bootstrapper = ClingoBootstrapConcretizer(configuration=spack.config.CONFIG)
-            concrete_spec = bootstrapper.concretize()
-        else:
-            concrete_spec = spack.concretize.concretize_one(request.abstract_spec)
+        concrete_spec = request.concretize(request.abstract_spec)
 
         tty.debug(f"[BOOTSTRAP] Try installing '{request.abstract_spec}' from sources")
         with spack.config.CONFIG.override(self.mirror_scope):
@@ -338,7 +351,11 @@ def _bootstrap_or_raise(
     )
 
 
-def ensure_module_importable_or_raise(module: str, abstract_spec: Optional[str] = None):
+def ensure_module_importable_or_raise(
+    module: str,
+    abstract_spec: Optional[str] = None,
+    concretize: Optional[Callable[[spack.spec.Spec], spack.spec.Spec]] = None,
+):
     """Make the requested module available for import, or raise.
 
     This function tries to import a Python module in the current interpreter
@@ -351,6 +368,8 @@ def ensure_module_importable_or_raise(module: str, abstract_spec: Optional[str] 
         module: module to be imported in the current interpreter
         abstract_spec: abstract spec that might provide the module. If not
             given it defaults to "module"
+        concretize: how to concretize the spec, when building from sources. Defaults to
+            the regular concretizer.
 
     Raises:
         ImportError: if the module couldn't be imported
@@ -362,7 +381,7 @@ def ensure_module_importable_or_raise(module: str, abstract_spec: Optional[str] 
 
     abstract_spec = abstract_spec or module
     _bootstrap_or_raise(
-        BootstrapRequest.for_module(module, abstract_spec),
+        BootstrapRequest.for_module(module, abstract_spec, concretize=concretize),
         what=f'the "{module}" Python module',
         abstract_spec=abstract_spec,
         error_type=ImportError,
@@ -437,9 +456,16 @@ def clingo_root_spec() -> str:
     return _root_spec("clingo-bootstrap@spack+python")
 
 
+def _concretize_clingo(abstract_spec: spack.spec.Spec) -> spack.spec.Spec:
+    """Return the clingo spec to be built, edited from a prototype instead of concretized."""
+    return ClingoBootstrapConcretizer(configuration=spack.config.CONFIG).concretize()
+
+
 def ensure_clingo_importable_or_raise() -> None:
     """Ensure that the clingo module is available for import."""
-    ensure_module_importable_or_raise(module="clingo", abstract_spec=clingo_root_spec())
+    ensure_module_importable_or_raise(
+        module="clingo", abstract_spec=clingo_root_spec(), concretize=_concretize_clingo
+    )
 
 
 def gnupg_root_spec() -> str:

--- a/lib/spack/spack/bootstrap/core.py
+++ b/lib/spack/spack/bootstrap/core.py
@@ -279,13 +279,16 @@ def source_is_enabled(conf: ConfigDictionary) -> bool:
 
 
 def _cannot_bootstrap_message(
-    what: str, abstract_spec: str, exception_handler: GroupedExceptionHandler, sources_tried: int
+    what: str,
+    abstract_spec: spack.spec.Spec,
+    exception_handler: GroupedExceptionHandler,
+    sources_tried: int,
 ) -> str:
     """Return the error message to report when no bootstrapping source succeeded.
 
     Args:
         what: description of what could not be bootstrapped
-        abstract_spec: abstract spec that was supposed to provide it
+        abstract_spec: spec that was searched for
         exception_handler: handler that collected the failure of each source
         sources_tried: number of sources that were tried
     """
@@ -310,7 +313,6 @@ def enabled_bootstrapping_sources() -> List[ConfigDictionary]:
 def _bootstrap_or_raise(
     request: BootstrapRequest[ResultT],
     what: str,
-    abstract_spec: str,
     error_type: Type[Exception],
     sources: Optional[Sequence[ConfigDictionary]] = None,
 ) -> ResultT:
@@ -321,7 +323,6 @@ def _bootstrap_or_raise(
     Args:
         request: software to be bootstrapped, and the probe that tests for it
         what: description of the software, to be used in the error message
-        abstract_spec: abstract spec that was supposed to provide it
         error_type: exception to be raised if no source succeeds
         sources: sources to be tried. Defaults to the enabled ones from configuration.
 
@@ -339,15 +340,13 @@ def _bootstrap_or_raise(
     exception_handler = GroupedExceptionHandler()
 
     for current_config in sources:
-        # The bootstrapper is constructed here, so that a source with broken metadata is
-        # reported like any other failure, instead of stopping the ones after it
         with exception_handler.forward(current_config["name"], Exception):
             result = create_bootstrapper(current_config).try_to_bootstrap(request)
             if result:
                 return result
 
     raise error_type(
-        _cannot_bootstrap_message(what, abstract_spec, exception_handler, len(sources))
+        _cannot_bootstrap_message(what, request.abstract_spec, exception_handler, len(sources))
     )
 
 
@@ -383,7 +382,6 @@ def ensure_module_importable_or_raise(
     _bootstrap_or_raise(
         BootstrapRequest.for_module(module, abstract_spec, concretize=concretize),
         what=f'the "{module}" Python module',
-        abstract_spec=abstract_spec,
         error_type=ImportError,
     )
 
@@ -418,7 +416,6 @@ def ensure_executables_in_path_or_raise(
     found = _bootstrap_or_raise(
         BootstrapRequest.for_executables(executables, abstract_spec),
         what=f"any of the {', '.join(executables)} executables",
-        abstract_spec=abstract_spec,
         error_type=RuntimeError,
     )
     # Additional environment variables needed to run the command
@@ -457,7 +454,11 @@ def clingo_root_spec() -> str:
 
 
 def _concretize_clingo(abstract_spec: spack.spec.Spec) -> spack.spec.Spec:
-    """Return the clingo spec to be built, edited from a prototype instead of concretized."""
+    """Return the clingo spec to be built, edited from a prototype.
+
+    The ``abstract_spec`` argument is discarded, so a change to ``clingo_root_spec()`` has
+    no effect on what is built from sources.
+    """
     return ClingoBootstrapConcretizer(configuration=spack.config.CONFIG).concretize()
 
 

--- a/lib/spack/spack/bootstrap/core.py
+++ b/lib/spack/spack/bootstrap/core.py
@@ -266,7 +266,7 @@ def source_is_enabled(conf: ConfigDictionary) -> bool:
 
 
 def _cannot_bootstrap_message(
-    what: str, abstract_spec: str, exception_handler: GroupedExceptionHandler
+    what: str, abstract_spec: str, exception_handler: GroupedExceptionHandler, sources_tried: int
 ) -> str:
     """Return the error message to report when no bootstrapping source succeeded.
 
@@ -274,31 +274,43 @@ def _cannot_bootstrap_message(
         what: description of what could not be bootstrapped
         abstract_spec: abstract spec that was supposed to provide it
         exception_handler: handler that collected the failure of each source
+        sources_tried: number of sources that were tried
     """
-    msg = f'cannot bootstrap {what} from spec "{abstract_spec}" '
-    if not exception_handler:
+    msg = f'cannot bootstrap {what} from spec "{abstract_spec}"'
+    if not sources_tried:
         msg += ": no bootstrapping sources are enabled"
+    elif not exception_handler:
+        msg += ": no bootstrapping source could provide it"
     elif spack.error.debug or spack.error.SHOW_BACKTRACE:
-        msg += exception_handler.grouped_message(with_tracebacks=True)
+        msg += " " + exception_handler.grouped_message(with_tracebacks=True)
     else:
-        msg += exception_handler.grouped_message(with_tracebacks=False)
+        msg += " " + exception_handler.grouped_message(with_tracebacks=False)
         msg += "\nRun `spack --backtrace ...` for more detailed errors"
     return msg
 
 
+def enabled_bootstrapping_sources() -> List[ConfigDictionary]:
+    """Return the configured bootstrapping sources that are enabled, in order."""
+    return [x for x in bootstrapping_sources() if source_is_enabled(x)]
+
+
 def _bootstrap_or_raise(
-    request: BootstrapRequest[ResultT], what: str, abstract_spec: str, error_type: Type[Exception]
+    request: BootstrapRequest[ResultT],
+    what: str,
+    abstract_spec: str,
+    error_type: Type[Exception],
+    sources: Optional[Sequence[ConfigDictionary]] = None,
 ) -> ResultT:
     """Make the requested software available in the bootstrap store, or raise.
 
-    The enabled bootstrapping sources are tried in order, and the function exits on the
-    first success.
+    The sources are tried in order, and the function exits on the first success.
 
     Args:
         request: software to be bootstrapped, and the probe that tests for it
         what: description of the software, to be used in the error message
         abstract_spec: abstract spec that was supposed to provide it
         error_type: exception to be raised if no source succeeds
+        sources: sources to be tried. Defaults to the enabled ones from configuration.
 
     Raises:
         error_type: if the software could not be bootstrapped
@@ -308,18 +320,22 @@ def _bootstrap_or_raise(
     if result:
         return result
 
+    if sources is None:
+        sources = enabled_bootstrapping_sources()
+
     exception_handler = GroupedExceptionHandler()
 
-    for current_config in bootstrapping_sources():
-        if not source_is_enabled(current_config):
-            continue
-
+    for current_config in sources:
+        # The bootstrapper is constructed here, so that a source with broken metadata is
+        # reported like any other failure, instead of stopping the ones after it
         with exception_handler.forward(current_config["name"], Exception):
             result = create_bootstrapper(current_config).try_to_bootstrap(request)
             if result:
                 return result
 
-    raise error_type(_cannot_bootstrap_message(what, abstract_spec, exception_handler))
+    raise error_type(
+        _cannot_bootstrap_message(what, abstract_spec, exception_handler, len(sources))
+    )
 
 
 def ensure_module_importable_or_raise(module: str, abstract_spec: Optional[str] = None):

--- a/lib/spack/spack/bootstrap/core.py
+++ b/lib/spack/spack/bootstrap/core.py
@@ -448,9 +448,14 @@ def _add_externals_if_missing() -> None:
     )
 
 
-def clingo_root_spec() -> str:
-    """Return the root spec used to bootstrap clingo"""
-    return _root_spec("clingo-bootstrap@spack+python")
+def clingo_root_spec(platform: Optional[str] = None, target: Optional[str] = None) -> str:
+    """Return the root spec used to bootstrap clingo.
+
+    Args:
+        platform: platform the binary will run on. Defaults to the host platform.
+        target: target family the binary will run on. Defaults to the host target family.
+    """
+    return _root_spec("clingo-bootstrap@spack+python", platform=platform, target=target)
 
 
 def _concretize_clingo(abstract_spec: spack.spec.Spec) -> spack.spec.Spec:

--- a/lib/spack/spack/test/bootstrap.py
+++ b/lib/spack/spack/test/bootstrap.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+import json
 import pathlib
 
 import pytest
@@ -20,6 +21,10 @@ import spack.spec
 import spack.store
 import spack.util.executable
 from spack.active_environment import active_environment
+
+CLINGO_METADATA = sorted(pathlib.Path(spack.paths.share_path).glob("bootstrap/*/clingo.json"))
+if not CLINGO_METADATA:
+    raise RuntimeError(f"no clingo metadata in {spack.paths.share_path}")
 
 PROTOTYPE_DIR = pathlib.Path(spack.bootstrap.clingo.__file__).parent / "prototypes"
 PROTOTYPES = sorted(x.name for x in PROTOTYPE_DIR.glob("*.json"))
@@ -382,3 +387,33 @@ def test_verify_patchelf_when_the_command_fails(mock_executable):
         str(mock_executable("patchelf", 'echo "patchelf 0.17.2"\nexit 1'))
     )
     assert spack.bootstrap.core.verify_patchelf(patchelf) is False
+
+
+def _clingo_spec_for(platform: str, target: str, python_version: str) -> spack.spec.Spec:
+    """Return the spec a host with the given platform, target and interpreter looks for."""
+    parts = [
+        x
+        for x in spack.bootstrap.core.clingo_root_spec().split()
+        if not x.startswith(("platform=", "target="))
+    ]
+    parts.extend([f"platform={platform}", f"target={target}", f"^python@{python_version}"])
+    return spack.spec.Spec(" ".join(parts))
+
+
+@pytest.mark.regression("52922")
+@pytest.mark.parametrize("metadata_file", CLINGO_METADATA, ids=lambda x: x.parent.name)
+def test_at_most_one_clingo_binary_matches_an_interpreter(metadata_file: pathlib.Path):
+    """A host must select a single clingo binary. When more than one matched, a cold
+    bootstrap installed a prefix per interpreter until one of them imported.
+    """
+    data = json.loads(metadata_file.read_text(encoding="utf-8"))
+    entries = [spack.spec.Spec(x["spec"]) for x in data["verified"]]
+    combinations = {
+        (str(x.architecture.platform), str(x.architecture.target), str(x["python"].versions))
+        for x in entries
+    }
+
+    for platform, target, python_version in sorted(combinations):
+        abstract_spec = _clingo_spec_for(platform, target, python_version)
+        matching = spack.bootstrap.core._matching_entries(data, abstract_spec)
+        assert len(matching) <= 1, [str(x["spec"]) for x in matching]

--- a/lib/spack/spack/test/bootstrap.py
+++ b/lib/spack/spack/test/bootstrap.py
@@ -59,9 +59,7 @@ def active_mock_environment(mutable_config, mutable_mock_env_path):
 
 
 def _assert_bootstrap_store_is_active() -> None:
-    """Assert what every bootstrap context looks like from the inside: the bootstrap store,
-    with no padding, is the one in use.
-    """
+    """Assert that the store in use is the bootstrap store, configured without padding."""
     bootstrap_store = spack.bootstrap.config.store_path()
     assert spack.store.STORE.root == bootstrap_store
     assert spack.config.CONFIG.get("config:install_tree:root") == bootstrap_store
@@ -320,7 +318,7 @@ def test_prototype_matches_a_constraint_on_its_compiler(prototype):
 
 
 def test_no_bootstrapping_sources_enabled(mutable_config):
-    """When no source is trusted, the error says so instead of listing failures."""
+    """Tests the message raised when no source is trusted."""
     mutable_config.set("bootstrap:trusted", {})
     with pytest.raises(ImportError, match="no bootstrapping sources are enabled"):
         spack.bootstrap.core.ensure_module_importable_or_raise("asdf")
@@ -349,7 +347,7 @@ def test_verify_patchelf(version_output, expected, mock_executable):
 
 @pytest.mark.not_on_windows("The mock executable quotes its output on Windows")
 def test_verify_patchelf_when_the_command_fails(mock_executable):
-    """A good version string is not enough, the command must also succeed."""
+    """Tests that a non-zero exit status is rejected, whatever the version string is."""
     patchelf = spack.util.executable.Executable(
         str(mock_executable("patchelf", 'echo "patchelf 0.17.2"\nexit 1'))
     )
@@ -439,7 +437,7 @@ def test_the_store_is_probed_once_for_all_the_sources(fake_bootstrap_type):
 
     with pytest.raises(RuntimeError, match="cannot bootstrap zlib"):
         spack.bootstrap.core._bootstrap_or_raise(
-            _fake_request(probes), "zlib", "zlib", RuntimeError, sources=sources
+            _fake_request(probes), "zlib", RuntimeError, sources=sources
         )
 
     assert len(probes) == 1
@@ -453,11 +451,7 @@ def test_software_in_the_store_skips_every_source(fake_bootstrap_type):
     sources = _fake_sources(tried, "from the source")
 
     result = spack.bootstrap.core._bootstrap_or_raise(
-        _fake_request(probes, result="from the store"),
-        "zlib",
-        "zlib",
-        RuntimeError,
-        sources=sources,
+        _fake_request(probes, result="from the store"), "zlib", RuntimeError, sources=sources
     )
 
     assert result == "from the store"
@@ -470,7 +464,7 @@ def test_the_first_successful_source_wins(fake_bootstrap_type):
     sources = _fake_sources(tried, RuntimeError("no"), "from src1", "from src2")
 
     result = spack.bootstrap.core._bootstrap_or_raise(
-        _fake_request(probes), "zlib", "zlib", RuntimeError, sources=sources
+        _fake_request(probes), "zlib", RuntimeError, sources=sources
     )
 
     assert result == "from src1"
@@ -478,14 +472,14 @@ def test_the_first_successful_source_wins(fake_bootstrap_type):
 
 
 def test_every_source_failure_is_reported(fake_bootstrap_type):
-    """The last failure is rarely the interesting one, so all of them are reported."""
+    """Tests that the message includes the name and the failure of every source."""
     probes: List[Any] = []
     tried: List[str] = []
     sources = _fake_sources(tried, RuntimeError("first boom"), ValueError("second boom"))
 
     with pytest.raises(RuntimeError) as exc_info:
         spack.bootstrap.core._bootstrap_or_raise(
-            _fake_request(probes), "zlib", "zlib", RuntimeError, sources=sources
+            _fake_request(probes), "zlib", RuntimeError, sources=sources
         )
 
     message = str(exc_info.value)
@@ -494,26 +488,26 @@ def test_every_source_failure_is_reported(fake_bootstrap_type):
 
 
 def test_sources_that_provide_nothing_are_reported_as_such(fake_bootstrap_type):
-    """A source can decline without failing, e.g. when no binary matches the interpreter."""
+    """Tests the message when every source returns None, without raising."""
     probes: List[Any] = []
     tried: List[str] = []
     sources = _fake_sources(tried, None, None)
 
     with pytest.raises(RuntimeError, match="no bootstrapping source could provide it"):
         spack.bootstrap.core._bootstrap_or_raise(
-            _fake_request(probes), "zlib", "zlib", RuntimeError, sources=sources
+            _fake_request(probes), "zlib", RuntimeError, sources=sources
         )
 
     assert tried == ["src0", "src1"]
 
 
 def test_no_sources_to_try_is_reported_as_such(fake_bootstrap_type):
-    """Without sources there is no failure to report, so the message says why."""
+    """Tests the message when the list of sources is empty."""
     probes: List[Any] = []
 
     with pytest.raises(RuntimeError, match='from spec "zlib": no bootstrapping sources'):
         spack.bootstrap.core._bootstrap_or_raise(
-            _fake_request(probes), "zlib", "zlib", RuntimeError, sources=[]
+            _fake_request(probes), "zlib", RuntimeError, sources=[]
         )
 
 
@@ -542,7 +536,7 @@ class _RecordingInstaller:
 
 
 class _FakeConcreteSpec:
-    """Stand-in for the result of concretization, carrying a recognizable package."""
+    """Stand-in for the result of concretization. Holds a recognizable ``package``."""
 
     def __init__(self, abstract_spec: Any) -> None:
         self.abstract_spec = abstract_spec
@@ -595,8 +589,8 @@ def test_the_install_type_maps_to_the_source_bootstrapper(mutable_config):
 def test_the_source_bootstrapper_installs_from_its_own_mirror(
     make_request, expected_installer_args, recording_installer, mutable_config
 ):
-    """Tests that the request decides what is installed and how, the source decides where it
-    comes from.
+    """Tests that the installer arguments come from the request, and the mirror from the
+    source.
     """
     mutable_config.set("bootstrap:sources", [SPACK_INSTALL_SOURCE])
     conf = spack.bootstrap.core.bootstrapping_sources()[0]
@@ -615,12 +609,12 @@ def test_the_source_bootstrapper_installs_from_its_own_mirror(
 def test_the_source_bootstrapper_concretizes_with_the_request(
     recording_installer, mutable_config, monkeypatch
 ):
-    """Tests that the request decides how its spec is concretized, so that software which
-    cannot go through the regular concretizer can say so.
+    """Tests that the source bootstrapper concretizes with ``request.concretize``, and never
+    calls ``spack.concretize.concretize_one``.
     """
 
     def _regular_concretizer(abstract_spec):
-        raise AssertionError("the request asked for its own concretizer")
+        raise AssertionError("concretize_one was called instead of request.concretize")
 
     monkeypatch.setattr(spack.concretize, "concretize_one", _regular_concretizer)
     mutable_config.set("bootstrap:sources", [SPACK_INSTALL_SOURCE])
@@ -666,13 +660,13 @@ def backtrace_flags(monkeypatch):
 
 
 def test_source_failures_point_at_the_backtrace_flag(fake_bootstrap_type, backtrace_flags):
-    """Tests that by default the failures are reported without the noise of their tracebacks."""
+    """Tests that by default the failures are reported without their tracebacks."""
     tried: List[str] = []
     sources = _fake_sources(tried, RuntimeError("boom"))
 
     with pytest.raises(RuntimeError) as exc_info:
         spack.bootstrap.core._bootstrap_or_raise(
-            _fake_request([]), "zlib", "zlib", RuntimeError, sources=sources
+            _fake_request([]), "zlib", RuntimeError, sources=sources
         )
 
     message = str(exc_info.value)
@@ -682,7 +676,7 @@ def test_source_failures_point_at_the_backtrace_flag(fake_bootstrap_type, backtr
 
 
 @pytest.mark.parametrize("flag", ["debug", "SHOW_BACKTRACE"])
-def test_source_failures_carry_their_traceback_when_asked(
+def test_source_failures_include_their_traceback_when_the_flag_is_set(
     fake_bootstrap_type, backtrace_flags, flag
 ):
     """Tests that either flag turns the tracebacks on, and the hint to enable them off."""
@@ -692,7 +686,7 @@ def test_source_failures_carry_their_traceback_when_asked(
 
     with pytest.raises(RuntimeError) as exc_info:
         spack.bootstrap.core._bootstrap_or_raise(
-            _fake_request([]), "zlib", "zlib", RuntimeError, sources=sources
+            _fake_request([]), "zlib", RuntimeError, sources=sources
         )
 
     message = str(exc_info.value)

--- a/lib/spack/spack/test/bootstrap.py
+++ b/lib/spack/spack/test/bootstrap.py
@@ -252,7 +252,7 @@ def test_status_function_find_files(
     "gpg_in_path,gpg_in_store,expected_missing",
     [
         (True, False, False),  # gpg exists in PATH
-        (False, True, False),  # gpg exists in bootstrap store
+        (False, True, False),  # gpg exists in the bootstrap store
         (False, False, True),  # gpg is missing
     ],
 )
@@ -266,38 +266,21 @@ def test_gpg_status_check(
     expected_missing,
 ):
     """Test that gpg/gpg2 status is detected whether it's in PATH or in the bootstrap store."""
-    # Set up mock PATH with or without gpg
-    path_dir = tmp_path / "bin"
-    path_dir.mkdir(exist_ok=True)
-    monkeypatch.setenv("PATH", str(path_dir))
-
     if gpg_in_path:
         mock_executable("gpg2", "echo GPG 2.3.4")
+    monkeypatch.setenv("PATH", str(tmp_path / "bin"))
 
-    # Mock the bootstrap store function
-    def mock_executables_in_store(exes, query_spec):
-        if not gpg_in_store:
+    def _only_gnupg_in_store(exes, query_spec):
+        if not gpg_in_store or "gpg2" not in exes:
             return None
-
-        # Simulate found gpg in bootstrap store
         return spack.bootstrap._common.ExecutableInfo(
             spec=spack.spec.Spec("gnupg@2.5.12"), command=spack.util.executable.Executable("gpg")
         )
 
-    monkeypatch.setattr(spack.bootstrap.status, "_executables_in_store", mock_executables_in_store)
+    monkeypatch.setattr(spack.bootstrap.status, "_executables_in_store", _only_gnupg_in_store)
 
-    # Call only the buildcache requirements function directly to isolate the test
-    requirements = spack.bootstrap.status._buildcache_requirements()
-
-    # Find the gpg entry by examining the calls made to set up requirements
-    # We know the first entry in requirements is the gpg entry because of how
-    # _buildcache_requirements is structured:
-    # Make sure we're not out of bounds
-    assert len(requirements) >= 1, "No gpg requirement found"
-
-    # Check that the gpg requirement matches our expectations
-    gpg_req = requirements[0]
-    assert gpg_req[0] is not expected_missing
+    msg, _ = spack.bootstrap.status_message("buildcache")
+    assert ('MISSING "gpg2"' in msg) is expected_missing
 
 
 @pytest.mark.regression("31042")

--- a/lib/spack/spack/test/bootstrap.py
+++ b/lib/spack/spack/test/bootstrap.py
@@ -58,6 +58,16 @@ def active_mock_environment(mutable_config, mutable_mock_env_path):
         yield env
 
 
+def _assert_bootstrap_store_is_active() -> None:
+    """Assert what every bootstrap context looks like from the inside: the bootstrap store,
+    with no padding, is the one in use.
+    """
+    bootstrap_store = spack.bootstrap.config.store_path()
+    assert spack.store.STORE.root == bootstrap_store
+    assert spack.config.CONFIG.get("config:install_tree:root") == bootstrap_store
+    assert spack.config.CONFIG.get("config:install_tree:padded_length") == 0
+
+
 @pytest.mark.regression("22294")
 def test_store_is_restored_correctly_after_bootstrap(mutable_config, tmp_path: pathlib.Path):
     """Tests that the store is correctly swapped during bootstrapping, and restored afterward."""
@@ -66,7 +76,7 @@ def test_store_is_restored_correctly_after_bootstrap(mutable_config, tmp_path: p
         assert spack.store.STORE.root == user_path
         assert spack.config.CONFIG.get("config:install_tree:root") == user_path
         with spack.bootstrap.ensure_bootstrap_configuration():
-            assert spack.store.STORE.root == spack.bootstrap.config.store_path()
+            _assert_bootstrap_store_is_active()
         assert spack.store.STORE.root == user_path
         assert spack.config.CONFIG.get("config:install_tree:root") == user_path
 
@@ -80,8 +90,7 @@ def test_store_padding_length_is_zero_during_bootstrapping(mutable_config, tmp_p
     with spack.store.use_store(user_path, extra_data={"padded_length": 512}):
         assert spack.config.CONFIG.get("config:install_tree:padded_length") == 512
         with spack.bootstrap.ensure_bootstrap_configuration():
-            assert spack.store.STORE.root == spack.bootstrap.config.store_path()
-            assert spack.config.CONFIG.get("config:install_tree:padded_length") == 0
+            _assert_bootstrap_store_is_active()
         assert spack.config.CONFIG.get("config:install_tree:padded_length") == 512
 
 
@@ -94,12 +103,7 @@ def test_install_tree_customization_is_respected(mutable_config, tmp_path: pathl
     store_dir = tmp_path / "store"
     spack.config.CONFIG.set("config:install_tree:root", str(store_dir))
     with spack.bootstrap.ensure_bootstrap_configuration():
-        assert spack.store.STORE.root == spack.bootstrap.config.store_path()
-        assert (
-            spack.config.CONFIG.get("config:install_tree:root")
-            == spack.bootstrap.config.store_path()
-        )
-        assert spack.config.CONFIG.get("config:install_tree:padded_length") == 0
+        _assert_bootstrap_store_is_active()
     assert spack.config.CONFIG.get("config:install_tree:root") == str(store_dir)
     assert spack.store.STORE.root == str(store_dir)
 
@@ -297,30 +301,6 @@ def test_source_is_disabled(mutable_config):
     # Try to explicitly disable the source and verify that the behavior is the same as above
     spack.config.CONFIG.add("bootstrap:trusted:{0}:{1}".format(conf["name"], False))
     assert not spack.bootstrap.core.source_is_enabled(conf)
-
-
-@pytest.mark.regression("45247")
-def test_use_store_does_not_try_writing_outside_root(
-    tmp_path: pathlib.Path, monkeypatch, mutable_config
-):
-    """Tests that when we use the 'use_store' context manager, there is no attempt at creating
-    a Store outside the given root.
-    """
-    initial_store = mutable_config.get("config:install_tree:root")
-    user_store = tmp_path / "store"
-
-    fn = spack.store.Store.__init__
-
-    def _checked_init(self, root, *args, **kwargs):
-        fn(self, root, *args, **kwargs)
-        assert self.root == str(user_store)
-
-    monkeypatch.setattr(spack.store.Store, "__init__", _checked_init)
-
-    spack.store.reinitialize()
-    with spack.store.use_store(user_store):
-        assert spack.config.CONFIG.get("config:install_tree:root") == str(user_store)
-    assert spack.config.CONFIG.get("config:install_tree:root") == initial_store
 
 
 @pytest.mark.parametrize("prototype", PROTOTYPES)

--- a/lib/spack/spack/test/bootstrap.py
+++ b/lib/spack/spack/test/bootstrap.py
@@ -23,7 +23,8 @@ from spack.active_environment import active_environment
 
 PROTOTYPE_DIR = pathlib.Path(spack.bootstrap.clingo.__file__).parent / "prototypes"
 PROTOTYPES = sorted(x.name for x in PROTOTYPE_DIR.glob("*.json"))
-assert PROTOTYPES, f"no bootstrap prototypes in {PROTOTYPE_DIR}"
+if not PROTOTYPES:
+    raise RuntimeError(f"no bootstrap prototypes in {PROTOTYPE_DIR}")
 
 
 @pytest.fixture(autouse=True)
@@ -344,3 +345,40 @@ def test_prototype_matches_a_constraint_on_its_compiler(prototype):
 
     assert s.satisfies(f"%{compiler.name}")
     assert s.satisfies(f"%{compiler.name}@{compiler.version}")
+
+
+def test_no_bootstrapping_sources_enabled(mutable_config):
+    """When no source is trusted, the error says so instead of listing failures."""
+    mutable_config.set("bootstrap:trusted", {})
+    with pytest.raises(ImportError, match="no bootstrapping sources are enabled"):
+        spack.bootstrap.core.ensure_module_importable_or_raise("asdf")
+
+
+@pytest.mark.not_on_windows("The mock executable quotes its output on Windows")
+@pytest.mark.parametrize(
+    "version_output,expected",
+    [
+        ("patchelf 0.17.2", True),
+        # 0.13.1 is the oldest version we accept
+        ("patchelf 0.13.1", True),
+        ("patchelf 0.12", False),
+        # no version at all in the output
+        ("patchelf", False),
+        # a second token that is not a version
+        ("patchelf /usr/bin/patchelf", False),
+    ],
+)
+def test_verify_patchelf(version_output, expected, mock_executable):
+    patchelf = spack.util.executable.Executable(
+        str(mock_executable("patchelf", f'echo "{version_output}"'))
+    )
+    assert spack.bootstrap.core.verify_patchelf(patchelf) is expected
+
+
+@pytest.mark.not_on_windows("The mock executable quotes its output on Windows")
+def test_verify_patchelf_when_the_command_fails(mock_executable):
+    """A good version string is not enough, the command must also succeed."""
+    patchelf = spack.util.executable.Executable(
+        str(mock_executable("patchelf", 'echo "patchelf 0.17.2"\nexit 1'))
+    )
+    assert spack.bootstrap.core.verify_patchelf(patchelf) is False

--- a/lib/spack/spack/test/bootstrap.py
+++ b/lib/spack/spack/test/bootstrap.py
@@ -423,7 +423,11 @@ def _fake_request(probes: List[Any], result: Optional[str] = None):
         return result
 
     return spack.bootstrap.core.BootstrapRequest(
-        abstract_spec=spack.spec.Spec("zlib"), metadata_name="zlib", probe=probe, installer_args={}
+        abstract_spec=spack.spec.Spec("zlib"),
+        metadata_name="zlib",
+        probe=probe,
+        installer_args={},
+        concretize=spack.concretize.concretize_one,
     )
 
 
@@ -608,32 +612,43 @@ def test_the_source_bootstrapper_installs_from_its_own_mirror(
     assert result == f"probed package of {request.abstract_spec}"
 
 
-def test_clingo_is_not_concretized_by_the_regular_concretizer(
+def test_the_source_bootstrapper_concretizes_with_the_request(
     recording_installer, mutable_config, monkeypatch
 ):
-    """Among the binaries we have clingo, so we can't concretize that with clingo."""
-
-    class _FakeClingoConcretizer:
-        def __init__(self, configuration) -> None:
-            self.configuration = configuration
-
-        def concretize(self) -> "_FakeConcreteSpec":
-            return _FakeConcreteSpec("the clingo prototype")
+    """Tests that the request decides how its spec is concretized, so that software which
+    cannot go through the regular concretizer can say so.
+    """
 
     def _regular_concretizer(abstract_spec):
-        raise AssertionError("clingo must not go through the regular concretizer")
+        raise AssertionError("the request asked for its own concretizer")
 
     monkeypatch.setattr(spack.concretize, "concretize_one", _regular_concretizer)
-    monkeypatch.setattr(spack.bootstrap.core, "ClingoBootstrapConcretizer", _FakeClingoConcretizer)
-
     mutable_config.set("bootstrap:sources", [SPACK_INSTALL_SOURCE])
-    conf = spack.bootstrap.core.bootstrapping_sources()[0]
-    bootstrapper = spack.bootstrap.core.create_bootstrapper(conf)
+    bootstrapper = spack.bootstrap.core.create_bootstrapper(
+        spack.bootstrap.core.bootstrapping_sources()[0]
+    )
 
-    request = spack.bootstrap.core.BootstrapRequest.for_module("clingo", "clingo-bootstrap")
+    request = spack.bootstrap.core.BootstrapRequest.for_module(
+        "clingo", "clingo-bootstrap", concretize=lambda _: _FakeConcreteSpec("a prototype")
+    )
     request.probe = lambda concrete_spec: concrete_spec.package
 
-    assert bootstrapper.try_to_bootstrap(request) == "package of the clingo prototype"
+    assert bootstrapper.try_to_bootstrap(request) == "package of a prototype"
+
+
+def test_clingo_is_not_concretized_by_the_regular_concretizer(mutable_config, monkeypatch):
+    """Among the binaries we have clingo, so we can't concretize that with clingo."""
+    requests: List[Any] = []
+    monkeypatch.setattr(spack.bootstrap.core, "_python_import", lambda module: False)
+    monkeypatch.setattr(
+        spack.bootstrap.core,
+        "_bootstrap_or_raise",
+        lambda request, **kwargs: requests.append(request),
+    )
+
+    spack.bootstrap.core.ensure_clingo_importable_or_raise()
+
+    assert requests[0].concretize is spack.bootstrap.core._concretize_clingo
 
 
 @pytest.fixture

--- a/lib/spack/spack/test/bootstrap.py
+++ b/lib/spack/spack/test/bootstrap.py
@@ -354,17 +354,6 @@ def test_verify_patchelf_when_the_command_fails(mock_executable):
     assert spack.bootstrap.core.verify_patchelf(patchelf) is False
 
 
-def _clingo_spec_for(platform: str, target: str, python_version: str) -> spack.spec.Spec:
-    """Return the spec a host with the given platform, target and interpreter looks for."""
-    parts = [
-        x
-        for x in spack.bootstrap.core.clingo_root_spec().split()
-        if not x.startswith(("platform=", "target="))
-    ]
-    parts.extend([f"platform={platform}", f"target={target}", f"^python@{python_version}"])
-    return spack.spec.Spec(" ".join(parts))
-
-
 @pytest.mark.regression("52922")
 @pytest.mark.parametrize("metadata_file", CLINGO_METADATA, ids=lambda x: x.parent.name)
 def test_exactly_one_clingo_binary_matches_an_interpreter(metadata_file: pathlib.Path):
@@ -377,7 +366,8 @@ def test_exactly_one_clingo_binary_matches_an_interpreter(metadata_file: pathlib
     }
 
     for platform, target, python_version in sorted(combinations):
-        abstract_spec = _clingo_spec_for(platform, target, python_version)
+        root_spec = spack.bootstrap.core.clingo_root_spec(platform=platform, target=target)
+        abstract_spec = spack.spec.Spec(f"{root_spec} ^python@{python_version}")
         matching = spack.bootstrap.core._matching_entries(data, abstract_spec)
         assert len(matching) == 1, f"{abstract_spec} matches {[x['spec'] for x in matching]}"
 

--- a/lib/spack/spack/test/bootstrap.py
+++ b/lib/spack/spack/test/bootstrap.py
@@ -367,10 +367,8 @@ def _clingo_spec_for(platform: str, target: str, python_version: str) -> spack.s
 
 @pytest.mark.regression("52922")
 @pytest.mark.parametrize("metadata_file", CLINGO_METADATA, ids=lambda x: x.parent.name)
-def test_at_most_one_clingo_binary_matches_an_interpreter(metadata_file: pathlib.Path):
-    """A host must select a single clingo binary. When more than one matched, a cold
-    bootstrap installed a prefix per interpreter until one of them imported.
-    """
+def test_exactly_one_clingo_binary_matches_an_interpreter(metadata_file: pathlib.Path):
+    """A host must select a single clingo binary."""
     data = json.loads(metadata_file.read_text(encoding="utf-8"))
     entries = [spack.spec.Spec(x["spec"]) for x in data["verified"]]
     combinations = {
@@ -381,7 +379,7 @@ def test_at_most_one_clingo_binary_matches_an_interpreter(metadata_file: pathlib
     for platform, target, python_version in sorted(combinations):
         abstract_spec = _clingo_spec_for(platform, target, python_version)
         matching = spack.bootstrap.core._matching_entries(data, abstract_spec)
-        assert len(matching) <= 1, [str(x["spec"]) for x in matching]
+        assert len(matching) == 1, f"{abstract_spec} matches {[x['spec'] for x in matching]}"
 
 
 class _FakeBootstrapper(spack.bootstrap.core.Bootstrapper):

--- a/lib/spack/spack/test/bootstrap.py
+++ b/lib/spack/spack/test/bootstrap.py
@@ -4,6 +4,7 @@
 
 import json
 import pathlib
+from typing import Any, Dict, List, Optional
 
 import pytest
 
@@ -417,3 +418,130 @@ def test_at_most_one_clingo_binary_matches_an_interpreter(metadata_file: pathlib
         abstract_spec = _clingo_spec_for(platform, target, python_version)
         matching = spack.bootstrap.core._matching_entries(data, abstract_spec)
         assert len(matching) <= 1, [str(x["spec"]) for x in matching]
+
+
+class _FakeBootstrapper(spack.bootstrap.core.Bootstrapper):
+    """Bootstrapper returning a canned result, or raising it when it is an exception."""
+
+    def __init__(self, conf: Dict[str, Any]) -> None:
+        self.name = conf["name"]
+        self.result = conf["result"]
+        self.tried = conf["tried"]
+
+    def try_to_bootstrap(self, request):
+        self.tried.append(self.name)
+        if isinstance(self.result, Exception):
+            raise self.result
+        return self.result
+
+
+@pytest.fixture
+def fake_bootstrap_type(monkeypatch):
+    """Register a bootstrapper type used by the sources built with ``_fake_sources``."""
+    monkeypatch.setitem(spack.bootstrap.core._bootstrap_methods, "fake", _FakeBootstrapper)
+
+
+def _fake_sources(tried: List[str], *results: Any) -> List[Dict[str, Any]]:
+    """Return one source per result, appending its name to ``tried`` when it is used."""
+    return [
+        {"name": f"src{i}", "type": "fake", "result": x, "tried": tried}
+        for i, x in enumerate(results)
+    ]
+
+
+def _fake_request(probes: List[Any], result: Optional[str] = None):
+    """Return a request whose probe records its calls and returns ``result``."""
+
+    def probe(query_spec):
+        probes.append(query_spec)
+        return result
+
+    return spack.bootstrap.core.BootstrapRequest(
+        abstract_spec=spack.spec.Spec("zlib"), metadata_name="zlib", probe=probe, installer_args={}
+    )
+
+
+def test_the_store_is_probed_once_for_all_the_sources(fake_bootstrap_type):
+    """The store does not depend on the source, so it is queried once, before the loop."""
+    probes: List[Any] = []
+    tried: List[str] = []
+    sources = _fake_sources(tried, RuntimeError("no"), RuntimeError("no"), RuntimeError("no"))
+
+    with pytest.raises(RuntimeError, match="cannot bootstrap zlib"):
+        spack.bootstrap.core._bootstrap_or_raise(
+            _fake_request(probes), "zlib", "zlib", RuntimeError, sources=sources
+        )
+
+    assert len(probes) == 1
+    assert tried == ["src0", "src1", "src2"]
+
+
+def test_software_in_the_store_skips_every_source(fake_bootstrap_type):
+    """When the probe finds the software, no source is tried."""
+    probes: List[Any] = []
+    tried: List[str] = []
+    sources = _fake_sources(tried, "from the source")
+
+    result = spack.bootstrap.core._bootstrap_or_raise(
+        _fake_request(probes, result="from the store"),
+        "zlib",
+        "zlib",
+        RuntimeError,
+        sources=sources,
+    )
+
+    assert result == "from the store"
+    assert tried == []
+
+
+def test_the_first_successful_source_wins(fake_bootstrap_type):
+    probes: List[Any] = []
+    tried: List[str] = []
+    sources = _fake_sources(tried, RuntimeError("no"), "from src1", "from src2")
+
+    result = spack.bootstrap.core._bootstrap_or_raise(
+        _fake_request(probes), "zlib", "zlib", RuntimeError, sources=sources
+    )
+
+    assert result == "from src1"
+    assert tried == ["src0", "src1"]
+
+
+def test_every_source_failure_is_reported(fake_bootstrap_type):
+    """The last failure is rarely the interesting one, so all of them are reported."""
+    probes: List[Any] = []
+    tried: List[str] = []
+    sources = _fake_sources(tried, RuntimeError("first boom"), ValueError("second boom"))
+
+    with pytest.raises(RuntimeError) as exc_info:
+        spack.bootstrap.core._bootstrap_or_raise(
+            _fake_request(probes), "zlib", "zlib", RuntimeError, sources=sources
+        )
+
+    message = str(exc_info.value)
+    for expected in ("src0", "first boom", "src1", "second boom"):
+        assert expected in message
+
+
+def test_sources_that_provide_nothing_are_reported_as_such(fake_bootstrap_type):
+    """A source can decline without failing, e.g. when no binary matches the interpreter."""
+    probes: List[Any] = []
+    tried: List[str] = []
+    sources = _fake_sources(tried, None, None)
+
+    with pytest.raises(RuntimeError, match="no bootstrapping source could provide it"):
+        spack.bootstrap.core._bootstrap_or_raise(
+            _fake_request(probes), "zlib", "zlib", RuntimeError, sources=sources
+        )
+
+    assert tried == ["src0", "src1"]
+
+
+def test_no_sources_to_try_is_reported_as_such(fake_bootstrap_type):
+    """Without sources there is no failure to report, so the message says why."""
+    probes: List[Any] = []
+
+    with pytest.raises(RuntimeError, match='from spec "zlib": no bootstrapping sources'):
+        spack.bootstrap.core._bootstrap_or_raise(
+            _fake_request(probes), "zlib", "zlib", RuntimeError, sources=[]
+        )

--- a/lib/spack/spack/test/bootstrap.py
+++ b/lib/spack/spack/test/bootstrap.py
@@ -18,6 +18,7 @@ import spack.compilers.config
 import spack.concretize
 import spack.config
 import spack.environment
+import spack.error
 import spack.installer_dispatch
 import spack.paths
 import spack.spec
@@ -653,3 +654,53 @@ def test_clingo_is_not_concretized_by_the_regular_concretizer(
     request.probe = lambda concrete_spec: concrete_spec.package
 
     assert bootstrapper.try_to_bootstrap(request) == "package of the clingo prototype"
+
+
+@pytest.fixture
+def backtrace_flags(monkeypatch):
+    """Return a function setting the two flags that turn tracebacks on. Sets them both
+    off to start.
+    """
+
+    def _set(**flags: bool) -> None:
+        monkeypatch.setattr(spack.error, "debug", flags.get("debug", False))
+        monkeypatch.setattr(spack.error, "SHOW_BACKTRACE", flags.get("SHOW_BACKTRACE", False))
+
+    _set()
+    return _set
+
+
+def test_source_failures_point_at_the_backtrace_flag(fake_bootstrap_type, backtrace_flags):
+    """Tests that by default the failures are reported without the noise of their tracebacks."""
+    tried: List[str] = []
+    sources = _fake_sources(tried, RuntimeError("boom"))
+
+    with pytest.raises(RuntimeError) as exc_info:
+        spack.bootstrap.core._bootstrap_or_raise(
+            _fake_request([]), "zlib", "zlib", RuntimeError, sources=sources
+        )
+
+    message = str(exc_info.value)
+    assert "boom" in message
+    assert 'File "' not in message
+    assert "spack --backtrace" in message
+
+
+@pytest.mark.parametrize("flag", ["debug", "SHOW_BACKTRACE"])
+def test_source_failures_carry_their_traceback_when_asked(
+    fake_bootstrap_type, backtrace_flags, flag
+):
+    """Tests that either flag turns the tracebacks on, and the hint to enable them off."""
+    backtrace_flags(**{flag: True})
+    tried: List[str] = []
+    sources = _fake_sources(tried, RuntimeError("boom"))
+
+    with pytest.raises(RuntimeError) as exc_info:
+        spack.bootstrap.core._bootstrap_or_raise(
+            _fake_request([]), "zlib", "zlib", RuntimeError, sources=sources
+        )
+
+    message = str(exc_info.value)
+    assert "boom" in message
+    assert 'File "' in message and "try_to_bootstrap" in message
+    assert "spack --backtrace" not in message

--- a/lib/spack/spack/test/bootstrap.py
+++ b/lib/spack/spack/test/bootstrap.py
@@ -15,8 +15,10 @@ import spack.bootstrap.config
 import spack.bootstrap.core
 import spack.bootstrap.status
 import spack.compilers.config
+import spack.concretize
 import spack.config
 import spack.environment
+import spack.installer_dispatch
 import spack.paths
 import spack.spec
 import spack.store
@@ -528,3 +530,126 @@ def test_no_sources_to_try_is_reported_as_such(fake_bootstrap_type):
         spack.bootstrap.core._bootstrap_or_raise(
             _fake_request(probes), "zlib", "zlib", RuntimeError, sources=[]
         )
+
+
+#: The source, shipped with Spack, that builds the software it needs from sources
+SPACK_INSTALL_SOURCE = {
+    "name": "spack-install",
+    "metadata": "$spack/share/spack/bootstrap/spack-install",
+}
+
+
+class _RecordingInstaller:
+    """Stand-in for ``create_installer``, recording what it is asked to install."""
+
+    def __init__(self) -> None:
+        self.packages: Any = None
+        self.installer_args: Optional[Dict[str, Any]] = None
+        self.mirrors_when_installing: Optional[Dict[str, Any]] = None
+
+    def __call__(self, packages: Any, **installer_args: Any) -> "_RecordingInstaller":
+        self.packages = packages
+        self.installer_args = installer_args
+        return self
+
+    def install(self) -> None:
+        self.mirrors_when_installing = spack.config.CONFIG.get("mirrors")
+
+
+class _FakeConcreteSpec:
+    """Stand-in for the result of concretization, carrying a recognizable package."""
+
+    def __init__(self, abstract_spec: Any) -> None:
+        self.abstract_spec = abstract_spec
+        self.package = f"package of {abstract_spec}"
+
+
+@pytest.fixture
+def recording_installer(monkeypatch):
+    """Let the source bootstrapper run without detecting, concretizing or installing."""
+    installer = _RecordingInstaller()
+    monkeypatch.setattr(spack.bootstrap.core, "_add_externals_if_missing", lambda: None)
+    monkeypatch.setattr(spack.concretize, "concretize_one", _FakeConcreteSpec)
+    monkeypatch.setattr(spack.installer_dispatch, "create_installer", installer)
+    return installer
+
+
+def test_the_install_type_maps_to_the_source_bootstrapper(mutable_config):
+    """Tests that the source shipped with Spack to build from sources is dispatched to the
+    right class.
+    """
+    mutable_config.set("bootstrap:sources", [SPACK_INSTALL_SOURCE])
+    conf = spack.bootstrap.core.bootstrapping_sources()[0]
+    assert conf["type"] == "install"
+    assert isinstance(
+        spack.bootstrap.core.create_bootstrapper(conf), spack.bootstrap.core.SourceBootstrapper
+    )
+
+
+@pytest.mark.parametrize(
+    "make_request,expected_installer_args",
+    [
+        # A module is always built from sources, while an executable may come from a build cache
+        (
+            lambda: spack.bootstrap.core.BootstrapRequest.for_module("pytest", "py-pytest"),
+            {
+                "fail_fast": True,
+                "root_policy": "source_only",
+                "dependencies_policy": "source_only",
+            },
+        ),
+        (
+            lambda: spack.bootstrap.core.BootstrapRequest.for_executables(
+                ["patchelf"], "patchelf@0.13.1:"
+            ),
+            {},
+        ),
+    ],
+    ids=["module", "executable"],
+)
+def test_the_source_bootstrapper_installs_from_its_own_mirror(
+    make_request, expected_installer_args, recording_installer, mutable_config
+):
+    """Tests that the request decides what is installed and how, the source decides where it
+    comes from.
+    """
+    mutable_config.set("bootstrap:sources", [SPACK_INSTALL_SOURCE])
+    conf = spack.bootstrap.core.bootstrapping_sources()[0]
+    bootstrapper = spack.bootstrap.core.create_bootstrapper(conf)
+
+    request = make_request()
+    request.probe = lambda concrete_spec: f"probed {concrete_spec.package}"
+    result = bootstrapper.try_to_bootstrap(request)
+
+    assert recording_installer.packages == [f"package of {request.abstract_spec}"]
+    assert recording_installer.installer_args == expected_installer_args
+    assert recording_installer.mirrors_when_installing == {"spack-install": bootstrapper.url}
+    assert result == f"probed package of {request.abstract_spec}"
+
+
+def test_clingo_is_not_concretized_by_the_regular_concretizer(
+    recording_installer, mutable_config, monkeypatch
+):
+    """Among the binaries we have clingo, so we can't concretize that with clingo."""
+
+    class _FakeClingoConcretizer:
+        def __init__(self, configuration) -> None:
+            self.configuration = configuration
+
+        def concretize(self) -> "_FakeConcreteSpec":
+            return _FakeConcreteSpec("the clingo prototype")
+
+    def _regular_concretizer(abstract_spec):
+        raise AssertionError("clingo must not go through the regular concretizer")
+
+    monkeypatch.setattr(spack.concretize, "concretize_one", _regular_concretizer)
+    monkeypatch.setattr(spack.bootstrap.core, "ClingoBootstrapConcretizer", _FakeClingoConcretizer)
+
+    mutable_config.set("bootstrap:sources", [SPACK_INSTALL_SOURCE])
+    conf = spack.bootstrap.core.bootstrapping_sources()[0]
+    bootstrapper = spack.bootstrap.core.create_bootstrapper(conf)
+
+    request = spack.bootstrap.core.BootstrapRequest.for_module("clingo", "clingo-bootstrap")
+    request.probe = lambda concrete_spec: concrete_spec.package
+
+    assert bootstrapper.try_to_bootstrap(request) == "package of the clingo prototype"

--- a/lib/spack/spack/test/bootstrap.py
+++ b/lib/spack/spack/test/bootstrap.py
@@ -15,16 +15,31 @@ import spack.bootstrap.status
 import spack.compilers.config
 import spack.config
 import spack.environment
+import spack.paths
 import spack.spec
 import spack.store
 import spack.util.executable
 from spack.active_environment import active_environment
 
-from .conftest import _true
-
 PROTOTYPE_DIR = pathlib.Path(spack.bootstrap.clingo.__file__).parent / "prototypes"
 PROTOTYPES = sorted(x.name for x in PROTOTYPE_DIR.glob("*.json"))
 assert PROTOTYPES, f"no bootstrap prototypes in {PROTOTYPE_DIR}"
+
+
+@pytest.fixture(autouse=True)
+def isolated_bootstrap_root(monkeypatch, tmp_path: pathlib.Path):
+    """Point the bootstrap root at a temporary directory, so that tests entering
+    ``ensure_bootstrap_configuration`` do not mount the user's real bootstrap config.
+
+    Two settings resolve the root: the default scope has ``root: $user_cache_path/bootstrap``,
+    and ``root_path()`` falls back to ``default_user_bootstrap_path`` when no config defines
+    it. Both are pinned here so that they agree.
+    """
+    user_cache_path = tmp_path / "user_cache"
+    monkeypatch.setattr(spack.paths, "user_cache_path", str(user_cache_path))
+    monkeypatch.setattr(
+        spack.paths, "default_user_bootstrap_path", str(user_cache_path / "bootstrap")
+    )
 
 
 @pytest.fixture
@@ -106,14 +121,14 @@ def test_raising_exception_if_bootstrap_disabled(mutable_config):
         spack.bootstrap.config.store_path()
 
 
-def test_raising_exception_module_importable(config, monkeypatch):
-    monkeypatch.setattr(spack.bootstrap.core, "source_is_enabled", _true)
+def test_raising_exception_module_importable(mutable_config):
+    mutable_config.set("bootstrap:trusted", {"github-actions": True})
     with pytest.raises(ImportError, match='cannot bootstrap the "asdf" Python module'):
         spack.bootstrap.core.ensure_module_importable_or_raise("asdf")
 
 
-def test_raising_exception_executables_in_path(config, monkeypatch):
-    monkeypatch.setattr(spack.bootstrap.core, "source_is_enabled", _true)
+def test_raising_exception_executables_in_path(mutable_config):
+    mutable_config.set("bootstrap:trusted", {"github-actions": True})
     with pytest.raises(RuntimeError, match="cannot bootstrap any of the asdf, fdsa executables"):
         spack.bootstrap.core.ensure_executables_in_path_or_raise(["asdf", "fdsa"], "python")
 

--- a/lib/spack/spack/test/config_values.py
+++ b/lib/spack/spack/test/config_values.py
@@ -7,6 +7,7 @@ import pathlib
 import pytest
 
 import spack.concretize
+import spack.config
 import spack.store
 
 
@@ -31,3 +32,27 @@ def test_set_install_hash_length_upper_case(mutable_config, tmp_path: pathlib.Pa
         prefix = spec.prefix
         hash_str = prefix.rsplit("-")[-1]
         assert len(hash_str) == 5
+
+
+@pytest.mark.regression("45247")
+def test_use_store_does_not_try_writing_outside_root(
+    tmp_path: pathlib.Path, monkeypatch, mutable_config
+):
+    """Tests that when we use the 'use_store' context manager, there is no attempt at creating
+    a Store outside the given root.
+    """
+    initial_store = mutable_config.get("config:install_tree:root")
+    user_store = tmp_path / "store"
+
+    fn = spack.store.Store.__init__
+
+    def _checked_init(self, root, *args, **kwargs):
+        fn(self, root, *args, **kwargs)
+        assert self.root == str(user_store)
+
+    monkeypatch.setattr(spack.store.Store, "__init__", _checked_init)
+
+    spack.store.reinitialize()
+    with spack.store.use_store(user_store):
+        assert spack.config.CONFIG.get("config:install_tree:root") == str(user_store)
+    assert spack.config.CONFIG.get("config:install_tree:root") == initial_store


### PR DESCRIPTION
This PR builds on #52923 to add more tests to the `spack.bootstrap` module. In  particular:
- It fixes a leak in one test, which caused the user configuration to be read
- It covers most of the logic for bootstrapping, which previously was not covered
- It adds a `concretize` attribute to the `BootstrapRequest`, defaulting to `concretize_one`, which is the best place to special case `clingo` bootstrapping from sources