### PR TITLE
concretizer: report every diagnostic exactly once

### DIFF
--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -374,7 +374,9 @@ class Result:
     def __init__(self, specs):
         self.satisfiable = None
         self.optimal = None
-        self.warnings = None
+        # Diagnostics about the answer set. Stored, rather than warned about while building
+        # specs, so that a result served from the concretization cache reports them too.
+        self.warnings: List[str] = []
         self.nmodels = 0
 
         # specs ordered by optimization level
@@ -456,7 +458,7 @@ class Result:
                 self._concrete_specs.append(answer[node])
                 self._concrete_specs_by_input[input_spec] = answer[node]
             elif candidate and candidate.build_spec.satisfies(input_spec):
-                tty.warn(
+                warnings.warn(
                     "explicit splice configuration has caused the concretized spec"
                     f" {candidate} not to satisfy the input spec {input_spec}"
                 )
@@ -514,7 +516,8 @@ class Result:
         result = Result(specs)
         result.criteria = [OptimizationCriteria(*t) for t in obj["criteria"]]
         result.optimal = obj["optimal"]
-        result.warnings = obj["warnings"]
+        # Entries written before warnings were recorded store None here
+        result.warnings = obj["warnings"] or []
         result.nmodels = obj["nmodels"]
         result.satisfiable = obj["satisfiable"]
         result.answers = [
@@ -1046,6 +1049,9 @@ class PyclingoDriver:
         # add best spec to the results
         result.answers.append((list(min_cost), 0, spec_dict))
 
+        # diagnostics collected while building the specs, cached along with the answer
+        result.warnings = builder.warnings
+
         # get optimization criteria
         criteria_args = extract_args(best_model, "opt_priority")
         result.criteria = build_criteria_names(min_cost, criteria_args)
@@ -1163,6 +1169,10 @@ class PyclingoDriver:
             # write result back to the cache *before* post-processing
             if cache and cache_key is not None:
                 cache.store(cache_key, result, self.control.statistics)
+
+        # emitted here, so that a cached result reports the same diagnostics as a fresh solve
+        for message in result.warnings:
+            warnings.warn(message)
 
         # apply post-concretization transformations
         for _, _, spec_dict in result.answers:
@@ -3576,6 +3586,9 @@ class SpecBuilder:
     def __init__(self, specs, hash_lookup=None):
         self._specs: Dict[NodeId, spack.spec.Spec] = {}
 
+        #: Diagnostics about the answer set, collected for the Result to carry
+        self.warnings: List[str] = []
+
         # Matches parent nodes to splice node
         self._splices: SpliceDict = {}
 
@@ -3645,7 +3658,7 @@ class SpecBuilder:
         dependencies[0].update_virtuals(virtual)
 
     def deprecated(self, node: NodeId, version: str) -> None:
-        tty.warn(f'using "{node.pkg}@{version}" which is a deprecated version')
+        self.warnings.append(f'using "{node.pkg}@{version}" which is a deprecated version')
 
     def splice_at_hash(
         self, parent_node: NodeId, splice_node: NodeId, child_name: str, child_hash: str
@@ -3969,7 +3982,7 @@ def _specs_with_commits(spec):
 
     if "commit" not in spec.variants:
         if not spec.is_develop:
-            tty.warn(
+            warnings.warn(
                 f"Unable to resolve the git commit for {spec.name}. "
                 "An installation of this binary won't have complete binary provenance."
             )

--- a/lib/spack/spack/test/concretization/core.py
+++ b/lib/spack/spack/test/concretization/core.py
@@ -2589,7 +2589,6 @@ packages:
         database_mutable_config: Database,
         mock_packages,
         transitive,
-        capfd,
     ):
         mpich_spec = database_mutable_config.query("mpich")[0]
         splice_info = {
@@ -2599,7 +2598,10 @@ packages:
         }
         mutable_config.set("concretizer", {"splice": {"explicit": [splice_info]}})
 
-        spec = spack.concretize.concretize_one("hdf5 ^zmpi")
+        with pytest.warns(
+            UserWarning, match="explicit splice configuration has caused"
+        ) as recorded:
+            spec = spack.concretize.concretize_one("hdf5 ^zmpi")
 
         assert spec.satisfies(f"^mpich@{mpich_spec.version}")
         assert spec.build_spec.dependencies(name="zmpi", deptype="link")
@@ -2607,10 +2609,9 @@ packages:
         assert not spec.build_spec.satisfies(f"^mpich/{mpich_spec.dag_hash()}")
         assert not spec.dependencies(name="zmpi", deptype="link")
 
-        captured = capfd.readouterr()
-        assert "Warning: explicit splice configuration has caused" in captured.err
-        assert "hdf5 ^zmpi" in captured.err
-        assert str(spec) in captured.err
+        warned = "\n".join(str(x.message) for x in recorded)
+        assert "hdf5 ^zmpi" in warned
+        assert str(spec) in warned
 
     def test_explicit_splice_fails_nonexistent(
         self, mutable_config: Configuration, mock_packages, mock_store
@@ -5714,3 +5715,34 @@ def test_target_star_concretizes(mock_packages, config):
 def test_solve_kind_from_unify_configuration(unify, expected):
     """Tests the mapping from 'concretizer:unify' to the kind of solve it prescribes."""
     assert spack.concretize.solve_kind(unify) is expected
+
+
+def test_deprecated_version_warns_on_a_concretization_cache_hit(
+    use_concretization_cache, mutable_config: Configuration, monkeypatch
+):
+    """Tests that a result served from the concretization cache reports the same diagnostics as a
+    fresh solve. SpecBuilder does not run on a cache hit, so the warnings ride on the Result.
+    """
+    mutable_config.set("config:deprecated", True)
+    spec_str = "deprecated-versions@1.1.0"
+
+    with pytest.warns(UserWarning, match='using "deprecated-versions@1.1.0"'):
+        spack.concretize.concretize_one(spec_str)
+
+    def fail(*args, **kwargs):
+        raise AssertionError("the second solve should have been served from the cache")
+
+    monkeypatch.setattr(spack.solver.asp.PyclingoDriver, "_run_clingo", fail)
+
+    with pytest.warns(UserWarning, match='using "deprecated-versions@1.1.0"'):
+        spack.concretize.concretize_one(spec_str)
+
+
+def test_result_warnings_survive_serialization(mock_packages, mutable_config: Configuration):
+    """Tests that the diagnostics of a solve are part of what the concretization cache stores."""
+    specs = [Spec("deprecated-versions@1.1.0")]
+
+    result = spack.solver.asp.Solver().solve(specs, allow_deprecated=True)
+
+    assert result.warnings == ['using "deprecated-versions@1.1.0" which is a deprecated version']
+    assert spack.solver.asp.Result.from_dict(result.to_dict(), specs) == result

--- a/lib/spack/spack/test/package_class.py
+++ b/lib/spack/spack/test/package_class.py
@@ -388,7 +388,7 @@ def test_git_provenance_find_commit_ls_remote(
 @pytest.mark.require_provenance
 @pytest.mark.disable_clean_stage_check
 def test_git_provenance_cant_resolve_commit(
-    mock_packages: RepoPath, monkeypatch, config, capfd, tmp_path
+    mock_packages: RepoPath, monkeypatch, config, tmp_path
 ):
     """Fail all attempts to resolve git commits"""
     repo_path = str(tmp_path / "non_existent")
@@ -397,10 +397,9 @@ def test_git_provenance_cant_resolve_commit(
     monkeypatch.setattr(spack.package_base.PackageBase, "git", repo_path, raising=False)
     monkeypatch.setattr(mock_packages.get_pkg_class("git-ref-package"), "git", repo_path)
     monkeypatch.setattr(spack.package_base.PackageBase, "do_fetch", lambda *args, **kwargs: None)
-    spec = spack.concretize.concretize_one("git-ref-package@develop")
-    captured = capfd.readouterr()
+    with pytest.warns(UserWarning, match="Unable to resolve the git commit"):
+        spec = spack.concretize.concretize_one("git-ref-package@develop")
     assert "commit" not in spec.variants
-    assert "Warning: Unable to resolve the git commit" in captured.err
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
`SpecBuilder.deprecated()` warned while building specs from the answer set, but `SpecBuilder` only runs inside _run_clingo, which a cache hit skips entirely.

Since concretization_cache is enabled by default, the deprecated version warning disappeared as soon as the cache was warm. Collect the messages on the Result instead, so a cached answer carries its own diagnostics.