### PR TITLE
modules: add defaults_format option to define default versions in modulerc

### DIFF
--- a/lib/spack/docs/module_file_support.rst
+++ b/lib/spack/docs/module_file_support.rst
@@ -279,6 +279,20 @@ To pin a specific version as the default, add a ``defaults`` key to your modules
 The spec can be as specific as needed.
 If multiple packages in the same directory match, the last one generated wins.
 
+By default, the default version is defined with a ``default`` symlink pointing to the module file.
+Set the ``defaults_format`` option to ``modulerc`` to define the default version with a statement in the ``.modulerc`` file located in the module directory instead (a ``module-version`` command for ``tcl``, a ``module_version`` function call in ``.modulerc.lua`` for ``lmod``):
+
+.. code-block:: yaml
+
+   modules:
+     my-module-set:
+       tcl:
+         defaults_format: modulerc
+         defaults:
+         - gcc@10.2.1
+
+After changing ``defaults_format``, regenerate the module files (e.g., ``spack module tcl refresh``) to convert the existing default version definitions to the newly configured format.
+
 Module content
 ^^^^^^^^^^^^^^
 

--- a/lib/spack/spack/modules/common.py
+++ b/lib/spack/spack/modules/common.py
@@ -26,6 +26,7 @@ import warnings
 from typing import (
     IO,
     Any,
+    Callable,
     ClassVar,
     Dict,
     Iterator,
@@ -68,6 +69,7 @@ from spack.util.lang import Singleton, dedupe
 from .error import (
     CoreCompilersNotFoundError,
     DefaultTemplateNotDefined,
+    DefaultVersionCmdFormatNotDefined,
     HideCmdFormatNotDefined,
     ModulercHeaderNotDefined,
     ModulesError,
@@ -463,6 +465,11 @@ class BaseConfiguration:
     def defaults(self) -> List[str]:
         """Returns the specs configured as defaults or []."""
         return self.conf.get("defaults", [])
+
+    @property
+    def defaults_format(self) -> str:
+        """Mechanism used to define default module versions ("symlink" or "modulerc")."""
+        return self._config.get("defaults_format", "symlink")
 
     @property
     def env(self) -> spack.util.environment.EnvironmentModifications:
@@ -1227,6 +1234,7 @@ class ModuleContext(tengine.Context):
 class BaseModuleFileWriter:
     default_template: str
     hide_cmd_format: str
+    default_version_cmd_format: str
     modulerc_header: List[str]
 
     configuration_class: ClassVar[Type["BaseConfiguration"]]
@@ -1234,6 +1242,7 @@ class BaseModuleFileWriter:
     _required_attrs = (
         ("default_template", DefaultTemplateNotDefined),
         ("hide_cmd_format", HideCmdFormatNotDefined),
+        ("default_version_cmd_format", DefaultVersionCmdFormatNotDefined),
         ("modulerc_header", ModulercHeaderNotDefined),
     )
 
@@ -1352,21 +1361,78 @@ class BaseModuleFileWriter:
         if os.path.exists(self.layout.filename):
             fp.set_permissions_by_spec(self.layout.filename, self.spec)
 
-        # Symlink defaults if needed
+        # Record default version if needed
         self.update_module_defaults()
 
         # record module hiddenness if implicit
         self.update_module_hiddenness()
 
-    def update_module_defaults(self) -> None:
-        if any(self.spec.satisfies(default) for default in self.conf.defaults):
-            # This spec matches a default, it needs to be symlinked to default
-            # Symlink to a tmp location first and move, so that existing
-            # symlinks do not cause an error.
-            default_path = os.path.join(os.path.dirname(self.layout.filename), "default")
-            default_tmp = os.path.join(os.path.dirname(self.layout.filename), ".tmp_spack_default")
-            os.symlink(self.layout.filename, default_tmp)
-            os.rename(default_tmp, default_path)
+    def update_module_defaults(self, remove: bool = False) -> None:
+        """Update the default version definition for this module.
+
+        Depending on the ``defaults_format`` configuration option, the default version is
+        defined with a ``default`` symlink or with a default version statement in the
+        modulerc file. The definition possibly left over by the other format is cleaned up,
+        so that module trees converge to the configured format when module files are
+        rewritten.
+
+        Args:
+            remove (bool): if True, default version information for module is removed.
+        """
+        is_default = not remove and any(
+            self.spec.satisfies(default) for default in self.conf.defaults
+        )
+        default_version_cmd = self.default_version_cmd_format % self.layout.use_name
+
+        # a directory holds a single default: when this module becomes the default, drop
+        # the definition possibly owned by another module file, in whatever format; a
+        # module that is not the default only drops the definitions it owns
+        remove_matching = self._is_default_version_cmd if is_default else None
+
+        if self.conf.defaults_format == "modulerc":
+            self._update_modulerc_entries(
+                [default_version_cmd], present=is_default, remove_matching=remove_matching
+            )
+            # remove default symlink left over from symlink format
+            self._remove_default_symlink(only_own=not is_default)
+        else:
+            # remove default version statement left over from modulerc format
+            self._update_modulerc_entries(
+                [default_version_cmd], present=False, remove_matching=remove_matching
+            )
+            if is_default:
+                # This spec matches a default, it needs to be symlinked to default
+                # Symlink to a tmp location first and move, so that existing
+                # symlinks do not cause an error.
+                default_path = os.path.join(os.path.dirname(self.layout.filename), "default")
+                default_tmp = os.path.join(
+                    os.path.dirname(self.layout.filename), ".tmp_spack_default"
+                )
+                os.symlink(self.layout.filename, default_tmp)
+                os.rename(default_tmp, default_path)
+            else:
+                # remove default symlink left over if module is not the default anymore
+                self._remove_default_symlink(only_own=True)
+
+    def _is_default_version_cmd(self, line: str) -> bool:
+        """Returns True if line is a default version statement, whatever module it targets."""
+        prefix, _, suffix = self.default_version_cmd_format.partition("%s")
+        return line.startswith(prefix) and line.endswith(suffix)
+
+    def _remove_default_symlink(self, only_own: bool) -> None:
+        """Removes the default symlink.
+
+        Args:
+            only_own (bool): if True, only remove the symlink if it targets this module file.
+        """
+        default_path = os.path.join(os.path.dirname(self.layout.filename), "default")
+        try:
+            if os.path.islink(default_path) and (
+                not only_own or os.readlink(default_path) == self.layout.filename
+            ):
+                os.unlink(default_path)
+        except OSError:
+            pass
 
     def update_module_hiddenness(self, remove: bool = False) -> None:
         """Update modulerc file corresponding to module to add or remove
@@ -1376,46 +1442,66 @@ class BaseModuleFileWriter:
             remove (bool): if True, hiddenness information for module is
                 removed from modulerc.
         """
-        modulerc_path = self.layout.modulerc
         hide_module_cmd = self.hide_cmd_format % self.layout.use_name
         hidden = self.conf.hidden and not remove
-        modulerc_exists = os.path.exists(modulerc_path)
-        updated = False
+        self._update_modulerc_entries([hide_module_cmd], present=hidden)
 
+    def _update_modulerc_entries(
+        self,
+        lines: List[str],
+        present: bool,
+        remove_matching: Optional[Callable[[str], bool]] = None,
+        modulerc_path: Optional[str] = None,
+    ) -> None:
+        """Add or remove command lines in a modulerc file of this module.
+
+        Lines owned by other features are preserved. The modulerc file is created when
+        needed and removed when its content boils down to the header.
+
+        Args:
+            lines: modulerc command lines owned by the calling feature
+            present: whether lines should be in modulerc after the update
+            remove_matching: additional lines matching this predicate are removed
+            modulerc_path: modulerc file to update (the modulerc file next to this
+                module file if not set)
+        """
+        if modulerc_path is None:
+            modulerc_path = self.layout.modulerc
+        modulerc_exists = os.path.exists(modulerc_path)
+
+        content = []
         if modulerc_exists:
             with open(modulerc_path, encoding="utf-8") as f:
                 content = f.read().splitlines()
-            already_hidden = hide_module_cmd in content
 
-            # remove hide command if module not hidden
-            if already_hidden and not hidden:
-                content.remove(hide_module_cmd)
-                updated = True
+        def keep(line: str) -> bool:
+            if line in lines:
+                return present
+            return remove_matching is None or not remove_matching(line)
 
-            # add hide command if module is hidden
-            elif not already_hidden and hidden:
-                if not content:
-                    content = self.modulerc_header.copy()
-                content.append(hide_module_cmd)
-                updated = True
-        else:
-            content = self.modulerc_header.copy()
-            if hidden:
-                content.append(hide_module_cmd)
-                updated = True
+        updated_content = [x for x in content if keep(x)]
+        if present:
+            for line in lines:
+                if line not in updated_content:
+                    if not updated_content:
+                        updated_content = self.modulerc_header.copy()
+                    updated_content.append(line)
 
         # no modulerc file change if no content update
-        if updated:
-            is_empty = content == self.modulerc_header or not content
-            # remove existing modulerc if empty
-            if modulerc_exists and is_empty:
+        if updated_content == content:
+            return
+
+        is_empty = updated_content == self.modulerc_header or not updated_content
+        # remove existing modulerc if empty
+        if is_empty:
+            if modulerc_exists:
                 os.remove(modulerc_path)
-            # create or update modulerc
-            elif not is_empty:
-                # ensure file ends with a newline character
-                content.append("")
-                with open(modulerc_path, "w", encoding="utf-8") as f:
-                    f.write("\n".join(content))
+        # create or update modulerc
+        else:
+            # ensure file ends with a newline character
+            updated_content.append("")
+            with open(modulerc_path, "w", encoding="utf-8") as f:
+                f.write("\n".join(updated_content))
 
     def remove(self) -> None:
         """Deletes the module file."""
@@ -1423,7 +1509,8 @@ class BaseModuleFileWriter:
         if os.path.exists(mod_file):
             try:
                 os.remove(mod_file)  # Remove the module file
-                self.remove_module_defaults()  # Remove default targeting module file
+                # Remove default version targeting module file
+                self.update_module_defaults(remove=True)
                 self.update_module_hiddenness(remove=True)  # Remove hide cmd in modulerc
                 os.removedirs(
                     os.path.dirname(mod_file)
@@ -1431,18 +1518,6 @@ class BaseModuleFileWriter:
             except OSError:
                 # removedirs throws OSError on first non-empty directory found
                 pass
-
-    def remove_module_defaults(self) -> None:
-        if not any(self.spec.satisfies(default) for default in self.conf.defaults):
-            return
-
-        # This spec matches a default, symlink needs to be removed as we remove the module
-        # file it targets.
-        default_symlink = os.path.join(os.path.dirname(self.layout.filename), "default")
-        try:
-            os.unlink(default_symlink)
-        except OSError:
-            pass
 
 
 @contextlib.contextmanager

--- a/lib/spack/spack/modules/error.py
+++ b/lib/spack/spack/modules/error.py
@@ -27,6 +27,10 @@ class ModulercHeaderNotDefined(AttributeError, ModulesError):
     """Raised if ``modulerc_header`` has not been specified in the derived class."""
 
 
+class DefaultVersionCmdFormatNotDefined(AttributeError, ModulesError):
+    """Raised if ``default_version_cmd_format`` has not been specified in the derived class."""
+
+
 class ModulesTemplateNotFoundError(ModulesError, RuntimeError):
     """Raised if the template for a module file was not found."""
 

--- a/lib/spack/spack/modules/lmod.py
+++ b/lib/spack/spack/modules/lmod.py
@@ -36,3 +36,5 @@ class LmodModulefileWriter(BaseModuleFileWriter):
     modulerc_header = []
 
     hide_cmd_format = 'hide_version("%s")'
+
+    default_version_cmd_format = 'module_version("%s", "default")'

--- a/lib/spack/spack/modules/tcl.py
+++ b/lib/spack/spack/modules/tcl.py
@@ -36,3 +36,5 @@ class TclModulefileWriter(BaseModuleFileWriter):
     modulerc_header = ["#%Module4.7"]
 
     hide_cmd_format = "module-hide --soft --hidden-loaded %s"
+
+    default_version_cmd_format = "module-version %s default"

--- a/lib/spack/spack/schema/modules.py
+++ b/lib/spack/spack/schema/modules.py
@@ -106,8 +106,15 @@ common_props = {
     },
     "defaults": {
         **array_of_strings,
-        "description": "List of specs for which to create default module symlinks when multiple "
+        "description": "List of specs for which to define a default module version when multiple "
         "versions exist",
+    },
+    "defaults_format": {
+        "type": "string",
+        "enum": ["symlink", "modulerc"],
+        "default": "symlink",
+        "description": "Mechanism used to define default module versions: a 'default' symlink "
+        "or a default version statement in the modulerc file",
     },
     "hide_implicits": {
         "type": "boolean",

--- a/lib/spack/spack/test/cmd/module.py
+++ b/lib/spack/spack/test/cmd/module.py
@@ -222,3 +222,76 @@ def test_setdefault_command(mutable_database, mutable_config: Configuration):
         assert os.path.exists(writers[k].layout.filename)
     assert os.path.exists(link_name) and os.path.islink(link_name)
     assert os.path.realpath(link_name) == os.path.realpath(writers[preferred].layout.filename)
+
+
+@pytest.mark.db
+def test_setdefault_command_modulerc(mutable_database, mutable_config: Configuration, module_type):
+    """Tests setdefault with the modulerc format, including defaults_format changes."""
+    module_conf: dict = {"defaults_format": "modulerc"}
+    if module_type == "lmod":
+        module_conf.update({"core_compilers": ["clang@3.3"], "hierarchy": ["mpi"]})
+    data = {"default": {"enable": [module_type], module_type: module_conf}}
+    mutable_config.set("modules", data)
+
+    # Install two different versions of pkg-a
+    other_spec, preferred = "pkg-a@1.0", "pkg-a@2.0"
+
+    specs = [
+        spack.concretize.concretize_one(other_spec),
+        spack.concretize.concretize_one(preferred),
+    ]
+    PackageInstaller([s.package for s in specs], explicit=True, fake=True).install()
+
+    writer_cls = spack.modules.module_types[module_type]
+    writers = {
+        preferred: writer_cls.from_spec(specs[1], "default"),
+        other_spec: writer_cls.from_spec(specs[0], "default"),
+    }
+
+    # Create two module files for the same software
+    module(module_type, "refresh", "-y", "--delete-tree", preferred, other_spec)
+
+    modulerc = writers[preferred].layout.modulerc
+    link_name = os.path.join(os.path.dirname(writers[preferred].layout.filename), "default")
+    default_version_cmds = {
+        k: writers[k].default_version_cmd_format % writers[k].layout.use_name
+        for k in (preferred, other_spec)
+    }
+
+    def modulerc_content():
+        with open(modulerc, encoding="utf-8") as f:
+            return f.read().splitlines()
+
+    # Assert initial directory state: no default version definition
+    assert not os.path.exists(modulerc)
+    assert not os.path.lexists(link_name)
+
+    # Set the default to be the other spec: defined in modulerc, no symlink
+    module(module_type, "setdefault", other_spec)
+    content = modulerc_content()
+    assert content.count(default_version_cmds[other_spec]) == 1
+    assert default_version_cmds[preferred] not in content
+    assert not os.path.lexists(link_name)
+
+    # Reset the default to be the preferred spec: the other spec statement is replaced
+    module(module_type, "setdefault", preferred)
+    content = modulerc_content()
+    assert content.count(default_version_cmds[preferred]) == 1
+    assert default_version_cmds[other_spec] not in content
+    assert not os.path.lexists(link_name)
+
+    # Switch to symlink format and set the default to the other spec: the preferred spec
+    # statement is dropped from modulerc and the symlink is created
+    mutable_config.set(f"modules:default:{module_type}:defaults_format", "symlink")
+    module(module_type, "setdefault", other_spec)
+    assert not os.path.exists(modulerc)
+    assert os.path.realpath(link_name) == os.path.realpath(writers[other_spec].layout.filename)
+
+    # Switch back to modulerc format and set the default to the preferred spec: the
+    # symlink is dropped and the default version statement is defined
+    mutable_config.set(f"modules:default:{module_type}:defaults_format", "modulerc")
+    module(module_type, "setdefault", preferred)
+    assert not os.path.lexists(link_name)
+    content = modulerc_content()
+    assert content.count(default_version_cmds[preferred]) == 1
+    assert default_version_cmds[other_spec] not in content

--- a/lib/spack/spack/test/modules/common.py
+++ b/lib/spack/spack/test/modules/common.py
@@ -50,6 +50,25 @@ def mock_module_defaults(monkeypatch):
 
 
 @pytest.fixture()
+def mock_module_defaults_format(monkeypatch):
+    def impl(value):
+        monkeypatch.setattr(spack.modules.common.BaseConfiguration, "defaults_format", value)
+
+    return impl
+
+
+@pytest.fixture()
+def mock_module_per_spec_filename(monkeypatch, tmp_path):
+    """Modules of all specs are written with distinct file names in the same directory."""
+    monkeypatch.setattr(
+        spack.modules.common.FileLayout,
+        "filename",
+        property(lambda self: str(tmp_path / self.spec.format("{name}-{version}"))),
+    )
+    yield str(tmp_path)
+
+
+@pytest.fixture()
 def mock_package_perms(monkeypatch):
     perms = stat.S_IRGRP | stat.S_IWGRP
     monkeypatch.setattr(spack.package_prefs, "get_package_permissions", lambda spec: perms)
@@ -87,6 +106,323 @@ def test_modules_default_symlink(
 
     generator.remove()
     assert not os.path.lexists(link_path)
+
+
+@pytest.mark.parametrize("module_type", ["tcl", "lmod"])
+def test_modules_default_symlink_removed_when_not_default_anymore(
+    module_type, mock_packages, mock_module_filename, mock_module_defaults, config
+):
+    """Tests the removal of the default symlink when module stops matching defaults."""
+    spec = spack.concretize.concretize_one("mpileaks@2.3")
+    mock_module_defaults(spec.format("{name}{@version}"))
+
+    generator_cls = spack.modules.module_types[module_type]
+    generator = generator_cls.from_spec(spec, "default")
+    generator.write()
+
+    link_path = os.path.join(os.path.dirname(mock_module_filename), "default")
+    assert readlink(link_path) == mock_module_filename
+
+    # module is not the default anymore, symlink is removed when module is rewritten
+    mock_module_defaults()
+    generator.write(overwrite=True)
+    assert not os.path.lexists(link_path)
+
+
+@pytest.mark.parametrize("module_type", ["tcl", "lmod"])
+def test_modules_default_symlink_of_other_module_preserved(
+    module_type, mock_packages, mock_module_filename, mock_module_defaults, config
+):
+    """Tests that a default symlink not targeting this module file is left untouched."""
+    spec = spack.concretize.concretize_one("mpileaks@2.3")
+    mock_module_defaults()
+
+    generator_cls = spack.modules.module_types[module_type]
+    generator = generator_cls.from_spec(spec, "default")
+
+    # default symlink targets another module file
+    other_module = os.path.join(os.path.dirname(mock_module_filename), "other-module")
+    link_path = os.path.join(os.path.dirname(mock_module_filename), "default")
+    os.symlink(other_module, link_path)
+
+    generator.write()
+    assert readlink(link_path) == other_module
+
+    generator.remove()
+    assert readlink(link_path) == other_module
+
+
+@pytest.mark.parametrize("module_type", ["tcl", "lmod"])
+def test_modules_default_symlink_removal_failure_ignored(
+    module_type, monkeypatch, mock_packages, mock_module_filename, mock_module_defaults, config
+):
+    """Tests that a failure to remove the default symlink does not abort module update."""
+    spec = spack.concretize.concretize_one("mpileaks@2.3")
+    mock_module_defaults(spec.format("{name}{@version}"))
+
+    generator_cls = spack.modules.module_types[module_type]
+    generator = generator_cls.from_spec(spec, "default")
+    generator.write()
+
+    link_path = os.path.join(os.path.dirname(mock_module_filename), "default")
+    assert readlink(link_path) == mock_module_filename
+
+    real_unlink = os.unlink
+
+    def raising_unlink(path, *args, **kwargs):
+        if str(path) == link_path:
+            raise OSError(f"cannot unlink {path}")
+        return real_unlink(path, *args, **kwargs)
+
+    monkeypatch.setattr(os, "unlink", raising_unlink)
+    generator.update_module_defaults(remove=True)
+    assert readlink(link_path) == mock_module_filename
+
+
+@pytest.mark.parametrize("module_type", ["tcl", "lmod"])
+def test_modules_default_modulerc(
+    module_type,
+    mock_packages,
+    mock_module_filename,
+    mock_module_defaults,
+    mock_module_defaults_format,
+    config,
+):
+    """Tests the definition and removal of default version statement in modulerc."""
+    spec = spack.concretize.concretize_one("mpileaks@2.3")
+    mock_module_defaults(spec.format("{name}{@version}"))
+    mock_module_defaults_format("modulerc")
+
+    generator_cls = spack.modules.module_types[module_type]
+    generator = generator_cls.from_spec(spec, "default")
+    generator.write()
+
+    default_version_cmd = generator.default_version_cmd_format % generator.layout.use_name
+    assert os.path.exists(generator.layout.modulerc)
+    with open(generator.layout.modulerc, encoding="utf-8") as f:
+        content = f.read().splitlines()
+    assert content.count(default_version_cmd) == 1
+
+    # no default symlink is created with modulerc format
+    link_path = os.path.join(os.path.dirname(mock_module_filename), "default")
+    assert not os.path.lexists(link_path)
+
+    # module removal also removes its default version statement
+    generator.remove()
+    assert not os.path.exists(generator.layout.modulerc)
+
+
+@pytest.mark.parametrize("module_type", ["tcl", "lmod"])
+def test_modules_default_format_transition(
+    module_type,
+    mock_packages,
+    mock_module_filename,
+    mock_module_defaults,
+    mock_module_defaults_format,
+    config,
+):
+    """Tests the conversion of the default version definition when defaults_format changes."""
+    spec = spack.concretize.concretize_one("mpileaks@2.3")
+    mock_module_defaults(spec.format("{name}{@version}"))
+
+    generator_cls = spack.modules.module_types[module_type]
+    generator = generator_cls.from_spec(spec, "default")
+    link_path = os.path.join(os.path.dirname(mock_module_filename), "default")
+    default_version_cmd = generator.default_version_cmd_format % generator.layout.use_name
+
+    # default version is initially defined with a symlink
+    generator.write()
+    assert readlink(link_path) == mock_module_filename
+    assert not os.path.exists(generator.layout.modulerc)
+
+    # switching to modulerc format converts the definition when module is rewritten
+    mock_module_defaults_format("modulerc")
+    generator.write(overwrite=True)
+    assert not os.path.lexists(link_path)
+    with open(generator.layout.modulerc, encoding="utf-8") as f:
+        content = f.read().splitlines()
+    assert default_version_cmd in content
+
+    # switching back to symlink format converts the definition again
+    mock_module_defaults_format("symlink")
+    generator.write(overwrite=True)
+    assert readlink(link_path) == mock_module_filename
+    assert not os.path.exists(generator.layout.modulerc)
+
+
+@pytest.mark.parametrize("module_type", ["tcl", "lmod"])
+def test_modules_default_target_and_format_changed_at_once(
+    module_type,
+    mock_packages,
+    mock_module_per_spec_filename,
+    mock_module_defaults,
+    mock_module_defaults_format,
+    config,
+):
+    """Tests the conversion when both the default target and defaults_format change."""
+    mock_module_defaults("mpileaks@2.3")
+    mock_module_defaults_format("symlink")
+    generator_cls = spack.modules.module_types[module_type]
+
+    spec = spack.concretize.concretize_one("mpileaks@2.3")
+    generator = generator_cls.from_spec(spec, "default")
+    spec_alt = spack.concretize.concretize_one("mpileaks@2.1")
+    generator_alt = generator_cls.from_spec(spec_alt, "default")
+    generator.write()
+    generator_alt.write()
+
+    link_path = os.path.join(mock_module_per_spec_filename, "default")
+    default_version_cmd = generator.default_version_cmd_format % generator.layout.use_name
+    default_version_cmd_alt = (
+        generator_alt.default_version_cmd_format % generator_alt.layout.use_name
+    )
+    assert readlink(link_path) == generator.layout.filename
+    assert not os.path.exists(generator.layout.modulerc)
+
+    # default becomes the other module and format becomes modulerc at once: writing the
+    # new default module alone drops the former default symlink and defines the new
+    # default version in modulerc
+    mock_module_defaults("mpileaks@2.1")
+    mock_module_defaults_format("modulerc")
+    generator_alt.write(overwrite=True)
+    assert not os.path.lexists(link_path)
+    with open(generator.layout.modulerc, encoding="utf-8") as f:
+        content = f.read().splitlines()
+    assert default_version_cmd not in content
+    assert content.count(default_version_cmd_alt) == 1
+
+    # rewriting the former default module changes nothing
+    generator.write(overwrite=True)
+    assert not os.path.lexists(link_path)
+    with open(generator.layout.modulerc, encoding="utf-8") as f:
+        content = f.read().splitlines()
+    assert default_version_cmd not in content
+    assert content.count(default_version_cmd_alt) == 1
+
+    # default and format are changed back at once: writing the new default module alone
+    # drops the default version statement of the former default and creates the symlink
+    mock_module_defaults("mpileaks@2.3")
+    mock_module_defaults_format("symlink")
+    generator.write(overwrite=True)
+    assert readlink(link_path) == generator.layout.filename
+    assert not os.path.exists(generator.layout.modulerc)
+
+    # rewriting the former default module changes nothing
+    generator_alt.write(overwrite=True)
+    assert readlink(link_path) == generator.layout.filename
+    assert not os.path.exists(generator.layout.modulerc)
+
+
+@pytest.mark.parametrize("module_type", ["tcl", "lmod"])
+@pytest.mark.parametrize("defaults_format", ["symlink", "modulerc"])
+def test_modules_default_last_generated_wins(
+    module_type,
+    defaults_format,
+    mock_packages,
+    mock_module_per_spec_filename,
+    mock_module_defaults,
+    mock_module_defaults_format,
+    config,
+):
+    """Tests that when multiple modules match defaults, the last one generated wins."""
+    mock_module_defaults("mpileaks")
+    mock_module_defaults_format(defaults_format)
+    generator_cls = spack.modules.module_types[module_type]
+
+    spec = spack.concretize.concretize_one("mpileaks@2.3")
+    generator = generator_cls.from_spec(spec, "default")
+    generator.write()
+
+    spec_alt = spack.concretize.concretize_one("mpileaks@2.1")
+    generator_alt = generator_cls.from_spec(spec_alt, "default")
+    generator_alt.write()
+
+    if defaults_format == "symlink":
+        link_path = os.path.join(mock_module_per_spec_filename, "default")
+        assert readlink(link_path) == generator_alt.layout.filename
+    else:
+        default_version_cmd = generator.default_version_cmd_format % generator.layout.use_name
+        default_version_cmd_alt = (
+            generator_alt.default_version_cmd_format % generator_alt.layout.use_name
+        )
+        with open(generator_alt.layout.modulerc, encoding="utf-8") as f:
+            content = f.read().splitlines()
+        assert default_version_cmd not in content
+        assert content.count(default_version_cmd_alt) == 1
+
+
+@pytest.mark.parametrize("module_type", ["tcl", "lmod"])
+def test_modules_default_modulerc_new_default_replaces_former(
+    module_type,
+    mock_packages,
+    mock_module_filename,
+    mock_module_defaults,
+    mock_module_defaults_format,
+    config,
+):
+    """Tests that a new default module drops the default version statement of the former one."""
+    mock_module_defaults_format("modulerc")
+    generator_cls = spack.modules.module_types[module_type]
+
+    spec = spack.concretize.concretize_one("mpileaks@2.3")
+    mock_module_defaults(spec.format("{name}{@version}"))
+    generator = generator_cls.from_spec(spec, "default")
+    generator.write()
+
+    spec_alt = spack.concretize.concretize_one("mpileaks@2.1")
+    mock_module_defaults(spec_alt.format("{name}{@version}"))
+    generator_alt = generator_cls.from_spec(spec_alt, "default")
+    generator_alt.write(overwrite=True)
+
+    default_version_cmd = generator.default_version_cmd_format % generator.layout.use_name
+    default_version_cmd_alt = (
+        generator_alt.default_version_cmd_format % generator_alt.layout.use_name
+    )
+    with open(generator_alt.layout.modulerc, encoding="utf-8") as f:
+        content = f.read().splitlines()
+    assert default_version_cmd not in content
+    assert content.count(default_version_cmd_alt) == 1
+
+
+@pytest.mark.parametrize("module_type", ["tcl", "lmod"])
+def test_modules_default_modulerc_coexists_with_hiddenness(
+    module_type,
+    monkeypatch,
+    mock_packages,
+    mock_module_filename,
+    mock_module_defaults,
+    mock_module_defaults_format,
+    config,
+):
+    """Tests that default version and hiddenness statements update independently in modulerc."""
+    spec = spack.concretize.concretize_one("mpileaks@2.3")
+    mock_module_defaults(spec.format("{name}{@version}"))
+    mock_module_defaults_format("modulerc")
+    monkeypatch.setattr(spack.modules.common.BaseConfiguration, "hidden", True)
+
+    generator_cls = spack.modules.module_types[module_type]
+    generator = generator_cls.from_spec(spec, "default")
+    generator.write()
+
+    hide_cmd = generator.hide_cmd_format % generator.layout.use_name
+    default_version_cmd = generator.default_version_cmd_format % generator.layout.use_name
+    with open(generator.layout.modulerc, encoding="utf-8") as f:
+        content = f.read().splitlines()
+    assert content.count(hide_cmd) == 1
+    assert content.count(default_version_cmd) == 1
+
+    # module is not the default anymore: its default version statement is dropped while
+    # its hiddenness statement is preserved
+    mock_module_defaults()
+    generator.write(overwrite=True)
+    with open(generator.layout.modulerc, encoding="utf-8") as f:
+        content = f.read().splitlines()
+    assert content.count(hide_cmd) == 1
+    assert default_version_cmd not in content
+
+    # module removal drops the whole modulerc file
+    generator.remove()
+    assert not os.path.exists(generator.layout.modulerc)
 
 
 class MockDb:


### PR DESCRIPTION
Add a `defaults_format` option to the `tcl` and `lmod` module set configurations to select the mechanism used to define default module versions among the specs matching `defaults`:

* `symlink` (default value): a `default` symlink targeting the module file, preserving existing behavior
* `modulerc`: a default version statement in the modulerc file located in the module directory (`module-version` command for `tcl`, `module_version` function call in `.modulerc.lua` for `lmod`)

```yaml
modules:
  default:
    tcl:
      defaults_format: modulerc
      defaults:
      - gcc@10.2.1
```

### Behavior

When a module becomes the default, the default version definition possibly owned by another module file is dropped, whatever its format: the default symlink is removed even if it targets another module file and any default version statement in modulerc is replaced. Default and `defaults_format` changes hence apply as soon as the new default module is written, making `spack module [tcl|lmod] setdefault` fully effective in one shot.

A module that is not the default only drops the definitions it owns (a default symlink targeting its own file or its own default version statement), so it never clobbers the actual default definition, while stale definitions still converge to the configuration when module files are rewritten. This also fixes stale symlinks remaining when a module stops matching the `defaults` configuration, and only actual symlinks are ever removed, never a regular file named `default`.

The modulerc read-modify-write logic is factored out of `update_module_hiddenness` into a shared helper, so that hiddenness and default version statements update independently in the same modulerc file.

### Tests

* definition and removal of default version statement in modulerc, coexistence with hiddenness statements
* conversion of the default version definition in both directions when `defaults_format` changes, including when the default target changes at the same time
* replacement of the former default definition when a new module becomes the default ("last one generated wins")
* preservation of a default symlink owned by another module file
* `setdefault` command with modulerc format and across `defaults_format` changes, for both `tcl` and `lmod`
