### PR TITLE
fetch_strategy.py:  archive to a file object instead of a path

### DIFF
--- a/lib/spack/spack/fetch_strategy.py
+++ b/lib/spack/spack/fetch_strategy.py
@@ -32,14 +32,13 @@ import hashlib
 import http.client
 import os
 import re
-import secrets
 import shutil
 import sys
 import time
 import urllib.parse
 import urllib.request
 from pathlib import PurePath
-from typing import Callable, List, Mapping, Optional, Type
+from typing import IO, Callable, List, Mapping, Optional, Type
 
 import spack.config
 import spack.error
@@ -55,7 +54,14 @@ import spack.version
 from spack.util import crypto, tty
 from spack.util.compression import decompressor_for
 from spack.util.executable import CommandNotFoundError, Executable, which
-from spack.util.filesystem import get_single_file, mkdirp, symlink, temp_cwd, working_dir
+from spack.util.filesystem import (
+    get_single_file,
+    mkdirp,
+    symlink,
+    temp_cwd,
+    working_dir,
+    write_tmp_and_move,
+)
 
 #: List of all fetch strategies, created by FetchStrategy metaclass.
 all_strategies: List[Type["FetchStrategy"]] = []
@@ -134,12 +140,12 @@ class FetchStrategy:
         For archive files, this may just re-expand the archive.
         """
 
-    def archive(self, destination):
-        """Create an archive of the downloaded data for a mirror.
+    def archive(self, fileobj: IO[bytes]) -> None:
+        """Write an archive of the downloaded data to ``fileobj``, for a mirror.
 
-        For downloaded files, this should preserve the checksum of the
-        original file. For repositories, it should just create an
-        expandable tarball out of the downloaded repository.
+        For downloaded files, this writes the bytes as they were fetched, so the checksum of
+        the original file is preserved. For repositories, it writes an expandable tarball of
+        the downloaded repository. ``fileobj`` is left open; the caller closes it.
         """
 
     @property
@@ -576,14 +582,13 @@ class URLFetchStrategy(FetchStrategy):
         with fs.exploding_archive_catch(self.stage):
             decompress(self.archive_file)
 
-    def archive(self, destination):
-        """Just moves this archive to the destination."""
+    def archive(self, fileobj: IO[bytes]) -> None:
+        """Copies the fetched archive, byte for byte, into ``fileobj``."""
         if not self.archive_file:
             raise NoArchiveFileError("Cannot call archive() before fetching.")
 
-        web_util.push_to_url(
-            self.archive_file, url_util.path_to_file_url(destination), keep_original=True
-        )
+        with open(self.archive_file, "rb") as f:
+            shutil.copyfileobj(f, fileobj)
 
     @_needs_stage
     def check(self):
@@ -714,15 +719,14 @@ class VCSFetchStrategy(FetchStrategy):
         tty.debug(f"Source fetched with {self.url_attr} is already expanded.")
 
     @_needs_stage
-    def archive(self, destination, *, exclude: Optional[str] = None):
-        assert spack.util.url.extension_from_path(destination) == "tar.gz"
+    def archive(self, fileobj: IO[bytes], *, exclude: Optional[str] = None) -> None:
         assert self.stage.source_path.startswith(self.stage.path)
         # We need to prepend this dir name to every entry of the tarfile
         top_level_dir = PurePath(self.stage.srcdir or os.path.basename(self.stage.source_path))
 
-        with working_dir(self.stage.source_path), spack.util.archive.gzip_compressed_tarfile(
-            destination
-        ) as (tar, _, _):
+        with working_dir(
+            self.stage.source_path
+        ), spack.util.archive.gzip_compressed_tarfile_from_fileobj(fileobj) as (tar, _, _):
             spack.util.archive.reproducible_tarfile_from_prefix(
                 tar=tar,
                 prefix=".",
@@ -786,8 +790,8 @@ class GoFetchStrategy(VCSFetchStrategy):
             env["GOPATH"] = os.path.join(os.getcwd(), "go")
             self.go("get", "-v", "-d", self.url, env=env)
 
-    def archive(self, destination):
-        super().archive(destination, exclude=".git")
+    def archive(self, fileobj: IO[bytes]) -> None:
+        super().archive(fileobj, exclude=".git")
 
     @_needs_stage
     def expand(self):
@@ -1155,8 +1159,8 @@ class CvsFetchStrategy(VCSFetchStrategy):
                     if os.path.isfile(path):
                         os.unlink(path)
 
-    def archive(self, destination):
-        super().archive(destination, exclude="CVS")
+    def archive(self, fileobj: IO[bytes]) -> None:
+        super().archive(fileobj, exclude="CVS")
 
     @_needs_stage
     def reset(self):
@@ -1248,8 +1252,8 @@ class SvnFetchStrategy(VCSFetchStrategy):
                 elif os.path.isdir(path):
                     shutil.rmtree(path, ignore_errors=True)
 
-    def archive(self, destination):
-        super().archive(destination, exclude=".svn")
+    def archive(self, fileobj: IO[bytes]) -> None:
+        super().archive(fileobj, exclude=".svn")
 
     @_needs_stage
     def reset(self):
@@ -1351,8 +1355,8 @@ class HgFetchStrategy(VCSFetchStrategy):
             self.stage.srcdir = repo_name
             shutil.move(repo_name, self.stage.source_path)
 
-    def archive(self, destination):
-        super().archive(destination, exclude=".hg")
+    def archive(self, fileobj: IO[bytes]) -> None:
+        super().archive(fileobj, exclude=".hg")
 
     @_needs_stage
     def reset(self):
@@ -1568,19 +1572,8 @@ class FsCacheBase:
     def store(self, fetcher, relative_dest):
         dst = os.path.join(self.root, relative_dest)
         mkdirp(os.path.dirname(dst))
-        tmp = os.path.join(
-            os.path.dirname(dst), ".tmp." + secrets.token_hex(6) + "." + os.path.basename(dst)
-        )
-        open(tmp, "xb").close()
-        try:
-            fetcher.archive(tmp)
-            os.replace(tmp, dst)
-        except BaseException:
-            try:
-                os.unlink(tmp)
-            except OSError:
-                pass
-            raise
+        with write_tmp_and_move(dst, mode="wb") as f:
+            fetcher.archive(f)
 
 
 class FsCache(FsCacheBase):

--- a/lib/spack/spack/mirrors/layout.py
+++ b/lib/spack/spack/mirrors/layout.py
@@ -132,6 +132,14 @@ def default_mirror_layout(
     # an option to specify an extension, so it must be inferred for those.
     ext = ext or _determine_extension(fetcher)
 
+    # VCSFetchStrategy.archive always writes a gzipped tarball, so a declared extension that
+    # says otherwise would mislabel the mirror entry.
+    if isinstance(fetcher, spack.fetch_strategy.VCSFetchStrategy) and ext != "tar.gz":
+        raise MirrorError(
+            f"Cannot store {fetcher} in a mirror as '{ext}': sources fetched from a repository "
+            f"are archived as 'tar.gz'"
+        )
+
     if ext:
         per_package_ref += ".%s" % ext
 

--- a/lib/spack/spack/test/mirror.py
+++ b/lib/spack/spack/test/mirror.py
@@ -12,13 +12,16 @@ import pytest
 import spack.caches
 import spack.cmd.mirror
 import spack.concretize
+import spack.error
 import spack.fetch_strategy
 import spack.mirrors.layout
 import spack.mirrors.mirror
 import spack.mirrors.utils
 import spack.patch
+import spack.repo
 import spack.stage
 import spack.util.url as url_util
+import spack.version
 from spack.cmd.common.arguments import mirror_name_or_url
 from spack.config import Configuration
 from spack.spec import Spec
@@ -225,9 +228,8 @@ class MockFetcher:
     """
 
     @staticmethod
-    def archive(dst):
-        with open(dst, "w", encoding="utf-8"):
-            pass
+    def archive(fileobj):
+        pass
 
 
 def test_cache_store_atomic_on_failure(tmp_path: pathlib.Path):
@@ -237,9 +239,8 @@ def test_cache_store_atomic_on_failure(tmp_path: pathlib.Path):
         cachable = True
 
         @staticmethod
-        def archive(dst):
-            with open(dst, "wb") as f:
-                f.write(b"partial")
+        def archive(fileobj):
+            fileobj.write(b"partial")
             raise RuntimeError("simulated failure mid-archive")
 
     for cache in [
@@ -490,3 +491,27 @@ def test_mirror_matches(mock_packages, mutable_config):
     )
     assert m.matches_binary(spec, direction="fetch") is False
     assert m.matches_binary(spec, direction="push") is True
+
+
+def test_mirror_layout_rejects_declared_extension_for_vcs(monkeypatch):
+    """Tests that a version fetched from a repository cannot declare its own extension.
+
+    VCSFetchStrategy.archive always writes a gzipped tarball, so any other extension would
+    mislabel the mirror entry.
+    """
+
+    class MockPkg:
+        versions = {spack.version.Version("1.0"): {"extension": "zip"}}
+
+    monkeypatch.setattr(spack.repo.PATH, "get_pkg_class", lambda name: MockPkg)
+    spec = Spec("pkg-a@=1.0")
+
+    fetcher = spack.fetch_strategy.GitFetchStrategy(git="https://example.com/repo.git")
+    with pytest.raises(spack.error.MirrorError, match="archived as 'tar.gz'"):
+        spack.mirrors.layout.default_mirror_layout(fetcher, "pkg-a/pkg-a-1.0", spec)
+
+    # fetch strategies that do not archive as a tarball are not subject to the check
+    layout = spack.mirrors.layout.default_mirror_layout(
+        spack.fetch_strategy.BundleFetchStrategy(), "pkg-a/pkg-a-1.0", spec
+    )
+    assert layout.path.endswith(".zip")

--- a/lib/spack/spack/test/url_fetch.py
+++ b/lib/spack/spack/test/url_fetch.py
@@ -4,6 +4,7 @@
 
 import collections
 import filecmp
+import io
 import os
 import pathlib
 import sys
@@ -142,7 +143,7 @@ def test_archive_file_errors(
         with Stage(fetcher, path=str(tmp_path)) as stage:
             assert fetcher.archive_file is None
             with pytest.raises(fs.NoArchiveFileError):
-                fetcher.archive(str(tmp_path))
+                fetcher.archive(io.BytesIO())
             with pytest.raises(fs.NoArchiveFileError):
                 fetcher.expand()
             with pytest.raises(fs.NoArchiveFileError):

--- a/lib/spack/spack/util/archive.py
+++ b/lib/spack/spack/util/archive.py
@@ -9,7 +9,7 @@ import pathlib
 import tarfile
 from contextlib import closing, contextmanager
 from gzip import GzipFile
-from typing import Callable, Dict, Generator, List, Tuple
+from typing import IO, Callable, Dict, Generator, List, Tuple
 
 from spack.util import tty
 from spack.util.filesystem import readlink
@@ -97,6 +97,28 @@ class ChecksumWriter(io.BufferedIOBase):
 
 
 @contextmanager
+def gzip_compressed_tarfile_from_fileobj(
+    fileobj: IO[bytes],
+) -> Generator[Tuple[tarfile.TarFile, ChecksumWriter, ChecksumWriter], None, None]:
+    """Same as :py:func:`gzip_compressed_tarfile`, writing into an already open binary file
+    object. ``fileobj`` is left open; the caller closes it."""
+    # Create gzip compressed tarball of the install prefix
+    # 1) Use explicit empty filename and mtime 0 for gzip header reproducibility.
+    #    If the filename="" is dropped, Python will use fileobj.name instead.
+    #    This should effectively mimic `gzip --no-name`.
+    # 2) On AMD Ryzen 3700X and an SSD disk, we have the following on compression speed:
+    # compresslevel=6 gzip default: llvm takes 4mins, roughly 2.1GB
+    # compresslevel=9 python default: llvm takes 12mins, roughly 2.1GB
+    # So we follow gzip.
+    with ChecksumWriter(fileobj) as gzip_checksum, closing(
+        GzipFile(filename="", mode="wb", compresslevel=6, mtime=0, fileobj=gzip_checksum)
+    ) as gzip_file, ChecksumWriter(gzip_file) as tarfile_checksum, tarfile.TarFile(
+        name="", mode="w", fileobj=tarfile_checksum
+    ) as tar:
+        yield tar, gzip_checksum, tarfile_checksum
+
+
+@contextmanager
 def gzip_compressed_tarfile(
     path: str,
 ) -> Generator[Tuple[tarfile.TarFile, ChecksumWriter, ChecksumWriter], None, None]:
@@ -111,20 +133,8 @@ def gzip_compressed_tarfile(
         * :class:`ChecksumWriter`: checksum of the gzip compressed tarfile
         * :class:`ChecksumWriter`: checksum of the uncompressed tarfile
     """
-    # Create gzip compressed tarball of the install prefix
-    # 1) Use explicit empty filename and mtime 0 for gzip header reproducibility.
-    #    If the filename="" is dropped, Python will use fileobj.name instead.
-    #    This should effectively mimic `gzip --no-name`.
-    # 2) On AMD Ryzen 3700X and an SSD disk, we have the following on compression speed:
-    # compresslevel=6 gzip default: llvm takes 4mins, roughly 2.1GB
-    # compresslevel=9 python default: llvm takes 12mins, roughly 2.1GB
-    # So we follow gzip.
-    with open(path, "wb") as f, ChecksumWriter(f) as gzip_checksum, closing(
-        GzipFile(filename="", mode="wb", compresslevel=6, mtime=0, fileobj=gzip_checksum)
-    ) as gzip_file, ChecksumWriter(gzip_file) as tarfile_checksum, tarfile.TarFile(
-        name="", mode="w", fileobj=tarfile_checksum
-    ) as tar:
-        yield tar, gzip_checksum, tarfile_checksum
+    with open(path, "wb") as f, gzip_compressed_tarfile_from_fileobj(f) as tarfile_and_checksums:
+        yield tarfile_and_checksums
 
 
 def default_path_to_name(path: str) -> str:


### PR DESCRIPTION
`FsCacheBase.store` now uses `write_tmp_and_move` instead of duplicating it, and `URLFetchStrategy.archive` copies a local file directly instead of going through `push_to_url` with a `file://` URL. The assert on the destination extension moves to `default_mirror_layout`, where the extension is chosen, and becomes a `MirrorError`.