### PR TITLE
concretization_cache_plugin: mark xdist hook as optional

### DIFF
--- a/lib/spack/spack/test/concretization_cache_plugin.py
+++ b/lib/spack/spack/test/concretization_cache_plugin.py
@@ -22,6 +22,8 @@ import functools
 import os
 from typing import Optional, Tuple
 
+import pytest
+
 import spack.solver.asp
 
 _stats = {"hits": 0, "misses": 0}
@@ -109,6 +111,7 @@ def pytest_sessionfinish(session):
         workeroutput["spack_concretization_cache_stats"] = _stats
 
 
+@pytest.hookimpl(optionalhook=True)
 def pytest_testnodedown(node, error):
     # xdist controller: add the counters of a finished worker
     stats = getattr(node, "workeroutput", {}).get("spack_concretization_cache_stats")


### PR DESCRIPTION
pytest_testnodedown is a pytest-xdist hook; pluggy rejects the plugin at collection time when xdist is not installed. Mark it optionalhook so the plugin works with and without xdist.

Discovered while testing an unrelated PR

Assisted-by: Claude (Fable 5)