### PR TITLE
modules: add option to keep tcl module cache updated

### DIFF
--- a/lib/spack/docs/module_file_support.rst
+++ b/lib/spack/docs/module_file_support.rst
@@ -580,6 +580,34 @@ The ``setdefault`` subcommand marks a specific module version as the default, cr
 
 .. command-output:: spack module lmod setdefault --help
 
+.. _modules-tcl-module-cache:
+
+Module cache
+^^^^^^^^^^^^
+
+Environment Modules can build a per-directory cache to speed up the resolution of ``module avail`` and ``module load`` commands.
+Spack can keep this cache in sync with the Tcl module files it generates, when the ``update_cache`` option is set in the ``tcl`` section of the configuration:
+
+.. code-block:: yaml
+
+   modules:
+     default:
+       tcl:
+         update_cache: true
+
+With this option enabled, every Spack command that creates, removes, or regenerates Tcl module files (``spack install``, ``spack uninstall``, ``spack module tcl refresh``, etc.) ends with a single module cache update of the modulepath directories it has changed.
+The cache of these directories is cleared then built again.
+
+The cache can also be managed explicitly with the ``cachebuild`` and ``cacheclear`` subcommands, which respectively build and clear the module cache of every modulepath directory managed by Spack:
+
+.. command-output:: spack module tcl cachebuild --help
+
+.. command-output:: spack module tcl cacheclear --help
+
+.. note::
+
+   The module cache is specific to Tcl module files and requires Environment Modules >= 5.3, which introduced the ``module cachebuild`` and ``module cacheclear`` commands used underneath.
+
 
 .. _modules-in-shell-scripts:
 

--- a/lib/spack/spack/cmd/install.py
+++ b/lib/spack/spack/cmd/install.py
@@ -13,6 +13,7 @@ import spack.cmd
 import spack.config
 import spack.environment as ev
 import spack.installer_dispatch
+import spack.modules.cache
 import spack.paths
 import spack.spec
 import spack.store
@@ -339,6 +340,9 @@ def install(parser, args):
         if args.show_log_on_error:
             _dump_log_on_error(e)
         raise
+    finally:
+        # Update module cache once, after all module file changes
+        spack.modules.cache.flush()
 
 
 def _maybe_add_and_concretize(args, env, specs):

--- a/lib/spack/spack/cmd/modules/__init__.py
+++ b/lib/spack/spack/cmd/modules/__init__.py
@@ -13,6 +13,7 @@ import spack.cmd
 import spack.config
 import spack.error
 import spack.modules
+import spack.modules.cache
 import spack.modules.common
 import spack.modules.error
 import spack.repo
@@ -388,6 +389,12 @@ def modules_cmd(parser, args, module_type, callbacks=callbacks):
     }
     query_args = constraint_qualifiers.get(args.subparser_name, {})
 
+    # Sub-commands that take no spec constraint have no 'specs' attribute
+    if not hasattr(args, "specs"):
+        callbacks[args.subparser_name](module_type, None, args)
+        spack.modules.cache.flush()
+        return
+
     # Get the specs that match the query from the DB
     specs = args.specs(**query_args)
 
@@ -411,3 +418,6 @@ def modules_cmd(parser, args, module_type, callbacks=callbacks):
         query = " ".join(str(s) for s in args.constraint_specs)
         msg = f"the constraint '{query}' matches no package."
         tty.die(msg, "In this context exactly *one* match is needed.")
+
+    # Update module cache once, after all module file changes
+    spack.modules.cache.flush()

--- a/lib/spack/spack/cmd/modules/tcl.py
+++ b/lib/spack/spack/cmd/modules/tcl.py
@@ -2,11 +2,17 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 import functools
+import os
 
 import spack.cmd.common.arguments
 import spack.cmd.modules
 import spack.config
 import spack.modules
+import spack.modules.cache
+import spack.repo
+import spack.store
+from spack.util import tty
+from spack.util.string import plural
 
 
 def add_command(parser, command_dict):
@@ -19,8 +25,14 @@ def add_command(parser, command_dict):
     )
     spack.cmd.common.arguments.add_common_arguments(setdefault_parser, ["constraint"])
 
+    # Build or clear module cache in modulepath directories managed by spack
+    sp.add_parser("cachebuild", help="build module cache")
+    sp.add_parser("cacheclear", help="clear module cache")
+
     callbacks = dict(spack.cmd.modules.callbacks.items())
     callbacks["setdefault"] = setdefault
+    callbacks["cachebuild"] = cachebuild
+    callbacks["cacheclear"] = cacheclear
 
     command_dict["tcl"] = functools.partial(
         spack.cmd.modules.modules_cmd, module_type="tcl", callbacks=callbacks
@@ -37,3 +49,42 @@ def setdefault(module_type, specs, args):
     with spack.config.CONFIG.override(scope):
         writer = spack.modules.module_types["tcl"].from_spec(spec, args.module_set_name)
         writer.update_module_defaults()
+        writer.register_cache_update()
+
+
+def _spack_modulepaths(module_type, args):
+    """Modulepath directories of the module set holding module files for the
+    installed specs."""
+    spack.cmd.modules.check_module_set_name(args.module_set_name)
+    cls = spack.modules.module_types[module_type]
+    cache = {}
+    dirs = set()
+    for spec in spack.store.STORE.db.query():
+        if not spack.repo.PATH.exists(spec.name):
+            continue
+        writer = cls.from_spec(spec, args.module_set_name, cache=cache)
+        if not writer.conf.excluded:
+            dirs.add(writer.layout.modulepath)
+    return sorted(d for d in dirs if os.path.isdir(d))
+
+
+def cachebuild(module_type, specs, args):
+    """build the module cache of every modulepath directory managed by spack"""
+    dirs = _spack_modulepaths(module_type, args)
+    if not dirs:
+        tty.msg("No modulepath directory found to build module cache")
+        return
+    dirs_str = plural(len(dirs), "modulepath directory", "modulepath directories")
+    tty.msg(f"Building module cache in {dirs_str}")
+    spack.modules.cache.cachebuild(dirs)
+
+
+def cacheclear(module_type, specs, args):
+    """clear the module cache of every modulepath directory managed by spack"""
+    dirs = _spack_modulepaths(module_type, args)
+    if not dirs:
+        tty.msg("No modulepath directory found to clear module cache")
+        return
+    dirs_str = plural(len(dirs), "modulepath directory", "modulepath directories")
+    tty.msg(f"Clearing module cache in {dirs_str}")
+    spack.modules.cache.cacheclear(dirs)

--- a/lib/spack/spack/cmd/uninstall.py
+++ b/lib/spack/spack/cmd/uninstall.py
@@ -8,6 +8,7 @@ from typing import Dict, List, Optional, Tuple
 
 import spack.cmd
 import spack.environment as ev
+import spack.modules.cache
 import spack.package_base
 import spack.spec
 import spack.store
@@ -333,4 +334,8 @@ def uninstall(parser, args):
 
     # [None] here handles the --all case by forcing all specs to be returned
     specs = spack.cmd.parse_specs(args.specs) if args.specs else [None]
-    uninstall_specs(args, specs)
+    try:
+        uninstall_specs(args, specs)
+    finally:
+        # Update module cache once, after all module file changes
+        spack.modules.cache.flush()

--- a/lib/spack/spack/modules/cache.py
+++ b/lib/spack/spack/modules/cache.py
@@ -1,0 +1,89 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+"""Keep module caches in sync with the modulepath directories managed by Spack.
+
+Caches are built and cleared by shelling out to the ``module`` command (``module
+cachebuild`` and ``module cacheclear``, available in Environment Modules >= 5.3), so
+knowledge of the cache file format stays within the module system.
+"""
+
+import os
+from typing import List, Sequence, Set
+
+import spack.util.module_cmd
+from spack.util import tty
+from spack.util.string import plural
+
+#: Modulepath directories with pending module file changes, whose cache should be
+#: updated by the next call to :py:func:`flush`
+_pending_dirs: Set[str] = set()
+
+
+def register(dirname: str) -> None:
+    """Records a modulepath directory whose content changed, so that its module cache
+    is updated by the next call to :py:func:`flush`."""
+    _pending_dirs.add(dirname)
+
+
+def flush() -> None:
+    """Updates the module cache of every modulepath directory registered since the
+    last flush, then clears the pending list.
+
+    Directories that no longer exist are skipped: their cache vanished with them.
+    The cache of remaining directories is first cleared, as an obsolete cache file is
+    not removed by a cache build, then directories left empty are pruned, and finally
+    the cache of those still existing is built with a single ``module cachebuild`` run.
+    """
+    dirs = sorted(d for d in _pending_dirs if os.path.isdir(d))
+    _pending_dirs.clear()
+    if not dirs:
+        return
+    dirs_str = plural(len(dirs), "modulepath directory", "modulepath directories")
+    tty.msg(f"Updating module cache in {dirs_str}")
+    cacheclear(dirs)
+    for dirname in dirs:
+        try:
+            # Remove modulepath directory if left empty, and its empty parents
+            os.removedirs(dirname)
+        except OSError:
+            pass
+    dirs = [d for d in dirs if os.path.isdir(d)]
+    if dirs:
+        cachebuild(dirs)
+
+
+def cachebuild(dirs: Sequence[str]) -> None:
+    """Builds the module cache of each given modulepath directory, with a single
+    ``module cachebuild`` run."""
+    _run_module_cmd("cachebuild", *dirs)
+
+
+def cacheclear(dirs: Sequence[str]) -> None:
+    """Clears the module cache of each given modulepath directory, with a single
+    ``module cacheclear`` run.
+
+    Since ``module cacheclear`` accepts no directory argument, it is run with a
+    ``MODULEPATH`` environment variable set to the given directories only. The
+    ``MODULEPATH`` value inherited by the Spack process is ignored, so that only
+    caches of Spack-managed directories are cleared.
+    """
+    environb = dict(os.environb)
+    environb[b"MODULEPATH"] = os.fsencode(os.pathsep.join(dirs))
+    _run_module_cmd("cacheclear", environb=environb)
+
+
+def _run_module_cmd(*args: str, environb=None) -> None:
+    """Runs a cache-related module sub-command, reporting output and errors."""
+    output = spack.util.module_cmd.module(*args, environb=environb)
+    error_lines: List[str] = []
+    for line in (output or "").splitlines():
+        if "ERROR" in line:
+            error_lines.append(line)
+        elif line:
+            tty.debug(line)
+    if error_lines:
+        tty.warn(
+            f"'module {args[0]}' failed (Environment Modules >= 5.3 is required)", *error_lines
+        )

--- a/lib/spack/spack/modules/common.py
+++ b/lib/spack/spack/modules/common.py
@@ -814,6 +814,15 @@ class FileLayout:
         # Return the absolute path
         return os.path.join(self.arch_dirname, filename)
 
+    @property
+    def modulepath(self) -> str:
+        """Directory to add to ``MODULEPATH`` for the module system to find this
+        module file, i.e. the module file path stripped of the module name parts."""
+        dirname = self.filename
+        for _ in self.use_name.split(os.sep):
+            dirname = os.path.dirname(dirname)
+        return dirname
+
     def token_to_path(self, name: str, value: spack.spec.Spec) -> str:
         """Transforms a hierarchy token into the corresponding path part.
 
@@ -1358,6 +1367,9 @@ class BaseModuleFileWriter:
         # record module hiddenness if implicit
         self.update_module_hiddenness()
 
+        # Register written module file for a module cache update
+        self.register_cache_update()
+
     def update_module_defaults(self) -> None:
         if any(self.spec.satisfies(default) for default in self.conf.defaults):
             # This spec matches a default, it needs to be symlinked to default
@@ -1417,6 +1429,14 @@ class BaseModuleFileWriter:
                 with open(modulerc_path, "w", encoding="utf-8") as f:
                     f.write("\n".join(content))
 
+    def register_cache_update(self) -> None:
+        """Registers this module file for a module cache update.
+
+        This default implementation does nothing: subclasses whose module system
+        supports a module cache should override it to record the modulepath directory
+        of this module file, when cache update is enabled in configuration.
+        """
+
     def remove(self) -> None:
         """Deletes the module file."""
         mod_file = self.layout.filename
@@ -1425,6 +1445,7 @@ class BaseModuleFileWriter:
                 os.remove(mod_file)  # Remove the module file
                 self.remove_module_defaults()  # Remove default targeting module file
                 self.update_module_hiddenness(remove=True)  # Remove hide cmd in modulerc
+                self.register_cache_update()  # Register removal for a module cache update
                 os.removedirs(
                     os.path.dirname(mod_file)
                 )  # Remove all the empty directories from the leaf up

--- a/lib/spack/spack/modules/tcl.py
+++ b/lib/spack/spack/modules/tcl.py
@@ -6,6 +6,7 @@
 
 from typing import Tuple
 
+from . import cache
 from .common import BaseConfiguration, BaseModuleFileWriter
 
 
@@ -13,6 +14,12 @@ class TclConfiguration(BaseConfiguration):
     """Configuration class for tcl module files."""
 
     module_system = "tcl"
+
+    @property
+    def update_cache(self) -> bool:
+        """Returns True if the module cache of the modulepath directories changed by
+        Spack should be kept updated, False otherwise."""
+        return self._config.get("update_cache", False)
 
     def manipulate_path(self, token: str) -> str:
         if token in self.hierarchy_tokens:
@@ -29,6 +36,8 @@ class TclConfiguration(BaseConfiguration):
 class TclModulefileWriter(BaseModuleFileWriter):
     """Writer class for tcl module files."""
 
+    conf: TclConfiguration
+
     configuration_class = TclConfiguration
 
     default_template = "modules/modulefile.tcl"
@@ -36,3 +45,9 @@ class TclModulefileWriter(BaseModuleFileWriter):
     modulerc_header = ["#%Module4.7"]
 
     hide_cmd_format = "module-hide --soft --hidden-loaded %s"
+
+    def register_cache_update(self) -> None:
+        """Registers the modulepath directory of this module file for a module cache
+        update, if enabled in configuration."""
+        if self.conf.update_cache:
+            cache.register(self.layout.modulepath)

--- a/lib/spack/spack/schema/modules.py
+++ b/lib/spack/spack/schema/modules.py
@@ -159,7 +159,15 @@ tcl_configuration = {
     "description": "Configuration for Tcl module files compatible with Environment Modules and "
     "Lmod",
     "additionalKeysAreSpecs": True,
-    "properties": {**common_props},
+    "properties": {
+        **common_props,
+        "update_cache": {
+            "type": "boolean",
+            "default": False,
+            "description": "Keep the module cache updated when module files are created or "
+            "removed",
+        },
+    },
     "additionalProperties": ref_module_file_configuration,
 }
 

--- a/lib/spack/spack/test/cmd/module.py
+++ b/lib/spack/spack/test/cmd/module.py
@@ -11,9 +11,11 @@ import spack.concretize
 import spack.config
 import spack.main
 import spack.modules
+import spack.modules.cache
 import spack.modules.lmod
 import spack.repo
 import spack.store
+import spack.util.module_cmd
 from spack.config import Configuration
 from spack.old_installer import PackageInstaller
 
@@ -222,3 +224,135 @@ def test_setdefault_command(mutable_database, mutable_config: Configuration):
         assert os.path.exists(writers[k].layout.filename)
     assert os.path.exists(link_name) and os.path.islink(link_name)
     assert os.path.realpath(link_name) == os.path.realpath(writers[preferred].layout.filename)
+
+
+@pytest.fixture()
+def module_cmd_calls(monkeypatch):
+    """Intercepts module command runs, and returns the list of their arguments."""
+    monkeypatch.setattr(spack.modules.cache, "_pending_dirs", set())
+    calls = []
+
+    def fake_module(*args, environb=None, **kwargs):
+        calls.append((args, environb))
+        return ""
+
+    monkeypatch.setattr(spack.util.module_cmd, "module", fake_module)
+    return calls
+
+
+def _enable_update_cache(mutable_config):
+    mutable_config.set("modules", {"default": {"enable": ["tcl"], "tcl": {"update_cache": True}}})
+
+
+@pytest.mark.db
+def test_tcl_refresh_updates_module_cache(mutable_database, mutable_config, module_cmd_calls):
+    """Tests that a refresh ends with a single cachebuild of the changed directories,
+    when 'update_cache' is set."""
+    _enable_update_cache(mutable_config)
+
+    module("tcl", "refresh", "-y", "mpileaks")
+
+    assert len(module_cmd_calls) == 2
+    assert module_cmd_calls[0][0] == ("cacheclear",)
+    args, _ = module_cmd_calls[1]
+    assert args[0] == "cachebuild"
+    assert len(args) > 1 and all(os.path.isdir(d) for d in args[1:])
+
+    # Module file removal also triggers a cache update
+    module_cmd_calls.clear()
+    module("tcl", "rm", "-y", "mpileaks")
+
+    assert len(module_cmd_calls) == 2
+    assert module_cmd_calls[0][0] == ("cacheclear",)
+    assert module_cmd_calls[1][0][0] == "cachebuild"
+
+
+@pytest.mark.db
+def test_tcl_refresh_no_update_cache_by_default(mutable_database, module_cmd_calls):
+    """Tests that no cache update happens when 'update_cache' is not set."""
+    module("tcl", "refresh", "-y", "mpileaks")
+    assert not module_cmd_calls
+
+
+@pytest.mark.db
+def test_tcl_setdefault_updates_module_cache(
+    mutable_database, mutable_config: Configuration, module_cmd_calls
+):
+    """Tests that setting the default module file triggers a cache update, when
+    'update_cache' is set."""
+    _enable_update_cache(mutable_config)
+    other_spec, preferred = "pkg-a@1.0", "pkg-a@2.0"
+    specs = [
+        spack.concretize.concretize_one(other_spec),
+        spack.concretize.concretize_one(preferred),
+    ]
+    PackageInstaller([s.package for s in specs], explicit=True, fake=True).install()
+    module("tcl", "refresh", "-y", preferred, other_spec)
+
+    module_cmd_calls.clear()
+    module("tcl", "setdefault", other_spec)
+
+    assert len(module_cmd_calls) == 2
+    assert module_cmd_calls[0][0] == ("cacheclear",)
+    assert module_cmd_calls[1][0][0] == "cachebuild"
+
+
+@pytest.mark.db
+def test_tcl_cachebuild_command(mutable_database, mutable_config: Configuration, module_cmd_calls):
+    """Tests that 'spack module tcl cachebuild' builds the cache of every modulepath
+    directory managed by spack, even when 'update_cache' is not set."""
+    # Exclude one package from module file generation to also verify that excluded
+    # specs do not contribute modulepath directories
+    mutable_config.set(
+        "modules", {"default": {"enable": ["tcl"], "tcl": {"exclude": ["libdwarf"]}}}
+    )
+    module("tcl", "refresh", "-y")
+    module_cmd_calls.clear()
+
+    module("tcl", "cachebuild")
+
+    assert len(module_cmd_calls) == 1
+    args, _ = module_cmd_calls[0]
+    assert args[0] == "cachebuild"
+    assert len(args) > 1 and all(os.path.isdir(d) for d in args[1:])
+
+
+@pytest.mark.db
+def test_tcl_cacheclear_command(database, module_cmd_calls, monkeypatch):
+    """Tests that 'spack module tcl cacheclear' runs with MODULEPATH set to the
+    modulepath directories managed by spack, ignoring the inherited value."""
+    monkeypatch.setenv("MODULEPATH", "/some/user/modulepath")
+    module("tcl", "refresh", "-y")
+    module_cmd_calls.clear()
+
+    module("tcl", "cacheclear")
+
+    assert len(module_cmd_calls) == 1
+    args, environb = module_cmd_calls[0]
+    assert args == ("cacheclear",)
+    modulepath = os.fsdecode(environb[b"MODULEPATH"])
+    assert modulepath and all(os.path.isdir(d) for d in modulepath.split(os.pathsep))
+    assert "/some/user/modulepath" not in modulepath
+
+
+@pytest.mark.db
+def test_cache_subcommands_without_modulepath_directory(database, module_cmd_calls, monkeypatch):
+    """Tests that cache sub-commands run no module command when no modulepath
+    directory holds module files of known installed packages."""
+    monkeypatch.setattr(spack.repo.PATH, "exists", lambda name: False)
+
+    out = module("tcl", "cachebuild")
+    assert "No modulepath directory found" in out
+
+    out = module("tcl", "cacheclear")
+    assert "No modulepath directory found" in out
+
+    assert not module_cmd_calls
+
+
+@pytest.mark.db
+def test_cache_subcommands_are_tcl_only(database):
+    """Tests that cache sub-commands are not available for lmod."""
+    for subcommand in ("cachebuild", "cacheclear"):
+        with pytest.raises(spack.main.SpackCommandError):
+            module("lmod", subcommand)

--- a/lib/spack/spack/test/data/modules/tcl/update_cache.yaml
+++ b/lib/spack/spack/test/data/modules/tcl/update_cache.yaml
@@ -1,0 +1,8 @@
+enable:
+  - tcl
+tcl:
+  update_cache: true
+  exclude:
+    - callpath
+  all:
+    autoload: direct

--- a/lib/spack/spack/test/modules/cache.py
+++ b/lib/spack/spack/test/modules/cache.py
@@ -1,0 +1,134 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+import os
+
+import pytest
+
+import spack.modules.cache
+import spack.util.module_cmd
+
+pytestmark = pytest.mark.not_on_windows("does not run on windows")
+
+
+@pytest.fixture(autouse=True)
+def no_pending_dirs(monkeypatch):
+    """Starts each test with an empty list of pending modulepath directories."""
+    monkeypatch.setattr(spack.modules.cache, "_pending_dirs", set())
+
+
+@pytest.fixture()
+def module_cmd_calls(monkeypatch):
+    """Intercepts module command runs, and returns the list of their arguments."""
+    calls = []
+
+    def fake_module(*args, environb=None, **kwargs):
+        calls.append((args, environb))
+        return ""
+
+    monkeypatch.setattr(spack.util.module_cmd, "module", fake_module)
+    return calls
+
+
+def test_flush_without_registration(module_cmd_calls):
+    """Tests that a flush with no pending directory does not run the module command."""
+    spack.modules.cache.flush()
+    assert not module_cmd_calls
+
+
+def _make_modulepath_dir(root, name, empty=False):
+    """Creates a modulepath directory, holding one module file unless empty."""
+    dirname = root / name
+    dirname.mkdir()
+    if not empty:
+        (dirname / "modulefile").write_text("#%Module")
+    return str(dirname)
+
+
+def test_flush_clears_then_builds_cache_once(tmp_path, module_cmd_calls):
+    """Tests that a flush clears then builds the cache of the deduplicated list of
+    pending directories, with one run of each module sub-command, then clears the
+    pending list."""
+    dir_a = _make_modulepath_dir(tmp_path, "a")
+    dir_b = _make_modulepath_dir(tmp_path, "b")
+    spack.modules.cache.register(dir_a)
+    spack.modules.cache.register(dir_b)
+    spack.modules.cache.register(dir_a)
+    spack.modules.cache.flush()
+
+    assert len(module_cmd_calls) == 2
+    clear_args, clear_environb = module_cmd_calls[0]
+    assert clear_args == ("cacheclear",)
+    assert clear_environb[b"MODULEPATH"] == os.fsencode(os.pathsep.join([dir_a, dir_b]))
+    assert module_cmd_calls[1] == (("cachebuild", dir_a, dir_b), None)
+
+    # The pending list has been cleared: a second flush is a no-op
+    spack.modules.cache.flush()
+    assert len(module_cmd_calls) == 2
+
+
+def test_flush_prunes_emptied_directories(tmp_path, module_cmd_calls):
+    """Tests that directories left with no module file are pruned after the cache
+    clear, and excluded from the cache build."""
+    dir_a = _make_modulepath_dir(tmp_path, "a")
+    dir_b = _make_modulepath_dir(tmp_path, "b", empty=True)
+    spack.modules.cache.register(dir_a)
+    spack.modules.cache.register(dir_b)
+    spack.modules.cache.flush()
+
+    assert not os.path.exists(dir_b)
+    assert module_cmd_calls[0][0] == ("cacheclear",)
+    assert module_cmd_calls[1] == (("cachebuild", dir_a), None)
+
+    # No cache build at all if every pending directory has been pruned
+    module_cmd_calls.clear()
+    dir_c = _make_modulepath_dir(tmp_path, "c", empty=True)
+    spack.modules.cache.register(dir_c)
+    spack.modules.cache.flush()
+
+    assert not os.path.exists(dir_c)
+    assert [args for args, _ in module_cmd_calls] == [("cacheclear",)]
+
+
+def test_flush_skips_vanished_directories(tmp_path, module_cmd_calls):
+    """Tests that directories removed since their registration are not cachebuilt."""
+    dir_a = _make_modulepath_dir(tmp_path, "a")
+    dir_b = str(tmp_path / "b")
+    spack.modules.cache.register(dir_a)
+    spack.modules.cache.register(dir_b)
+    spack.modules.cache.flush()
+    assert [args for args, _ in module_cmd_calls] == [("cacheclear",), ("cachebuild", dir_a)]
+
+    # No module command run at all if every pending directory vanished
+    spack.modules.cache.register(dir_b)
+    spack.modules.cache.flush()
+    assert len(module_cmd_calls) == 2
+
+
+def test_cacheclear_restricts_modulepath(tmp_path, module_cmd_calls, monkeypatch):
+    """Tests that cacheclear runs with MODULEPATH set to the given directories only,
+    ignoring the MODULEPATH value inherited by the Spack process."""
+    monkeypatch.setenv("MODULEPATH", "/some/user/modulepath")
+    dirs = [str(tmp_path / "a"), str(tmp_path / "b")]
+    spack.modules.cache.cacheclear(dirs)
+
+    (args, environb) = module_cmd_calls[0]
+    assert args == ("cacheclear",)
+    assert environb[b"MODULEPATH"] == os.fsencode(os.pathsep.join(dirs))
+
+
+def test_module_cmd_error_reported(monkeypatch, capsys):
+    """Tests that errors reported by the module command turn into a warning, while
+    its regular output is kept for debug."""
+
+    def fake_module(*args, environb=None, **kwargs):
+        return "Creating /some/dir/.modulecache\n\nERROR: Invalid sub-command 'cachebuild'\n"
+
+    monkeypatch.setattr(spack.util.module_cmd, "module", fake_module)
+    spack.modules.cache.cachebuild(["/some/dir"])
+
+    captured = capsys.readouterr()
+    assert "Environment Modules >= 5.3" in captured.err
+    assert "Invalid sub-command" in captured.err
+    assert "Creating /some/dir/.modulecache" not in captured.err

--- a/lib/spack/spack/test/modules/tcl.py
+++ b/lib/spack/spack/test/modules/tcl.py
@@ -10,6 +10,7 @@ import spack.vendor.archspec.cpu
 
 import spack.concretize
 import spack.config
+import spack.modules.cache
 import spack.modules.common
 import spack.modules.error
 import spack.modules.tcl
@@ -842,3 +843,69 @@ class TestTcl:
         writer, _ = factory("mpich@3.0.4")
         assert "namematch" in writer.layout.use_name
         assert "depmatch" not in writer.layout.use_name
+
+    def test_update_cache_registration(self, factory, module_configuration, monkeypatch):
+        """Tests that writing or removing a module file registers its modulepath
+        directory for a module cache update."""
+        module_configuration("update_cache")
+        monkeypatch.setattr(spack.modules.cache, "_pending_dirs", set())
+        writer, _ = factory(mpileaks_spec_string)
+
+        # The module file path is the modulepath directory plus the module use name
+        assert writer.layout.filename == os.path.join(
+            writer.layout.modulepath, writer.layout.use_name
+        )
+
+        writer.write()
+        assert spack.modules.cache._pending_dirs == {writer.layout.modulepath}
+
+        # An already existing module file is not overwritten, hence not registered
+        spack.modules.cache._pending_dirs.clear()
+        with pytest.warns(UserWarning):
+            writer.write()
+        assert spack.modules.cache._pending_dirs == set()
+
+        writer.write(overwrite=True)
+        assert spack.modules.cache._pending_dirs == {writer.layout.modulepath}
+
+        spack.modules.cache._pending_dirs.clear()
+        writer.remove()
+        assert spack.modules.cache._pending_dirs == {writer.layout.modulepath}
+
+        # Removing an already absent module file does not register
+        spack.modules.cache._pending_dirs.clear()
+        writer.remove()
+        assert spack.modules.cache._pending_dirs == set()
+
+    def test_update_cache_excluded_spec(self, factory, module_configuration, monkeypatch):
+        """Tests that a spec excluded from module file generation does not register its
+        modulepath directory for a module cache update."""
+        module_configuration("update_cache")
+        monkeypatch.setattr(spack.modules.cache, "_pending_dirs", set())
+        writer, _ = factory("callpath")
+
+        writer.write()
+        assert not os.path.exists(writer.layout.filename)
+        assert spack.modules.cache._pending_dirs == set()
+
+    def test_update_cache_disabled(self, factory, module_configuration, monkeypatch):
+        """Tests that no cache update is registered when 'update_cache' is off."""
+        module_configuration("autoload_direct")
+        monkeypatch.setattr(spack.modules.cache, "_pending_dirs", set())
+        writer, _ = factory(mpileaks_spec_string)
+
+        assert not writer.conf.update_cache
+
+        writer.write()
+        writer.register_cache_update()
+        writer.remove()
+        assert spack.modules.cache._pending_dirs == set()
+
+    def test_modulepath_hierarchical(self, factory, module_configuration):
+        """Tests the modulepath directory computation for a hierarchical layout."""
+        module_configuration("complex_hierarchy")
+        writer, _ = factory("mpich@3.0.4 %gcc@=10.2.1")
+
+        assert writer.layout.filename == os.path.join(
+            writer.layout.modulepath, writer.layout.use_name
+        )

--- a/lib/spack/spack/test/util/module_cmd.py
+++ b/lib/spack/spack/test/util/module_cmd.py
@@ -10,6 +10,22 @@ import spack.util.module_cmd
 
 
 @pytest.mark.not_on_windows("Module files are not supported on Windows")
+def test_module_env_is_passed_to_non_state_changing_commands():
+    """Test that the environb argument sets the environment of module commands whose
+    output is returned, like cache-related ones."""
+    environb = dict(os.environb)
+    environb[b"MODULEPATH"] = b"/spack/test/modulepath"
+    # Ensure the real module initialization script is not sourced
+    environb.pop(b"MODULESHOME", None)
+
+    output = spack.util.module_cmd.module(
+        "cacheclear", module_template='echo "$MODULEPATH"', environb=environb
+    )
+
+    assert output.strip() == "/spack/test/modulepath"
+
+
+@pytest.mark.not_on_windows("Module files are not supported on Windows")
 def test_load_module_success(monkeypatch, working_env):
     """Test that load_module properly handles successful module loads.
 

--- a/lib/spack/spack/util/module_cmd.py
+++ b/lib/spack/spack/util/module_cmd.py
@@ -82,6 +82,7 @@ def module(
             stderr=subprocess.STDOUT,
             shell=True,
             executable="/bin/bash",
+            env=environb,
         )
         # Decode and str to return a string object in both python 2 and 3
         return str(module_p.communicate()[0].decode())

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -1609,7 +1609,7 @@ _spack_module_tcl() {
     then
         SPACK_COMPREPLY="-h --help -n --name"
     else
-        SPACK_COMPREPLY="refresh find rm loads setdefault"
+        SPACK_COMPREPLY="refresh find rm loads setdefault cachebuild cacheclear"
     fi
 }
 
@@ -1656,6 +1656,14 @@ _spack_module_tcl_setdefault() {
     else
         _installed_packages
     fi
+}
+
+_spack_module_tcl_cachebuild() {
+    SPACK_COMPREPLY="-h --help"
+}
+
+_spack_module_tcl_cacheclear() {
+    SPACK_COMPREPLY="-h --help"
 }
 
 _spack_patch() {

--- a/share/spack/spack-completion.fish
+++ b/share/spack/spack-completion.fish
@@ -2645,6 +2645,8 @@ complete -c spack -n '__fish_spack_using_command_pos 0 module tcl' -f -a find -d
 complete -c spack -n '__fish_spack_using_command_pos 0 module tcl' -f -a rm -d 'remove module files'
 complete -c spack -n '__fish_spack_using_command_pos 0 module tcl' -f -a loads -d 'prompt the list of modules associated with a constraint'
 complete -c spack -n '__fish_spack_using_command_pos 0 module tcl' -f -a setdefault -d 'set the default module file for a package'
+complete -c spack -n '__fish_spack_using_command_pos 0 module tcl' -f -a cachebuild -d 'build module cache'
+complete -c spack -n '__fish_spack_using_command_pos 0 module tcl' -f -a cacheclear -d 'clear module cache'
 complete -c spack -n '__fish_spack_using_command module tcl' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command module tcl' -s h -l help -d 'show this help message and exit'
 complete -c spack -n '__fish_spack_using_command module tcl' -s n -l name -r -f -a module_set_name
@@ -2699,6 +2701,16 @@ set -g __fish_spack_optspecs_spack_module_tcl_setdefault h/help
 complete -c spack -n '__fish_spack_using_command_pos_remainder 0 module tcl setdefault' -f -a '(__fish_spack_installed_specs)'
 complete -c spack -n '__fish_spack_using_command module tcl setdefault' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command module tcl setdefault' -s h -l help -d 'show this help message and exit'
+
+# spack module tcl cachebuild
+set -g __fish_spack_optspecs_spack_module_tcl_cachebuild h/help
+complete -c spack -n '__fish_spack_using_command module tcl cachebuild' -s h -l help -f -a help
+complete -c spack -n '__fish_spack_using_command module tcl cachebuild' -s h -l help -d 'show this help message and exit'
+
+# spack module tcl cacheclear
+set -g __fish_spack_optspecs_spack_module_tcl_cacheclear h/help
+complete -c spack -n '__fish_spack_using_command module tcl cacheclear' -s h -l help -f -a help
+complete -c spack -n '__fish_spack_using_command module tcl cacheclear' -s h -l help -d 'show this help message and exit'
 
 # spack patch
 set -g __fish_spack_optspecs_spack_patch h/help n/no-checksum f/force U/fresh reuse fresh-roots deprecated


### PR DESCRIPTION
Add the `update_cache` boolean option to the `tcl` section of the modules configuration. When enabled, every Spack command that creates, removes or regenerates Tcl module files (`spack install`, `spack uninstall`, `spack module tcl refresh/rm/setdefault`) ends with a single module cache update of the modulepath directories it has changed: their cache is cleared then built again, and directories left without any module file are pruned along the way.

```yaml
modules:
  default:
    tcl:
      update_cache: true
```

Also add the `cachebuild` and `cacheclear` sub-commands to `spack module tcl`, to explicitly build or clear the module cache of every modulepath directory managed by Spack, regardless of the `update_cache` option.

- Cache generation is performed with the `module` command itself (through `spack.util.module_cmd`), so knowledge of the cache file format stays within the module system. This requires Environment Modules >= 5.3, which introduced the `module cachebuild` and `module cacheclear` sub-commands.
- Building the cache is I/O expensive, so Tcl module file writers only register the modulepath directory they touched; a single flush at the end of the Spack command runs the module commands once over the deduplicated directory list.
- `module cacheclear` takes no directory argument, so it is always run with a `MODULEPATH` environment variable set to the Spack-managed directories only, ignoring the value inherited by the Spack process.
- The registration hook is a no-op in `BaseModuleFileWriter` and overridden by the Tcl writer, making it easy to add cache support for Lmod later on.
- The option is only available for `tcl` (enforced by schema). Lmod builds its spider cache with an external tool and a user-configured cache directory, which is out of scope here.
