### PR TITLE
tests: use the `mock_packages` fixture in three more tests

### DIFF
--- a/lib/spack/spack/test/cmd/graph.py
+++ b/lib/spack/spack/test/cmd/graph.py
@@ -68,7 +68,7 @@ def test_graph_deptype():
     graph("--deptype", "all", "dt-diamond")
 
 
-def test_graph_no_specs():
+def test_graph_no_specs(mock_packages):
     """Tests spack graph with no arguments"""
 
     with pytest.raises(SpackCommandError):

--- a/lib/spack/spack/test/concretization/core.py
+++ b/lib/spack/spack/test/concretization/core.py
@@ -3464,7 +3464,7 @@ def test_selecting_reused_sources(reuse_yaml, expected_length, mutable_config):
         (["cmake@3.27.9 %gcc", "foo %gcc"], ["%gcc"], ["cmake"], ["foo %gcc"]),
     ],
 )
-def test_spec_filters(specs, include, exclude, expected):
+def test_spec_filters(specs, include, exclude, expected, mock_packages):
     specs = [Spec(x) for x in specs]
     expected = [Spec(x) for x in expected]
     f = spack.spec_filter.SpecFilter(

--- a/lib/spack/spack/test/repo.py
+++ b/lib/spack/spack/test/repo.py
@@ -1012,7 +1012,7 @@ def test_repo_use_bad_syntax(config, repo_builder: RepoBuilder):
             spack.repo.PATH.get_pkg_class("erroneous")
 
 
-def test_unknownpkgerror_match_fails():
+def test_unknownpkgerror_match_fails(mock_packages):
     """Ensure fails with basic message when get_close_matches fails."""
 
     def _get_close_matches(*args, **kwargs):


### PR DESCRIPTION
Three tests were not using the builtin.mock repository. That can eventually lead to failures like in:
- https://github.com/spack/spack/actions/runs/33013164570/job/98442619641

if the builtin repository is loaded last, and we keep it's makefile builder in the BUILDER_CLS global.

Not using the `mock_packages` fixture where we should is a bug regardless, so this commit fixes that. More fixes related to BUILDER_CLS may follow.