### PR TITLE
concretization ui: ensure each "started" event has a corresponding "finished" 

### DIFF
--- a/lib/spack/spack/concretize.py
+++ b/lib/spack/spack/concretize.py
@@ -3,11 +3,23 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 """High-level functions to concretize list of specs"""
 
+import contextlib
 import importlib
 import sys
 import time
 from collections import Counter
-from typing import TYPE_CHECKING, Any, Dict, Iterable, List, Optional, Sequence, Tuple, Union
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Dict,
+    Iterable,
+    Iterator,
+    List,
+    Optional,
+    Sequence,
+    Tuple,
+    Union,
+)
 
 import spack.compilers
 import spack.compilers.config
@@ -18,7 +30,14 @@ import spack.repo
 import spack.solver.core
 import spack.traverse
 import spack.util.parallel
-from spack.concretize_ui import ConcretizerUI, HeadlessUI, SolveKind
+from spack.concretize_ui import (
+    DEFAULT_USER_SPEC_GROUP,
+    ConcretizerUI,
+    HeadlessUI,
+    SolveKind,
+    concretization_span,
+    group_span,
+)
 from spack.spec import Spec
 from spack.util import tty
 
@@ -28,6 +47,13 @@ TestsType = Union[bool, Iterable[str]]
 
 if TYPE_CHECKING:
     from spack.solver.reuse import SpecFiltersFactory
+
+
+def _needs_solving(abstract: Spec, concrete: Optional[Spec]) -> bool:
+    """Return whether a spec pair has to go through a solve. A pair that does not is passed
+    through unchanged, and is not reported to a frontend.
+    """
+    return concrete is None and not abstract.concrete
 
 
 def _concretize_specs_together(
@@ -53,12 +79,12 @@ def _concretize_specs_together(
     return [s.copy() for s in result.specs]
 
 
-def concretize_together(
+def _concretize_together(
     spec_list: Sequence[SpecPairInput],
     *,
     tests: TestsType = False,
     factory: Optional["SpecFiltersFactory"] = None,
-    ui: Optional[ConcretizerUI] = None,
+    ui: ConcretizerUI,
 ) -> List[SpecPair]:
     """Given a number of specs as input, tries to concretize them together.
 
@@ -68,32 +94,33 @@ def concretize_together(
         tests: list of package names for which to consider tests dependencies. If True, all nodes
             will have test dependencies. If False, test dependencies will be disregarded.
         factory: optional factory to produce a list of specs to be reused
-        ui: frontend to report progress to. Defaults to a headless frontend.
+        ui: frontend to report progress to. The group these specs belong to is assumed to be
+            opened by the caller.
     """
-    ui = ui or HeadlessUI()
-
     to_concretize = [concrete if concrete else abstract for abstract, concrete in spec_list]
-    abstract_specs = [abstract for abstract, _ in spec_list]
 
-    ui.on_concretization_started(kind=SolveKind.TOGETHER, total=len(to_concretize), processes=1)
     start = time.monotonic()
     concrete_specs = _concretize_specs_together(to_concretize, tests=tests, factory=factory)
     duration = time.monotonic() - start
 
     # A single solve produced all the specs, so they all report the duration of that solve
-    result = list(zip(abstract_specs, concrete_specs))
-    for count, (abstract, concrete) in enumerate(result, start=1):
+    result, count = [], 0
+    for (abstract, previous), concrete in zip(spec_list, concrete_specs):
+        result.append((abstract, concrete))
+        if not _needs_solving(abstract, previous):
+            continue
+        count += 1
         ui.on_spec_concretized(abstract, concrete=concrete, count=count, duration=duration)
 
     return result
 
 
-def concretize_together_when_possible(
+def _concretize_together_when_possible(
     spec_list: Sequence[SpecPairInput],
     *,
     tests: TestsType = False,
     factory: Optional["SpecFiltersFactory"] = None,
-    ui: Optional[ConcretizerUI] = None,
+    ui: ConcretizerUI,
 ) -> List[SpecPair]:
     """Given a number of specs as input, tries to concretize them together to the extent possible.
 
@@ -106,23 +133,21 @@ def concretize_together_when_possible(
         tests: list of package names for which to consider tests dependencies. If True, all nodes
             will have test dependencies. If False, test dependencies will be disregarded.
         factory: optional factory to produce a list of specs to be reused
-        ui: frontend to report progress to. Defaults to a headless frontend.
+        ui: frontend to report progress to.
     """
     from spack.solver.asp import Solver
-
-    ui = ui or HeadlessUI()
 
     to_concretize = [concrete if concrete else abstract for abstract, concrete in spec_list]
     old_concrete_to_abstract = {
         concrete: abstract for (abstract, concrete) in spec_list if concrete
     }
+    to_report = {
+        abstract for abstract, concrete in spec_list if _needs_solving(abstract, concrete)
+    }
 
     result_by_user_spec: Dict[Spec, Spec] = {}
     allow_deprecated = spack.config.CONFIG.get("config:deprecated", False)
     j = 0
-    ui.on_concretization_started(
-        kind=SolveKind.WHEN_POSSIBLE, total=len(to_concretize), processes=1
-    )
     start = time.monotonic()
     for result in Solver(specs_factory=factory).solve_in_rounds(
         to_concretize, tests=tests, allow_deprecated=allow_deprecated
@@ -130,6 +155,8 @@ def concretize_together_when_possible(
         now = time.monotonic()
         duration = now - start
         for abstract, concrete in result.specs_by_input.items():
+            if abstract not in to_report:
+                continue
             j += 1
             ui.on_spec_concretized(abstract, concrete=concrete, count=j, duration=duration)
         result_by_user_spec.update(result.specs_by_input)
@@ -143,12 +170,13 @@ def concretize_together_when_possible(
     ]
 
 
-def concretize_separately(
+def _concretize_separately(
     spec_list: Sequence[SpecPairInput],
     *,
     tests: TestsType = False,
     factory: Optional["SpecFiltersFactory"] = None,
-    ui: Optional[ConcretizerUI] = None,
+    ui: ConcretizerUI,
+    processes: int,
 ) -> List[SpecPair]:
     """Concretizes the input specs separately from each other.
 
@@ -158,7 +186,8 @@ def concretize_separately(
         tests: list of package names for which to consider tests dependencies. If True, all nodes
             will have test dependencies. If False, test dependencies will be disregarded.
         factory: optional factory to produce a list of specs to be reused
-        ui: frontend to report progress to. Defaults to a headless frontend.
+        ui: frontend to report progress to.
+        processes: size of the process pool
     """
     from spack.bootstrap import (
         ensure_bootstrap_configuration,
@@ -166,7 +195,6 @@ def concretize_separately(
         ensure_winsdk_external_or_raise,
     )
 
-    ui = ui or HeadlessUI()
     to_concretize = [abstract for abstract, concrete in spec_list if not concrete]
     args = [
         (i, str(abstract), tests, factory)
@@ -197,25 +225,12 @@ def concretize_separately(
     _ = spack.compilers.config.all_compilers()
 
     # Solve the environment in parallel on Linux. imap_unordered falls back to a serial map when
-    # parallelism is disabled (e.g. Windows)
-    num_procs = 1
-    if args and spack.util.parallel.ENABLE_PARALLELISM:
-        num_procs = min(len(args), spack.config.determine_number_of_jobs(parallel=True))
-    ui.on_concretization_started(kind=SolveKind.SEPARATELY, total=len(args), processes=num_procs)
-
-    # Early return if there is nothing to do
-    if len(args) == 0:
-        # Still have to combine the things that were passed in as abstract with the things
-        # that were passed in as pairs
-        return [(abstract, concrete) for abstract, (_, concrete) in zip(to_concretize, ret)] + [
-            (abstract, concrete) for abstract, concrete in spec_list if concrete
-        ]
-
+    # parallelism is disabled (e.g. Windows), and when there is at most one spec to solve
     for j, (i, concrete, duration) in enumerate(
         spack.util.parallel.imap_unordered(
             _concretize_task,
             args,
-            processes=num_procs,
+            processes=processes,
             debug=tty.is_debug(),
             maxtaskperchild=1,
             serialize_env=True,
@@ -225,7 +240,8 @@ def concretize_separately(
         ret.append((i, concrete))
         ui.on_spec_concretized(to_concretize[i], concrete=concrete, count=j, duration=duration)
 
-    # Add specs in original order
+    # Add specs in original order, then combine the ones passed in as abstract with the ones
+    # passed in as pairs
     ret.sort(key=lambda x: x[0])
 
     return [(abstract, concrete) for abstract, (_, concrete) in zip(to_concretize, ret)] + [
@@ -248,21 +264,53 @@ def concretize_one(
     *,
     tests: TestsType = False,
     factory: Optional["SpecFiltersFactory"] = None,
+    ui: Optional[ConcretizerUI] = None,
 ) -> Spec:
     """Return a concretized copy of the given spec.
 
     Args:
         tests: if False disregard test dependencies, if a list of names activate them for
             the packages in the list, if True activate test dependencies for all packages.
+        factory: optional factory to produce a list of specs to be reused
+        ui: frontend to report the solve to. Defaults to a headless frontend.
     """
-    from spack.solver.asp import Solver
+    ui = ui or HeadlessUI()
+    with concretization_span(ui):
+        return _concretize_one(spec, tests=tests, factory=factory, ui=ui)
 
+
+def _concretize_one(
+    spec: Union[str, Spec],
+    *,
+    tests: TestsType = False,
+    factory: Optional["SpecFiltersFactory"] = None,
+    ui: ConcretizerUI,
+) -> Spec:
+    """Concretize a single spec, as a group of one, inside a concretization that started."""
     if isinstance(spec, str):
         spec = Spec(spec)
     spec = spack.hash_lookup.lookup_hash(spec)
 
-    if spec.concrete:
-        return spec.copy()
+    # A single spec takes a single solve, whatever "concretizer:unify" prescribes
+    with group_span(
+        ui,
+        group=DEFAULT_USER_SPEC_GROUP,
+        kind=SolveKind.TOGETHER,
+        total=0 if spec.concrete else 1,
+        processes=1,
+    ):
+        if spec.concrete:
+            return spec.copy()
+
+        start = time.monotonic()
+        concrete = _solve_one(spec, tests=tests, factory=factory)
+        ui.on_spec_concretized(spec, concrete=concrete, count=1, duration=time.monotonic() - start)
+        return concrete
+
+
+def _solve_one(spec: Spec, *, tests: TestsType, factory: Optional["SpecFiltersFactory"]) -> Spec:
+    """Run the single solve that concretizes ``spec``, and pick its answer."""
+    from spack.solver.asp import Solver
 
     for node in spec.traverse():
         if not node.name:
@@ -293,10 +341,50 @@ def concretize_one(
 
 
 def solve_kind(unify: Any) -> SolveKind:
-    """Return the kind of solve that a ``concretizer:unify`` value prescribes."""
+    """Return the kind of solve that a ``concretizer:unify`` value prescribes.
+
+    Raises:
+        spack.error.ConfigError: if ``unify`` is not a value the schema allows
+    """
     if unify == "when_possible":
         return SolveKind.WHEN_POSSIBLE
+    if unify not in (True, False):
+        raise spack.error.ConfigError(f"concretization strategy not implemented [{unify}]")
     return SolveKind.TOGETHER if unify else SolveKind.SEPARATELY
+
+
+def _reported_total(spec_list: Sequence[SpecPairInput]) -> int:
+    """Return how many specs a group concretizing ``spec_list`` reports as concretized, which is
+    the ``total`` a frontend counts against. Only the specs that go through a solve are reported,
+    whatever the strategy.
+    """
+    return sum(1 for abstract, concrete in spec_list if _needs_solving(abstract, concrete))
+
+
+def _processes_for(kind: SolveKind, total: int) -> int:
+    """Return the size of the process pool that concretizing ``total`` specs as ``kind``
+    prescribes uses. Only solving separately runs more than one process.
+    """
+    if kind is not SolveKind.SEPARATELY or not total:
+        return 1
+    if not spack.util.parallel.ENABLE_PARALLELISM:
+        return 1
+    return min(total, spack.config.determine_number_of_jobs(parallel=True))
+
+
+@contextlib.contextmanager
+def solve_group(
+    ui: ConcretizerUI, *, group: str, kind: SolveKind, spec_list: Sequence[SpecPairInput]
+) -> Iterator[int]:
+    """Open the group that concretizes ``spec_list`` as ``kind`` prescribes, and yield the size
+    of the process pool it announced, so that the pool that runs is the one a frontend was told
+    about. A group whose specs need no solve announces a total of zero, and a frontend sees it
+    open and close with nothing in between.
+    """
+    total = _reported_total(spec_list)
+    processes = _processes_for(kind, total)
+    with group_span(ui, group=group, kind=kind, total=total, processes=processes):
+        yield processes
 
 
 def concretize_spec_pairs(
@@ -319,51 +407,68 @@ def concretize_spec_pairs(
         ui: frontend to report progress to. Defaults to a headless frontend.
     """
     ui = ui or HeadlessUI()
+    with concretization_span(ui):
+        return _dispatch_concretization(to_concretize, tests=tests, ui=ui)
+
+
+def _dispatch_concretization(
+    to_concretize: List[SpecPairInput], *, tests: TestsType, ui: ConcretizerUI
+) -> List[Spec]:
     kind = solve_kind(spack.config.CONFIG.get("concretizer:unify", False))
 
     # Special case for concretizing a single spec
     if len(to_concretize) == 1:
         abstract, concrete = to_concretize[0]
-        return [concrete or concretize_one(abstract, tests=tests)]
+        if concrete is None:
+            return [_concretize_one(abstract, tests=tests, ui=ui)]
+        # Nothing to solve, so the group reports a total of zero
+        with group_span(ui, group=DEFAULT_USER_SPEC_GROUP, kind=kind, total=0, processes=1):
+            return [concrete]
 
     # Special case if every spec is either concrete or has an abstract hash
     if all(
         concrete or abstract.concrete or abstract.abstract_hash
         for abstract, concrete in to_concretize
     ):
-        # Get all the concrete specs
-        ret = [
-            concrete
-            or (abstract if abstract.concrete else spack.hash_lookup.lookup_hash(abstract))
-            for abstract, concrete in to_concretize
-        ]
+        # No spec is solved, so the group reports a total of zero
+        with group_span(ui, group=DEFAULT_USER_SPEC_GROUP, kind=kind, total=0, processes=1):
+            # Get all the concrete specs
+            ret = [
+                concrete
+                or (abstract if abstract.concrete else spack.hash_lookup.lookup_hash(abstract))
+                for abstract, concrete in to_concretize
+            ]
 
-        # If unify: true, check that specs don't conflict
-        # Since all concrete, "when_possible" is not relevant
-        if kind is SolveKind.TOGETHER:
-            runtimes = spack.repo.PATH.packages_with_tags("runtime")
-            specs_per_name = Counter(
-                spec.name
-                for spec in spack.traverse.traverse_nodes(
-                    ret, deptype=("link", "run"), key=spack.traverse.by_dag_hash
+            # If unify: true, check that specs don't conflict
+            # Since all concrete, "when_possible" is not relevant
+            if kind is SolveKind.TOGETHER:
+                runtimes = spack.repo.PATH.packages_with_tags("runtime")
+                specs_per_name = Counter(
+                    spec.name
+                    for spec in spack.traverse.traverse_nodes(
+                        ret, deptype=("link", "run"), key=spack.traverse.by_dag_hash
+                    )
+                    if spec.name not in runtimes  # runtimes are allowed multiple times
                 )
-                if spec.name not in runtimes  # runtimes are allowed multiple times
-            )
 
-            conflicts = sorted(name for name, count in specs_per_name.items() if count > 1)
-            if conflicts:
-                raise spack.error.SpecError(
-                    "Specs conflict and `concretizer:unify` is configured true.",
-                    f"    specs depend on multiple versions of {', '.join(conflicts)}",
-                )
-        return ret
+                conflicts = sorted(name for name, count in specs_per_name.items() if count > 1)
+                if conflicts:
+                    raise spack.error.SpecError(
+                        "Specs conflict and `concretizer:unify` is configured true.",
+                        f"    specs depend on multiple versions of {', '.join(conflicts)}",
+                    )
+            return ret
 
     # Standard case
-    concretize_method = concretize_separately  # unify: false
-    if kind is SolveKind.TOGETHER:
-        concretize_method = concretize_together
-    elif kind is SolveKind.WHEN_POSSIBLE:
-        concretize_method = concretize_together_when_possible
-
-    concretized = concretize_method(to_concretize, tests=tests, ui=ui)
-    return [concrete for _, concrete in concretized]
+    with solve_group(
+        ui, group=DEFAULT_USER_SPEC_GROUP, kind=kind, spec_list=to_concretize
+    ) as processes:
+        if kind is SolveKind.TOGETHER:
+            concretized = _concretize_together(to_concretize, tests=tests, ui=ui)
+        elif kind is SolveKind.WHEN_POSSIBLE:
+            concretized = _concretize_together_when_possible(to_concretize, tests=tests, ui=ui)
+        else:
+            concretized = _concretize_separately(
+                to_concretize, tests=tests, ui=ui, processes=processes
+            )
+        return [concrete for _, concrete in concretized]

--- a/lib/spack/spack/concretize_ui.py
+++ b/lib/spack/spack/concretize_ui.py
@@ -5,13 +5,29 @@
 
 Defines the :class:`ConcretizerUI` contract (a headless no-op base) and the terminal
 :class:`TerminalUI` implementation.
+
+Concretization is reported as two nested spans, each with a ``started``/``finished`` pair:
+
+1. the concretization, one per request to concretize a set of specs;
+2. the group, inside which the configuration that drives concretization is fixed. Environments
+   define groups of user specs, a request without one has a single, default, group.
+
+Every span that opens closes exactly once, including when an exception passes through it. A close
+signals teardown and reports no outcome, so no callback takes an exception: anything raised
+propagates to the caller, which decides how to handle it.
 """
 
+import contextlib
 import enum
 import sys
+from typing import Iterator
 
 from spack.spec import Spec
 from spack.util import tty
+
+#: Name of the group of user specs that every concretization has. An environment can define more,
+#: a request without one has only this.
+DEFAULT_USER_SPEC_GROUP = "default"
 
 
 class SolveKind(enum.Enum):
@@ -33,15 +49,22 @@ class ConcretizerUI:
     Frontends therefore need no locking, and no capture of child output.
     """
 
-    def on_group_started(self, *, group: str, is_default: bool) -> None:
-        """A group of user specs is about to be concretized."""
-
-    def on_concretization_started(self, *, kind: SolveKind, total: int, processes: int) -> None:
-        """``total`` user specs are about to be concretized as ``kind`` prescribes, over
-        ``processes`` processes. Called once per group of user specs, before any spec of that
-        group is reported, with ``total`` equal to the number of ``on_spec_concretized`` calls
-        that will follow for it.
+    def on_concretization_started(self) -> None:
+        """A concretization is about to start. Frontends use it to scope the state they keep
+        for one request.
         """
+
+    def on_concretization_finished(self) -> None:
+        """The concretization that started is over."""
+
+    def on_group_started(self, *, group: str, kind: SolveKind, total: int, processes: int) -> None:
+        """The ``group`` of user specs is about to be concretized as ``kind`` prescribes, over
+        ``processes`` processes. ``total`` is the number of ``on_spec_concretized`` calls that
+        will follow for this group, which frontends may use to show a percentage.
+        """
+
+    def on_group_finished(self) -> None:
+        """The group that started is over."""
 
     def on_spec_concretized(
         self, abstract: Spec, *, concrete: Spec, count: int, duration: float
@@ -58,6 +81,33 @@ class ConcretizerUI:
 HeadlessUI = ConcretizerUI
 
 
+@contextlib.contextmanager
+def concretization_span(ui: ConcretizerUI) -> Iterator[None]:
+    """Report the start and the end of a concretization. The end is reported even when the body
+    raises, so that a frontend can tear down what it painted. The exception propagates to the
+    caller without being passed to the frontend.
+    """
+    ui.on_concretization_started()
+    try:
+        yield
+    finally:
+        ui.on_concretization_finished()
+
+
+@contextlib.contextmanager
+def group_span(
+    ui: ConcretizerUI, *, group: str, kind: SolveKind, total: int, processes: int
+) -> Iterator[None]:
+    """Report the start and the end of one group of user specs. As for ``concretization_span``,
+    the end is reported even when the body raises.
+    """
+    ui.on_group_started(group=group, kind=kind, total=total, processes=processes)
+    try:
+        yield
+    finally:
+        ui.on_group_finished()
+
+
 class TerminalUI(ConcretizerUI):
     """Terminal frontend: announces groups and solves, and reports per-spec progress."""
 
@@ -65,15 +115,14 @@ class TerminalUI(ConcretizerUI):
         self.kind = SolveKind.TOGETHER
         self.total = 0
 
-    def on_group_started(self, *, group: str, is_default: bool) -> None:
-        if is_default:
-            return
-        tty.msg(f"Concretizing the '{group}' group of specs")
-
-    def on_concretization_started(self, *, kind: SolveKind, total: int, processes: int) -> None:
+    def on_group_started(self, *, group: str, kind: SolveKind, total: int, processes: int) -> None:
         self.kind = kind
         self.total = total
-        if kind is not SolveKind.SEPARATELY or total == 0:
+        if total == 0:
+            return
+        if group != DEFAULT_USER_SPEC_GROUP:
+            tty.msg(f"Concretizing the '{group}' group of specs")
+        if kind is not SolveKind.SEPARATELY:
             return
         msg = "Starting concretization"
         if processes > 1:

--- a/lib/spack/spack/environment/environment.py
+++ b/lib/spack/spack/environment/environment.py
@@ -31,6 +31,7 @@ from typing import (
 
 import spack
 import spack.active_environment
+import spack.concretize
 import spack.config
 import spack.deptypes as dt
 import spack.error
@@ -55,7 +56,13 @@ import spack.util.tty.color as clr
 import spack.variant as vt
 from spack import traverse
 from spack.active_environment import active_environment
-from spack.concretize_ui import ConcretizerUI, HeadlessUI
+from spack.concretize_ui import (
+    DEFAULT_USER_SPEC_GROUP,
+    ConcretizerUI,
+    HeadlessUI,
+    SolveKind,
+    concretization_span,
+)
 from spack.config import substitute_path_variables
 from spack.enums import ConfigScopePriority
 from spack.schema.env import TOP_LEVEL_KEY
@@ -69,8 +76,6 @@ from spack.util.link_tree import ConflictingSpecsError
 from .list import SpecList, SpecListError, SpecListParser
 
 SpecPair = Tuple[Spec, Spec]
-
-DEFAULT_USER_SPEC_GROUP = "default"
 
 #: environment variable used to indicate the active environment
 spack_env_var = "SPACK_ENV"
@@ -2763,50 +2768,56 @@ class EnvironmentConcretizer:
     ) -> List[SpecPair]:
         if force is None:
             force = spack.config.CONFIG.get("concretizer:force")
-        self._prepare_environment_for_concretization(force=force)
 
-        result = []
-        # Sort so that the ordering is deterministic, and "default" specs are first
-        for current_group in self._order_groups():
-            with self.env.config_override_for_group(group=current_group):
-                partial_result = self._concretize_single_group(group=current_group, tests=tests)
-                result.extend(partial_result)
+        with concretization_span(self.ui):
+            self._prepare_environment_for_concretization(force=force)
 
-        # Unify the specs objects, so we get correct references to all parents
-        if result:
-            self.env.unify_specs()
-        return result
+            result = []
+            # Sort so that the ordering is deterministic, and "default" specs are first
+            for group in self._order_groups():
+                with self.env.config_override_for_group(group=group):
+                    result.extend(self._concretize_single_group(group=group, tests=tests))
+
+            # Unify the specs objects, so we get correct references to all parents
+            if result:
+                self.env.unify_specs()
+            return result
 
     def _concretize_single_group(
         self, *, group: str, tests: Union[bool, Sequence[str]]
     ) -> List[SpecPair]:
-        # Exit early if the set of concretized specs is the set of user specs
         new_user_specs, kept_user_specs = self._partition_user_specs(group=group)
-        if not new_user_specs:
-            return []
 
         # Pick the right concretization strategy
-        self.ui.on_group_started(group=group, is_default=group == DEFAULT_USER_SPEC_GROUP)
-        unify = spack.config.CONFIG.get_config("concretizer").get("unify", False)
-        factory = ReusableSpecsFactory(env=self.env, group=group)
-        if unify == "when_possible":
-            partial_result = self._concretize_together_where_possible(
-                new_user_specs, kept_user_specs, tests=tests, group=group, factory=factory
-            )
+        kind = spack.concretize.solve_kind(
+            spack.config.CONFIG.get_config("concretizer").get("unify", False)
+        )
 
-        elif unify is True:
-            partial_result = self._concretize_together(
-                new_user_specs, kept_user_specs, tests=tests, group=group, factory=factory
-            )
+        with spack.concretize.solve_group(
+            self.ui, group=group, kind=kind, spec_list=[(x, None) for x in new_user_specs]
+        ) as processes:
+            if not new_user_specs:
+                return []
 
-        elif unify is False:
-            partial_result = self._concretize_separately(
-                new_user_specs, kept_user_specs, tests=tests, group=group, factory=factory
-            )
-        else:
-            raise SpackEnvironmentError(f"concretization strategy not implemented [{unify}]")
+            factory = ReusableSpecsFactory(env=self.env, group=group)
+            if kind is SolveKind.WHEN_POSSIBLE:
+                return self._concretize_together_where_possible(
+                    new_user_specs, kept_user_specs, tests=tests, group=group, factory=factory
+                )
 
-        return partial_result
+            if kind is SolveKind.TOGETHER:
+                return self._concretize_together(
+                    new_user_specs, kept_user_specs, tests=tests, group=group, factory=factory
+                )
+
+            return self._concretize_separately(
+                new_user_specs,
+                kept_user_specs,
+                tests=tests,
+                group=group,
+                factory=factory,
+                processes=processes,
+            )
 
     def _prepare_environment_for_concretization(self, *, force: bool):
         """Reset the environment concrete state and ensure consistency with user specs."""
@@ -2886,10 +2897,8 @@ class EnvironmentConcretizer:
         tests: Union[bool, Sequence] = False,
         factory: ReusableSpecsFactory,
     ) -> List[SpecPair]:
-        import spack.concretize
-
         specs_to_concretize = self._user_spec_pairs(to_compute, to_keep)
-        result = spack.concretize.concretize_together_when_possible(
+        result = spack.concretize._concretize_together_when_possible(
             specs_to_concretize, tests=tests, factory=factory, ui=self.ui
         )
         result = [x for x in result if x[0] in to_compute]
@@ -2907,11 +2916,9 @@ class EnvironmentConcretizer:
         tests: Union[bool, Sequence] = False,
         factory: ReusableSpecsFactory,
     ) -> List[SpecPair]:
-        import spack.concretize
-
         to_concretize = self._user_spec_pairs(to_compute, to_keep)
         try:
-            concrete_pairs = spack.concretize.concretize_together(
+            concrete_pairs = spack.concretize._concretize_together(
                 to_concretize, tests=tests, factory=factory, ui=self.ui
             )
         except spack.error.UnsatisfiableSpecError as e:
@@ -2944,13 +2951,12 @@ class EnvironmentConcretizer:
         group: Optional[str] = None,
         tests: Union[bool, Sequence] = False,
         factory: ReusableSpecsFactory,
+        processes: int,
     ) -> List[SpecPair]:
         """Concretization strategy that concretizes separately one user spec after the other"""
-        import spack.concretize
-
         to_concretize = [(x, None) for x in to_compute]
-        concrete_pairs = spack.concretize.concretize_separately(
-            to_concretize, tests=tests, factory=factory, ui=self.ui
+        concrete_pairs = spack.concretize._concretize_separately(
+            to_concretize, tests=tests, factory=factory, ui=self.ui, processes=processes
         )
 
         for abstract, concrete in concrete_pairs:

--- a/lib/spack/spack/test/cmd/env.py
+++ b/lib/spack/spack/test/cmd/env.py
@@ -34,6 +34,7 @@ import spack.util.spack_json as sjson
 import spack.util.spack_yaml
 from spack.active_environment import active_environment
 from spack.cmd.env import _env_create
+from spack.concretize_ui import SolveKind
 from spack.config import Configuration, substitute_path_variables
 from spack.environment import depfile
 from spack.main import SpackCommand, SpackCommandError
@@ -3755,7 +3756,7 @@ def test_virtual_spec_concretize_together(mutable_config):
 @pytest.mark.parametrize(
     "unify,method_to_fail",
     [
-        (True, (spack.concretize, "concretize_together")),
+        (True, (spack.concretize, "_concretize_together")),
         ("when_possible", (spack.solver.asp.Solver, "solve_in_rounds")),
         # An earlier failure so that we test the case where the internal state
         # has been changed, but the pointer to the internal variables has not change.
@@ -5093,5 +5094,61 @@ spack:
         e.concretize(ui=ui)
 
     # "default" is concretized first, the groups that don't need each other follow in any order
-    assert ui.groups[0] == ("default", True)
-    assert set(ui.groups[1:]) == {("apps1", False), ("apps2", False)}
+    assert ui.groups[0] == ("default", SolveKind.SEPARATELY, 1, 1)
+    assert set(ui.groups[1:]) == {
+        ("apps1", SolveKind.SEPARATELY, 1, 1),
+        ("apps2", SolveKind.SEPARATELY, 1, 1),
+    }
+    assert ui.groups_ended == 3
+    assert (ui.started, ui.ended) == (1, 1)
+
+
+def test_concretization_reports_a_group_with_nothing_to_do(environment_from_manifest):
+    """Tests that re-concretizing an environment still reports each group, including the ones
+    that are solved already.
+    """
+    e = environment_from_manifest("""
+spack:
+  specs:
+  - libelf
+  - group: apps1
+    specs:
+    - pkg-a
+""")
+    with e:
+        e.concretize()
+        e.write()
+
+        ui = RecordingUI()
+        e.concretize(ui=ui)
+
+    # Nothing is left to solve, but both groups are still opened and closed
+    assert set(ui.groups) == {
+        ("default", SolveKind.SEPARATELY, 0, 1),
+        ("apps1", SolveKind.SEPARATELY, 0, 1),
+    }
+    assert ui.groups_ended == 2
+    assert not ui.concretized
+    assert (ui.started, ui.ended) == (1, 1)
+
+
+@pytest.mark.parametrize("unify", [True, "when_possible", False])
+def test_reported_total_ignores_specs_that_were_kept(unify, mutable_config, mock_packages):
+    """Tests that adding a spec to an already concretized environment announces a total of one,
+    whatever 'concretizer:unify' prescribes. The specs that were kept go through the solve for
+    'unify: true' and 'when_possible', and a frontend counting them would run past 100%.
+    """
+    mutable_config.set("concretizer:unify", unify)
+    e = ev.create("test")
+    e.add("libelf")
+    e.concretize()
+    e.write()
+
+    e.add("mpileaks")
+    ui = RecordingUI()
+    e.concretize(ui=ui)
+
+    total = ui.groups[0][2]
+    assert total == 1
+    assert [count for _, _, count, _ in ui.concretized] == [1]
+    assert [abstract.name for abstract, _, _, _ in ui.concretized] == ["mpileaks"]

--- a/lib/spack/spack/test/cmd/spec.py
+++ b/lib/spack/spack/test/cmd/spec.py
@@ -446,3 +446,13 @@ def test_spec_json_output_is_jsonl(mutable_config):
 
     assert len(lines) == 2
     assert {spack.spec.Spec.from_dict(json.loads(x)).name for x in lines} == {"libelf", "mpich"}
+
+
+@pytest.mark.parametrize("unify", [True, False, "when_possible"])
+def test_concretizing_single_spec_announces_no_group(unify, mutable_config):
+    """Tests that concretizing a single spec stays silent about groups and pools."""
+    mutable_config.set("concretizer:unify", unify)
+    output = spec("libelf")
+
+    assert "Starting concretization" not in output
+    assert "group of specs" not in output

--- a/lib/spack/spack/test/concretization/core.py
+++ b/lib/spack/spack/test/concretization/core.py
@@ -48,6 +48,7 @@ import spack.util.hash
 import spack.util.lang
 import spack.util.spack_yaml as syaml
 import spack.variant as vt
+from spack.concretize_ui import SolveKind
 from spack.config import Configuration
 from spack.database import Database
 from spack.externals import ExternalDependencyError
@@ -3541,9 +3542,10 @@ def test_spec_unification(unify, mutable_config: Configuration, mock_packages):
 @pytest.mark.enable_parallelism
 def test_parallel_concretization(mutable_config, mock_packages):
     """Test whether parallel unify-false style concretization works."""
+    mutable_config.set("concretizer:unify", False)
     specs = [(Spec("pkg-a"), None), (Spec("pkg-b"), None)]
-    result = spack.concretize.concretize_separately(specs)
-    assert {s.name for s, _ in result} == {"pkg-a", "pkg-b"}
+    result = spack.concretize.concretize_spec_pairs(specs)
+    assert {s.name for s in result} == {"pkg-a", "pkg-b"}
 
 
 @pytest.mark.usefixtures("mutable_config", "mock_packages")
@@ -5578,16 +5580,18 @@ def test_solve_in_rounds_with_no_specs(mock_packages, config):
 
 
 def test_concretize_separately_reports_progress(mutable_config, mock_packages):
-    """Tests that concretizing separately reports the start of the concretization, and one event
-    per spec, to the injected frontend.
+    """Tests that concretizing separately reports the group of user specs, and one event per
+    spec, to the injected frontend.
     """
+    mutable_config.set("concretizer:unify", False)
     ui = RecordingUI()
-    spack.concretize.concretize_separately([(Spec("pkg-a"), None), (Spec("pkg-b"), None)], ui=ui)
+    spack.concretize.concretize_spec_pairs([(Spec("pkg-a"), None), (Spec("pkg-b"), None)], ui=ui)
 
-    assert ui.started == [(spack.concretize_ui.SolveKind.SEPARATELY, 2, 1)]
+    assert len(ui.groups) == 1
+    group, kind, total, _ = ui.groups[0]
+    assert (group, kind, total) == ("default", SolveKind.SEPARATELY, 2)
     assert [count for _, _, count, _ in ui.concretized] == [1, 2]
     assert {abstract.name for abstract, _, _, _ in ui.concretized} == {"pkg-a", "pkg-b"}
-    assert not ui.groups
 
     for abstract, concrete, _, _ in ui.concretized:
         assert concrete.concrete and concrete.satisfies(abstract)
@@ -5598,12 +5602,13 @@ def test_concretize_together_when_possible_reports_progress(mutable_config, mock
     event per spec. The two specs cannot be unified, so they are solved in different rounds, and
     the count has to keep increasing across rounds.
     """
+    mutable_config.set("concretizer:unify", "when_possible")
     ui = RecordingUI()
-    spack.concretize.concretize_together_when_possible(
+    spack.concretize.concretize_spec_pairs(
         [(Spec("pkg-a@1.0"), None), (Spec("pkg-a@2.0"), None)], ui=ui
     )
 
-    assert ui.started == [(spack.concretize_ui.SolveKind.WHEN_POSSIBLE, 2, 1)]
+    assert ui.groups == [("default", SolveKind.WHEN_POSSIBLE, 2, 1)]
     assert [count for _, _, count, _ in ui.concretized] == [1, 2]
     assert {str(abstract) for abstract, _, _, _ in ui.concretized} == {"pkg-a@1.0", "pkg-a@2.0"}
 
@@ -5615,61 +5620,42 @@ def test_concretize_together_reports_progress(mutable_config, mock_packages):
     """Tests that concretizing together reports the start of the concretization, and one event
     per spec.
     """
+    mutable_config.set("concretizer:unify", True)
     ui = RecordingUI()
-    spack.concretize.concretize_together([(Spec("pkg-a"), None), (Spec("pkg-b"), None)], ui=ui)
+    spack.concretize.concretize_spec_pairs([(Spec("pkg-a"), None), (Spec("pkg-b"), None)], ui=ui)
 
-    assert ui.started == [(spack.concretize_ui.SolveKind.TOGETHER, 2, 1)]
+    assert ui.groups == [("default", SolveKind.TOGETHER, 2, 1)]
     assert [count for _, _, count, _ in ui.concretized] == [1, 2]
     assert {abstract.name for abstract, _, _, _ in ui.concretized} == {"pkg-a", "pkg-b"}
     assert len({duration for _, _, _, duration in ui.concretized}) == 1
-    assert not ui.groups
 
     for abstract, concrete, _, _ in ui.concretized:
         assert concrete.concrete and concrete.satisfies(abstract)
 
 
-@pytest.mark.parametrize(
-    "concretize_fn",
-    [
-        spack.concretize.concretize_together,
-        spack.concretize.concretize_together_when_possible,
-        spack.concretize.concretize_separately,
-    ],
-)
-def test_reported_total_matches_number_of_specs(concretize_fn, mutable_config, mock_packages):
-    """Tests that, whatever the concretization strategy, the total announced when concretization
-    starts is the number of specs that are reported as concretized afterwards, and that the counts
-    reported along the way run from 1 to that total. Frontends rely on this to show a percentage.
+@pytest.mark.parametrize("unify", [True, False, "when_possible"])
+def test_reported_total_matches_number_of_specs(unify, mutable_config, mock_packages):
+    """Tests that, whatever the concretization strategy, the total a group announces is the number
+    of specs reported as concretized afterwards, and that the counts reported along the way run
+    from 1 to that total. Frontends rely on this to show a percentage.
     """
+    mutable_config.set("concretizer:unify", unify)
     ui = RecordingUI()
-    concretize_fn([(Spec("pkg-a"), None), (Spec("pkg-b"), None), (Spec("libelf"), None)], ui=ui)
+    spack.concretize.concretize_spec_pairs(
+        [(Spec("pkg-a"), None), (Spec("pkg-b"), None), (Spec("libelf"), None)], ui=ui
+    )
 
-    assert len(ui.started) == 1
-    _, total, _ = ui.started[0]
+    assert len(ui.groups) == 1
+    total = ui.groups[0][2]
     assert total == len(ui.concretized) == 3
     assert [count for _, _, count, _ in ui.concretized] == list(range(1, total + 1))
-
-
-def test_concretize_separately_reports_start_with_nothing_to_do(mutable_config, mock_packages):
-    """Tests that concretization is announced even when every input spec is already concrete, so
-    that frontends always see a start event.
-    """
-    concrete = spack.concretize.concretize_one(Spec("pkg-a"))
-    ui = RecordingUI()
-    result = spack.concretize.concretize_separately([(Spec("pkg-a"), concrete)], ui=ui)
-
-    assert ui.started == [(spack.concretize_ui.SolveKind.SEPARATELY, 0, 1)]
-    assert not ui.concretized
-    assert [concrete for _, concrete in result] == [concrete]
 
 
 @pytest.mark.parametrize("total,announced", [(2, True), (0, False)])
 def test_terminal_ui_announces_pool_only_when_solving(total, announced, capsys):
     """Tests that the terminal frontend stays silent when there is nothing to concretize."""
     ui = spack.concretize_ui.TerminalUI()
-    ui.on_concretization_started(
-        kind=spack.concretize_ui.SolveKind.SEPARATELY, total=total, processes=1
-    )
+    ui.on_group_started(group="default", kind=SolveKind.SEPARATELY, total=total, processes=1)
 
     assert ("Starting concretization" in capsys.readouterr().out) is announced
 
@@ -5792,3 +5778,107 @@ def test_git_ref_version_is_assigned_once_at_concretization(monkeypatch):
     concrete = spack.concretize.concretize_one("git-test-commit@git.1.x")
     assert str(concrete.version) == "git.1.x=1.2" and calls == ["1.x"]
     assert spack.concretize.concretize_one(concrete) == concrete and calls == ["1.x"]
+
+
+def test_group_is_announced_when_every_spec_is_already_concrete(mutable_config, mock_packages):
+    """Tests that a group is announced even when every input spec is already concrete, so that
+    frontends always see it open and close.
+    """
+    mutable_config.set("concretizer:unify", False)
+    pkg_a = spack.concretize.concretize_one(Spec("pkg-a"))
+    pkg_b = spack.concretize.concretize_one(Spec("pkg-b"))
+    ui = RecordingUI()
+    result = spack.concretize.concretize_spec_pairs(
+        [(Spec("pkg-a"), pkg_a), (Spec("pkg-b"), pkg_b)], ui=ui
+    )
+
+    assert ui.groups == [("default", SolveKind.SEPARATELY, 0, 1)]
+    assert ui.groups_ended == 1
+    assert not ui.concretized
+    assert result == [pkg_a, pkg_b]
+
+
+def test_concretization_reports_when_it_is_over(mutable_config, mock_packages):
+    """Tests that a concretization, and the group inside it report their end exactly once."""
+    ui = RecordingUI()
+    spack.concretize.concretize_spec_pairs([(Spec("pkg-a"), None), (Spec("pkg-b"), None)], ui=ui)
+
+    assert (ui.started, ui.ended) == (1, 1)
+    assert (len(ui.groups), ui.groups_ended) == (1, 1)
+    assert len(ui.concretized) == 2
+
+
+def test_every_span_is_closed_when_a_solve_raises(mutable_config, mock_packages):
+    """Tests that a concretization that raises still closes both the concretization and the group,
+    so that a frontend can tear down what it painted before the error is printed. The exception
+    propagates to the caller without being passed to the frontend.
+    """
+    ui = RecordingUI()
+
+    unsatisfiable = Spec("mpileaks ^mpich@3.0.3 ^mpich@3.0.4")
+    with pytest.raises(spack.error.UnsatisfiableSpecError):
+        spack.concretize.concretize_spec_pairs(
+            [(unsatisfiable, None), (Spec("pkg-b"), None)], ui=ui
+        )
+
+    assert (ui.started, ui.ended) == (1, 1)
+    assert (len(ui.groups), ui.groups_ended) == (1, 1)
+
+
+@pytest.mark.parametrize("total,announced", [(2, True), (0, False)])
+def test_terminal_ui_announces_a_group_only_when_it_has_work(total, announced, capsys):
+    """Tests that the terminal frontend holds the group header back until it knows the group has
+    specs to concretize, so re-concretizing an environment doesn't announce empty groups.
+    """
+    ui = spack.concretize_ui.TerminalUI()
+    ui.on_group_started(group="apps", kind=SolveKind.SEPARATELY, total=total, processes=1)
+
+    assert ("Concretizing the 'apps' group" in capsys.readouterr().out) is announced
+
+
+def test_terminal_ui_never_announces_the_default_group(capsys):
+    """Tests that the group every environment has stays implicit."""
+    ui = spack.concretize_ui.TerminalUI()
+    ui.on_group_started(group="default", kind=SolveKind.SEPARATELY, total=2, processes=1)
+
+    assert "group of specs" not in capsys.readouterr().out
+
+
+def test_single_spec_shortcut_opens_a_group(mutable_config, mock_packages):
+    """Tests that the single spec shortcut in concretize_spec_pairs reports a group of one, so
+    the solve it runs is enclosed like any other.
+    """
+    mutable_config.set("concretizer:unify", False)
+    ui = RecordingUI()
+    spack.concretize.concretize_spec_pairs([(Spec("pkg-a"), None)], ui=ui)
+
+    assert ui.groups == [("default", SolveKind.TOGETHER, 1, 1)]
+    assert (ui.started, ui.ended) == (1, 1)
+    assert ui.groups_ended == 1
+
+
+def test_concretize_one_opens_its_own_spans(mutable_config, mock_packages):
+    """Tests that concretize_one, which callers use as an entry point of its own, opens and
+    closes both the concretization and the group around its solve.
+    """
+    ui = RecordingUI()
+    concrete = spack.concretize.concretize_one(Spec("pkg-a"), ui=ui)
+
+    assert concrete.concrete
+    assert ui.groups == [("default", SolveKind.TOGETHER, 1, 1)]
+    assert (ui.started, ui.ended) == (1, 1)
+    assert ui.groups_ended == 1
+    assert [count for _, _, count, _ in ui.concretized] == [1]
+
+
+def test_concretize_one_reports_an_already_concrete_spec_as_no_work(mutable_config, mock_packages):
+    """Tests that concretize_one on an already concrete spec opens a group with nothing in it,
+    rather than reporting a spec it did not solve.
+    """
+    concrete = spack.concretize.concretize_one(Spec("pkg-a"))
+    ui = RecordingUI()
+    spack.concretize.concretize_one(concrete, ui=ui)
+
+    assert ui.groups == [("default", SolveKind.TOGETHER, 0, 1)]
+    assert ui.groups_ended == 1
+    assert not ui.concretized

--- a/lib/spack/spack/test/concretization/flag_mixing.py
+++ b/lib/spack/spack/test/concretization/flag_mixing.py
@@ -42,6 +42,7 @@ import spack.paths
 import spack.repo
 import spack.spec
 import spack.util.spack_yaml as syaml
+from spack.concretize_ui import HeadlessUI
 
 
 @pytest.fixture
@@ -113,7 +114,9 @@ def test_pkg_flags_from_compiler_and_none(concretize_scope, mock_packages):
 
     s1 = spack.spec.Spec("cmake%gcc@12.100.100")
     s2 = spack.spec.Spec("cmake-client^cmake%clang@19.1.0")
-    concrete = dict(spack.concretize.concretize_together([(s1, None), (s2, None)]))
+    concrete = dict(
+        spack.concretize._concretize_together([(s1, None), (s2, None)], ui=HeadlessUI())
+    )
 
     assert concrete[s1].compiler_flags["cflags"] == ["-Wall"]
     assert concrete[s2]["cmake"].compiler_flags["cflags"] == []

--- a/lib/spack/spack/test/utilities.py
+++ b/lib/spack/spack/test/utilities.py
@@ -42,23 +42,32 @@ class RecordingUI(ConcretizerUI):
     Example usage::
 
         ui = RecordingUI()
-        spack.concretize.concretize_separately([(Spec("pkg-a"), None)], ui=ui)
-        assert ui.started == [(SolveKind.SEPARATELY, 1, 1)]
+        spack.concretize.concretize_spec_pairs([(Spec("pkg-a"), None)], ui=ui)
+        assert ui.groups == [("default", SolveKind.TOGETHER, 1, 1)]
     """
 
     def __init__(self) -> None:
-        #: (group, is_default) for each group that started
-        self.groups: List[Tuple[str, bool]] = []
-        #: (kind, total, processes) for each concretization that started
-        self.started: List[Tuple[SolveKind, int, int]] = []
+        #: how many concretizations started, and how many of them reported their end
+        self.started = 0
+        self.ended = 0
+        #: (group, kind, total, processes) for each group that started
+        self.groups: List[Tuple[str, SolveKind, int, int]] = []
+        #: how many groups reported their end
+        self.groups_ended = 0
         #: (abstract, concrete, count, duration) for each spec that was concretized
         self.concretized: List[Tuple[Spec, Spec, int, float]] = []
 
-    def on_group_started(self, *, group: str, is_default: bool) -> None:
-        self.groups.append((group, is_default))
+    def on_concretization_started(self) -> None:
+        self.started += 1
 
-    def on_concretization_started(self, *, kind: SolveKind, total: int, processes: int) -> None:
-        self.started.append((kind, total, processes))
+    def on_concretization_finished(self) -> None:
+        self.ended += 1
+
+    def on_group_started(self, *, group: str, kind: SolveKind, total: int, processes: int) -> None:
+        self.groups.append((group, kind, total, processes))
+
+    def on_group_finished(self) -> None:
+        self.groups_ended += 1
 
     def on_spec_concretized(
         self, abstract: Spec, *, concrete: Spec, count: int, duration: float


### PR DESCRIPTION
Extracted from #52891 

Concretization is reported as two nested spans:

1. The overall request to concretized possibly different set of specs
2. The group of user specs whose configuration is fixed

Each span now has a started/finished pair, and the end is reported even when an exception passes through, so a frontend can tear down what it rendered.