### PR TITLE
spec.py: remove mutability checks

### DIFF
--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -6351,28 +6351,10 @@ class MissingSpecHashError(spack.error.SpecError):
 
 
 class _ImmutableSpec(Spec):
-    """An immutable Spec that prevents a class of accidental mutations."""
+    """A Spec that is immutable by convention: it is interned in caches and shared across
+    package classes, so callers copy before mutating. Immutability is not enforced."""
 
-    _mutable: bool
     _str_cache: str
-
-    def __init__(self, spec_like: Optional[str] = None) -> None:
-        object.__setattr__(self, "_mutable", True)
-        super().__init__(spec_like)
-        object.__delattr__(self, "_mutable")
-
-    def __setstate__(self, state) -> None:
-        object.__setattr__(self, "_mutable", True)
-        super().__setstate__(state)
-        object.__delattr__(self, "_mutable")
-
-    def constrain(self, *args, **kwargs) -> bool:
-        assert self._mutable
-        return super().constrain(*args, **kwargs)
-
-    def add_dependency_edge(self, *args, **kwargs):
-        assert self._mutable
-        return super().add_dependency_edge(*args, **kwargs)
 
     def __str__(self) -> str:
         # Cache the str value of immutable specs as an optimization
@@ -6380,16 +6362,8 @@ class _ImmutableSpec(Spec):
             return self._str_cache
         except AttributeError:
             s = self._str(color=False)
-            object.__setattr__(self, "_str_cache", s)
+            self._str_cache = s
             return s
-
-    def __setattr__(self, name, value) -> None:
-        assert self._mutable
-        super().__setattr__(name, value)
-
-    def __delattr__(self, name) -> None:
-        assert self._mutable
-        object.__delattr__(self, name)
 
 
 #: Immutable empty spec, for fast comparisons and reduced memory usage.


### PR DESCRIPTION
In `_ImmutableSpec` we set and delete the `_mutable` key to detect operations
that are mutating. Turns out this leads to an increase in storage of 400->1176
bytes per instance on Python 3.10 and earlier, because delattr unshares the
`__dict__` keys.

I think it's better to just delete the mutability check, because it only ensures
no mutation at depth 0, but Spec object have tons of attributes that are
themselves mutable, so not much is guaranteed anyways.

Loading all 9008 packages of spack-packages "interns" 81531 spec objects.
With this change the memory usage changes as follows:

    python 3.10: 733.4 MB -> 672.5 MB
    python 3.12: 561.5 MB -> 561.5 MB

