### PR TITLE
config: extract a function to build the flattened configuration

### DIFF
--- a/lib/spack/spack/cmd/config.py
+++ b/lib/spack/spack/cmd/config.py
@@ -239,17 +239,9 @@ def print_flattened_configuration(*, blame: bool, yaml: bool) -> None:
         blame: if True, shows file provenance for each entry in the configuration.
     """
     env = active_environment()
-    if env is not None:
-        pristine = env.manifest.yaml_content
-        flattened = pristine.copy()
-        flattened[spack.schema.env.TOP_LEVEL_KEY] = pristine[spack.schema.env.TOP_LEVEL_KEY].copy()
-    else:
-        flattened = syaml.syaml_dict()
-        flattened[spack.schema.env.TOP_LEVEL_KEY] = syaml.syaml_dict()
+    manifest = env.manifest.yaml_content if env is not None else None
+    flattened = spack.config.flattened_configuration(manifest)
 
-    for config_section in spack.config.SECTION_SCHEMAS:
-        current = spack.config.CONFIG.get(config_section)
-        flattened[spack.schema.env.TOP_LEVEL_KEY][config_section] = current
     if blame or yaml:
         syaml.dump_config(flattened, stream=sys.stdout, default_flow_style=False, blame=blame)
     else:

--- a/lib/spack/spack/config.py
+++ b/lib/spack/spack/config.py
@@ -1734,6 +1734,31 @@ def writable_scopes() -> List[ConfigScope]:
     return scopes
 
 
+def flattened_configuration(manifest: Optional[YamlConfigDict] = None) -> YamlConfigDict:
+    """Return every configuration section, merged across scopes, as a single document.
+
+    The sections are written under the top level key of an environment manifest, so that the
+    result can be read back by the same code that reads a ``spack.yaml``.
+
+    Args:
+        manifest: content of an environment manifest to merge the sections into. Its other
+            keys, like ``specs`` and ``view``, are kept as they are. Passing the manifest of
+            the active environment is what makes the result describe that environment.
+    """
+    top_level_key = spack.schema.env.TOP_LEVEL_KEY
+    if manifest is not None:
+        flattened = manifest.copy()
+        flattened[top_level_key] = manifest[top_level_key].copy()
+    else:
+        flattened = syaml.syaml_dict()
+        flattened[top_level_key] = syaml.syaml_dict()
+
+    for section in SECTION_SCHEMAS:
+        flattened[top_level_key][section] = CONFIG.get(section)
+
+    return flattened
+
+
 def _validate_section_name(section: str) -> None:
     """Exit if the section is not a valid section."""
     if section not in SECTION_SCHEMAS:

--- a/lib/spack/spack/test/config.py
+++ b/lib/spack/spack/test/config.py
@@ -2204,3 +2204,31 @@ def test_env_substitution_follows_activation(mutable_mock_env_path, mutable_conf
     # After deactivation "$env" is a no-op again
     assert mutable_config.env_path is None
     assert spack.config.substitute_path_variables("$env/foo/bar") == "$env/foo/bar"
+
+
+def test_flattened_configuration_has_every_section(mutable_config: Configuration):
+    """Tests that flattening the configuration gives the merged content of every section."""
+    flattened = spack.config.flattened_configuration()
+
+    assert list(flattened) == [spack.schema.env.TOP_LEVEL_KEY]
+    sections = flattened[spack.schema.env.TOP_LEVEL_KEY]
+    assert set(sections) == set(spack.config.SECTION_SCHEMAS)
+    for name in spack.config.SECTION_SCHEMAS:
+        assert sections[name] == mutable_config.get(name)
+
+
+def test_flattened_configuration_leaves_the_manifest_alone(mutable_config: Configuration):
+    """Tests that a manifest keeps the keys that are not config sections."""
+    manifest = syaml.load(
+        """\
+spack:
+  specs:
+  - mpileaks
+  view: true
+"""
+    )
+    flattened = spack.config.flattened_configuration(manifest)[spack.schema.env.TOP_LEVEL_KEY]
+
+    assert flattened["specs"] == ["mpileaks"]
+    assert flattened["view"] is True
+    assert flattened["config"] == mutable_config.get("config")


### PR DESCRIPTION
The flattened configuration is currently built and printed within the `spack.cmd.config` module, since it's the only place that uses it.

Here we extract a function that builds it in `spack.config`, and use it in `spack.cmd.config`. This prepares the machinery we need to store the merged configuration as part of the environment checkpoint.