### PR TITLE
spec: intern immutable spec values, share the defaults

### DIFF
--- a/lib/spack/spack/bootstrap/clingo.py
+++ b/lib/spack/spack/bootstrap/clingo.py
@@ -39,7 +39,7 @@ def _select_best_version(
         best_version = spack.package_base.sort_by_pkg_preference(allowed_versions, pkg=pkg_cls)[0]
     except (KeyError, ValueError, IndexError):
         return
-    node.versions.versions = [spack.version.from_string(f"={best_version}")]
+    node.versions = spack.version.VersionList([spack.version.from_string(f"={best_version}")])
 
 
 def _add_compilers_if_missing() -> None:
@@ -180,7 +180,7 @@ class ClingoBootstrapConcretizer:
 
         # Can't use re2c@3.1 with Python 3.6
         if self.host_python.satisfies("@3.6"):
-            s["re2c"].versions.versions = [spack.version.from_string("=2.2")]
+            s["re2c"].versions = spack.version.VersionList([spack.version.from_string("=2.2")])
 
         for edge in spack.traverse.traverse_edges([s], cover="edges"):
             if edge.spec.name == "python":

--- a/lib/spack/spack/bootstrap/clingo.py
+++ b/lib/spack/spack/bootstrap/clingo.py
@@ -166,7 +166,7 @@ class ClingoBootstrapConcretizer:
             # Clear patches, we'll compute them correctly later
             node.patches.clear()
             if "patches" in node.variants:
-                del node.variants["patches"]
+                node.variants = node.variants.without("patches")
 
             node.architecture.os = str(self.host_os)
             node.architecture = self.host_architecture
@@ -220,6 +220,5 @@ class ClingoBootstrapConcretizer:
     def _external_spec(self, initial_spec) -> "spack.spec.Spec":
         initial_spec.namespace = "builtin"
         initial_spec.architecture = self.host_architecture
-        for flag_type in spack.spec.FlagMap.valid_compiler_flags():
-            initial_spec.compiler_flags[flag_type] = ()
+        initial_spec.compiler_flags = spack.spec.EMPTY_COMPILER_FLAGS
         return spack.spec.parse_with_version_concrete(initial_spec)

--- a/lib/spack/spack/bootstrap/clingo.py
+++ b/lib/spack/spack/bootstrap/clingo.py
@@ -221,5 +221,5 @@ class ClingoBootstrapConcretizer:
         initial_spec.namespace = "builtin"
         initial_spec.architecture = self.host_architecture
         for flag_type in spack.spec.FlagMap.valid_compiler_flags():
-            initial_spec.compiler_flags[flag_type] = []
+            initial_spec.compiler_flags[flag_type] = ()
         return spack.spec.parse_with_version_concrete(initial_spec)

--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -445,7 +445,8 @@ def set_wrapper_environment_variables_for_flags(pkg, env):
         else:
             handler = pkg.flag_handler.__func__
 
-        injf, envf, bsf = handler(pkg, flag, spec.compiler_flags[flag][:])
+        # recipes mutate the list they are handed, so pass a list of the stored flags
+        injf, envf, bsf = handler(pkg, flag, list(spec.compiler_flags[flag]))
         inject_flags[flag] = injf or []
         env_flags[flag] = envf or []
         build_system_flags[flag] = bsf or []

--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -445,7 +445,7 @@ def set_wrapper_environment_variables_for_flags(pkg, env):
         else:
             handler = pkg.flag_handler.__func__
 
-        # recipes mutate the list they are handed, so pass a list of the stored flags
+        # flag_handler mutates this list, so pass a list of the stored flags
         injf, envf, bsf = handler(pkg, flag, list(spec.compiler_flags[flag]))
         inject_flags[flag] = injf or []
         env_flags[flag] = envf or []

--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -1127,8 +1127,7 @@ def load_external_modules(context: SetupContext) -> None:
         context: A populated SetupContext object
     """
     for spec, _ in context.external:
-        external_modules = spec.external_modules or []
-        for external_module in external_modules:
+        for external_module in spec.external_modules or ():
             spack.util.module_cmd.load_module(external_module)
 
 

--- a/lib/spack/spack/cmd/info.py
+++ b/lib/spack/spack/cmd/info.py
@@ -201,7 +201,9 @@ def print_dependency_suggestion(pkg: PackageBase) -> None:
             # skip if user specified, or already saw a value (e.g. many +mpi and ~mpi)
             if name in spec.variants or name in pkg.spec.variants:
                 continue
-            spec.variants.set(spack.variant.BoolValuedVariant(name, not val))
+            spec.variants = spec.variants.with_value(
+                spack.variant.BoolValuedVariant(name, not val)
+            )
 
         # if there is new stuff to add beyond the input
         if spec.variants:

--- a/lib/spack/spack/compilers/config.py
+++ b/lib/spack/spack/compilers/config.py
@@ -333,7 +333,7 @@ class CompilerFactory:
                     s.extra_attributes = {**s.extra_attributes, **attributes}
 
                 if "modules" in compiler_dict:
-                    s.external_modules = list(compiler_dict["modules"])
+                    s.external_modules = tuple(compiler_dict["modules"])
 
             result.extend(detected)
 

--- a/lib/spack/spack/compilers/config.py
+++ b/lib/spack/spack/compilers/config.py
@@ -323,7 +323,7 @@ class CompilerFactory:
                 continue
 
             for s in detected:
-                # specs share their extra attributes, so replace them instead of writing through
+                # specs share their extra attributes, so store a new dict
                 attributes: Dict[str, Any] = {
                     key: compiler_dict[key]
                     for key in ("flags", "environment", "extra_rpaths")

--- a/lib/spack/spack/compilers/config.py
+++ b/lib/spack/spack/compilers/config.py
@@ -323,9 +323,14 @@ class CompilerFactory:
                 continue
 
             for s in detected:
-                for key in ("flags", "environment", "extra_rpaths"):
-                    if key in compiler_dict:
-                        s.extra_attributes[key] = compiler_dict[key]
+                # specs share their extra attributes, so replace them instead of writing through
+                attributes: Dict[str, Any] = {
+                    key: compiler_dict[key]
+                    for key in ("flags", "environment", "extra_rpaths")
+                    if key in compiler_dict
+                }
+                if attributes:
+                    s.extra_attributes = {**s.extra_attributes, **attributes}
 
                 if "modules" in compiler_dict:
                     s.external_modules = list(compiler_dict["modules"])

--- a/lib/spack/spack/detection/common.py
+++ b/lib/spack/spack/detection/common.py
@@ -42,7 +42,7 @@ def _externals_in_packages_yaml() -> Set[spack.spec.Spec]:
     return already_defined_specs
 
 
-ExternalEntryType = Union[str, Dict[str, str]]
+ExternalEntryType = Union[str, List[str], Dict[str, str]]
 
 
 def _pkg_config_dict(
@@ -74,7 +74,7 @@ def _pkg_config_dict(
             ("prefix", pathlib.Path(e.external_path).as_posix()),
         ]
         if e.external_modules:
-            external_items.append(("modules", e.external_modules))
+            external_items.append(("modules", list(e.external_modules)))
 
         if e.extra_attributes:
             external_items.append(

--- a/lib/spack/spack/environment/environment.py
+++ b/lib/spack/spack/environment/environment.py
@@ -1677,7 +1677,7 @@ class Environment:
                 variant = vt.SingleValuedVariant("dev_path", path)
             else:
                 variant = vt.VariantValueRemoval("dev_path")
-            mutator.variants.set(variant)
+            mutator.variants = mutator.variants.with_value(variant)
 
             msg = (
                 f"Develop spec '{spec}' conflicts with concrete specs in environment."

--- a/lib/spack/spack/externals.py
+++ b/lib/spack/spack/externals.py
@@ -95,7 +95,7 @@ def complete_architecture(node: spack.spec.Spec, repo: spack.repo.RepoPath) -> N
 
     node.namespace = repo.repo_for_pkg(node.name).namespace
     for flag_type in spack.spec.FlagMap.valid_compiler_flags():
-        node.compiler_flags.setdefault(flag_type, [])
+        node.compiler_flags.setdefault(flag_type, ())
 
 
 def _default_variant_value(node: spack.spec.Spec, vdef: vt.Variant) -> Optional[vt.VariantValue]:

--- a/lib/spack/spack/externals.py
+++ b/lib/spack/spack/externals.py
@@ -94,8 +94,7 @@ def complete_architecture(node: spack.spec.Spec, repo: spack.repo.RepoPath) -> N
         node.architecture.target = spack.archspec.HOST_TARGET_FAMILY
 
     node.namespace = repo.repo_for_pkg(node.name).namespace
-    for flag_type in spack.spec.FlagMap.valid_compiler_flags():
-        node.compiler_flags.setdefault(flag_type, ())
+    node.compiler_flags = node.compiler_flags.with_all_flag_types()
 
 
 def _default_variant_value(node: spack.spec.Spec, vdef: vt.Variant) -> Optional[vt.VariantValue]:
@@ -147,7 +146,7 @@ def complete_variants_and_architecture(node: spack.spec.Spec, repo: spack.repo.R
                     if default is None:
                         continue
                     # Cannot use Spec.constrain, because we lose information on the variant type
-                    node.variants.set(default)
+                    node.variants = node.variants.with_value(default)
                 elif (
                     node.variants[name].type != vdef.variant_type
                     and len(node.variants[name].values) == 1
@@ -156,7 +155,7 @@ def complete_variants_and_architecture(node: spack.spec.Spec, repo: spack.repo.R
                     # using the package definition, preserving the user-specified value.
                     existing = node.variants[name]
                     corrected = vdef.make_variant(*existing.values)
-                    node.variants.set(corrected)
+                    node.variants = node.variants.with_value(corrected)
             changed = True
 
 

--- a/lib/spack/spack/mirrors/utils.py
+++ b/lib/spack/spack/mirrors/utils.py
@@ -76,7 +76,7 @@ def get_matching_versions(specs, num_versions=1):
             if spec.concrete or v.intersects(spec.versions):
                 s = spack.spec.Spec(pkg.name)
                 s.versions = spack.version.VersionList([v])
-                s.variants = spec.variants.copy()
+                s.variants = spec.variants
                 matching_spec.append(s)
                 pkg_versions -= 1
 

--- a/lib/spack/spack/package_base.py
+++ b/lib/spack/spack/package_base.py
@@ -1023,7 +1023,9 @@ class PackageBase(WindowsRPath, PackageViewMixin, metaclass=PackageMeta):
         else:
             v_attrs = cls.versions.get(spec.version, {})
             if "commit" in v_attrs:
-                spec.variants.set(spack.variant.SingleValuedVariant("commit", v_attrs["commit"]))
+                spec.variants = spec.variants.with_value(
+                    spack.variant.SingleValuedVariant("commit", v_attrs["commit"])
+                )
                 return
             ref = v_attrs.get("tag") or v_attrs.get("branch")
 
@@ -1057,7 +1059,9 @@ class PackageBase(WindowsRPath, PackageViewMixin, metaclass=PackageMeta):
             sha = spack.util.git.get_commit_sha(url, ref)
 
         if sha:
-            spec.variants.set(spack.variant.SingleValuedVariant("commit", sha))
+            spec.variants = spec.variants.with_value(
+                spack.variant.SingleValuedVariant("commit", sha)
+            )
 
     def resolve_binary_provenance(self):
         """

--- a/lib/spack/spack/package_base.py
+++ b/lib/spack/spack/package_base.py
@@ -2671,9 +2671,7 @@ def _for_package_version(pkg, version=None):
         if not isinstance(version, spack.version.StandardVersion):
             version = spack.version.Version(version)
 
-        version_list = spack.version.VersionList()
-        version_list.add(version)
-        pkg.spec.versions = version_list
+        pkg.spec.versions = spack.version.VersionList([version])
     else:
         version = pkg.version
 

--- a/lib/spack/spack/provider_index.py
+++ b/lib/spack/spack/provider_index.py
@@ -135,7 +135,7 @@ class ProviderIndex:
                     # TODO: fix this comment.
                     # We want satisfaction other than flags
                     provider_spec = provider_spec_readonly.copy()
-                    provider_spec.compiler_flags = spec.compiler_flags.copy()
+                    provider_spec.compiler_flags = spec.compiler_flags
 
                     if spec.intersects(provider_spec, deps=False):
                         provided_name = provided_spec.name

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -3041,7 +3041,7 @@ class SpecBuilder:
             variant.append(value)
 
     def version(self, node, version):
-        self._specs[node].versions = vn.VersionList([vn.Version(version)])
+        self._specs[node].versions = vn.intern_version_list(vn.VersionList([vn.Version(version)]))
 
     def node_flag(self, node, node_flag):
         self._specs[node].compiler_flags.add_flag(

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -3038,7 +3038,7 @@ class SpecBuilder:
                 f"Can't have multiple values for single-valued variant: "
                 f"{node}, {name}, {value}, {variant_type}, {variant_id}"
             )
-            variant.append(value)
+            spec.variants.set(variant.with_value_added(value))
 
     def version(self, node, version):
         self._specs[node].versions = vn.intern_version_list(vn.VersionList([vn.Version(version)]))

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -3007,7 +3007,7 @@ class SpecBuilder:
         if node not in self._specs:
             self._specs[node] = spack.spec.Spec(node.pkg)
             for flag_type in spack.spec.FlagMap.valid_compiler_flags():
-                self._specs[node].compiler_flags[flag_type] = []
+                self._specs[node].compiler_flags[flag_type] = ()
 
     def _arch(self, node):
         arch = self._specs[node].architecture
@@ -3240,7 +3240,7 @@ def reorder_flags(specs: SpecDict) -> None:
             msg = f"{set(compiler_flags)} does not equal {set(ordered_flags)}"
             assert set(compiler_flags) == set(ordered_flags), msg
 
-            spec.compiler_flags.update({flag_type: ordered_flags})
+            spec.compiler_flags.update({flag_type: tuple(ordered_flags)})
 
 
 def post_process_fresh_solve(specs: SpecDict, splices: Optional[SpliceDict]) -> None:

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -1361,7 +1361,7 @@ class SpackSolverSetup:
 
             # make a spec indicating whether the variant has this conditional value
             variant_has_value = spack.spec.Spec()
-            variant_has_value.variants.set(
+            variant_has_value.variants = variant_has_value.variants.with_value(
                 vt.VariantValue(vt.VariantType.MULTI, name, (value.value,))
             )
 
@@ -3006,8 +3006,7 @@ class SpecBuilder:
     def node(self, node):
         if node not in self._specs:
             self._specs[node] = spack.spec.Spec(node.pkg)
-            for flag_type in spack.spec.FlagMap.valid_compiler_flags():
-                self._specs[node].compiler_flags[flag_type] = ()
+            self._specs[node].compiler_flags = spack.spec.EMPTY_COMPILER_FLAGS
 
     def _arch(self, node):
         arch = self._specs[node].architecture
@@ -3032,19 +3031,21 @@ class SpecBuilder:
         spec = self._specs[node]
         variant = spec.variants.get(name)
         if not variant:
-            spec.variants.set(vt.VariantValue.from_concretizer(name, value, variant_type))
+            spec.variants = spec.variants.with_value(
+                vt.VariantValue.from_concretizer(name, value, variant_type)
+            )
         else:
             assert variant_type == "multi", (
                 f"Can't have multiple values for single-valued variant: "
                 f"{node}, {name}, {value}, {variant_type}, {variant_id}"
             )
-            spec.variants.set(variant.with_value_added(value))
+            spec.variants = spec.variants.with_value(variant.with_value_added(value))
 
     def version(self, node, version):
         self._specs[node].versions = vn.intern_version_list(vn.VersionList([vn.Version(version)]))
 
     def node_flag(self, node, node_flag):
-        self._specs[node].compiler_flags.add_flag(
+        self._specs[node].compiler_flags = self._specs[node].compiler_flags.with_flag(
             node_flag.flag_type, node_flag.flag, False, node_flag.flag_group, node_flag.source
         )
 
@@ -3240,7 +3241,7 @@ def reorder_flags(specs: SpecDict) -> None:
             msg = f"{set(compiler_flags)} does not equal {set(ordered_flags)}"
             assert set(compiler_flags) == set(ordered_flags), msg
 
-            spec.compiler_flags.update({flag_type: tuple(ordered_flags)})
+            spec.compiler_flags = spec.compiler_flags.with_flags(flag_type, tuple(ordered_flags))
 
 
 def post_process_fresh_solve(specs: SpecDict, splices: Optional[SpliceDict]) -> None:
@@ -3371,7 +3372,9 @@ def _specs_with_commits(spec, *, repo: spack.repo.RepoPath):
 
     if isinstance(spec.version, vn.GitVersion):
         if "commit" not in spec.variants and spec.version.commit_sha:
-            spec.variants.set(vt.SingleValuedVariant("commit", spec.version.commit_sha))
+            spec.variants = spec.variants.with_value(
+                vt.SingleValuedVariant("commit", spec.version.commit_sha)
+            )
 
     pkg_class._resolve_git_provenance(spec)
 
@@ -3442,7 +3445,8 @@ def _develop_specs_from_env(spec, env, *, config: spack.config.Configuration):
 
         assert spec.variants["dev_path"].value == path, error_msg
     else:
-        spec.variants.setdefault("dev_path", vt.SingleValuedVariant("dev_path", path))
+        if "dev_path" not in spec.variants:
+            spec.variants = spec.variants.with_value(vt.SingleValuedVariant("dev_path", path))
 
     assert spec.satisfies(dev_info["spec"])
 

--- a/lib/spack/spack/solver/reuse.py
+++ b/lib/spack/spack/solver/reuse.py
@@ -115,10 +115,12 @@ def _is_reusable(
             expected_prefix = entry.get("prefix")
             if expected_prefix is not None:
                 expected_prefix = spack.util.path.path_to_os_path(expected_prefix)[0]
+            expected_modules = entry.get("modules")
             if (
                 spec.satisfies(entry["spec"])
                 and spec.external_path == expected_prefix
-                and spec.external_modules == entry.get("modules")
+                and spec.external_modules
+                == (tuple(expected_modules) if expected_modules else None)
             ):
                 return True
 

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -3338,7 +3338,10 @@ class Spec:
             self.namespace = other.namespace
             changed = True
 
-        changed |= self.versions.intersect(other.versions)
+        new_versions = self.versions.intersection(other.versions)
+        if new_versions.versions != self.versions.versions:
+            self.versions = vn.intern_version_list(new_versions)
+            changed = True
         changed |= self._constrain_variants(other)
 
         changed |= self.compiler_flags.constrain(other.compiler_flags)
@@ -3824,7 +3827,7 @@ class Spec:
 
         # Local node attributes get copied first.
         self.name = other.name
-        self.versions = other.versions.copy()
+        self.versions = other.versions
         self.architecture = other.architecture.copy() if other.architecture else None
         self.compiler_flags = other.compiler_flags.copy()
         self.variants = other.variants.copy()
@@ -5385,7 +5388,7 @@ def parse_with_version_concrete(spec_like: Union[str, Spec]):
     s = Spec(spec_like)
     interpreted_version = s.versions.concrete_range_as_version
     if interpreted_version:
-        s.versions = vn.VersionList([interpreted_version])
+        s.versions = vn.intern_version_list(vn.VersionList([interpreted_version]))
     return s
 
 
@@ -5496,7 +5499,7 @@ class SpecfileReaderBase(abc.ABC):
         spec.abstract_hash = node.get("abstract_hash", None)
 
         if "version" in node or "versions" in node:
-            spec.versions = vn.VersionList.from_dict(node)
+            spec.versions = vn.intern_version_list(vn.VersionList.from_dict(node))
 
         if "arch" in node:
             spec.architecture = ArchSpec.from_dict(node)

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -71,6 +71,7 @@ from typing import (
     List,
     Match,
     NamedTuple,
+    NoReturn,
     Optional,
     Sequence,
     Set,
@@ -1156,6 +1157,11 @@ else:
 
 @lang.lazy_lexicographic_ordering
 class FlagMap(_FlagMapBase):
+    """Map of compiler flags, keyed by flag type.
+
+    Specs share these maps, so a map is never modified once it exists; see :class:`VariantMap`.
+    """
+
     __slots__ = ()
 
     def satisfies(self, other):
@@ -1164,37 +1170,63 @@ class FlagMap(_FlagMapBase):
     def intersects(self, other):
         return True
 
-    def constrain(self, other):
-        """Add all flags in other that aren't in self to self.
-
-        Return whether the spec changed.
-        """
-        changed = False
+    def constrained(self, other: "FlagMap") -> Optional["FlagMap"]:
+        """This map with all flags of other added to it, or None when other adds nothing."""
+        merged = None
         for flag_type, other_flags in other.items():
             flags = self.get(flag_type)
             if flags is None:
-                self[flag_type] = other_flags
-                changed = True
+                merged = merged if merged is not None else dict(self)
+                merged[flag_type] = other_flags
                 continue
 
             extra_other = set(other_flags) - set(flags)
             if extra_other:
                 flags = (*flags, *(x for x in other_flags if x in extra_other))
-                changed = True
 
             # Next, if any flags in other propagate, we force them to propagate in our case.
             other_propagate = {f for f in other_flags if f.propagate}
             if any(f in other_propagate and not f.propagate for f in flags):
                 flags = tuple(f.as_propagated() if f in other_propagate else f for f in flags)
-                changed = True
 
-            if flags is not self.get(flag_type):
-                self[flag_type] = flags
+            if flags is not self[flag_type]:
+                merged = merged if merged is not None else dict(self)
+                merged[flag_type] = flags
 
         # TODO: what happens if flag groups with a partial (but not complete)
         # intersection specify different behaviors for flag propagation?
 
-        return changed
+        return None if merged is None else intern_flag_map(FlagMap(merged))
+
+    def with_flags(self, flag_type: str, flags: Tuple[CompilerFlag, ...]) -> "FlagMap":
+        """This map, with ``flags`` stored under ``flag_type``, replacing any entry there."""
+        if self.get(flag_type) == flags and flag_type in self:
+            return self
+        return intern_flag_map(FlagMap({**self, flag_type: flags}))
+
+    def with_all_flag_types(self) -> "FlagMap":
+        """This map, with an empty entry for every flag type it does not have; a concrete spec
+        records them all."""
+        if len(self) == len(_valid_compiler_flags):
+            return self
+        return intern_flag_map(FlagMap({**{f: () for f in _valid_compiler_flags}, **self}))
+
+    def with_flag(
+        self, flag_type: str, value: str, propagation: bool, flag_group=None, source=None
+    ) -> "FlagMap":
+        """This map, with one more flag stored under ``flag_type``."""
+        flag = CompilerFlag(
+            value, propagate=propagation, flag_group=flag_group or value, source=source
+        )
+        return self.with_flags(flag_type, (*self.get(flag_type, ()), flag))
+
+    def _immutable(self, *args, **kwargs) -> NoReturn:
+        raise TypeError("FlagMap is immutable, store the result of with_flag() instead")
+
+    add_flag = __setitem__ = __delitem__ = pop = popitem = setdefault = update = clear = _immutable
+
+    def __reduce__(self):
+        return _flag_map_from_items, (tuple(self.items()),)
 
     def to_dict(self) -> Dict[str, List[Dict[str, Any]]]:
         """Values and propagation of the flags, unlike ``yaml_entry``, which drops everything but
@@ -1206,33 +1238,16 @@ class FlagMap(_FlagMapBase):
 
     @staticmethod
     def from_dict(d: Dict[str, List[Dict[str, Any]]]) -> "FlagMap":
-        result = FlagMap()
-        for flag_type, flags in d.items():
-            result[flag_type] = tuple(CompilerFlag.from_dict(flag) for flag in flags)
-        return result
+        return intern_flag_map(
+            FlagMap(
+                (flag_type, tuple(CompilerFlag.from_dict(flag) for flag in flags))
+                for flag_type, flags in d.items()
+            )
+        )
 
     @staticmethod
     def valid_compiler_flags():
         return _valid_compiler_flags
-
-    def copy(self) -> "FlagMap":
-        return FlagMap(self)
-
-    def add_flag(self, flag_type, value, propagation, flag_group=None, source=None):
-        """Stores the flag's value in CompilerFlag and adds it
-        to the FlagMap
-
-        Args:
-            flag_type (str): the type of flag
-            value (str): the flag's value that will be added to the flag_type's
-                corresponding list
-            propagation (bool): if ``True`` the flag value will be passed to
-                the packages' dependencies. If``False`` it will not be passed
-        """
-        flag_group = flag_group or value
-        flag = CompilerFlag(value, propagate=propagation, flag_group=flag_group, source=source)
-
-        self[flag_type] = (*self.get(flag_type, ()), flag)
 
     def yaml_entry(self, flag_type):
         """Returns the flag type and a list of the flag values since the
@@ -1940,9 +1955,9 @@ class Spec:
         # init an empty spec that matches anything.
         self.name: str = ""
         self.versions = vn.VersionList.any()
-        self.variants = VariantMap()
+        self.variants = EMPTY_VARIANTS
         self.architecture = None
-        self.compiler_flags = FlagMap()
+        self.compiler_flags = EMPTY_FLAGS
         self._dependents = {}
         self._dependencies = {}
         self.namespace = None
@@ -2174,11 +2189,13 @@ class Spec:
             flags_and_propagation = spack.compilers.flags.tokenize_flags(value, propagate)
             flag_group = " ".join(x for (x, y) in flags_and_propagation)
             for flag, propagation in flags_and_propagation:
-                self.compiler_flags.add_flag(name, flag, propagation, flag_group)
+                self.compiler_flags = self.compiler_flags.with_flag(
+                    name, flag, propagation, flag_group
+                )
         else:
             if name in self.variants:
                 raise vt.DuplicateVariantError(f'Cannot specify variant "{name}" twice')
-            self.variants.set(
+            self.variants = self.variants.with_value(
                 vt.VariantValue.from_string_or_bool(
                     name, value, propagate=propagate, concrete=concrete
                 )
@@ -2866,13 +2883,13 @@ class Spec:
 
         for vname, value in change_spec.variants.items():
             if vname in package_cls.variant_names():
-                new_spec.variants.set(value)
+                new_spec.variants = new_spec.variants.with_value(value)
             else:
                 raise ValueError("{0} is not a variant of {1}".format(vname, new_spec.name))
 
         if change_spec.compiler_flags:
             for flagname, flagvals in change_spec.compiler_flags.items():
-                new_spec.compiler_flags[flagname] = flagvals
+                new_spec.compiler_flags = new_spec.compiler_flags.with_flags(flagname, flagvals)
         if change_spec.architecture:
             new_spec.architecture = ArchSpec.override(
                 new_spec.architecture, change_spec.architecture
@@ -3120,9 +3137,7 @@ class Spec:
             edge.direct = not value
         if value:
             self._validate_version()
-            for variant in list(self.variants.values()):
-                if not variant.concrete:
-                    self.variants.set(variant.as_concrete())
+            self.variants = self.variants.as_concrete()
 
     def _validate_version(self):
         # Specs that were concretized with just a git sha as version, without associated
@@ -3338,7 +3353,10 @@ class Spec:
             changed = True
         changed |= self._constrain_variants(other)
 
-        changed |= self.compiler_flags.constrain(other.compiler_flags)
+        merged_flags = self.compiler_flags.constrained(other.compiler_flags)
+        if merged_flags is not None:
+            self.compiler_flags = merged_flags
+            changed = True
 
         sarch, oarch = self.architecture, other.architecture
         if sarch is not None and oarch is not None:
@@ -3751,7 +3769,7 @@ class Spec:
                 if k not in other.variants:
                     raise vt.UnsatisfiableVariantSpecError(self.variants[k], "<absent>")
 
-        changed = False
+        variants = self.variants
         for k in other.variants:
             if k in self.variants:
                 if not self.variants[k].intersects(other.variants[k]):
@@ -3759,14 +3777,16 @@ class Spec:
                 # If they are compatible merge them
                 merged = self.variants[k].constrained(other.variants[k])
                 if merged is not None:
-                    self.variants.set(merged)
-                    changed = True
+                    variants = variants.with_value(merged)
             else:
                 # If it is not present take it straight away
-                self.variants.set(other.variants[k])
-                changed = True
+                variants = variants.with_value(other.variants[k])
 
-        return changed
+        if variants is self.variants:
+            return False
+
+        self.variants = variants
+        return True
 
     @property  # type: ignore[misc] # decorated prop not supported in mypy
     def patches(self):
@@ -3826,8 +3846,8 @@ class Spec:
         self.name = other.name
         self.versions = other.versions
         self.architecture = other.architecture.copy() if other.architecture else None
-        self.compiler_flags = other.compiler_flags.copy()
-        self.variants = other.variants.copy()
+        self.compiler_flags = other.compiler_flags
+        self.variants = other.variants
         self._build_spec = other._build_spec
 
         # Clear dependencies
@@ -5116,17 +5136,19 @@ class Spec:
             if variant == self.variants.get(name, None):
                 continue
 
-            old_variant = self.variants.pop(name, None)
-            if not isinstance(variant, vt.VariantValueRemoval):  # sigil type for removing variant
+            old_variant = self.variants.get(name)
+            if isinstance(variant, vt.VariantValueRemoval):  # sigil type for removing variant
+                self.variants = self.variants.without(name)
+            else:
                 if old_variant:
                     variant = variant.as_type(old_variant.type)  # coerce variant type to match
-                self.variants.set(variant)
+                self.variants = self.variants.with_value(variant)
             changed = True
 
         for name, flags in mutator.compiler_flags.items():
             if not flags or flags == self.compiler_flags[name]:
                 continue
-            self.compiler_flags[name] = flags
+            self.compiler_flags = self.compiler_flags.with_flags(name, flags)
             changed = True
 
         if mutator.architecture:
@@ -5212,7 +5234,11 @@ class Spec:
 
 @lang.lazy_lexicographic_ordering
 class VariantMap(_VariantMapBase):
-    """Map of variant instances, keyed by variant name."""
+    """Map of variant instances, keyed by variant name.
+
+    Specs share these maps, so a map is never modified once it exists: the ``with_*`` methods
+    return the map to store back on the spec, and the mutators of the base class refuse.
+    """
 
     __slots__ = ()
 
@@ -5225,9 +5251,41 @@ class VariantMap(_VariantMapBase):
         # compat with boost's package.py, which uses this former private attribute; to be removed
         return self
 
-    def set(self, vspec: vt.VariantValue) -> None:
-        """Stores ``vspec`` under its own name, replacing any entry already there."""
-        self[vspec.name] = vt.intern_variant_value(vspec)
+    def with_value(self, vspec: vt.VariantValue) -> "VariantMap":
+        """This map, with ``vspec`` stored under its own name, replacing any entry there."""
+        vspec = vt.intern_variant_value(vspec)
+        if self.get(vspec.name) is vspec:
+            return self
+        return intern_variant_map(VariantMap({**self, vspec.name: vspec}))
+
+    def with_values(self, values: Iterable[vt.VariantValue]) -> "VariantMap":
+        """This map, with every value in ``values`` stored under its own name."""
+        merged = dict(self)
+        for vspec in values:
+            merged[vspec.name] = vt.intern_variant_value(vspec)
+        if len(merged) == len(self) and all(v is self[k] for k, v in merged.items()):
+            return self
+        return intern_variant_map(VariantMap(merged))
+
+    def without(self, name: str) -> "VariantMap":
+        """This map, with the entry under ``name`` removed."""
+        if name not in self:
+            return self
+        return intern_variant_map(VariantMap({k: v for k, v in self.items() if k != name}))
+
+    def as_concrete(self) -> "VariantMap":
+        """This map, with every value marked concrete."""
+        if all(v.concrete for v in self.values()):
+            return self
+        return self.with_values([v.as_concrete() for v in self.values()])
+
+    def _immutable(self, *args, **kwargs) -> NoReturn:
+        raise TypeError("VariantMap is immutable, store the result of with_value() instead")
+
+    set = __setitem__ = __delitem__ = pop = popitem = setdefault = update = clear = _immutable
+
+    def __reduce__(self):
+        return _variant_map_from_items, (tuple(self.items()),)
 
     def partition_variants(self):
         non_prop, prop = lang.stable_partition(self.values(), lambda x: not x.propagate)
@@ -5235,12 +5293,6 @@ class VariantMap(_VariantMapBase):
         non_prop = [x.name for x in non_prop]
         prop = [x.name for x in prop]
         return non_prop, prop
-
-    def copy(self) -> "VariantMap":
-        clone = VariantMap()
-        for variant in self.values():
-            clone.set(variant)
-        return clone
 
     def string(self, abbreviate_patches: bool = False) -> str:
         """The string representation of the map. ``abbreviate_patches`` is passed on to each
@@ -5274,6 +5326,61 @@ class VariantMap(_VariantMapBase):
             sorted(self.keys()), lambda x: self[x].type == vt.VariantType.BOOL
         )
         return bool_keys, kv_keys
+
+
+#: The variants of the nodes of a solve repeat heavily: a solve for trilinos holds 33 766 variant
+#: maps taking 2 675 distinct values, and every spec without variants shares the empty one.
+_VARIANT_MAP_CACHE: Dict[Tuple, VariantMap] = {}
+
+#: The same for compiler flags, where 33 766 maps take 18 distinct values.
+_FLAG_MAP_CACHE: Dict[Tuple, FlagMap] = {}
+
+
+def intern_variant_map(variants: VariantMap) -> VariantMap:
+    """Return the shared VariantMap equal to ``variants``. Every value it holds is interned, and
+    a value's key names it, so the keys of its values identify the map."""
+    if len(variants) > 1:
+        key = tuple(variants[name]._key for name in sorted(variants))
+    else:
+        key = tuple(v._key for v in variants.values())
+    cached = _VARIANT_MAP_CACHE.get(key)
+    if cached is not None:
+        return cached
+    _VARIANT_MAP_CACHE[key] = variants
+    return variants
+
+
+def intern_flag_map(flags: FlagMap) -> FlagMap:
+    """Return the shared FlagMap equal to ``flags``."""
+    key = tuple(
+        sorted(
+            (flag_type, tuple((str(f), f.propagate, f.flag_group, f.source) for f in values))
+            for flag_type, values in flags.items()
+        )
+    )
+    cached = _FLAG_MAP_CACHE.get(key)
+    if cached is not None:
+        return cached
+    _FLAG_MAP_CACHE[key] = flags
+    return flags
+
+
+def _variant_map_from_items(items: Tuple[Tuple[str, vt.VariantValue], ...]) -> VariantMap:
+    """Rebuild an interned VariantMap; see :meth:`VariantMap.__reduce__`."""
+    return EMPTY_VARIANTS.with_values(v for _, v in items)
+
+
+def _flag_map_from_items(items: Tuple[Tuple[str, Tuple[CompilerFlag, ...]], ...]) -> FlagMap:
+    """Rebuild an interned FlagMap; see :meth:`FlagMap.__reduce__`."""
+    return intern_flag_map(FlagMap(items))
+
+
+#: Shared by every spec without variants and without compiler flags.
+EMPTY_VARIANTS = intern_variant_map(VariantMap())
+EMPTY_FLAGS = intern_flag_map(FlagMap())
+
+#: Shared by every spec that records all flag types with no flags, as concrete specs do.
+EMPTY_COMPILER_FLAGS = intern_flag_map(FlagMap((f, ()) for f in _valid_compiler_flags))
 
 
 class SpecBuildInterface(lang.ObjectWrapper, Spec):
@@ -5337,7 +5444,7 @@ def substitute_abstract_variants(spec: Spec, *, repo=None):
             continue
 
         if name in ("dev_path", "commit"):
-            spec.variants.set(v.as_type(vt.VariantType.SINGLE))
+            spec.variants = spec.variants.with_value(v.as_type(vt.VariantType.SINGLE))
             continue
         elif name in vt.RESERVED_NAMES:
             continue
@@ -5362,7 +5469,7 @@ def substitute_abstract_variants(spec: Spec, *, repo=None):
 
         new_variant = pkg_variant.make_variant(*v.values)
         pkg_variant.validate_or_raise(new_variant, spec.name)
-        spec.variants.set(new_variant)
+        spec.variants = spec.variants.with_value(new_variant)
 
     if unknown:
         variants = spack.util.string.plural(len(unknown), "variant")
@@ -5500,20 +5607,27 @@ class SpecfileReaderBase(abc.ABC):
 
         propagated_names = node.get("propagate", [])
         abstract_variants = set(node.get("abstract", ()))
+        variants = []
+        flags = {}
         for name, values in node.get("parameters", {}).items():
             propagate = name in propagated_names
             if name in _valid_compiler_flags:
                 if name in spec.compiler_flags:
                     continue
-                spec.compiler_flags[name] = ()
-                for val in values:
-                    spec.compiler_flags.add_flag(name, val, propagate)
+                flags[name] = tuple(
+                    CompilerFlag(val, propagate=propagate, flag_group=val) for val in values
+                )
             else:
-                spec.variants.set(
+                variants.append(
                     vt.VariantValue.from_node_dict(
                         name, values, propagate=propagate, abstract=name in abstract_variants
                     )
                 )
+
+        if variants:
+            spec.variants = spec.variants.with_values(variants)
+        if flags:
+            spec.compiler_flags = intern_flag_map(FlagMap({**spec.compiler_flags, **flags}))
 
         spec.external_path = None
         spec.external_modules = None
@@ -5537,7 +5651,7 @@ class SpecfileReaderBase(abc.ABC):
             patches = node["patches"]
             if len(patches) > 0:
                 mvar = spec.variants.get("patches") or vt.MultiValuedVariant("patches", ())
-                spec.variants.set(mvar.with_values(tuple(patches)))
+                spec.variants = spec.variants.with_value(mvar.with_values(tuple(patches)))
                 spec._patches_in_order_of_appearance = patches
 
         # Annotate the compiler spec, might be used later
@@ -6015,7 +6129,9 @@ def _inject_patches_variant(root: Spec, *, repo: spack.repo.RepoPath) -> None:
 
         patches = list(spec_to_patches[id(spec)])
         variant = spec.variants.get("patches") or vt.MultiValuedVariant("patches", ())
-        spec.variants.set(variant.with_values(tuple(p.sha256 for p in patches)))
+        spec.variants = spec.variants.with_value(
+            variant.with_values(tuple(p.sha256 for p in patches))
+        )
         ordered_hashes = [(*p.ordering_key, p.sha256) for p in patches if p.ordering_key]
         ordered_hashes.sort()
         tty.debug(

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -3125,8 +3125,9 @@ class Spec:
             edge.direct = not value
         if value:
             self._validate_version()
-            for variant in self.variants.values():
-                variant.concrete = True
+            for variant in list(self.variants.values()):
+                if not variant.concrete:
+                    self.variants.set(variant.as_concrete())
 
     def _validate_version(self):
         # Specs that were concretized with just a git sha as version, without associated
@@ -3761,10 +3762,13 @@ class Spec:
                 if not self.variants[k].intersects(other.variants[k]):
                     raise vt.UnsatisfiableVariantSpecError(self.variants[k], other.variants[k])
                 # If they are compatible merge them
-                changed |= self.variants[k].constrain(other.variants[k])
+                merged = self.variants[k].constrained(other.variants[k])
+                if merged is not None:
+                    self.variants.set(merged)
+                    changed = True
             else:
-                # If it is not present copy it straight away
-                self.variants.set(other.variants[k].copy())
+                # If it is not present take it straight away
+                self.variants.set(other.variants[k])
                 changed = True
 
         return changed
@@ -5120,7 +5124,7 @@ class Spec:
             old_variant = self.variants.pop(name, None)
             if not isinstance(variant, vt.VariantValueRemoval):  # sigil type for removing variant
                 if old_variant:
-                    variant.type = old_variant.type  # coerce variant type to match
+                    variant = variant.as_type(old_variant.type)  # coerce variant type to match
                 self.variants.set(variant)
             changed = True
 
@@ -5228,7 +5232,7 @@ class VariantMap(_VariantMapBase):
 
     def set(self, vspec: vt.VariantValue) -> None:
         """Stores ``vspec`` under its own name, replacing any entry already there."""
-        self[vspec.name] = vspec
+        self[vspec.name] = vt.intern_variant_value(vspec)
 
     def partition_variants(self):
         non_prop, prop = lang.stable_partition(self.values(), lambda x: not x.propagate)
@@ -5240,7 +5244,7 @@ class VariantMap(_VariantMapBase):
     def copy(self) -> "VariantMap":
         clone = VariantMap()
         for variant in self.values():
-            clone.set(variant.copy())
+            clone.set(variant)
         return clone
 
     def string(self, abbreviate_patches: bool = False) -> str:
@@ -5333,13 +5337,12 @@ def substitute_abstract_variants(spec: Spec, *, repo=None):
     # This method needs to be best effort so that it works in matrix exclusion
     # in $spack/lib/spack/spack/spec_list.py
     unknown = []
-    for name, v in spec.variants.items():
+    for name, v in list(spec.variants.items()):
         if v.concrete and v.type == vt.VariantType.MULTI:
             continue
 
         if name in ("dev_path", "commit"):
-            v.type = vt.VariantType.SINGLE
-            v.concrete = True
+            spec.variants.set(v.as_type(vt.VariantType.SINGLE))
             continue
         elif name in vt.RESERVED_NAMES:
             continue
@@ -5538,8 +5541,8 @@ class SpecfileReaderBase(abc.ABC):
         if "patches" in node:
             patches = node["patches"]
             if len(patches) > 0:
-                mvar = spec.variants.setdefault("patches", vt.MultiValuedVariant("patches", ()))
-                mvar.set(*patches)
+                mvar = spec.variants.get("patches") or vt.MultiValuedVariant("patches", ())
+                spec.variants.set(mvar.with_values(tuple(patches)))
                 spec._patches_in_order_of_appearance = patches
 
         # Annotate the compiler spec, might be used later
@@ -6016,10 +6019,8 @@ def _inject_patches_variant(root: Spec, *, repo: spack.repo.RepoPath) -> None:
             continue
 
         patches = list(spec_to_patches[id(spec)])
-        variant: vt.VariantValue = spec.variants.setdefault(
-            "patches", vt.MultiValuedVariant("patches", ())
-        )
-        variant.set(*(p.sha256 for p in patches))
+        variant = spec.variants.get("patches") or vt.MultiValuedVariant("patches", ())
+        spec.variants.set(variant.with_values(tuple(p.sha256 for p in patches)))
         ordered_hashes = [(*p.ordering_key, p.sha256) for p in patches if p.ordering_key]
         ordered_hashes.sort()
         tty.debug(

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -3376,7 +3376,7 @@ class Spec:
             changed = True
 
         new_versions = self.versions.intersection(other.versions)
-        if new_versions.versions != self.versions.versions:
+        if new_versions != self.versions:
             self.versions = vn.intern_version_list(new_versions)
             changed = True
         changed |= self._constrain_variants(other)

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -1221,6 +1221,7 @@ class FlagMap(_FlagMapBase):
         return self.with_flags(flag_type, (*self.get(flag_type, ()), flag))
 
     def _immutable(self, *args, **kwargs) -> NoReturn:
+        """Override of all mutating methods to prevent modification of the map."""
         raise TypeError("FlagMap is immutable, store the result of with_flag() instead")
 
     add_flag = __setitem__ = __delitem__ = pop = popitem = setdefault = update = clear = _immutable
@@ -5322,6 +5323,7 @@ class VariantMap(_VariantMapBase):
         return self.with_values([v.as_concrete() for v in self.values()])
 
     def _immutable(self, *args, **kwargs) -> NoReturn:
+        """Override of all mutating methods to prevent modification of the map."""
         raise TypeError("VariantMap is immutable, store the result of with_value() instead")
 
     set = __setitem__ = __delitem__ = pop = popitem = setdefault = update = clear = _immutable

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -1686,25 +1686,42 @@ def tree(
 
 
 class SpecAnnotations:
+    """What a spec file said about a spec, beyond the spec itself.
+
+    Specs share these, so an instance is never modified once it exists: the ``with_*`` methods
+    return the annotations to store back on the spec.
+    """
+
     __slots__ = ("original_spec_format", "compiler_node_attribute")
 
-    def __init__(self) -> None:
-        self.original_spec_format = SPECFILE_FORMAT_VERSION
-        self.compiler_node_attribute: Optional["Spec"] = None
+    def __init__(
+        self,
+        original_spec_format: int = SPECFILE_FORMAT_VERSION,
+        compiler_node_attribute: Optional["Spec"] = None,
+    ) -> None:
+        self.original_spec_format = original_spec_format
+        self.compiler_node_attribute = compiler_node_attribute
 
     def with_spec_format(self, spec_format: int) -> "SpecAnnotations":
-        self.original_spec_format = spec_format
-        return self
+        """These annotations, recording a different spec file format."""
+        if spec_format == self.original_spec_format:
+            return self
+        return SpecAnnotations(spec_format, self.compiler_node_attribute)
 
     def with_compiler(self, compiler: "Spec") -> "SpecAnnotations":
-        self.compiler_node_attribute = compiler
-        return self
+        """These annotations, recording the compiler a spec file named."""
+        return SpecAnnotations(self.original_spec_format, compiler)
 
     def __repr__(self) -> str:
         result = f"SpecAnnotations().with_spec_format({self.original_spec_format})"
         if self.compiler_node_attribute:
             result += f".with_compiler({str(self.compiler_node_attribute)})"
         return result
+
+
+#: Shared by every spec written in the current spec file format without a legacy compiler, which
+#: is 95% of the specs of a solve.
+DEFAULT_ANNOTATIONS = SpecAnnotations()
 
 
 def _format_edge(
@@ -2009,7 +2026,7 @@ class Spec:
         # is deployed "as built."
         # Build spec should be the actual build spec unless marked dirty.
         self._build_spec = None
-        self.annotations = SpecAnnotations()
+        self.annotations = DEFAULT_ANNOTATIONS
 
         if isinstance(spec_like, str):
             spack.spec_parser.parse_one_or_raise(spec_like, self)
@@ -5675,13 +5692,17 @@ class SpecfileReaderBase(abc.ABC):
         # Annotate the compiler spec, might be used later
         if "annotations" not in node:
             # Specfile v4 and earlier
-            spec.annotations.with_spec_format(cls.SPEC_VERSION)
+            spec.annotations = spec.annotations.with_spec_format(cls.SPEC_VERSION)
             if "compiler" in node:
-                spec.annotations.with_compiler(cls.legacy_compiler(node))
+                spec.annotations = spec.annotations.with_compiler(cls.legacy_compiler(node))
         else:
-            spec.annotations.with_spec_format(node["annotations"]["original_specfile_version"])
+            spec.annotations = spec.annotations.with_spec_format(
+                node["annotations"]["original_specfile_version"]
+            )
             if "compiler" in node["annotations"]:
-                spec.annotations.with_compiler(Spec(f"{node['annotations']['compiler']}"))
+                spec.annotations = spec.annotations.with_compiler(
+                    Spec(f"{node['annotations']['compiler']}")
+                )
 
         # Don't read dependencies here; from_dict() is used by
         # from_yaml() and from_json() to read the root *and* each dependency

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -1295,9 +1295,9 @@ class FlagMap(_FlagMapBase):
 
 EdgeMap = Dict[str, List[DependencySpec]]
 
-#: Backs every edge map without edges and every spec without extra attributes. 82% of the edge maps
-#: and 99.96% of the extra attributes of a solve are empty. Reads work on it unchanged, including
-#: the ``spec.extra_attributes`` that package recipes do; writers replace it with a private dict.
+#: Backs every edge map without edges and every spec without extra attributes. Reads work on it
+#: unchanged, including the ``spec.extra_attributes`` that package recipes do; writers replace it
+#: with a private dict.
 _EMPTY_DICT: Dict = {}
 
 
@@ -1686,7 +1686,7 @@ def tree(
 
 
 class SpecAnnotations:
-    """What a spec file said about a spec, beyond the spec itself.
+    """What a spec file records about a spec, beyond the spec itself.
 
     Specs share these, so an instance is never modified once it exists: the ``with_*`` methods
     return the annotations to store back on the spec.
@@ -1709,7 +1709,7 @@ class SpecAnnotations:
         return SpecAnnotations(spec_format, self.compiler_node_attribute)
 
     def with_compiler(self, compiler: "Spec") -> "SpecAnnotations":
-        """These annotations, recording the compiler a spec file named."""
+        """These annotations, recording the compiler attribute of a spec file."""
         return SpecAnnotations(self.original_spec_format, compiler)
 
     def __repr__(self) -> str:
@@ -1719,8 +1719,7 @@ class SpecAnnotations:
         return result
 
 
-#: Shared by every spec written in the current spec file format without a legacy compiler, which
-#: is 95% of the specs of a solve.
+#: Shared by every spec written in the current spec file format without a legacy compiler.
 DEFAULT_ANNOTATIONS = SpecAnnotations()
 
 
@@ -5272,7 +5271,7 @@ class VariantMap(_VariantMapBase):
     """Map of variant instances, keyed by variant name.
 
     Specs share these maps, so a map is never modified once it exists: the ``with_*`` methods
-    return the map to store back on the spec, and the mutators of the base class refuse.
+    return the map to store back on the spec, and the mutators inherited from dict raise.
     """
 
     __slots__ = ()
@@ -5363,11 +5362,11 @@ class VariantMap(_VariantMapBase):
         return bool_keys, kv_keys
 
 
-#: The variants of the nodes of a solve repeat heavily: a solve for trilinos holds 33 766 variant
-#: maps taking 2 675 distinct values, and every spec without variants shares the empty one.
+#: Variant maps repeat across the nodes of a solve and across package recipes. They are immutable,
+#: so equal maps are one object, and every spec without variants shares the empty one.
 _VARIANT_MAP_CACHE: Dict[Tuple, VariantMap] = {}
 
-#: The same for compiler flags, where 33 766 maps take 18 distinct values.
+#: The same for compiler flags.
 _FLAG_MAP_CACHE: Dict[Tuple, FlagMap] = {}
 
 

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -2007,15 +2007,12 @@ class Spec:
 
         # sha256s of this spec's patches in the order the concretizer applies them; the "patches"
         # variant stores the same set, but sorted
-        self._patches_in_order_of_appearance: Optional[List[str]] = None
+        self._patches_in_order_of_appearance: Optional[Tuple[str, ...]] = None
 
         # External detection details that can be set by internal Spack calls
         # in the constructor.
         self._external_path = external_path
-        if external_modules:
-            self.external_modules = list(external_modules)
-        else:
-            self.external_modules = None
+        self.external_modules = external_modules
 
         # This attribute is used to store custom information for external specs.
         self.extra_attributes: Dict[str, Any] = _EMPTY_DICT
@@ -2032,6 +2029,17 @@ class Spec:
 
         elif spec_like is not None:
             raise TypeError(f"Can't make spec out of {type(spec_like)}")
+
+    @property
+    def external_modules(self) -> Optional[Tuple[str, ...]]:
+        return self._external_modules
+
+    @external_modules.setter
+    def external_modules(self, modules) -> None:
+        # a plain tuple of strings: a module list read from a configuration file may contain
+        # YAML formatting that is discarded (non-essential) when stored as a Spec dictionary,
+        # and specs share the modules without copying them
+        self._external_modules = tuple(modules) if modules else None
 
     @property
     def external_path(self):
@@ -2741,7 +2749,7 @@ class Spec:
         if self.external:
             d["external"] = {
                 "path": self.external_path,
-                "module": self.external_modules or None,
+                "module": list(self.external_modules) if self.external_modules else None,
                 "extra_attributes": syaml.sorted_dict(self.extra_attributes),
             }
 
@@ -2749,7 +2757,7 @@ class Spec:
             d["concrete"] = False
 
         if self._patches_in_order_of_appearance:
-            d["patches"] = self._patches_in_order_of_appearance
+            d["patches"] = list(self._patches_in_order_of_appearance)
 
         # Assigned at concretization time; old specs may not have one
         if self._package_hash:
@@ -5673,8 +5681,6 @@ class SpecfileReaderBase(abc.ABC):
             if node["external"]:
                 spec.external_path = node["external"]["path"]
                 spec.external_modules = node["external"]["module"]
-                if spec.external_modules is False:
-                    spec.external_modules = None
                 spec.extra_attributes = node["external"].get("extra_attributes") or _EMPTY_DICT
 
         # specs read in are concrete unless marked abstract
@@ -5686,7 +5692,7 @@ class SpecfileReaderBase(abc.ABC):
             if len(patches) > 0:
                 mvar = spec.variants.get("patches") or vt.MultiValuedVariant("patches", ())
                 spec.variants = spec.variants.with_value(mvar.with_values(tuple(patches)))
-                spec._patches_in_order_of_appearance = patches
+                spec._patches_in_order_of_appearance = tuple(patches)
 
         # Annotate the compiler spec, might be used later
         if "annotations" not in node:
@@ -6178,7 +6184,7 @@ def _inject_patches_variant(root: Spec, *, repo: spack.repo.RepoPath) -> None:
             f"Ordered hashes [{spec.name}]: "
             + ", ".join("/".join(str(e) for e in t) for t in ordered_hashes)
         )
-        spec._patches_in_order_of_appearance = [sha256 for _, _, sha256 in ordered_hashes]
+        spec._patches_in_order_of_appearance = tuple(sha256 for _, _, sha256 in ordered_hashes)
 
 
 class InvalidVariantForSpecError(spack.error.SpecError):

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -1295,14 +1295,24 @@ class FlagMap(_FlagMapBase):
 
 EdgeMap = Dict[str, List[DependencySpec]]
 
+#: Backs every edge map without edges and every spec without extra attributes. 82% of the edge maps
+#: and 99.96% of the extra attributes of a solve are empty. Reads work on it unchanged, including
+#: the ``spec.extra_attributes`` that package recipes do; writers replace it with a private dict.
+_EMPTY_DICT: Dict = {}
 
-def _add_edge_to_map(edge_map: EdgeMap, key: str, edge: DependencySpec) -> None:
+
+def _add_edge_to_map(edge_map: EdgeMap, key: str, edge: DependencySpec) -> EdgeMap:
+    """Add ``edge`` under ``key``, returning the map to store back on the spec: an empty map is
+    shared, so a private one takes its place on the first write."""
+    if edge_map is _EMPTY_DICT:
+        return {key: [edge]}
     if key in edge_map:
         lst = edge_map[key]
         lst.append(edge)
         lst.sort()
     else:
         edge_map[key] = [edge]
+    return edge_map
 
 
 def _select_edges(
@@ -1958,8 +1968,8 @@ class Spec:
         self.variants = EMPTY_VARIANTS
         self.architecture = None
         self.compiler_flags = EMPTY_FLAGS
-        self._dependents = {}
-        self._dependencies = {}
+        self._dependents = _EMPTY_DICT
+        self._dependencies = _EMPTY_DICT
         self.namespace = None
         self.abstract_hash = None
 
@@ -1992,7 +2002,7 @@ class Spec:
             self.external_modules = None
 
         # This attribute is used to store custom information for external specs.
-        self.extra_attributes: Dict[str, Any] = {}
+        self.extra_attributes: Dict[str, Any] = _EMPTY_DICT
 
         # This attribute holds the original build copy of the spec if it is
         # deployed differently than it was built. None signals that the spec
@@ -2028,12 +2038,12 @@ class Spec:
 
     def clear_dependencies(self):
         """Trim the dependencies of this spec."""
-        self._dependencies.clear()
+        self._dependencies = _EMPTY_DICT
 
     def clear_edges(self):
         """Trim the dependencies and dependents of this spec."""
-        self._dependencies.clear()
-        self._dependents.clear()
+        self._dependencies = _EMPTY_DICT
+        self._dependents = _EMPTY_DICT
 
     def detach(self, deptype="all"):
         """Remove any reference that dependencies have of this node.
@@ -2052,7 +2062,7 @@ class Spec:
                 for edge in dependents_copy:
                     if edge.parent.dag_hash() == key:
                         continue
-                    _add_edge_to_map(dep._dependents, edge.parent.name, edge)
+                    dep._dependents = _add_edge_to_map(dep._dependents, edge.parent.name, edge)
 
     def _get_dependency(self, name):
         # WARNING: This function is an implementation detail of the
@@ -2355,8 +2365,10 @@ class Spec:
 
         if not owned:
             candidate.spec = candidate.spec.copy(deps=True)
-        _add_edge_to_map(self._dependencies, candidate.spec.name, candidate)
-        _add_edge_to_map(candidate.spec._dependents, self.name, candidate)
+        self._dependencies = _add_edge_to_map(self._dependencies, candidate.spec.name, candidate)
+        candidate.spec._dependents = _add_edge_to_map(
+            candidate.spec._dependents, self.name, candidate
+        )
         return True
 
     def _detach_edge(self, edge: DependencySpec) -> None:
@@ -3341,7 +3353,7 @@ class Spec:
                     dependents[""] = remaining
                 else:
                     del dependents[""]
-                _add_edge_to_map(dependents, self.name, edge)
+                edge.spec._dependents = _add_edge_to_map(dependents, self.name, edge)
 
         if not self.namespace and other.namespace:
             self.namespace = other.namespace
@@ -3851,8 +3863,8 @@ class Spec:
         self._build_spec = other._build_spec
 
         # Clear dependencies
-        self._dependents = {}
-        self._dependencies = {}
+        self._dependents = _EMPTY_DICT
+        self._dependencies = _EMPTY_DICT
 
         self._patches_in_order_of_appearance = other._patches_in_order_of_appearance
 
@@ -3915,8 +3927,12 @@ class Spec:
                 when=edge.when,
             )
             # Don't use add_dependency_edge here, copy edges verbatim
-            _add_edge_to_map(new_parent._dependencies, new_child.name, new_edge)
-            _add_edge_to_map(new_child._dependents, new_parent.name, new_edge)
+            new_parent._dependencies = _add_edge_to_map(
+                new_parent._dependencies, new_child.name, new_edge
+            )
+            new_child._dependents = _add_edge_to_map(
+                new_child._dependents, new_parent.name, new_edge
+            )
 
     def copy(self, deps: Union[bool, dt.DepTypes, dt.DepFlag] = True, **kwargs):
         """Make a copy of this spec.
@@ -4838,11 +4854,11 @@ class Spec:
         they are only present because of ``dep_name``.
         """
         for spec in list(self.traverse()):
-            new_dependencies = {}
+            new_dependencies: EdgeMap = _EMPTY_DICT
             for pkg_name, edge_list in spec._dependencies.items():
                 for edge in edge_list:
                     if (dep_name not in edge.virtuals) and (not dep_name == edge.spec.name):
-                        _add_edge_to_map(new_dependencies, edge.spec.name, edge)
+                        new_dependencies = _add_edge_to_map(new_dependencies, edge.spec.name, edge)
             spec._dependencies = new_dependencies
 
     def _virtuals_provided(self, root):
@@ -5216,13 +5232,15 @@ class Spec:
 
         # Reconstruct dependents map
         if not hasattr(self, "_dependents"):
-            self._dependents = {}
+            self._dependents = _EMPTY_DICT
 
         for edges in self._dependencies.values():
             for edge in edges:
                 if not hasattr(edge.spec, "_dependents"):
-                    edge.spec._dependents = {}
-                _add_edge_to_map(edge.spec._dependents, edge.parent.name, edge)
+                    edge.spec._dependents = _EMPTY_DICT
+                edge.spec._dependents = _add_edge_to_map(
+                    edge.spec._dependents, edge.parent.name, edge
+                )
 
     def original_spec_format(self) -> int:
         """Returns the spec format originally used for this spec."""
@@ -5641,7 +5659,7 @@ class SpecfileReaderBase(abc.ABC):
                 spec.external_modules = node["external"]["module"]
                 if spec.external_modules is False:
                     spec.external_modules = None
-                spec.extra_attributes = node["external"].get("extra_attributes") or {}
+                spec.extra_attributes = node["external"].get("extra_attributes") or _EMPTY_DICT
 
         # specs read in are concrete unless marked abstract
         if node.get("concrete", True):
@@ -5747,8 +5765,10 @@ def wire_spec_nodes(
                 when=Spec(dep.when) if dep.when else EMPTY_SPEC,
                 propagation=PropagationPolicy[dep.propagation],
             )
-            _add_edge_to_map(node_spec._dependencies, edge.spec.name, edge)
-            _add_edge_to_map(edge.spec._dependents, edge.parent.name, edge)
+            node_spec._dependencies = _add_edge_to_map(
+                node_spec._dependencies, edge.spec.name, edge
+            )
+            edge.spec._dependents = _add_edge_to_map(edge.spec._dependents, edge.parent.name, edge)
 
         if "build_spec" in node.keys():
             bname, bhash, _ = reader.extract_build_spec_info_from_node_dict(

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -1122,10 +1122,11 @@ class CompilerFlag(str):
         obj.source = kwargs.pop("source", None)
         return obj
 
-    def copy(self) -> "CompilerFlag":
-        return CompilerFlag(
-            self, propagate=self.propagate, flag_group=self.flag_group, source=self.source
-        )
+    def as_propagated(self) -> "CompilerFlag":
+        """This flag, marked as propagating to dependencies."""
+        if self.propagate:
+            return self
+        return CompilerFlag(self, propagate=True, flag_group=self.flag_group, source=self.source)
 
     def to_dict(self) -> Dict[str, Any]:
         """Value and propagation of this flag, unlike ``FlagMap.yaml_entry``, which is its value
@@ -1147,7 +1148,7 @@ _valid_compiler_flags = ("cflags", "cxxflags", "fflags", "ldflags", "ldlibs", "c
 
 # typing.Dict bases are slow at runtime on Python 3.6
 if TYPE_CHECKING:
-    _FlagMapBase = Dict[str, List[CompilerFlag]]
+    _FlagMapBase = Dict[str, Tuple[CompilerFlag, ...]]
     _VariantMapBase = Dict[str, vt.VariantValue]
 else:
     _FlagMapBase = _VariantMapBase = dict
@@ -1169,26 +1170,26 @@ class FlagMap(_FlagMapBase):
         Return whether the spec changed.
         """
         changed = False
-        for flag_type in other:
-            if flag_type not in self:
-                # copy the list and its flags, so that self and other share no mutable state
-                self[flag_type] = [f.copy() for f in other[flag_type]]
+        for flag_type, other_flags in other.items():
+            flags = self.get(flag_type)
+            if flags is None:
+                self[flag_type] = other_flags
                 changed = True
                 continue
 
-            extra_other = set(other[flag_type]) - set(self[flag_type])
+            extra_other = set(other_flags) - set(flags)
             if extra_other:
-                self[flag_type] = list(self[flag_type]) + [
-                    x.copy() for x in other[flag_type] if x in extra_other
-                ]
+                flags = (*flags, *(x for x in other_flags if x in extra_other))
                 changed = True
 
             # Next, if any flags in other propagate, we force them to propagate in our case.
-            other_propagate = {f for f in other[flag_type] if f.propagate}
-            for f in self[flag_type]:
-                if not f.propagate and f in other_propagate:
-                    f.propagate = True
-                    changed = True
+            other_propagate = {f for f in other_flags if f.propagate}
+            if any(f in other_propagate and not f.propagate for f in flags):
+                flags = tuple(f.as_propagated() if f in other_propagate else f for f in flags)
+                changed = True
+
+            if flags is not self.get(flag_type):
+                self[flag_type] = flags
 
         # TODO: what happens if flag groups with a partial (but not complete)
         # intersection specify different behaviors for flag propagation?
@@ -1207,18 +1208,15 @@ class FlagMap(_FlagMapBase):
     def from_dict(d: Dict[str, List[Dict[str, Any]]]) -> "FlagMap":
         result = FlagMap()
         for flag_type, flags in d.items():
-            result[flag_type] = [CompilerFlag.from_dict(flag) for flag in flags]
+            result[flag_type] = tuple(CompilerFlag.from_dict(flag) for flag in flags)
         return result
 
     @staticmethod
     def valid_compiler_flags():
         return _valid_compiler_flags
 
-    def copy(self):
-        clone = FlagMap()
-        for flag_type, flags in self.items():
-            clone[flag_type] = [f.copy() for f in flags]
-        return clone
+    def copy(self) -> "FlagMap":
+        return FlagMap(self)
 
     def add_flag(self, flag_type, value, propagation, flag_group=None, source=None):
         """Stores the flag's value in CompilerFlag and adds it
@@ -1234,10 +1232,7 @@ class FlagMap(_FlagMapBase):
         flag_group = flag_group or value
         flag = CompilerFlag(value, propagate=propagation, flag_group=flag_group, source=source)
 
-        if flag_type not in self:
-            self[flag_type] = [flag]
-        else:
-            self[flag_type].append(flag)
+        self[flag_type] = (*self.get(flag_type, ()), flag)
 
     def yaml_entry(self, flag_type):
         """Returns the flag type and a list of the flag values since the
@@ -5510,7 +5505,7 @@ class SpecfileReaderBase(abc.ABC):
             if name in _valid_compiler_flags:
                 if name in spec.compiler_flags:
                     continue
-                spec.compiler_flags[name] = []
+                spec.compiler_flags[name] = ()
                 for val in values:
                     spec.compiler_flags.add_flag(name, val, propagate)
             else:

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -1969,6 +1969,10 @@ class Spec:
         # whether the spec is concrete or not; set at the end of concretization
         self._concrete = False
 
+        # sha256s of this spec's patches in the order the concretizer applies them; the "patches"
+        # variant stores the same set, but sorted
+        self._patches_in_order_of_appearance: Optional[List[str]] = None
+
         # External detection details that can be set by internal Spack calls
         # in the constructor.
         self._external_path = external_path
@@ -2704,10 +2708,8 @@ class Spec:
         if not self._concrete:
             d["concrete"] = False
 
-        if "patches" in self.variants:
-            variant = self.variants["patches"]
-            if hasattr(variant, "_patches_in_order_of_appearance"):
-                d["patches"] = variant._patches_in_order_of_appearance
+        if self._patches_in_order_of_appearance:
+            d["patches"] = self._patches_in_order_of_appearance
 
         # Assigned at concretization time; old specs may not have one
         if self._package_hash:
@@ -3102,15 +3104,11 @@ class Spec:
 
     def _patches_assigned(self):
         """Whether patches have been assigned to this spec by the concretizer."""
-        # FIXME: _patches_in_order_of_appearance is attached after concretization
-        # FIXME: to store the order of patches.
-        # FIXME: Probably needs to be refactored in a cleaner way.
         if "patches" not in self.variants:
             return False
 
         # ensure that patch state is consistent
-        patch_variant = self.variants["patches"]
-        assert hasattr(patch_variant, "_patches_in_order_of_appearance"), (
+        assert self._patches_in_order_of_appearance is not None, (
             "patches should always be assigned with a patch variant."
         )
 
@@ -3794,7 +3792,7 @@ class Spec:
 
             # translate patch sha256sums to patch objects by consulting the index
             if self._patches_assigned():
-                sha256s = list(self.variants["patches"]._patches_in_order_of_appearance)
+                sha256s = list(self._patches_in_order_of_appearance or [])
                 pkg_cls = repo.get_pkg_class(self.fullname)
                 try:
                     self._patches = repo.get_patches_for_package(sha256s, pkg_cls)
@@ -3837,13 +3835,7 @@ class Spec:
         self._dependents = {}
         self._dependencies = {}
 
-        # FIXME: we manage _patches_in_order_of_appearance specially here
-        # to keep it from leaking out of spec.py, but we should figure
-        # out how to handle it more elegantly in the Variant classes.
-        for k, v in other.variants.items():
-            patches = getattr(v, "_patches_in_order_of_appearance", None)
-            if patches:
-                self.variants[k]._patches_in_order_of_appearance = patches
+        self._patches_in_order_of_appearance = other._patches_in_order_of_appearance
 
         self.external_path = other.external_path
         self.external_modules = other.external_modules
@@ -5548,8 +5540,7 @@ class SpecfileReaderBase(abc.ABC):
             if len(patches) > 0:
                 mvar = spec.variants.setdefault("patches", vt.MultiValuedVariant("patches", ()))
                 mvar.set(*patches)
-                # FIXME: Monkey patches mvar to store patches order
-                mvar._patches_in_order_of_appearance = patches
+                spec._patches_in_order_of_appearance = patches
 
         # Annotate the compiler spec, might be used later
         if "annotations" not in node:
@@ -6029,16 +6020,13 @@ def _inject_patches_variant(root: Spec, *, repo: spack.repo.RepoPath) -> None:
             "patches", vt.MultiValuedVariant("patches", ())
         )
         variant.set(*(p.sha256 for p in patches))
-        # FIXME: Monkey patches variant to store patches order
         ordered_hashes = [(*p.ordering_key, p.sha256) for p in patches if p.ordering_key]
         ordered_hashes.sort()
         tty.debug(
             f"Ordered hashes [{spec.name}]: "
             + ", ".join("/".join(str(e) for e in t) for t in ordered_hashes)
         )
-        setattr(
-            variant, "_patches_in_order_of_appearance", [sha256 for _, _, sha256 in ordered_hashes]
-        )
+        spec._patches_in_order_of_appearance = [sha256 for _, _, sha256 in ordered_hashes]
 
 
 class InvalidVariantForSpecError(spack.error.SpecError):

--- a/lib/spack/spack/spec_parser.py
+++ b/lib/spack/spack/spec_parser.py
@@ -758,7 +758,9 @@ class SpecParser:
                     self.curr = curr
                     self._raise_parsing_error("Spec cannot have multiple versions")
 
-                spec.versions = spack.version.VersionList(curr.group(_VERSION_LIST))
+                spec.versions = spack.version.intern_version_list(
+                    spack.version.VersionList(curr.group(_VERSION_LIST))
+                )
                 has_version = True
 
             elif kind == _BOOL_VARIANT:

--- a/lib/spack/spack/stage.py
+++ b/lib/spack/spack/stage.py
@@ -1197,7 +1197,7 @@ def interactive_version_filter(
                 print()
                 continue
             try:
-                version_filter.intersect(VersionList([filter_spec]))
+                version_filter = version_filter.intersection(VersionList([filter_spec]))
             except ValueError:
                 tty.warn(f"Invalid version specifier: {filter_spec}")
                 continue

--- a/lib/spack/spack/test/cmd/spec.py
+++ b/lib/spack/spack/test/cmd/spec.py
@@ -80,8 +80,8 @@ def test_spec_parse_cflags_quoting():
     output = spec("--yaml", 'gcc cflags="-Os -pipe" cxxflags="-flto -Os"')
     gh_flagged = spack.spec.Spec.from_yaml(output)
 
-    assert ["-Os", "-pipe"] == gh_flagged.compiler_flags["cflags"]
-    assert ["-flto", "-Os"] == gh_flagged.compiler_flags["cxxflags"]
+    assert ("-Os", "-pipe") == gh_flagged.compiler_flags["cflags"]
+    assert ("-flto", "-Os") == gh_flagged.compiler_flags["cxxflags"]
 
 
 def test_spec_yaml():

--- a/lib/spack/spack/test/compilers/conversion.py
+++ b/lib/spack/spack/test/compilers/conversion.py
@@ -87,7 +87,7 @@ def test_compiler_conversion_modules(mock_compiler):
     mock_compiler["modules"] = modules
     compiler_spec = CompilerFactory.from_legacy_yaml(mock_compiler)[0]
     assert compiler_spec.external
-    assert compiler_spec.external_modules == modules
+    assert compiler_spec.external_modules == tuple(modules)
 
 
 @pytest.mark.regression("49717")

--- a/lib/spack/spack/test/concretization/core.py
+++ b/lib/spack/spack/test/concretization/core.py
@@ -4448,10 +4448,12 @@ def test_commit_variant_enters_the_hash(mutable_config, mock_packages, monkeypat
 
     def _mock_resolve(spec) -> None:
         if first_call:
-            spec.variants["commit"] = vt.SingleValuedVariant("commit", f"{'b' * 40}")
+            spec.variants = spec.variants.with_value(
+                vt.SingleValuedVariant("commit", f"{'b' * 40}")
+            )
             return
 
-        spec.variants["commit"] = vt.SingleValuedVariant("commit", f"{'a' * 40}")
+        spec.variants = spec.variants.with_value(vt.SingleValuedVariant("commit", f"{'a' * 40}"))
 
     monkeypatch.setattr(spack.package_base.PackageBase, "_resolve_git_provenance", _mock_resolve)
 
@@ -4730,7 +4732,9 @@ def test_concretization_cache_reapplies_patches_on_hit(
         for s in root.traverse():
             if s.name == "patch" and not s.concrete and "patches" in s.variants:
                 existing = list(s.variants["patches"].value)
-                s.variants.set(s.variants["patches"].with_values((*existing, EXTRA_SHA256)))
+                s.variants = s.variants.with_value(
+                    s.variants["patches"].with_values((*existing, EXTRA_SHA256))
+                )
                 break
 
     monkeypatch.setattr(spack.spec, "_inject_patches_variant", inject_with_new_patch)

--- a/lib/spack/spack/test/concretization/core.py
+++ b/lib/spack/spack/test/concretization/core.py
@@ -457,7 +457,7 @@ class TestConcretize:
         for _ in range(3):
             s = spack.concretize.concretize_one(spec_str)
             assert all(
-                s.compiler_flags[x] == ["-O0", "-g"] for x in ("cflags", "cxxflags", "fflags")
+                s.compiler_flags[x] == ("-O0", "-g") for x in ("cflags", "cxxflags", "fflags")
             )
 
     @pytest.mark.parametrize(

--- a/lib/spack/spack/test/concretization/core.py
+++ b/lib/spack/spack/test/concretization/core.py
@@ -4730,7 +4730,7 @@ def test_concretization_cache_reapplies_patches_on_hit(
         for s in root.traverse():
             if s.name == "patch" and not s.concrete and "patches" in s.variants:
                 existing = list(s.variants["patches"].value)
-                s.variants["patches"].set(*existing, EXTRA_SHA256)
+                s.variants.set(s.variants["patches"].with_values((*existing, EXTRA_SHA256)))
                 break
 
     monkeypatch.setattr(spack.spec, "_inject_patches_variant", inject_with_new_patch)

--- a/lib/spack/spack/test/concretization/flag_mixing.py
+++ b/lib/spack/spack/test/concretization/flag_mixing.py
@@ -118,8 +118,8 @@ def test_pkg_flags_from_compiler_and_none(concretize_scope, mock_packages):
         spack.concretize._concretize_together([(s1, None), (s2, None)], ui=HeadlessUI())
     )
 
-    assert concrete[s1].compiler_flags["cflags"] == ["-Wall"]
-    assert concrete[s2]["cmake"].compiler_flags["cflags"] == []
+    assert concrete[s1].compiler_flags["cflags"] == ("-Wall",)
+    assert concrete[s2]["cmake"].compiler_flags["cflags"] == ()
 
 
 @pytest.mark.parametrize(
@@ -179,17 +179,17 @@ packages:
     spec = root_spec["y"]
     satisfy_flags = " ".join(x for x in [cmd_flags, req_flags, cmp_flags, expected_dflags] if x)
     assert spec.satisfies(f'cflags="{satisfy_flags}"')
-    assert spec.compiler_flags["cflags"] == expected_order.split()
+    assert spec.compiler_flags["cflags"] == tuple(expected_order.split())
 
 
 def test_two_dependents_flag_mixing(concretize_scope, test_repo):
     root_spec1 = spack.concretize.concretize_one("w~moveflaglater")
     spec1 = root_spec1["y"]
-    assert spec1.compiler_flags["cflags"] == "-d0 -d1 -d2".split()
+    assert spec1.compiler_flags["cflags"] == ("-d0", "-d1", "-d2")
 
     root_spec2 = spack.concretize.concretize_one("w+moveflaglater")
     spec2 = root_spec2["y"]
-    assert spec2.compiler_flags["cflags"] == "-d3 -d1 -d2".split()
+    assert spec2.compiler_flags["cflags"] == ("-d3", "-d1", "-d2")
 
 
 def test_propagate_and_compiler_cfg(concretize_scope, test_repo):
@@ -272,7 +272,7 @@ def test_diamond_dep_flag_mixing(concretize_scope, test_repo):
     root_spec1 = spack.concretize.concretize_one("t")
     spec1 = root_spec1["y"]
     assert spec1.satisfies('cflags="-c1 -c2 -d1 -d2 -e1 -e2"')
-    assert spec1.compiler_flags["cflags"] == "-c1 -c2 -e1 -e2 -d1 -d2".split()
+    assert spec1.compiler_flags["cflags"] == ("-c1", "-c2", "-e1", "-e2", "-d1", "-d2")
 
 
 def test_flag_injection_different_compilers(mock_packages, mutable_config):
@@ -341,4 +341,4 @@ packages:
     assert s["c"].name == "gcc"
     assert s["llvm"].external and s["llvm"].satisfies("@19.1.0")
     # the external llvm's cflags must not be injected into its dependent
-    assert s.compiler_flags["cflags"] == []
+    assert s.compiler_flags["cflags"] == ()

--- a/lib/spack/spack/test/git_fetch.py
+++ b/lib/spack/spack/test/git_fetch.py
@@ -113,7 +113,7 @@ def test_fetch(
     monkeypatch.setitem(s.package.versions, Version("git"), t.args)
 
     if type_of_test == "commit":
-        s.variants["commit"] = SingleValuedVariant("commit", t.args["commit"])
+        s.variants = s.variants.with_value(SingleValuedVariant("commit", t.args["commit"]))
 
     # Enter the stage directory and check some properties
     with s.package.stage:
@@ -280,7 +280,7 @@ def test_get_full_repo(
         git_exe = mock_git_repository.git_exe
         url = mock_git_repository.url
         commit = git_exe("ls-remote", url, t.revision, output=str).strip().split()[0]
-        s.variants["commit"] = SingleValuedVariant("commit", commit)
+        s.variants = s.variants.with_value(SingleValuedVariant("commit", commit))
         if can_use_direct_commit:
             path = mock_git_repository.path
             git_exe("-C", path, "config", "uploadpack.allowReachableSHA1InWant", "true")
@@ -493,7 +493,7 @@ def test_commit_variant_clone(git, config, mutable_mock_repo, mock_git_version_i
     s = spack.concretize.concretize_one("git-test")
     args = {"git": pathlib.Path(repo_path).as_uri()}
     monkeypatch.setitem(s.package.versions, Version("git"), args)
-    s.variants["commit"] = SingleValuedVariant("commit", test_commit)
+    s.variants = s.variants.with_value(SingleValuedVariant("commit", test_commit))
     s.package.do_stage()
     with working_dir(s.package.stage.source_path):
         assert git("rev-parse", "HEAD", output=str, error=str).strip() == test_commit

--- a/lib/spack/spack/test/hooks/sbom_generate.py
+++ b/lib/spack/spack/test/hooks/sbom_generate.py
@@ -326,7 +326,9 @@ def test_sbom_checksums_include_both_sha256_and_git_commit(
     git_commit = "b" * 40  # Typical SHA1 length
 
     monkeypatch.setattr(spec.package, "git", git_url, raising=False)
-    spec.variants["commit"] = spack.variant.SingleValuedVariant("commit", git_commit)
+    spec.variants = spec.variants.with_value(
+        spack.variant.SingleValuedVariant("commit", git_commit)
+    )
 
     generate_spdx_2_3(spec)
 
@@ -358,7 +360,9 @@ def test_sbom_checksums_git_commit_only(mock_packages, install_mockery, monkeypa
     git_commit = "c" * 40  # Typical SHA1 length
 
     monkeypatch.setattr(spec.package, "git", git_url, raising=False)
-    spec.variants["commit"] = spack.variant.SingleValuedVariant("commit", git_commit)
+    spec.variants = spec.variants.with_value(
+        spack.variant.SingleValuedVariant("commit", git_commit)
+    )
 
     generate_spdx_2_3(spec)
 

--- a/lib/spack/spack/test/patch.py
+++ b/lib/spack/spack/test/patch.py
@@ -170,9 +170,7 @@ def test_patch_in_spec(mock_packages, config):
     # patch directive.
     assert (bar_sha256, foo_sha256, baz_sha256) == spec.variants["patches"].value
 
-    assert (foo_sha256, bar_sha256, baz_sha256) == tuple(
-        spec.variants["patches"]._patches_in_order_of_appearance
-    )
+    assert (foo_sha256, bar_sha256, baz_sha256) == tuple(spec._patches_in_order_of_appearance)
 
 
 def test_stale_patch_cache_falls_back_to_fresh(mock_packages: RepoPath, config):
@@ -234,7 +232,7 @@ def test_patch_order(mock_packages, config):
     )
 
     dep = spec["patch"]
-    patch_order = dep.variants["patches"]._patches_in_order_of_appearance
+    patch_order = dep._patches_in_order_of_appearance
     # 'mid2' comes after 'mid1' alphabetically
     # 'top' comes after 'mid1'/'mid2' alphabetically
     # 'patch' comes last of all specs in the dag, alphabetically, so the

--- a/lib/spack/spack/test/spec_semantics.py
+++ b/lib/spack/spack/test/spec_semantics.py
@@ -2774,7 +2774,7 @@ def test_constrain_does_not_share_flags_or_architecture_with_the_rhs(mock_packag
 
 
 def test_copy_shares_variants_and_keeps_specs_independent():
-    """Specs share variant maps, so constraining one must leave the other alone."""
+    """Specs share variant maps, so constraining one does not change the other."""
     old = Spec("foo=bar")
     new = old.copy()
     assert new.variants is old.variants
@@ -2786,8 +2786,8 @@ def test_copy_shares_variants_and_keeps_specs_independent():
 
 
 def test_copy_shares_flags_and_keeps_specs_independent(mock_packages):
-    """CompilerFlag values are immutable, so a copy shares them. Constraining the copy leaves the
-    flags of the original alone, including their propagation."""
+    """CompilerFlag values are immutable, so a copy shares them. Constraining the copy does not
+    change the flags of the original, including their propagation."""
     old = Spec("pkg-a cflags=-O2 cflags=-g")
     new = old.copy()
     assert new.compiler_flags["cflags"] is old.compiler_flags["cflags"]

--- a/lib/spack/spack/test/spec_semantics.py
+++ b/lib/spack/spack/test/spec_semantics.py
@@ -2773,6 +2773,18 @@ def test_constrain_does_not_share_flags_or_architecture_with_the_rhs(mock_packag
     assert rhs.to_dict() == before
 
 
+def test_copy_shares_variants_and_keeps_specs_independent():
+    """Specs share variant maps, so constraining one must leave the other alone."""
+    old = Spec("foo=bar")
+    new = old.copy()
+    assert new.variants is old.variants
+
+    new.constrain(Spec("foobar=baz"))
+
+    assert "foobar" not in old.variants
+    assert new.variants["foobar"].value == ("baz",)
+
+
 def test_copy_shares_flags_and_keeps_specs_independent(mock_packages):
     """CompilerFlag values are immutable, so a copy shares them. Constraining the copy leaves the
     flags of the original alone, including their propagation."""

--- a/lib/spack/spack/test/spec_semantics.py
+++ b/lib/spack/spack/test/spec_semantics.py
@@ -1539,8 +1539,8 @@ class TestSpecSemantics:
         # 'variant=value' (regardless of whether it in fact does).
         assert "foo=baz" not in new_spec
         assert "foobar=baz" in new_spec
-        assert new_spec.compiler_flags["cflags"] == ["-O2"]
-        assert new_spec.compiler_flags["cxxflags"] == ["-O1"]
+        assert new_spec.compiler_flags["cflags"] == ("-O2",)
+        assert new_spec.compiler_flags["cxxflags"] == ("-O1",)
 
     def test_spec_override_with_nonexisting_variant(self):
         init_spec = Spec("pkg-a foo=baz foobar=baz cflags=-O3 cxxflags=-O1")
@@ -2773,14 +2773,19 @@ def test_constrain_does_not_share_flags_or_architecture_with_the_rhs(mock_packag
     assert rhs.to_dict() == before
 
 
-def test_copy_does_not_share_flag_instances(mock_packages):
-    """CompilerFlag is a mutable string in FlagMap; it should not be shared on copy."""
-    old = Spec("pkg-a cflags=-O2 cflags==-g")
+def test_copy_shares_flags_and_keeps_specs_independent(mock_packages):
+    """CompilerFlag values are immutable, so a copy shares them. Constraining the copy leaves the
+    flags of the original alone, including their propagation."""
+    old = Spec("pkg-a cflags=-O2 cflags=-g")
     new = old.copy()
-    assert len(new.compiler_flags["cflags"]) == len(old.compiler_flags["cflags"]) == 2
-    for x, y in zip(old.compiler_flags["cflags"], new.compiler_flags["cflags"]):
-        assert x is not y
-        assert x == y and x.propagate == y.propagate and x.flag_group == y.flag_group
+    assert new.compiler_flags["cflags"] is old.compiler_flags["cflags"]
+
+    new.constrain(Spec("pkg-a cflags==-O2 cflags=-O3"))
+
+    assert [str(f) for f in old.compiler_flags["cflags"]] == ["-O2", "-g"]
+    assert [f.propagate for f in old.compiler_flags["cflags"]] == [False, False]
+    assert [str(f) for f in new.compiler_flags["cflags"]] == ["-O2", "-g", "-O3"]
+    assert [f.propagate for f in new.compiler_flags["cflags"]] == [True, False, False]
 
 
 @pytest.mark.parametrize(

--- a/lib/spack/spack/test/variant.py
+++ b/lib/spack/spack/test/variant.py
@@ -414,32 +414,57 @@ class TestVariant:
 
 
 class TestVariantMapTest:
-    def test_set(self) -> None:
+    def test_with_value(self) -> None:
         # All three types of variants are accepted, keyed by their own name
         a = VariantMap()
 
-        a.set(BoolValuedVariant("foo", True))
-        a.set(SingleValuedVariant("bar", "baz"))
-        a.set(MultiValuedVariant("foobar", ("a", "b", "c", "d", "e")))
+        a = a.with_value(BoolValuedVariant("foo", True))
+        a = a.with_value(SingleValuedVariant("bar", "baz"))
+        a = a.with_value(MultiValuedVariant("foobar", ("a", "b", "c", "d", "e")))
 
         assert list(a) == ["foo", "bar", "foobar"]
 
         # An entry already under that name is replaced
-        a.set(SingleValuedVariant("foo", "bar"))
-        assert a["foo"] == SingleValuedVariant("foo", "bar")
+        b = a.with_value(SingleValuedVariant("foo", "bar"))
+        assert b["foo"] == SingleValuedVariant("foo", "bar")
+
+        # The map it was built from is untouched, and storing the same value again is a no-op
+        assert a["foo"] == BoolValuedVariant("foo", True)
+        assert b.with_value(SingleValuedVariant("foo", "bar")) is b
+
+    def test_map_is_immutable(self) -> None:
+        a = VariantMap().with_value(BoolValuedVariant("foo", True))
+        with pytest.raises(TypeError):
+            a["bar"] = SingleValuedVariant("bar", "baz")
+        with pytest.raises(TypeError):
+            a.pop("foo")
+
+    def test_maps_are_interned(self) -> None:
+        a = VariantMap().with_value(SingleValuedVariant("foo", "bar"))
+        b = VariantMap().with_value(SingleValuedVariant("foo", "bar"))
+        assert a is b
+        assert a.without("foo") is spack.spec.EMPTY_VARIANTS
 
     def test_satisfies_and_constrain(self) -> None:
         # foo=bar foobar=fee feebar=foo
         a = Spec()
-        a.variants["foo"] = MultiValuedVariant("foo", ("bar",))
-        a.variants["foobar"] = SingleValuedVariant("foobar", "fee")
-        a.variants["feebar"] = SingleValuedVariant("feebar", "foo")
+        a.variants = a.variants.with_values(
+            [
+                MultiValuedVariant("foo", ("bar",)),
+                SingleValuedVariant("foobar", "fee"),
+                SingleValuedVariant("feebar", "foo"),
+            ]
+        )
 
         # foo=bar,baz foobar=fee shared=True
         b = Spec()
-        b.variants["foo"] = MultiValuedVariant("foo", ("bar", "baz"))
-        b.variants["foobar"] = SingleValuedVariant("foobar", "fee")
-        b.variants["shared"] = BoolValuedVariant("shared", True)
+        b.variants = b.variants.with_values(
+            [
+                MultiValuedVariant("foo", ("bar", "baz")),
+                SingleValuedVariant("foobar", "fee"),
+                BoolValuedVariant("shared", True),
+            ]
+        )
 
         # concrete, different values do not intersect / satisfy each other
         assert not a.intersects(b) and not b.intersects(a)
@@ -447,30 +472,28 @@ class TestVariantMapTest:
 
         # foo=bar,baz foobar=fee feebar=foo shared=True
         c = Spec()
-        c.variants["foo"] = MultiValuedVariant("foo", ("bar", "baz"))
-        c.variants["foobar"] = SingleValuedVariant("foobar", "fee")
-        c.variants["feebar"] = SingleValuedVariant("feebar", "foo")
-        c.variants["shared"] = BoolValuedVariant("shared", True)
+        c.variants = c.variants.with_values(
+            [
+                MultiValuedVariant("foo", ("bar", "baz")),
+                SingleValuedVariant("foobar", "fee"),
+                SingleValuedVariant("feebar", "foo"),
+                BoolValuedVariant("shared", True),
+            ]
+        )
 
         # concrete values cannot be constrained
         with pytest.raises(spack.variant.UnsatisfiableVariantSpecError):
             a._constrain_variants(b)
 
-    def test_copy(self) -> None:
-        a = VariantMap()
-        a["foo"] = BoolValuedVariant("foo", True)
-        a["bar"] = SingleValuedVariant("bar", "baz")
-        a["foobar"] = MultiValuedVariant("foobar", ("a", "b", "c", "d", "e"))
-
-        c = a.copy()
-        assert a == c
-
     def test_str(self) -> None:
-        c = VariantMap()
-        c["foo"] = MultiValuedVariant("foo", ("bar", "baz"))
-        c["foobar"] = SingleValuedVariant("foobar", "fee")
-        c["feebar"] = SingleValuedVariant("feebar", "foo")
-        c["shared"] = BoolValuedVariant("shared", True)
+        c = VariantMap().with_values(
+            [
+                MultiValuedVariant("foo", ("bar", "baz")),
+                SingleValuedVariant("foobar", "fee"),
+                SingleValuedVariant("feebar", "foo"),
+                BoolValuedVariant("shared", True),
+            ]
+        )
         assert str(c) == "+shared feebar=foo foo:=bar,baz foobar=fee"
 
 

--- a/lib/spack/spack/test/variant.py
+++ b/lib/spack/spack/test/variant.py
@@ -45,8 +45,8 @@ class TestMultiValuedVariant:
         assert a == c
         assert hash(a) == hash(c)
 
-        # Check the copy
-        d = a.copy()
+        # Check an equal value
+        d = MultiValuedVariant("foo", ("bar", "baz"))
         assert str(a) == str(d)
         assert d.values == ("bar", "baz")
         assert "bar" in d
@@ -106,15 +106,15 @@ class TestMultiValuedVariant:
         a = MultiValuedVariant("foo", ("bar", "baz"))
         b = MultiValuedVariant("foo", ("bar",))
         with pytest.raises(UnsatisfiableVariantSpecError):
-            a.constrain(b)
+            a.constrained(b)
         with pytest.raises(UnsatisfiableVariantSpecError):
-            b.constrain(a)
+            b.constrained(a)
 
         # Try to constrain on the same value
         a = MultiValuedVariant("foo", ("bar", "baz"))
-        b = a.copy()
+        b = MultiValuedVariant("foo", ("bar", "baz"))
 
-        assert not a.constrain(b)
+        assert a.constrained(b) is None
         assert a == b == MultiValuedVariant("foo", ("bar", "baz"))
 
         # Try to constrain on a different name
@@ -122,7 +122,7 @@ class TestMultiValuedVariant:
         b = MultiValuedVariant("fee", ("bar",))
 
         with pytest.raises(UnsatisfiableVariantSpecError):
-            a.constrain(b)
+            a.constrained(b)
 
     def test_yaml_entry(self):
         a = MultiValuedVariant("foo", ("bar", "baz", "barbaz"))
@@ -145,8 +145,8 @@ class TestSingleValuedVariant:
         assert a.value == "bar"
         assert "bar" in a
 
-        # Check the copy
-        b = a.copy()
+        # Check an equal value
+        b = SingleValuedVariant("foo", "bar")
         assert str(a) == str(b)
         assert b.values == ("bar",)
         assert b.value == "bar"
@@ -190,7 +190,7 @@ class TestSingleValuedVariant:
         a = SingleValuedVariant("foo", "bar")
         b = SingleValuedVariant("foo", "bar")
 
-        assert not a.constrain(b)
+        assert a.constrained(b) is None
         assert a == SingleValuedVariant("foo", "bar")
 
         # Try to constrain on a value with a different value
@@ -202,13 +202,13 @@ class TestSingleValuedVariant:
         b = SingleValuedVariant("fee", "bar")
 
         with pytest.raises(UnsatisfiableVariantSpecError):
-            b.constrain(a)
+            b.constrained(a)
 
         # Try to constrain on the same value
         a = SingleValuedVariant("foo", "bar")
-        b = a.copy()
+        b = SingleValuedVariant("foo", "bar")
 
-        assert not a.constrain(b)
+        assert a.constrained(b) is None
         assert a == SingleValuedVariant("foo", "bar")
 
     def test_yaml_entry(self):
@@ -227,8 +227,8 @@ class TestBoolValuedVariant:
         assert a.values == (True,)
         assert True in a
 
-        # Copy - True value
-        b = a.copy()
+        # An equal value - True
+        b = BoolValuedVariant("foo", True)
         assert str(a) == str(b)
         assert b.value is True
         assert b.values == (True,)
@@ -237,9 +237,9 @@ class TestBoolValuedVariant:
         assert a is not b
         assert hash(a) == hash(b)
 
-        # Copy - False value
+        # An equal value - False
         a = BoolValuedVariant("foo", False)
-        b = a.copy()
+        b = BoolValuedVariant("foo", False)
         assert str(a) == str(b)
         assert b.value is False
         assert b.values == (False,)
@@ -307,7 +307,7 @@ class TestBoolValuedVariant:
         a = BoolValuedVariant("foo", True)
         b = BoolValuedVariant("foo", True)
 
-        assert not a.constrain(b)
+        assert a.constrained(b) is None
         assert a == BoolValuedVariant("foo", True)
 
         # Try to constrain on a value with a different value
@@ -315,20 +315,20 @@ class TestBoolValuedVariant:
         b = BoolValuedVariant("foo", False)
 
         with pytest.raises(UnsatisfiableVariantSpecError):
-            b.constrain(a)
+            b.constrained(a)
 
         # Try to constrain on a value with a different value
         a = BoolValuedVariant("foo", True)
         b = BoolValuedVariant("fee", True)
 
         with pytest.raises(UnsatisfiableVariantSpecError):
-            b.constrain(a)
+            b.constrained(a)
 
         # Try to constrain on the same value
         a = BoolValuedVariant("foo", True)
-        b = a.copy()
+        b = BoolValuedVariant("foo", True)
 
-        assert not a.constrain(b)
+        assert a.constrained(b) is None
         assert a == BoolValuedVariant("foo", True)
 
     def test_yaml_entry(self):
@@ -363,7 +363,7 @@ class TestVariant:
 
         # Multiple values are not allowed
         with pytest.raises(MultipleValuesInExclusiveVariantError):
-            vspec.set("bar", "baz")
+            vspec.with_values(("bar", "baz"))
 
         # Inconsistent vspec
         vspec.name = "FOO"
@@ -375,7 +375,7 @@ class TestVariant:
         vspec = a.make_variant("bar", "baz")
         a.validate_or_raise(vspec, "test-package")
         # Add an invalid value
-        vspec.set("bar", "baz", "barbaz")
+        vspec = vspec.with_values(("bar", "baz", "barbaz"))
         with pytest.raises(InvalidVariantValueError):
             a.validate_or_raise(vspec, "test-package")
 
@@ -389,9 +389,9 @@ class TestVariant:
         a = Variant("foo", default="1024", description="", values=validator, multi=False)
         vspec = a.make_default()
         a.validate_or_raise(vspec, "test-package")
-        vspec.set("2056")
+        vspec = vspec.with_values(("2056",))
         a.validate_or_raise(vspec, "test-package")
-        vspec.set("foo")
+        vspec = vspec.with_values(("foo",))
         with pytest.raises(InvalidVariantValueError):
             a.validate_or_raise(vspec, "test-package")
 

--- a/lib/spack/spack/test/versions.py
+++ b/lib/spack/spack/test/versions.py
@@ -938,6 +938,13 @@ def test_git_ref_can_be_assigned_a_version(vstring, eq_vstring, is_commit):
     assert v_equivalent == v.ref_version
 
 
+def test_version_lists_are_shared_between_specs():
+    """Specs that name the same versions share one list."""
+    assert spack.spec.Spec("foo@1.2.3").versions is spack.spec.Spec("bar@1.2.3").versions
+    foo, bar = spack.spec.Spec("foo@git.develop"), spack.spec.Spec("bar@git.develop")
+    assert foo.versions is bar.versions
+
+
 @pytest.mark.parametrize(
     "lhs_str,rhs_str,expected",
     [

--- a/lib/spack/spack/util/module_cmd.py
+++ b/lib/spack/spack/util/module_cmd.py
@@ -157,12 +157,12 @@ def path_from_modules(modules):
     path at which the library supported by said module can be found.
 
     Args:
-        modules (list): module files to be loaded to get an external package
+        modules: module files to be loaded to get an external package
 
     Returns:
         Guess of the prefix path where the package
     """
-    assert isinstance(modules, list), 'the "modules" argument must be a list'
+    assert isinstance(modules, (list, tuple)), 'the "modules" argument must be a sequence'
 
     best_choice = None
     for module_name in modules:

--- a/lib/spack/spack/variant.py
+++ b/lib/spack/spack/variant.py
@@ -16,6 +16,7 @@ from typing import (
     Any,
     Callable,
     Collection,
+    Dict,
     Iterable,
     List,
     Optional,
@@ -242,9 +243,7 @@ class Variant:
 
     def make_default(self) -> "VariantValue":
         """Factory that creates a variant holding the default value(s)."""
-        variant = VariantValue.from_string_or_bool(self.name, self.default)
-        variant.type = self.variant_type
-        return variant
+        return VariantValue.from_string_or_bool(self.name, self.default).as_type(self.variant_type)
 
     def make_variant(self, *value: Union[str, bool]) -> "VariantValue":
         """Factory that creates a variant holding the value(s) passed."""
@@ -329,9 +328,7 @@ class VariantValue:
         self.propagate = propagate
         # only multi-valued variants can be abstract
         self.concrete = concrete or type in (VariantType.BOOL, VariantType.SINGLE)
-
-        # Invokes property setter
-        self.set(*value)
+        self._values = self._validated(value)
 
     @staticmethod
     def from_node_dict(
@@ -402,8 +399,8 @@ class VariantValue:
     def value(self) -> Union[ValueType, bool, str]:
         return self._values[0] if self.type != VariantType.MULTI else self._values
 
-    def set(self, *value: Union[bool, str]) -> None:
-        """Set the value(s) of the variant."""
+    def _validated(self, value: ValueType) -> ValueType:
+        """The value(s) sorted and deduplicated, checked against this variant's type."""
         if len(value) > 1:
             value = tuple(sorted(set(value)))
 
@@ -419,18 +416,39 @@ class VariantValue:
         if "*" in value:
             raise InvalidVariantValueError("cannot use reserved value '*'")
 
-        self._values = value
+        return value
+
+    def with_values(self, value: ValueType) -> "VariantValue":
+        """This variant, with different value(s)."""
+        return VariantValue(
+            self.type, self.name, value, propagate=self.propagate, concrete=self.concrete
+        )
+
+    def with_value_added(self, value: Union[str, bool]) -> "VariantValue":
+        """This variant, with one more value."""
+        return self.with_values((*self._values, value))
+
+    def as_type(self, type: VariantType) -> "VariantValue":
+        """This variant, as a different variant type."""
+        if type == self.type:
+            return self
+        return VariantValue(
+            type, self.name, self._values, propagate=self.propagate, concrete=self.concrete
+        )
+
+    def as_concrete(self) -> "VariantValue":
+        """This variant, marked concrete."""
+        if self.concrete:
+            return self
+        return VariantValue(
+            self.type, self.name, self._values, propagate=self.propagate, concrete=True
+        )
 
     def _cmp_iter(self) -> Iterable:
         yield self.name
         yield self.propagate
         yield self.concrete
         yield from (str(v) for v in self.values)
-
-    def copy(self) -> "VariantValue":
-        return VariantValue(
-            self.type, self.name, self.values, propagate=self.propagate, concrete=self.concrete
-        )
 
     def _merged_values(self, other: "VariantValue") -> Tuple[Union[str, bool], ...]:
         """The values of both sides. For patches a value identified by a checksum prefix and the
@@ -481,26 +499,26 @@ class VariantValue:
         # both abstract: the union is a valid concretization of both
         return True
 
-    def constrain(self, other: "VariantValue") -> bool:
-        """Constrain self with other if they intersect. Returns true iff self was changed."""
+    def constrained(self, other: "VariantValue") -> Optional["VariantValue"]:
+        """This variant constrained with other, or None when other adds nothing to it. Raises
+        UnsatisfiableVariantSpecError if the two do not intersect."""
         if not self.intersects(other):
             raise UnsatisfiableVariantSpecError(self, other)
-        old_values = self.values
-        self.set(*self._merged_values(other))
-        changed = old_values != self.values
-        if self.propagate and not other.propagate:
-            self.propagate = False
-            changed = True
-        if not self.concrete and other.concrete:
-            self.concrete = True
-            changed = True
-        if self.type > other.type:
-            self.type = other.type
-            changed = True
-        return changed
-
-    def append(self, value: Union[str, bool]) -> None:
-        self.set(*self.values, value)
+        result = VariantValue(
+            min(self.type, other.type),
+            self.name,
+            self._merged_values(other),
+            propagate=self.propagate and other.propagate,
+            concrete=self.concrete or other.concrete,
+        )
+        if (
+            result._values == self._values
+            and result.type == self.type
+            and result.propagate == self.propagate
+            and result.concrete == self.concrete
+        ):
+            return None
+        return result
 
     def __contains__(self, item: Union[str, bool]) -> bool:
         return item in self.values
@@ -551,6 +569,22 @@ def SingleValuedVariant(
 
 def BoolValuedVariant(name: str, value: bool, propagate: bool = False) -> VariantValue:
     return VariantValue(VariantType.BOOL, name, (value,), propagate=propagate)
+
+
+#: Variant values repeat across the nodes of a solve and across package recipes: a solve for
+#: trilinos stores 38 490 of them, holding 1 883 distinct values. They are immutable, so every
+#: occurrence hands out the same object.
+_VARIANT_VALUE_CACHE: Dict[Tuple, VariantValue] = {}
+
+
+def intern_variant_value(value: VariantValue) -> VariantValue:
+    """Return the shared VariantValue equal to ``value``."""
+    key = (value.type, value.name, value.propagate, value.concrete, value._values)
+    cached = _VARIANT_VALUE_CACHE.get(key)
+    if cached is not None:
+        return cached
+    _VARIANT_VALUE_CACHE[key] = value
+    return value
 
 
 class VariantValueRemoval(VariantValue):

--- a/lib/spack/spack/variant.py
+++ b/lib/spack/spack/variant.py
@@ -573,17 +573,16 @@ def BoolValuedVariant(name: str, value: bool, propagate: bool = False) -> Varian
     return VariantValue(VariantType.BOOL, name, (value,), propagate=propagate)
 
 
-#: Variant values repeat across the nodes of a solve and across package recipes: a solve for
-#: trilinos stores 38 490 of them, holding 1 883 distinct values. They are immutable, so every
-#: occurrence hands out the same object.
+#: Variant values repeat across the nodes of a solve and across package recipes. They are
+#: immutable, so every occurrence of a value is the same object.
 _VARIANT_VALUE_CACHE: Dict[Tuple, VariantValue] = {}
 
 
 def intern_variant_value(value: VariantValue) -> VariantValue:
     """Return the shared VariantValue equal to ``value``.
 
-    The result carries ``_key``, which identifies it exactly, unlike ``__eq__``, which ignores the
-    variant type. Maps of variant values are interned by the keys of the values they hold.
+    The result has a ``_key`` that identifies it exactly, including the variant type that
+    ``__eq__`` ignores. Maps of variant values are interned by the keys of the values they hold.
     """
     key = (value.type, value.name, value.propagate, value.concrete, value._values)
     cached = _VARIANT_VALUE_CACHE.get(key)

--- a/lib/spack/spack/variant.py
+++ b/lib/spack/spack/variant.py
@@ -313,15 +313,7 @@ class VariantValue:
     type: VariantType
     _values: ValueType
 
-    # _patches_in_order_of_appearance is attached to the "patches" variant after concretization
-    __slots__ = (
-        "name",
-        "propagate",
-        "concrete",
-        "type",
-        "_values",
-        "_patches_in_order_of_appearance",
-    )
+    __slots__ = ("name", "propagate", "concrete", "type", "_values")
 
     def __init__(
         self,

--- a/lib/spack/spack/variant.py
+++ b/lib/spack/spack/variant.py
@@ -311,8 +311,10 @@ class VariantValue:
     concrete: bool
     type: VariantType
     _values: ValueType
+    _key: Tuple
 
-    __slots__ = ("name", "propagate", "concrete", "type", "_values")
+    #: ``_key`` is set on interned values only; see :func:`intern_variant_value`
+    __slots__ = ("name", "propagate", "concrete", "type", "_values", "_key")
 
     def __init__(
         self,
@@ -578,11 +580,16 @@ _VARIANT_VALUE_CACHE: Dict[Tuple, VariantValue] = {}
 
 
 def intern_variant_value(value: VariantValue) -> VariantValue:
-    """Return the shared VariantValue equal to ``value``."""
+    """Return the shared VariantValue equal to ``value``.
+
+    The result carries ``_key``, which identifies it exactly, unlike ``__eq__``, which ignores the
+    variant type. Maps of variant values are interned by the keys of the values they hold.
+    """
     key = (value.type, value.name, value.propagate, value.concrete, value._values)
     cached = _VARIANT_VALUE_CACHE.get(key)
     if cached is not None:
         return cached
+    value._key = key
     _VARIANT_VALUE_CACHE[key] = value
     return value
 

--- a/lib/spack/spack/version/__init__.py
+++ b/lib/spack/spack/version/__init__.py
@@ -37,7 +37,7 @@ from .version_types import (
 )
 
 #: This version contains all possible versions.
-any_version: VersionList = VersionList([":"])
+any_version: VersionList = VersionList.any()
 
 __all__ = [
     "ClosedOpenRange",

--- a/lib/spack/spack/version/__init__.py
+++ b/lib/spack/spack/version/__init__.py
@@ -32,6 +32,7 @@ from .version_types import (
     _next_version,
     _prev_version,
     from_string,
+    intern_version_list,
     ver,
 )
 
@@ -48,6 +49,7 @@ __all__ = [
     "VersionChecksumError",
     "VersionError",
     "VersionList",
+    "intern_version_list",
     "VersionLookupError",
     "VersionRange",
     "VersionType",

--- a/lib/spack/spack/version/version_types.py
+++ b/lib/spack/spack/version/version_types.py
@@ -128,9 +128,8 @@ VersionTuple = Tuple[VersionComponentTuple, PrereleaseTuple]
 #: Separators from a parsed version.
 SeparatorTuple = Tuple[str, ...]
 
-#: Version literals repeat heavily across package recipes: a solve for trilinos parses 46k
-#: StandardVersions with only 4.4k distinct values. These types are immutable once constructed,
-#: so every occurrence of a literal hands out the same object.
+#: Version literals repeat across package recipes. These types are immutable once constructed, so
+#: every occurrence of a literal is the same object.
 _STR_COMPONENT_CACHE: Dict[str, "VersionStrComponent"] = {}
 _STANDARD_VERSION_CACHE: Dict[str, "StandardVersion"] = {}
 _CLOSED_OPEN_RANGE_CACHE: Dict[Tuple, "ClosedOpenRange"] = {}
@@ -780,7 +779,7 @@ class ClosedOpenRange(VersionType):
     def from_version_range(cls, lo: StandardVersion, hi: StandardVersion) -> "ClosedOpenRange":
         """Construct ClosedOpenRange from lo:hi range."""
         # StandardVersions compare equal when they parse the same, so "3.0.0" and "3.0.00" are
-        # one key; the original strings are part of the key to hand back the range as written.
+        # one key; the original strings are part of the key, so the range is returned as written.
         key = (lo._string, lo.version, hi._string, hi.version)
         cached = _CLOSED_OPEN_RANGE_CACHE.get(key)
         if cached is not None:
@@ -1144,8 +1143,7 @@ class VersionList(VersionType):
         """Return a VersionList that matches any version.
 
         Every Spec starts out with one of these, so they are all the same object. Constraining a
-        spec replaces its VersionList instead of mutating it, which keeps this shared instance
-        intact.
+        spec replaces its VersionList, which leaves this shared instance intact.
         """
         return _ANY_VERSION_LIST
 
@@ -1425,8 +1423,7 @@ _UNBOUNDED_RANGE = ClosedOpenRange.from_version_range(
 _ANY_VERSION_LIST = VersionList.__new__(VersionList)
 _ANY_VERSION_LIST.versions = [_UNBOUNDED_RANGE]
 
-#: Version constraints repeat across package recipes and across the nodes of a solve: 24k lists
-#: for a trilinos solve hold only 3.7k distinct values.
+#: Version constraints repeat across package recipes and across the nodes of a solve.
 _VERSION_LIST_CACHE: Dict[str, VersionList] = {}
 
 
@@ -1434,7 +1431,7 @@ def intern_version_list(version_list: VersionList) -> VersionList:
     """Return the shared VersionList equal to ``version_list``.
 
     Callers must treat the result as immutable, which is how specs already use it: constraining a
-    spec replaces its VersionList instead of mutating it.
+    spec replaces its VersionList.
     """
     key = str(version_list)
     cached = _VERSION_LIST_CACHE.get(key)

--- a/lib/spack/spack/version/version_types.py
+++ b/lib/spack/spack/version/version_types.py
@@ -55,6 +55,10 @@ class VersionStrComponent:
 
     @staticmethod
     def from_string(string: str) -> "VersionStrComponent":
+        cached = _STR_COMPONENT_CACHE.get(string)
+        if cached is not None:
+            return cached
+
         value: Union[int, str] = string
         if len(string) >= iv_min_len:
             try:
@@ -62,7 +66,9 @@ class VersionStrComponent:
             except ValueError:
                 pass
 
-        return VersionStrComponent(value)
+        result = VersionStrComponent(value)
+        _STR_COMPONENT_CACHE[string] = result
+        return result
 
     def __hash__(self) -> int:
         return hash(self.data)
@@ -121,6 +127,13 @@ VersionTuple = Tuple[VersionComponentTuple, PrereleaseTuple]
 
 #: Separators from a parsed version.
 SeparatorTuple = Tuple[str, ...]
+
+#: Version literals repeat heavily across package recipes: a solve for trilinos parses 46k
+#: StandardVersions with only 4.4k distinct values. These types are immutable once constructed,
+#: so every occurrence of a literal hands out the same object.
+_STR_COMPONENT_CACHE: Dict[str, "VersionStrComponent"] = {}
+_STANDARD_VERSION_CACHE: Dict[str, "StandardVersion"] = {}
+_CLOSED_OPEN_RANGE_CACHE: Dict[Tuple, "ClosedOpenRange"] = {}
 
 
 def parse_string_components(string: str) -> Tuple[VersionTuple, SeparatorTuple]:
@@ -254,8 +267,14 @@ class StandardVersion(ConcreteVersion):
 
     @staticmethod
     def from_string(string: str) -> "StandardVersion":
+        cached = _STANDARD_VERSION_CACHE.get(string)
+        if cached is not None:
+            return cached
+
         version, separators = parse_string_components(string)
-        return StandardVersion(string, version, separators)
+        result = StandardVersion(string, version, separators)
+        _STANDARD_VERSION_CACHE[string] = result
+        return result
 
     @staticmethod
     def typemin() -> "StandardVersion":
@@ -760,6 +779,13 @@ class ClosedOpenRange(VersionType):
     @classmethod
     def from_version_range(cls, lo: StandardVersion, hi: StandardVersion) -> "ClosedOpenRange":
         """Construct ClosedOpenRange from lo:hi range."""
+        # StandardVersions compare equal when they parse the same, so "3.0.0" and "3.0.00" are
+        # one key; the original strings are part of the key to hand back the range as written.
+        key = (lo._string, lo.version, hi._string, hi.version)
+        cached = _CLOSED_OPEN_RANGE_CACHE.get(key)
+        if cached is not None:
+            return cached
+
         try:
             r = ClosedOpenRange(lo, _next_version(hi))
         except EmptyRangeError as e:
@@ -768,6 +794,7 @@ class ClosedOpenRange(VersionType):
         # Cache hash and string representation
         r._hash = hash((lo, hi))
         r._string = _str_range(lo, hi)
+        _CLOSED_OPEN_RANGE_CACHE[key] = r
         return r
 
     def __str__(self) -> str:
@@ -1114,10 +1141,13 @@ class VersionList(VersionType):
 
     @classmethod
     def any(cls) -> "VersionList":
-        """Return a VersionList that matches any version."""
-        version_list = cls.__new__(cls)
-        version_list.versions = [_UNBOUNDED_RANGE]
-        return version_list
+        """Return a VersionList that matches any version.
+
+        Every Spec starts out with one of these, so they are all the same object. Constraining a
+        spec replaces its VersionList instead of mutating it, which keeps this shared instance
+        intact.
+        """
+        return _ANY_VERSION_LIST
 
     def update(self, other: "VersionList") -> None:
         self.add(other)
@@ -1390,3 +1420,25 @@ _STANDARD_VERSION_TYPEMAX = StandardVersion(
 _UNBOUNDED_RANGE = ClosedOpenRange.from_version_range(
     _STANDARD_VERSION_TYPEMIN, _STANDARD_VERSION_TYPEMAX
 )
+
+#: Shared by every unconstrained spec; see VersionList.any().
+_ANY_VERSION_LIST = VersionList.__new__(VersionList)
+_ANY_VERSION_LIST.versions = [_UNBOUNDED_RANGE]
+
+#: Version constraints repeat across package recipes and across the nodes of a solve: 24k lists
+#: for a trilinos solve hold only 3.7k distinct values.
+_VERSION_LIST_CACHE: Dict[str, VersionList] = {}
+
+
+def intern_version_list(version_list: VersionList) -> VersionList:
+    """Return the shared VersionList equal to ``version_list``.
+
+    Callers must treat the result as immutable, which is how specs already use it: constraining a
+    spec replaces its VersionList instead of mutating it.
+    """
+    key = str(version_list)
+    cached = _VERSION_LIST_CACHE.get(key)
+    if cached is not None:
+        return cached
+    _VERSION_LIST_CACHE[key] = version_list
+    return version_list

--- a/lib/spack/spack/version/version_types.py
+++ b/lib/spack/spack/version/version_types.py
@@ -5,7 +5,7 @@
 import copy
 import re
 from bisect import bisect_left
-from typing import Dict, Iterable, Iterator, List, Optional, Tuple, Union
+from typing import TYPE_CHECKING, Dict, Iterable, Iterator, List, Optional, Sequence, Tuple, Union
 
 from spack.util.typing import SupportsRichComparison
 
@@ -639,9 +639,9 @@ class GitVersion(ConcreteVersion):
         return self._with_constraint(constraint)
 
     def union(self, other: VersionType) -> VersionType:
-        result = VersionList([self])
-        result.add(other)
-        return result[0] if len(result) == 1 else result
+        versions: List[VersionType] = [self]
+        _add(versions, other)
+        return versions[0] if len(versions) == 1 else VersionList._from_sorted(versions)
 
     def satisfies(self, other: VersionType) -> bool:
         if isinstance(other, GitVersion):
@@ -894,9 +894,7 @@ class ClosedOpenRange(VersionType):
 
     def union(self, other: VersionType) -> VersionType:
         if isinstance(other, VersionList):
-            v = other.copy()
-            v.add(self)
-            return v
+            return other.union(self)
 
         result = self._union_if_not_disjoint(other)
         return result if result is not None else VersionList([self, other])
@@ -930,122 +928,139 @@ def _element_str(v: VersionType) -> str:
     return f"={v}" if type(v) is StandardVersion else str(v)
 
 
-class VersionList(VersionType):
-    """Sorted, non-redundant list of Version and ClosedOpenRange elements."""
+def _ranged_refs_start(versions: Sequence[VersionType]) -> int:
+    """The index where the git refs constrained to a range start: they sort last."""
+    i = len(versions)
+    while i > 0 and _is_ranged_ref(versions[i - 1]):
+        i -= 1
+    return i
 
-    __slots__ = ("versions",)
 
-    versions: List[VersionType]
-
-    def __init__(self, vlist: Optional[Union[str, VersionType, Iterable]] = None):
-        if isinstance(vlist, str):
-            vlist = from_string(vlist)
-            if isinstance(vlist, VersionList):
-                self.versions = vlist.versions
-            else:
-                self.versions = [vlist]
-
-        elif vlist is None:
-            self.versions = []
-
-        elif isinstance(vlist, VersionList):
-            self.versions = vlist[:]
-
-        elif isinstance(vlist, (ConcreteVersion, ClosedOpenRange)):
-            self.versions = [vlist]
-
-        elif isinstance(vlist, Iterable):
-            self.versions = []
-            for v in vlist:
-                self.add(ver(v))
-
+def _add_ranged_ref(versions: List[VersionType], item: GitVersion) -> None:
+    """Add a git ref constrained to a range."""
+    # Skip when already covered: by a plain range, or by a wider constraint on the ref.
+    if any(item.satisfies(v) for v in versions):
+        return
+    # Widen it over the plain ranges it touches, then merge it with the constraints on the
+    # same ref it touches. One pass in list order suffices: plain ranges come first and are
+    # pairwise disjoint, and a constraint on the ref already contains the plain ranges it
+    # touches, so merging it cannot make the result touch anything new.
+    constraint = item.constraint
+    assert isinstance(constraint, ClosedOpenRange)
+    for v in versions:
+        if isinstance(v, ClosedOpenRange):
+            union = constraint._union_if_not_disjoint(v)
+        elif isinstance(v, GitVersion) and v.ref == item.ref:
+            union = constraint._union_if_not_disjoint(v.constraint)
         else:
-            raise TypeError(f"Cannot construct VersionList from {type(vlist)}")
+            continue
+        if union is not None:
+            constraint = union
+    item = item._with_constraint(constraint)
+    # It covers assigned versions of the ref, and the constraints on it that were merged.
+    versions[:] = [v for v in versions if not v.satisfies(item)]
+    versions.insert(bisect_left(versions, item), item)
 
-    def _ranged_refs_start(self) -> int:
-        """The index where the git refs constrained to a range start: they sort last."""
-        i = len(self.versions)
-        while i > 0 and _is_ranged_ref(self.versions[i - 1]):
+
+def _add(versions: List[VersionType], item: VersionType) -> None:
+    """Insert ``item`` into the sorted, non-redundant list ``versions``, merging as needed."""
+    if isinstance(item, ClosedOpenRange):
+        i = bisect_left(versions, item)
+
+        # Note: can span multiple concrete versions to the left (as well as to the right).
+        # For instance insert 1.2: into [1.2, hash=1.2, 1.3, 1.4:1.5]
+        # would bisect at i = 1 and merge i = 0 too.
+        while i > 0:
+            union = item._union_if_not_disjoint(versions[i - 1])
+            if union is None:  # disjoint
+                break
+            item = union
+            del versions[i - 1]
             i -= 1
-        return i
 
-    def _add_ranged_ref(self, item: GitVersion) -> None:
-        """Add a git ref constrained to a range."""
-        # Skip when already covered: by a plain range, or by a wider constraint on the ref.
-        if item.satisfies(self):
-            return
-        # Widen it over the plain ranges it touches, then merge it with the constraints on the
-        # same ref it touches. One pass in list order suffices: plain ranges come first and are
-        # pairwise disjoint, and a constraint on the ref already contains the plain ranges it
-        # touches, so merging it cannot make the result touch anything new.
-        constraint = item.constraint
-        assert isinstance(constraint, ClosedOpenRange)
-        for v in self.versions:
-            if isinstance(v, ClosedOpenRange):
-                union = constraint._union_if_not_disjoint(v)
-            elif isinstance(v, GitVersion) and v.ref == item.ref:
-                union = constraint._union_if_not_disjoint(v.constraint)
-            else:
-                continue
-            if union is not None:
-                constraint = union
-        item = item._with_constraint(constraint)
-        # It covers assigned versions of the ref, and the constraints on it that were merged.
-        self.versions = [v for v in self.versions if not v.satisfies(item)]
-        self.versions.insert(bisect_left(self.versions, item), item)
+        while i < len(versions):
+            union = item._union_if_not_disjoint(versions[i])
+            if union is None:
+                break
+            item = union
+            del versions[i]
 
-    def add(self, item: VersionType) -> None:
-        if isinstance(item, ClosedOpenRange):
-            i = bisect_left(self.versions, item)
+        versions.insert(i, item)
+        # Re-add the constraints on git refs: it may cover or touch them, and they come
+        # after it, not necessarily next to it.
+        if _is_ranged_ref(versions[-1]):
+            start = _ranged_refs_start(versions)
+            refs = versions[start:]
+            del versions[start:]
+            for v in refs:
+                _add(versions, v)
 
-            # Note: can span multiple concrete versions to the left (as well as to the right).
-            # For instance insert 1.2: into [1.2, hash=1.2, 1.3, 1.4:1.5]
-            # would bisect at i = 1 and merge i = 0 too.
-            while i > 0:
-                union = item._union_if_not_disjoint(self[i - 1])
-                if union is None:  # disjoint
-                    break
-                item = union
-                del self.versions[i - 1]
-                i -= 1
+    elif isinstance(item, VersionList):
+        for v in item:
+            _add(versions, v)
 
-            while i < len(self):
-                union = item._union_if_not_disjoint(self[i])
-                if union is None:
-                    break
-                item = union
-                del self.versions[i]
+    elif isinstance(item, GitVersion):
+        if item.std_version is None:
+            _add_ranged_ref(versions, item)
+        # An assigned ref can be covered by a constraint on the ref anywhere in the list.
+        elif not any(item.satisfies(v) for v in versions):
+            versions.insert(bisect_left(versions, item), item)
 
-            self.versions.insert(i, item)
-            # Re-add the constraints on git refs: it may cover or touch them, and they come
-            # after it, not necessarily next to it.
-            if _is_ranged_ref(self.versions[-1]):
-                start = self._ranged_refs_start()
-                refs, self.versions = self.versions[start:], self.versions[:start]
-                for v in refs:
-                    self.add(v)
+    elif isinstance(item, StandardVersion):
+        i = bisect_left(versions, item)
+        # Only insert when prev and next do not cover it.
+        if (i == 0 or not item.satisfies(versions[i - 1])) and (
+            i == len(versions) or not item.satisfies(versions[i])
+        ):
+            versions.insert(i, item)
 
-        elif isinstance(item, VersionList):
-            for v in item:
-                self.add(v)
+    else:
+        raise TypeError("Can't add %s to VersionList" % type(item))
 
-        elif isinstance(item, GitVersion):
-            if item.std_version is None:
-                self._add_ranged_ref(item)
-            # An assigned ref can be covered by a constraint on the ref anywhere in the list.
-            elif not item.satisfies(self):
-                self.versions.insert(bisect_left(self.versions, item), item)
 
-        elif isinstance(item, StandardVersion):
-            i = bisect_left(self.versions, item)
-            # Only insert when prev and next do not cover it.
-            if (i == 0 or not item.satisfies(self[i - 1])) and (
-                i == len(self) or not item.satisfies(self[i])
-            ):
-                self.versions.insert(i, item)
+if TYPE_CHECKING:
+    _VersionListBase = Tuple[VersionType, ...]
+else:
+    _VersionListBase = tuple  # subclassing typing.Tuple is slow on 3.6 (GenericMeta)
 
-        else:
-            raise TypeError("Can't add %s to VersionList" % type(item))
+
+class VersionList(VersionType, _VersionListBase):
+    """Sorted, non-redundant tuple of Version and ClosedOpenRange elements.
+
+    Specs share these tuples, many of them interned, and the entries are never modified once
+    they exist: :meth:`union` and :meth:`intersection` return the list to store back on the
+    spec."""
+
+    __slots__ = ()
+
+    def __new__(cls, vlist: Optional[Union[str, VersionType, Iterable]] = None) -> "VersionList":
+        if vlist is None:
+            return tuple.__new__(cls)
+
+        if isinstance(vlist, str):
+            parsed = from_string(vlist)
+            if isinstance(parsed, VersionList):
+                return parsed
+            return tuple.__new__(cls, (parsed,))
+
+        if isinstance(vlist, VersionList):
+            return vlist
+
+        if isinstance(vlist, (ConcreteVersion, ClosedOpenRange)):
+            return tuple.__new__(cls, (vlist,))
+
+        if isinstance(vlist, Iterable):
+            versions: List[VersionType] = []
+            for v in vlist:
+                _add(versions, ver(v))
+            return tuple.__new__(cls, versions)
+
+        raise TypeError(f"Cannot construct VersionList from {type(vlist)}")
+
+    @classmethod
+    def _from_sorted(cls, versions: Iterable[VersionType]) -> "VersionList":
+        """Construct from already sorted, non-redundant entries."""
+        return tuple.__new__(cls, versions)
 
     @property
     def concrete(self) -> Optional[ConcreteVersion]:
@@ -1064,23 +1079,18 @@ class VersionList(VersionType):
             return v.lo
         return None
 
-    def copy(self) -> "VersionList":
-        return VersionList(self)
-
     def lowest(self) -> Optional[StandardVersion]:
         """Get the lowest version in the list."""
-        return next((v for v in self.versions if isinstance(v, StandardVersion)), None)
+        return next((v for v in self if isinstance(v, StandardVersion)), None)
 
     def highest(self) -> Optional[StandardVersion]:
         """Get the highest version in the list."""
-        return next((v for v in reversed(self.versions) if isinstance(v, StandardVersion)), None)
+        return next((v for v in reversed(self) if isinstance(v, StandardVersion)), None)
 
     def highest_numeric(self) -> Optional[StandardVersion]:
         """Get the highest numeric version in the list."""
         numeric = (
-            v
-            for v in reversed(self.versions)
-            if isinstance(v, StandardVersion) and not v.isdevelop()
+            v for v in reversed(self) if isinstance(v, StandardVersion) and not v.isdevelop()
         )
         return next(numeric, None)
 
@@ -1105,7 +1115,7 @@ class VersionList(VersionType):
 
         if isinstance(other, VersionList):
             # Walk the two lists in lockstep, up to the git refs without an assigned version
-            s_tail, o_tail = self._ranged_refs_start(), other._ranged_refs_start()
+            s_tail, o_tail = _ranged_refs_start(self), _ranged_refs_start(other)
             s = o = 0
             while s < s_tail and o < o_tail:
                 if self[s].intersects(other[o]):
@@ -1114,11 +1124,11 @@ class VersionList(VersionType):
                     s += 1
                 else:
                     o += 1
-            if s_tail == len(self.versions) and o_tail == len(other.versions):
+            if s_tail == len(self) and o_tail == len(other):
                 return False
             # Those refs can intersect elements anywhere in the other list: check them one by one
-            return any(v.intersects(other) for v in self.versions[s_tail:]) or any(
-                v.intersects(self) for v in other.versions[o_tail:]
+            return any(v.intersects(other) for v in self[s_tail:]) or any(
+                v.intersects(self) for v in other[o_tail:]
             )
 
         raise TypeError(f"'intersects()' not supported for instances of {type(other)}")
@@ -1147,101 +1157,85 @@ class VersionList(VersionType):
         """
         return _ANY_VERSION_LIST
 
-    def update(self, other: "VersionList") -> None:
-        self.add(other)
-
     def union(self, other: VersionType) -> VersionType:
-        result = self.copy()
-        result.add(other)
-        return result
+        versions = list(self)
+        _add(versions, other)
+        return VersionList._from_sorted(versions)
 
     def intersection(self, other: VersionType) -> "VersionList":
-        result = VersionList()
         if isinstance(other, VersionList):
+            result: List[VersionType] = []
             for lhs, rhs in ((self, other), (other, self)):
-                lhs_tail, rhs_tail = lhs._ranged_refs_start(), rhs._ranged_refs_start()
+                lhs_tail, rhs_tail = _ranged_refs_start(lhs), _ranged_refs_start(rhs)
                 # Up to the git refs without an assigned version, an element meets at most its
                 # two neighbors in the other list
-                for x in lhs.versions[:lhs_tail]:
-                    i = bisect_left(rhs.versions, x, 0, rhs_tail)
+                for x in lhs[:lhs_tail]:
+                    i = bisect_left(rhs, x, 0, rhs_tail)
                     if i > 0:
-                        result.add(rhs[i - 1].intersection(x))
+                        _add(result, rhs[i - 1].intersection(x))
                     if i < rhs_tail:
-                        result.add(rhs[i].intersection(x))
+                        _add(result, rhs[i].intersection(x))
                 # Those refs can meet elements anywhere in the other list: meet them one by one
-                for x in lhs.versions[lhs_tail:]:
-                    for y in rhs.versions:
-                        result.add(x.intersection(y))
-            return result
+                for x in lhs[lhs_tail:]:
+                    for y in rhs:
+                        _add(result, x.intersection(y))
+            return VersionList._from_sorted(result)
         else:
             return self.intersection(VersionList(other))
 
-    def intersect(self, other: VersionType) -> bool:
-        """Intersect this spec's list with other.
+    def __contains__(self, other):
+        if isinstance(other, (ClosedOpenRange, StandardVersion)):
+            i = bisect_left(self, other)
+            return (i > 0 and other in self[i - 1]) or (i < len(self) and other in self[i])
 
-        Return True if the spec changed as a result; False otherwise
-        """
-        isection = self.intersection(other)
-        changed = isection.versions != self.versions
-        self.versions = isection.versions
-        return changed
+        # a git ref sorts by the version assigned to it, and a constraint on it sorts last, so
+        # neither is found next to where it would be inserted: scan for those
+        if isinstance(other, (GitVersion, VersionList)):
+            return other.satisfies(self)
 
-    def __getitem__(self, index):
-        return self.versions[index]
-
-    def __iter__(self) -> Iterator:
-        return iter(self.versions)
-
-    def __reversed__(self) -> Iterator:
-        return reversed(self.versions)
-
-    def __len__(self) -> int:
-        return len(self.versions)
-
-    def __bool__(self) -> bool:
-        return bool(self.versions)
+        return False
 
     def __eq__(self, other) -> bool:
-        if isinstance(other, VersionList):
-            return self.versions == other.versions
-        return False
+        return isinstance(other, VersionList) and tuple.__eq__(self, other)
 
     def __ne__(self, other) -> bool:
-        if isinstance(other, VersionList):
-            return self.versions != other.versions
-        return False
+        return isinstance(other, VersionList) and tuple.__ne__(self, other)
 
     def __lt__(self, other) -> bool:
         if isinstance(other, VersionList):
-            return self.versions < other.versions
+            return tuple.__lt__(self, other)
         return NotImplemented
 
     def __le__(self, other) -> bool:
         if isinstance(other, VersionList):
-            return self.versions <= other.versions
+            return tuple.__le__(self, other)
         return NotImplemented
 
     def __ge__(self, other) -> bool:
         if isinstance(other, VersionList):
-            return self.versions >= other.versions
+            return tuple.__ge__(self, other)
         return NotImplemented
 
     def __gt__(self, other) -> bool:
         if isinstance(other, VersionList):
-            return self.versions > other.versions
+            return tuple.__gt__(self, other)
         return NotImplemented
 
-    def __hash__(self) -> int:
-        return hash(tuple(self.versions))
+    __hash__ = tuple.__hash__
+
+    def __reduce__(self):
+        # going through intern_version_list means specs that shared a list still share it after
+        # unpickling
+        return _unpickle_version_list, (tuple(self),)
 
     def __str__(self) -> str:
-        if not self.versions:
+        if not self:
             return ""
 
-        return ",".join(_element_str(v) for v in self.versions)
+        return ",".join(_element_str(v) for v in self)
 
     def __repr__(self) -> str:
-        return str(self.versions)
+        return repr(list(self))
 
 
 def _next_str(s: str) -> str:
@@ -1420,8 +1414,7 @@ _UNBOUNDED_RANGE = ClosedOpenRange.from_version_range(
 )
 
 #: Shared by every unconstrained spec; see VersionList.any().
-_ANY_VERSION_LIST = VersionList.__new__(VersionList)
-_ANY_VERSION_LIST.versions = [_UNBOUNDED_RANGE]
+_ANY_VERSION_LIST = VersionList._from_sorted((_UNBOUNDED_RANGE,))
 
 #: Version constraints repeat across package recipes and across the nodes of a solve.
 _VERSION_LIST_CACHE: Dict[str, VersionList] = {}
@@ -1439,3 +1432,7 @@ def intern_version_list(version_list: VersionList) -> VersionList:
         return cached
     _VERSION_LIST_CACHE[key] = version_list
     return version_list
+
+
+def _unpickle_version_list(versions: Tuple[VersionType, ...]) -> VersionList:
+    return intern_version_list(VersionList._from_sorted(versions))


### PR DESCRIPTION
This description is generated by an LLM.

Copy-on-write instead of mutation shrinks the heap, because a value that cannot change after a spec stores it can be shared. That allows two things: interning immutable values, so every occurrence of the same version, variant value, variant map or flag map is one object, and deduplicating the defaults that no spec ever mutates — the empty edge maps, no extra attributes, no variants, no flags, the current spec file format — so that one instance backs them all.

Objects alive when `main()` returns for `spack spec trilinos` on a concretization cache hit, and the RSS of that process:

| | objects | RSS |
|---|---:|---:|
| develop | 882 640 | 275.7 MB |
| `spec.py: simplify VariantMap and FlagMap` (#52939, the base of this PR) | 815 025 | 271.7 MB |
| intern version literals, ranges and lists | 689 965 | 249.6 MB |
| store the patch order on the spec | 689 962 | 251.1 MB |
| make `VariantValue` immutable | 655 344 | 241.7 MB |
| store compiler flags in tuples | 637 818 | 242.6 MB |
| make `VariantMap` and `FlagMap` immutable and interned | 576 007 | 230.5 MB |
| share the empty edge maps and extra attributes | 487 599 | 224.5 MB |
| share the default spec annotations | 456 105 | 223.7 MB |

That is 48.3% fewer objects and 52.0 MB less RSS than develop. Wall time of the whole `spack spec trilinos` process goes 9.15s -> 8.24s, min of eight alternating rounds.

Sharing shows up in pickles too, since pickle memoizes by identity: an interned value is written once and referenced afterwards. Reading the 3.5 MB `spack.lock` of a concrete environment (2 178 nodes) and pickling its 275 roots:

| | develop | this PR |
|---|---:|---:|
| pickle size | 3 422 375 B | 2 631 999 B (-23.1%) |
| `pickle.dumps` | 0.098s | 0.055s |
| `pickle.loads` | 0.114s | 0.091s |

The solve is unchanged: every commit hits the concretization cache entry develop wrote, so the ASP problem is identical, dag hashes and lockfile node dicts match, and the test suite is green.

Two companion changes are needed in spack-packages: `boost` reads `spec.variants.dict`, which #52939 removes, and `nek5000` and `nektools` append to `spec.compiler_flags["fflags"]`, which is a tuple now.

The commits that made package recipes cheaper moved to #52956, and the clingo import to #52953. Neither depends on the interning here.
