### PR TITLE
spec.py: simplify VariantMap and FlagMap

### DIFF
--- a/lib/spack/spack/cmd/info.py
+++ b/lib/spack/spack/cmd/info.py
@@ -201,7 +201,7 @@ def print_dependency_suggestion(pkg: PackageBase) -> None:
             # skip if user specified, or already saw a value (e.g. many +mpi and ~mpi)
             if name in spec.variants or name in pkg.spec.variants:
                 continue
-            spec.variants[name] = spack.variant.BoolValuedVariant(name, not val)
+            spec.variants.set(spack.variant.BoolValuedVariant(name, not val))
 
         # if there is new stuff to add beyond the input
         if spec.variants:

--- a/lib/spack/spack/environment/environment.py
+++ b/lib/spack/spack/environment/environment.py
@@ -1671,7 +1671,7 @@ class Environment:
                 variant = vt.SingleValuedVariant("dev_path", path)
             else:
                 variant = vt.VariantValueRemoval("dev_path")
-            mutator.variants["dev_path"] = variant
+            mutator.variants.set(variant)
 
             msg = (
                 f"Develop spec '{spec}' conflicts with concrete specs in environment."

--- a/lib/spack/spack/externals.py
+++ b/lib/spack/spack/externals.py
@@ -139,7 +139,7 @@ def complete_variants_and_architecture(node: spack.spec.Spec) -> None:
                     if default is None:
                         continue
                     # Cannot use Spec.constrain, because we lose information on the variant type
-                    node.variants[name] = default
+                    node.variants.set(default)
                 elif (
                     node.variants[name].type != vdef.variant_type
                     and len(node.variants[name].values) == 1
@@ -148,7 +148,7 @@ def complete_variants_and_architecture(node: spack.spec.Spec) -> None:
                     # using the package definition, preserving the user-specified value.
                     existing = node.variants[name]
                     corrected = vdef.make_variant(*existing.values)
-                    node.variants.substitute(corrected)
+                    node.variants.set(corrected)
             changed = True
 
 

--- a/lib/spack/spack/package_base.py
+++ b/lib/spack/spack/package_base.py
@@ -1023,9 +1023,7 @@ class PackageBase(WindowsRPath, PackageViewMixin, metaclass=PackageMeta):
         else:
             v_attrs = cls.versions.get(spec.version, {})
             if "commit" in v_attrs:
-                spec.variants["commit"] = spack.variant.SingleValuedVariant(
-                    "commit", v_attrs["commit"]
-                )
+                spec.variants.set(spack.variant.SingleValuedVariant("commit", v_attrs["commit"]))
                 return
             ref = v_attrs.get("tag") or v_attrs.get("branch")
 
@@ -1059,7 +1057,7 @@ class PackageBase(WindowsRPath, PackageViewMixin, metaclass=PackageMeta):
             sha = spack.util.git.get_commit_sha(url, ref)
 
         if sha:
-            spec.variants["commit"] = spack.variant.SingleValuedVariant("commit", sha)
+            spec.variants.set(spack.variant.SingleValuedVariant("commit", sha))
 
     def resolve_binary_provenance(self):
         """

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -1348,8 +1348,8 @@ class SpackSolverSetup:
 
             # make a spec indicating whether the variant has this conditional value
             variant_has_value = spack.spec.Spec()
-            variant_has_value.variants[name] = vt.VariantValue(
-                vt.VariantType.MULTI, name, (value.value,)
+            variant_has_value.variants.set(
+                vt.VariantValue(vt.VariantType.MULTI, name, (value.value,))
             )
 
             if value.when:
@@ -2994,7 +2994,7 @@ class SpecBuilder:
         spec = self._specs[node]
         variant = spec.variants.get(name)
         if not variant:
-            spec.variants[name] = vt.VariantValue.from_concretizer(name, value, variant_type)
+            spec.variants.set(vt.VariantValue.from_concretizer(name, value, variant_type))
         else:
             assert variant_type == "multi", (
                 f"Can't have multiple values for single-valued variant: "
@@ -3330,7 +3330,7 @@ def _specs_with_commits(spec):
 
     if isinstance(spec.version, vn.GitVersion):
         if "commit" not in spec.variants and spec.version.commit_sha:
-            spec.variants["commit"] = vt.SingleValuedVariant("commit", spec.version.commit_sha)
+            spec.variants.set(vt.SingleValuedVariant("commit", spec.version.commit_sha))
 
     pkg_class._resolve_git_provenance(spec)
 

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -1243,7 +1243,7 @@ class FlagMap(lang.HashableMap[str, List[CompilerFlag]]):
         return flag_type, [str(flag) for flag in self[flag_type]]
 
     def _cmp_iter(self):
-        for k, v in sorted(self.dict.items()):
+        for k, v in sorted(self.items()):
             yield k
 
             def flags():
@@ -2168,8 +2168,12 @@ class Spec:
             for flag, propagation in flags_and_propagation:
                 self.compiler_flags.add_flag(name, flag, propagation, flag_group)
         else:
-            self.variants[name] = vt.VariantValue.from_string_or_bool(
-                name, value, propagate=propagate, concrete=concrete
+            if name in self.variants:
+                raise vt.DuplicateVariantError(f'Cannot specify variant "{name}" twice')
+            self.variants.set(
+                vt.VariantValue.from_string_or_bool(
+                    name, value, propagate=propagate, concrete=concrete
+                )
             )
 
     def _set_architecture(self, **kwargs):
@@ -2856,10 +2860,7 @@ class Spec:
 
         for vname, value in change_spec.variants.items():
             if vname in package_cls.variant_names():
-                if vname in new_spec.variants:
-                    new_spec.variants.substitute(value)
-                else:
-                    new_spec.variants[vname] = value
+                new_spec.variants.set(value)
             else:
                 raise ValueError("{0} is not a variant of {1}".format(vname, new_spec.name))
 
@@ -3728,8 +3729,8 @@ class Spec:
         return result
 
     def _intersects_variants(self, other: "Spec") -> bool:
-        self_dict = self.variants.dict
-        other_dict = other.variants.dict
+        self_dict = self.variants
+        other_dict = other.variants
         return all(self_dict[k].intersects(other_dict[k]) for k in other_dict if k in self_dict)
 
     def _constrain_variants(self, other: "Spec") -> bool:
@@ -3749,7 +3750,7 @@ class Spec:
                 changed |= self.variants[k].constrain(other.variants[k])
             else:
                 # If it is not present copy it straight away
-                self.variants[k] = other.variants[k].copy()
+                self.variants.set(other.variants[k].copy())
                 changed = True
 
         return changed
@@ -5104,7 +5105,7 @@ class Spec:
             if not isinstance(variant, vt.VariantValueRemoval):  # sigil type for removing variant
                 if old_variant:
                     variant.type = old_variant.type  # coerce variant type to match
-                self.variants[name] = variant
+                self.variants.set(variant)
             changed = True
 
         for name, flags in mutator.compiler_flags.items():
@@ -5149,7 +5150,7 @@ class Spec:
                     self.name,
                     self.namespace,
                     self.versions,
-                    (self.variants if self.variants.dict else None),
+                    (self.variants or None),
                     self.architecture,
                     self.abstract_hash,
                 )
@@ -5170,29 +5171,11 @@ class Spec:
         state.pop("last_query", None)
         state.pop("indirect_spec", None)
 
-        # Optimize variants and compiler_flags serialization
-        variants = state.pop("variants", None)
-        if variants:
-            state["_variants_data"] = variants.dict
-        flags = state.pop("compiler_flags", None)
-        if flags:
-            state["_compiler_flags_data"] = flags.dict
-
         return state
 
     def __setstate__(self, state):
-        variants_data = state.pop("_variants_data", None)
-        compiler_flags_data = state.pop("_compiler_flags_data", None)
         self.__dict__.update(state)
         self._package = None
-
-        # Reconstruct variants and compiler_flags
-        self.variants = VariantMap()
-        self.compiler_flags = FlagMap()
-        if variants_data is not None:
-            self.variants.dict = variants_data
-        if compiler_flags_data is not None:
-            self.compiler_flags.dict = compiler_flags_data
 
         # Reconstruct dependents map
         if not hasattr(self, "_dependents"):
@@ -5213,44 +5196,18 @@ class Spec:
 
 
 class VariantMap(lang.HashableMap[str, vt.VariantValue]):
-    """Map containing variant instances. New values can be added only
-    if the key is not already present."""
+    """Map of variant instances, keyed by variant name."""
 
     __slots__ = ()
 
-    def __setitem__(self, name, vspec):
-        # Raise a TypeError if vspec is not of the right type
-        if not isinstance(vspec, vt.VariantValue):
-            raise TypeError(
-                "VariantMap accepts only values of variant types "
-                f"[got {type(vspec).__name__} instead]"
-            )
+    @property
+    def dict(self) -> "VariantMap":
+        # compat with boost's package.py, which uses this former private attribute; to be removed
+        return self
 
-        # Raise an error if the variant was already in this map
-        if name in self.dict:
-            msg = 'Cannot specify variant "{0}" twice'.format(name)
-            raise vt.DuplicateVariantError(msg)
-
-        # Raise an error if name and vspec.name don't match
-        if name != vspec.name:
-            raise KeyError(
-                f'Inconsistent key "{name}", must be "{vspec.name}" to match VariantSpec'
-            )
-
-        # Set the item
-        super().__setitem__(name, vspec)
-
-    def substitute(self, vspec):
-        """Substitutes the entry under ``vspec.name`` with ``vspec``.
-
-        Args:
-            vspec: variant spec to be substituted
-        """
-        if vspec.name not in self:
-            raise KeyError(f"cannot substitute a key that does not exist [{vspec.name}]")
-
-        # Set the item
-        super().__setitem__(vspec.name, vspec)
+    def set(self, vspec: vt.VariantValue) -> None:
+        """Stores ``vspec`` under its own name, replacing any entry already there."""
+        self[vspec.name] = vspec
 
     def partition_variants(self):
         non_prop, prop = lang.stable_partition(self.values(), lambda x: not x.propagate)
@@ -5261,8 +5218,8 @@ class VariantMap(lang.HashableMap[str, vt.VariantValue]):
 
     def copy(self) -> "VariantMap":
         clone = VariantMap()
-        for name, variant in self.items():
-            clone[name] = variant.copy()
+        for variant in self.values():
+            clone.set(variant.copy())
         return clone
 
     def string(self, abbreviate_patches: bool = False) -> str:
@@ -5384,7 +5341,7 @@ def substitute_abstract_variants(spec: Spec):
 
         new_variant = pkg_variant.make_variant(*v.values)
         pkg_variant.validate_or_raise(new_variant, spec.name)
-        spec.variants.substitute(new_variant)
+        spec.variants.set(new_variant)
 
     if unknown:
         variants = spack.util.string.plural(len(unknown), "variant")
@@ -5531,8 +5488,10 @@ class SpecfileReaderBase(abc.ABC):
                 for val in values:
                     spec.compiler_flags.add_flag(name, val, propagate)
             else:
-                spec.variants[name] = vt.VariantValue.from_node_dict(
-                    name, values, propagate=propagate, abstract=name in abstract_variants
+                spec.variants.set(
+                    vt.VariantValue.from_node_dict(
+                        name, values, propagate=propagate, abstract=name in abstract_variants
+                    )
                 )
 
         spec.external_path = None

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -1145,7 +1145,16 @@ class CompilerFlag(str):
 _valid_compiler_flags = ("cflags", "cxxflags", "fflags", "ldflags", "ldlibs", "cppflags")
 
 
-class FlagMap(lang.HashableMap[str, List[CompilerFlag]]):
+# typing.Dict bases are slow at runtime on Python 3.6
+if TYPE_CHECKING:
+    _FlagMapBase = Dict[str, List[CompilerFlag]]
+    _VariantMapBase = Dict[str, vt.VariantValue]
+else:
+    _FlagMapBase = _VariantMapBase = dict
+
+
+@lang.lazy_lexicographic_ordering
+class FlagMap(_FlagMapBase):
     __slots__ = ()
 
     def satisfies(self, other):
@@ -5195,10 +5204,15 @@ class Spec:
         return bool(self.dependencies(virtuals=(virtual,)))
 
 
-class VariantMap(lang.HashableMap[str, vt.VariantValue]):
+@lang.lazy_lexicographic_ordering
+class VariantMap(_VariantMapBase):
     """Map of variant instances, keyed by variant name."""
 
     __slots__ = ()
+
+    def _cmp_iter(self):
+        for _, v in sorted(self.items()):
+            yield v
 
     @property
     def dict(self) -> "VariantMap":

--- a/lib/spack/spack/test/spec_syntax.py
+++ b/lib/spack/spack/test/spec_syntax.py
@@ -1705,6 +1705,10 @@ def test_disambiguate_hash_by_spec(spec1, spec2, constraint, mock_packages, monk
         ("zlib %[c=gcc]", "edge attributes"),
         # regression: an unconsumed token used to make the parser loop forever
         ("zlib ]", "unexpected token"),
+        # The same variant cannot be specified twice
+        ("x +foo +foo", "twice"),
+        ("x +foo ~foo", "twice"),
+        ("x foo=bar foo=baz", "twice"),
     ],
 )
 def test_error_conditions(text, match_string):

--- a/lib/spack/spack/test/variant.py
+++ b/lib/spack/spack/test/variant.py
@@ -14,7 +14,6 @@ from spack.spec import Spec, VariantMap
 from spack.variant import (
     BoolValuedVariant,
     ConditionalValue,
-    DuplicateVariantError,
     InconsistentValidationError,
     InvalidVariantValueError,
     MultipleValuesInExclusiveVariantError,
@@ -415,45 +414,19 @@ class TestVariant:
 
 
 class TestVariantMapTest:
-    def test_invalid_values(self) -> None:
-        # Value with invalid type
-        a = VariantMap()
-        with pytest.raises(TypeError):
-            a["foo"] = 2
-
-        # Duplicate variant
-        a["foo"] = MultiValuedVariant("foo", ("bar", "baz"))
-        with pytest.raises(DuplicateVariantError):
-            a["foo"] = MultiValuedVariant("foo", ("bar",))
-
-        with pytest.raises(DuplicateVariantError):
-            a["foo"] = SingleValuedVariant("foo", "bar")
-
-        with pytest.raises(DuplicateVariantError):
-            a["foo"] = BoolValuedVariant("foo", True)
-
-        # Non matching names between key and vspec.name
-        with pytest.raises(KeyError):
-            a["bar"] = MultiValuedVariant("foo", ("bar",))
-
-    def test_set_item(self) -> None:
-        # Check that all the three types of variants are accepted
+    def test_set(self) -> None:
+        # All three types of variants are accepted, keyed by their own name
         a = VariantMap()
 
-        a["foo"] = BoolValuedVariant("foo", True)
-        a["bar"] = SingleValuedVariant("bar", "baz")
-        a["foobar"] = MultiValuedVariant("foobar", ("a", "b", "c", "d", "e"))
+        a.set(BoolValuedVariant("foo", True))
+        a.set(SingleValuedVariant("bar", "baz"))
+        a.set(MultiValuedVariant("foobar", ("a", "b", "c", "d", "e")))
 
-    def test_substitute(self) -> None:
-        # Check substitution of a key that exists
-        a = VariantMap()
-        a["foo"] = BoolValuedVariant("foo", True)
-        a.substitute(SingleValuedVariant("foo", "bar"))
+        assert list(a) == ["foo", "bar", "foobar"]
 
-        # Trying to substitute something that is not
-        # in the map will raise a KeyError
-        with pytest.raises(KeyError):
-            a.substitute(BoolValuedVariant("bar", True))
+        # An entry already under that name is replaced
+        a.set(SingleValuedVariant("foo", "bar"))
+        assert a["foo"] == SingleValuedVariant("foo", "bar")
 
     def test_satisfies_and_constrain(self) -> None:
         # foo=bar foobar=fee feebar=foo

--- a/lib/spack/spack/util/lang.py
+++ b/lib/spack/spack/util/lang.py
@@ -21,7 +21,6 @@ from typing import (
     Dict,
     Generic,
     Iterable,
-    Iterator,
     List,
     Mapping,
     Optional,
@@ -431,32 +430,14 @@ V = TypeVar("V")
 
 
 @lazy_lexicographic_ordering
-class HashableMap(typing.MutableMapping[K, V]):
+class HashableMap(Dict[K, V]):
     """This is a hashable, comparable dictionary.  Hash is performed on
     a tuple of the values in the dictionary."""
 
-    __slots__ = ("dict",)
-
-    def __init__(self):
-        self.dict: Dict[K, V] = {}
-
-    def __getitem__(self, key: K) -> V:
-        return self.dict[key]
-
-    def __setitem__(self, key: K, value: V) -> None:
-        self.dict[key] = value
-
-    def __iter__(self) -> Iterator[K]:
-        return iter(self.dict)
-
-    def __len__(self) -> int:
-        return len(self.dict)
-
-    def __delitem__(self, key: K) -> None:
-        del self.dict[key]
+    __slots__ = ()
 
     def _cmp_iter(self):
-        for _, v in sorted(self.dict.items()):
+        for _, v in sorted(self.items()):
             yield v
 
 

--- a/lib/spack/spack/util/lang.py
+++ b/lib/spack/spack/util/lang.py
@@ -425,22 +425,6 @@ def lazy_lexicographic_ordering(cls, set_hash=True):
     return cls
 
 
-K = TypeVar("K")
-V = TypeVar("V")
-
-
-@lazy_lexicographic_ordering
-class HashableMap(Dict[K, V]):
-    """This is a hashable, comparable dictionary.  Hash is performed on
-    a tuple of the values in the dictionary."""
-
-    __slots__ = ()
-
-    def _cmp_iter(self):
-        for _, v in sorted(self.items()):
-            yield v
-
-
 def match_predicate(*args):
     """Utility function for making string matching predicates.
 


### PR DESCRIPTION
Many problems in Python can be solved by removing a layer of indirection. The
mutable mapping wrapper would take 2 or 3 Python frames what can be done in a
single call to the C-side (even if I'm not the biggest fan of sub-classing builtins)

On old cpython, using `typing.Dict[K, V]` as a base type is actually quite inefficient,
so a little bit of `if TYPE_CHECKING` cheating with the base type ensures that we
have types for keys and values without runtime overhead.

| Python | `x in m` | `if not m` | `m[k]` | `sorted(m.items())` |                                                                             
| ------ | -------- | -------- | -------- | -------- |                                                                                        
| 3.6 | 314 -> 65 | 170 -> 17 | 176 -> 106 | 3886 -> 750 |                                                                                    
| 3.8 | 210 -> 59 | 129 -> 18 | 127 -> 67 | 2953 -> 637 |                                                                                     
| 3.11 | 79 -> 33 | 53 -> 13 | 49 -> 35 | 1510 -> 471 |                                                                                       
| 3.14 | 89 -> 38 | 58 -> 15 | 42 -> 26 | 1677 -> 600 | 

The validation of `VariantMap.__setitem__` is avoided by making invalid state
impossible through `VariantMap.set(...)` and replacing runtime type checks with
static type checking.

`spack solve` performance improves mildly, pickle size reduces a bit too.

note: `VariantMap.dict` is kept to ensure old `boost/package.py` doesn't break,
cause it used this private attribute explicitly.
