### PR TITLE
new installer: restore install_times.json file in new installer

### DIFF
--- a/lib/spack/spack/installer/build.py
+++ b/lib/spack/spack/installer/build.py
@@ -32,6 +32,7 @@ import spack.config
 import spack.error
 import spack.hooks
 import spack.mirrors.mirror
+import spack.repo
 import spack.sandbox
 import spack.spec
 import spack.store
@@ -39,6 +40,7 @@ import spack.url_buildcache
 import spack.util.environment
 import spack.util.filesystem as fs
 import spack.util.lock
+import spack.util.timer
 import spack.util.tty
 from spack.installer.base import (
     ExitCode,
@@ -49,7 +51,6 @@ from spack.installer.base import (
     Makeflags,
     ProcessExitNotifier,
 )
-from spack.old_installer import _do_fake_install, dump_packages
 from spack.subprocess_context import GlobalStateMarshaler
 from spack.util.executable import ProcessError
 
@@ -174,6 +175,112 @@ class ChildInfo:
         return exit_code
 
 
+def dump_packages(spec: spack.spec.Spec, path: str) -> None:
+    """
+    Dump all package information for a spec and its dependencies.
+
+    This creates a package repository within path for every namespace in the
+    spec DAG, and fills the repos with package files and patch files for every
+    node in the DAG.
+
+    Args:
+        spec: the Spack spec whose package information is to be dumped
+        path: the path to the build packages directory
+    """
+    fs.mkdirp(path)
+
+    # Copy in package.py files from any dependencies.
+    # Note that we copy them in as they are in the *install* directory
+    # NOT as they are in the repository, because we want a snapshot of
+    # how *this* particular build was done.
+    for node in spec.traverse(deptype="all"):
+        if node is not spec:
+            # Locate the dependency package in the install tree and find
+            # its provenance information.
+            source = spack.store.STORE.layout.build_packages_path(node)
+            source_repo_root = os.path.join(source, node.namespace)
+
+            # If there's no provenance installed for the package, skip it.
+            # If it's external, skip it because it either:
+            # 1) it wasn't built with Spack, so it has no Spack metadata
+            # 2) it was built by another Spack instance, and we do not
+            # (currently) use Spack metadata to associate repos with externals
+            # built by other Spack instances.
+            # Spack can always get something current from the builtin repo.
+            if node.external or not os.path.isdir(source_repo_root):
+                continue
+
+            # Create a source repo and get the pkg directory out of it.
+            try:
+                source_repo = spack.repo.from_path(source_repo_root)
+                source_pkg_dir = source_repo.dirname_for_package_name(node.name)
+            except spack.repo.RepoError as err:
+                spack.util.tty.debug(f"Failed to create source repo for {node.name}: {str(err)}")
+                source_pkg_dir = None
+                spack.util.tty.warn(f"Warning: Couldn't copy in provenance for {node.name}")
+
+        # Create a destination repository
+        pkg_api = spack.repo.PATH.get_repo(node.namespace).package_api
+        repo_root = os.path.join(path, node.namespace) if pkg_api < (2, 0) else path
+        repo = spack.repo.create_or_construct(
+            repo_root, namespace=node.namespace, package_api=pkg_api
+        )
+
+        # Get the location of the package in the dest repo.
+        dest_pkg_dir = repo.dirname_for_package_name(node.name)
+        if node is spec:
+            spack.repo.PATH.dump_provenance(node, dest_pkg_dir)
+        elif source_pkg_dir:
+            fs.install_tree(source_pkg_dir, dest_pkg_dir)
+
+
+def _do_fake_install(pkg: "spack.package_base.PackageBase") -> None:
+    """Make a fake install directory with fake executables, headers, and libraries."""
+    command = pkg.name
+    header = pkg.name
+    library = pkg.name
+
+    # Avoid double 'lib' for packages whose names already start with lib
+    if not pkg.name.startswith("lib"):
+        library = "lib" + library
+
+    plat_shared = ".dll" if sys.platform == "win32" else ".so"
+    plat_static = ".lib" if sys.platform == "win32" else ".a"
+    dso_suffix = ".dylib" if sys.platform == "darwin" else plat_shared
+
+    # Install fake command
+    fs.mkdirp(pkg.prefix.bin)
+    executable = lambda path, flags: os.open(path, flags, 0o700)
+    open(os.path.join(pkg.prefix.bin, command), "wb", opener=executable).close()
+
+    # Install fake header file
+    fs.mkdirp(pkg.prefix.include)
+    fs.touch(os.path.join(pkg.prefix.include, header + ".h"))
+
+    # Install fake shared and static libraries
+    fs.mkdirp(pkg.prefix.lib)
+    for suffix in [dso_suffix, plat_static]:
+        fs.touch(os.path.join(pkg.prefix.lib, library + suffix))
+
+    # Install fake man page
+    fs.mkdirp(pkg.prefix.man.man1)
+
+    packages_dir = spack.store.STORE.layout.build_packages_path(pkg.spec)
+    dump_packages(pkg.spec, packages_dir)
+
+
+def _write_timer_json(
+    pkg: "spack.package_base.PackageBase", timer: spack.util.timer.Timer, cache: bool
+) -> None:
+    extra_attributes = {"name": pkg.name, "cache": cache, "hash": pkg.spec.dag_hash()}
+    try:
+        with open(pkg.times_log_path, "w", encoding="utf-8") as timelog:
+            timer.write_json(timelog, extra_attributes=extra_attributes)
+    except Exception as e:
+        spack.util.tty.debug(str(e))
+        return
+
+
 def send_state(state: str, state_pipe: io.TextIOWrapper) -> None:
     """Send a state update message."""
     json.dump({"state": state}, state_pipe, separators=(",", ":"))
@@ -197,6 +304,7 @@ def install_from_buildcache(
     spec: spack.spec.Spec,
     unsigned: Optional[bool],
     state_stream: io.TextIOWrapper,
+    timer: spack.util.timer.BaseTimer = spack.util.timer.NULL_TIMER,
 ) -> bool:
     # Skip if no configured mirror accepts this spec (select/exclude filters)
     if not any(
@@ -207,9 +315,10 @@ def install_from_buildcache(
 
     send_state("fetching from build cache", state_stream)
     try:
-        tarball_stage = spack.binary_distribution.download_tarball(
-            spec.build_spec, unsigned, mirrors
-        )
+        with timer.measure("fetch"):
+            tarball_stage = spack.binary_distribution.download_tarball(
+                spec.build_spec, unsigned, mirrors
+            )
     except spack.binary_distribution.NoConfiguredBinaryMirrors:
         return False
 
@@ -217,7 +326,8 @@ def install_from_buildcache(
         return False
 
     send_state("relocating", state_stream)
-    spack.binary_distribution.extract_tarball(spec, tarball_stage, force=False)
+    with timer.measure("install"):
+        spack.binary_distribution.extract_tarball(spec, tarball_stage, force=False, timer=timer)
 
     if spec.spliced:  # overwrite old metadata with new
         spack.store.STORE.layout.write_spec(spec, spack.store.STORE.layout.spec_file_path(spec))
@@ -578,15 +688,23 @@ def _install(
     pkg = spec.package
     pkg.run_tests = request.run_tests
 
+    # timer for install phases, dumped to install_times.json on success
+    t = spack.util.timer.Timer()
+
     if request.fake:
         store.layout.create_install_directory(spec)
         _do_fake_install(pkg)
-        spack.hooks.post_install(spec, explicit)
+        with t.measure("post-install"):
+            spack.hooks.post_install(spec, explicit)
+        t.stop()
+        _write_timer_json(pkg, t, False)
         return
 
     # Try to install from buildcache, unless user asked for source only
     if install_policy != "source_only":
-        if install_from_buildcache(request.mirrors, spec, request.unsigned, state_stream):
+        if install_from_buildcache(request.mirrors, spec, request.unsigned, state_stream, t):
+            t.stop()
+            _write_timer_json(pkg, t, True)
             spack.hooks.post_install(spec, explicit)
             return
         elif install_policy == "cache_only":
@@ -642,10 +760,11 @@ def _install(
 
         send_state("staging", state_stream)
 
-        if not request.skip_patch:
-            pkg.do_patch()
-        else:
-            pkg.do_stage()
+        with t.measure("stage"):
+            if not request.skip_patch:
+                pkg.do_patch()
+            else:
+                pkg.do_stage()
 
         os.chdir(stage.source_path)
 
@@ -674,7 +793,8 @@ def _install(
             old_debug = spack.util.tty.debug_level()
             spack.util.tty.set_debug(1)
             try:
-                phase.execute()
+                with t.measure(phase.name):
+                    phase.execute()
             finally:
                 spack.util.tty.set_debug(old_debug)
             if stop_at is not None and phase.name == stop_at:
@@ -682,7 +802,10 @@ def _install(
                 raise spack.error.StopPhase(f"Stopping at '{stop_at}'")
 
         _archive_build_metadata(pkg)
-        spack.hooks.post_install(spec, explicit)
+        with t.measure("post-install"):
+            spack.hooks.post_install(spec, explicit)
+        t.stop()
+        _write_timer_json(pkg, t, False)
 
 
 def start_build(request: BuildRequest, jobserver: JobServerBase) -> ChildInfo:

--- a/lib/spack/spack/installer/build.py
+++ b/lib/spack/spack/installer/build.py
@@ -334,8 +334,6 @@ def install_from_buildcache(
 
     # now a block of curious things follow that should be fixed.
     pkg = spec.package
-    if hasattr(pkg, "_post_buildcache_install_hook"):
-        pkg._post_buildcache_install_hook()
     pkg.installed_from_binary_cache = True
 
     # inform also the parent that this package was installed from binary cache.
@@ -664,18 +662,23 @@ def _enable_sandbox(config: dict, spec: spack.spec.Spec, stage_path: str) -> Non
         raise spack.error.InstallError(f"Cannot enable build sandbox: {e}") from e
 
 
-def _rewire_no_db(spec: spack.spec.Spec, explicit: bool) -> None:
+def _rewire_no_db(
+    spec: spack.spec.Spec, timer: spack.util.timer.BaseTimer = spack.util.timer.NULL_TIMER
+) -> None:
     """Rewire a spliced spec from its build_spec prefix, without writing to the database."""
     tmpdir = tempfile.mkdtemp()
     try:
-        tarball = os.path.join(tmpdir, f"{spec.dag_hash()}.tar.gz")
-        spack.binary_distribution.create_tarball(spec.build_spec, tarball)
-        spack.hooks.pre_install(spec)
-        spack.binary_distribution.extract_buildcache_tarball(tarball, destination=spec.prefix)
-        spack.binary_distribution.relocate_package(spec)
+        with timer.measure("setup"):
+            tarball = os.path.join(tmpdir, f"{spec.dag_hash()}.tar.gz")
+            spack.binary_distribution.create_tarball(spec.build_spec, tarball)
+        with timer.measure("pre-install"):
+            spack.hooks.pre_install(spec)
+        with timer.measure("extract"):
+            spack.binary_distribution.extract_buildcache_tarball(tarball, destination=spec.prefix)
+        with timer.measure("relocate"):
+            spack.binary_distribution.relocate_package(spec)
     finally:
         shutil.rmtree(tmpdir, ignore_errors=True)
-    spack.hooks.post_install(spec, explicit)
 
 
 def _install(
@@ -689,23 +692,18 @@ def _install(
     pkg.run_tests = request.run_tests
 
     # timer for install phases, dumped to install_times.json on success
-    t = spack.util.timer.Timer()
+    timer = spack.util.timer.Timer()
 
     if request.fake:
         store.layout.create_install_directory(spec)
         _do_fake_install(pkg)
-        with t.measure("post-install"):
-            spack.hooks.post_install(spec, explicit)
-        t.stop()
-        _write_timer_json(pkg, t, False)
+        _post_install(pkg, spec, explicit, timer, False)
         return
 
     # Try to install from buildcache, unless user asked for source only
     if install_policy != "source_only":
-        if install_from_buildcache(request.mirrors, spec, request.unsigned, state_stream, t):
-            t.stop()
-            _write_timer_json(pkg, t, True)
-            spack.hooks.post_install(spec, explicit)
+        if install_from_buildcache(request.mirrors, spec, request.unsigned, state_stream, timer):
+            _post_install(pkg, spec, explicit, timer, True)
             return
         elif install_policy == "cache_only":
             send_state("no binary available", state_stream)
@@ -715,7 +713,8 @@ def _install(
     if spec.build_spec is not spec:
         if install_policy == "source_only":
             send_state("rewiring", state_stream)
-            _rewire_no_db(spec, explicit)
+            _rewire_no_db(spec, timer)
+            _post_install(pkg, spec, explicit, timer, False)
             return
         # Binary cache was the only option; signal miss for force_source expansion.
         send_state("no binary available", state_stream)
@@ -760,7 +759,7 @@ def _install(
 
         send_state("staging", state_stream)
 
-        with t.measure("stage"):
+        with timer.measure("stage"):
             if not request.skip_patch:
                 pkg.do_patch()
             else:
@@ -793,7 +792,7 @@ def _install(
             old_debug = spack.util.tty.debug_level()
             spack.util.tty.set_debug(1)
             try:
-                with t.measure(phase.name):
+                with timer.measure(phase.name):
                     phase.execute()
             finally:
                 spack.util.tty.set_debug(old_debug)
@@ -802,10 +801,25 @@ def _install(
                 raise spack.error.StopPhase(f"Stopping at '{stop_at}'")
 
         _archive_build_metadata(pkg)
-        with t.measure("post-install"):
-            spack.hooks.post_install(spec, explicit)
-        t.stop()
-        _write_timer_json(pkg, t, False)
+        _post_install(pkg, spec, explicit, timer, False)
+
+
+def _post_install(
+    pkg: "spack.package_base.PackageBase",
+    spec: spack.spec.Spec,
+    explicit: bool,
+    timer: spack.util.timer.BaseTimer = spack.util.timer.NULL_TIMER,
+    binary: bool = False
+) -> None:
+    # Do post install (and potentially post binary install) hooks
+    with timer.measure("post-install"):
+        if binary:
+            if hasattr(pkg, "_post_buildcache_install_hook"):
+                pkg._post_buildcache_install_hook()
+        spack.hooks.post_install(spec, explicit)
+
+    timer.stop()
+    _write_timer_json(pkg, timer, binary)
 
 
 def start_build(request: BuildRequest, jobserver: JobServerBase) -> ChildInfo:

--- a/lib/spack/spack/installer/build.py
+++ b/lib/spack/spack/installer/build.py
@@ -697,13 +697,13 @@ def _install(
     if request.fake:
         store.layout.create_install_directory(spec)
         _do_fake_install(pkg)
-        _post_install(pkg, spec, explicit, timer, False)
+        _post_install(pkg, spec, explicit, timer, cache=False)
         return
 
     # Try to install from buildcache, unless user asked for source only
     if install_policy != "source_only":
         if install_from_buildcache(request.mirrors, spec, request.unsigned, state_stream, timer):
-            _post_install(pkg, spec, explicit, timer, True)
+            _post_install(pkg, spec, explicit, timer, cache=True)
             return
         elif install_policy == "cache_only":
             send_state("no binary available", state_stream)
@@ -714,7 +714,7 @@ def _install(
         if install_policy == "source_only":
             send_state("rewiring", state_stream)
             _rewire_no_db(spec, timer)
-            _post_install(pkg, spec, explicit, timer, False)
+            _post_install(pkg, spec, explicit, timer, cache=False)
             return
         # Binary cache was the only option; signal miss for force_source expansion.
         send_state("no binary available", state_stream)
@@ -801,25 +801,25 @@ def _install(
                 raise spack.error.StopPhase(f"Stopping at '{stop_at}'")
 
         _archive_build_metadata(pkg)
-        _post_install(pkg, spec, explicit, timer, False)
+        _post_install(pkg, spec, explicit, timer, cache=False)
 
 
 def _post_install(
     pkg: "spack.package_base.PackageBase",
     spec: spack.spec.Spec,
     explicit: bool,
-    timer: spack.util.timer.BaseTimer = spack.util.timer.NULL_TIMER,
-    binary: bool = False
+    timer: spack.util.timer.Timer,
+    cache: bool = False,
 ) -> None:
     # Do post install (and potentially post binary install) hooks
     with timer.measure("post-install"):
-        if binary:
+        if cache:
             if hasattr(pkg, "_post_buildcache_install_hook"):
                 pkg._post_buildcache_install_hook()
         spack.hooks.post_install(spec, explicit)
 
     timer.stop()
-    _write_timer_json(pkg, timer, binary)
+    _write_timer_json(pkg, timer, cache)
 
 
 def start_build(request: BuildRequest, jobserver: JobServerBase) -> ChildInfo:

--- a/lib/spack/spack/old_installer.py
+++ b/lib/spack/spack/old_installer.py
@@ -52,7 +52,6 @@ import spack.hooks
 import spack.mirrors.mirror
 import spack.package_base
 import spack.package_prefs as prefs
-import spack.repo
 import spack.report
 import spack.rewiring
 import spack.store
@@ -60,6 +59,7 @@ import spack.util.filesystem as fs
 import spack.util.lock as lk
 import spack.util.path
 from spack import binary_distribution
+from spack.installer.build import _do_fake_install, _write_timer_json, dump_packages
 from spack.url_buildcache import BuildcacheEntryError
 from spack.util import timer, tty
 from spack.util.environment import EnvironmentModifications, dump_environment
@@ -107,16 +107,6 @@ class BuildStatus(enum.Enum):
 
     def __str__(self):
         return f"{self.name.lower()}"
-
-
-def _write_timer_json(pkg, timer, cache):
-    extra_attributes = {"name": pkg.name, "cache": cache, "hash": pkg.spec.dag_hash()}
-    try:
-        with open(pkg.times_log_path, "w", encoding="utf-8") as timelog:
-            timer.write_json(timelog, extra_attributes=extra_attributes)
-    except Exception as e:
-        tty.debug(str(e))
-        return
 
 
 class ExecuteResult(enum.Enum):
@@ -262,41 +252,6 @@ def _handle_external_and_upstream(pkg: "spack.package_base.PackageBase", explici
         return True
 
     return False
-
-
-def _do_fake_install(pkg: "spack.package_base.PackageBase") -> None:
-    """Make a fake install directory with fake executables, headers, and libraries."""
-    command = pkg.name
-    header = pkg.name
-    library = pkg.name
-
-    # Avoid double 'lib' for packages whose names already start with lib
-    if not pkg.name.startswith("lib"):
-        library = "lib" + library
-
-    plat_shared = ".dll" if sys.platform == "win32" else ".so"
-    plat_static = ".lib" if sys.platform == "win32" else ".a"
-    dso_suffix = ".dylib" if sys.platform == "darwin" else plat_shared
-
-    # Install fake command
-    fs.mkdirp(pkg.prefix.bin)
-    executable = lambda path, flags: os.open(path, flags, 0o700)
-    open(os.path.join(pkg.prefix.bin, command), "wb", opener=executable).close()
-
-    # Install fake header file
-    fs.mkdirp(pkg.prefix.include)
-    fs.touch(os.path.join(pkg.prefix.include, header + ".h"))
-
-    # Install fake shared and static libraries
-    fs.mkdirp(pkg.prefix.lib)
-    for suffix in [dso_suffix, plat_static]:
-        fs.touch(os.path.join(pkg.prefix.lib, library + suffix))
-
-    # Install fake man page
-    fs.mkdirp(pkg.prefix.man.man1)
-
-    packages_dir = spack.store.STORE.layout.build_packages_path(pkg.spec)
-    dump_packages(pkg.spec, packages_dir)
 
 
 def _hms(seconds: int) -> str:
@@ -527,65 +482,6 @@ def combine_phase_logs(phase_log_files: List[str], log_path: str) -> None:
         for phase_log_file in phase_log_files:
             with open(phase_log_file, "br") as phase_log:
                 shutil.copyfileobj(phase_log, log_file)
-
-
-def dump_packages(spec: "spack.spec.Spec", path: str) -> None:
-    """
-    Dump all package information for a spec and its dependencies.
-
-    This creates a package repository within path for every namespace in the
-    spec DAG, and fills the repos with package files and patch files for every
-    node in the DAG.
-
-    Args:
-        spec: the Spack spec whose package information is to be dumped
-        path: the path to the build packages directory
-    """
-    fs.mkdirp(path)
-
-    # Copy in package.py files from any dependencies.
-    # Note that we copy them in as they are in the *install* directory
-    # NOT as they are in the repository, because we want a snapshot of
-    # how *this* particular build was done.
-    for node in spec.traverse(deptype="all"):
-        if node is not spec:
-            # Locate the dependency package in the install tree and find
-            # its provenance information.
-            source = spack.store.STORE.layout.build_packages_path(node)
-            source_repo_root = os.path.join(source, node.namespace)
-
-            # If there's no provenance installed for the package, skip it.
-            # If it's external, skip it because it either:
-            # 1) it wasn't built with Spack, so it has no Spack metadata
-            # 2) it was built by another Spack instance, and we do not
-            # (currently) use Spack metadata to associate repos with externals
-            # built by other Spack instances.
-            # Spack can always get something current from the builtin repo.
-            if node.external or not os.path.isdir(source_repo_root):
-                continue
-
-            # Create a source repo and get the pkg directory out of it.
-            try:
-                source_repo = spack.repo.from_path(source_repo_root)
-                source_pkg_dir = source_repo.dirname_for_package_name(node.name)
-            except spack.repo.RepoError as err:
-                tty.debug(f"Failed to create source repo for {node.name}: {str(err)}")
-                source_pkg_dir = None
-                tty.warn(f"Warning: Couldn't copy in provenance for {node.name}")
-
-        # Create a destination repository
-        pkg_api = spack.repo.PATH.get_repo(node.namespace).package_api
-        repo_root = os.path.join(path, node.namespace) if pkg_api < (2, 0) else path
-        repo = spack.repo.create_or_construct(
-            repo_root, namespace=node.namespace, package_api=pkg_api
-        )
-
-        # Get the location of the package in the dest repo.
-        dest_pkg_dir = repo.dirname_for_package_name(node.name)
-        if node is spec:
-            spack.repo.PATH.dump_provenance(node, dest_pkg_dir)
-        elif source_pkg_dir:
-            fs.install_tree(source_pkg_dir, dest_pkg_dir)
 
 
 def get_dependent_ids(spec: "spack.spec.Spec") -> List[str]:

--- a/lib/spack/spack/test/install.py
+++ b/lib/spack/spack/test/install.py
@@ -212,10 +212,10 @@ def test_installed_dependency_request_conflicts(install_mockery, mock_fetch, mut
         spack.concretize.concretize_one(dependent)
 
 
-def test_install_times(install_mockery, mock_fetch, mutable_mock_repo):
+def test_install_times(install_mockery, mock_fetch, mutable_mock_repo, installer_variant):
     """Test install times added."""
     spec = spack.concretize.concretize_one("dev-build-test-install-phases")
-    PackageInstaller([spec.package], explicit=True).install()
+    spack.installer_dispatch.create_installer([spec.package], explicit=True).install()
 
     # Ensure dependency directory exists after the installation.
     install_times = os.path.join(spec.package.prefix, ".spack", spack_times_log)


### PR DESCRIPTION
Recreates timer functionality from old installer in new installer. Moves shared methods between the two installers into the new installer.

Assisted-by: Claude Fable 5