### PR TITLE
util.parallel: re-emit worker warnings in the parent process

### DIFF
--- a/lib/spack/spack/test/util/parallel.py
+++ b/lib/spack/spack/test/util/parallel.py
@@ -1,0 +1,87 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+import warnings
+
+import pytest
+
+from spack.util.parallel import ErrorFromWorker, Task, imap_unordered
+
+
+class CustomWarning(UserWarning):
+    """Warning class defined in this module, to check the category survives the round trip."""
+
+
+def _quiet(x):
+    return x * 2
+
+
+def _warns_once(x):
+    warnings.warn("the same diagnostic from every worker")
+    return x
+
+
+def _warns_then_raises(x):
+    warnings.warn("emitted before the failure", CustomWarning)
+    raise ValueError("worker failed")
+
+
+def test_task_returns_value_and_no_warnings():
+    """A task that warns about nothing reports an empty list of warnings."""
+    value, recorded = Task(_quiet)(21)
+
+    assert value == 42
+    assert recorded == []
+
+
+def test_task_captures_warnings_instead_of_emitting_them(recwarn):
+    """Warnings raised by the wrapped function are captured, not emitted in the caller's scope."""
+    value, recorded = Task(_warns_once)(1)
+
+    assert value == 1
+    assert len(recorded) == 1
+    assert recorded[0].message == "the same diagnostic from every worker"
+    assert recorded[0].category is UserWarning
+    # The warning was captured by the task, so it never reached this process' machinery
+    assert len(recwarn) == 0
+
+
+def test_task_captures_warnings_raised_before_an_error():
+    """A task that fails still reports the warnings raised before the exception."""
+    value, recorded = Task(_warns_then_raises)(1)
+
+    assert isinstance(value, ErrorFromWorker)
+    assert "worker failed" in str(value)
+    assert len(recorded) == 1
+    assert recorded[0].message == "emitted before the failure"
+    assert recorded[0].category is CustomWarning
+
+
+@pytest.mark.enable_parallelism
+@pytest.mark.not_on_windows("processes pools are disabled on Windows")
+def test_imap_unordered_deduplicates_warnings_across_workers():
+    """A warning raised by every worker is re-emitted once in this process, so that a solve per
+    spec doesn't repeat the same diagnostic once per spec.
+
+    The deduplication is the one the "default" filter action performs through the warning
+    registry, so this sets that action explicitly instead of using ``pytest.warns``, which forces
+    "always" and bypasses the registry.
+    """
+    with warnings.catch_warnings(record=True) as recorded:
+        warnings.simplefilter("default")
+        results = list(imap_unordered(_warns_once, list(range(8)), processes=4, maxtaskperchild=1))
+
+    assert sorted(results) == list(range(8))
+    assert len(recorded) == 1
+    assert "the same diagnostic" in str(recorded[0].message)
+    # Provenance is preserved, so the warning is not attributed to spack.util.parallel
+    assert recorded[0].filename == __file__
+
+
+@pytest.mark.enable_parallelism
+@pytest.mark.not_on_windows("processes pools are disabled on Windows")
+def test_imap_unordered_reports_warnings_from_a_failing_worker():
+    """Warnings raised before a worker fails are re-emitted, before the error is raised."""
+    with pytest.warns(CustomWarning, match="emitted before the failure"):
+        with pytest.raises(RuntimeError, match="worker failed"):
+            list(imap_unordered(_warns_then_raises, list(range(2)), processes=2))

--- a/lib/spack/spack/util/parallel.py
+++ b/lib/spack/spack/util/parallel.py
@@ -6,7 +6,8 @@ import multiprocessing
 import os
 import sys
 import traceback
-from typing import Optional
+import warnings
+from typing import Any, Dict, List, NamedTuple, Optional, Tuple, Type
 
 from spack.util.cpus import cpus_available
 
@@ -40,9 +41,19 @@ class ErrorFromWorker:
         return self.error_message
 
 
+class WarningRecord(NamedTuple):
+    """A warning raised in a worker process, in a form that can be sent over a pipe."""
+
+    message: str
+    category: Type[Warning]
+    filename: str
+    lineno: int
+
+
 class Task:
     """Wrapped task that trap every Exception and return it as an
-    ErrorFromWorker object.
+    ErrorFromWorker object, and capture warnings so that the parent process can
+    re-emit them.
 
     We are using a wrapper class instead of a decorator since the class
     is pickleable, while a decorator with an inner closure is not.
@@ -51,12 +62,17 @@ class Task:
     def __init__(self, func):
         self.func = func
 
-    def __call__(self, *args, **kwargs):
-        try:
-            value = self.func(*args, **kwargs)
-        except Exception:
-            value = ErrorFromWorker(*sys.exc_info())
-        return value
+    def __call__(self, *args, **kwargs) -> Tuple[Any, List[WarningRecord]]:
+        with warnings.catch_warnings(record=True) as recorded:
+            # Report every warning, and let the parent process decide what to deduplicate
+            warnings.simplefilter("always")
+            try:
+                value = self.func(*args, **kwargs)
+            except Exception:
+                value = ErrorFromWorker(*sys.exc_info())
+        return value, [
+            WarningRecord(str(w.message), w.category, w.filename, w.lineno) for w in recorded
+        ]
 
 
 def imap_unordered(
@@ -79,6 +95,9 @@ def imap_unordered(
         maxtaskperchild: number of tasks to be executed by a child before being
             killed and substituted
 
+    Warnings raised in the worker processes are re-emitted here, so that they are formatted by
+    this process' ``showwarning`` hook and deduplicated across workers.
+
     Raises:
         RuntimeError: if any error occurred in the worker processes
     """
@@ -90,10 +109,20 @@ def imap_unordered(
     from spack.subprocess_context import GlobalStateMarshaler
 
     marshaler = GlobalStateMarshaler(serialize_env=serialize_env)
+    # A single registry, so a warning raised by every worker is shown once
+    registry: Dict[Any, Any] = {}
     with multiprocessing.Pool(
         processes, initializer=marshaler.restore, maxtasksperchild=maxtaskperchild
     ) as p:
-        for result in p.imap_unordered(Task(f), list_of_args):
+        for result, recorded in p.imap_unordered(Task(f), list_of_args):
+            for record in recorded:
+                warnings.warn_explicit(
+                    record.message,
+                    record.category,
+                    record.filename,
+                    record.lineno,
+                    registry=registry,
+                )
             if isinstance(result, ErrorFromWorker):
                 raise RuntimeError(result.stacktrace if debug else str(result))
             yield result


### PR DESCRIPTION
Warnings raised inside a worker never reach the process that started the pool: they are filtered and printed there, so the parent's filters and its showwarning hook do not apply, and each worker keeps its own warning registry.

Here we let `Task` capture warnings and return them alongside its value, and have `imap_unordered` replay them with `warn_explicit` against a single registry.