### PR TITLE
Fix active environment highlighting in spack env list

### DIFF
--- a/lib/spack/spack/environment/environment.py
+++ b/lib/spack/spack/environment/environment.py
@@ -117,15 +117,21 @@ def environment_name(path: Union[str, pathlib.Path]) -> str:
     """
     env_root = pathlib.Path(env_root_path()).resolve()
     path_path = pathlib.Path(path)
+    path_path_resolved = path_path.resolve()
 
     # For a managed environment created in Spack, env.path is ENV_ROOT/NAME
     # For a tracked environment from `spack env track`, the path is symlinked to ENV_ROOT/NAME
-    # So if ENV_ROOT/NAME resolves to env.path we know the environment is tracked/managed.
-    # Otherwise, it is an independent environment and  we return the path.
+    # If env.path is under ENV_ROOT, we return the relative path from ENV_ROOT.
+    # If ENV_ROOT/NAME resolves to env.path we know the environment is tracked/managed.
+    # Otherwise, it is an independent environment and we return the full path.
     #
     # We resolve both paths fully because the env_root itself could also be a symlink,
     # and any directory in env.path could be a symlink.
-    if (env_root / path_path.name).resolve() == path_path.resolve():
+    if path_path_resolved.drive == env_root.drive and os.path.commonpath(
+        [path_path_resolved, env_root]
+    ) == str(env_root):
+        return str(path_path_resolved.relative_to(env_root))
+    elif (env_root / path_path.name).resolve() == path_path_resolved:
         return path_path.name
     else:
         return str(path)

--- a/lib/spack/spack/test/env.py
+++ b/lib/spack/spack/test/env.py
@@ -21,7 +21,7 @@ import spack.util.filesystem as fs
 from spack.config import Configuration
 from spack.enums import ConfigScopePriority
 from spack.environment import SpackEnvironmentConfigError
-from spack.environment.environment import EnvironmentManifestFile
+from spack.environment.environment import EnvironmentManifestFile, environment_name
 from spack.environment.list import UndefinedReferenceError
 from spack.traverse import traverse_nodes
 
@@ -1068,6 +1068,25 @@ def test_cannot_create_env_above_another_env(mutable_mock_env_path):
     ev.create("group/inner")
     with pytest.raises(ev.SpackEnvironmentError, match="would contain existing environment"):
         ev.create("group")
+
+
+def test_environment_name_with_symlinked_path(mutable_mock_env_path, tmp_path):
+    """Test that environment_name correctly handles symlinked paths."""
+    env = ev.create("test_env")
+    symlink_dir = tmp_path / "symlinked"
+    symlink_dir.mkdir()
+    symlink_to_env = symlink_dir / "env_link"
+    symlink_to_env.symlink_to(env.path)
+
+    result = environment_name(symlink_to_env)
+    assert result == "test_env", f"Expected 'test_env', got '{result}'"
+
+    nested_env = ev.create("group/nested_env")
+    symlink_to_nested = symlink_dir / "nested_link"
+    symlink_to_nested.symlink_to(nested_env.path)
+
+    result = environment_name(symlink_to_nested)
+    assert result == "group/nested_env", f"Expected 'group/nested_env', got '{result}'"
 
 
 def test_env_include_configs(mutable_mock_env_path, mutable_config: Configuration):


### PR DESCRIPTION
Fixes a bug that prevented the active environment from being highlighted in `spack env list` when the environment path involves symlinks or nested (grouped) environment names.
  