### PR TITLE
`spack env list`: don't descend into environment subdirectories

### DIFF
--- a/lib/spack/spack/environment/environment.py
+++ b/lib/spack/spack/environment/environment.py
@@ -526,18 +526,46 @@ def _rewrite_relative_repos_paths_on_relocation(env, init_file_dir, copied_env=F
 def environment_dir_from_name(name: str, exists_ok: bool = True) -> str:
     """Returns the directory associated with a named environment.
 
+    TODO: this function is probably doing too much. With ``exists_ok=False``, it's
+    really "ensure a new environment can be created". It checks for existence and fails
+    with creation-related errors. Consider splitting this into separate validation and
+    naming functions later.
+
     Args:
         name: name of the environment
-        exists_ok: if False, raise an error if the environment exists already
+        exists_ok: if False, raise an error if the environment exists already, or if
+            creating one at ``name`` would nest environments
 
     Raises:
-        SpackEnvironmentError: if exists_ok is False and the environment exists already
+        SpackEnvironmentError: if exists_ok is False and an environment at ``name``
+            would conflict with an existing environment
+
     """
     if not exists_ok and exists(name):
         raise SpackEnvironmentError(f"'{name}': environment already exists at {root(name)}")
 
     ensure_env_root_path_exists()
     validate_env_name(name)
+
+    if not exists_ok:
+        # environments are leaves in the managed environment directory: refuse to
+        # create one inside an existing environment
+        ancestor = os.path.dirname(name)
+        while ancestor:
+            if exists(ancestor):
+                raise SpackEnvironmentError(
+                    f"cannot create environment '{name}' inside existing environment '{ancestor}'"
+                )
+            ancestor = os.path.dirname(ancestor)
+
+        # also disallow creating an env above an existing one
+        nested = next((n for n in all_environment_names() if n.startswith(name + os.sep)), None)
+        if nested is not None:
+            raise SpackEnvironmentError(
+                f"cannot create environment '{name}': "
+                f"it would contain existing environment '{nested}'"
+            )
+
     return root(name)
 
 
@@ -617,21 +645,39 @@ def all_environment_names():
     env_root = pathlib.Path(env_root_path()).resolve()
 
     def yaml_paths():
+        # track visited inodes so that arbitrary symlink cycles terminate
+        root_stat = env_root.stat()
+        visited = {(root_stat.st_dev, root_stat.st_ino)}
+
         for root, dirs, files in os.walk(env_root, topdown=True, followlinks=True):
-            dirs[:] = [
-                d
-                for d in dirs
-                if not d.startswith(".") and not env_root.samefile(os.path.join(root, d))
-            ]
-            if manifest_name in files:
+            if manifest_name in files and root != str(env_root):
+                # environments are leaves: don't descend into their contents
+                dirs.clear()
                 yield os.path.join(root, manifest_name)
+                continue
+
+            subdirs = []
+            for d in dirs:
+                if d.startswith("."):
+                    continue
+
+                try:
+                    st = os.stat(os.path.join(root, d))
+                except OSError:
+                    continue
+                if (st.st_dev, st.st_ino) in visited:
+                    continue
+
+                visited.add((st.st_dev, st.st_ino))
+                subdirs.append(d)
+            dirs[:] = subdirs
 
     names = []
     for yaml_path in yaml_paths():
         candidate = str(pathlib.Path(yaml_path).relative_to(env_root).parent)
         if valid_env_name(candidate):
             names.append(candidate)
-    return names
+    return sorted(names)
 
 
 def all_environments():

--- a/lib/spack/spack/test/env.py
+++ b/lib/spack/spack/test/env.py
@@ -985,6 +985,54 @@ def test_environment_from_name_or_dir(mutable_mock_env_path):
         _ = ev.environment_from_name_or_dir("fake-env")
 
 
+def test_all_environment_names_ignores_env_contents(mutable_mock_env_path):
+    """Environments are leaves: listing must not descend into their contents."""
+    ev.create("test")
+    ev.create("group/nested")
+
+    # simulate a user keeping a stage directory inside a managed environment
+    stage = mutable_mock_env_path / "test" / "stage" / "spack-stage-foo-1-0-abcdef"
+    stage.mkdir(parents=True)
+    # even a stray manifest below an environment must not be listed as an environment
+    (stage / ev.manifest_name).write_text("spack:\n  specs: []\n")
+
+    assert ev.all_environment_names() == ["group/nested", "test"]
+
+
+def test_all_environment_names_handles_symlink_cycles(mutable_mock_env_path):
+    """Symlink cycles in the environment root must not hang the listing."""
+    ev.create("group/nested")
+    (mutable_mock_env_path / "group" / "loop").symlink_to(mutable_mock_env_path / "group")
+
+    assert ev.all_environment_names() == ["group/nested"]
+
+
+def test_all_environment_names_follows_symlinked_envs(mutable_mock_env_path, tmp_path):
+    """Symlinked environment dirs (e.g. from spack env track) are still listed."""
+    external = tmp_path / "external_env"
+    external.mkdir()
+    (external / ev.manifest_name).write_text("spack:\n  specs: []\n")
+
+    mutable_mock_env_path.mkdir(parents=True, exist_ok=True)
+    (mutable_mock_env_path / "tracked").symlink_to(external)
+
+    assert ev.all_environment_names() == ["tracked"]
+
+
+def test_cannot_create_env_nested_in_another_env(mutable_mock_env_path):
+    """Creating an environment inside an existing environment is an error."""
+    ev.create("outer")
+    with pytest.raises(ev.SpackEnvironmentError, match="inside existing environment 'outer'"):
+        ev.create("outer/inner")
+
+
+def test_cannot_create_env_above_another_env(mutable_mock_env_path):
+    """Creating an environment above an existing environment is an error."""
+    ev.create("group/inner")
+    with pytest.raises(ev.SpackEnvironmentError, match="would contain existing environment"):
+        ev.create("group")
+
+
 def test_env_include_configs(mutable_mock_env_path, mutable_config: Configuration):
     """check config and package values using new include schema"""
     env_path = mutable_mock_env_path


### PR DESCRIPTION
Since #50994, `all_environment_names()` has walked the entire environments root with `os.walk(followlinks=True)` to support nested environment names. But, it has no idea where to stop walking, so it can descend into directories inside environments -- stages, views, etc. With envs containing large stage directories, `spack env list` can crawl thousands of directories, making it very slow. Also, the only symlink-cycle protection is a `samefile()` check against the root.

To fix this:
- [x] Treat discovered environments as leaves. Once we find a `spack.yaml` file, yield it and prune the walk so that directories inside of environments are never visited.
- [x] Track visited inodes so that symlink cycles terminate while symlinked environments (`spack env track`) are still listed.
- [x] Make creating an environment inside or above an existing one an error.
