### PR TITLE
modules: add alias option to define module aliases in modulerc

### DIFF
--- a/lib/spack/docs/module_file_support.rst
+++ b/lib/spack/docs/module_file_support.rst
@@ -347,6 +347,31 @@ Using the ``conflict`` key under a spec pattern, you can prevent two incompatibl
 This prevents loading any other version of the same package (via ``{name}``) or ``intel/14.0.1``.
 For Lmod, and for Environment Modules versions prior to 4.2, the conflict must be expressed on both module files conflicting with each other.
 
+Module aliases
+""""""""""""""
+
+Using the ``alias`` key under a spec pattern, you can define one or more module aliases pointing at the module of each matching installed spec:
+
+.. code-block:: yaml
+
+   modules:
+     default:
+       tcl:
+         mpich:
+           alias:
+           - "mpi/{name}/{version}"
+         openmpi:
+           alias:
+           - "mpi/{name}/{version}"
+
+Alias names may use the same format tokens as projections (e.g. ``{name}``, ``{version}``), which are resolved against the matching spec.
+With the above configuration, users can for instance load ``mpi/mpich/3.0.4`` whatever the projection of the corresponding ``mpich`` module is.
+Aliases are defined in a ``.modulerc`` (Tcl) or ``.modulerc.lua`` (Lua) file stored under the modulepath directory, which requires Environment Modules >= 4.3 or Lmod >= 8.4.13.
+
+If several installed specs match a spec pattern with an alias defined on it, each generated module file redefines the alias onto itself, so the alias ends up pointing at the last module file generated, and a warning is emitted for each redefinition.
+Constrain the spec pattern so that a single installation matches to avoid the ambiguity.
+A warning is also emitted when an alias shadows an existing module file or directory of the same name, or when a generated module file is shadowed by an existing alias: in both cases the module system resolves the name to the alias target.
+
 .. _customize-env-modifications:
 
 Global environment modifications

--- a/lib/spack/spack/modules/common.py
+++ b/lib/spack/spack/modules/common.py
@@ -26,6 +26,7 @@ import warnings
 from typing import (
     IO,
     Any,
+    Callable,
     ClassVar,
     Dict,
     Iterator,
@@ -66,6 +67,7 @@ from spack.util import tty
 from spack.util.lang import Singleton, dedupe
 
 from .error import (
+    AliasCmdFormatNotDefined,
     CoreCompilersNotFoundError,
     DefaultTemplateNotDefined,
     HideCmdFormatNotDefined,
@@ -503,6 +505,11 @@ class BaseConfiguration:
         return self.conf.get("conflict", [])
 
     @property
+    def aliases(self) -> List[str]:
+        """Module aliases to be defined onto this module file"""
+        return self.conf.get("alias", [])
+
+    @property
     def excluded(self) -> bool:
         """Returns True if the module has been excluded, False otherwise."""
 
@@ -743,13 +750,22 @@ class FileLayout:
             None
         )
 
-    @property
-    def modulerc(self) -> str:
-        """Returns the modulerc file for this module file."""
-        dirname = os.path.dirname(self.filename)
+    def _modulerc_path(self, dirname: str) -> str:
+        """Returns the path of the modulerc file contained in ``dirname``."""
         if self.conf.file_extension:
             return os.path.join(dirname, f".modulerc.{self.conf.file_extension}")
         return os.path.join(dirname, ".modulerc")
+
+    @property
+    def modulerc(self) -> str:
+        """Returns the modulerc file sitting next to this module file."""
+        return self._modulerc_path(os.path.dirname(self.filename))
+
+    @property
+    def modulepath_modulerc(self) -> str:
+        """Returns the modulerc file at the root of the modulepath directory holding this
+        module file."""
+        return self._modulerc_path(self.modulepath)
 
     @property
     def spec(self) -> spack.spec.Spec:
@@ -813,6 +829,15 @@ class FileLayout:
 
         # Return the absolute path
         return os.path.join(self.arch_dirname, filename)
+
+    @property
+    def modulepath(self) -> str:
+        """Directory to add to ``MODULEPATH`` for the module system to find this
+        module file, i.e. the module file path stripped of the module name parts."""
+        dirname = self.filename
+        for _ in self.use_name.split(os.sep):
+            dirname = os.path.dirname(dirname)
+        return dirname
 
     def token_to_path(self, name: str, value: spack.spec.Spec) -> str:
         """Transforms a hierarchy token into the corresponding path part.
@@ -1227,6 +1252,7 @@ class ModuleContext(tengine.Context):
 class BaseModuleFileWriter:
     default_template: str
     hide_cmd_format: str
+    alias_cmd_format: str
     modulerc_header: List[str]
 
     configuration_class: ClassVar[Type["BaseConfiguration"]]
@@ -1234,6 +1260,7 @@ class BaseModuleFileWriter:
     _required_attrs = (
         ("default_template", DefaultTemplateNotDefined),
         ("hide_cmd_format", HideCmdFormatNotDefined),
+        ("alias_cmd_format", AliasCmdFormatNotDefined),
         ("modulerc_header", ModulercHeaderNotDefined),
     )
 
@@ -1358,6 +1385,9 @@ class BaseModuleFileWriter:
         # record module hiddenness if implicit
         self.update_module_hiddenness()
 
+        # record module aliases defined onto this module
+        self.update_module_aliases()
+
     def update_module_defaults(self) -> None:
         if any(self.spec.satisfies(default) for default in self.conf.defaults):
             # This spec matches a default, it needs to be symlinked to default
@@ -1376,46 +1406,147 @@ class BaseModuleFileWriter:
             remove (bool): if True, hiddenness information for module is
                 removed from modulerc.
         """
-        modulerc_path = self.layout.modulerc
         hide_module_cmd = self.hide_cmd_format % self.layout.use_name
         hidden = self.conf.hidden and not remove
-        modulerc_exists = os.path.exists(modulerc_path)
-        updated = False
+        self._update_modulerc_entries([hide_module_cmd], present=hidden)
 
+    def _update_modulerc_entries(
+        self,
+        lines: List[str],
+        present: bool,
+        remove_matching: Optional[Callable[[str], bool]] = None,
+        modulerc_path: Optional[str] = None,
+    ) -> None:
+        """Add or remove command lines in a modulerc file of this module.
+
+        Lines owned by other features are preserved. The modulerc file is created when
+        needed and removed when its content boils down to the header.
+
+        Args:
+            lines: modulerc command lines owned by the calling feature
+            present: whether lines should be in modulerc after the update
+            remove_matching: additional lines matching this predicate are removed
+            modulerc_path: modulerc file to update (the modulerc file next to this
+                module file if not set)
+        """
+        if modulerc_path is None:
+            modulerc_path = self.layout.modulerc
+        modulerc_exists = os.path.exists(modulerc_path)
+
+        content = []
         if modulerc_exists:
             with open(modulerc_path, encoding="utf-8") as f:
                 content = f.read().splitlines()
-            already_hidden = hide_module_cmd in content
 
-            # remove hide command if module not hidden
-            if already_hidden and not hidden:
-                content.remove(hide_module_cmd)
-                updated = True
+        def keep(line: str) -> bool:
+            if line in lines:
+                return present
+            return remove_matching is None or not remove_matching(line)
 
-            # add hide command if module is hidden
-            elif not already_hidden and hidden:
-                if not content:
-                    content = self.modulerc_header.copy()
-                content.append(hide_module_cmd)
-                updated = True
-        else:
-            content = self.modulerc_header.copy()
-            if hidden:
-                content.append(hide_module_cmd)
-                updated = True
+        updated_content = [x for x in content if keep(x)]
+        if present:
+            for line in lines:
+                if line not in updated_content:
+                    if not updated_content:
+                        updated_content = self.modulerc_header.copy()
+                    updated_content.append(line)
 
         # no modulerc file change if no content update
-        if updated:
-            is_empty = content == self.modulerc_header or not content
-            # remove existing modulerc if empty
-            if modulerc_exists and is_empty:
+        if updated_content == content:
+            return
+
+        is_empty = updated_content == self.modulerc_header or not updated_content
+        # remove existing modulerc if empty
+        if is_empty:
+            if modulerc_exists:
                 os.remove(modulerc_path)
-            # create or update modulerc
-            elif not is_empty:
-                # ensure file ends with a newline character
-                content.append("")
-                with open(modulerc_path, "w", encoding="utf-8") as f:
-                    f.write("\n".join(content))
+        # create or update modulerc
+        else:
+            # ensure file ends with a newline character
+            updated_content.append("")
+            with open(modulerc_path, "w", encoding="utf-8") as f:
+                f.write("\n".join(updated_content))
+
+    def update_module_aliases(self, remove: bool = False) -> None:
+        """Update the module aliases defined onto this module.
+
+        This writer owns every alias line that targets this module: aliases dropped
+        from the configuration are removed and configured ones are (re)defined. When
+        an alias currently targeting another module is redefined onto this module, the
+        previous definition is replaced and a warning is emitted (the last written
+        module wins).
+
+        Args:
+            remove (bool): if True, all aliases targeting this module are removed from
+                modulerc.
+        """
+        aliases = [] if remove else self.conf.aliases
+        use_name = self.layout.use_name
+
+        # Alias names may resolve projection-like tokens (e.g. '{name}')
+        msg = "some tokens cannot be part of a module alias name"
+        desired = []
+        for item in aliases:
+            _check_tokens_are_valid(item, error_message=msg)
+            desired.append(self.spec.format(item))
+
+        # aliases are defined in the modulerc file at the root of the modulepath
+        # directory, as the module resolution process would not find them if they were
+        # defined in the modulerc file next to their target module
+        modulerc_path = self.layout.modulepath_modulerc
+
+        # regular expression matching any alias line written from alias_cmd_format
+        prefix, sep, suffix = (re.escape(x) for x in self.alias_cmd_format.split("%s"))
+        alias_line_re = re.compile(rf"{prefix}(\S+){sep}(\S+){suffix}")
+
+        already_defined = set()
+        if os.path.exists(modulerc_path):
+            with open(modulerc_path, encoding="utf-8") as f:
+                for line in f.read().splitlines():
+                    m = alias_line_re.fullmatch(line)
+                    if m is None:
+                        continue
+                    alias_name, target = m.groups()
+                    if target == use_name:
+                        already_defined.add(alias_name)
+                    elif alias_name in desired:
+                        warnings.warn(
+                            f"alias '{alias_name}' points at module '{target}' and is "
+                            f"redefined onto module '{use_name}': multiple installed "
+                            "specs may match the alias configuration in modules.yaml"
+                        )
+                    elif alias_name == use_name:
+                        warnings.warn(
+                            f"module '{use_name}' is shadowed by an alias of the same "
+                            f"name pointing at module '{target}'"
+                        )
+
+        for alias_name in desired:
+            if alias_name in already_defined:
+                continue
+            # warn if the alias shadows an existing module file or directory
+            alias_path = os.path.join(self.layout.modulepath, alias_name)
+            if self.conf.file_extension:
+                alias_path = f"{alias_path}.{self.conf.file_extension}"
+            if os.path.exists(alias_path):
+                warnings.warn(
+                    f"alias '{alias_name}' pointing at module '{use_name}' shadows the "
+                    f"existing module file or directory '{alias_path}'"
+                )
+
+        def owned_or_redefined(line: str) -> bool:
+            m = alias_line_re.fullmatch(line)
+            if m is None:
+                return False
+            alias_name, target = m.groups()
+            return target == use_name or alias_name in desired
+
+        self._update_modulerc_entries(
+            [self.alias_cmd_format % (name, use_name) for name in desired],
+            present=True,
+            remove_matching=owned_or_redefined,
+            modulerc_path=modulerc_path,
+        )
 
     def remove(self) -> None:
         """Deletes the module file."""
@@ -1425,6 +1556,7 @@ class BaseModuleFileWriter:
                 os.remove(mod_file)  # Remove the module file
                 self.remove_module_defaults()  # Remove default targeting module file
                 self.update_module_hiddenness(remove=True)  # Remove hide cmd in modulerc
+                self.update_module_aliases(remove=True)  # Remove alias cmds in root modulerc
                 os.removedirs(
                     os.path.dirname(mod_file)
                 )  # Remove all the empty directories from the leaf up

--- a/lib/spack/spack/modules/error.py
+++ b/lib/spack/spack/modules/error.py
@@ -23,6 +23,10 @@ class HideCmdFormatNotDefined(AttributeError, ModulesError):
     """Raised if ``hide_cmd_format`` has not been specified in the derived class."""
 
 
+class AliasCmdFormatNotDefined(AttributeError, ModulesError):
+    """Raised if ``alias_cmd_format`` has not been specified in the derived class."""
+
+
 class ModulercHeaderNotDefined(AttributeError, ModulesError):
     """Raised if ``modulerc_header`` has not been specified in the derived class."""
 

--- a/lib/spack/spack/modules/lmod.py
+++ b/lib/spack/spack/modules/lmod.py
@@ -36,3 +36,5 @@ class LmodModulefileWriter(BaseModuleFileWriter):
     modulerc_header = []
 
     hide_cmd_format = 'hide_version("%s")'
+
+    alias_cmd_format = 'module_alias("%s", "%s")'

--- a/lib/spack/spack/modules/tcl.py
+++ b/lib/spack/spack/modules/tcl.py
@@ -36,3 +36,5 @@ class TclModulefileWriter(BaseModuleFileWriter):
     modulerc_header = ["#%Module4.7"]
 
     hide_cmd_format = "module-hide --soft --hidden-loaded %s"
+
+    alias_cmd_format = "module-alias %s %s"

--- a/lib/spack/spack/schema/modules.py
+++ b/lib/spack/spack/schema/modules.py
@@ -61,6 +61,10 @@ module_file_configuration = {
             **array_of_strings,
             "description": "List of additional modules to load when this module is loaded",
         },
+        "alias": {
+            **array_of_strings,
+            "description": "List of module aliases to define onto this module",
+        },
         "suffixes": {
             "type": "object",
             "description": "Add custom suffixes to module names based on spec matching for better "

--- a/lib/spack/spack/test/data/modules/lmod/alias.yaml
+++ b/lib/spack/spack/test/data/modules/lmod/alias.yaml
@@ -1,0 +1,13 @@
+enable:
+  - lmod
+lmod:
+  core_compilers:
+    - 'clang@3.3'
+  hierarchy:
+    - mpi
+  all:
+    autoload: none
+  mpileaks:
+    alias:
+      - '{name}-latest'
+      - 'mpi-app'

--- a/lib/spack/spack/test/data/modules/tcl/alias.yaml
+++ b/lib/spack/spack/test/data/modules/tcl/alias.yaml
@@ -1,0 +1,12 @@
+enable:
+  - tcl
+tcl:
+  all:
+    autoload: none
+  mpileaks:
+    alias:
+      - '{name}-latest'
+      - 'mpi-app'
+  libdwarf:
+    alias:
+      - 'dwarf'

--- a/lib/spack/spack/test/data/modules/tcl/wrong_alias.yaml
+++ b/lib/spack/spack/test/data/modules/tcl/wrong_alias.yaml
@@ -1,0 +1,8 @@
+enable:
+  - tcl
+tcl:
+  all:
+    autoload: none
+  mpileaks:
+    alias:
+      - '{name}/{prefix}'

--- a/lib/spack/spack/test/modules/conftest.py
+++ b/lib/spack/spack/test/modules/conftest.py
@@ -45,4 +45,5 @@ def factory(request, mock_modules_root):
 def mock_module_filename(monkeypatch, tmp_path: pathlib.Path):
     filename = tmp_path / "module"
     monkeypatch.setattr(spack.modules.common.FileLayout, "filename", str(filename))
+    monkeypatch.setattr(spack.modules.common.FileLayout, "modulepath", str(tmp_path))
     yield str(filename)

--- a/lib/spack/spack/test/modules/lmod.py
+++ b/lib/spack/spack/test/modules/lmod.py
@@ -566,6 +566,70 @@ class TestLmod:
         assert len([x for x in content if hide_cmd_alt1 == x]) == 0
         assert len([x for x in content if hide_cmd_alt2 == x]) == 1
 
+    def test_alias(self, module_configuration, temporary_store):
+        """Tests the addition and removal of module alias commands in the root modulerc."""
+        module_configuration("alias")
+
+        spec = spack.concretize.concretize_one("mpileaks@2.3")
+        writer = writer_cls.from_spec(spec, "default", True)
+        writer.write()
+
+        # aliases are defined in the .modulerc.lua at the root of the modulepath directory
+        # unlocked by the hierarchy prefix of this module, not next to the module file
+        modulerc = writer.layout.modulepath_modulerc
+        assert modulerc == os.path.join(writer.layout.modulepath, ".modulerc.lua")
+        assert modulerc != writer.layout.modulerc
+        assert writer.layout.filename == os.path.join(
+            writer.layout.modulepath, f"{writer.layout.use_name}.lua"
+        )
+        assert os.path.exists(modulerc)
+        with open(modulerc, encoding="utf-8") as f:
+            content = [x.strip() for x in f.readlines()]
+        alias_cmd = f'module_alias("mpileaks-latest", "{writer.layout.use_name}")'
+        alias_cmd_other = f'module_alias("mpi-app", "{writer.layout.use_name}")'
+        assert len([x for x in content if x == alias_cmd]) == 1
+        assert len([x for x in content if x == alias_cmd_other]) == 1
+
+        # another installation matching the alias configuration redefines the alias onto its
+        # own module (last written module wins) and a warning is emitted
+        spec_alt = spack.concretize.concretize_one("mpileaks@2.2")
+        writer_alt = writer_cls.from_spec(spec_alt, "default", True)
+        with pytest.warns(UserWarning, match="redefined onto"):
+            writer_alt.write()
+        with open(modulerc, encoding="utf-8") as f:
+            content = [x.strip() for x in f.readlines()]
+        assert alias_cmd not in content
+        assert f'module_alias("mpileaks-latest", "{writer_alt.layout.use_name}")' in content
+
+        # removing both modules removes the aliases and the emptied modulerc file
+        writer_alt.remove()
+        writer.remove()
+        assert not os.path.exists(modulerc)
+
+        # aliases no longer defined in the configuration are removed when the module
+        # file is rewritten
+        writer.write(overwrite=True)
+        assert os.path.exists(modulerc)
+        module_configuration("autoload_direct")
+        writer = writer_cls.from_spec(spec, "default", True)
+        writer.write(overwrite=True)
+        assert not os.path.exists(modulerc)
+
+    def test_alias_shadowing_module(self, module_configuration, temporary_store):
+        """Tests the warning emitted when a module alias clashes with a module file."""
+        module_configuration("alias")
+
+        # a module file existing where the alias is defined is reported as shadowed
+        spec = spack.concretize.concretize_one("mpileaks@2.3")
+        writer = writer_cls.from_spec(spec, "default", True)
+        os.makedirs(writer.layout.modulepath, exist_ok=True)
+        with open(
+            os.path.join(writer.layout.modulepath, "mpi-app.lua"), "w", encoding="utf-8"
+        ) as f:
+            f.write("")
+        with pytest.warns(UserWarning, match="shadows the existing module file"):
+            writer.write()
+
     def test_naming_scheme_compat(self, factory, module_configuration):
         """Tests backwards compatibility for naming_scheme key"""
         module_configuration("naming_scheme")

--- a/lib/spack/spack/test/modules/tcl.py
+++ b/lib/spack/spack/test/modules/tcl.py
@@ -613,6 +613,94 @@ class TestTcl:
         assert len([x for x in content if hide_cmd_alt1 == x]) == 0
         assert len([x for x in content if hide_cmd_alt2 == x]) == 1
 
+    def test_alias(self, module_configuration, temporary_store):
+        """Tests the addition and removal of module alias commands in the root modulerc."""
+        module_configuration("alias")
+
+        spec = spack.concretize.concretize_one("mpileaks@2.3")
+        writer = writer_cls.from_spec(spec, "default", True)
+        writer.write()
+
+        # aliases are defined in the modulerc at the root of the modulepath directory, not in
+        # the modulerc next to the module file
+        modulerc = writer.layout.modulepath_modulerc
+        assert modulerc == os.path.join(writer.layout.modulepath, ".modulerc")
+        assert modulerc != writer.layout.modulerc
+        assert os.path.exists(modulerc)
+        with open(modulerc, encoding="utf-8") as f:
+            content = [x.strip() for x in f.readlines()]
+        alias_cmd = f"module-alias mpileaks-latest {writer.layout.use_name}"
+        alias_cmd_other = f"module-alias mpi-app {writer.layout.use_name}"
+        assert len([x for x in content if x == alias_cmd]) == 1
+        assert len([x for x in content if x == alias_cmd_other]) == 1
+
+        # rewriting the same module leaves the modulerc unchanged
+        writer.write(overwrite=True)
+        with open(modulerc, encoding="utf-8") as f:
+            assert content == [x.strip() for x in f.readlines()]
+
+        # another installation matching the alias configuration redefines the alias onto its
+        # own module (last written module wins) and a warning is emitted
+        spec_alt = spack.concretize.concretize_one("mpileaks@2.2")
+        writer_alt = writer_cls.from_spec(spec_alt, "default", True)
+        with pytest.warns(UserWarning, match="redefined onto"):
+            writer_alt.write()
+        with open(modulerc, encoding="utf-8") as f:
+            content = [x.strip() for x in f.readlines()]
+        assert alias_cmd not in content
+        assert f"module-alias mpileaks-latest {writer_alt.layout.use_name}" in content
+        assert len([x for x in content if x.startswith("module-alias mpileaks-latest ")]) == 1
+        assert len([x for x in content if x.startswith("module-alias mpi-app ")]) == 1
+
+        # removing the module owning the aliases removes them, leaving an empty modulerc
+        # that gets deleted
+        writer_alt.remove()
+        assert not os.path.exists(modulerc)
+
+        # regenerating the remaining module defines the aliases onto it again
+        writer.write(overwrite=True)
+        with open(modulerc, encoding="utf-8") as f:
+            content = [x.strip() for x in f.readlines()]
+        assert alias_cmd in content
+
+        # aliases no longer defined in the configuration are removed when the module
+        # file is rewritten
+        module_configuration("autoload_direct")
+        writer = writer_cls.from_spec(spec, "default", True)
+        writer.write(overwrite=True)
+        assert not os.path.exists(modulerc)
+
+    def test_alias_shadowing_module(self, module_configuration, temporary_store):
+        """Tests the warnings emitted when a module alias clashes with a module file."""
+        module_configuration("alias")
+
+        # a module file existing where the alias is defined is reported as shadowed
+        spec = spack.concretize.concretize_one("mpileaks@2.3")
+        writer = writer_cls.from_spec(spec, "default", True)
+        os.makedirs(writer.layout.modulepath, exist_ok=True)
+        with open(os.path.join(writer.layout.modulepath, "mpi-app"), "w", encoding="utf-8") as f:
+            f.write("#%Module\n")
+        with pytest.warns(UserWarning, match="shadows the existing module file"):
+            writer.write()
+
+        # a module file generated where an alias is defined is reported as shadowed
+        spec = spack.concretize.concretize_one("libdwarf")
+        writer = writer_cls.from_spec(spec, "default", True)
+        modulerc = writer.layout.modulepath_modulerc
+        with open(modulerc, "a", encoding="utf-8") as f:
+            f.write(f"module-alias {writer.layout.use_name} foo/1.0\n")
+        with pytest.warns(UserWarning, match="is shadowed by an alias"):
+            writer.write()
+
+    def test_alias_with_invalid_token(self, module_configuration, temporary_store):
+        """Tests the error raised when an alias name uses an invalid format token."""
+        module_configuration("wrong_alias")
+
+        spec = spack.concretize.concretize_one("mpileaks")
+        writer = writer_cls.from_spec(spec, "default", True)
+        with pytest.raises(RuntimeError, match="cannot be part of a module alias name"):
+            writer.write()
+
     @pytest.mark.regression("37788")
     @pytest.mark.parametrize("modules_config", ["core_compilers", "core_compilers_at_equal"])
     def test_layout_for_specs_compiled_with_core_compilers(


### PR DESCRIPTION
Introduce a new `alias` key under a spec pattern in `modules.yaml` to define one or more module aliases pointing at the module of each matching installed spec. Alias names may resolve projection-like tokens, like other similar keys:

```yaml
modules:
  default:
    tcl:
      mpich:
        alias:
        - "mpi/{name}/{version}"
      openmpi:
        alias:
        - "mpi/{name}/{version}"
```

Aliases are defined with the `module-alias` (Tcl) or `module_alias` (Lua) command in the modulerc file stored at the root of the modulepath directory holding the target module file, as the module resolution process would not find them if they were defined in the modulerc file next to their target. This location requires Environment Modules >= 4.3 or Lmod >= 8.4.13.

Each module file owns the alias definitions targeting it: aliases dropped from the configuration are removed when the module file is rewritten or removed. When several installed specs match an alias configuration, each generated module file redefines the alias onto itself, so the alias ends up pointing at the last module file generated and a warning is emitted for each redefinition. A warning is also emitted when an alias shadows an existing module file or when a generated module file is shadowed by an existing alias, as the module system resolves such a name to the alias target.