### PR TITLE
concretization cache: support shared caches

### DIFF
--- a/etc/spack/defaults/base/concretizer.yaml
+++ b/etc/spack/defaults/base/concretizer.yaml
@@ -99,6 +99,8 @@ concretizer:
 
   # If enabled, concretizations are cached in the misc_cache. The cache is keyed by the hash
   # of solver inputs, so we only need to run setup (not solve) if there is a cache hit.
+  # The cache is per-user by default, but can be shared -- see the documentation for
+  # concretization_cache:url for how to set that up.
   concretization_cache:
     enable: true
 

--- a/lib/spack/docs/config_yaml.rst
+++ b/lib/spack/docs/config_yaml.rst
@@ -309,6 +309,29 @@ Currently this only supports paths on the local filesystem.
 
 Default location is under the :ref:`Misc Cache` at: ``$misc_cache/concretization``
 
+The cache can be shared among users on the same machine.
+Spack creates cache directories and entries with permissions that follow your umask, so sharing is controlled entirely by how the cache directory is set up.
+There are two ways to share:
+
+* **Read-only sharing**: one user (e.g. a CI account) populates the cache with a typical umask (e.g. ``022``), and other users point ``concretization_cache:url`` at it.
+  Spack degrades gracefully in a cache it cannot write to.
+  Hits are returned, and misses simply re-run the solver.
+
+* **Read/write sharing**: point ``concretization_cache:url`` at a directory owned by a common group, group-writable, and with the setgid bit set:
+
+  .. code-block:: console
+
+     $ chgrp spackusers $cache_dir
+     $ chmod 2770 $cache_dir
+
+  If sharers may have restrictive umasks, you can also set a default ACL so that entries are always group read/write:
+
+  .. code-block:: console
+
+     $ setfacl -d -m u::rwx,g::rwx,o::--- $cache_dir
+
+  Avoid sticky, world-writable locations like ``/tmp``: the sticky bit prevents users from replacing or pruning each other's entries.
+
 ``concretization_cache:entry_limit``
 ------------------------------------
 

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -14,7 +14,6 @@ import pprint
 import random
 import re
 import sys
-import tempfile
 import time
 import warnings
 from typing import (
@@ -58,6 +57,7 @@ import spack.spec
 import spack.store
 import spack.traverse
 import spack.util.crypto
+import spack.util.filesystem as fs
 import spack.util.hash
 import spack.util.lang
 import spack.util.module_cmd as md
@@ -623,6 +623,13 @@ class ConcretizationCache:
         prefix = self._prefix_digest(problem)
         return self.root / prefix
 
+    @staticmethod
+    def _write_entry(cache_path: pathlib.Path, cache_dict: dict) -> None:
+        """Write ``cache_dict`` to ``cache_path`` as gzipped JSON, atomically."""
+        with fs.write_tmp_and_move(str(cache_path), mode="wb") as f:
+            with gzip.open(f, "wb", compresslevel=6) as gz:
+                gz.write(json.dumps(cache_dict).encode())
+
     def store(self, problem: str, result: Result, statistics: List) -> None:
         """Creates entry in concretization cache for problem if none exists,
         storing the concretization Result object and statistics in the cache
@@ -646,28 +653,18 @@ class ConcretizationCache:
             "statistics": statistics,
         }
 
-        # Write to a temp file in the same directory, then atomically rename.
-        # mkstemp appends random characters after the prefix, so names are unique.
-        # A missing root dir is the only expected failure; create it and retry once.
+        # Entry and directory permissions follow the user's umask, so directory setup
+        # (and things like setgid and default ACLs) determines who can share the cache.
         # The whole store is best-effort: failures (e.g. a shared cache another user
         # owns and we can only read) must not block a successful concretization.
-        tmp_path: Optional[str] = None
         try:
             try:
-                fd, tmp_path = tempfile.mkstemp(dir=self.root, prefix=".tmp_")
-            except FileNotFoundError:
+                self._write_entry(cache_path, cache_dict)
+            except FileNotFoundError:  # missing cache root; create it and retry once
                 self.root.mkdir(parents=True, exist_ok=True)
-                fd, tmp_path = tempfile.mkstemp(dir=self.root, prefix=".tmp_")
-            with os.fdopen(fd, "wb") as raw_f:
-                with gzip.open(raw_f, "wb", compresslevel=6) as f:
-                    f.write(json.dumps(cache_dict).encode())
-            # entries keep mkstemp's 0o600 mode: caches are per-user by default, and
-            # sites that want to share one manage permissions themselves.
-            os.replace(tmp_path, cache_path)
+                self._write_entry(cache_path, cache_dict)
         except OSError as e:
             tty.debug(f"Failed to store concretization cache entry {cache_path}: {e}")
-            if tmp_path is not None:
-                self._remove_entry(pathlib.Path(tmp_path))
             return
 
         # Only a newly stored entry can push the cache over its entry limit, so this is the

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -649,20 +649,25 @@ class ConcretizationCache:
         # Write to a temp file in the same directory, then atomically rename.
         # mkstemp appends random characters after the prefix, so names are unique.
         # A missing root dir is the only expected failure; create it and retry once.
+        # The whole store is best-effort: failures (e.g. a shared cache another user
+        # owns and we can only read) must not block a successful concretization.
+        tmp_path: Optional[str] = None
         try:
-            fd, tmp_path = tempfile.mkstemp(dir=self.root, prefix=".tmp_")
-        except FileNotFoundError:
-            self.root.mkdir(parents=True, exist_ok=True)
-            fd, tmp_path = tempfile.mkstemp(dir=self.root, prefix=".tmp_")
-        try:
+            try:
+                fd, tmp_path = tempfile.mkstemp(dir=self.root, prefix=".tmp_")
+            except FileNotFoundError:
+                self.root.mkdir(parents=True, exist_ok=True)
+                fd, tmp_path = tempfile.mkstemp(dir=self.root, prefix=".tmp_")
             with os.fdopen(fd, "wb") as raw_f:
                 with gzip.open(raw_f, "wb", compresslevel=6) as f:
                     f.write(json.dumps(cache_dict).encode())
+            # entries keep mkstemp's 0o600 mode: caches are per-user by default, and
+            # sites that want to share one manage permissions themselves.
             os.replace(tmp_path, cache_path)
         except OSError as e:
-            # Cache store is best-effort; failures shouldn't block a successful concretization.
             tty.debug(f"Failed to store concretization cache entry {cache_path}: {e}")
-            self._remove_entry(pathlib.Path(tmp_path))
+            if tmp_path is not None:
+                self._remove_entry(pathlib.Path(tmp_path))
             return
 
         # Only a newly stored entry can push the cache over its entry limit, so this is the
@@ -732,8 +737,12 @@ class ConcretizationCache:
             self._remove_entry(cache_path)
             return None, None
 
-        # update mod/access time for use w/ LRU cleanup
-        os.utime(cache_path)
+        # Update mod/access time for use w/ LRU cleanup. Best-effort: in a shared
+        # cache, readers may not be able to touch entries written by another user.
+        try:
+            os.utime(cache_path)
+        except OSError as e:
+            tty.debug(f"Failed to update LRU time for {cache_path}: {e}")
         return result, cache_content["statistics"]
 
 

--- a/lib/spack/spack/test/concretization/core.py
+++ b/lib/spack/spack/test/concretization/core.py
@@ -57,6 +57,7 @@ from spack.spec import Spec
 from spack.store import Store
 from spack.test.conftest import RepoBuilder
 from spack.test.utilities import RecordingUI
+from spack.util.filesystem import getuid
 from spack.version import Version, VersionList, ver
 
 
@@ -5449,6 +5450,52 @@ def test_concretization_cache_store_cleans_temp_on_error(use_concretization_cach
     # No leftover temp files
     temps = list(cache.root.glob(".tmp_*"))
     assert temps == []
+
+
+def test_concretization_cache_fetch_updates_lru_time(use_concretization_cache):
+    """A cache hit refreshes the entry's mtime, so cleanup() sees it as recently used.
+
+    cleanup() prunes in ascending mtime order; if fetch() stopped touching entries,
+    the most-used entries would be evicted first instead of last.
+    """
+    cache = spack.solver.asp.ConcretizationCache(str(use_concretization_cache))
+    problem = "lru update test"
+    cache.store(problem, Result(specs=[]), statistics=["stats"])
+    cache_path = cache._cache_path_from_problem(problem)
+
+    # backdate the entry, then check that a hit brings its mtime back to the present
+    old_time = cache_path.stat().st_mtime - 3600
+    os.utime(cache_path, (old_time, old_time))
+
+    result, _ = cache.fetch(problem, specs=[])
+    assert result is not None
+    assert cache_path.stat().st_mtime > old_time + 1800
+
+
+@pytest.mark.not_on_windows("test manipulates POSIX permissions")
+@pytest.mark.skipif(getuid() == 0, reason="user is root")
+def test_concretization_cache_store_readonly_cache(use_concretization_cache):
+    """store() silently skips caching when the cache directory isn't writable.
+
+    The cache is an optimization: not being able to write to it (e.g. a shared
+    cache owned by a CI user) must not fail the concretization that produced
+    the result.
+    """
+    cache = spack.solver.asp.ConcretizationCache(str(use_concretization_cache))
+    cache.root.mkdir(parents=True, exist_ok=True)
+    old_mode = cache.root.stat().st_mode
+    os.chmod(cache.root, 0o555)
+    try:
+        # existing but read-only cache root
+        cache.store("read-only store test", Result(specs=[]), statistics=[])
+        assert not cache._cache_path_from_problem("read-only store test").exists()
+
+        # missing cache root that can't be created because its parent is read-only
+        nested = spack.solver.asp.ConcretizationCache(str(cache.root / "sub"))
+        nested.store("read-only mkdir test", Result(specs=[]), statistics=[])
+        assert not nested.root.exists()
+    finally:
+        os.chmod(cache.root, old_mode)
 
 
 def test_concretization_cache_skips_automatic_splice(

--- a/lib/spack/spack/test/concretization/core.py
+++ b/lib/spack/spack/test/concretization/core.py
@@ -41,6 +41,7 @@ import spack.spec
 import spack.spec_filter
 import spack.traverse
 import spack.util.file_cache
+import spack.util.filesystem
 import spack.util.hash
 import spack.util.lang
 import spack.util.spack_yaml as syaml
@@ -5435,20 +5436,20 @@ def test_concretization_cache_store_cleans_temp_on_error(use_concretization_cach
     cache = spack.solver.asp.ConcretizationCache(str(use_concretization_cache))
     problem = "write failure test"
 
-    def failing_replace(src, dst):
-        raise OSError("replace failed")
+    def failing_rename(src, dst):
+        raise OSError("rename failed")
 
-    monkeypatch.setattr(os, "replace", failing_replace)
+    monkeypatch.setattr(spack.util.filesystem, "rename", failing_rename)
 
-    # store() must not raise even though os.replace did
+    # store() must not raise even though the final rename did
     cache.store(problem, Result(specs=[]), statistics=[])
 
     # The final cache path should not exist
     cache_path = cache._cache_path_from_problem(problem)
     assert not cache_path.exists()
 
-    # No leftover temp files
-    temps = list(cache.root.glob(".tmp_*"))
+    # No leftover temp files (in-flight temp files are dot-prefixed)
+    temps = [p for p in cache.root.iterdir() if p.name.startswith(".")]
     assert temps == []
 
 
@@ -5496,6 +5497,24 @@ def test_concretization_cache_store_readonly_cache(use_concretization_cache):
         assert not nested.root.exists()
     finally:
         os.chmod(cache.root, old_mode)
+
+
+@pytest.mark.not_on_windows("test checks POSIX permissions")
+def test_concretization_cache_entries_follow_umask(use_concretization_cache):
+    """Cache directories and entries follow the umask, so a shared read/write
+    cache gets group-usable entries without external fixups."""
+    cache = spack.solver.asp.ConcretizationCache(str(use_concretization_cache))
+
+    # typical umask for a setgid, group-writable shared cache
+    old_umask = os.umask(0o007)
+    try:
+        cache.store("umask problem", Result(specs=[]), statistics=[])
+    finally:
+        os.umask(old_umask)
+
+    assert cache.root.stat().st_mode & 0o777 == 0o770
+    entry = cache._cache_path_from_problem("umask problem")
+    assert entry.stat().st_mode & 0o777 == 0o660
 
 
 def test_concretization_cache_skips_automatic_splice(


### PR DESCRIPTION
The concretization cache couldn't be shared among users on a machine: entries were always written with `mkstemp()`'s 0o600 mode, so nobody but the populating user could read them.

This is split into two commits: the first makes Spack *tolerate* read-only caches (a user with only read access degrades gracefully instead of crashing on both hits and misses), and the second lets the umask and directory setup determine who can use a cache:

- [x] write entries with `write_tmp_and_move()`, which respects the umask, instead of `mkstemp()`
- [x] document read-only sharing (umask) and read/write sharing (setgid directory plus a default ACL) in the config docs

Assisted-By: Claude <noreply@anthropic.com>
