### PR TITLE
ci: let wait-for-build-jobs fail without failing the pipeline

### DIFF
--- a/lib/spack/spack/ci/gitlab.py
+++ b/lib/spack/spack/ci/gitlab.py
@@ -387,7 +387,11 @@ def generate_gitlab_yaml(pipeline: PipelineDag, spack_ci: SpackCIConfig, options
             stage_names.append("stage-wait")
             wait_job = spack_ci_ir["jobs"]["noop"]["attributes"]
             wait_job["stage"] = "stage-wait"
+
+            # If this job fails ignore the status and carry on
             wait_job["retry"] = 0
+            wait_job["allow_failure"] = True
+
             wait_job["when"] = "always"
             wait_job["script"] = ["echo 'Open the pod bay doors HAL'"]
             wait_job["dependencies"] = []


### PR DESCRIPTION
This fixes GitLab job failures, such as [this one](https://gitlab.spack.io/spack/spack-packages/-/jobs/24099711), that have recently started happening after https://github.com/spack/spack-packages/pull/6187 shortened the timeout for noop jobs.

In practice, what https://github.com/spack/spack-packages/pull/6187 did was make it so the vast majority of noop jobs will now fail immediately after starting, since it usually takes more than 1 second for one of these jobs to complete. This is fine for other noop jobs like `no-specs-to-rebuild`, because [they set `allow_failure: true`](https://github.com/spack/spack/blob/c3b3001ddc13b607cd1e36ad81c81c0453d6814d/lib/spack/spack/ci/gitlab.py#L454-L456). The `wait-for-build-jobs` job does not currently set `allow_failure`, so a timeout for that job causes the entire pipeline to be incorrectly marked as failed.
