### PR TITLE
spec parser: accept usage requests in edge attributes (no propagation yet)

### DIFF
--- a/lib/spack/spack/spec_parser.py
+++ b/lib/spack/spack/spec_parser.py
@@ -55,6 +55,12 @@ either use whitespace, or you can just use ``~variant`` since it means the same
 thing.  Spack uses ``~variant`` in directory names and in the canonical form of
 specs to avoid ambiguity.  Both are provided because ``~`` can cause shell
 expansion when it is the first character in an id typed on the command line.
+
+Inside edge properties (``%[...]`` or ``^[...]``), a boolean token such as
+``+sarif`` requests a *usage* on that edge: a build modifier that the dependency
+enacts on behalf of the dependent.  Whitespace is required between a
+``key=value`` attribute and a following usage token (``%[virtuals=c +sarif]``);
+without it the ``+`` is consumed as part of the value.
 """
 
 import json
@@ -553,6 +559,13 @@ class FileParser:
 
 
 class EdgeAttributeParser:
+    """Parse the attributes enclosed in ``%[...]`` or ``^[...]`` on a dependency edge.
+
+    Accepts ``deptypes=``, ``virtuals=`` and ``when=`` key-value pairs, and boolean
+    usage requests (``+name`` / ``~name``). Usages are validated (conflicting values
+    and propagation sigils are parse errors) but not yet stored on the edge.
+    """
+
     __slots__ = "ctx", "literal_str"
 
     def __init__(self, ctx, literal_str):
@@ -576,7 +589,16 @@ class EdgeAttributeParser:
                         'are "deptypes", "virtuals", and "when"'
                     )
                     raise SpecParsingError(msg, self.ctx.current_token, self.literal_str)
-            # TODO: Add code to accept bool variants here as soon as use variants are implemented
+            elif self.ctx.accept(SpecTokens.BOOL_VARIANT):
+                name = self.ctx.current_token.value[1:].strip()
+                value = self.ctx.current_token.value[0] == "+"
+                usage = attributes.setdefault("usage", {})
+                if usage.setdefault(name, value) != value:
+                    msg = f"conflicting values for usage '{name}' on the same edge"
+                    raise SpecParsingError(msg, self.ctx.current_token, self.literal_str)
+            elif self.ctx.expect(SpecTokens.PROPAGATED_BOOL_VARIANT):
+                msg = "usages cannot be propagated; use a single '+' or '~' sigil"
+                raise SpecParsingError(msg, self.ctx.next_token, self.literal_str)
             elif self.ctx.accept(SpecTokens.END_EDGE_PROPERTIES):
                 virtuals = attributes.get("virtuals", ())
                 virtuals += parse_virtual_assignment(self.ctx)
@@ -594,6 +616,10 @@ class EdgeAttributeParser:
         # Turn "when" into a spec
         if "when" in attributes:
             attributes["when"] = parse_one_or_raise(attributes["when"])
+
+        # Usages are parsed and validated above, but not yet attached to the edge
+        # TODO(usages RFD): pass through to DependencySpec once it grows a `usage` attribute
+        attributes.pop("usage", None)
 
         return attributes
 

--- a/lib/spack/spack/test/spec_syntax.py
+++ b/lib/spack/spack/test/spec_syntax.py
@@ -921,6 +921,84 @@ def specfile_for(config, mock_packages):
             ],
             "zlib %fortran=gcc@14.1 %c,cxx=clang",
         ),
+        # Usages requested on an edge, alone and next to other edge attributes.
+        # They are validated but not yet stored on the edge, so they don't
+        # appear in the round-tripped string.
+        (
+            "zlib-ng %[virtuals=c +sarif] gcc",
+            [
+                Token(SpecTokens.UNQUALIFIED_PACKAGE_NAME, "zlib-ng"),
+                Token(SpecTokens.START_EDGE_PROPERTIES, value="%["),
+                Token(SpecTokens.KEY_VALUE_PAIR, value="virtuals=c"),
+                Token(SpecTokens.BOOL_VARIANT, value="+sarif"),
+                Token(SpecTokens.END_EDGE_PROPERTIES, value="]"),
+                Token(SpecTokens.UNQUALIFIED_PACKAGE_NAME, value="gcc"),
+            ],
+            "zlib-ng %c=gcc",
+        ),
+        (
+            "zlib-ng %[+sarif] gcc",
+            [
+                Token(SpecTokens.UNQUALIFIED_PACKAGE_NAME, "zlib-ng"),
+                Token(SpecTokens.START_EDGE_PROPERTIES, value="%["),
+                Token(SpecTokens.BOOL_VARIANT, value="+sarif"),
+                Token(SpecTokens.END_EDGE_PROPERTIES, value="]"),
+                Token(SpecTokens.UNQUALIFIED_PACKAGE_NAME, value="gcc"),
+            ],
+            "zlib-ng %gcc",
+        ),
+        (
+            "zlib-ng %[~sarif] gcc",
+            [
+                Token(SpecTokens.UNQUALIFIED_PACKAGE_NAME, "zlib-ng"),
+                Token(SpecTokens.START_EDGE_PROPERTIES, value="%["),
+                Token(SpecTokens.BOOL_VARIANT, value="~sarif"),
+                Token(SpecTokens.END_EDGE_PROPERTIES, value="]"),
+                Token(SpecTokens.UNQUALIFIED_PACKAGE_NAME, value="gcc"),
+            ],
+            "zlib-ng %gcc",
+        ),
+        # Multiple usages on the same edge
+        (
+            "zlib-ng %[+sarif +foo] gcc",
+            [
+                Token(SpecTokens.UNQUALIFIED_PACKAGE_NAME, "zlib-ng"),
+                Token(SpecTokens.START_EDGE_PROPERTIES, value="%["),
+                Token(SpecTokens.BOOL_VARIANT, value="+sarif"),
+                Token(SpecTokens.BOOL_VARIANT, value="+foo"),
+                Token(SpecTokens.END_EDGE_PROPERTIES, value="]"),
+                Token(SpecTokens.UNQUALIFIED_PACKAGE_NAME, value="gcc"),
+            ],
+            "zlib-ng %gcc",
+        ),
+        # Two direct deps on the same name merge into one edge
+        (
+            "zlib-ng %[+sarif] gcc %[virtuals=c] gcc",
+            [
+                Token(SpecTokens.UNQUALIFIED_PACKAGE_NAME, "zlib-ng"),
+                Token(SpecTokens.START_EDGE_PROPERTIES, value="%["),
+                Token(SpecTokens.BOOL_VARIANT, value="+sarif"),
+                Token(SpecTokens.END_EDGE_PROPERTIES, value="]"),
+                Token(SpecTokens.UNQUALIFIED_PACKAGE_NAME, value="gcc"),
+                Token(SpecTokens.START_EDGE_PROPERTIES, value="%["),
+                Token(SpecTokens.KEY_VALUE_PAIR, value="virtuals=c"),
+                Token(SpecTokens.END_EDGE_PROPERTIES, value="]"),
+                Token(SpecTokens.UNQUALIFIED_PACKAGE_NAME, value="gcc"),
+            ],
+            "zlib-ng %c=gcc",
+        ),
+        # Usages are accepted on ^ edges as well
+        (
+            "foo ^[+sarif] bar",
+            [
+                Token(SpecTokens.UNQUALIFIED_PACKAGE_NAME, "foo"),
+                Token(SpecTokens.START_EDGE_PROPERTIES, value="^["),
+                Token(SpecTokens.BOOL_VARIANT, value="+sarif"),
+                Token(SpecTokens.END_EDGE_PROPERTIES, value="]"),
+                Token(SpecTokens.UNQUALIFIED_PACKAGE_NAME, value="bar"),
+            ],
+            "foo ^bar",
+        ),
         (
             "zlib %fortran=gcc@14.1 %c,cxx=clang",
             [
@@ -1051,6 +1129,29 @@ def test_parse_single_spec(spec_str, tokens, expected_roundtrip, mock_git_test_p
     parser = SpecParser(spec_str)
     assert tokens == parser.tokens()
     assert expected_roundtrip == str(parser.next_spec())
+
+
+@pytest.mark.parametrize(
+    "spec_str",
+    [
+        "zlib-ng %[virtuals=c +sarif] gcc",
+        "zlib-ng %[~sarif] gcc",
+        # A repeated request with the same value is not a conflict
+        "zlib-ng %[+sarif +sarif] gcc",
+        "zlib-ng %[+sarif +foo] gcc",
+    ],
+)
+def test_edge_usage_requests(spec_str):
+    """Usages requested in edge attributes parse cleanly.
+
+    They are validated but not yet stored on the edge, so they must not leak
+    into the spec.
+
+    TODO(usages RFD): assert the values on the edge once DependencySpec grows
+    a `usage` attribute.
+    """
+    spec = SpecParser(spec_str).next_spec()
+    assert "sarif" not in str(spec)
 
 
 @pytest.mark.parametrize(
@@ -1573,6 +1674,10 @@ def test_disambiguate_hash_by_spec(spec1, spec2, constraint, mock_packages, monk
         ("^[@foo] zlib", "edge attributes"),
         # TODO: Remove this as soon as use variants are added and we can parse custom attributes
         ("^[foo=bar] zlib", "edge attributes"),
+        # Usages are edge-scoped and cannot be propagated
+        ("zlib %[++sarif] gcc", "propagated"),
+        # Conflicting usage values on the same edge
+        ("zlib %[+sarif ~sarif] gcc", "conflicting values"),
         # Propagating reserved names generates a parse error
         ("x namespace==foo.bar.baz", "Propagation"),
         ("x arch==linux-rhel9-x86_64", "Propagation"),


### PR DESCRIPTION
Bigger component for https://github.com/spack/spack/issues/52913.

This PR allow the spec parser to accept boolean usage requests inside edge properties, e.g.:

  zlib-ng %[virtuals=c +sarif] gcc
  foo ^[+sarif] bar

A usage is a build modifier that a dependency enacts on behalf of its dependent. This PR only covers parsing and validation — usages are not yet stored on the edge, so they don't survive round-tripping. A follow-up will add a usage attribute to DependencySpec and pass the parsed values through.

  Specifically, EdgeAttributeParser now:

  - accepts +name / ~name tokens inside %[...] and ^[...], alongside the existing deptypes=, virtuals=, and when= attributes
  - raises a parse error on conflicting values for the same usage on one edge (%[+sarif ~sarif]); repeating the same value is fine
  - raises a parse error on propagation sigils (%[++sarif]) — usages are edge-scoped and cannot be propagated

Note: I know that we're still going back and worth on the name in general, but I can change it from usage to usages. It seems like we might move to edge variants, though?