### PR TITLE
core: avoid lru_cache caching self

### DIFF
--- a/lib/spack/spack/repo.py
+++ b/lib/spack/spack/repo.py
@@ -58,7 +58,7 @@ import spack.util.path
 import spack.util.spack_yaml as syaml
 from spack.util import tty
 from spack.util.filesystem import working_dir
-from spack.util.lang import Singleton, ensure_unwrapped, memoized
+from spack.util.lang import Singleton, ensure_unwrapped
 
 if TYPE_CHECKING:
     import spack.package_base
@@ -724,6 +724,10 @@ class RepoPath:
         self._index_is_fresh: bool = False
         self._tag_index: Optional[spack.tag.TagIndex] = None
 
+        # Package names by include_virtuals, dropped when the search path changes
+        self._package_names: Dict[bool, List[str]] = {}
+        self._package_names_set: Dict[bool, Set[str]] = {}
+
         for repo in repos:
             self.put_last(repo)
 
@@ -775,6 +779,7 @@ class RepoPath:
 
         self.repos.insert(0, repo)
         self.by_namespace[repo.namespace] = repo
+        self._forget_package_names()
 
     def put_last(self, repo):
         """Add repo last in the search path."""
@@ -784,6 +789,7 @@ class RepoPath:
             return
 
         self.repos.append(repo)
+        self._forget_package_names()
 
         # don't mask any higher-precedence repos with same namespace
         if repo.namespace not in self.by_namespace:
@@ -793,6 +799,7 @@ class RepoPath:
         """Remove a repo from the search path."""
         if repo in self.repos:
             self.repos.remove(repo)
+            self._forget_package_names()
 
     def get_repo(self, namespace: str) -> "Repo":
         """Get a repository by namespace."""
@@ -804,17 +811,24 @@ class RepoPath:
         """Get the first repo in precedence order."""
         return self.repos[0] if self.repos else None
 
-    @memoized
-    def _all_package_names_set(self, include_virtuals) -> Set[str]:
-        return {name for repo in self.repos for name in repo.all_package_names(include_virtuals)}
+    def _forget_package_names(self) -> None:
+        self._package_names.clear()
+        self._package_names_set.clear()
 
-    @memoized
-    def _all_package_names(self, include_virtuals: bool) -> List[str]:
-        """Return all unique package names in all repositories."""
-        return sorted(self._all_package_names_set(include_virtuals), key=lambda n: n.lower())
+    def _all_package_names_set(self, include_virtuals: bool) -> Set[str]:
+        result = self._package_names_set.get(include_virtuals)
+        if result is None:
+            result = {n for repo in self.repos for n in repo.all_package_names(include_virtuals)}
+            self._package_names_set[include_virtuals] = result
+        return result
 
     def all_package_names(self, include_virtuals: bool = False) -> List[str]:
-        return self._all_package_names(include_virtuals)
+        """Return all unique package names in all repositories."""
+        result = self._package_names.get(include_virtuals)
+        if result is None:
+            result = sorted(self._all_package_names_set(include_virtuals), key=lambda n: n.lower())
+            self._package_names[include_virtuals] = result
+        return result
 
     def package_path(self, name: str) -> str:
         """Get path to package.py file for this repo."""

--- a/lib/spack/spack/repo.py
+++ b/lib/spack/spack/repo.py
@@ -816,19 +816,17 @@ class RepoPath:
         self._package_names_set.clear()
 
     def _all_package_names_set(self, include_virtuals: bool) -> Set[str]:
-        result = self._package_names_set.get(include_virtuals)
-        if result is None:
+        if include_virtuals not in self._package_names_set:
             result = {n for repo in self.repos for n in repo.all_package_names(include_virtuals)}
             self._package_names_set[include_virtuals] = result
-        return result
+        return self._package_names_set[include_virtuals]
 
     def all_package_names(self, include_virtuals: bool = False) -> List[str]:
         """Return all unique package names in all repositories."""
-        result = self._package_names.get(include_virtuals)
-        if result is None:
+        if include_virtuals not in self._package_names:
             result = sorted(self._all_package_names_set(include_virtuals), key=lambda n: n.lower())
             self._package_names[include_virtuals] = result
-        return result
+        return self._package_names[include_virtuals]
 
     def package_path(self, name: str) -> str:
         """Get path to package.py file for this repo."""

--- a/lib/spack/spack/solver/input_analysis.py
+++ b/lib/spack/spack/solver/input_analysis.py
@@ -4,7 +4,7 @@
 """Classes to analyze the input of a solve, and provide information to set up the ASP problem"""
 
 import collections
-from typing import Dict, List, NamedTuple, Set, Tuple, Union
+from typing import Dict, List, NamedTuple, Optional, Set, Tuple, Union
 
 import spack.vendor.archspec.cpu
 
@@ -18,7 +18,7 @@ import spack.spec
 import spack.store
 from spack.error import SpackError
 from spack.spec import EMPTY_SPEC
-from spack.util import lang, tty
+from spack.util import tty
 
 
 class PossibleGraph(NamedTuple):
@@ -30,7 +30,7 @@ class PossibleGraph(NamedTuple):
 class PossibleDependencyGraph:
     """Returns information needed to set up an ASP problem"""
 
-    def unreachable(self, *, pkg_name: str, when_spec: spack.spec.Spec) -> bool:
+    def unreachable(self, *, pkg_name: str, when_spec: Union[str, spack.spec.Spec]) -> bool:
         """Returns true if the context can determine that the condition cannot ever
         be met on pkg_name.
         """
@@ -74,6 +74,7 @@ class NoStaticAnalysis(PossibleDependencyGraph):
         self._platform_condition = spack.spec.Spec(
             f"platform={spack.platforms.host()} target={spack.vendor.archspec.cpu.host().family}:"
         )
+        self._allowed_on_platform: Dict[str, bool] = {}
 
         try:
             self.libc_pkgs = [x.name for x in self.providers_for("libc")]
@@ -83,9 +84,15 @@ class NoStaticAnalysis(PossibleDependencyGraph):
     def is_virtual(self, name: str) -> bool:
         return self.repo.is_virtual(name)
 
-    @lang.memoized
     def is_allowed_on_this_platform(self, *, pkg_name: str) -> bool:
         """Returns true if a package is allowed on the current host"""
+        result = self._allowed_on_platform.get(pkg_name)
+        if result is None:
+            result = self._compute_allowed_on_platform(pkg_name)
+            self._allowed_on_platform[pkg_name] = result
+        return result
+
+    def _compute_allowed_on_platform(self, pkg_name: str) -> bool:
         pkg_cls = self.repo.get_pkg_class(pkg_name)
         for when_spec, conditions in pkg_cls.requirements.items():
             # Restrict analysis to unconditional requirements
@@ -105,7 +112,7 @@ class NoStaticAnalysis(PossibleDependencyGraph):
         """Returns True if a package can be installed, False otherwise."""
         return True
 
-    def unreachable(self, *, pkg_name: str, when_spec: spack.spec.Spec) -> bool:
+    def unreachable(self, *, pkg_name: str, when_spec: Union[str, spack.spec.Spec]) -> bool:
         """Returns true if the context can determine that the condition cannot ever
         be met on pkg_name.
         """
@@ -273,10 +280,22 @@ class StaticAnalysis(NoStaticAnalysis):
     ):
         self.store = store
         self.binary_index = binary_index
+        # Set before super().__init__, which resolves the providers for libc
+        self._providers: Dict[str, List[spack.spec.Spec]] = {}
+        self._buildcache_specs: Optional[List[spack.spec.Spec]] = None
+        self._installable: Dict[str, bool] = {}
+        self._provider_candidates: Dict[Tuple[str, str], bool] = {}
+        self._unreachable: Dict[Tuple[str, Union[str, spack.spec.Spec]], bool] = {}
         super().__init__(configuration=configuration, repo=repo)
 
-    @lang.memoized
     def providers_for(self, virtual_str: str) -> List[spack.spec.Spec]:
+        result = self._providers.get(virtual_str)
+        if result is None:
+            result = self._compute_providers_for(virtual_str)
+            self._providers[virtual_str] = result
+        return result
+
+    def _compute_providers_for(self, virtual_str: str) -> List[spack.spec.Spec]:
         candidates = super().providers_for(virtual_str)
         result = []
         for spec in candidates:
@@ -285,13 +304,20 @@ class StaticAnalysis(NoStaticAnalysis):
             result.append(spec)
         return result
 
-    @lang.memoized
     def buildcache_specs(self) -> List[spack.spec.Spec]:
-        self.binary_index.update()
-        return self.binary_index.get_all_built_specs()
+        if self._buildcache_specs is None:
+            self.binary_index.update()
+            self._buildcache_specs = self.binary_index.get_all_built_specs()
+        return self._buildcache_specs
 
-    @lang.memoized
     def can_be_installed(self, *, pkg_name) -> bool:
+        result = self._installable.get(pkg_name)
+        if result is None:
+            result = self._compute_can_be_installed(pkg_name)
+            self._installable[pkg_name] = result
+        return result
+
+    def _compute_can_be_installed(self, pkg_name: str) -> bool:
         if self.configuration.get(f"packages:{pkg_name}:buildable", True):
             return True
 
@@ -308,8 +334,14 @@ class StaticAnalysis(NoStaticAnalysis):
         tty.debug(f"[{__name__}] {pkg_name} cannot be installed")
         return False
 
-    @lang.memoized
     def _is_provider_candidate(self, *, pkg_name: str, virtual: str) -> bool:
+        result = self._provider_candidates.get((pkg_name, virtual))
+        if result is None:
+            result = self._compute_is_provider_candidate(pkg_name, virtual)
+            self._provider_candidates[(pkg_name, virtual)] = result
+        return result
+
+    def _compute_is_provider_candidate(self, pkg_name: str, virtual: str) -> bool:
         if not self.is_allowed_on_this_platform(pkg_name=pkg_name):
             return False
 
@@ -323,11 +355,17 @@ class StaticAnalysis(NoStaticAnalysis):
 
         return True
 
-    @lang.memoized
-    def unreachable(self, *, pkg_name: str, when_spec: spack.spec.Spec) -> bool:
+    def unreachable(self, *, pkg_name: str, when_spec: Union[str, spack.spec.Spec]) -> bool:
         """Returns true if the context can determine that the condition cannot ever
         be met on pkg_name.
         """
+        result = self._unreachable.get((pkg_name, when_spec))
+        if result is None:
+            result = self._compute_unreachable(pkg_name, when_spec)
+            self._unreachable[(pkg_name, when_spec)] = result
+        return result
+
+    def _compute_unreachable(self, pkg_name: str, when_spec: Union[str, spack.spec.Spec]) -> bool:
         candidates = self.configuration.get(f"packages:{pkg_name}:require", [])
         if not candidates and pkg_name != "all":
             return self.unreachable(pkg_name="all", when_spec=when_spec)

--- a/lib/spack/spack/solver/input_analysis.py
+++ b/lib/spack/spack/solver/input_analysis.py
@@ -86,11 +86,9 @@ class NoStaticAnalysis(PossibleDependencyGraph):
 
     def is_allowed_on_this_platform(self, *, pkg_name: str) -> bool:
         """Returns true if a package is allowed on the current host"""
-        result = self._allowed_on_platform.get(pkg_name)
-        if result is None:
-            result = self._compute_allowed_on_platform(pkg_name)
-            self._allowed_on_platform[pkg_name] = result
-        return result
+        if pkg_name not in self._allowed_on_platform:
+            self._allowed_on_platform[pkg_name] = self._compute_allowed_on_platform(pkg_name)
+        return self._allowed_on_platform[pkg_name]
 
     def _compute_allowed_on_platform(self, pkg_name: str) -> bool:
         pkg_cls = self.repo.get_pkg_class(pkg_name)
@@ -289,11 +287,9 @@ class StaticAnalysis(NoStaticAnalysis):
         super().__init__(configuration=configuration, repo=repo)
 
     def providers_for(self, virtual_str: str) -> List[spack.spec.Spec]:
-        result = self._providers.get(virtual_str)
-        if result is None:
-            result = self._compute_providers_for(virtual_str)
-            self._providers[virtual_str] = result
-        return result
+        if virtual_str not in self._providers:
+            self._providers[virtual_str] = self._compute_providers_for(virtual_str)
+        return self._providers[virtual_str]
 
     def _compute_providers_for(self, virtual_str: str) -> List[spack.spec.Spec]:
         candidates = super().providers_for(virtual_str)
@@ -311,11 +307,9 @@ class StaticAnalysis(NoStaticAnalysis):
         return self._buildcache_specs
 
     def can_be_installed(self, *, pkg_name) -> bool:
-        result = self._installable.get(pkg_name)
-        if result is None:
-            result = self._compute_can_be_installed(pkg_name)
-            self._installable[pkg_name] = result
-        return result
+        if pkg_name not in self._installable:
+            self._installable[pkg_name] = self._compute_can_be_installed(pkg_name)
+        return self._installable[pkg_name]
 
     def _compute_can_be_installed(self, pkg_name: str) -> bool:
         if self.configuration.get(f"packages:{pkg_name}:buildable", True):
@@ -335,11 +329,10 @@ class StaticAnalysis(NoStaticAnalysis):
         return False
 
     def _is_provider_candidate(self, *, pkg_name: str, virtual: str) -> bool:
-        result = self._provider_candidates.get((pkg_name, virtual))
-        if result is None:
-            result = self._compute_is_provider_candidate(pkg_name, virtual)
-            self._provider_candidates[(pkg_name, virtual)] = result
-        return result
+        key = (pkg_name, virtual)
+        if key not in self._provider_candidates:
+            self._provider_candidates[key] = self._compute_is_provider_candidate(*key)
+        return self._provider_candidates[key]
 
     def _compute_is_provider_candidate(self, pkg_name: str, virtual: str) -> bool:
         if not self.is_allowed_on_this_platform(pkg_name=pkg_name):
@@ -359,11 +352,10 @@ class StaticAnalysis(NoStaticAnalysis):
         """Returns true if the context can determine that the condition cannot ever
         be met on pkg_name.
         """
-        result = self._unreachable.get((pkg_name, when_spec))
-        if result is None:
-            result = self._compute_unreachable(pkg_name, when_spec)
-            self._unreachable[(pkg_name, when_spec)] = result
-        return result
+        key = (pkg_name, when_spec)
+        if key not in self._unreachable:
+            self._unreachable[key] = self._compute_unreachable(pkg_name, when_spec)
+        return self._unreachable[key]
 
     def _compute_unreachable(self, pkg_name: str, when_spec: Union[str, spack.spec.Spec]) -> bool:
         candidates = self.configuration.get(f"packages:{pkg_name}:require", [])

--- a/lib/spack/spack/test/repo.py
+++ b/lib/spack/spack/test/repo.py
@@ -106,6 +106,22 @@ def test_all_package_names_is_cached_correctly(mock_packages: RepoPath):
     assert "mpi" not in mock_packages.all_package_names(include_virtuals=False)
 
 
+def test_all_package_names_is_updated_on_repo_changes(
+    mock_packages: RepoPath, repo_builder: RepoBuilder
+):
+    """Package names are cached, but changing the search path drops the cache."""
+    repo_builder.add_package("pkg-in-extra-repo")
+    extra_repo = spack.repo.from_path(repo_builder.root)
+    repos = RepoPath(*mock_packages.repos)
+    assert "pkg-in-extra-repo" not in repos.all_package_names()
+
+    repos.put_first(extra_repo)
+    assert "pkg-in-extra-repo" in repos.all_package_names()
+
+    repos.remove(extra_repo)
+    assert "pkg-in-extra-repo" not in repos.all_package_names()
+
+
 @pytest.mark.regression("29203")
 def test_use_repositories_doesnt_change_class(mock_packages):
     """Test that we don't create the same package module and class multiple times


### PR DESCRIPTION
Using `lru_cache` on a method extends the lifetime of `self` to end of
process. Not a big deal, but it's a memory leak in unit tests.
