### PR TITLE
solver: move spec clause generation to its own module

### DIFF
--- a/lib/spack/spack/cmd/diff.py
+++ b/lib/spack/spack/cmd/diff.py
@@ -11,7 +11,7 @@ import spack.hash_lookup
 import spack.util.spack_json as sjson
 from spack.active_environment import active_environment
 from spack.cmd.common import arguments
-from spack.solver import asp
+from spack.solver import asp, clauses
 from spack.util import tty
 from spack.util.tty.color import cprint, get_color_when
 
@@ -83,21 +83,21 @@ def compare_specs(a, b, to_string=False, color=None, ignore_packages=None):
             a.trim(pkg_name)
             b.trim(pkg_name)
 
-    # Prepare a solver setup to parse differences
-    setup = asp.SpackSolverSetup()
+    # Prepare a clause generator to parse differences
+    generator = clauses.SpecClauseGenerator()
 
     # get facts for specs, making sure to include build dependencies of concrete
     # specs and to descend into dependency hashes so we include all facts.
     a_facts = {
         shift(func)
-        for func in setup.spec_clauses(
+        for func in generator.spec_clauses(
             a, body=True, expand_hashes=True, concrete_build_deps=True, include_runtimes=True
         )
         if func.name == "attr"
     }
     b_facts = {
         shift(func)
-        for func in setup.spec_clauses(
+        for func in generator.spec_clauses(
             b, body=True, expand_hashes=True, concrete_build_deps=True, include_runtimes=True
         )
         if func.name == "attr"

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -2677,8 +2677,6 @@ class SpackSolverSetup:
             )
         self._validate_input_specs(specs)
         self.gen = ProblemInstanceBuilder()
-
-        # pkg_class() and spec_clauses() read these, so generate them at the beginning
         self.clauses = SpecClauseGenerator(
             libcs=sorted(all_libcs()),
             explicitly_required_namespaces={
@@ -2964,8 +2962,7 @@ class SpackSolverSetup:
             self.gen.fact(fn.pkg_fact(spec.name, fn.condition_effect(condition_id, effect_id)))
 
             # Create subcondition with any conditional dependencies
-            # self.spec_clauses does not do anything with conditional
-            # dependencies
+            # spec_clauses() does not do anything with conditional dependencies
             self.generate_conditional_dep_conditions(spec, condition_id)
 
             if self.concretize_everything:

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -2231,6 +2231,206 @@ class SpackSolverSetup:
             raise RuntimeError(msg)
         return clauses
 
+    def _arch_clauses(self, spec: spack.spec.Spec, f, *, name: str) -> List[AspFunction]:
+        """Return clauses for the architecture of a spec."""
+        # seed architecture at the root (we'll propagate later)
+        # TODO: use better semantics.
+        arch = spec.architecture
+        if not arch:
+            return []
+
+        clauses = []
+        if arch.platform:
+            clauses.append(f.node_platform(name, arch.platform))
+        if arch.os:
+            clauses.append(f.node_os(name, arch.os))
+        if arch.target:
+            clauses.extend(self.target_ranges(spec, f.node_target, name=name))
+        return clauses
+
+    def _variant_clauses(
+        self, spec: spack.spec.Spec, f, *, name: str, body: bool
+    ) -> List[AspFunction]:
+        """Return clauses for the variants of a spec."""
+        clauses = []
+        for vname, variant in sorted(spec.variants.items()):
+            # TODO: variant="*" means 'variant is defined to something', which used to
+            # be meaningless in concretization, as all variants had to be defined. But
+            # now that variants can be conditional, it should force a variant to exist.
+            if not variant.values:
+                continue
+
+            for value in variant.values:
+                # ensure that the value *can* be valid for the spec
+                if name and not spec.concrete and not spack.repo.PATH.is_virtual(name):
+                    variant_defs = vt.prevalidate_variant_value(
+                        self.pkg_class(name), variant, spec
+                    )
+
+                    # Record that that this is a valid possible value. Accounts for
+                    # int/str/etc., where valid values can't be listed in the package
+                    for variant_def in variant_defs:
+                        self.variant_values_from_specs.add((name, id(variant_def), value))
+
+                if variant.propagate:
+                    clauses.append(f.propagate(name, fn.variant_value(vname, value)))
+                    if self.pkg_class(name).has_variant(vname):
+                        clauses.append(f.variant_value(name, vname, value))
+                    continue
+
+                variant_clause = f.variant_value(name, vname, value)
+                if variant.concrete and variant.type == vt.VariantType.MULTI and not spec.concrete:
+                    if body is False:
+                        variant_clause.args = (
+                            f"concrete_{variant_clause.args[0]}",
+                            *variant_clause.args[1:],
+                        )
+                    else:
+                        clauses.append(fn.attr("concrete_variant_request", name, vname, value))
+                clauses.append(variant_clause)
+        return clauses
+
+    def _flag_clauses(
+        self, spec: spack.spec.Spec, f, *, name: str, context: Optional[SourceContext]
+    ) -> List[AspFunction]:
+        """Return clauses for the compiler flags of a spec."""
+        source = context.source if context else "none"
+        clauses = []
+        for flag_type, flags in spec.compiler_flags.items():
+            flag_group = " ".join(flags)
+            for flag in flags:
+                clauses.append(
+                    f.node_flag(name, fn.node_flag(flag_type, flag, flag_group, source))
+                )
+                if not spec.concrete and flag.propagate is True:
+                    clauses.append(
+                        f.propagate(
+                            name,
+                            fn.node_flag(flag_type, flag, flag_group, source),
+                            fn.edge_types("link", "run"),
+                        )
+                    )
+        return clauses
+
+    def _virtuals_from_dependents(
+        self, spec: spack.spec.Spec, *, name: str, body: bool
+    ) -> List[AspFunction]:
+        """Return clauses for the virtuals a spec provides on its incoming edges."""
+        # TODO: a loop over `edges_to_dependencies` is preferred over `edges_from_dependents`
+        # since dependents can point to specs out of scope for the solver.
+        edges = spec.edges_from_dependents()
+        clauses = []
+        if not body and not spec.concrete:
+            virtuals = sorted(set(itertools.chain.from_iterable(edge.virtuals for edge in edges)))
+            for virtual in virtuals:
+                clauses.append(fn.attr("provider_set", name, virtual))
+                clauses.append(fn.attr("virtual_node", virtual))
+            return clauses
+
+        # direct dependencies are handled under `edges_to_dependencies()`
+        virtual_iter = (edge.virtuals for edge in edges if not edge.direct)
+        virtuals = sorted(set(itertools.chain.from_iterable(virtual_iter)))
+        for virtual in virtuals:
+            clauses.append(fn.attr("virtual_on_incoming_edges", name, virtual))
+        return clauses
+
+    def _concrete_edge_clauses(
+        self,
+        dspec: spack.spec.DependencySpec,
+        *,
+        name: str,
+        concrete_build_deps: bool,
+        include_runtimes: bool,
+    ) -> Tuple[List[AspFunction], bool]:
+        """Return clauses for an edge of a concrete spec, and whether the dependency at the
+        other end still has to be traversed."""
+        dep = dspec.spec
+        clauses: List[AspFunction] = []
+
+        # GCC runtime is solved again by clingo, even on concrete specs, to give
+        # the possibility to reuse specs built against a different runtime.
+        if dep.name == "gcc-runtime":
+            clauses.append(fn.attr("compatible_runtime", name, dep.name, f"{dep.version}:"))
+            constraint_spec = spack.spec.Spec(f"{dep.name}@{dep.version}")
+            self.spec_versions(constraint_spec)
+            if not include_runtimes:
+                return clauses, False
+
+        # libc is also solved again by clingo, but in this case the compatibility
+        # is not encoded in the parent node - so we need to emit explicit facts
+        if "libc" in dspec.virtuals:
+            clauses.append(fn.attr("needs_libc", name))
+            for libc in self.libcs:
+                if libc_is_compatible(libc, dep):
+                    clauses.append(fn.attr("compatible_libc", name, libc.name, libc.version))
+            if not include_runtimes:
+                return clauses, False
+
+        # We know dependencies are real for concrete specs. For abstract
+        # specs they just mean the dep is somehow in the DAG.
+        for dtype in dt.ALL_FLAGS:
+            if not dspec.depflag & dtype:
+                continue
+            # skip build dependencies of already-installed specs
+            if concrete_build_deps or dtype != dt.BUILD:
+                clauses.append(fn.attr("depends_on", name, dep.name, dt.flag_to_string(dtype)))
+                for virtual_name in dspec.virtuals:
+                    clauses.append(fn.attr("virtual_on_edge", name, dep.name, virtual_name))
+                    clauses.append(fn.attr("virtual_node", virtual_name))
+
+        # imposing hash constraints for all but pure build deps of
+        # already-installed concrete specs.
+        if concrete_build_deps or dspec.depflag != dt.BUILD:
+            clauses.append(fn.attr("hash", dep.name, dep.dag_hash()))
+        elif not concrete_build_deps and dspec.depflag:
+            clauses.append(fn.attr("concrete_build_dependency", name, dep.name, dep.dag_hash()))
+            for virtual_name in dspec.virtuals:
+                clauses.append(fn.attr("virtual_on_build_edge", name, dep.name, virtual_name))
+
+        return clauses, True
+
+    def _dependency_edge_clauses(
+        self,
+        dspec: spack.spec.DependencySpec,
+        dependency_clauses: List[AspFunction],
+        *,
+        name: str,
+        body: bool,
+        context: Optional[SourceContext],
+    ) -> List[AspFunction]:
+        """Return the clauses of a dependency, attached to the edge that reaches it."""
+        ###
+        # Dependency expressed with "^"
+        ###
+        if not dspec.direct:
+            return dependency_clauses
+
+        ###
+        # Direct dependencies expressed with "%"
+        ###
+        dep = dspec.spec
+        clauses = [
+            fn.attr("depends_on", name, dep.name, dependency_type)
+            for dependency_type in dt.flag_to_tuple(dspec.depflag)
+        ]
+
+        for virtual in dspec.virtuals:
+            dependency_clauses.append(fn.attr("virtual_on_edge", name, dep.name, virtual))
+
+        # By default, wrap head of rules, unless the context says otherwise
+        wrap_node_requirement = body is False
+        if context and context.wrap_node_requirement is not None:
+            wrap_node_requirement = context.wrap_node_requirement
+
+        if not wrap_node_requirement:
+            clauses.extend(dependency_clauses)
+            return clauses
+
+        for clause in dependency_clauses:
+            clause.name = "node_requirement"
+            clauses.append(fn.attr("direct_dependency", name, clause))
+        return clauses
+
     def _spec_clauses(
         self,
         spec: spack.spec.Spec,
@@ -2282,74 +2482,9 @@ class SpackSolverSetup:
             clauses.append(f.namespace(name, spec.namespace))
 
         clauses.extend(self.spec_versions(spec, name=name))
-
-        # seed architecture at the root (we'll propagate later)
-        # TODO: use better semantics.
-        arch = spec.architecture
-        if arch:
-            if arch.platform:
-                clauses.append(f.node_platform(name, arch.platform))
-            if arch.os:
-                clauses.append(f.node_os(name, arch.os))
-            if arch.target:
-                clauses.extend(self.target_ranges(spec, f.node_target, name=name))
-
-        # variants
-        for vname, variant in sorted(spec.variants.items()):
-            # TODO: variant="*" means 'variant is defined to something', which used to
-            # be meaningless in concretization, as all variants had to be defined. But
-            # now that variants can be conditional, it should force a variant to exist.
-            if not variant.values:
-                continue
-
-            for value in variant.values:
-                # ensure that the value *can* be valid for the spec
-                if name and not spec.concrete and not spack.repo.PATH.is_virtual(name):
-                    variant_defs = vt.prevalidate_variant_value(
-                        self.pkg_class(name), variant, spec
-                    )
-
-                    # Record that that this is a valid possible value. Accounts for
-                    # int/str/etc., where valid values can't be listed in the package
-                    for variant_def in variant_defs:
-                        self.variant_values_from_specs.add((name, id(variant_def), value))
-
-                if variant.propagate:
-                    clauses.append(f.propagate(name, fn.variant_value(vname, value)))
-                    if self.pkg_class(name).has_variant(vname):
-                        clauses.append(f.variant_value(name, vname, value))
-                else:
-                    variant_clause = f.variant_value(name, vname, value)
-                    if (
-                        variant.concrete
-                        and variant.type == vt.VariantType.MULTI
-                        and not spec.concrete
-                    ):
-                        if body is False:
-                            variant_clause.args = (
-                                f"concrete_{variant_clause.args[0]}",
-                                *variant_clause.args[1:],
-                            )
-                        else:
-                            clauses.append(fn.attr("concrete_variant_request", name, vname, value))
-                    clauses.append(variant_clause)
-
-        # compiler flags
-        source = context.source if context else "none"
-        for flag_type, flags in spec.compiler_flags.items():
-            flag_group = " ".join(flags)
-            for flag in flags:
-                clauses.append(
-                    f.node_flag(name, fn.node_flag(flag_type, flag, flag_group, source))
-                )
-                if not spec.concrete and flag.propagate is True:
-                    clauses.append(
-                        f.propagate(
-                            name,
-                            fn.node_flag(flag_type, flag, flag_group, source),
-                            fn.edge_types("link", "run"),
-                        )
-                    )
+        clauses.extend(self._arch_clauses(spec, f, name=name))
+        clauses.extend(self._variant_clauses(spec, f, name=name, body=body))
+        clauses.extend(self._flag_clauses(spec, f, name=name, context=context))
 
         # Hash for concrete specs
         if spec.concrete:
@@ -2361,20 +2496,7 @@ class SpackSolverSetup:
             if spec.external:
                 clauses.append(fn.attr("external", name))
 
-        # TODO: a loop over `edges_to_dependencies` is preferred over `edges_from_dependents`
-        # since dependents can point to specs out of scope for the solver.
-        edges = spec.edges_from_dependents()
-        if not body and not spec.concrete:
-            virtuals = sorted(set(itertools.chain.from_iterable(edge.virtuals for edge in edges)))
-            for virtual in virtuals:
-                clauses.append(fn.attr("provider_set", name, virtual))
-                clauses.append(fn.attr("virtual_node", virtual))
-        else:
-            # direct dependencies are handled under `edges_to_dependencies()`
-            virtual_iter = (edge.virtuals for edge in edges if not edge.direct)
-            virtuals = sorted(set(itertools.chain.from_iterable(virtual_iter)))
-            for virtual in virtuals:
-                clauses.append(fn.attr("virtual_on_incoming_edges", name, virtual))
+        clauses.extend(self._virtuals_from_dependents(spec, name=name, body=body))
 
         # If the spec is external and concrete, we allow all the libcs on the system
         if spec.external and spec.concrete and spack.platforms.using_libc_compatibility():
@@ -2395,57 +2517,15 @@ class SpackSolverSetup:
             dep = dspec.spec
 
             if spec.concrete:
-                # GCC runtime is solved again by clingo, even on concrete specs, to give
-                # the possibility to reuse specs built against a different runtime.
-                if dep.name == "gcc-runtime":
-                    edge_clauses.append(
-                        fn.attr("compatible_runtime", name, dep.name, f"{dep.version}:")
-                    )
-                    constraint_spec = spack.spec.Spec(f"{dep.name}@{dep.version}")
-                    self.spec_versions(constraint_spec)
-                    if not include_runtimes:
-                        continue
-
-                # libc is also solved again by clingo, but in this case the compatibility
-                # is not encoded in the parent node - so we need to emit explicit facts
-                if "libc" in dspec.virtuals:
-                    edge_clauses.append(fn.attr("needs_libc", name))
-                    for libc in self.libcs:
-                        if libc_is_compatible(libc, dep):
-                            edge_clauses.append(
-                                fn.attr("compatible_libc", name, libc.name, libc.version)
-                            )
-                    if not include_runtimes:
-                        continue
-
-                # We know dependencies are real for concrete specs. For abstract
-                # specs they just mean the dep is somehow in the DAG.
-                for dtype in dt.ALL_FLAGS:
-                    if not dspec.depflag & dtype:
-                        continue
-                    # skip build dependencies of already-installed specs
-                    if concrete_build_deps or dtype != dt.BUILD:
-                        edge_clauses.append(
-                            fn.attr("depends_on", name, dep.name, dt.flag_to_string(dtype))
-                        )
-                        for virtual_name in dspec.virtuals:
-                            edge_clauses.append(
-                                fn.attr("virtual_on_edge", name, dep.name, virtual_name)
-                            )
-                            edge_clauses.append(fn.attr("virtual_node", virtual_name))
-
-                # imposing hash constraints for all but pure build deps of
-                # already-installed concrete specs.
-                if concrete_build_deps or dspec.depflag != dt.BUILD:
-                    edge_clauses.append(fn.attr("hash", dep.name, dep.dag_hash()))
-                elif not concrete_build_deps and dspec.depflag:
-                    edge_clauses.append(
-                        fn.attr("concrete_build_dependency", name, dep.name, dep.dag_hash())
-                    )
-                    for virtual_name in dspec.virtuals:
-                        edge_clauses.append(
-                            fn.attr("virtual_on_build_edge", name, dep.name, virtual_name)
-                        )
+                concrete_clauses, traverse = self._concrete_edge_clauses(
+                    dspec,
+                    name=name,
+                    concrete_build_deps=concrete_build_deps,
+                    include_runtimes=include_runtimes,
+                )
+                edge_clauses.extend(concrete_clauses)
+                if not traverse:
+                    continue
 
             # if the spec is abstract, descend into dependencies.
             # if it's concrete, then the hashes above take care of dependency
@@ -2459,34 +2539,11 @@ class SpackSolverSetup:
                     context=context,
                     seen=seen,
                 )
-                ###
-                # Dependency expressed with "^"
-                ###
-                if not dspec.direct:
-                    edge_clauses.extend(dependency_clauses)
-                    continue
-
-                ###
-                # Direct dependencies expressed with "%"
-                ###
-                for dependency_type in dt.flag_to_tuple(dspec.depflag):
-                    edge_clauses.append(fn.attr("depends_on", name, dep.name, dependency_type))
-
-                for virtual in dspec.virtuals:
-                    dependency_clauses.append(fn.attr("virtual_on_edge", name, dep.name, virtual))
-
-                # By default, wrap head of rules, unless the context says otherwise
-                wrap_node_requirement = body is False
-                if context and context.wrap_node_requirement is not None:
-                    wrap_node_requirement = context.wrap_node_requirement
-
-                if not wrap_node_requirement:
-                    edge_clauses.extend(dependency_clauses)
-                    continue
-
-                for clause in dependency_clauses:
-                    clause.name = "node_requirement"
-                    edge_clauses.append(fn.attr("direct_dependency", name, clause))
+                edge_clauses.extend(
+                    self._dependency_edge_clauses(
+                        dspec, dependency_clauses, name=name, body=body, context=context
+                    )
+                )
 
         clauses.extend(edge_clauses)
         return clauses

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -73,6 +73,7 @@ from spack.spec import EMPTY_SPEC
 from spack.util import tty
 from spack.util.lang import elide_list
 
+from .clauses import SpecClauseGenerator
 from .compat import default_clingo_control, make_error_control
 from .core import AspFunction, AspVar, NodeId, SourceContext, extract_args, fn
 from .input_analysis import create_counter, create_graph_analyzer
@@ -236,14 +237,6 @@ def dag_closure_by_deptype(
             root, leaf = edge.parent.name, edge.spec.name
             return [fn.attr("closure", root, leaf, "linkrun")]
     return facts
-
-
-def libc_is_compatible(lhs: spack.spec.Spec, rhs: spack.spec.Spec) -> bool:
-    return (
-        lhs.name == rhs.name
-        and lhs.external_path == rhs.external_path
-        and lhs.version >= rhs.version
-    )
 
 
 def c_compiler_runs(compiler) -> bool:
@@ -1379,6 +1372,7 @@ class SpackSolverSetup:
     """Class to set up and run a Spack concretization solve."""
 
     gen: "ProblemInstanceBuilder"
+    clauses: "SpecClauseGenerator"
     possible_versions: Dict[str, Dict[GitOrStandardVersion, List[Provenance]]]
 
     def __init__(self, tests: spack.concretize.TestsType = False):
@@ -1401,9 +1395,6 @@ class SpackSolverSetup:
         self.possible_compilers: List[spack.spec.Spec] = []
         self.rejected_compilers: Set[spack.spec.Spec] = set()
         self.possible_oses: Set = set()
-        self.variant_values_from_specs: Set = set()
-        self.version_constraints: Dict[str, Set] = collections.defaultdict(set)
-        self.target_constraints: Set = set()
         self.default_targets: List = []
         self.variant_ids_by_def_id: Dict[int, int] = {}
 
@@ -1424,10 +1415,8 @@ class SpackSolverSetup:
 
         # Set during the call to setup
         self.pkgs: Set[str] = set()
-        self.explicitly_required_namespaces: Dict[str, str] = {}
 
         # list of unique libc specs targeted by compilers (or an educated guess if no compiler)
-        self.libcs: List[spack.spec.Spec] = []
 
         # If true, we have to load the code for synthesizing splices
         self.enable_splicing: bool = spack.config.CONFIG.get("concretizer:splice:automatic")
@@ -1467,41 +1456,6 @@ class SpackSolverSetup:
         deprecated = self.deprecated_versions[pkg.name]
         for v in sorted(deprecated):
             self.gen.fact(fn.pkg_fact(pkg.name, fn.deprecated_version(v)))
-
-    def spec_versions(
-        self, spec: spack.spec.Spec, *, name: Optional[str] = None
-    ) -> List[AspFunction]:
-        """Return list of clauses expressing spec's version constraints."""
-        name = spec.name or name
-        assert name, "Internal Error: spec with no name occurred. Please file an issue."
-
-        if spec.concrete:
-            return [fn.attr("version", name, spec.version)]
-
-        if spec.versions == vn.any_version:
-            return []
-
-        # record all version constraints for later
-        self.version_constraints[name].add(spec.versions)
-        return [fn.attr("node_version_satisfies", name, spec.versions)]
-
-    def target_ranges(
-        self, spec: spack.spec.Spec, single_target_fn, *, name: Optional[str] = None
-    ) -> List[AspFunction]:
-        name = spec.name or name
-        assert name, "Internal Error: spec with no name occurred. Please file an issue."
-        target = spec.architecture.target
-
-        # target is unconstrained
-        if str(target) == ":":
-            return []
-
-        # Check if the target is a concrete target
-        if str(target) in spack.vendor.archspec.cpu.TARGETS:
-            return [single_target_fn(name, target)]
-
-        self.target_constraints.add(target)
-        return [fn.attr("node_target_satisfies", name, target)]
 
     def conflict_rules(self, pkg):
         for when_spec, conflict_specs in pkg.conflicts.items():
@@ -1548,7 +1502,7 @@ class SpackSolverSetup:
         self.emit_facts_from_requirement_rules(self.requirement_parser.rules(pkg))
 
     def pkg_rules(self, pkg, tests):
-        pkg = self.pkg_class(pkg)
+        pkg = self.clauses.pkg_class(pkg)
 
         # Namespace of the package
         self.gen.fact(fn.pkg_fact(pkg.name, fn.namespace(pkg.namespace)))
@@ -1757,7 +1711,7 @@ class SpackSolverSetup:
             return result[0]
 
         cond_id = next(self._id_counter)
-        requirements = self.spec_clauses(cond, name=name, body=body, context=context)
+        requirements = self.clauses.spec_clauses(cond, name=name, body=body, context=context)
         if context.transform:
             requirements = context.transform(name, cond, requirements)
         pkg_cache[named_cond_key] = (cond_id, requirements)
@@ -1945,18 +1899,20 @@ class SpackSolverSetup:
         for i, (cond, (spec_to_splice, match_variants)) in enumerate(
             sorted(pkg.splice_specs.items())
         ):
-            self.version_constraints[pkg.name].add(cond.versions)
-            self.version_constraints[spec_to_splice.name].add(spec_to_splice.versions)
+            self.clauses.record_version_constraint(pkg.name, cond.versions)
+            self.clauses.record_version_constraint(spec_to_splice.name, spec_to_splice.versions)
             hash_var = AspVar("Hash")
             splice_node = fn.node(AspVar("NID"), pkg.name)
             when_spec_attrs = [
                 fn.attr(c.args[0], splice_node, *(c.args[2:]))
-                for c in self.spec_clauses(cond, name=pkg.name, body=True, required_from=None)
+                for c in self.clauses.spec_clauses(
+                    cond, name=pkg.name, body=True, required_from=None
+                )
                 if c.args[0] != "node"
             ]
             splice_spec_hash_attrs = [
                 fn.hash_attr(hash_var, *(c.args))
-                for c in self.spec_clauses(spec_to_splice, body=True, required_from=None)
+                for c in self.clauses.spec_clauses(spec_to_splice, body=True, required_from=None)
                 if c.args[0] != "node"
             ]
             if match_variants is None:
@@ -2165,7 +2121,9 @@ class SpackSolverSetup:
 
             # perform validation of the variant and values
             try:
-                variant_defs = vt.prevalidate_variant_value(self.pkg_class(pkg_name), variant)
+                variant_defs = vt.prevalidate_variant_value(
+                    self.clauses.pkg_class(pkg_name), variant
+                )
             except (vt.InvalidVariantValueError, KeyError, ValueError) as e:
                 tty.debug(
                     f"[SETUP]: rejected {str(variant)} as a preference for {pkg_name}: {str(e)}"
@@ -2174,7 +2132,7 @@ class SpackSolverSetup:
 
             for value in variant.values:
                 for variant_def in variant_defs:
-                    self.variant_values_from_specs.add((pkg_name, id(variant_def), value))
+                    self.clauses.record_variant_value(pkg_name, variant_def, value)
                 self.gen.fact(
                     fn.variant_default_value_from_packages_yaml(pkg_name, variant.name, value)
                 )
@@ -2193,368 +2151,13 @@ class SpackSolverSetup:
         for i, preferred in enumerate(package_targets):
             self.gen.fact(fn.target_weight(str(preferred.architecture.target), i))
 
-    def spec_clauses(
-        self,
-        spec: spack.spec.Spec,
-        *,
-        name: Optional[str] = None,
-        body: bool = False,
-        transitive: bool = True,
-        expand_hashes: bool = False,
-        concrete_build_deps=False,
-        include_runtimes=False,
-        required_from: Optional[str] = None,
-        context: Optional[SourceContext] = None,
-    ) -> List[AspFunction]:
-        """Wrap a call to ``_spec_clauses()`` into a try/except block with better error handling.
-
-        Arguments are as for ``_spec_clauses()`` except ``required_from``.
-
-        Arguments:
-            required_from: name of package that caused this call.
-        """
-        try:
-            clauses = self._spec_clauses(
-                spec,
-                name=spec.name or name,
-                body=body,
-                transitive=transitive,
-                expand_hashes=expand_hashes,
-                concrete_build_deps=concrete_build_deps,
-                include_runtimes=include_runtimes,
-                context=context,
-            )
-        except RuntimeError as exc:
-            msg = str(exc)
-            if required_from:
-                msg += f" [required from package '{required_from}']"
-            raise RuntimeError(msg)
-        return clauses
-
-    def _arch_clauses(self, spec: spack.spec.Spec, f, *, name: str) -> List[AspFunction]:
-        """Return clauses for the architecture of a spec."""
-        # seed architecture at the root (we'll propagate later)
-        # TODO: use better semantics.
-        arch = spec.architecture
-        if not arch:
-            return []
-
-        clauses = []
-        if arch.platform:
-            clauses.append(f.node_platform(name, arch.platform))
-        if arch.os:
-            clauses.append(f.node_os(name, arch.os))
-        if arch.target:
-            clauses.extend(self.target_ranges(spec, f.node_target, name=name))
-        return clauses
-
-    def _variant_clauses(
-        self, spec: spack.spec.Spec, f, *, name: str, body: bool
-    ) -> List[AspFunction]:
-        """Return clauses for the variants of a spec."""
-        clauses = []
-        for vname, variant in sorted(spec.variants.items()):
-            # TODO: variant="*" means 'variant is defined to something', which used to
-            # be meaningless in concretization, as all variants had to be defined. But
-            # now that variants can be conditional, it should force a variant to exist.
-            if not variant.values:
-                continue
-
-            for value in variant.values:
-                # ensure that the value *can* be valid for the spec
-                if name and not spec.concrete and not spack.repo.PATH.is_virtual(name):
-                    variant_defs = vt.prevalidate_variant_value(
-                        self.pkg_class(name), variant, spec
-                    )
-
-                    # Record that that this is a valid possible value. Accounts for
-                    # int/str/etc., where valid values can't be listed in the package
-                    for variant_def in variant_defs:
-                        self.variant_values_from_specs.add((name, id(variant_def), value))
-
-                if variant.propagate:
-                    clauses.append(f.propagate(name, fn.variant_value(vname, value)))
-                    if self.pkg_class(name).has_variant(vname):
-                        clauses.append(f.variant_value(name, vname, value))
-                    continue
-
-                variant_clause = f.variant_value(name, vname, value)
-                if variant.concrete and variant.type == vt.VariantType.MULTI and not spec.concrete:
-                    if body is False:
-                        variant_clause.args = (
-                            f"concrete_{variant_clause.args[0]}",
-                            *variant_clause.args[1:],
-                        )
-                    else:
-                        clauses.append(fn.attr("concrete_variant_request", name, vname, value))
-                clauses.append(variant_clause)
-        return clauses
-
-    def _flag_clauses(
-        self, spec: spack.spec.Spec, f, *, name: str, context: Optional[SourceContext]
-    ) -> List[AspFunction]:
-        """Return clauses for the compiler flags of a spec."""
-        source = context.source if context else "none"
-        clauses = []
-        for flag_type, flags in spec.compiler_flags.items():
-            flag_group = " ".join(flags)
-            for flag in flags:
-                clauses.append(
-                    f.node_flag(name, fn.node_flag(flag_type, flag, flag_group, source))
-                )
-                if not spec.concrete and flag.propagate is True:
-                    clauses.append(
-                        f.propagate(
-                            name,
-                            fn.node_flag(flag_type, flag, flag_group, source),
-                            fn.edge_types("link", "run"),
-                        )
-                    )
-        return clauses
-
-    def _virtuals_from_dependents(
-        self, spec: spack.spec.Spec, *, name: str, body: bool
-    ) -> List[AspFunction]:
-        """Return clauses for the virtuals a spec provides on its incoming edges."""
-        # TODO: a loop over `edges_to_dependencies` is preferred over `edges_from_dependents`
-        # since dependents can point to specs out of scope for the solver.
-        edges = spec.edges_from_dependents()
-        clauses = []
-        if not body and not spec.concrete:
-            virtuals = sorted(set(itertools.chain.from_iterable(edge.virtuals for edge in edges)))
-            for virtual in virtuals:
-                clauses.append(fn.attr("provider_set", name, virtual))
-                clauses.append(fn.attr("virtual_node", virtual))
-            return clauses
-
-        # direct dependencies are handled under `edges_to_dependencies()`
-        virtual_iter = (edge.virtuals for edge in edges if not edge.direct)
-        virtuals = sorted(set(itertools.chain.from_iterable(virtual_iter)))
-        for virtual in virtuals:
-            clauses.append(fn.attr("virtual_on_incoming_edges", name, virtual))
-        return clauses
-
-    def _concrete_edge_clauses(
-        self,
-        dspec: spack.spec.DependencySpec,
-        *,
-        name: str,
-        concrete_build_deps: bool,
-        include_runtimes: bool,
-    ) -> Tuple[List[AspFunction], bool]:
-        """Return clauses for an edge of a concrete spec, and whether the dependency at the
-        other end still has to be traversed."""
-        dep = dspec.spec
-        clauses: List[AspFunction] = []
-
-        # GCC runtime is solved again by clingo, even on concrete specs, to give
-        # the possibility to reuse specs built against a different runtime.
-        if dep.name == "gcc-runtime":
-            clauses.append(fn.attr("compatible_runtime", name, dep.name, f"{dep.version}:"))
-            constraint_spec = spack.spec.Spec(f"{dep.name}@{dep.version}")
-            self.spec_versions(constraint_spec)
-            if not include_runtimes:
-                return clauses, False
-
-        # libc is also solved again by clingo, but in this case the compatibility
-        # is not encoded in the parent node - so we need to emit explicit facts
-        if "libc" in dspec.virtuals:
-            clauses.append(fn.attr("needs_libc", name))
-            for libc in self.libcs:
-                if libc_is_compatible(libc, dep):
-                    clauses.append(fn.attr("compatible_libc", name, libc.name, libc.version))
-            if not include_runtimes:
-                return clauses, False
-
-        # We know dependencies are real for concrete specs. For abstract
-        # specs they just mean the dep is somehow in the DAG.
-        for dtype in dt.ALL_FLAGS:
-            if not dspec.depflag & dtype:
-                continue
-            # skip build dependencies of already-installed specs
-            if concrete_build_deps or dtype != dt.BUILD:
-                clauses.append(fn.attr("depends_on", name, dep.name, dt.flag_to_string(dtype)))
-                for virtual_name in dspec.virtuals:
-                    clauses.append(fn.attr("virtual_on_edge", name, dep.name, virtual_name))
-                    clauses.append(fn.attr("virtual_node", virtual_name))
-
-        # imposing hash constraints for all but pure build deps of
-        # already-installed concrete specs.
-        if concrete_build_deps or dspec.depflag != dt.BUILD:
-            clauses.append(fn.attr("hash", dep.name, dep.dag_hash()))
-        elif not concrete_build_deps and dspec.depflag:
-            clauses.append(fn.attr("concrete_build_dependency", name, dep.name, dep.dag_hash()))
-            for virtual_name in dspec.virtuals:
-                clauses.append(fn.attr("virtual_on_build_edge", name, dep.name, virtual_name))
-
-        return clauses, True
-
-    def _dependency_edge_clauses(
-        self,
-        dspec: spack.spec.DependencySpec,
-        dependency_clauses: List[AspFunction],
-        *,
-        name: str,
-        body: bool,
-        context: Optional[SourceContext],
-    ) -> List[AspFunction]:
-        """Return the clauses of a dependency, attached to the edge that reaches it."""
-        ###
-        # Dependency expressed with "^"
-        ###
-        if not dspec.direct:
-            return dependency_clauses
-
-        ###
-        # Direct dependencies expressed with "%"
-        ###
-        dep = dspec.spec
-        clauses = [
-            fn.attr("depends_on", name, dep.name, dependency_type)
-            for dependency_type in dt.flag_to_tuple(dspec.depflag)
-        ]
-
-        for virtual in dspec.virtuals:
-            dependency_clauses.append(fn.attr("virtual_on_edge", name, dep.name, virtual))
-
-        # By default, wrap head of rules, unless the context says otherwise
-        wrap_node_requirement = body is False
-        if context and context.wrap_node_requirement is not None:
-            wrap_node_requirement = context.wrap_node_requirement
-
-        if not wrap_node_requirement:
-            clauses.extend(dependency_clauses)
-            return clauses
-
-        for clause in dependency_clauses:
-            clause.name = "node_requirement"
-            clauses.append(fn.attr("direct_dependency", name, clause))
-        return clauses
-
-    def _spec_clauses(
-        self,
-        spec: spack.spec.Spec,
-        *,
-        name: Optional[str] = None,
-        body: bool = False,
-        transitive: bool = True,
-        expand_hashes: bool = False,
-        concrete_build_deps: bool = False,
-        include_runtimes: bool = False,
-        context: Optional[SourceContext] = None,
-        seen: Optional[Set[int]] = None,
-    ) -> List[AspFunction]:
-        """Return a list of clauses for a spec mandates are true.
-
-        Arguments:
-            spec: the spec to analyze
-            name: optional fallback of spec.name (used for anonymous roots)
-            body: if True, generate clauses to be used in rule bodies (final values) instead
-                of rule heads (setters).
-            transitive: if False, don't generate clauses from dependencies (default True)
-            expand_hashes: if True, descend into hashes of concrete specs (default False)
-            concrete_build_deps: if False, do not include pure build deps of concrete specs
-                (as they have no effect on runtime constraints)
-            include_runtimes: generate full dependency clauses from runtime libraries that
-                are omitted from the solve.
-            context: tracks what constraint this clause set is generated for (e.g. a
-                ``depends_on`` constraint in a package.py file)
-            seen: set of ids of specs that have already been processed (for internal use only)
-
-        Normally, if called with ``transitive=True``, ``spec_clauses()`` just generates
-        hashes for the dependency requirements of concrete specs. If ``expand_hashes``
-        is ``True``, we'll *also* output all the facts implied by transitive hashes,
-        which are redundant during a solve but useful outside of one (e.g.,
-        for spec ``diff``).
-        """
-        clauses = []
-        seen = seen if seen is not None else set()
-        name = spec.name or name or ""
-        seen.add(id(spec))
-
-        f: Union[Type[_Head], Type[_Body]] = _Body if body else _Head
-
-        if name:
-            clauses.append(
-                f.node(name) if not spack.repo.PATH.is_virtual(name) else f.virtual_node(name)
-            )
-        if spec.namespace:
-            clauses.append(f.namespace(name, spec.namespace))
-
-        clauses.extend(self.spec_versions(spec, name=name))
-        clauses.extend(self._arch_clauses(spec, f, name=name))
-        clauses.extend(self._variant_clauses(spec, f, name=name, body=body))
-        clauses.extend(self._flag_clauses(spec, f, name=name, context=context))
-
-        # Hash for concrete specs
-        if spec.concrete:
-            # older specs do not have package hashes, so we have to do this carefully
-            package_hash = getattr(spec, "_package_hash", None)
-            if package_hash:
-                clauses.append(fn.attr("package_hash", name, package_hash))
-            clauses.append(fn.attr("hash", name, spec.dag_hash()))
-            if spec.external:
-                clauses.append(fn.attr("external", name))
-
-        clauses.extend(self._virtuals_from_dependents(spec, name=name, body=body))
-
-        # If the spec is external and concrete, we allow all the libcs on the system
-        if spec.external and spec.concrete and spack.platforms.using_libc_compatibility():
-            clauses.append(fn.attr("needs_libc", name))
-            for libc in self.libcs:
-                clauses.append(fn.attr("compatible_libc", name, libc.name, libc.version))
-
-        if not transitive:
-            return clauses
-
-        # Dependencies
-        edge_clauses = []
-        for dspec in spec.edges_to_dependencies():
-            # Ignore conditional dependencies, they are handled by caller
-            if dspec.when != EMPTY_SPEC:
-                continue
-
-            dep = dspec.spec
-
-            if spec.concrete:
-                concrete_clauses, traverse = self._concrete_edge_clauses(
-                    dspec,
-                    name=name,
-                    concrete_build_deps=concrete_build_deps,
-                    include_runtimes=include_runtimes,
-                )
-                edge_clauses.extend(concrete_clauses)
-                if not traverse:
-                    continue
-
-            # if the spec is abstract, descend into dependencies.
-            # if it's concrete, then the hashes above take care of dependency
-            # constraints, but expand the hashes if asked for.
-            if (not spec.concrete or expand_hashes) and id(dep) not in seen:
-                dependency_clauses = self._spec_clauses(
-                    dep,
-                    body=body,
-                    expand_hashes=expand_hashes,
-                    concrete_build_deps=concrete_build_deps,
-                    context=context,
-                    seen=seen,
-                )
-                edge_clauses.extend(
-                    self._dependency_edge_clauses(
-                        dspec, dependency_clauses, name=name, body=body, context=context
-                    )
-                )
-
-        clauses.extend(edge_clauses)
-        return clauses
-
     def define_package_versions_and_validate_preferences(
         self, possible_pkgs: Set[str], *, require_checksum: bool, allow_deprecated: bool
     ):
         """Declare any versions in specs not declared in packages."""
         packages_yaml = spack.config.CONFIG.get_config("packages")
         for pkg_name in sorted(possible_pkgs):
-            pkg_cls = self.pkg_class(pkg_name)
+            pkg_cls = self.clauses.pkg_class(pkg_name)
 
             # All the versions from the corresponding package.py file. Since concepts
             # like being a "develop" version or being preferred exist only at a
@@ -2714,7 +2317,7 @@ class SpackSolverSetup:
                         f"Run 'spack arch --known-targets' to see valid targets."
                     )
                 # range/list constraint (contains ':' or ','): keep existing path
-                self.target_ranges(spec, None)
+                self.clauses.target_ranges(spec, None)
                 continue
 
             if target not in candidate_targets and not host_compatible:
@@ -2789,7 +2392,7 @@ class SpackSolverSetup:
             self.gen.newline()
         self.gen.newline()
 
-        for pkg_name, set_of_versions in sorted(self.version_constraints.items()):
+        for pkg_name, set_of_versions in sorted(self.clauses.version_constraints.items()):
             possible_versions = sorted_versions.get(pkg_name)
             if possible_versions is None:
                 continue
@@ -2834,7 +2437,7 @@ class SpackSolverSetup:
         # Define a set of synthetic possible versions for virtuals that don't define versions in a
         # package.py file. This ensures that `version_satisfies(Package, Constraint, Version)` has
         # the same semantics for virtuals as for regular packages.
-        for pkg_name, versions in self.version_constraints.items():
+        for pkg_name, versions in self.clauses.version_constraints.items():
             # Not a virtual package
             if pkg_name not in self.possible_virtuals:
                 continue
@@ -2864,7 +2467,7 @@ class SpackSolverSetup:
             return allowed_targets
 
         cache = {}
-        for target_constraint in sorted(self.target_constraints, key=lambda x: x.name):
+        for target_constraint in sorted(self.clauses.target_constraints, key=lambda x: x.name):
             # Construct the list of allowed targets for this constraint
             allowed_targets = []
             for single_constraint in str(target_constraint).split(","):
@@ -2885,7 +2488,7 @@ class SpackSolverSetup:
         """
         # for determinism, sort by variant ids, not variant def ids (which are object ids)
         def_info = []
-        for pkg_name, variant_def_id, value in sorted(self.variant_values_from_specs):
+        for pkg_name, variant_def_id, value in sorted(self.clauses.variant_values_from_specs):
             try:
                 vid = self.variant_ids_by_def_id[variant_def_id]
             except KeyError:
@@ -2924,7 +2527,7 @@ class SpackSolverSetup:
                 # the hash is known, but only a parent being reused can impose it
                 self.gen.fact(fn.imposable_hash(spec.name, h))
             # indirection layer between hash constraints and imposition to allow for splicing
-            for pred in self.spec_clauses(spec, body=True, required_from=None):
+            for pred in self.clauses.spec_clauses(spec, body=True, required_from=None):
                 self.gen.fact(fn.hash_attr(h, *pred.args))
             self.gen.newline()
             # Declare as possible parts of specs that are not in package.py
@@ -3076,10 +2679,14 @@ class SpackSolverSetup:
         self.gen = ProblemInstanceBuilder()
 
         # pkg_class() and spec_clauses() read these, so generate them at the beginning
-        self.libcs = sorted(all_libcs())
-        for node in traverse.traverse_nodes(specs):
-            if node.namespace is not None:
-                self.explicitly_required_namespaces[node.name] = node.namespace
+        self.clauses = SpecClauseGenerator(
+            libcs=sorted(all_libcs()),
+            explicitly_required_namespaces={
+                node.name: node.namespace
+                for node in traverse.traverse_nodes(specs)
+                if node.namespace is not None
+            },
+        )
 
         # Get compilers from buildcaches only if injected through "reuse" specs
         supported_compilers = spack.compilers.config.supported_compilers()
@@ -3125,7 +2732,7 @@ class SpackSolverSetup:
         self.requirement_parser.parse_rules_from_input_specs(specs)
         self.gen.h1("Generic information")
         if spack.platforms.using_libc_compatibility():
-            for libc in self.libcs:
+            for libc in self.clauses.libcs:
                 self.gen.fact(fn.host_libc(libc.name, libc.version))
 
         if not allow_deprecated:
@@ -3334,7 +2941,7 @@ class SpackSolverSetup:
                 effect_id = next(self._id_counter)
                 context = SourceContext()
                 context.source = "literal"
-                requirements = self.spec_clauses(spec, context=context)
+                requirements = self.clauses.spec_clauses(spec, context=context)
             root_name = spec.name
             for clause in requirements:
                 clause_name = clause.args[0]
@@ -3478,41 +3085,6 @@ class SpackSolverSetup:
             key = "one_of" if "one_of" in spec_group else "any_of"
             for s in spec_group[key]:
                 yield _spec_with_default_name(s, pkg_name)
-
-    def pkg_class(self, pkg_name: str) -> Type[spack.package_base.PackageBase]:
-        request = pkg_name
-        if pkg_name in self.explicitly_required_namespaces:
-            namespace = self.explicitly_required_namespaces[pkg_name]
-            request = f"{namespace}.{pkg_name}"
-        return spack.repo.PATH.get_pkg_class(request)
-
-
-class _Head:
-    """ASP functions used to express spec clauses in the HEAD of a rule"""
-
-    node = fn.attr("node")
-    namespace = fn.attr("namespace_set")
-    virtual_node = fn.attr("virtual_node")
-    node_platform = fn.attr("node_platform_set")
-    node_os = fn.attr("node_os_set")
-    node_target = fn.attr("node_target_set")
-    variant_value = fn.attr("variant_set")
-    node_flag = fn.attr("node_flag_set")
-    propagate = fn.attr("propagate")
-
-
-class _Body:
-    """ASP functions used to express spec clauses in the BODY of a rule"""
-
-    node = fn.attr("node")
-    namespace = fn.attr("namespace")
-    virtual_node = fn.attr("virtual_node")
-    node_platform = fn.attr("node_platform")
-    node_os = fn.attr("node_os")
-    node_target = fn.attr("node_target")
-    variant_value = fn.attr("variant_value")
-    node_flag = fn.attr("node_flag")
-    propagate = fn.attr("propagate")
 
 
 class ProblemInstanceBuilder:

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -3075,6 +3075,12 @@ class SpackSolverSetup:
         self._validate_input_specs(specs)
         self.gen = ProblemInstanceBuilder()
 
+        # pkg_class() and spec_clauses() read these, so generate them at the beginning
+        self.libcs = sorted(all_libcs())
+        for node in traverse.traverse_nodes(specs):
+            if node.namespace is not None:
+                self.explicitly_required_namespaces[node.name] = node.namespace
+
         # Get compilers from buildcaches only if injected through "reuse" specs
         supported_compilers = spack.compilers.config.supported_compilers()
         compilers_from_reuse = {
@@ -3115,11 +3121,6 @@ class SpackSolverSetup:
         )
         self.possible_virtuals = node_counter.possible_virtuals()
         self.pkgs = node_counter.possible_dependencies()
-        self.libcs = sorted(all_libcs())
-
-        for node in traverse.traverse_nodes(specs):
-            if node.namespace is not None:
-                self.explicitly_required_namespaces[node.name] = node.namespace
 
         self.requirement_parser.parse_rules_from_input_specs(specs)
         self.gen.h1("Generic information")

--- a/lib/spack/spack/solver/clauses.py
+++ b/lib/spack/spack/solver/clauses.py
@@ -1,0 +1,491 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+"""Translation of specs into the ASP facts that describe them."""
+
+import collections
+import itertools
+from typing import Dict, List, Optional, Set, Tuple, Type, Union
+
+import spack.vendor.archspec.cpu
+
+import spack.deptypes as dt
+import spack.package_base
+import spack.platforms
+import spack.repo
+import spack.spec
+import spack.variant as vt
+import spack.version as vn
+from spack.spec import EMPTY_SPEC
+
+from .core import AspFunction, SourceContext, fn
+
+
+def libc_is_compatible(lhs: spack.spec.Spec, rhs: spack.spec.Spec) -> bool:
+    return (
+        lhs.name == rhs.name
+        and lhs.external_path == rhs.external_path
+        and lhs.version >= rhs.version
+    )
+
+
+class _Head:
+    """ASP functions used to express spec clauses in the HEAD of a rule"""
+
+    node = fn.attr("node")
+    namespace = fn.attr("namespace_set")
+    virtual_node = fn.attr("virtual_node")
+    node_platform = fn.attr("node_platform_set")
+    node_os = fn.attr("node_os_set")
+    node_target = fn.attr("node_target_set")
+    variant_value = fn.attr("variant_set")
+    node_flag = fn.attr("node_flag_set")
+    propagate = fn.attr("propagate")
+
+
+class _Body:
+    """ASP functions used to express spec clauses in the BODY of a rule"""
+
+    node = fn.attr("node")
+    namespace = fn.attr("namespace")
+    virtual_node = fn.attr("virtual_node")
+    node_platform = fn.attr("node_platform")
+    node_os = fn.attr("node_os")
+    node_target = fn.attr("node_target")
+    variant_value = fn.attr("variant_value")
+    node_flag = fn.attr("node_flag")
+    propagate = fn.attr("propagate")
+
+
+class SpecClauseGenerator:
+    """Translates specs into the ASP facts that describe them.
+
+    Generating clauses also discovers constraints that the solver setup turns into facts
+    later: the version and target constraints that were mentioned, and the variant values
+    that were seen. They accumulate here, and are read back once clause generation is done.
+    """
+
+    def __init__(
+        self,
+        *,
+        libcs: Optional[List[spack.spec.Spec]] = None,
+        explicitly_required_namespaces: Optional[Dict[str, str]] = None,
+    ) -> None:
+        """
+        Arguments:
+            libcs: libcs available on the system, used for compatibility clauses
+            explicitly_required_namespaces: package name to namespace, for specs that
+                requested one explicitly
+        """
+        self.libcs = libcs if libcs is not None else []
+        self.explicitly_required_namespaces = (
+            explicitly_required_namespaces if explicitly_required_namespaces is not None else {}
+        )
+        self.version_constraints: Dict[str, Set] = collections.defaultdict(set)
+        self.target_constraints: Set = set()
+        self.variant_values_from_specs: Set = set()
+
+    def record_version_constraint(self, name: str, versions) -> None:
+        """Record that `versions` was requested for package `name`."""
+        self.version_constraints[name].add(versions)
+
+    def record_variant_value(self, pkg_name: str, variant_def, value) -> None:
+        """Record that `value` was seen for a variant defined by `variant_def`."""
+        self.variant_values_from_specs.add((pkg_name, id(variant_def), value))
+
+    def spec_versions(
+        self, spec: spack.spec.Spec, *, name: Optional[str] = None
+    ) -> List[AspFunction]:
+        """Return list of clauses expressing spec's version constraints."""
+        name = spec.name or name
+        assert name, "Internal Error: spec with no name occurred. Please file an issue."
+
+        if spec.concrete:
+            return [fn.attr("version", name, spec.version)]
+
+        if spec.versions == vn.any_version:
+            return []
+
+        # record all version constraints for later
+        self.version_constraints[name].add(spec.versions)
+        return [fn.attr("node_version_satisfies", name, spec.versions)]
+
+    def target_ranges(
+        self, spec: spack.spec.Spec, single_target_fn, *, name: Optional[str] = None
+    ) -> List[AspFunction]:
+        name = spec.name or name
+        assert name, "Internal Error: spec with no name occurred. Please file an issue."
+        target = spec.architecture.target
+
+        # target is unconstrained
+        if str(target) == ":":
+            return []
+
+        # Check if the target is a concrete target
+        if str(target) in spack.vendor.archspec.cpu.TARGETS:
+            return [single_target_fn(name, target)]
+
+        self.target_constraints.add(target)
+        return [fn.attr("node_target_satisfies", name, target)]
+
+    def spec_clauses(
+        self,
+        spec: spack.spec.Spec,
+        *,
+        name: Optional[str] = None,
+        body: bool = False,
+        transitive: bool = True,
+        expand_hashes: bool = False,
+        concrete_build_deps=False,
+        include_runtimes=False,
+        required_from: Optional[str] = None,
+        context: Optional[SourceContext] = None,
+    ) -> List[AspFunction]:
+        """Wrap a call to ``_spec_clauses()`` into a try/except block with better error handling.
+
+        Arguments are as for ``_spec_clauses()`` except ``required_from``.
+
+        Arguments:
+            required_from: name of package that caused this call.
+        """
+        try:
+            clauses = self._spec_clauses(
+                spec,
+                name=spec.name or name,
+                body=body,
+                transitive=transitive,
+                expand_hashes=expand_hashes,
+                concrete_build_deps=concrete_build_deps,
+                include_runtimes=include_runtimes,
+                context=context,
+            )
+        except RuntimeError as exc:
+            msg = str(exc)
+            if required_from:
+                msg += f" [required from package '{required_from}']"
+            raise RuntimeError(msg)
+        return clauses
+
+    def _arch_clauses(self, spec: spack.spec.Spec, f, *, name: str) -> List[AspFunction]:
+        """Return clauses for the architecture of a spec."""
+        # seed architecture at the root (we'll propagate later)
+        # TODO: use better semantics.
+        arch = spec.architecture
+        if not arch:
+            return []
+
+        clauses = []
+        if arch.platform:
+            clauses.append(f.node_platform(name, arch.platform))
+        if arch.os:
+            clauses.append(f.node_os(name, arch.os))
+        if arch.target:
+            clauses.extend(self.target_ranges(spec, f.node_target, name=name))
+        return clauses
+
+    def _variant_clauses(
+        self, spec: spack.spec.Spec, f, *, name: str, body: bool
+    ) -> List[AspFunction]:
+        """Return clauses for the variants of a spec."""
+        clauses = []
+        for vname, variant in sorted(spec.variants.items()):
+            # TODO: variant="*" means 'variant is defined to something', which used to
+            # be meaningless in concretization, as all variants had to be defined. But
+            # now that variants can be conditional, it should force a variant to exist.
+            if not variant.values:
+                continue
+
+            for value in variant.values:
+                # ensure that the value *can* be valid for the spec
+                if name and not spec.concrete and not spack.repo.PATH.is_virtual(name):
+                    variant_defs = vt.prevalidate_variant_value(
+                        self.pkg_class(name), variant, spec
+                    )
+
+                    # Record that that this is a valid possible value. Accounts for
+                    # int/str/etc., where valid values can't be listed in the package
+                    for variant_def in variant_defs:
+                        self.variant_values_from_specs.add((name, id(variant_def), value))
+
+                if variant.propagate:
+                    clauses.append(f.propagate(name, fn.variant_value(vname, value)))
+                    if self.pkg_class(name).has_variant(vname):
+                        clauses.append(f.variant_value(name, vname, value))
+                    continue
+
+                variant_clause = f.variant_value(name, vname, value)
+                if variant.concrete and variant.type == vt.VariantType.MULTI and not spec.concrete:
+                    if body is False:
+                        variant_clause.args = (
+                            f"concrete_{variant_clause.args[0]}",
+                            *variant_clause.args[1:],
+                        )
+                    else:
+                        clauses.append(fn.attr("concrete_variant_request", name, vname, value))
+                clauses.append(variant_clause)
+        return clauses
+
+    def _flag_clauses(
+        self, spec: spack.spec.Spec, f, *, name: str, context: Optional[SourceContext]
+    ) -> List[AspFunction]:
+        """Return clauses for the compiler flags of a spec."""
+        source = context.source if context else "none"
+        clauses = []
+        for flag_type, flags in spec.compiler_flags.items():
+            flag_group = " ".join(flags)
+            for flag in flags:
+                clauses.append(
+                    f.node_flag(name, fn.node_flag(flag_type, flag, flag_group, source))
+                )
+                if not spec.concrete and flag.propagate is True:
+                    clauses.append(
+                        f.propagate(
+                            name,
+                            fn.node_flag(flag_type, flag, flag_group, source),
+                            fn.edge_types("link", "run"),
+                        )
+                    )
+        return clauses
+
+    def _virtuals_from_dependents(
+        self, spec: spack.spec.Spec, *, name: str, body: bool
+    ) -> List[AspFunction]:
+        """Return clauses for the virtuals a spec provides on its incoming edges."""
+        # TODO: a loop over `edges_to_dependencies` is preferred over `edges_from_dependents`
+        # since dependents can point to specs out of scope for the solver.
+        edges = spec.edges_from_dependents()
+        clauses = []
+        if not body and not spec.concrete:
+            virtuals = sorted(set(itertools.chain.from_iterable(edge.virtuals for edge in edges)))
+            for virtual in virtuals:
+                clauses.append(fn.attr("provider_set", name, virtual))
+                clauses.append(fn.attr("virtual_node", virtual))
+            return clauses
+
+        # direct dependencies are handled under `edges_to_dependencies()`
+        virtual_iter = (edge.virtuals for edge in edges if not edge.direct)
+        virtuals = sorted(set(itertools.chain.from_iterable(virtual_iter)))
+        for virtual in virtuals:
+            clauses.append(fn.attr("virtual_on_incoming_edges", name, virtual))
+        return clauses
+
+    def _concrete_edge_clauses(
+        self,
+        dspec: spack.spec.DependencySpec,
+        *,
+        name: str,
+        concrete_build_deps: bool,
+        include_runtimes: bool,
+    ) -> Tuple[List[AspFunction], bool]:
+        """Return clauses for an edge of a concrete spec, and whether the dependency at the
+        other end still has to be traversed."""
+        dep = dspec.spec
+        clauses: List[AspFunction] = []
+
+        # GCC runtime is solved again by clingo, even on concrete specs, to give
+        # the possibility to reuse specs built against a different runtime.
+        if dep.name == "gcc-runtime":
+            clauses.append(fn.attr("compatible_runtime", name, dep.name, f"{dep.version}:"))
+            constraint_spec = spack.spec.Spec(f"{dep.name}@{dep.version}")
+            self.spec_versions(constraint_spec)
+            if not include_runtimes:
+                return clauses, False
+
+        # libc is also solved again by clingo, but in this case the compatibility
+        # is not encoded in the parent node - so we need to emit explicit facts
+        if "libc" in dspec.virtuals:
+            clauses.append(fn.attr("needs_libc", name))
+            for libc in self.libcs:
+                if libc_is_compatible(libc, dep):
+                    clauses.append(fn.attr("compatible_libc", name, libc.name, libc.version))
+            if not include_runtimes:
+                return clauses, False
+
+        # We know dependencies are real for concrete specs. For abstract
+        # specs they just mean the dep is somehow in the DAG.
+        for dtype in dt.ALL_FLAGS:
+            if not dspec.depflag & dtype:
+                continue
+            # skip build dependencies of already-installed specs
+            if concrete_build_deps or dtype != dt.BUILD:
+                clauses.append(fn.attr("depends_on", name, dep.name, dt.flag_to_string(dtype)))
+                for virtual_name in dspec.virtuals:
+                    clauses.append(fn.attr("virtual_on_edge", name, dep.name, virtual_name))
+                    clauses.append(fn.attr("virtual_node", virtual_name))
+
+        # imposing hash constraints for all but pure build deps of
+        # already-installed concrete specs.
+        if concrete_build_deps or dspec.depflag != dt.BUILD:
+            clauses.append(fn.attr("hash", dep.name, dep.dag_hash()))
+        elif not concrete_build_deps and dspec.depflag:
+            clauses.append(fn.attr("concrete_build_dependency", name, dep.name, dep.dag_hash()))
+            for virtual_name in dspec.virtuals:
+                clauses.append(fn.attr("virtual_on_build_edge", name, dep.name, virtual_name))
+
+        return clauses, True
+
+    def _dependency_edge_clauses(
+        self,
+        dspec: spack.spec.DependencySpec,
+        dependency_clauses: List[AspFunction],
+        *,
+        name: str,
+        body: bool,
+        context: Optional[SourceContext],
+    ) -> List[AspFunction]:
+        """Return the clauses of a dependency, attached to the edge that reaches it."""
+        ###
+        # Dependency expressed with "^"
+        ###
+        if not dspec.direct:
+            return dependency_clauses
+
+        ###
+        # Direct dependencies expressed with "%"
+        ###
+        dep = dspec.spec
+        clauses = [
+            fn.attr("depends_on", name, dep.name, dependency_type)
+            for dependency_type in dt.flag_to_tuple(dspec.depflag)
+        ]
+
+        for virtual in dspec.virtuals:
+            dependency_clauses.append(fn.attr("virtual_on_edge", name, dep.name, virtual))
+
+        # By default, wrap head of rules, unless the context says otherwise
+        wrap_node_requirement = body is False
+        if context and context.wrap_node_requirement is not None:
+            wrap_node_requirement = context.wrap_node_requirement
+
+        if not wrap_node_requirement:
+            clauses.extend(dependency_clauses)
+            return clauses
+
+        for clause in dependency_clauses:
+            clause.name = "node_requirement"
+            clauses.append(fn.attr("direct_dependency", name, clause))
+        return clauses
+
+    def _spec_clauses(
+        self,
+        spec: spack.spec.Spec,
+        *,
+        name: Optional[str] = None,
+        body: bool = False,
+        transitive: bool = True,
+        expand_hashes: bool = False,
+        concrete_build_deps: bool = False,
+        include_runtimes: bool = False,
+        context: Optional[SourceContext] = None,
+        seen: Optional[Set[int]] = None,
+    ) -> List[AspFunction]:
+        """Return a list of clauses for a spec mandates are true.
+
+        Arguments:
+            spec: the spec to analyze
+            name: optional fallback of spec.name (used for anonymous roots)
+            body: if True, generate clauses to be used in rule bodies (final values) instead
+                of rule heads (setters).
+            transitive: if False, don't generate clauses from dependencies (default True)
+            expand_hashes: if True, descend into hashes of concrete specs (default False)
+            concrete_build_deps: if False, do not include pure build deps of concrete specs
+                (as they have no effect on runtime constraints)
+            include_runtimes: generate full dependency clauses from runtime libraries that
+                are omitted from the solve.
+            context: tracks what constraint this clause set is generated for (e.g. a
+                ``depends_on`` constraint in a package.py file)
+            seen: set of ids of specs that have already been processed (for internal use only)
+
+        Normally, if called with ``transitive=True``, ``spec_clauses()`` just generates
+        hashes for the dependency requirements of concrete specs. If ``expand_hashes``
+        is ``True``, we'll *also* output all the facts implied by transitive hashes,
+        which are redundant during a solve but useful outside of one (e.g.,
+        for spec ``diff``).
+        """
+        clauses = []
+        seen = seen if seen is not None else set()
+        name = spec.name or name or ""
+        seen.add(id(spec))
+
+        f: Union[Type[_Head], Type[_Body]] = _Body if body else _Head
+
+        if name:
+            clauses.append(
+                f.node(name) if not spack.repo.PATH.is_virtual(name) else f.virtual_node(name)
+            )
+        if spec.namespace:
+            clauses.append(f.namespace(name, spec.namespace))
+
+        clauses.extend(self.spec_versions(spec, name=name))
+        clauses.extend(self._arch_clauses(spec, f, name=name))
+        clauses.extend(self._variant_clauses(spec, f, name=name, body=body))
+        clauses.extend(self._flag_clauses(spec, f, name=name, context=context))
+
+        # Hash for concrete specs
+        if spec.concrete:
+            # older specs do not have package hashes, so we have to do this carefully
+            package_hash = getattr(spec, "_package_hash", None)
+            if package_hash:
+                clauses.append(fn.attr("package_hash", name, package_hash))
+            clauses.append(fn.attr("hash", name, spec.dag_hash()))
+            if spec.external:
+                clauses.append(fn.attr("external", name))
+
+        clauses.extend(self._virtuals_from_dependents(spec, name=name, body=body))
+
+        # If the spec is external and concrete, we allow all the libcs on the system
+        if spec.external and spec.concrete and spack.platforms.using_libc_compatibility():
+            clauses.append(fn.attr("needs_libc", name))
+            for libc in self.libcs:
+                clauses.append(fn.attr("compatible_libc", name, libc.name, libc.version))
+
+        if not transitive:
+            return clauses
+
+        # Dependencies
+        edge_clauses = []
+        for dspec in spec.edges_to_dependencies():
+            # Ignore conditional dependencies, they are handled by caller
+            if dspec.when != EMPTY_SPEC:
+                continue
+
+            dep = dspec.spec
+
+            if spec.concrete:
+                concrete_clauses, traverse = self._concrete_edge_clauses(
+                    dspec,
+                    name=name,
+                    concrete_build_deps=concrete_build_deps,
+                    include_runtimes=include_runtimes,
+                )
+                edge_clauses.extend(concrete_clauses)
+                if not traverse:
+                    continue
+
+            # if the spec is abstract, descend into dependencies.
+            # if it's concrete, then the hashes above take care of dependency
+            # constraints, but expand the hashes if asked for.
+            if (not spec.concrete or expand_hashes) and id(dep) not in seen:
+                dependency_clauses = self._spec_clauses(
+                    dep,
+                    body=body,
+                    expand_hashes=expand_hashes,
+                    concrete_build_deps=concrete_build_deps,
+                    context=context,
+                    seen=seen,
+                )
+                edge_clauses.extend(
+                    self._dependency_edge_clauses(
+                        dspec, dependency_clauses, name=name, body=body, context=context
+                    )
+                )
+
+        clauses.extend(edge_clauses)
+        return clauses
+
+    def pkg_class(self, pkg_name: str) -> Type[spack.package_base.PackageBase]:
+        request = pkg_name
+        if pkg_name in self.explicitly_required_namespaces:
+            namespace = self.explicitly_required_namespaces[pkg_name]
+            request = f"{namespace}.{pkg_name}"
+        return spack.repo.PATH.get_pkg_class(request)

--- a/lib/spack/spack/solver/core.py
+++ b/lib/spack/spack/solver/core.py
@@ -151,7 +151,7 @@ def extract_args(model, predicate_name):
 
 class SourceContext:
     """Tracks context in which a Spec's clause-set is generated (i.e.
-    with ``SpackSolverSetup.spec_clauses``).
+    with ``SpecClauseGenerator.spec_clauses``).
 
     Facts generated for the spec may include this context.
     """

--- a/lib/spack/spack/solver/runtimes.py
+++ b/lib/spack/spack/solver/runtimes.py
@@ -82,12 +82,14 @@ class RuntimePropertyRecorder:
 
         dependency_spec = spack.spec.Spec(dependency_str)
         if dependency_spec.versions != spack.version.any_version:
-            self._setup.version_constraints[dependency_spec.name].add(dependency_spec.versions)
+            self._setup.clauses.record_version_constraint(
+                dependency_spec.name, dependency_spec.versions
+            )
 
         self.injected_dependencies.add(dependency_spec)
         body_str, node_variable = self.rule_body_from(when_spec)
 
-        head_clauses = self._setup.spec_clauses(dependency_spec, body=False)
+        head_clauses = self._setup.clauses.spec_clauses(dependency_spec, body=False)
         runtime_pkg = dependency_spec.name
         is_virtual = head_clauses[0].args[0] == "virtual_node"
         main_rule = (
@@ -137,7 +139,9 @@ class RuntimePropertyRecorder:
         when_substitutions = {}
         for s in when_spec.traverse(root=False):
             when_substitutions[f'"{s.name}"'] = self.node_for(s.name)
-        body_clauses = self._setup.spec_clauses(when_spec, name=node_placeholder, body=True)
+        body_clauses = self._setup.clauses.spec_clauses(
+            when_spec, name=node_placeholder, body=True
+        )
         for clause in body_clauses:
             if clause.args[0] == "virtual_on_incoming_edges":
                 # Substitute: attr("virtual_on_incoming_edges", ProviderNode, Virtual)
@@ -196,10 +200,12 @@ class RuntimePropertyRecorder:
         body_str, node_variable = self.rule_body_from(when_spec)
         constraint_spec = spack.spec.Spec(constraint_str)
 
-        constraint_clauses = self._setup.spec_clauses(constraint_spec, body=False)
+        constraint_clauses = self._setup.clauses.spec_clauses(constraint_spec, body=False)
         for clause in constraint_clauses:
             if clause.args[0] == "node_version_satisfies":
-                self._setup.version_constraints[constraint_spec.name].add(constraint_spec.versions)
+                self._setup.clauses.record_version_constraint(
+                    constraint_spec.name, constraint_spec.versions
+                )
                 args = f'"{constraint_spec.name}", "{constraint_spec.versions}"'
                 head_str = f"propagate({node_variable}, node_version_satisfies({args}))"
                 rule = f"{head_str} :-\n{body_str}."
@@ -218,7 +224,7 @@ class RuntimePropertyRecorder:
         for flag_type, default_values in flags.items():
             root_spec_str = f"{root_spec_str} {flag_type}='{default_values}'"
         root_spec = spack.spec.Spec(root_spec_str)
-        head_clauses = self._setup.spec_clauses(
+        head_clauses = self._setup.clauses.spec_clauses(
             root_spec, body=False, context=SourceContext(source="compiler")
         )
         self.rules.append(f"% Default compiler flags for {spec}\n")

--- a/lib/spack/spack/test/concretization/core.py
+++ b/lib/spack/spack/test/concretization/core.py
@@ -34,6 +34,7 @@ import spack.platforms
 import spack.platforms.test
 import spack.repo
 import spack.solver.asp
+import spack.solver.clauses
 import spack.solver.core
 import spack.solver.input_analysis
 import spack.solver.reuse
@@ -5225,6 +5226,7 @@ def test_imposed_spec_dependency_duplication(mock_packages: spack.repo.Repo):
     pkg = mock_packages.get_pkg_class("trigger-and-effect-deps")
     setup = spack.solver.asp.SpackSolverSetup()
     setup.gen = spack.solver.asp.ProblemInstanceBuilder()
+    setup.clauses = spack.solver.clauses.SpecClauseGenerator()
     setup.package_dependencies_rules(pkg)
     setup.trigger_rules()
     setup.effect_rules()


### PR DESCRIPTION
This PR moves spec clauses generation in `solver/clauses.py`, together with the version constraints, target constraints and variant values it discovers along the way (which the setup reads back once generation is done).

The clauses and their order are unchanged: the ASP program text is byte identical for abstract, namespaced and reused specs.
