### PR TITLE
filesystem.py: windows fixes

### DIFF
--- a/lib/spack/spack/test/util/filesystem.py
+++ b/lib/spack/spack/test/util/filesystem.py
@@ -590,6 +590,22 @@ def test_filter_files_start_stop(tmp_path: pathlib.Path):
         assert all("X" == line.strip() for line in f.readlines())
 
 
+def _raise_on_replacement(match):
+    raise ZeroDivisionError("boom")
+
+
+def test_filter_file_restores_original_on_error(tmp_path: pathlib.Path):
+    path = tmp_path / "file.txt"
+    path.write_text("hello world\n", encoding="utf-8")
+
+    with pytest.raises(ZeroDivisionError):
+        fs.filter_file("world", _raise_on_replacement, str(path))
+
+    assert path.read_text(encoding="utf-8") == "hello world\n"
+    # the copy taken before filtering is the file that was put back
+    assert [p.name for p in tmp_path.iterdir()] == ["file.txt"]
+
+
 # Each test input is a tuple of entries which prescribe
 # - the 'subdirs' to be created from tmp_path
 # - the 'files' in that directory

--- a/lib/spack/spack/util/filesystem.py
+++ b/lib/spack/spack/util/filesystem.py
@@ -399,7 +399,7 @@ def filter_file(
 
         except BaseException:
             # restore the original file
-            os.rename(temp_path, path)
+            rename(temp_path, path)
             errored = True
             raise
 

--- a/lib/spack/spack/util/filesystem.py
+++ b/lib/spack/spack/util/filesystem.py
@@ -3250,7 +3250,7 @@ def _windows_read_hard_link(link: str) -> str:
         raise SymlinkError("Can't read hard link on non-Windows OS.")
     link = os.path.abspath(link)
     fsutil_cmd = ["fsutil", "hardlink", "list", link]
-    proc = subprocess.Popen(fsutil_cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True)
+    proc = subprocess.Popen(fsutil_cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     out, err = proc.communicate()
     if proc.returncode != 0:
         raise SymlinkError(f"An error occurred while reading hard link: {err.decode()}")
@@ -3276,8 +3276,9 @@ def _windows_read_junction(link: str):
     link = os.path.abspath(link)
     link_basename = os.path.basename(link)
     link_parent = os.path.dirname(link)
-    fsutil_cmd = ["dir", "/a:l", link_parent]
-    proc = subprocess.Popen(fsutil_cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True)
+    # dir is a cmd builtin
+    cmd = ["cmd", "/C", "dir", "/a:l", link_parent]
+    proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     out, err = proc.communicate()
     if proc.returncode != 0:
         raise SymlinkError(f"An error occurred while reading junction: {err.decode()}")


### PR DESCRIPTION
The `shell=True` bit is unsafe for certain inputs; use `rename` over `os.rename` for Windows support.
