### PR TITLE
spec.py: round-trip abstract `patches:=<checksum>`

### DIFF
--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -4359,8 +4359,7 @@ class Spec:
         if compiler_flags_str:
             parts.append(compiler_flags_str)
 
-        variants = self.variants.abbreviate_patches() if self._concrete else self.variants
-        variants_str = str(variants)
+        variants_str = self.variants.string(abbreviate_patches=self._concrete)
         if variants_str:
             parts.append(variants_str)
 
@@ -4581,9 +4580,6 @@ class Spec:
                             f"Attempted to format attribute {attribute}. "
                             f"Spec {'.'.join(parts[:idx])} has no attribute {part}"
                         )
-                    if isinstance(current, VariantMap) and current_node._concrete:
-                        current = current.abbreviate_patches()
-
                     if isinstance(current, vn.VersionList) and current == vn.any_version:
                         # don't print empty version lists
                         return ""
@@ -4630,7 +4626,8 @@ class Spec:
                     if style == spack.enums.PartStyle.HIDDEN:
                         continue
                     key_color: Optional[str] = _STYLE_COLOR_MAP.get(style, color_code)
-                    result += prefix + safe_color(sig, str(current[key]), key_color)
+                    variant_str = current[key].string(current_node._concrete)
+                    result += prefix + safe_color(sig, variant_str, key_color)
                 return result
 
             if variant_style_fn and is_variant_part and not isinstance(current, VariantMap):
@@ -4639,7 +4636,12 @@ class Spec:
                     return ""
                 color_code = _STYLE_COLOR_MAP.get(style, color_code)
 
-            return safe_color(sig, str(current), color_code)
+            if isinstance(current, (VariantMap, vt.VariantValue)):
+                string = current.string(abbreviate_patches=current_node._concrete)
+            else:
+                string = str(current)
+
+            return safe_color(sig, string, color_code)
 
         return SPEC_FORMAT_RE.sub(format_attribute, format_string).strip()
 
@@ -5454,21 +5456,9 @@ class VariantMap(lang.HashableMap[str, vt.VariantValue]):
             clone[name] = variant.copy()
         return clone
 
-    def abbreviate_patches(self) -> "VariantMap":
-        """The same map with patch checksums shortened to 7-character prefixes: a weaker
-        ``patches=`` constraint that the original satisfies. Rendered for concrete specs,
-        whose full checksums are in their hash. Entries are shared, so read-only."""
-        patches = self.get("patches")
-        if patches is None or not patches.values:
-            return self
-        shortened = vt.VariantValue(
-            vt.VariantType.MULTI, "patches", tuple(str(v)[:7] for v in patches.values)
-        )
-        variants = VariantMap()
-        variants.dict = {**self.dict, "patches": shortened}
-        return variants
-
-    def __str__(self):
+    def string(self, abbreviate_patches: bool = False) -> str:
+        """The string representation of the map. ``abbreviate_patches`` is passed on to each
+        variant, see :meth:`~spack.variant.VariantValue.string`."""
         if not self:
             return ""
 
@@ -5481,13 +5471,16 @@ class VariantMap(lang.HashableMap[str, vt.VariantValue]):
         string = io.StringIO()
 
         for key in bool_keys:
-            string.write(str(self[key]))
+            string.write(self[key].string(abbreviate_patches))
 
         for key in kv_keys:
             string.write(" ")
-            string.write(str(self[key]))
+            string.write(self[key].string(abbreviate_patches))
 
         return string.getvalue()
+
+    def __str__(self):
+        return self.string()
 
     def partition_keys(self) -> Tuple[List[str], List[str]]:
         """Partition the keys of the map into two lists: booleans and key-value pairs."""

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -4359,7 +4359,8 @@ class Spec:
         if compiler_flags_str:
             parts.append(compiler_flags_str)
 
-        variants_str = str(self.variants)
+        variants = self.variants.abbreviate_patches() if self._concrete else self.variants
+        variants_str = str(variants)
         if variants_str:
             parts.append(variants_str)
 
@@ -4580,6 +4581,9 @@ class Spec:
                             f"Attempted to format attribute {attribute}. "
                             f"Spec {'.'.join(parts[:idx])} has no attribute {part}"
                         )
+                    if isinstance(current, VariantMap) and current_node._concrete:
+                        current = current.abbreviate_patches()
+
                     if isinstance(current, vn.VersionList) and current == vn.any_version:
                         # don't print empty version lists
                         return ""
@@ -5449,6 +5453,20 @@ class VariantMap(lang.HashableMap[str, vt.VariantValue]):
         for name, variant in self.items():
             clone[name] = variant.copy()
         return clone
+
+    def abbreviate_patches(self) -> "VariantMap":
+        """The same map with patch checksums shortened to 7-character prefixes: a weaker
+        ``patches=`` constraint that the original satisfies. Rendered for concrete specs,
+        whose full checksums are in their hash. Entries are shared, so read-only."""
+        patches = self.get("patches")
+        if patches is None or not patches.values:
+            return self
+        shortened = vt.VariantValue(
+            vt.VariantType.MULTI, "patches", tuple(str(v)[:7] for v in patches.values)
+        )
+        variants = VariantMap()
+        variants.dict = {**self.dict, "patches": shortened}
+        return variants
 
     def __str__(self):
         if not self:

--- a/lib/spack/spack/test/spec_format.py
+++ b/lib/spack/spack/test/spec_format.py
@@ -4,6 +4,7 @@
 """Tests formatting of spec strings"""
 
 import spack.concretize
+import spack.spec
 from spack.enums import PartStyle
 from spack.spec import DIM_COLOR, HIGHLIGHT_COLOR, VARIANT_COLOR, VERSION_COLOR, Spec
 from spack.util.tty.color import colorize
@@ -238,3 +239,20 @@ def test_color_reaches_dependencies_of_transitive_dependencies():
         f"^dep{VERSION_COLOR}@@2@. %compiler{VERSION_COLOR}@@3@.", color=True
     )
     assert s._format_dependencies(color=False) == "^dep@2 %compiler@3"
+
+
+def test_variants_of_concrete_spec_abbreviate_patches(config, mock_packages):
+    """A concrete spec renders its patch checksums as 7-character prefixes with a single =,
+    a weaker constraint it satisfies; the full checksums remain available through its hash.
+    An abstract spec prints its variants exactly, so its string form round-trips."""
+    concrete = spack.concretize.concretize_one("patch")
+    checksums = concrete.variants["patches"].values
+    assert checksums
+    prefixes = "patches=" + ",".join(c[:7] for c in checksums)
+    assert prefixes in concrete.format("{variants}")
+    assert "patches:=" not in concrete.format("{variants}")
+    assert prefixes in concrete.format()
+    assert concrete.satisfies(Spec(concrete.format(spack.spec.DISPLAY_FORMAT)))
+
+    abstract = Spec(f"patches:={','.join(checksums)}")
+    assert abstract.format("{variants}") == f"patches:={','.join(checksums)}"

--- a/lib/spack/spack/test/spec_format.py
+++ b/lib/spack/spack/test/spec_format.py
@@ -252,6 +252,10 @@ def test_variants_of_concrete_spec_abbreviate_patches(config, mock_packages):
     assert prefixes in concrete.format("{variants}")
     assert "patches:=" not in concrete.format("{variants}")
     assert prefixes in concrete.format()
+    assert concrete.format("{variants.patches}") == prefixes
+    styled = concrete.format("{variants}", variant_style_fn=_always_variant(PartStyle.NORMAL))
+    assert prefixes in styled
+    assert "patches:=" not in styled
     assert concrete.satisfies(Spec(concrete.format(spack.spec.DISPLAY_FORMAT)))
 
     abstract = Spec(f"patches:={','.join(checksums)}")

--- a/lib/spack/spack/test/variant.py
+++ b/lib/spack/spack/test/variant.py
@@ -896,6 +896,16 @@ def test_patches_variant_prefix_intersects_and_constrains():
     assert s.variants["patches"].values == ("abcdef",)
 
 
+def test_patches_variant_round_trips_through_str():
+    """A concrete-flagged patches variant prints its full checksums, so the string form
+    parses back into an equal spec."""
+    checksum_a, checksum_b = "a1" * 32, "b2" * 32
+    s = Spec(f"patches:={checksum_a},{checksum_b}")
+    round_tripped = Spec(str(s))
+    assert round_tripped == s
+    assert round_tripped.satisfies(s) and s.satisfies(round_tripped)
+
+
 def test_constrain_narrowing():
     s = Spec("foo=*")
     assert s.variants["foo"].type == spack.variant.VariantType.MULTI

--- a/lib/spack/spack/variant.py
+++ b/lib/spack/spack/variant.py
@@ -487,7 +487,9 @@ class VariantValue:
     def __contains__(self, item: Union[str, bool]) -> bool:
         return item in self.values
 
-    def __str__(self) -> str:
+    def string(self, abbreviate_patches: bool = False) -> str:
+        """The string representation of this variant. With ``abbreviate_patches``, a ``patches``
+        variant is printed as 7-character checksum prefixes without the concreteness marker."""
         # boolean variants are printed +foo or ~foo
         if self.type == VariantType.BOOL:
             sigil = "+" if self.value else "~"
@@ -495,14 +497,22 @@ class VariantValue:
                 sigil *= 2
             return f"{sigil}{self.name}"
 
+        delim = "==" if self.propagate else "="
+
+        if abbreviate_patches and self.name == "patches" and self.values:
+            value_str = ",".join(str(x)[:7] for x in self.values)
+            return f"{self.name}{delim}{spack.spec_parser.quote_if_needed(value_str)}"
+
         # concrete multi-valued foo:=bar,baz
         concrete = ":" if self.type == VariantType.MULTI and self.concrete else ""
-        delim = "==" if self.propagate else "="
         if not self.values:
             value_str = "*"
         else:
             value_str = ",".join(str(x) for x in self.values)
         return f"{self.name}{concrete}{delim}{spack.spec_parser.quote_if_needed(value_str)}"
+
+    def __str__(self) -> str:
+        return self.string()
 
     def __repr__(self):
         return (

--- a/lib/spack/spack/variant.py
+++ b/lib/spack/spack/variant.py
@@ -500,8 +500,6 @@ class VariantValue:
         delim = "==" if self.propagate else "="
         if not self.values:
             value_str = "*"
-        elif self.name == "patches" and self.concrete:
-            value_str = ",".join(str(x)[:7] for x in self.values)
         else:
             value_str = ",".join(str(x) for x in self.values)
         return f"{self.name}{concrete}{delim}{spack.spec_parser.quote_if_needed(value_str)}"


### PR DESCRIPTION
Spack has a "display format" which does not round-trip, for example when
you run `spack find` it shows `foo@1.2.3`, which is weaker than
`foo@=1.2.3`. Similarly for variants we distinguish between abstract
`patches=abc,def` and concrete `patches:=<full abc...>,<full def...>`
where the latter round-trips as string. Concrete patches in abstract
specs mean that their values are literal and exhaustive, so they can't
be further `constrain`ed and satisfies between two concrete patches
variants is set equality.

This was omitted in `spack find -lv` and other commands, which printed
`patches:=abc,def` with abbreviated patch prefixes, which is inbetween
concrete and abstract and entirely disjoint from the original spec. For
example, if you copy the `patches:=...` output verbatim back into
`spack find patches:=...` there are no results due to set equality.

This commit fixes that: the display format turns into abstract
`patches=abc,def` while abstract specs with concrete patches correctly
round-trip:

```python
str(Spec("patches:=<full abc...>")) == "patches:=<full abc...>"
```

