### PR TITLE
audit: ensure @when and @run_* are not used on the same method

### DIFF
--- a/lib/spack/spack/audit.py
+++ b/lib/spack/spack/audit.py
@@ -47,7 +47,7 @@ import pathlib
 import pickle
 import re
 import warnings
-from typing import Iterable, List, Set, Tuple
+from typing import Iterable, List, Optional, Set, Tuple
 from urllib.request import urlopen
 
 import spack.builder
@@ -820,6 +820,50 @@ def _uses_deprecated_globals(pkgs, error_cls):
                         for name, line in visitor.references_to_globals
                     ],
                 )
+            )
+
+    return errors
+
+
+#: Decorators registering a phase callback, which accept a ``when=`` argument
+PHASE_CALLBACK_DECORATORS = ("run_before", "run_after")
+
+
+def _decorator_name(node: ast.expr) -> Optional[str]:
+    """Return the name of the callable used as a decorator, or None if it cannot be determined."""
+    if isinstance(node, ast.Call):
+        node = node.func
+    if isinstance(node, ast.Attribute):
+        return node.attr
+    if isinstance(node, ast.Name):
+        return node.id
+    return None
+
+
+@package_properties
+def _ensure_when_is_not_combined_with_phase_callbacks(pkgs, error_cls):
+    """Ensure @when is not used on the same method as @run_before or @run_after."""
+    errors = []
+    for pkg_name in pkgs:
+        file = spack.repo.PATH.filename_for_package_name(pkg_name)
+        tree = ast.parse(open(file, "rb").read())
+        details = []
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.FunctionDef):
+                continue
+            decorators = [_decorator_name(d) for d in node.decorator_list]
+            if "when" not in decorators:
+                continue
+            for name in decorators:
+                if name in PHASE_CALLBACK_DECORATORS:
+                    details.append(
+                        f"{file}:{node.lineno} '{node.name}' is decorated with both @when and "
+                        f"@{name}, pass the condition to @{name}(..., when=...) instead"
+                    )
+
+        if details:
+            errors.append(
+                error_cls(f"Package '{pkg_name}' combines @when with a phase callback", details)
             )
 
     return errors

--- a/lib/spack/spack/test/audit.py
+++ b/lib/spack/spack/test/audit.py
@@ -121,3 +121,15 @@ def test_config_audits(
     with mutable_config.override(config_section, data):
         reports = spack.audit.run_group("configs")
         assert any((check == failing_check) and errors for check, errors in reports)
+
+
+def test_when_combined_with_phase_callbacks(mock_packages):
+    """Ensure @when on a method decorated with @run_before or @run_after is reported"""
+    errors = spack.audit.run_check("PKG-PROPERTIES", pkgs=["fail-test-audit-when-callback"])
+    details = [d for e in errors for d in e.details]
+    assert any(
+        "'callback_outside' is decorated with both @when and @run_before" in d for d in details
+    )
+    assert any(
+        "'callback_inside' is decorated with both @when and @run_after" in d for d in details
+    )

--- a/var/spack/test_repos/spack_repo/builtin_mock/packages/fail_test_audit_when_callback/package.py
+++ b/var/spack/test_repos/spack_repo/builtin_mock/packages/fail_test_audit_when_callback/package.py
@@ -1,0 +1,25 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+from spack_repo.builtin_mock.build_systems.makefile import MakefilePackage
+
+from spack.package import *
+
+
+class FailTestAuditWhenCallback(MakefilePackage):
+    """Simple package combining @when with phase callback decorators."""
+
+    homepage = "http://github.com/dummy/fail-test-audit-when-callback"
+    url = "https://github.com/dummy/fail-test-audit-when-callback/archive/v1.0.tar.gz"
+
+    version("1.0", sha256="abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234")
+
+    @run_before("build")
+    @when("@1.0:")
+    def callback_outside(self):
+        pass
+
+    @when("@1.0:")
+    @run_after("install")
+    def callback_inside(self):
+        pass


### PR DESCRIPTION
The `run_after` and `run_before` decorators have a `when=` argument that should be used instead. 

On `builtin` it currently reports:
```console
$ spack audit packages
PKG-DIRECTIVES: passed
PKG-ATTRIBUTES: passed
PKG-PROPERTIES: 9 issues found
1. Package 'crtm' combines @when with a phase callback
    /home/culpo/spack-packages/repos/spack_repo/builtin/packages/crtm/package.py:133 'cmake_config_softlinks' is decorated with both @when and @run_after, pass the condition to @run_after(..., when=...) instead
2. Package 'gurobi' combines @when with a phase callback
    /home/culpo/spack-packages/repos/spack_repo/builtin/packages/gurobi/package.py:67 'gurobipy' is decorated with both @when and @run_after, pass the condition to @run_after(..., when=...) instead
3. Package 'mapl' combines @when with a phase callback
    /home/culpo/spack-packages/repos/spack_repo/builtin/packages/mapl/package.py:571 'check' is decorated with both @when and @run_after, pass the condition to @run_after(..., when=...) instead
4. Package 'nest' combines @when with a phase callback
    /home/culpo/spack-packages/repos/spack_repo/builtin/packages/nest/package.py:131 'install_headers' is decorated with both @when and @run_after, pass the condition to @run_after(..., when=...) instead
5. Package 'openfoam' combines @when with a phase callback
    /home/culpo/spack-packages/repos/spack_repo/builtin/packages/openfoam/package.py:652 'make_amd_rules' is decorated with both @when and @run_before, pass the condition to @run_before(..., when=...) instead
    /home/culpo/spack-packages/repos/spack_repo/builtin/packages/openfoam/package.py:665 'make_fujitsu_rules' is decorated with both @when and @run_before, pass the condition to @run_before(..., when=...) instead
6. Package 'py-matplotlib' combines @when with a phase callback
    /home/culpo/spack-packages/repos/spack_repo/builtin/packages/py_matplotlib/package.py:384 'configure' is decorated with both @when and @run_before, pass the condition to @run_before(..., when=...) instead
7. Package 'py-metatensor-torch' combines @when with a phase callback
    /home/culpo/spack-packages/repos/spack_repo/builtin/packages/py_metatensor_torch/package.py:63 'workaround' is decorated with both @when and @run_after, pass the condition to @run_after(..., when=...) instead
8. Package 'py-nbconvert' combines @when with a phase callback
    /home/culpo/spack-packages/repos/spack_repo/builtin/packages/py_nbconvert/package.py:123 'install_css' is decorated with both @when and @run_before, pass the condition to @run_before(..., when=...) instead
9. Package 'py-numpy' combines @when with a phase callback
    /home/culpo/spack-packages/repos/spack_repo/builtin/packages/py_numpy/package.py:525 'set_blas_lapack' is decorated with both @when and @run_before, pass the condition to @run_before(..., when=...) instead

```