### PR TITLE
error: pickle Spack errors by state, not by calling their constructor

### DIFF
--- a/lib/spack/spack/error.py
+++ b/lib/spack/spack/error.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 import sys
-from typing import Optional
+from typing import Optional, Type
 
 from spack.util import tty
 
@@ -87,7 +87,14 @@ class SpackError(Exception):
         return f"{qualified_name}({repr(self.message)}, {repr(self.long_message)})"
 
     def __reduce__(self):
-        return type(self), (self.message, self.long_message)
+        # Pickle reconstructs an exception by calling its class, which fails for the many
+        # subclasses whose __init__ takes something other than (message, long_message)
+        return _rebuild_error, (type(self),), self.__dict__
+
+
+def _rebuild_error(cls: Type["SpackError"]) -> "SpackError":
+    """Build an error without calling __init__, so pickle can restore its state onto it."""
+    return cls.__new__(cls)
 
 
 class NoLibrariesError(SpackError):

--- a/lib/spack/spack/test/error.py
+++ b/lib/spack/spack/test/error.py
@@ -1,0 +1,66 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+"""Tests for the base class of every Spack error."""
+
+import pickle
+
+import pytest
+
+import spack.error
+import spack.solver.asp
+from spack.spec import Spec
+
+
+def test_error_keeps_its_state_through_a_pipe():
+    """Tests that an error carries everything it holds to another process, and not just what
+    its constructor takes.
+    """
+    error = spack.error.SpackError("boom", "details")
+    # Saved by a child build process, so that the parent can print it
+    error.traceback = "Traceback from the child\n"
+
+    replayed = pickle.loads(pickle.dumps(error))
+
+    assert type(replayed) is spack.error.SpackError
+    assert (replayed.message, replayed.long_message) == ("boom", "details")
+    assert replayed.traceback == "Traceback from the child\n"
+
+
+@pytest.mark.parametrize(
+    "factory",
+    [
+        lambda: spack.solver.asp.UnsatisfiableSpecError("boom"),
+        lambda: spack.solver.asp.InternalConcretizerError("boom"),
+        lambda: spack.solver.asp.SolverError(Spec("pkg-a")),
+        lambda: spack.solver.asp.OutputDoesNotSatisfyInputError(
+            [(Spec("pkg-a"), Spec("pkg-b")), (Spec("pkg-c"), None)]
+        ),
+    ],
+    ids=["unsatisfiable", "internal", "solver", "output-does-not-satisfy-input"],
+)
+def test_errors_with_their_own_constructor_survive_a_pipe(factory):
+    """Tests that an error whose __init__ takes something other than (message, long_message)
+    round trips: rebuilding it by calling its class cannot work.
+    """
+    error = factory()
+
+    replayed = pickle.loads(pickle.dumps(error))
+
+    assert type(replayed) is type(error)
+    assert str(replayed) == str(error)
+
+
+def test_output_does_not_satisfy_input_keeps_its_specs():
+    """Tests that the specs survive, and not just the message built from them: they are what
+    spack.main._handle_solver_bug reports, and dumps to JSON for bug reports.
+    """
+    unsolved = [(Spec("pkg-a"), Spec("pkg-b")), (Spec("pkg-c"), None)]
+    error = spack.solver.asp.OutputDoesNotSatisfyInputError(unsolved)
+
+    replayed = pickle.loads(pickle.dumps(error))
+
+    assert [(str(i), str(o) if o else None) for i, o in replayed.input_to_output] == [
+        ("pkg-a", "pkg-b"),
+        ("pkg-c", None),
+    ]

--- a/lib/spack/spack/test/error.py
+++ b/lib/spack/spack/test/error.py
@@ -13,9 +13,7 @@ from spack.spec import Spec
 
 
 def test_error_keeps_its_state_through_a_pipe():
-    """Tests that an error carries everything it holds to another process, and not just what
-    its constructor takes.
-    """
+    """Tests that unpickling an error restores every attribute set on it."""
     error = spack.error.SpackError("boom", "details")
     # Saved by a child build process, so that the parent can print it
     error.traceback = "Traceback from the child\n"
@@ -40,8 +38,8 @@ def test_error_keeps_its_state_through_a_pipe():
     ids=["unsatisfiable", "internal", "solver", "output-does-not-satisfy-input"],
 )
 def test_errors_with_their_own_constructor_survive_a_pipe(factory):
-    """Tests that an error whose __init__ takes something other than (message, long_message)
-    round trips: rebuilding it by calling its class cannot work.
+    """Tests that unpickling works for an error whose __init__ signature is different from
+    SpackError.__init__.
     """
     error = factory()
 
@@ -52,15 +50,13 @@ def test_errors_with_their_own_constructor_survive_a_pipe(factory):
 
 
 def test_output_does_not_satisfy_input_keeps_its_specs():
-    """Tests that the specs survive, and not just the message built from them: they are what
-    spack.main._handle_solver_bug reports, and dumps to JSON for bug reports.
-    """
+    """Tests that OutputDoesNotSatisfyInputError keeps its specs over a pickle round-trip."""
     unsolved = [(Spec("pkg-a"), Spec("pkg-b")), (Spec("pkg-c"), None)]
     error = spack.solver.asp.OutputDoesNotSatisfyInputError(unsolved)
 
     replayed = pickle.loads(pickle.dumps(error))
 
-    assert [(str(i), str(o) if o else None) for i, o in replayed.input_to_output] == [
-        ("pkg-a", "pkg-b"),
-        ("pkg-c", None),
+    assert [(i, o if o else None) for i, o in replayed.input_to_output] == [
+        (Spec("pkg-a"), Spec("pkg-b")),
+        (Spec("pkg-c"), None),
     ]


### PR DESCRIPTION
Extracted from #52891 

`SpackError.__reduce__` rebuilt an error as:
```python
type(self)(message, long_message).
```
That fails for every subclass whose `__init__` takes something else and it silently dropped everything the constructor does not take, including the `traceback` saved from a child build process.[^1]

[^1]: Since BaseException defines its own `__reduce__`, we cannot solve this pickling issue by defining `__getstate__` / `__setstate__`.