### PR TITLE
directives: inherit _patches_dependencies from base classes

### DIFF
--- a/lib/spack/spack/directives_meta.py
+++ b/lib/spack/spack/directives_meta.py
@@ -51,16 +51,23 @@ class DirectiveMeta(type):
     #: Stack of default args from `with default_args(...)` context managers
     _default_args_stack: List[dict] = []
     #: This property is set *automatically* during class definition as directives are invoked,
-    #: if any ``depends_on`` or ``extends`` calls include patches for dependencies. This flag can
-    #: be used as an optimization to detect whether a package provides patches for dependencies,
-    #: without triggering the expensive deferred execution of those directives (without populating
-    #: the ``dependencies`` dictionary).
+    #: if any ``depends_on`` or ``extends`` calls include patches for dependencies, on the class
+    #: itself or on one of its bases. This flag can be used as an optimization to detect whether a
+    #: package provides patches for dependencies, without triggering the expensive deferred
+    #: execution of those directives (without populating the ``dependencies`` dictionary).
     _patches_dependencies: bool = False
 
     def __new__(
         cls: Type["DirectiveMeta"], name: str, bases: tuple, attr_dict: dict
     ) -> "DirectiveMeta":
-        attr_dict["_patches_dependencies"] = DirectiveMeta._patches_dependencies
+        # the bases contribute their directives to the queue below, so also their flag
+        patches_dependencies = DirectiveMeta._patches_dependencies
+        if not patches_dependencies:
+            for base in bases:
+                if getattr(base, "_patches_dependencies", False):
+                    patches_dependencies = True
+                    break
+        attr_dict["_patches_dependencies"] = patches_dependencies
         # Initialize the attribute containing the list of directives to be executed. Here we go
         # reversed because we want to execute commands in the order they were defined, following
         # the MRO.

--- a/lib/spack/spack/test/directives.py
+++ b/lib/spack/spack/test/directives.py
@@ -11,6 +11,7 @@ import spack.spec
 import spack.version
 from spack.directives import _make_when_spec, depends_on, extends, patch
 from spack.directives_meta import DirectiveDictDescriptor, DirectiveMeta
+from spack.patch import PatchCache
 from spack.repo import RepoPath
 from spack.spec import Spec
 
@@ -301,3 +302,50 @@ def test_patched_dependencies_sets_class_attribute():
 
     assert DoesNotPatchDependencies._patches_dependencies is False
     assert DoesNotPatchDependencies.patches  # type: ignore
+
+
+def test_patched_dependencies_is_inherited():
+    """A subclass runs the patched ``depends_on`` of its base, so it has to report the flag too:
+    ``PatchCache._index_patches`` skips a package's dependencies when the flag is False."""
+    sha256 = "b" * 64
+
+    class PatchesDependencies(metaclass=DirectiveMeta):
+        name = "patches-dependencies"
+        fullname = "patches-dependencies"
+        depends_on("dependency", patches=patch("https://example.com/diff.patch", sha256=sha256))
+
+    class InheritsPatchedDependency(PatchesDependencies):
+        name = "inherits-patched-dependency"
+        fullname = "inherits-patched-dependency"
+
+    dependency = InheritsPatchedDependency.dependencies[Spec()]["dependency"]  # type: ignore
+    assert [p.sha256 for p in dependency.patches[Spec()]] == [sha256]
+    assert InheritsPatchedDependency._patches_dependencies is True
+
+    class DoesNotPatchDependencies(metaclass=DirectiveMeta):
+        name = "does-not-patch-dependencies"
+        fullname = "does-not-patch-dependencies"
+        patch("https://example.com/diff.patch", sha256=sha256)
+
+    class InheritsPatch(DoesNotPatchDependencies):
+        name = "inherits-patch"
+        fullname = "inherits-patch"
+
+    assert InheritsPatch._patches_dependencies is False
+
+
+def test_index_patches_covers_inherited_patched_dependency(mock_packages: RepoPath):
+    """The patch cache indexes the dependency patches a package inherits from its base."""
+    sha256 = "c" * 64
+
+    class PatchesDependencies(metaclass=DirectiveMeta):
+        name = "patches-dependencies"
+        fullname = "patches-dependencies"
+        depends_on("libelf", patches=patch("https://example.com/diff.patch", sha256=sha256))
+
+    class InheritsPatchedDependency(PatchesDependencies):
+        name = "inherits-patched-dependency"
+        fullname = "inherits-patched-dependency"
+
+    index = PatchCache._index_patches(InheritsPatchedDependency, mock_packages)  # type: ignore
+    assert index[sha256].keys() == {"builtin_mock.libelf"}


### PR DESCRIPTION
The `_patches_dependencies` prop is an optimization to avoid executing `depends_on` directives when none of them have `patches=...`. That speeds up creation of the shasum->package lookup that we cache on disk.

This commit fixes a bug of an edge case where pkg A extends pkg B and pkg B depends on pkg C with `patches=...`, which means that pkg A also needs `_patches_dependencies = True`.