### PR TITLE
directives: reduce allocations from package recipes

### DIFF
--- a/lib/spack/docs/conf.py
+++ b/lib/spack/docs/conf.py
@@ -361,6 +361,7 @@ nitpick_ignore = [
     ("py:class", "posix.DirEntry"),
     # Spack classes that are private and we don't want to expose
     ("py:class", "spack_repo.builtin.build_systems._checks.BuilderWithDefaults"),
+    ("py:class", "spack.directives._Patch"),
     ("py:class", "spack.repo._PrependFileLoader"),
     # Spack classes that intersphinx is unable to resolve
     ("py:class", "BuildStatus"),

--- a/lib/spack/spack/dependency.py
+++ b/lib/spack/spack/dependency.py
@@ -3,13 +3,12 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 """Data structures that represent Spack's dependency relationships."""
 
-from typing import TYPE_CHECKING, Dict, List, Optional, Type
+from typing import TYPE_CHECKING, Dict, List, Optional
 
 import spack.deptypes as dt
 import spack.spec
 
 if TYPE_CHECKING:
-    import spack.package_base
     import spack.patch
 
 
@@ -40,22 +39,15 @@ class Dependency:
 
     """
 
-    __slots__ = "pkg", "spec", "patches", "depflag"
+    __slots__ = "spec", "patches", "depflag"
 
-    def __init__(
-        self,
-        pkg: Type["spack.package_base.PackageBase"],
-        spec: spack.spec.Spec,
-        depflag: dt.DepFlag = dt.DEFAULT,
-    ):
+    def __init__(self, spec: spack.spec.Spec, depflag: dt.DepFlag = dt.DEFAULT):
         """Create a new Dependency.
 
         Args:
-            pkg: Package that has this dependency
             spec: Spec indicating dependency requirements
-            type: strings describing dependency relationship
+            depflag: flags describing the dependency relationship
         """
-        self.pkg = pkg
         self.spec = spec
 
         # Maps condition specs to lists of Patch objects, as the patches dict on packages
@@ -72,6 +64,6 @@ class Dependency:
     def __repr__(self) -> str:
         types = dt.flag_to_chars(self.depflag)
         if self.patches:
-            return f"<Dependency: {self.pkg.name} -> {self.spec} [{types}, {self.patches}]>"
+            return f"<Dependency: {self.spec} [{types}, {self.patches}]>"
         else:
-            return f"<Dependency: {self.pkg.name} -> {self.spec} [{types}]>"
+            return f"<Dependency: {self.spec} [{types}]>"

--- a/lib/spack/spack/dependency.py
+++ b/lib/spack/spack/dependency.py
@@ -3,13 +3,29 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 """Data structures that represent Spack's dependency relationships."""
 
-from typing import TYPE_CHECKING, Dict, List, Optional
+from typing import TYPE_CHECKING, Dict, List, Optional, Tuple
 
 import spack.deptypes as dt
 import spack.spec
 
 if TYPE_CHECKING:
     import spack.patch
+
+
+#: Recipes declare the same requirement over and over: a trilinos solve holds 24.7k Dependency
+#: objects with 11.4k distinct (spec, depflag) pairs.
+_DEPENDENCY_CACHE: Dict[Tuple[str, dt.DepFlag], "Dependency"] = {}
+
+
+def intern_dependency(dependency: "Dependency") -> "Dependency":
+    """Return the shared Dependency equal to ``dependency``. Only unpatched dependencies are
+    shared, since patches are attached per dependent package."""
+    key = (str(dependency.spec), dependency.depflag)
+    cached = _DEPENDENCY_CACHE.get(key)
+    if cached is not None:
+        return cached
+    _DEPENDENCY_CACHE[key] = dependency
+    return dependency
 
 
 class Dependency:

--- a/lib/spack/spack/dependency.py
+++ b/lib/spack/spack/dependency.py
@@ -12,8 +12,8 @@ if TYPE_CHECKING:
     import spack.patch
 
 
-#: Recipes declare the same requirement over and over: a trilinos solve holds 24.7k Dependency
-#: objects with 11.4k distinct (spec, depflag) pairs.
+#: Recipes declare the same requirement over and over, so equal unpatched dependencies are one
+#: object; see :func:`intern_dependency`.
 _DEPENDENCY_CACHE: Dict[Tuple[str, dt.DepFlag], "Dependency"] = {}
 
 
@@ -67,8 +67,7 @@ class Dependency:
         self.spec = spec
 
         # Maps condition specs to lists of Patch objects, as the patches dict on packages
-        # does. None until a patch is actually attached: only a handful of packages patch
-        # their dependencies, and an empty dict per Dependency is a large share of the heap.
+        # does. None until a patch directive attaches one, which few packages do.
         self.patches: Optional[Dict[spack.spec.Spec, List["spack.patch.Patch"]]] = None
         self.depflag = depflag
 

--- a/lib/spack/spack/dependency.py
+++ b/lib/spack/spack/dependency.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 """Data structures that represent Spack's dependency relationships."""
 
-from typing import TYPE_CHECKING, Dict, List, Type
+from typing import TYPE_CHECKING, Dict, List, Optional, Type
 
 import spack.deptypes as dt
 import spack.spec
@@ -58,9 +58,10 @@ class Dependency:
         self.pkg = pkg
         self.spec = spec
 
-        # This dict maps condition specs to lists of Patch objects, just
-        # as the patches dict on packages does.
-        self.patches: Dict[spack.spec.Spec, List["spack.patch.Patch"]] = {}
+        # Maps condition specs to lists of Patch objects, as the patches dict on packages
+        # does. None until a patch is actually attached: only a handful of packages patch
+        # their dependencies, and an empty dict per Dependency is a large share of the heap.
+        self.patches: Optional[Dict[spack.spec.Spec, List["spack.patch.Patch"]]] = None
         self.depflag = depflag
 
     @property

--- a/lib/spack/spack/directives.py
+++ b/lib/spack/spack/directives.py
@@ -152,9 +152,9 @@ def _make_when_spec(value: Union[WhenType, Tuple[str, ...]]) -> Optional[spack.s
     return get_spec(value)
 
 
-#: Nested `with when(...)` blocks reduce to the same spec over and over: a trilinos solve combines
-#: 6057 condition stacks drawn from 991 distinct ones. Combined when-specs are only ever used as
-#: keys of the package class dictionaries, like the single-condition ones `get_spec` shares.
+#: Nested `with when(...)` blocks reduce to the same spec over and over. Combined when-specs are
+#: only ever used as keys of the package class dictionaries, like the single-condition ones
+#: `get_spec` shares.
 _WHEN_STACK_CACHE: Dict[Tuple[str, ...], spack.spec.Spec] = {}
 
 

--- a/lib/spack/spack/directives.py
+++ b/lib/spack/spack/directives.py
@@ -29,15 +29,20 @@ The available directives are:
 * ``requires``
 * ``redistribute``
 
-They're implemented as functions that return a Directive holding the arguments, which is
-later executed with a package class as first argument::
+They're implemented as functions that return a NamedTuple holding the arguments, which is
+later called with a package class::
 
     @directive("example")
     def example_directive(arg1, arg2):
-        return Directive((_execute_example_directive, arg1, arg2))
+        return _Example(arg1, arg2)
 
-    def _execute_example_directive(pkg, arg1, arg2):
-        # modify pkg.example based on arg1 and arg2
+    class _Example(NamedTuple):
+        arg1: int
+        arg2: int
+
+        def __call__(self, pkg):
+            arg1, arg2 = self
+            # modify pkg.example based on arg1 and arg2
 """
 
 import collections
@@ -45,7 +50,7 @@ import collections.abc
 import os
 import re
 import warnings
-from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple, Type, Union
+from typing import Any, Callable, Dict, List, NamedTuple, Optional, Sequence, Tuple, Type, Union
 
 import spack.deptypes as dt
 import spack.error
@@ -57,7 +62,7 @@ import spack.util.crypto
 import spack.util.tty.color
 import spack.variant
 from spack.dependency import Dependency, intern_dependency
-from spack.directives_meta import Directive, DirectiveError, directive, get_spec
+from spack.directives_meta import DirectiveError, directive, get_spec
 from spack.resource import Resource
 from spack.spec import EMPTY_SPEC
 from spack.version import StandardVersion, VersionChecksumError, VersionError
@@ -88,7 +93,7 @@ SpecType = str
 DepType = Union[Tuple[str, ...], str]
 WhenType = Optional[Union[spack.spec.Spec, str, bool]]
 PackageType = Type[spack.package_base.PackageBase]
-PatchesType = Union[Directive, str, List[Union[Directive, str]]]
+PatchesType = Union["_Patch", str, List[Union["_Patch", str]]]
 
 
 def _make_when_spec(value: Union[WhenType, Tuple[str, ...]]) -> Optional[spack.spec.Spec]:
@@ -245,28 +250,33 @@ def version(
         )
         if value is not None
     }
-    return Directive((_execute_version, ver, kwargs))
+    return _Version(ver, kwargs)
 
 
-def _execute_version(pkg: PackageType, ver: Union[str, int], kwargs: dict):
-    if (
-        (any(s in kwargs for s in spack.util.crypto.hashes) or "checksum" in kwargs)
-        and hasattr(pkg, "has_code")
-        and not pkg.has_code
-    ):
-        raise VersionChecksumError(
-            f"{pkg.name}: Checksums not allowed in no-code packages (see '{ver}' version)."
-        )
+class _Version(NamedTuple):
+    ver: Union[str, int]
+    kwargs: dict
 
-    if not isinstance(ver, (int, str)):
-        raise VersionError(
-            f"{pkg.name}: declared version '{ver!r}' in package should be a string or int."
-        )
+    def __call__(self, pkg: PackageType) -> None:
+        ver, kwargs = self
+        if (
+            (any(s in kwargs for s in spack.util.crypto.hashes) or "checksum" in kwargs)
+            and hasattr(pkg, "has_code")
+            and not pkg.has_code
+        ):
+            raise VersionChecksumError(
+                f"{pkg.name}: Checksums not allowed in no-code packages (see '{ver}' version)."
+            )
 
-    version = StandardVersion.from_string(str(ver))
+        if not isinstance(ver, (int, str)):
+            raise VersionError(
+                f"{pkg.name}: declared version '{ver!r}' in package should be a string or int."
+            )
 
-    # Store kwargs for the package to later with a fetch_strategy.
-    pkg.versions[version] = kwargs
+        version = StandardVersion.from_string(str(ver))
+
+        # Store kwargs for the package to later with a fetch_strategy.
+        pkg.versions[version] = kwargs
 
 
 @directive("conflicts")
@@ -287,19 +297,25 @@ def conflicts(conflict_spec: SpecType, when: WhenType = None, msg: Optional[str]
         when: optional condition that triggers the conflict
         msg: optional user defined message
     """
-    return Directive((_execute_conflicts, conflict_spec, when, msg))
+    return _Conflicts(conflict_spec, when, msg)
 
 
-def _execute_conflicts(pkg: PackageType, conflict_spec, when, msg):
-    # If when is not specified the conflict always holds
-    when_spec = _make_when_spec(when)
-    if not when_spec:
-        return
+class _Conflicts(NamedTuple):
+    conflict_spec: SpecType
+    when: WhenType
+    msg: Optional[str]
 
-    # Save in a list the conflicts and the associated custom messages
-    conflict_spec_list = pkg.conflicts.setdefault(when_spec, [])
-    msg_with_name = f"{pkg.name}: {msg}" if msg is not None else msg
-    conflict_spec_list.append((get_spec(conflict_spec), msg_with_name))
+    def __call__(self, pkg: PackageType) -> None:
+        conflict_spec, when, msg = self
+        # If when is not specified the conflict always holds
+        when_spec = _make_when_spec(when)
+        if not when_spec:
+            return
+
+        # Save in a list the conflicts and the associated custom messages
+        conflict_spec_list = pkg.conflicts.setdefault(when_spec, [])
+        msg_with_name = f"{pkg.name}: {msg}" if msg is not None else msg
+        conflict_spec_list.append((get_spec(conflict_spec), msg_with_name))
 
 
 @directive("dependencies", can_patch_dependencies=True)
@@ -324,90 +340,88 @@ def depends_on(
         patches: single result of :py:func:`patch` directive, a
             ``str`` to be passed to ``patch``, or a list of these
     """
-    return Directive((_execute_depends_on, spec, when, type, patches))
+    return _DependsOn(spec, when, type, patches)
 
 
-def _execute_depends_on(
-    pkg: PackageType,
-    spec: Union[str, spack.spec.Spec],
-    when: WhenType = None,
-    type: DepType = dt.DEFAULT_TYPES,
-    patches: Optional[PatchesType] = None,
-):
-    spec = get_spec(spec) if isinstance(spec, str) else spec
-    when_spec = _make_when_spec(when)
-    if not when_spec:
-        return
+class _DependsOn(NamedTuple):
+    spec: Union[str, spack.spec.Spec]
+    when: WhenType = None
+    type: DepType = dt.DEFAULT_TYPES
+    patches: Optional[PatchesType] = None
 
-    if not spec.name:
-        raise DependencyError(
-            f"Invalid dependency specification in package '{pkg.name}':", str(spec)
-        )
-    if pkg.name == spec.name:
-        raise CircularReferenceError(f"Package '{pkg.name}' cannot depend on itself.")
+    def __call__(self, pkg: PackageType) -> None:
+        spec, when, type, patches = self
+        spec = get_spec(spec) if isinstance(spec, str) else spec
+        when_spec = _make_when_spec(when)
+        if not when_spec:
+            return
 
-    depflag = dt.canonicalize(type)
-
-    # call this patches here for clarity -- we want patch to be a list,
-    # but the caller doesn't have to make it one.
-
-    # Note: we cannot check whether a package is virtual in a directive
-    # because directives are run as part of class instantiation, and specs
-    # instantiate the package class as part of the `virtual` check.
-    # To be technical, specs only instantiate the package class as part of the
-    # virtual check if the provider index hasn't been created yet.
-    # TODO: There could be a cache warming strategy that would allow us to
-    # ensure `Spec.virtual` is a valid thing to call in a directive.
-    # For now, we comment out the following check to allow for virtual packages
-    # with package files.
-    # if patches and spec.virtual:
-    #     raise DependencyPatchError("Cannot patch a virtual dependency.")
-
-    # a single patch, given as a filename or as the result of the patch directive, stands for a
-    # one-element list. Directive is a tuple, so it has to be matched before the list check.
-    patch_list: Sequence[Union[Directive, str]]
-    if patches is None:
-        patch_list = ()
-    elif isinstance(patches, (str, Directive)):
-        patch_list = (patches,)
-    else:
-        patch_list = patches
-
-    # this is where we actually add the dependency to this package
-    deps_by_name = pkg.dependencies.setdefault(when_spec, {})
-    dependency = deps_by_name.get(spec.name)
-
-    edges = spec.edges_to_dependencies()
-    if edges and not all(x.direct for x in edges):
-        raise DirectiveError(
-            f"the '^' sigil cannot be used in 'depends_on' directives. Please reformulate "
-            f"the directive below as multiple directives:\n\n"
-            f'\tdepends_on("{spec}", when="{when_spec}")\n'
-        )
-
-    if not dependency:
-        dependency = Dependency(spec, depflag=depflag)
-    else:
-        merged_spec = dependency.spec.copy()
-        merged_spec.constrain(spec, deps=False)
-        # an existing Dependency may be shared with other packages, so build a new one
-        merged = Dependency(merged_spec, depflag=dependency.depflag | depflag)
-        merged.patches = dependency.patches
-        dependency = merged
-    deps_by_name[spec.name] = dependency
-
-    # apply patches to the dependency
-    for patch in patch_list:
-        if isinstance(patch, str):
-            _execute_patch(pkg, patch, dependency=dependency)
-        else:
-            assert isinstance(patch, Directive) and patch[0] is _execute_patch, (
-                f"Invalid patch argument: {patch!r}"
+        if not spec.name:
+            raise DependencyError(
+                f"Invalid dependency specification in package '{pkg.name}':", str(spec)
             )
-            _execute_patch(pkg, *patch[1:], dependency=dependency)
+        if pkg.name == spec.name:
+            raise CircularReferenceError(f"Package '{pkg.name}' cannot depend on itself.")
 
-    if dependency.patches is None:
-        deps_by_name[spec.name] = intern_dependency(dependency)
+        depflag = dt.canonicalize(type)
+
+        # call this patches here for clarity -- we want patch to be a list,
+        # but the caller doesn't have to make it one.
+
+        # Note: we cannot check whether a package is virtual in a directive
+        # because directives are run as part of class instantiation, and specs
+        # instantiate the package class as part of the `virtual` check.
+        # To be technical, specs only instantiate the package class as part of the
+        # virtual check if the provider index hasn't been created yet.
+        # TODO: There could be a cache warming strategy that would allow us to
+        # ensure `Spec.virtual` is a valid thing to call in a directive.
+        # For now, we comment out the following check to allow for virtual packages
+        # with package files.
+        # if patches and spec.virtual:
+        #     raise DependencyPatchError("Cannot patch a virtual dependency.")
+
+        # a single patch, given as a filename or as the result of the patch directive, stands for a
+        # one-element list. _Patch is a tuple, so it has to be matched before the list check.
+        patch_list: Sequence[Union[_Patch, str]]
+        if patches is None:
+            patch_list = ()
+        elif isinstance(patches, (str, _Patch)):
+            patch_list = (patches,)
+        else:
+            patch_list = patches
+
+        # this is where we actually add the dependency to this package
+        deps_by_name = pkg.dependencies.setdefault(when_spec, {})
+        dependency = deps_by_name.get(spec.name)
+
+        edges = spec.edges_to_dependencies()
+        if edges and not all(x.direct for x in edges):
+            raise DirectiveError(
+                f"the '^' sigil cannot be used in 'depends_on' directives. Please reformulate "
+                f"the directive below as multiple directives:\n\n"
+                f'\tdepends_on("{spec}", when="{when_spec}")\n'
+            )
+
+        if not dependency:
+            dependency = Dependency(spec, depflag=depflag)
+        else:
+            merged_spec = dependency.spec.copy()
+            merged_spec.constrain(spec, deps=False)
+            # an existing Dependency may be shared with other packages, so build a new one
+            merged = Dependency(merged_spec, depflag=dependency.depflag | depflag)
+            merged.patches = dependency.patches
+            dependency = merged
+        deps_by_name[spec.name] = dependency
+
+        # apply patches to the dependency
+        for patch in patch_list:
+            if isinstance(patch, str):
+                patch = _Patch(patch)
+            assert isinstance(patch, _Patch), f"Invalid patch argument: {patch!r}"
+            patch(pkg, dependency)
+
+        if dependency.patches is None:
+            deps_by_name[spec.name] = intern_dependency(dependency)
 
 
 @directive("disable_redistribute")
@@ -419,42 +433,47 @@ def redistribute(
     By default, packages allow source/binary distribution (in mirrors/build caches resp.).
     This directive allows users to explicitly disable redistribution for specs.
     """
-    return Directive((_execute_redistribute, source, binary, when))
+    return _Redistribute(source, binary, when)
 
 
-def _execute_redistribute(
-    pkg: PackageType, source: Optional[bool], binary: Optional[bool], when: WhenType
-):
-    if source is None and binary is None:
-        return
-    elif (source is True) or (binary is True):
-        raise DirectiveError(
-            "Source/binary distribution are true by default, they can only be explicitly disabled."
-        )
+class _Redistribute(NamedTuple):
+    source: Optional[bool]
+    binary: Optional[bool]
+    when: WhenType
 
-    if source is None:
-        source = True
-    if binary is None:
-        binary = True
+    def __call__(self, pkg: PackageType) -> None:
+        source, binary, when = self
+        if source is None and binary is None:
+            return
+        elif (source is True) or (binary is True):
+            raise DirectiveError(
+                "Source/binary distribution are true by default, they can only be "
+                "explicitly disabled."
+            )
 
-    when_spec = _make_when_spec(when)
-    if not when_spec:
-        return
-    if source is False:
-        max_constraint = get_spec(f"{pkg.name}@{when_spec.versions}")
-        if not max_constraint.satisfies(when_spec):
-            raise DirectiveError("Source distribution can only be disabled for versions")
+        if source is None:
+            source = True
+        if binary is None:
+            binary = True
 
-    if when_spec in pkg.disable_redistribute:
-        disable = pkg.disable_redistribute[when_spec]
-        if not source:
-            disable.source = True
-        if not binary:
-            disable.binary = True
-    else:
-        pkg.disable_redistribute[when_spec] = spack.package_base.DisableRedistribute(
-            source=not source, binary=not binary
-        )
+        when_spec = _make_when_spec(when)
+        if not when_spec:
+            return
+        if source is False:
+            max_constraint = get_spec(f"{pkg.name}@{when_spec.versions}")
+            if not max_constraint.satisfies(when_spec):
+                raise DirectiveError("Source distribution can only be disabled for versions")
+
+        if when_spec in pkg.disable_redistribute:
+            disable = pkg.disable_redistribute[when_spec]
+            if not source:
+                disable.source = True
+            if not binary:
+                disable.binary = True
+        else:
+            pkg.disable_redistribute[when_spec] = spack.package_base.DisableRedistribute(
+                source=not source, binary=not binary
+            )
 
 
 @directive(("extendees", "dependencies"), can_patch_dependencies=True)
@@ -473,26 +492,31 @@ def extends(
        Notice that the default ``type`` is ``("build", "run")``, which is different from
        :func:`depends_on` where the default is ``("build", "link")``."""
 
-    return Directive((_execute_extends, spec, when, type, patches))
+    return _Extends(spec, when, type, patches)
 
 
-def _execute_extends(
-    pkg: PackageType, spec: str, when: WhenType, type: DepType, patches: Optional[PatchesType]
-):
-    when_spec = _make_when_spec(when)
-    if not when_spec:
-        return
+class _Extends(NamedTuple):
+    spec: str
+    when: WhenType
+    type: DepType
+    patches: Optional[PatchesType]
 
-    dep_spec = get_spec(spec)
+    def __call__(self, pkg: PackageType) -> None:
+        spec, when, type, patches = self
+        when_spec = _make_when_spec(when)
+        if not when_spec:
+            return
 
-    _execute_depends_on(pkg, dep_spec, when=when, type=type, patches=patches)
+        dep_spec = get_spec(spec)
 
-    # When extending python, also add a dependency on python-venv. This is done so that
-    # Spack environment views are Python virtual environments.
-    if dep_spec.name == "python" and not pkg.name == "python-venv":
-        _execute_depends_on(pkg, "python-venv", when=when, type=("build", "run"))
+        _DependsOn(dep_spec, when=when, type=type, patches=patches)(pkg)
 
-    pkg.extendees[dep_spec.name] = (dep_spec, when_spec)
+        # When extending python, also add a dependency on python-venv. This is done so that
+        # Spack environment views are Python virtual environments.
+        if dep_spec.name == "python" and not pkg.name == "python-venv":
+            _DependsOn("python-venv", when=when, type=("build", "run"))(pkg)
+
+        pkg.extendees[dep_spec.name] = (dep_spec, when_spec)
 
 
 @directive(("provided", "provided_together"))
@@ -507,24 +531,29 @@ def provides(*specs: SpecType, when: WhenType = None):
         when: condition when this provides clause needs to be considered
     """
 
-    return Directive((_execute_provides, specs, when))
+    return _Provides(specs, when)
 
 
-def _execute_provides(pkg: PackageType, specs: Tuple[SpecType, ...], when: WhenType):
-    when_spec = _make_when_spec(when)
-    if not when_spec:
-        return
+class _Provides(NamedTuple):
+    specs: Tuple[SpecType, ...]
+    when: WhenType
 
-    spec_objs = [get_spec(x) for x in specs]
-    spec_names = [x.name for x in spec_objs]
-    if len(spec_names) > 1:
-        pkg.provided_together.setdefault(when_spec, []).append(set(spec_names))
+    def __call__(self, pkg: PackageType) -> None:
+        specs, when = self
+        when_spec = _make_when_spec(when)
+        if not when_spec:
+            return
 
-    for provided_spec in spec_objs:
-        if pkg.name == provided_spec.name:
-            raise CircularReferenceError(f"Package '{pkg.name}' cannot provide itself.")
+        spec_objs = [get_spec(x) for x in specs]
+        spec_names = [x.name for x in spec_objs]
+        if len(spec_names) > 1:
+            pkg.provided_together.setdefault(when_spec, []).append(set(spec_names))
 
-        pkg.provided.setdefault(when_spec, set()).add(provided_spec)
+        for provided_spec in spec_objs:
+            if pkg.name == provided_spec.name:
+                raise CircularReferenceError(f"Package '{pkg.name}' cannot provide itself.")
+
+            pkg.provided.setdefault(when_spec, set()).add(provided_spec)
 
 
 @directive("splice_specs")
@@ -547,22 +576,26 @@ def can_splice(
             be applied to multi-valued variants and multi-valued variants will be skipped by ``*``.
     """
 
-    return Directive((_execute_can_splice, target, when, match_variants))
+    return _CanSplice(target, when, match_variants)
 
 
-def _execute_can_splice(
-    pkg: PackageType, target: SpecType, when: SpecType, match_variants: Union[None, str, List[str]]
-):
-    when_spec = _make_when_spec(when)
-    if isinstance(match_variants, str) and match_variants != "*":
-        raise ValueError(
-            "* is the only valid string for match_variants "
-            "if looking to provide a single variant, use "
-            f"[{match_variants}] instead"
-        )
-    if when_spec is None:
-        return
-    pkg.splice_specs[when_spec] = (get_spec(target), match_variants)
+class _CanSplice(NamedTuple):
+    target: SpecType
+    when: SpecType
+    match_variants: Union[None, str, List[str]]
+
+    def __call__(self, pkg: PackageType) -> None:
+        target, when, match_variants = self
+        when_spec = _make_when_spec(when)
+        if isinstance(match_variants, str) and match_variants != "*":
+            raise ValueError(
+                "* is the only valid string for match_variants "
+                "if looking to provide a single variant, use "
+                f"[{match_variants}] instead"
+            )
+        if when_spec is None:
+            return
+        pkg.splice_specs[when_spec] = (get_spec(target), match_variants)
 
 
 @directive("patches")
@@ -574,7 +607,7 @@ def patch(
     reverse: bool = False,
     sha256: Optional[str] = None,
     archive_sha256: Optional[str] = None,
-) -> Directive:
+) -> "_Patch":
     """Declare a patch to apply to package sources. A when spec can be provided to indicate that a
     particular patch should only be applied when the package's spec meets certain conditions.
 
@@ -594,75 +627,64 @@ def patch(
             compressed URL patches)
     """
 
-    return Directive(
-        (
-            _execute_patch,
-            url_or_filename,
-            level,
-            when,
-            working_dir,
-            reverse,
-            sha256,
-            archive_sha256,
-        )
-    )
+    return _Patch(url_or_filename, level, when, working_dir, reverse, sha256, archive_sha256)
 
 
-def _execute_patch(
-    pkg: PackageType,
-    url_or_filename: str,
-    level: int = 1,
-    when: WhenType = None,
-    working_dir: str = ".",
-    reverse: bool = False,
-    sha256: Optional[str] = None,
-    archive_sha256: Optional[str] = None,
-    dependency: Optional[Dependency] = None,
-) -> None:
-    """``pkg`` is the package that declares the patch; the patch file is looked up in its
-    directory. The patch is added to ``dependency`` when set, otherwise to ``pkg`` itself."""
-    target: Union[PackageType, Dependency] = pkg if dependency is None else dependency
+class _Patch(NamedTuple):
+    url_or_filename: str
+    level: int = 1
+    when: WhenType = None
+    working_dir: str = "."
+    reverse: bool = False
+    sha256: Optional[str] = None
+    archive_sha256: Optional[str] = None
 
-    if hasattr(pkg, "has_code") and not pkg.has_code:
-        raise UnsupportedPackageDirective(
-            "Patches are not allowed in {0}: package has no code.".format(pkg.name)
-        )
+    def __call__(self, pkg: PackageType, dependency: Optional[Dependency] = None) -> None:
+        """``pkg`` is the package that declares the patch; the patch file is looked up in its
+        directory. The patch is added to ``dependency`` when set, otherwise to ``pkg`` itself."""
+        url_or_filename, level, when, working_dir, reverse, sha256, archive_sha256 = self
+        target: Union[PackageType, Dependency] = pkg if dependency is None else dependency
 
-    when_spec = _make_when_spec(when)
-    if not when_spec:
-        return
+        if hasattr(pkg, "has_code") and not pkg.has_code:
+            raise UnsupportedPackageDirective(
+                "Patches are not allowed in {0}: package has no code.".format(pkg.name)
+            )
 
-    # If this spec is identical to some other, then append this
-    # patch to the existing list.
-    if target.patches is None:
-        target.patches = {}
-    cur_patches = target.patches.setdefault(when_spec, [])
+        when_spec = _make_when_spec(when)
+        if not when_spec:
+            return
 
-    global _patch_order_index
-    ordering_key = (pkg.name, _patch_order_index)
-    _patch_order_index += 1
+        # If this spec is identical to some other, then append this
+        # patch to the existing list.
+        if target.patches is None:
+            target.patches = {}
+        cur_patches = target.patches.setdefault(when_spec, [])
 
-    patch: spack.patch.Patch
-    if "://" in url_or_filename:
-        if sha256 is None:
-            raise ValueError("patch() with a url requires a sha256")
+        global _patch_order_index
+        ordering_key = (pkg.name, _patch_order_index)
+        _patch_order_index += 1
 
-        patch = spack.patch.UrlPatch(
-            pkg,
-            url_or_filename,
-            level,
-            working_dir=working_dir,
-            reverse=reverse,
-            ordering_key=ordering_key,
-            sha256=sha256,
-            archive_sha256=archive_sha256,
-        )
-    else:
-        patch = spack.patch.FilePatch(
-            pkg, url_or_filename, level, working_dir, reverse, ordering_key=ordering_key
-        )
+        patch: spack.patch.Patch
+        if "://" in url_or_filename:
+            if sha256 is None:
+                raise ValueError("patch() with a url requires a sha256")
 
-    cur_patches.append(patch)
+            patch = spack.patch.UrlPatch(
+                pkg,
+                url_or_filename,
+                level,
+                working_dir=working_dir,
+                reverse=reverse,
+                ordering_key=ordering_key,
+                sha256=sha256,
+                archive_sha256=archive_sha256,
+            )
+        else:
+            patch = spack.patch.FilePatch(
+                pkg, url_or_filename, level, working_dir, reverse, ordering_key=ordering_key
+            )
+
+        cur_patches.append(patch)
 
 
 def conditional(*values: Union[str, bool], when: Optional[WhenType] = None):
@@ -706,9 +728,7 @@ def variant(
     Raises:
         spack.directives_meta.DirectiveError: If arguments passed to the directive are invalid
     """
-    return Directive(
-        (_execute_variant, name, default, description, values, multi, validator, when, sticky)
-    )
+    return _Variant(name, default, description, values, multi, validator, when, sticky)
 
 
 def _format_error(msg, pkg, name):
@@ -716,108 +736,108 @@ def _format_error(msg, pkg, name):
     return spack.util.tty.color.colorize(msg.format(pkg.name, name))
 
 
-def _execute_variant(
-    pkg: PackageType,
-    name: str,
-    default: Optional[Union[bool, str, Tuple[str, ...]]],
-    description: str,
-    values: Optional[Union[collections.abc.Sequence, Callable[[Any], bool]]],
-    multi: Optional[bool],
-    validator: Optional[Callable[[str, str, Tuple[Any, ...]], None]],
-    when: Optional[Union[str, bool]],
-    sticky: bool,
-):
+class _Variant(NamedTuple):
+    name: str
+    default: Optional[Union[bool, str, Tuple[str, ...]]]
+    description: str
+    values: Optional[Union[collections.abc.Sequence, Callable[[Any], bool]]]
+    multi: Optional[bool]
+    validator: Optional[Callable[[str, str, Tuple[Any, ...]], None]]
+    when: Optional[Union[str, bool]]
+    sticky: bool
 
-    # This validation can be removed at runtime and enforced with an audit in Spack v1.0.
-    # For now it's a warning to let people migrate faster.
-    if not (
-        default is None
-        or type(default) in (bool, str)
-        or (type(default) is tuple and all(type(x) is str for x in default))
-    ):
-        if isinstance(default, (list, tuple)):
-            did_you_mean = f"default={','.join(str(x) for x in default)!r}"
-        else:
-            did_you_mean = f"default={str(default)!r}"
-        warnings.warn(
-            f"default value for variant '{name}' is not a boolean or string: default={default!r}. "
-            f"Did you mean {did_you_mean}?",
-            stacklevel=3,
-            category=spack.error.SpackAPIWarning,
-        )
-
-    if name in spack.variant.RESERVED_NAMES:
-        raise DirectiveError(_format_error(f"The name '{name}' is reserved by Spack", pkg, name))
-
-    # Ensure we have a sequence of allowed variant values, or a
-    # predicate for it.
-    if values is None:
-        if (
-            default in (True, False)
-            or type(default) is str
-            and default.upper() in ("TRUE", "FALSE")
+    def __call__(self, pkg: PackageType) -> None:
+        name, default, description, values, multi, validator, when, sticky = self
+        if not (
+            default is None
+            or type(default) in (bool, str)
+            or (type(default) is tuple and all(type(x) is str for x in default))
         ):
-            values = (True, False)
-        else:
-            values = lambda x: True
-
-    # The object defining variant values might supply its own defaults for
-    # all the other arguments. Ensure we have no conflicting definitions
-    # in place.
-    for argument in ("default", "multi", "validator"):
-        # TODO: we can consider treating 'default' differently from other
-        # TODO: attributes and let a packager decide whether to use the fluent
-        # TODO: interface or the directive argument
-        if hasattr(values, argument) and locals()[argument] is not None:
-            raise DirectiveError(
-                _format_error(
-                    f"Remove specification of {argument} argument: it is handled "
-                    "by an attribute of the 'values' argument",
-                    pkg,
-                    name,
-                )
+            if isinstance(default, (list, tuple)):
+                did_you_mean = f"default={','.join(str(x) for x in default)!r}"
+            else:
+                did_you_mean = f"default={str(default)!r}"
+            warnings.warn(
+                f"default value for variant '{name}' is not a boolean or string: "
+                f"default={default!r}. Did you mean {did_you_mean}?",
+                stacklevel=3,
+                category=spack.error.SpackAPIWarning,
             )
 
-    # Allow for the object defining the allowed values to supply its own
-    # default value and group validator, say if it supports multiple values.
-    default = getattr(values, "default", default)
-    validator = getattr(values, "validator", validator)
-    multi = getattr(values, "multi", bool(multi))
+        if name in spack.variant.RESERVED_NAMES:
+            raise DirectiveError(
+                _format_error(f"The name '{name}' is reserved by Spack", pkg, name)
+            )
 
-    # Here we sanitize against a default value being either None
-    # or the empty string, as the former indicates that a default
-    # was not set while the latter will make the variant unparsable
-    # from the command line
-    if isinstance(default, tuple):
-        default = ",".join(default)
+        # Ensure we have a sequence of allowed variant values, or a
+        # predicate for it.
+        if values is None:
+            if (
+                default in (True, False)
+                or type(default) is str
+                and default.upper() in ("TRUE", "FALSE")
+            ):
+                values = (True, False)
+            else:
+                values = lambda x: True
 
-    if default is None or default == "":
-        if default is None:
-            msg = "either a default was not explicitly set, or 'None' was used"
-        else:
-            msg = "the default cannot be an empty string"
-        raise DirectiveError(_format_error(msg, pkg, name))
+        # The object defining variant values might supply its own defaults for
+        # all the other arguments. Ensure we have no conflicting definitions
+        # in place.
+        for argument, value in (("default", default), ("multi", multi), ("validator", validator)):
+            # TODO: we can consider treating 'default' differently from other
+            # TODO: attributes and let a packager decide whether to use the fluent
+            # TODO: interface or the directive argument
+            if hasattr(values, argument) and value is not None:
+                raise DirectiveError(
+                    _format_error(
+                        f"Remove specification of {argument} argument: it is handled "
+                        "by an attribute of the 'values' argument",
+                        pkg,
+                        name,
+                    )
+                )
 
-    description = str(description).strip()
-    when_spec = _make_when_spec(when)
+        # Allow for the object defining the allowed values to supply its own
+        # default value and group validator, say if it supports multiple values.
+        default = getattr(values, "default", default)
+        validator = getattr(values, "validator", validator)
+        multi = getattr(values, "multi", bool(multi))
 
-    if not re.match(spack.spec.IDENTIFIER_RE, name):
-        raise DirectiveError("variant", f"Invalid variant name in {pkg.name}: '{name}'")
+        # Here we sanitize against a default value being either None
+        # or the empty string, as the former indicates that a default
+        # was not set while the latter will make the variant unparsable
+        # from the command line
+        if isinstance(default, tuple):
+            default = ",".join(default)
 
-    # variants are stored by condition then by name (so only the last variant of a
-    # given name takes precedence *per condition*).
-    # NOTE: variant defaults and values can conflict if when conditions overlap.
-    variants_by_name = pkg.variants.setdefault(when_spec, {})  # type: ignore[arg-type]
-    variants_by_name[name] = spack.variant.Variant(
-        name=name,
-        default=default,
-        description=description,
-        values=values,
-        multi=multi,
-        validator=validator,
-        sticky=sticky,
-        precedence=pkg.num_variant_definitions(),
-    )
+        if default is None or default == "":
+            if default is None:
+                msg = "either a default was not explicitly set, or 'None' was used"
+            else:
+                msg = "the default cannot be an empty string"
+            raise DirectiveError(_format_error(msg, pkg, name))
+
+        description = str(description).strip()
+        when_spec = _make_when_spec(when)
+
+        if not re.match(spack.spec.IDENTIFIER_RE, name):
+            raise DirectiveError("variant", f"Invalid variant name in {pkg.name}: '{name}'")
+
+        # variants are stored by condition then by name (so only the last variant of a
+        # given name takes precedence *per condition*).
+        # NOTE: variant defaults and values can conflict if when conditions overlap.
+        variants_by_name = pkg.variants.setdefault(when_spec, {})  # type: ignore[arg-type]
+        variants_by_name[name] = spack.variant.Variant(
+            name=name,
+            default=default,
+            description=description,
+            values=values,
+            multi=multi,
+            validator=validator,
+            sticky=sticky,
+            precedence=pkg.num_variant_definitions(),
+        )
 
 
 @directive("resources")
@@ -844,43 +864,43 @@ def resource(
 
     """
 
-    return Directive((_execute_resource, name, destination, placement, when, kwargs))
+    return _Resource(name, destination, placement, when, kwargs)
 
 
-def _execute_resource(
-    pkg: PackageType,
-    name: Optional[str],
-    destination: str,
-    placement: Optional[str],
-    when: WhenType,
-    # additional kwargs are as for `version()`
-    kwargs: dict,
-):
-    when_spec = _make_when_spec(when)
-    if not when_spec:
-        return
+class _Resource(NamedTuple):
+    name: Optional[str]
+    destination: str
+    placement: Optional[str]
+    when: WhenType
+    kwargs: dict
 
-    # Check if the path is relative
-    if os.path.isabs(destination):
-        msg = "The destination keyword of a resource directive can't be an absolute path.\n"
-        msg += f"\tdestination : '{destination}\n'"
-        raise RuntimeError(msg)
+    def __call__(self, pkg: PackageType) -> None:
+        name, destination, placement, when, kwargs = self
+        when_spec = _make_when_spec(when)
+        if not when_spec:
+            return
 
-    # Check if the path falls within the main package stage area
-    test_path = "stage_folder_root"
+        # Check if the path is relative
+        if os.path.isabs(destination):
+            msg = "The destination keyword of a resource directive can't be an absolute path.\n"
+            msg += f"\tdestination : '{destination}\n'"
+            raise RuntimeError(msg)
 
-    # Normalized absolute path
-    normalized_destination = os.path.normpath(os.path.join(test_path, destination))
+        # Check if the path falls within the main package stage area
+        test_path = "stage_folder_root"
 
-    if test_path not in normalized_destination:
-        msg = "Destination of a resource must be within the package stage directory.\n"
-        msg += f"\tdestination : '{destination}'\n"
-        raise RuntimeError(msg)
+        # Normalized absolute path
+        normalized_destination = os.path.normpath(os.path.join(test_path, destination))
 
-    resources = pkg.resources.setdefault(when_spec, [])
-    resources.append(
-        Resource(name, spack.fetch_strategy.from_kwargs(**kwargs), destination, placement)
-    )
+        if test_path not in normalized_destination:
+            msg = "Destination of a resource must be within the package stage directory.\n"
+            msg += f"\tdestination : '{destination}'\n"
+            raise RuntimeError(msg)
+
+        resources = pkg.resources.setdefault(when_spec, [])
+        resources.append(
+            Resource(name, spack.fetch_strategy.from_kwargs(**kwargs), destination, placement)
+        )
 
 
 def build_system(*values, **kwargs):
@@ -907,13 +927,17 @@ def maintainers(*names: str):
     Args:
         names: GitHub username for the maintainer
     """
-    return Directive((_execute_maintainer, names))
+    return _Maintainers(names)
 
 
-def _execute_maintainer(pkg: PackageType, names: Tuple[str, ...]):
-    maintainers = set(pkg.maintainers)
-    maintainers.update(names)
-    pkg.maintainers = sorted(maintainers)
+class _Maintainers(NamedTuple):
+    names: Tuple[str, ...]
+
+    def __call__(self, pkg: PackageType) -> None:
+        (names,) = self
+        maintainers = set(pkg.maintainers)
+        maintainers.update(names)
+        pkg.maintainers = sorted(maintainers)
 
 
 @directive("licenses")
@@ -932,31 +956,36 @@ def license(
         when: A spec specifying when the license applies.
     """
 
-    return Directive((_execute_license, license_identifier, when))
+    return _License(license_identifier, when)
 
 
-def _execute_license(pkg: PackageType, license_identifier: str, when: Optional[Union[str, bool]]):
-    # If when is not specified the license always holds
-    when_spec = _make_when_spec(when)
-    if not when_spec:
-        return
+class _License(NamedTuple):
+    license_identifier: str
+    when: Optional[Union[str, bool]]
 
-    for other_when_spec in pkg.licenses:
-        if when_spec.intersects(other_when_spec):
-            when_message = ""
-            if when_spec != EMPTY_SPEC:
-                when_message = f"when {when_spec}"
-            other_when_message = ""
-            if other_when_spec != EMPTY_SPEC:
-                other_when_message = f"when {other_when_spec}"
-            err_msg = (
-                f"{pkg.name} is specified as being licensed as {license_identifier} "
-                f"{when_message}, but it is also specified as being licensed under "
-                f"{pkg.licenses[other_when_spec]} {other_when_message}, which conflict."
-            )
-            raise OverlappingLicenseError(err_msg)
+    def __call__(self, pkg: PackageType) -> None:
+        license_identifier, when = self
+        # If when is not specified the license always holds
+        when_spec = _make_when_spec(when)
+        if not when_spec:
+            return
 
-    pkg.licenses[when_spec] = license_identifier
+        for other_when_spec in pkg.licenses:
+            if when_spec.intersects(other_when_spec):
+                when_message = ""
+                if when_spec != EMPTY_SPEC:
+                    when_message = f"when {when_spec}"
+                other_when_message = ""
+                if other_when_spec != EMPTY_SPEC:
+                    other_when_message = f"when {other_when_spec}"
+                err_msg = (
+                    f"{pkg.name} is specified as being licensed as {license_identifier} "
+                    f"{when_message}, but it is also specified as being licensed under "
+                    f"{pkg.licenses[other_when_spec]} {other_when_message}, which conflict."
+                )
+                raise OverlappingLicenseError(err_msg)
+
+        pkg.licenses[when_spec] = license_identifier
 
 
 @directive("requirements")
@@ -986,32 +1015,33 @@ def requires(
         msg: optional user defined message
     """
 
-    return Directive((_execute_requires, requirement_specs, policy, when, msg))
+    return _Requires(requirement_specs, policy, when, msg)
 
 
-def _execute_requires(
-    pkg: PackageType,
-    requirement_specs: Tuple[str, ...],
-    policy: str,
-    when: Optional[str],
-    msg: Optional[str],
-):
-    if policy not in ("one_of", "any_of"):
-        err_msg = (
-            f"the 'policy' argument of the 'requires' directive in {pkg.name} is set "
-            f"to a wrong value (only 'one_of' or 'any_of' are allowed)"
-        )
-        raise DirectiveError(err_msg)
+class _Requires(NamedTuple):
+    requirement_specs: Tuple[str, ...]
+    policy: str
+    when: Optional[str]
+    msg: Optional[str]
 
-    when_spec = _make_when_spec(when)
-    if not when_spec:
-        return
+    def __call__(self, pkg: PackageType) -> None:
+        requirement_specs, policy, when, msg = self
+        if policy not in ("one_of", "any_of"):
+            err_msg = (
+                f"the 'policy' argument of the 'requires' directive in {pkg.name} is set "
+                f"to a wrong value (only 'one_of' or 'any_of' are allowed)"
+            )
+            raise DirectiveError(err_msg)
 
-    # Save in a list the requirements and the associated custom messages
-    requirement_list = pkg.requirements.setdefault(when_spec, [])
-    msg_with_name = f"{pkg.name}: {msg}" if msg is not None else msg
-    requirements = tuple(get_spec(s) for s in requirement_specs)
-    requirement_list.append((requirements, policy, msg_with_name))
+        when_spec = _make_when_spec(when)
+        if not when_spec:
+            return
+
+        # Save in a list the requirements and the associated custom messages
+        requirement_list = pkg.requirements.setdefault(when_spec, [])
+        msg_with_name = f"{pkg.name}: {msg}" if msg is not None else msg
+        requirements = tuple(get_spec(s) for s in requirement_specs)
+        requirement_list.append((requirements, policy, msg_with_name))
 
 
 class DependencyError(DirectiveError):

--- a/lib/spack/spack/directives.py
+++ b/lib/spack/spack/directives.py
@@ -612,6 +612,8 @@ def _execute_patch(
 
     # If this spec is identical to some other, then append this
     # patch to the existing list.
+    if pkg_or_dep.patches is None:
+        pkg_or_dep.patches = {}
     cur_patches = pkg_or_dep.patches.setdefault(when_spec, [])
 
     global _patch_order_index

--- a/lib/spack/spack/directives.py
+++ b/lib/spack/spack/directives.py
@@ -45,7 +45,7 @@ import collections.abc
 import os
 import re
 import warnings
-from typing import Any, Callable, List, Optional, Sequence, Tuple, Type, Union
+from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple, Type, Union
 
 import spack.deptypes as dt
 import spack.error
@@ -128,10 +128,13 @@ def _make_when_spec(value: Union[WhenType, Tuple[str, ...]]) -> Optional[spack.s
         # avoid a copy when there's only one condition
         if len(value) == 1:
             return get_spec(value[0])
-        # reduce the when-stack to a single spec by combining all constraints.
-        combined_spec = spack.spec.Spec(value[0])
-        for cond in value[1:]:
-            combined_spec._constrain_symbolically(get_spec(cond))
+        combined_spec = _WHEN_STACK_CACHE.get(value)
+        if combined_spec is None:
+            # reduce the when-stack to a single spec by combining all constraints.
+            combined_spec = spack.spec.Spec(value[0])
+            for cond in value[1:]:
+                combined_spec._constrain_symbolically(get_spec(cond))
+            _WHEN_STACK_CACHE[value] = combined_spec
         return combined_spec
 
     # Unsatisfiable conditions are discarded by the caller, and never
@@ -147,6 +150,12 @@ def _make_when_spec(value: Union[WhenType, Tuple[str, ...]]) -> Optional[spack.s
 
     # This is conditional on the spec
     return get_spec(value)
+
+
+#: Nested `with when(...)` blocks reduce to the same spec over and over: a trilinos solve combines
+#: 6057 condition stacks drawn from 991 distinct ones. Combined when-specs are only ever used as
+#: keys of the package class dictionaries, like the single-condition ones `get_spec` shares.
+_WHEN_STACK_CACHE: Dict[Tuple[str, ...], spack.spec.Spec] = {}
 
 
 SubmoduleCallback = Callable[[spack.package_base.PackageBase], Union[str, List[str], bool]]

--- a/lib/spack/spack/directives.py
+++ b/lib/spack/spack/directives.py
@@ -56,7 +56,7 @@ import spack.spec
 import spack.util.crypto
 import spack.util.tty.color
 import spack.variant
-from spack.dependency import Dependency
+from spack.dependency import Dependency, intern_dependency
 from spack.directives_meta import Directive, DirectiveError, directive, get_spec
 from spack.resource import Resource
 from spack.spec import EMPTY_SPEC
@@ -378,12 +378,14 @@ def _execute_depends_on(
 
     if not dependency:
         dependency = Dependency(spec, depflag=depflag)
-        deps_by_name[spec.name] = dependency
     else:
-        copy = dependency.spec.copy()
-        copy.constrain(spec, deps=False)
-        dependency.spec = copy
-        dependency.depflag |= depflag
+        merged_spec = dependency.spec.copy()
+        merged_spec.constrain(spec, deps=False)
+        # an existing Dependency may be shared with other packages, so build a new one
+        merged = Dependency(merged_spec, depflag=dependency.depflag | depflag)
+        merged.patches = dependency.patches
+        dependency = merged
+    deps_by_name[spec.name] = dependency
 
     # apply patches to the dependency
     for patch in patch_list:
@@ -394,6 +396,9 @@ def _execute_depends_on(
                 f"Invalid patch argument: {patch!r}"
             )
             _execute_patch(pkg, *patch[1:], dependency=dependency)
+
+    if dependency.patches is None:
+        deps_by_name[spec.name] = intern_dependency(dependency)
 
 
 @directive("disable_redistribute")

--- a/lib/spack/spack/directives.py
+++ b/lib/spack/spack/directives.py
@@ -29,12 +29,12 @@ The available directives are:
 * ``requires``
 * ``redistribute``
 
-They're implemented as functions that return partial functions that are later executed with a
-package class as first argument::
+They're implemented as functions that return a Directive holding the arguments, which is
+later executed with a package class as first argument::
 
     @directive("example")
     def example_directive(arg1, arg2):
-        return partial(_execute_example_directive, arg1=arg1, arg2=arg2)
+        return Directive((_execute_example_directive, arg1, arg2))
 
     def _execute_example_directive(pkg, arg1, arg2):
         # modify pkg.example based on arg1 and arg2
@@ -45,8 +45,7 @@ import collections.abc
 import os
 import re
 import warnings
-from functools import partial
-from typing import Any, Callable, List, Optional, Tuple, Type, Union
+from typing import Any, Callable, List, Optional, Sequence, Tuple, Type, Union
 
 import spack.deptypes as dt
 import spack.error
@@ -58,7 +57,7 @@ import spack.util.crypto
 import spack.util.tty.color
 import spack.variant
 from spack.dependency import Dependency
-from spack.directives_meta import DirectiveError, directive, get_spec
+from spack.directives_meta import Directive, DirectiveError, directive, get_spec
 from spack.resource import Resource
 from spack.spec import EMPTY_SPEC
 from spack.version import StandardVersion, VersionChecksumError, VersionError
@@ -89,8 +88,7 @@ SpecType = str
 DepType = Union[Tuple[str, ...], str]
 WhenType = Optional[Union[spack.spec.Spec, str, bool]]
 PackageType = Type[spack.package_base.PackageBase]
-Patcher = Callable[[Union[PackageType, Dependency]], None]
-PatchesType = Union[Patcher, str, List[Union[Patcher, str]]]
+PatchesType = Union[Directive, str, List[Union[Directive, str]]]
 
 
 def _make_when_spec(value: Union[WhenType, Tuple[str, ...]]) -> Optional[spack.spec.Spec]:
@@ -238,7 +236,7 @@ def version(
         )
         if value is not None
     }
-    return partial(_execute_version, ver=ver, kwargs=kwargs)
+    return Directive((_execute_version, ver, kwargs))
 
 
 def _execute_version(pkg: PackageType, ver: Union[str, int], kwargs: dict):
@@ -280,7 +278,7 @@ def conflicts(conflict_spec: SpecType, when: WhenType = None, msg: Optional[str]
         when: optional condition that triggers the conflict
         msg: optional user defined message
     """
-    return partial(_execute_conflicts, conflict_spec=conflict_spec, when=when, msg=msg)
+    return Directive((_execute_conflicts, conflict_spec, when, msg))
 
 
 def _execute_conflicts(pkg: PackageType, conflict_spec, when, msg):
@@ -317,13 +315,12 @@ def depends_on(
         patches: single result of :py:func:`patch` directive, a
             ``str`` to be passed to ``patch``, or a list of these
     """
-    return partial(_execute_depends_on, spec=spec, when=when, type=type, patches=patches)
+    return Directive((_execute_depends_on, spec, when, type, patches))
 
 
 def _execute_depends_on(
     pkg: PackageType,
     spec: Union[str, spack.spec.Spec],
-    *,
     when: WhenType = None,
     type: DepType = dt.DEFAULT_TYPES,
     patches: Optional[PatchesType] = None,
@@ -357,11 +354,15 @@ def _execute_depends_on(
     # if patches and spec.virtual:
     #     raise DependencyPatchError("Cannot patch a virtual dependency.")
 
-    # ensure patches is a list
+    # a single patch, given as a filename or as the result of the patch directive, stands for a
+    # one-element list. Directive is a tuple, so it has to be matched before the list check.
+    patch_list: Sequence[Union[Directive, str]]
     if patches is None:
-        patches = []
-    elif not isinstance(patches, (list, tuple)):
-        patches = [patches]
+        patch_list = ()
+    elif isinstance(patches, (str, Directive)):
+        patch_list = (patches,)
+    else:
+        patch_list = patches
 
     # this is where we actually add the dependency to this package
     deps_by_name = pkg.dependencies.setdefault(when_spec, {})
@@ -385,7 +386,7 @@ def _execute_depends_on(
         dependency.depflag |= depflag
 
     # apply patches to the dependency
-    for patch in patches:
+    for patch in patch_list:
         if isinstance(patch, str):
             _execute_patch(dependency, url_or_filename=patch)
         else:
@@ -402,7 +403,7 @@ def redistribute(
     By default, packages allow source/binary distribution (in mirrors/build caches resp.).
     This directive allows users to explicitly disable redistribution for specs.
     """
-    return partial(_execute_redistribute, source=source, binary=binary, when=when)
+    return Directive((_execute_redistribute, source, binary, when))
 
 
 def _execute_redistribute(
@@ -456,7 +457,7 @@ def extends(
        Notice that the default ``type`` is ``("build", "run")``, which is different from
        :func:`depends_on` where the default is ``("build", "link")``."""
 
-    return partial(_execute_extends, spec=spec, when=when, type=type, patches=patches)
+    return Directive((_execute_extends, spec, when, type, patches))
 
 
 def _execute_extends(
@@ -490,7 +491,7 @@ def provides(*specs: SpecType, when: WhenType = None):
         when: condition when this provides clause needs to be considered
     """
 
-    return partial(_execute_provides, specs=specs, when=when)
+    return Directive((_execute_provides, specs, when))
 
 
 def _execute_provides(pkg: PackageType, specs: Tuple[SpecType, ...], when: WhenType):
@@ -530,7 +531,7 @@ def can_splice(
             be applied to multi-valued variants and multi-valued variants will be skipped by ``*``.
     """
 
-    return partial(_execute_can_splice, target=target, when=when, match_variants=match_variants)
+    return Directive((_execute_can_splice, target, when, match_variants))
 
 
 def _execute_can_splice(
@@ -557,7 +558,7 @@ def patch(
     reverse: bool = False,
     sha256: Optional[str] = None,
     archive_sha256: Optional[str] = None,
-) -> Patcher:
+) -> Directive:
     """Declare a patch to apply to package sources. A when spec can be provided to indicate that a
     particular patch should only be applied when the package's spec meets certain conditions.
 
@@ -577,15 +578,17 @@ def patch(
             compressed URL patches)
     """
 
-    return partial(
-        _execute_patch,
-        when=when,
-        url_or_filename=url_or_filename,
-        level=level,
-        working_dir=working_dir,
-        reverse=reverse,
-        sha256=sha256,
-        archive_sha256=archive_sha256,
+    return Directive(
+        (
+            _execute_patch,
+            url_or_filename,
+            level,
+            when,
+            working_dir,
+            reverse,
+            sha256,
+            archive_sha256,
+        )
     )
 
 
@@ -684,16 +687,8 @@ def variant(
     Raises:
         spack.directives_meta.DirectiveError: If arguments passed to the directive are invalid
     """
-    return partial(
-        _execute_variant,
-        name=name,
-        default=default,
-        description=description,
-        values=values,
-        multi=multi,
-        validator=validator,
-        when=when,
-        sticky=sticky,
+    return Directive(
+        (_execute_variant, name, default, description, values, multi, validator, when, sticky)
     )
 
 
@@ -830,14 +825,7 @@ def resource(
 
     """
 
-    return partial(
-        _execute_resource,
-        name=name,
-        destination=destination,
-        placement=placement,
-        when=when,
-        kwargs=kwargs,
-    )
+    return Directive((_execute_resource, name, destination, placement, when, kwargs))
 
 
 def _execute_resource(
@@ -900,7 +888,7 @@ def maintainers(*names: str):
     Args:
         names: GitHub username for the maintainer
     """
-    return partial(_execute_maintainer, names=names)
+    return Directive((_execute_maintainer, names))
 
 
 def _execute_maintainer(pkg: PackageType, names: Tuple[str, ...]):
@@ -925,7 +913,7 @@ def license(
         when: A spec specifying when the license applies.
     """
 
-    return partial(_execute_license, license_identifier=license_identifier, when=when)
+    return Directive((_execute_license, license_identifier, when))
 
 
 def _execute_license(pkg: PackageType, license_identifier: str, when: Optional[Union[str, bool]]):
@@ -979,9 +967,7 @@ def requires(
         msg: optional user defined message
     """
 
-    return partial(
-        _execute_requires, requirement_specs=requirement_specs, policy=policy, when=when, msg=msg
-    )
+    return Directive((_execute_requires, requirement_specs, policy, when, msg))
 
 
 def _execute_requires(

--- a/lib/spack/spack/directives.py
+++ b/lib/spack/spack/directives.py
@@ -377,7 +377,7 @@ def _execute_depends_on(
         )
 
     if not dependency:
-        dependency = Dependency(pkg, spec, depflag=depflag)
+        dependency = Dependency(spec, depflag=depflag)
         deps_by_name[spec.name] = dependency
     else:
         copy = dependency.spec.copy()
@@ -388,10 +388,12 @@ def _execute_depends_on(
     # apply patches to the dependency
     for patch in patch_list:
         if isinstance(patch, str):
-            _execute_patch(dependency, url_or_filename=patch)
+            _execute_patch(pkg, patch, dependency=dependency)
         else:
-            assert callable(patch), f"Invalid patch argument: {patch!r}"
-            patch(dependency)
+            assert isinstance(patch, Directive) and patch[0] is _execute_patch, (
+                f"Invalid patch argument: {patch!r}"
+            )
+            _execute_patch(pkg, *patch[1:], dependency=dependency)
 
 
 @directive("disable_redistribute")
@@ -593,7 +595,7 @@ def patch(
 
 
 def _execute_patch(
-    pkg_or_dep: Union[PackageType, Dependency],
+    pkg: PackageType,
     url_or_filename: str,
     level: int = 1,
     when: WhenType = None,
@@ -601,8 +603,11 @@ def _execute_patch(
     reverse: bool = False,
     sha256: Optional[str] = None,
     archive_sha256: Optional[str] = None,
+    dependency: Optional[Dependency] = None,
 ) -> None:
-    pkg = pkg_or_dep.pkg if isinstance(pkg_or_dep, Dependency) else pkg_or_dep
+    """``pkg`` is the package that declares the patch; the patch file is looked up in its
+    directory. The patch is added to ``dependency`` when set, otherwise to ``pkg`` itself."""
+    target: Union[PackageType, Dependency] = pkg if dependency is None else dependency
 
     if hasattr(pkg, "has_code") and not pkg.has_code:
         raise UnsupportedPackageDirective(
@@ -615,9 +620,9 @@ def _execute_patch(
 
     # If this spec is identical to some other, then append this
     # patch to the existing list.
-    if pkg_or_dep.patches is None:
-        pkg_or_dep.patches = {}
-    cur_patches = pkg_or_dep.patches.setdefault(when_spec, [])
+    if target.patches is None:
+        target.patches = {}
+    cur_patches = target.patches.setdefault(when_spec, [])
 
     global _patch_order_index
     ordering_key = (pkg.name, _patch_order_index)

--- a/lib/spack/spack/directives_meta.py
+++ b/lib/spack/spack/directives_meta.py
@@ -33,9 +33,8 @@ def get_spec(spec_str: str) -> spack.spec.Spec:
 class Directive(tuple):
     """A directive queued for deferred execution: its function, followed by its arguments.
 
-    A tuple subclass so that a queued directive is one object; ``functools.partial`` is two, and
-    a solve holds tens of thousands of them. Code that sorts a directive result from a list of
-    them has to match this class before ``list``/``tuple``.
+    A tuple subclass, so that a queued directive is one object. Code that sorts a directive
+    result from a list of them has to match this class before ``list``/``tuple``.
     """
 
     __slots__ = ()

--- a/lib/spack/spack/directives_meta.py
+++ b/lib/spack/spack/directives_meta.py
@@ -29,15 +29,6 @@ def get_spec(spec_str: str) -> spack.spec.Spec:
     return SPEC_CACHE[spec_str]
 
 
-class Directive(tuple):
-    """A directive queued for deferred execution: its function, followed by its arguments."""
-
-    __slots__ = ()
-
-    def __call__(self, pkg):
-        return self[0](pkg, *self[1:])
-
-
 class DirectiveMeta(type):
     """Flushes the directives that were temporarily stored in the staging
     area into the package.
@@ -100,7 +91,7 @@ class DirectiveMeta(type):
             DirectiveMeta._dict_to_directives[d].append(name)
 
     @staticmethod
-    def _queued_directives(cls: type, name: str) -> Iterator[Directive]:
+    def _queued_directives(cls: type, name: str) -> Iterator[Callable]:
         """Directives of the given name queued for cls: base classes first, each class in the
         MRO once."""
         for klass in reversed(cls.__mro__):
@@ -142,7 +133,8 @@ class DirectiveMeta(type):
         # example of this is ``depends_on(..., patches=[patch(...), ...])``. In that case, we
         # should not execute those directives as part of the current package, but let the called
         # directive handle them. This function removes such directives from the execution queue.
-        if isinstance(value, (list, tuple)) and not isinstance(value, Directive):
+        # directive instances are callable tuples, so exclude them from the descent
+        if isinstance(value, (list, tuple)) and not callable(value):
             for item in value:
                 DirectiveMeta._remove_kwarg_value_directives_from_queue(item)
         elif callable(value):  # directives are always callable

--- a/lib/spack/spack/directives_meta.py
+++ b/lib/spack/spack/directives_meta.py
@@ -30,6 +30,24 @@ def get_spec(spec_str: str) -> spack.spec.Spec:
     return SPEC_CACHE[spec_str]
 
 
+class Directive(tuple):
+    """A directive queued for deferred execution: its function, followed by its arguments.
+
+    A tuple subclass so that a queued directive is one object; ``functools.partial`` is two, and
+    a solve holds tens of thousands of them. Code that sorts a directive result from a list of
+    them has to match this class before ``list``/``tuple``.
+    """
+
+    __slots__ = ()
+
+    #: Arguments may be unhashable (a version's kwargs dict), and dedupe compares queue entries.
+    __hash__ = object.__hash__
+    __eq__ = object.__eq__
+
+    def __call__(self, pkg):
+        return self[0](pkg, *self[1:])
+
+
 class DirectiveMeta(type):
     """Flushes the directives that were temporarily stored in the staging
     area into the package.
@@ -140,7 +158,7 @@ class DirectiveMeta(type):
         # example of this is ``depends_on(..., patches=[patch(...), ...])``. In that case, we
         # should not execute those directives as part of the current package, but let the called
         # directive handle them. This function removes such directives from the execution queue.
-        if isinstance(value, (list, tuple)):
+        if isinstance(value, (list, tuple)) and not isinstance(value, Directive):
             for item in value:
                 DirectiveMeta._remove_kwarg_value_directives_from_queue(item)
         elif callable(value):  # directives are always callable

--- a/lib/spack/spack/directives_meta.py
+++ b/lib/spack/spack/directives_meta.py
@@ -4,14 +4,13 @@
 
 import collections
 import functools
-from typing import Any, Callable, Dict, List, Set, Tuple, Type, TypeVar, Union
+from typing import Any, Callable, Dict, Iterator, List, Set, Tuple, Type, TypeVar, Union
 
 from spack.vendor.typing_extensions import ParamSpec
 
 import spack.error
 import spack.repo
 import spack.spec
-from spack.util.lang import dedupe
 
 P = ParamSpec("P")
 R = TypeVar("R")
@@ -31,17 +30,9 @@ def get_spec(spec_str: str) -> spack.spec.Spec:
 
 
 class Directive(tuple):
-    """A directive queued for deferred execution: its function, followed by its arguments.
-
-    A tuple subclass, so that a queued directive is one object. Code that sorts a directive
-    result from a list of them has to match this class before ``list``/``tuple``.
-    """
+    """A directive queued for deferred execution: its function, followed by its arguments."""
 
     __slots__ = ()
-
-    #: Arguments may be unhashable (a version's kwargs dict), and dedupe compares queue entries.
-    __hash__ = object.__hash__
-    __eq__ = object.__eq__
 
     def __call__(self, pkg):
         return self[0](pkg, *self[1:])
@@ -60,8 +51,9 @@ class DirectiveMeta(type):
     _descriptor_cache: Dict[str, "DirectiveDictDescriptor"] = {}
     #: Set of all known directive dictionary names from `@directive(dicts=...)`
     _directive_dict_names: Set[str] = set()
-    #: Lists of directives to be executed for the class being defined, grouped by directive
-    #: function name (e.g. "depends_on", "version", etc.)
+    #: Directives grouped by directive function name (e.g. "depends_on", "version", etc.). On
+    #: the metaclass this is the staging queue of the class body being executed; on a package
+    #: class it holds only the directives declared in that class's own body.
     _directives_to_be_executed: Dict[str, List[Callable]] = collections.defaultdict(list)
     #: Stack of when constraints from `with when(...)` context managers
     _when_constraints_stack: List[str] = []
@@ -78,23 +70,7 @@ class DirectiveMeta(type):
         cls: Type["DirectiveMeta"], name: str, bases: tuple, attr_dict: dict
     ) -> "DirectiveMeta":
         attr_dict["_patches_dependencies"] = DirectiveMeta._patches_dependencies
-        # Initialize the attribute containing the list of directives to be executed. Here we go
-        # reversed because we want to execute commands in the order they were defined, following
-        # the MRO.
-        merged: Dict[str, List[Callable]] = {}
-        sources = [getattr(b, "_directives_to_be_executed", None) or {} for b in reversed(bases)]
-        for source in sources:
-            for key, directive_list in source.items():
-                merged.setdefault(key, []).extend(directive_list)
-
-        merged = {key: list(dedupe(directive_list)) for key, directive_list in merged.items()}
-
-        # Add current class's directives (no deduplication needed here)
-        for key, directive_list in DirectiveMeta._directives_to_be_executed.items():
-            merged.setdefault(key, []).extend(directive_list)
-
-        attr_dict["_directives_to_be_executed"] = merged
-
+        attr_dict["_directives_to_be_executed"] = dict(DirectiveMeta._directives_to_be_executed)
         DirectiveMeta._directives_to_be_executed.clear()
         DirectiveMeta._patches_dependencies = False
 
@@ -112,7 +88,7 @@ class DirectiveMeta(type):
             # Historically, maintainers was not a directive. They were simply set as class
             # attributes `maintainers = ["alice", "bob"]`. Therefore, we execute these directives
             # eagerly.
-            for directive in cls._directives_to_be_executed.get("maintainers", ()):
+            for directive in DirectiveMeta._queued_directives(cls, "maintainers"):
                 directive(cls)
         super(DirectiveMeta, cls).__init__(name, bases, attr_dict)
 
@@ -122,6 +98,15 @@ class DirectiveMeta(type):
         DirectiveMeta._directive_to_dicts[name] = dicts
         for d in dicts:
             DirectiveMeta._dict_to_directives[d].append(name)
+
+    @staticmethod
+    def _queued_directives(cls: type, name: str) -> Iterator[Directive]:
+        """Directives of the given name queued for cls: base classes first, each class in the
+        MRO once."""
+        for klass in reversed(cls.__mro__):
+            own = klass.__dict__.get("_directives_to_be_executed")
+            if own:
+                yield from own.get(name, ())
 
     @staticmethod
     def _get_descriptor(name: str) -> "DirectiveDictDescriptor":
@@ -163,9 +148,9 @@ class DirectiveMeta(type):
         elif callable(value):  # directives are always callable
             # Remove directives args from the exec queue
             for lst in DirectiveMeta._directives_to_be_executed.values():
-                for directive in lst:
+                for i, directive in enumerate(lst):
                     if value is directive:
-                        lst.remove(directive)  # iterations ends, so mutation is fine
+                        del lst[i]
                         break
 
     @staticmethod
@@ -212,10 +197,8 @@ class DirectiveDictDescriptor:
 
         # Populate these dictionaries by running all directives that modify them
         for directive_name in self.directives_to_run:
-            directives = objtype._directives_to_be_executed.get(directive_name)
-            if directives:
-                for directive in directives:
-                    directive(objtype)
+            for directive in DirectiveMeta._queued_directives(objtype, directive_name):
+                directive(objtype)
 
         return getattr(objtype, self.private_name)
 

--- a/lib/spack/spack/package_base.py
+++ b/lib/spack/spack/package_base.py
@@ -1828,6 +1828,8 @@ class PackageBase(WindowsRPath, PackageViewMixin, metaclass=PackageMeta):
         pkg_deps = cls.dependencies
         for dep_name in pkg_deps:
             for _, dependency in pkg_deps[dep_name].items():
+                if not dependency.patches:
+                    continue
                 for _, patch_list in dependency.patches.items():
                     for patch in patch_list:
                         patches.append(patch)

--- a/lib/spack/spack/package_base.py
+++ b/lib/spack/spack/package_base.py
@@ -1814,28 +1814,6 @@ class PackageBase(WindowsRPath, PackageViewMixin, metaclass=PackageMeta):
             else:
                 fsys.touch(no_patches_file)
 
-    @classmethod
-    def all_patches(cls):
-        """Retrieve all patches associated with the package.
-
-        Retrieves patches on the package itself as well as patches on the
-        dependencies of the package."""
-        patches = []
-        for _, patch_list in cls.patches.items():
-            for patch in patch_list:
-                patches.append(patch)
-
-        pkg_deps = cls.dependencies
-        for dep_name in pkg_deps:
-            for _, dependency in pkg_deps[dep_name].items():
-                if not dependency.patches:
-                    continue
-                for _, patch_list in dependency.patches.items():
-                    for patch in patch_list:
-                        patches.append(patch)
-
-        return patches
-
     def content_hash(self, content: Optional[bytes] = None) -> str:
         """Create a hash based on the artifacts and patches used to build this package.
 

--- a/lib/spack/spack/patch.py
+++ b/lib/spack/spack/patch.py
@@ -549,6 +549,8 @@ class PatchCache:
 
         for deps_by_name in pkg_class.dependencies.values():
             for dependency in deps_by_name.values():
+                if not dependency.patches:
+                    continue
                 for patch_list in dependency.patches.values():
                     for patch in patch_list:
                         dspec_cls = repository.get_pkg_class(dependency.spec.name)

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -6198,13 +6198,10 @@ def _inject_patches_variant(root: Spec) -> None:
         edge_patches: List[spack.patch.Patch] = []
         for cond, deps_by_name in pkg_deps.items():
             dependency = deps_by_name.get(dspec.spec.name)
-            if not dependency:
+            if not dependency or not dependency.patches:
                 continue
 
             if not dspec.parent.satisfies(cond):
-                continue
-
-            if not dependency.patches:
                 continue
 
             for pcond, patch_list in dependency.patches.items():

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -6204,6 +6204,9 @@ def _inject_patches_variant(root: Spec) -> None:
             if not dspec.parent.satisfies(cond):
                 continue
 
+            if not dependency.patches:
+                continue
+
             for pcond, patch_list in dependency.patches.items():
                 if dspec.spec.satisfies(pcond):
                     edge_patches.extend(patch_list)

--- a/lib/spack/spack/test/directives.py
+++ b/lib/spack/spack/test/directives.py
@@ -9,7 +9,7 @@ import spack.concretize
 import spack.directives
 import spack.spec
 import spack.version
-from spack.directives import _make_when_spec, depends_on, extends, patch
+from spack.directives import _make_when_spec, conflicts, depends_on, extends, patch
 from spack.directives_meta import DirectiveDictDescriptor, DirectiveMeta
 from spack.repo import RepoPath
 from spack.spec import Spec
@@ -301,3 +301,29 @@ def test_patched_dependencies_sets_class_attribute():
 
     assert DoesNotPatchDependencies._patches_dependencies is False
     assert DoesNotPatchDependencies.patches  # type: ignore
+
+
+def test_diamond_inheritance_runs_shared_directives_once():
+    """A directive of a base class reachable through more than one base runs exactly once, and
+    directives run base classes first, following the MRO."""
+
+    class Base(metaclass=DirectiveMeta):
+        name = "base"
+        conflicts("%gcc")
+
+    class Left(Base):
+        conflicts("%clang")
+
+    class Right(Base):
+        conflicts("%intel")
+
+    class Diamond(Left, Right):
+        conflicts("%nvhpc")
+
+    def conflict_specs(cls):
+        return [str(spec) for spec, _ in cls.conflicts[Spec()]]
+
+    assert conflict_specs(Base) == ["%gcc"]
+    assert conflict_specs(Left) == ["%gcc", "%clang"]
+    assert conflict_specs(Right) == ["%gcc", "%intel"]
+    assert conflict_specs(Diamond) == ["%gcc", "%intel", "%clang", "%nvhpc"]

--- a/lib/spack/spack/test/directives.py
+++ b/lib/spack/spack/test/directives.py
@@ -90,7 +90,7 @@ def test_conditionally_extends_direct_dep(config, mock_packages):
 def test_error_on_anonymous_dependency(config, mock_packages: RepoPath):
     pkg = mock_packages.get_pkg_class("pkg-a")
     with pytest.raises(spack.directives.DependencyError):
-        spack.directives._execute_depends_on(pkg, spack.spec.Spec("@4.5"))
+        spack.directives._DependsOn(spack.spec.Spec("@4.5"))(pkg)
 
 
 @pytest.mark.regression("34879")
@@ -130,7 +130,7 @@ def test_duplicate_exact_range_license():
     )
 
     with pytest.raises(spack.directives.OverlappingLicenseError, match=msg):
-        spack.directives._execute_license(package, "MIT", "+foo")
+        spack.directives._License("MIT", "+foo")(package)
 
 
 def test_overlapping_duplicate_licenses():
@@ -144,7 +144,7 @@ def test_overlapping_duplicate_licenses():
     )
 
     with pytest.raises(spack.directives.OverlappingLicenseError, match=msg):
-        spack.directives._execute_license(package, "MIT", "+bar")
+        spack.directives._License("MIT", "+bar")(package)
 
 
 def test_version_type_validation():
@@ -157,11 +157,11 @@ def test_version_type_validation():
 
     # Pass a float
     with pytest.raises(spack.version.VersionError, match=msg):
-        spack.directives._execute_version(package(name="python"), ver=3.10, kwargs={})
+        spack.directives._Version(ver=3.10, kwargs={})(package(name="python"))
 
     # Try passing a bogus type; it's just that we want a nice error message
     with pytest.raises(spack.version.VersionError, match=msg):
-        spack.directives._execute_version(package(name="python"), ver={}, kwargs={})
+        spack.directives._Version(ver={}, kwargs={})(package(name="python"))
 
 
 @pytest.mark.parametrize(
@@ -197,11 +197,11 @@ def test_redistribute_override_when():
         disable_redistribute = {}
 
     cls = MockPackage
-    spack.directives._execute_redistribute(cls, source=False, binary=None, when="@1.0")
+    spack.directives._Redistribute(source=False, binary=None, when="@1.0")(cls)
     spec_key = spack.directives._make_when_spec("@1.0")
     assert not cls.disable_redistribute[spec_key].binary
     assert cls.disable_redistribute[spec_key].source
-    spack.directives._execute_redistribute(cls, source=None, binary=False, when="@1.0")
+    spack.directives._Redistribute(source=None, binary=False, when="@1.0")(cls)
     assert cls.disable_redistribute[spec_key].binary
     assert cls.disable_redistribute[spec_key].source
 

--- a/lib/spack/spack/test/patch.py
+++ b/lib/spack/spack/test/patch.py
@@ -262,11 +262,15 @@ def test_nested_directives(mock_packages: RepoPath):
     when_unconditional = package.dependencies[Spec()]
     assert when_unconditional.keys() == {"fake", "libelf"}
     # fake has two unconditional URL patches
-    assert when_unconditional["fake"].patches.keys() == {Spec()}
-    assert len(when_unconditional["fake"].patches[Spec()]) == 2
+    fake_patches = when_unconditional["fake"].patches
+    assert fake_patches is not None
+    assert fake_patches.keys() == {Spec()}
+    assert len(fake_patches[Spec()]) == 2
     # libelf has one unconditional patch
-    assert when_unconditional["libelf"].patches.keys() == {Spec()}
-    assert len(when_unconditional["libelf"].patches[Spec()]) == 1
+    libelf_patches = when_unconditional["libelf"].patches
+    assert libelf_patches is not None
+    assert libelf_patches.keys() == {Spec()}
+    assert len(libelf_patches[Spec()]) == 1
 
     # there are multiple depends_on directives for libelf under the +foo when clause; these must be
     # reduced to a single Dependency object.
@@ -275,16 +279,20 @@ def test_nested_directives(mock_packages: RepoPath):
     assert when_foo["libelf"].spec == Spec("libelf@0.8.10")
     assert when_foo["libelf"].depflag == dt.BUILD | dt.LINK
     # there is one unconditional patch for libelf under the +foo when clause
-    assert len(when_foo["libelf"].patches) == 1
-    assert len(when_foo["libelf"].patches[Spec()]) == 1
+    foo_libelf_patches = when_foo["libelf"].patches
+    assert foo_libelf_patches is not None
+    assert len(foo_libelf_patches) == 1
+    assert len(foo_libelf_patches[Spec()]) == 1
 
     # libdwarf is a dependency when @1.0 with two patches applied from a single depends_on
     # statement, one conditional on the libdwarf version
     when_1_0 = package.dependencies[Spec("@1.0")]
     assert when_1_0.keys() == {"libdwarf"}
-    assert when_1_0["libdwarf"].patches.keys() == {Spec(), Spec("@20111030")}
-    assert len(when_1_0["libdwarf"].patches[Spec()]) == 1
-    assert len(when_1_0["libdwarf"].patches[Spec("@20111030")]) == 1
+    libdwarf_patches = when_1_0["libdwarf"].patches
+    assert libdwarf_patches is not None
+    assert libdwarf_patches.keys() == {Spec(), Spec("@20111030")}
+    assert len(libdwarf_patches[Spec()]) == 1
+    assert len(libdwarf_patches[Spec("@20111030")]) == 1
 
 
 @pytest.mark.not_on_windows("Test requires Autotools")

--- a/lib/spack/spack/test/spec_dag.py
+++ b/lib/spack/spack/test/spec_dag.py
@@ -59,7 +59,7 @@ def set_dependency(saved_deps, monkeypatch):
             saved_deps[pkg_name] = (pkg_cls, pkg_cls.dependencies.copy())
 
         cond = Spec(pkg_cls.name)
-        dependency = Dependency(pkg_cls, spec)
+        dependency = Dependency(spec)
         monkeypatch.setitem(pkg_cls.dependencies, cond, {spec.name: dependency})
 
     return _mock


### PR DESCRIPTION
Some optimizations related to avoiding empty dict allocations and deduping immutable values as part of package class loading.

- Do not eagerly allocate `Dependency.patches = {}` because it's rarely used.
- Replace the `functools.partial` used for lazy directives with a `NamedTuple` subclass per directive, cause partials store positional arguments and kwargs separately as tuple and dict resp, which is allocation heavy. The instance is a single tuple whose fields keep the directive's parameter names, annotations and defaults, and whose `__call__` executes it on a package class.
- Many packages define the same `depends_on(...)`, which now share a `Dependency` value object across packages. A trilinos solve produces 24.7k of them with only 11.4k distinct `(spec, depflag)` pairs. A `Dependency` with patches is not shared, because the patch directive needs the package that declared it. The redundant `pkg` attribute is dropped altogether.
- Nested `with when(...)` blocks reduce to the same combined spec on every directive inside them. That spec is computed once per distinct condition stack: a trilinos solve combines 6057 stacks drawn from 991 distinct ones. develop already shares single-condition when-specs through `SPEC_CACHE`, so do similar for `with when`.
- Do not eagerly flatten the list of directives from all classes in the mro, cause it requires deduplication the list. Instead, use normal inheritance semantics: store directives locally per class, and on execute walk the mro.
- `PackageBase.all_patches` has no callers, so drop it.

Objects alive when `main()` returns for `spack spec trilinos` on a concretization cache hit, the RSS of that process, and the wall time of the whole process:

| | objects | RSS | wall |
|---|---:|---:|---:|
| develop | 751 302 | 359.7 MB | 3.13s |
| allocate the `patches` dict lazily | 727 356 | 358.9 MB | 3.06s |
| queue a slotted `Directive` tuple instead of a partial | 692 784 | 346.0 MB | 3.00s |
| intern unpatched `Dependency` objects | 679 307 | 345.8 MB | 3.03s |
| cache combined when-stack specs | 583 075 | 334.3 MB | 2.74s |
| queue own directives, walk the MRO | 582 035 | 334.4 MB | 2.75s |
| drop `all_patches` | 582 033 | 337.2 MB | 2.75s |
| use a `NamedTuple` subclass per directive | 582 623 | 336.3 MB | 2.76s |

That is 22.4% fewer objects and 23.4 MB less RSS than develop. Wall time is the min of eight alternating rounds, measured on the whole process so that teardown after `main()` is included.

A second process loads all 8982 builtin package classes and then builds the provider, tag and patch index:

| | objects | peak RSS | provider index | process |
|---|---:|---:|---:|---:|
| develop | 989 530 | 349.8 MB | 0.136s | 2.43s |
| allocate the `patches` dict lazily | 987 727 | 349.9 MB | 0.136s | 2.45s |
| queue a slotted `Directive` tuple instead of a partial | 791 785 | 300.5 MB | 0.135s | 2.27s |
| intern unpatched `Dependency` objects | 791 556 | 303.0 MB | 0.140s | 2.26s |
| cache combined when-stack specs | 791 453 | 299.8 MB | 0.137s | 2.25s |
| queue own directives, walk the MRO | 777 487 | 299.5 MB | 0.143s | 2.25s |
| drop `all_patches` | 777 481 | 301.0 MB | 0.146s | 2.27s |
| use a `NamedTuple` subclass per directive | 778 074 | 299.4 MB | 0.142s | 2.26s |

This shows that dropping the partial is useful.

