### PR TITLE
builder.py: ensure uniqueness of build systems

### DIFF
--- a/lib/spack/spack/builder.py
+++ b/lib/spack/spack/builder.py
@@ -44,6 +44,13 @@ def register_builder(build_system_name: str):
     """
 
     def _decorator(cls):
+        existing = BUILDER_CLS.get(build_system_name)
+        if existing is not None and existing is not cls:
+            raise SpackError(
+                f"cannot register builder {cls.__module__}.{cls.__qualname__} for build system "
+                f"'{build_system_name}': already registered by "
+                f"{existing.__module__}.{existing.__qualname__}"
+            )
         cls.build_system = build_system_name
         BUILDER_CLS[build_system_name] = cls
         return cls

--- a/lib/spack/spack/test/builder.py
+++ b/lib/spack/spack/test/builder.py
@@ -8,6 +8,7 @@ import pytest
 
 import spack.builder
 import spack.concretize
+import spack.error
 import spack.paths
 import spack.repo
 from spack.util.filesystem import touch
@@ -259,3 +260,24 @@ def test_get_builder_class_accepts_objects_and_classes():
 
     # Names that are not defined in any package module are not builders
     assert spack.builder.get_builder_class(pkg_cls, "UnknownBuilder") is None
+
+
+def test_register_builder_rejects_duplicate_names():
+    """A build system name can be registered by only one builder class."""
+
+    @spack.builder.register_builder("test-duplicate")
+    class FirstBuilder:
+        pass
+
+    try:
+        # re-registering the same class is idempotent
+        assert spack.builder.register_builder("test-duplicate")(FirstBuilder) is FirstBuilder
+
+        with pytest.raises(spack.error.SpackError, match="already registered"):
+
+            @spack.builder.register_builder("test-duplicate")
+            class SecondBuilder:
+                pass
+
+    finally:
+        del spack.builder.BUILDER_CLS["test-duplicate"]

--- a/lib/spack/spack/test/cmd/info.py
+++ b/lib/spack/spack/test/cmd/info.py
@@ -121,19 +121,19 @@ def test_info_fields(pkg_query, extra_args):
         # Ensure spack info knows that build_system is a single value variant
         (
             ["dual-cmake-autotools"],
-            [r"when\s*build_system=cmake", r"when\s*build_system=autotools"],
+            [r"when\s*build_system=mock_cmake", r"when\s*build_system=mock_autotools"],
             [],
         ),
         (
-            ["dual-cmake-autotools build_system=cmake"],
-            [r"when\s*build_system=cmake"],
-            [r"when\s*build_system=autotools"],
+            ["dual-cmake-autotools build_system=mock_cmake"],
+            [r"when\s*build_system=mock_cmake"],
+            [r"when\s*build_system=mock_autotools"],
         ),
-        # Ensure that gemerator=make implies build_system=cmake and therefore no autotools
+        # Ensure that gemerator=make implies build_system=mock_cmake and therefore no autotools
         (
             ["dual-cmake-autotools generator=make"],
-            [r"when\s*build_system=cmake"],
-            [r"when\s*build_system=autotools"],
+            [r"when\s*build_system=mock_cmake"],
+            [r"when\s*build_system=mock_autotools"],
         ),
         (
             ["optional-dep-test"],

--- a/lib/spack/spack/test/externals.py
+++ b/lib/spack/spack/test/externals.py
@@ -350,7 +350,7 @@ def test_external_node_completion(
 def test_external_spec_single_valued_variant_type_is_corrected(config):
     """Tests that an external spec string including a single-valued variant is parsed correctly."""
     externals_dict = [
-        {"spec": "dual-cmake-autotools@1.0 build_system=autotools", "prefix": "/usr/dual"}
+        {"spec": "dual-cmake-autotools@1.0 build_system=mock_autotools", "prefix": "/usr/dual"}
     ]
     parser = ExternalSpecsParser(externals_dict, complete_node=complete_variants_and_architecture)
     specs = parser.all_specs()
@@ -359,8 +359,8 @@ def test_external_spec_single_valued_variant_type_is_corrected(config):
 
     # Single-valued variants return the value, not a tuple of values
     build_system_value = spec.variants["build_system"].value
-    assert build_system_value == "autotools", (
-        f"Expected 'autotools' but got {build_system_value!r} "
+    assert build_system_value == "mock_autotools", (
+        f"Expected 'mock_autotools' but got {build_system_value!r} "
         f"(type: {type(build_system_value).__name__})"
     )
 

--- a/var/spack/test_repos/spack_repo/builtin_mock/build_systems/autotools.py
+++ b/var/spack/test_repos/spack_repo/builtin_mock/build_systems/autotools.py
@@ -22,10 +22,10 @@ class AutotoolsPackage(PackageBase):
     """Specialized class for packages built using GNU Autotools."""
 
     build_system_class = "AutotoolsPackage"
-    default_buildsystem = "autotools"
+    default_buildsystem = "mock_autotools"
 
-    build_system("autotools")
-    depends_on("gmake", type="build", when="build_system=autotools")
+    build_system("mock_autotools")
+    depends_on("gmake", type="build", when="build_system=mock_autotools")
 
     def flags_to_build_system_args(self, flags):
         """Produces a list of all command line arguments to pass compiler flags to configure."""
@@ -42,7 +42,7 @@ class AutotoolsPackage(PackageBase):
         setattr(self, "configure_flag_args", configure_flag_args)
 
 
-@register_builder("autotools")
+@register_builder("mock_autotools")
 class AutotoolsBuilder(BuilderWithDefaults):
     #: Phases of a GNU Autotools package
     phases = ("autoreconf", "configure", "build", "install")

--- a/var/spack/test_repos/spack_repo/builtin_mock/build_systems/bundle.py
+++ b/var/spack/test_repos/spack_repo/builtin_mock/build_systems/bundle.py
@@ -9,13 +9,13 @@ class BundlePackage(PackageBase):
     """General purpose bundle, or no-code, package class."""
 
     build_system_class = "BundlePackage"
-    default_buildsystem = "bundle"
+    default_buildsystem = "mock_bundle"
     has_code = False
 
-    build_system("bundle")
+    build_system("mock_bundle")
 
 
-@register_builder("bundle")
+@register_builder("mock_bundle")
 class BundleBuilder(Builder):
     phases = ("install",)
 

--- a/var/spack/test_repos/spack_repo/builtin_mock/build_systems/cmake.py
+++ b/var/spack/test_repos/spack_repo/builtin_mock/build_systems/cmake.py
@@ -27,11 +27,11 @@ class CMakePackage(PackageBase):
     """
 
     build_system_class = "CMakePackage"
-    default_buildsystem = "cmake"
+    default_buildsystem = "mock_cmake"
 
-    build_system("cmake")
+    build_system("mock_cmake")
 
-    depends_on("cmake", type="build", when="build_system=cmake")
+    depends_on("cmake", type="build", when="build_system=mock_cmake")
 
     def flags_to_build_system_args(self, flags):
         """Translate compiler flags to CMake arguments."""
@@ -57,7 +57,7 @@ class CMakePackage(PackageBase):
         setattr(self, "cmake_flag_args", cmake_flag_args)
 
 
-@register_builder("cmake")
+@register_builder("mock_cmake")
 class CMakeBuilder(BuilderWithDefaults):
     """Builder for CMake packages"""
 

--- a/var/spack/test_repos/spack_repo/builtin_mock/build_systems/makefile.py
+++ b/var/spack/test_repos/spack_repo/builtin_mock/build_systems/makefile.py
@@ -18,13 +18,13 @@ from ._checks import execute_build_time_tests
 
 class MakefilePackage(PackageBase):
     build_system_class = "MakefilePackage"
-    default_buildsystem = "makefile"
+    default_buildsystem = "mock_makefile"
 
-    build_system("makefile")
-    depends_on("gmake", type="build", when="build_system=makefile")
+    build_system("mock_makefile")
+    depends_on("gmake", type="build", when="build_system=mock_makefile")
 
 
-@register_builder("makefile")
+@register_builder("mock_makefile")
 class MakefileBuilder(BuilderWithDefaults):
     phases = ("edit", "build", "install")
     package_methods = ("check", "installcheck")

--- a/var/spack/test_repos/spack_repo/builtin_mock/build_systems/perl.py
+++ b/var/spack/test_repos/spack_repo/builtin_mock/build_systems/perl.py
@@ -19,16 +19,16 @@ class PerlPackage(PackageBase):
     """Specialized class for packages that are built using Perl."""
 
     build_system_class = "PerlPackage"
-    default_buildsystem = "perl"
+    default_buildsystem = "mock_perl"
 
-    build_system("perl")
-    extends("perl", when="build_system=perl")
+    build_system("mock_perl")
+    extends("perl", when="build_system=mock_perl")
 
     def test_use(self):
         pass
 
 
-@register_builder("perl")
+@register_builder("mock_perl")
 class PerlBuilder(BuilderWithDefaults):
     phases = ("configure", "build", "install")
     package_methods = ("check", "test_use")

--- a/var/spack/test_repos/spack_repo/builtin_mock/build_systems/python.py
+++ b/var/spack/test_repos/spack_repo/builtin_mock/build_systems/python.py
@@ -22,14 +22,14 @@ class PythonExtension(PackageBase):
 
 class PythonPackage(PythonExtension):
     build_system_class = "PythonPackage"
-    default_buildsystem = "python_pip"
+    default_buildsystem = "mock_python_pip"
     install_time_test_callbacks = ["test_imports"]
 
-    build_system("python_pip")
-    extends("python", when="build_system=python_pip")
+    build_system("mock_python_pip")
+    extends("python", when="build_system=mock_python_pip")
 
 
-@register_builder("python_pip")
+@register_builder("mock_python_pip")
 class PythonPipBuilder(BuilderWithDefaults):
     phases = ("install",)
     package_methods = ("test_imports",)

--- a/var/spack/test_repos/spack_repo/builtin_mock/packages/dual_cmake_autotools/package.py
+++ b/var/spack/test_repos/spack_repo/builtin_mock/packages/dual_cmake_autotools/package.py
@@ -14,15 +14,15 @@ class DualCmakeAutotools(AutotoolsPackage, CMakePackage):
     url = "http://www.example.com/dual-cmake-autotools-1.0.tar.gz"
 
     version("1.0")
-    build_system("autotools", "cmake", default="autotools")
+    build_system("mock_autotools", "mock_cmake", default="mock_autotools")
     variant(
         "generator",
         default="make",
         values=("make", "ninja"),
         description="the build system generator to use",
-        when="build_system=cmake",
+        when="build_system=mock_cmake",
     )
 
-    with when("build_system=cmake"):
+    with when("build_system=mock_cmake"):
         depends_on("cmake@3.5.1:", type="build")
         depends_on("cmake@3.14.0:", type="build", when="@2.1.0:")


### PR DESCRIPTION
Currently Spack assumes `build_system=*` values are unique, but this is not
enforced. That can result in build non-determinism related to import order,
because the last module that runs `@register_builder` on import will define
what builder class is used.

Even if we relax this and different repos can define build systems under the
same name, then we still need to guarantee uniqueness locally per repo /
namespace, so this commit isn't entirely a stop-gap.

What *is* a stop-gap is renaming `buitin_mock`'s build systems from `foo` to
`mock_foo`, which fixes a symptom of a deeper problem (the fact that many code
paths unexpectedly trigger repo reindex and hit `buitin` when `mock_packages`
is not used) that leads to spurious test failures on develop

