### PR TITLE
mirrors: expand $spack in file:// URLs

### DIFF
--- a/lib/spack/spack/mirrors/mirror.py
+++ b/lib/spack/spack/mirrors/mirror.py
@@ -56,13 +56,21 @@ def _url_or_path_to_url(url_or_path: str) -> str:
     """For simplicity we allow mirror URLs in config files to be local, relative paths.
     This helper function takes care of distinguishing between URLs and paths, and
     canonicalizes paths before transforming them into file:// URLs."""
-    # Is it a supported URL already? Then don't do path-related canonicalization.
-    parsed = urllib.parse.urlparse(url_or_path)
-    if parsed.scheme in supported_url_schemes:
-        return url_or_path
+    # Substitute before urlparse. ``file://$spack/../cache`` otherwise keeps
+    # ``$spack`` as the URL host and later resolves as ``/cache`` (#52959).
+    expanded = spack.config.substitute_path_variables(url_or_path)
+    parsed = urllib.parse.urlparse(expanded)
+    if parsed.scheme in supported_url_schemes and parsed.scheme != "file":
+        return expanded
 
-    # Otherwise we interpret it as path, and we should promote it to file:// URL.
-    return url_util.path_to_file_url(spack.config.canonicalize_path(url_or_path))
+    path = expanded
+    if path.lower().startswith("file://"):
+        # After expansion a Windows ``$spack`` is ``F:\...``, so
+        # ``file://F:\.../../cache`` has host ``F:\...`` under urlparse.
+        path = path[7:]
+        if path.startswith("/") and len(path) > 2 and path[2] == ":":
+            path = path[1:]
+    return url_util.path_to_file_url(spack.config.canonicalize_path(path))
 
 
 class Mirror:

--- a/lib/spack/spack/test/mirror.py
+++ b/lib/spack/spack/test/mirror.py
@@ -17,6 +17,7 @@ import spack.mirrors.layout
 import spack.mirrors.mirror
 import spack.mirrors.utils
 import spack.patch
+import spack.paths
 import spack.stage
 import spack.util.url as url_util
 from spack.cmd.common.arguments import mirror_name_or_url
@@ -283,6 +284,26 @@ def test_get_all_versions(specs, expected_specs):
     output_list = [str(x) for x in output_list]
     # Compare sets since order is not important
     assert set(output_list) == set(expected_specs)
+
+
+def test_file_url_expands_spack_variable():
+    """``file://$spack/../cache`` must expand $spack, not resolve as ``/cache``.
+
+    urlparse treats the placeholder as a host, so skipping substitution left
+    ``file://$spack/../spack-cache`` as a push to ``/spack-cache`` (#52959).
+    """
+    expected = url_util.path_to_file_url(
+        os.path.normpath(os.path.join(spack.paths.prefix, os.pardir, "spack-cache"))
+    )
+    m = spack.mirrors.mirror.Mirror("file://$spack/../spack-cache")
+    assert m.fetch_url == expected
+    assert m.push_url == expected
+    assert "$spack" not in m.fetch_url
+
+    opt = url_util.path_to_file_url(os.path.normpath(os.path.join(spack.paths.prefix, "opt")))
+    assert spack.mirrors.mirror.Mirror("file://$spack/opt").fetch_url == opt
+    assert spack.mirrors.mirror.Mirror("$spack/opt").fetch_url == opt
+    assert spack.mirrors.mirror.Mirror("https://example.com/m").fetch_url == "https://example.com/m"
 
 
 def test_update_1():


### PR DESCRIPTION
`file://$spack/../spack-cache` in mirrors.yaml was never expanded. `urlparse` treats `$spack` as the URL host, so the path collapsed to `/spack-cache` and `spack buildcache push` failed with `PermissionError: /spack-cache`.

Substitute config variables first, then canonicalize `file://` URLs as paths so `$spack` expands on POSIX and Windows.

Fixes #52959.

Tested:
```
PYTHONPATH=lib/spack python -m pytest lib/spack/spack/test/mirror.py::test_file_url_expands_spack_variable lib/spack/spack/test/mirror.py::test_update_1 lib/spack/spack/test/mirror.py::test_update_2 lib/spack/spack/test/mirror.py::test_update_3 lib/spack/spack/test/mirror.py::test_update_4 -q
```
5 passed.