### PR TITLE
solver: inject the compiler wrapper for language dependencies of type test

### DIFF
--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -78,7 +78,12 @@ from .core import AspFunction, AspVar, NodeId, SourceContext, extract_args, fn
 from .input_analysis import create_counter, create_graph_analyzer
 from .requirements import RequirementKind, RequirementOrigin, RequirementParser, RequirementRule
 from .reuse import ReusableSpecsSelector, SpecFiltersFactory
-from .runtimes import COMPILER_WRAPPER_LANGUAGES, RuntimePropertyRecorder, all_libcs
+from .runtimes import (
+    COMPILER_EDGE_DEPTYPES,
+    COMPILER_WRAPPER_LANGUAGES,
+    RuntimePropertyRecorder,
+    all_libcs,
+)
 from .versions import Provenance
 
 GitOrStandardVersion = Union[vn.GitVersion, vn.StandardVersion]
@@ -3216,17 +3221,22 @@ class SpackSolverSetup:
                 # Inject default flags for compilers
                 recorder("*").default_flags(compiler)
 
-            # Add a dependency on the compiler wrapper
+            # Add a dependency on the compiler wrapper, with the type of the edge the compiler
+            # is used on
             compiler_str = f"{compiler.name} /{compiler.dag_hash()}"
             for language in COMPILER_WRAPPER_LANGUAGES:
-                # Using compiler.name causes a bit of duplication, but that is taken care of by
-                # clingo during grounding.
-                recorder("*").depends_on(
-                    "compiler-wrapper",
-                    when=f"%[deptypes=build virtuals={language}] {compiler.name}",
-                    type="build",
-                    description=f"Add compiler wrapper when using {compiler.name} for {language}",
-                )
+                for deptype in COMPILER_EDGE_DEPTYPES:
+                    # Using compiler.name causes a bit of duplication, but that is taken care of
+                    # by clingo during grounding.
+                    recorder("*").depends_on(
+                        "compiler-wrapper",
+                        when=f"%[deptypes={deptype} virtuals={language}] {compiler.name}",
+                        type=deptype,
+                        description=(
+                            f"Add compiler wrapper when using {compiler.name} for {language} "
+                            f"({deptype})"
+                        ),
+                    )
 
             if not spack.platforms.using_libc_compatibility():
                 continue

--- a/lib/spack/spack/solver/runtimes.py
+++ b/lib/spack/spack/solver/runtimes.py
@@ -18,6 +18,9 @@ from .versions import Provenance
 #: Language virtuals wrapped by the compiler wrapper (same ones for which a flag exists)
 COMPILER_WRAPPER_LANGUAGES = ("c", "cxx", "fortran")
 
+#: Dependency types of the edges on which a compiler is used to compile the dependent
+COMPILER_EDGE_DEPTYPES = ("build", "test")
+
 
 class RuntimePropertyRecorder:
     """An object of this class is injected in callbacks to compilers, to let them declare
@@ -224,16 +227,17 @@ class RuntimePropertyRecorder:
         self.rules.append(f"% Default compiler flags for {spec}\n")
 
         # Inject the flags only when the compiler is actually used to compile the dependent,
-        # i.e. the build edge provides one of the language virtuals.
+        # i.e. the build or test edge provides one of the language virtuals.
         for language in COMPILER_WRAPPER_LANGUAGES:
-            when_spec = spack.spec.Spec(f"%[deptypes=build virtuals={language}] {spec}")
-            body_str, node_variable = self.rule_body_from(when_spec)
-            for clause in head_clauses:
-                if clause.args[0] == "node":
-                    continue
-                head_str = str(clause).replace(f'"{node_placeholder}"', f"{node_variable}")
-                rule = f"{head_str} :-\n{body_str}."
-                self.rules.append(rule)
+            for deptype in COMPILER_EDGE_DEPTYPES:
+                when_spec = spack.spec.Spec(f"%[deptypes={deptype} virtuals={language}] {spec}")
+                body_str, node_variable = self.rule_body_from(when_spec)
+                for clause in head_clauses:
+                    if clause.args[0] == "node":
+                        continue
+                    head_str = str(clause).replace(f'"{node_placeholder}"', f"{node_variable}")
+                    rule = f"{head_str} :-\n{body_str}."
+                    self.rules.append(rule)
 
         self.reset()
 

--- a/lib/spack/spack/test/concretization/core.py
+++ b/lib/spack/spack/test/concretization/core.py
@@ -5193,6 +5193,21 @@ def test_activating_variant_for_conditional_language_dependency(config, mock_pac
     assert s.satisfies("+fortran")
 
 
+def test_compiler_wrapper_for_language_dependency_of_type_test(config, mock_packages):
+    """Tests that a language dependency of type "test" pulls in the compiler wrapper with the
+    same dependency type, and only when tests are requested.
+    """
+    s = spack.concretize.concretize_one("language-test-dependency")
+    assert "cxx" not in s
+    assert "compiler-wrapper" not in s
+
+    s = spack.concretize.concretize_one("language-test-dependency", tests=True)
+    assert s.satisfies("%cxx=gcc")
+    edges = s.edges_to_dependencies(name="compiler-wrapper")
+    assert len(edges) == 1
+    assert edges[0].depflag == dt.TEST
+
+
 def test_when_condition_with_direct_dependency_on_virtual_provider(config, mock_packages):
     """If a when condition contains a direct dependency on a provider of a virtual, it should only
     trigger if the provider is used for that current package, and not if the provider happens to be

--- a/var/spack/test_repos/spack_repo/builtin_mock/packages/language_test_dependency/package.py
+++ b/var/spack/test_repos/spack_repo/builtin_mock/packages/language_test_dependency/package.py
@@ -1,0 +1,18 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack_repo.builtin_mock.build_systems.generic import Package
+
+from spack.package import *
+
+
+class LanguageTestDependency(Package):
+    """Package needing a compiler only for its tests (e.g. a header-only library)"""
+
+    homepage = "http://www.example.com"
+    url = "http://www.example.com/language-test-dependency-1.0.tar.gz"
+
+    version("1.0", md5="0123456789abcdef0123456789abcdef")
+
+    depends_on("cxx", type="test")


### PR DESCRIPTION
Fixes #45573.

A language dependency of type `test` pulls the compiler into the DAG under `--test`. But the compiler wrapper and the default compiler flags were only injected for `build` edges. Nothing set `CXX`, and the tests were compiled by whatever `c++` was in `PATH`, while the spec reported the Spack compiler. This is the case of a header-only library that only compiles its test suite.

The wrapper and flag rules now cover `build` and `test` edges, one rule per dependency type. The wrapper takes the type of the compiler edge it follows. Nothing changes for `build` language dependencies: the concretized specs and their hashes are the same as before.

Tested with a mock package in the unit tests. Also checked on a real header-only package with `depends_on("cxx", type="test")` and `spack install --test=root`: the wrapper is a test dependency, `CXX` points to it, and the tests are built with the compiler of the spec.
