### PR TITLE
filesystem.py: prefer fd over path, and more

### DIFF
--- a/lib/spack/spack/test/util/filesystem.py
+++ b/lib/spack/spack/test/util/filesystem.py
@@ -1069,6 +1069,33 @@ def test_rename_dest_exists(tmp_path: pathlib.Path):
         shutil.rmtree(str(f_dir))
 
 
+def test_force_symlink_replaces_existing(tmp_path: pathlib.Path):
+    target, other = tmp_path / "target", tmp_path / "other"
+    target.write_text("target", encoding="utf-8")
+    other.write_text("other", encoding="utf-8")
+
+    # over a regular file
+    link = tmp_path / "link"
+    link.write_text("stale", encoding="utf-8")
+    fs.force_symlink(str(target), str(link))
+    assert link.read_text(encoding="utf-8") == "target"
+
+    # over an existing link
+    fs.force_symlink(str(other), str(link))
+    assert link.read_text(encoding="utf-8") == "other"
+
+
+@pytest.mark.not_on_windows("the Windows symlink shim raises its own error type here")
+def test_force_symlink_propagates_other_errors(tmp_path: pathlib.Path):
+    """Only "the link exists" is retried; other errors propagate."""
+    target = tmp_path / "target"
+    target.write_text("target", encoding="utf-8")
+    with pytest.raises(FileNotFoundError) as exc_info:
+        fs.force_symlink(str(target), str(tmp_path / "missing" / "link"))
+    # the symlink call reports its src argument as filename
+    assert exc_info.value.filename == str(target)
+
+
 @pytest.mark.only_windows("Test is for Windows specific behavior")
 def test_windows_sfn(tmp_path: pathlib.Path):
     # first check some standard Windows locations

--- a/lib/spack/spack/util/filesystem.py
+++ b/lib/spack/spack/util/filesystem.py
@@ -1222,7 +1222,8 @@ def write_tmp_and_move(
     try:
         with f:
             try:
-                os.chmod(tmp, stat.S_IMODE(os.stat(filename).st_mode))
+                existing_mode = stat.S_IMODE(os.stat(filename).st_mode)
+                os.chmod(f.fileno() if os.chmod in os.supports_fd else tmp, existing_mode)
             except FileNotFoundError:
                 pass
             yield f

--- a/lib/spack/spack/util/filesystem.py
+++ b/lib/spack/spack/util/filesystem.py
@@ -329,8 +329,11 @@ def filter_file(
     Args:
         regex: The regular expression to search for
         repl: The string to replace matches with
-        *filenames: One or more files to search and replace string: Treat regex as a plain string.
-            Default it False backup: Make backup file(s) suffixed with ``~``. Default is False
+        *filenames: One or more files to search and replace
+        string: Treat regex as a plain string. Default is False
+        backup: Keep the copy of the original that is made before filtering instead of deleting
+            it. The copy is a temporary file next to the original, with a generated name. Default
+            is False
         ignore_absent: Ignore any files that don't exist. Default is False
         start_at: Marker used to start applying the replacements. If a text line matches this
             marker filtering is started at the next line. All contents before the marker and the

--- a/lib/spack/spack/util/filesystem.py
+++ b/lib/spack/spack/util/filesystem.py
@@ -1267,7 +1267,7 @@ def force_symlink(src: str, dest: str) -> None:
     """Create a symlink at ``dest`` pointing to ``src``. Similar to ``ln -sf``."""
     try:
         symlink(src, dest)
-    except OSError:
+    except (FileExistsError, AlreadyExistsError):
         os.remove(dest)
         symlink(src, dest)
 

--- a/lib/spack/spack/util/filesystem.py
+++ b/lib/spack/spack/util/filesystem.py
@@ -1246,7 +1246,7 @@ def touch(path):
     fd = None
     try:
         fd = os.open(path, perms)
-        os.utime(path, None)
+        os.utime(fd if os.utime in os.supports_fd else path, None)
     finally:
         if fd is not None:
             os.close(fd)


### PR DESCRIPTION
The most important fix is the first commit, which fixes a TOCTOU bug where
there's a gap between file creation and chmod in which an attacker with write
access to the dir can replace the file with a symlink to a user's file, making
it for example world readable. (This is a minor issue because the temporary
file has a non-deterministic name, but still a bug.)

Otherwise it's just small fixes.
