### PR TITLE
setup-env: don't mistake a flag's value for the subcommand

### DIFF
--- a/share/spack/csh/spack.csh
+++ b/share/spack/csh/spack.csh
@@ -36,16 +36,46 @@ if ( ${?DYLD_FALLBACK_LIBRARY_PATH} ) then
     setenv SPACK_DYLD_FALLBACK_LIBRARY_PATH $DYLD_FALLBACK_LIBRARY_PATH
 endif
 
-# accumulate initial flags for main spack command
+# accumulate initial flags for main spack command, stopping at the first
+# argument that is not a flag (the subcommand). Flags that take a required
+# value (e.g. -C DIR, --config-scope DIR) consume the value too, so it
+# isn't mistaken for the subcommand.
 set _sp_flags = ""
+set _sp_early_return = 0
 while ( $#_sp_args > 0 )
-    if ( "$_sp_args[1]" !~ "-*" ) break
-    set _sp_flags = "$_sp_flags $_sp_args[1]"
-    shift _sp_args
+    if ( "$_sp_args[1]" !~ "-*" ) then
+        break
+    else if ("$_sp_args[1]" == "--color" || "$_sp_args[1]" == "--config" || \
+             "$_sp_args[1]" == "--config-scope" || "$_sp_args[1]" == "--env" || \
+             "$_sp_args[1]" == "--env-dir" || "$_sp_args[1]" == "--print-shell-vars" || \
+             "$_sp_args[1]" == "--profile-file" || "$_sp_args[1]" == "--sorted-profile" || \
+             "$_sp_args[1]" == "--lines" || "$_sp_args[1]" == "-c" || \
+             "$_sp_args[1]" == "-C" || "$_sp_args[1]" == "-e" || "$_sp_args[1]" == "-D") then
+        # flags that take a required value
+        if ( $#_sp_args < 2 ) then
+            set _sp_flags = "$_sp_flags $_sp_args[1]"
+            shift _sp_args
+        else
+            set _sp_flags = "$_sp_flags $_sp_args[1] $_sp_args[2]"
+            shift _sp_args
+            shift _sp_args
+        endif
+    else if ("$_sp_args[1]" == "-h" || "$_sp_args[1]" == "-H" || "$_sp_args[1]" == "-V" || \
+             "$_sp_args[1]" == "--help" || "$_sp_args[1]" == "--all-help" || \
+             "$_sp_args[1]" == "--version") then
+        # flags that short-circuit to `\spack` below
+        set _sp_early_return = 1
+        set _sp_flags = "$_sp_flags $_sp_args[1]"
+        shift _sp_args
+    else
+        # all other flags take no value
+        set _sp_flags = "$_sp_flags $_sp_args[1]"
+        shift _sp_args
+    endif
 end
 
-# h and V flags don't require further output parsing.
-if ( "$_sp_flags" =~ *h* || "$_sp_flags" =~ *V* ) then
+# -h/-H/-V/--help/--all-help/--version don't require further output parsing.
+if ( $_sp_early_return == 1 ) then
     \spack $_sp_flags $_sp_args
     goto _sp_end
 endif

--- a/share/spack/qa/setup-env-test.fish
+++ b/share/spack/qa/setup-env-test.fish
@@ -322,6 +322,8 @@ title 'Testing `spack cd`'
 spt_contains "usage: spack cd " spack cd -h
 spt_contains "usage: spack cd " spack cd --help
 spt_contains "cd $b_install" spack cd -i shell-b
+spt_contains "cd $b_install" spack -C "$QA_DIR" cd -i shell-b
+spt_contains "cd $b_install" spack -c config:ccache:true --color always cd -i shell-b
 
 title 'Testing `spack module`'
 spt_contains "usage: spack module " spack -m module -h

--- a/share/spack/qa/setup-env-test.sh
+++ b/share/spack/qa/setup-env-test.sh
@@ -96,6 +96,8 @@ title 'Testing `spack cd`'
 contains "usage: spack cd " spack cd -h
 contains "usage: spack cd " spack cd --help
 contains "cd $b_install" spack cd -i shell-b
+contains "cd $b_install" spack -C "$SHARE_DIR" cd -i shell-b
+contains "cd $b_install" spack -kc config:ccache:true -cconfig:ccache:false --color always cd -i shell-b
 
 title 'Testing `spack module`'
 contains "usage: spack module " spack -m module -h

--- a/share/spack/setup-env.fish
+++ b/share/spack/setup-env.fish
@@ -180,33 +180,57 @@ end
 
 function get_sp_flags -d "return leading flags"
     #
-    # Accumulate initial flags for main spack command. NOTE: Sets the external
-    # array: `__sp_remaining_args` containing all unprocessed arguments.
+    # Accumulate initial flags for main spack command, stopping at the first
+    # argument that is not a flag (the subcommand). Flags that take a
+    # required value (e.g. -C DIR, --config-scope DIR) consume the value
+    # too, so it isn't mistaken for the subcommand.
     #
+    # NOTE: Sets the external variables: `__sp_remaining_args` (all
+    # unprocessed arguments) and `__sp_early_return` (set when a flag that
+    # short-circuits further parsing, e.g. -h or --version, was seen).
+    #
+
+    set -eg __sp_early_return
 
     # initialize argument counter
     set -l i 1
+    set -l n (count $argv)
 
-    # iterate over elements (`elt`) in `argv` array
-    for elt in $argv
+    while test $i -le $n
+        set -l elt $argv[$i]
 
         # match element `elt` of `argv` array to check if it has a leading dash
-        if echo $elt | string match -r -q "^-"
-            # by echoing the current `elt`, the calling stream accumulates list
-            # of valid flags. NOTE that this can also be done by adding to an
-            # array, but fish functions can only return integers, so this is the
-            # most elegant solution.
-            echo $elt
-        else
+        if not echo $elt | string match -r -q "^-"
             # bash compatibility: stop when the match first fails. Upon failure,
             # we pack the remainder of `argv` into a global `__sp_remaining_args`
-            # array (`i` tracks the index of the next element).
+            # array (`i` tracks the index of the current element).
             set __sp_remaining_args (stream_args $argv[$i..-1])
             return
         end
 
+        switch $elt
+            case --color --config --config-scope --env --env-dir --print-shell-vars --profile-file --sorted-profile --lines -c -C -e -D
+                # flags that take a required value: echo both the flag and
+                # its value, and skip over the value below
+                echo $elt
+                if test $i -lt $n
+                    set i (math $i+1)
+                    echo $argv[$i]
+                end
+            case -h -H -V --help --all-help --version
+                # flags that short-circuit further parsing
+                set -g __sp_early_return 1
+                echo $elt
+            case '*'
+                # by echoing the current `elt`, the calling stream accumulates
+                # list of valid flags. NOTE that this can also be done by
+                # adding to an array, but fish functions can only return
+                # integers, so this is the most elegant solution.
+                echo $elt
+        end
+
         # increment argument counter: used in place of bash's `shift` command
-        set -l i (math $i+1)
+        set i (math $i+1)
 
     end
 
@@ -224,24 +248,13 @@ end
 
 function check_sp_flags -d "check spack flags for h/V flags"
     #
-    # Check if inputs contain h or V flags.
+    # Return true if `get_sp_flags` saw a flag that short-circuits further
+    # parsing (-h, -H, -V, --help, --all-help, --version). Unlike the
+    # previous substring-based check, this can't be fooled by an `h` or `V`
+    # appearing inside a flag's value (e.g. `--env-dir /home/user`).
     #
 
-    # combine argument array into single string (space separated), to be passed
-    # to regular expression matching (`string match -r`)
-    set -l _a "$argv"
-
-    # skip if called with blank input. Notes: [1] (cf. EOF)
-    if test -n "$_a"
-        if echo $_a | string match -r -q ".*h.*"
-            return 0
-        end
-        if echo $_a | string match -r -q ".*V.*"
-            return 0
-        end
-    end
-
-    return 1
+    set -q __sp_early_return
 end
 
 

--- a/share/spack/setup-env.sh
+++ b/share/spack/setup-env.sh
@@ -59,21 +59,69 @@ _spack_shell_wrapper() {
         emulate -L sh
     fi
 
-    # accumulate flags meant for the main spack command
-    # the loop condition is unreadable, but it means:
-    #     while $1 is set (while there are arguments)
-    #       and $1 starts with '-' (and the arguments are flags)
+    # accumulate flags meant for the main spack command, stopping at the
+    # first argument that is not a flag (the subcommand). Flags that take a
+    # required value (e.g. -C DIR, --config-scope DIR) consume the value
+    # too, so it isn't mistaken for the subcommand.
     _sp_flags=""
-    while [ ! -z ${1+x} ] && [ "${1#-}" != "${1}" ]; do
-        _sp_flags="$_sp_flags $1"
-        shift
+    _sp_early_return=""
+    while [ ! -z ${1+x} ]; do
+        case "$1" in
+            --color|--config|--config-scope|--env|--env-dir|--print-shell-vars|--profile-file|--sorted-profile|--lines)
+                # long flags that take a required value
+                _sp_flags="$_sp_flags $1 $2"
+                shift 2
+                ;;
+            --help|--all-help|--version)
+                # long flags that short-circuit to `command spack` below
+                _sp_early_return=true
+                _sp_flags="$_sp_flags $1"
+                shift
+                ;;
+            --*)
+                # all other long flags take no value
+                _sp_flags="$_sp_flags $1"
+                shift
+                ;;
+            -?*)
+                # one or more bundled short flags, e.g. -kc, -Cvalue, -kCvalue
+                _sp_bundle="${1#-}"
+                shift
+                while [ -n "$_sp_bundle" ]; do
+                    _sp_char=$(printf '%s' "$_sp_bundle" | cut -c1)
+                    _sp_bundle=$(printf '%s' "$_sp_bundle" | cut -c2-)
+                    case "$_sp_char" in
+                        c | C | e | D)
+                            # short flags that take a required value: the
+                            # rest of the bundle is the value if there is
+                            # one, otherwise the value is the next argument
+                            if [ -n "$_sp_bundle" ]; then
+                                _sp_flags="$_sp_flags -$_sp_char $_sp_bundle"
+                                _sp_bundle=""
+                            else
+                                _sp_flags="$_sp_flags -$_sp_char $1"
+                                shift
+                            fi
+                            ;;
+                        h | H | V)
+                            _sp_early_return=true
+                            _sp_flags="$_sp_flags -$_sp_char"
+                            ;;
+                        *)
+                            _sp_flags="$_sp_flags -$_sp_char"
+                            ;;
+                    esac
+                done
+                ;;
+            *)
+                # not a flag: this is the subcommand
+                break
+                ;;
+        esac
     done
 
-    # h and V flags don't require further output parsing.
-    if [ -n "$_sp_flags" ] && \
-       [ "${_sp_flags#*h}" != "${_sp_flags}" ] || \
-       [ "${_sp_flags#*V}" != "${_sp_flags}" ];
-    then
+    # -h/-H/-V/--help/--all-help/--version don't require further output parsing.
+    if [ -n "$_sp_early_return" ]; then
         command spack $_sp_flags "$@"
         return
     fi


### PR DESCRIPTION
## Summary

The bash/dash, csh, and fish shell wrappers accumulate leading `spack` flags by just checking whether each argument starts with `-`, with no notion that some flags (`-C DIR`, `--config-scope DIR`, `-e ENV`, `--env ENV`, `--color always`, etc.) take a required value. So e.g.

```
spack -C /path/to/config cd -r
```

fails: the wrapper stops accumulating flags at `/path/to/config` (it doesn't start with `-`) and treats it as the subcommand instead of `cd`.

This rewrites the flag-accumulation loop in all three wrappers to classify each flag using the actual list from `lib/spack/spack/main.py`'s argparse setup, so a value-taking flag consumes its value instead of letting it fall through as the subcommand. The bash/dash wrapper (kept POSIX `sh` compatible, since it also has to run under `dash`) additionally supports bundled short flags with attached values (`-cVALUE`, `-kCVALUE`), matching what argparse itself accepts; csh and fish only recognize the flags as separate tokens, which is enough to fix the reported bug without the extra complexity of attached-value parsing in those two dialects.

As a side effect this also fixes `-H`/`--all-help`: the old h/V detection was a substring search over the joined flags string, so it matched lowercase `h` but never uppercase `H`, and could false-positive on an `h` or `V` inside a flag's *value* (e.g. `--env-dir /home/user`). The new code tracks early-return explicitly per recognized flag instead of substring-searching.

This closes out #22359, previously attempted in #22353 (bash only, closed unmerged in 2021 for lack of time — `@becker33` asked in review for csh/fish to be covered too, which this PR does).

## Testing

- The new sh/dash parsing logic was verified in isolation against a battery of cases (the original bug repro, bundled and attached-value short flags, long flags, `-h`/`-H`/`-V`) under both `dash` and `bash`, after normalizing the checked-out CRLF back to LF to match how git actually stores the file.
- `dash -n` / `bash -n` syntax-checked cleanly on the LF-normalized file.
- New test cases were added to `share/spack/qa/setup-env-test.sh` and `setup-env-test.fish`, mirroring the existing style (`spack -C ... cd -i shell-b`, bundled/attached-value variants).
- I could **not** run `csh`/`tcsh` (not available in my environment) or complete the full `setup-env-test.sh` integration suite (blocked by an unrelated, pre-existing bootstrap failure — `'NoneType' object is not iterable` — in my sandboxed environment; the same failure occurs running `spack style` there, unrelated to this change). The `spack cd -h` case that does exercise the new code path did pass. `setup-env-test.csh` has no command-dispatch test coverage to extend (its own header comment notes this — "we haven't ported the unit test functions ... to csh").
- The csh syntax was reviewed carefully against existing `if`/`else if`/`endif` idioms already used elsewhere in the same file, but CI should be treated as the final word on that untested path.

Closes #22359