### PR TITLE
spec.py: drop unused return value of `_dup`

### DIFF
--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -3931,32 +3931,14 @@ class Spec:
         deps: Union[bool, dt.DepTypes, dt.DepFlag] = True,
         *,
         propagation: Optional[PropagationPolicy] = None,
-    ) -> bool:
+    ) -> None:
         """Copies "other" into self, by overwriting all attributes.
 
         Args:
             other: spec to be copied onto ``self``
             deps: if True copies all the dependencies. If False copies None.
                 If deptype, or depflag, copy matching types.
-
-        Returns:
-            True if ``self`` changed because of the copy operation, False otherwise.
         """
-        # We don't count dependencies as changes here
-        changed = True
-        if hasattr(self, "name"):
-            changed = (
-                self.name != other.name
-                and self.versions != other.versions
-                and self.architecture != other.architecture
-                and self.variants != other.variants
-                and self.concrete != other.concrete
-                and self.external_path != other.external_path
-                and self.external_modules != other.external_modules
-                and self.compiler_flags != other.compiler_flags
-                and self.abstract_hash != other.abstract_hash
-            )
-
         self._package = None
 
         # Local node attributes get copied first.
@@ -4007,8 +3989,6 @@ class Spec:
             self._dunder_hash = None
             for h in ht.HASHES:
                 setattr(self, h.attr, None)
-
-        return changed
 
     def _dup_deps(
         self, other, depflag: dt.DepFlag, propagation: Optional[PropagationPolicy] = None


### PR DESCRIPTION
`Spec._dup` should've used `or` instead of `and`, but in any case, its
return value doesn't have any users, so remove it.

