### PR TITLE
solver: improve setup time

### DIFF
--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -1529,14 +1529,17 @@ class SpackSolverSetup:
             return
 
         self.gen.h2("Trigger conditions")
+        problem = self.gen.asp_problem
         for name in self._trigger_cache:
             cache = self._trigger_cache[name]
+            quoted_name = quote(name)
             for (spec_str, _), (trigger_id, requirements) in cache.items():
-                self.gen.pkg_fact(name, fn.trigger_id(trigger_id))
-                self.gen.pkg_fact(name, fn.trigger_msg(spec_str))
+                problem.append(f"pkg_fact({quoted_name},trigger_id({trigger_id})).")
+                problem.append(f"pkg_fact({quoted_name},trigger_msg({quote(spec_str)})).")
+                # the requirements are written out as they are, with the trigger id prepended
                 for predicate in requirements:
-                    self.gen.fact(fn.condition_requirement(trigger_id, *predicate.args))
-                self.gen.newline()
+                    problem.append(f"condition_requirement({trigger_id},{predicate.args_str()}).")
+                problem.append("")
         self._trigger_cache.clear()
 
     def effect_rules(self):
@@ -1545,14 +1548,17 @@ class SpackSolverSetup:
             return
 
         self.gen.h2("Imposed requirements")
+        problem = self.gen.asp_problem
         for name in sorted(self._effect_cache):
             cache = self._effect_cache[name]
+            quoted_name = quote(name)
             for (spec_str, _), (effect_id, requirements) in cache.items():
-                self.gen.pkg_fact(name, fn.effect_id(effect_id))
-                self.gen.pkg_fact(name, fn.effect_msg(spec_str))
+                problem.append(f"pkg_fact({quoted_name},effect_id({effect_id})).")
+                problem.append(f"pkg_fact({quoted_name},effect_msg({quote(spec_str)})).")
+                # see the note in trigger_rules()
                 for predicate in requirements:
-                    self.gen.fact(fn.imposed_constraint(effect_id, *predicate.args))
-                self.gen.newline()
+                    problem.append(f"imposed_constraint({effect_id},{predicate.args_str()}).")
+                problem.append("")
         self._effect_cache.clear()
 
     def define_variant(

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -75,7 +75,17 @@ from spack.util.lang import elide_list
 
 from .clauses import SpecClauseGenerator
 from .compat import default_clingo_control, make_error_control
-from .core import AspFunction, AspVar, NodeId, SourceContext, extract_args, fn, quote
+from .core import (
+    AspFunction,
+    AspVar,
+    NodeId,
+    SourceContext,
+    asp_argument,
+    extract_args,
+    fn,
+    quote,
+    quote_once,
+)
 from .input_analysis import create_counter, create_graph_analyzer
 from .requirements import RequirementKind, RequirementOrigin, RequirementParser, RequirementRule
 from .reuse import ReusableSpecsSelector, SpecFiltersFactory
@@ -1535,7 +1545,7 @@ class SpackSolverSetup:
             quoted_name = quote(name)
             for (spec_str, _), (trigger_id, requirements) in cache.items():
                 problem.append(f"pkg_fact({quoted_name},trigger_id({trigger_id})).")
-                problem.append(f"pkg_fact({quoted_name},trigger_msg({quote(spec_str)})).")
+                problem.append(f"pkg_fact({quoted_name},trigger_msg({quote_once(spec_str)})).")
                 # the requirements are written out as they are, with the trigger id prepended
                 for predicate in requirements:
                     problem.append(f"condition_requirement({trigger_id},{predicate.args_str()}).")
@@ -1554,7 +1564,7 @@ class SpackSolverSetup:
             quoted_name = quote(name)
             for (spec_str, _), (effect_id, requirements) in cache.items():
                 problem.append(f"pkg_fact({quoted_name},effect_id({effect_id})).")
-                problem.append(f"pkg_fact({quoted_name},effect_msg({quote(spec_str)})).")
+                problem.append(f"pkg_fact({quoted_name},effect_msg({quote_once(spec_str)})).")
                 # see the note in trigger_rules()
                 for predicate in requirements:
                     problem.append(f"imposed_constraint({effect_id},{predicate.args_str()}).")
@@ -1727,8 +1737,7 @@ class SpackSolverSetup:
         imposed_name: Optional[str] = None,
         msg: Optional[str] = None,
         context: Optional[ConditionContext] = None,
-    ) -> Tuple[List[AspFunction], int]:
-        clauses = []
+    ) -> Tuple[List[str], int]:
         required_name = required_spec.name or required_name
         if not required_name:
             raise ValueError(f"Must provide a name for anonymous condition: '{required_spec}'")
@@ -1749,9 +1758,13 @@ class SpackSolverSetup:
             body=True,
             context=requirement_context,
         )
-        clauses.append(fn.pkg_fact(required_name, fn.condition(condition_id)))
-        clauses.append(fn.condition_reason(condition_id, msg))
-        clauses.append(fn.pkg_fact(required_name, fn.condition_trigger(condition_id, trigger_id)))
+        quoted_name = quote(required_name)
+        quoted_msg = quote_once(msg) if type(msg) is str else asp_argument(msg)
+        clauses = [
+            f"pkg_fact({quoted_name},condition({condition_id})).",
+            f"condition_reason({condition_id},{quoted_msg}).",
+            f"pkg_fact({quoted_name},condition_trigger({condition_id},{trigger_id})).",
+        ]
         if not imposed_spec:
             return clauses, condition_id
 
@@ -1767,7 +1780,7 @@ class SpackSolverSetup:
             body=False,
             context=impose_context,
         )
-        clauses.append(fn.pkg_fact(required_name, fn.condition_effect(condition_id, effect_id)))
+        clauses.append(f"pkg_fact({quoted_name},condition_effect({condition_id},{effect_id})).")
 
         return clauses, condition_id
 
@@ -1804,8 +1817,7 @@ class SpackSolverSetup:
             msg=msg,
             context=context,
         )
-        for clause in clauses:
-            self.gen.fact(clause)
+        self.gen.asp_problem.extend(clauses)
 
         return condition_id
 

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -75,7 +75,7 @@ from spack.util.lang import elide_list
 
 from .clauses import SpecClauseGenerator
 from .compat import default_clingo_control, make_error_control
-from .core import AspFunction, AspVar, NodeId, SourceContext, extract_args, fn
+from .core import AspFunction, AspVar, NodeId, SourceContext, extract_args, fn, quote
 from .input_analysis import create_counter, create_graph_analyzer
 from .requirements import RequirementKind, RequirementOrigin, RequirementParser, RequirementRule
 from .reuse import ReusableSpecsSelector, SpecFiltersFactory
@@ -1436,16 +1436,12 @@ class SpackSolverSetup:
         # Set the deprecation penalty, according to the package. This should be enough to move the
         # first version last if deprecated.
         if ordered_versions:
-            self.gen.fact(
-                fn.pkg_fact(pkg.name, fn.version_deprecation_penalty(len(ordered_versions)))
-            )
+            self.gen.pkg_fact(pkg.name, fn.version_deprecation_penalty(len(ordered_versions)))
 
         for weight, declared_version in enumerate(ordered_versions):
-            self.gen.fact(fn.pkg_fact(pkg.name, fn.version_declared(declared_version, weight)))
+            self.gen.pkg_fact(pkg.name, fn.version_declared(declared_version, weight))
             for origin in version_provenance[declared_version]:
-                self.gen.fact(
-                    fn.pkg_fact(pkg.name, fn.version_origin(declared_version, str(origin)))
-                )
+                self.gen.pkg_fact(pkg.name, fn.version_origin(declared_version, str(origin)))
 
         for v in self.possible_versions[pkg.name]:
             if pkg.needs_commit(v):
@@ -1455,7 +1451,7 @@ class SpackSolverSetup:
         # Declare deprecated versions for this package, if any
         deprecated = self.deprecated_versions[pkg.name]
         for v in sorted(deprecated):
-            self.gen.fact(fn.pkg_fact(pkg.name, fn.deprecated_version(v)))
+            self.gen.pkg_fact(pkg.name, fn.deprecated_version(v))
 
     def conflict_rules(self, pkg):
         for when_spec, conflict_specs in pkg.conflicts.items():
@@ -1482,10 +1478,8 @@ class SpackSolverSetup:
                     required_name=conflict_spec.name or pkg.name,
                     msg=conflict_spec_msg,
                 )
-                self.gen.fact(
-                    fn.pkg_fact(
-                        pkg.name, fn.conflict(conflict_spec_id, when_spec_id, conflict_msg)
-                    )
+                self.gen.pkg_fact(
+                    pkg.name, fn.conflict(conflict_spec_id, when_spec_id, conflict_msg)
                 )
                 self.gen.newline()
 
@@ -1505,7 +1499,7 @@ class SpackSolverSetup:
         pkg = self.clauses.pkg_class(pkg)
 
         # Namespace of the package
-        self.gen.fact(fn.pkg_fact(pkg.name, fn.namespace(pkg.namespace)))
+        self.gen.pkg_fact(pkg.name, fn.namespace(pkg.namespace))
 
         # versions
         self.pkg_version_rules(pkg)
@@ -1538,8 +1532,8 @@ class SpackSolverSetup:
         for name in self._trigger_cache:
             cache = self._trigger_cache[name]
             for (spec_str, _), (trigger_id, requirements) in cache.items():
-                self.gen.fact(fn.pkg_fact(name, fn.trigger_id(trigger_id)))
-                self.gen.fact(fn.pkg_fact(name, fn.trigger_msg(spec_str)))
+                self.gen.pkg_fact(name, fn.trigger_id(trigger_id))
+                self.gen.pkg_fact(name, fn.trigger_msg(spec_str))
                 for predicate in requirements:
                     self.gen.fact(fn.condition_requirement(trigger_id, *predicate.args))
                 self.gen.newline()
@@ -1554,8 +1548,8 @@ class SpackSolverSetup:
         for name in sorted(self._effect_cache):
             cache = self._effect_cache[name]
             for (spec_str, _), (effect_id, requirements) in cache.items():
-                self.gen.fact(fn.pkg_fact(name, fn.effect_id(effect_id)))
-                self.gen.fact(fn.pkg_fact(name, fn.effect_msg(spec_str)))
+                self.gen.pkg_fact(name, fn.effect_id(effect_id))
+                self.gen.pkg_fact(name, fn.effect_msg(spec_str))
                 for predicate in requirements:
                     self.gen.fact(fn.imposed_constraint(effect_id, *predicate.args))
                 self.gen.newline()
@@ -1568,7 +1562,7 @@ class SpackSolverSetup:
         when: spack.spec.Spec,
         variant_def: vt.Variant,
     ):
-        pkg_fact = lambda f: self.gen.fact(fn.pkg_fact(pkg.name, f))
+        pkg_fact = lambda f: self.gen.pkg_fact(pkg.name, f)
 
         # Every variant id has a unique definition (conditional or unconditional), and
         # higher variant id definitions take precedence when variants intersect.
@@ -1813,7 +1807,7 @@ class SpackSolverSetup:
         for vpkg_name in pkg.provided_virtual_names():
             if vpkg_name not in self.possible_virtuals:
                 continue
-            self.gen.fact(fn.pkg_fact(pkg.name, fn.possible_provider(vpkg_name)))
+            self.gen.pkg_fact(pkg.name, fn.possible_provider(vpkg_name))
 
         for when, provided in pkg.provided.items():
             for vpkg in sorted(provided):
@@ -1822,9 +1816,7 @@ class SpackSolverSetup:
 
                 msg = f"{pkg.name} provides {vpkg}{'' if when == EMPTY_SPEC else f' when {when}'}"
                 condition_id = self.condition(when, vpkg, required_name=pkg.name, msg=msg)
-                self.gen.fact(
-                    fn.pkg_fact(pkg.name, fn.provider_condition(condition_id, vpkg.name))
-                )
+                self.gen.pkg_fact(pkg.name, fn.provider_condition(condition_id, vpkg.name))
             self.gen.newline()
 
         for when, sets_of_virtuals in pkg.provided_together.items():
@@ -1833,9 +1825,7 @@ class SpackSolverSetup:
             )
             for set_id, virtuals_together in enumerate(sorted(sets_of_virtuals)):
                 for name in sorted(virtuals_together):
-                    self.gen.fact(
-                        fn.pkg_fact(pkg.name, fn.provided_together(condition_id, set_id, name))
-                    )
+                    self.gen.pkg_fact(pkg.name, fn.provided_together(condition_id, set_id, name))
             self.gen.newline()
 
     def package_dependencies_rules(self, pkg):
@@ -2382,13 +2372,13 @@ class SpackSolverSetup:
             possible_versions.sort()
             sorted_versions[pkg_name] = possible_versions
             for idx, v in enumerate(possible_versions):
-                self.gen.fact(fn.pkg_fact(pkg_name, fn.version_order(v, idx)))
+                self.gen.pkg_fact(pkg_name, fn.version_order(v, idx))
                 if v in self.git_commit_versions[pkg_name]:
                     sha = self.git_commit_versions[pkg_name].get(v)
                     if sha:
-                        self.gen.fact(fn.pkg_fact(pkg_name, fn.version_has_commit(v, sha)))
+                        self.gen.pkg_fact(pkg_name, fn.version_has_commit(v, sha))
                     else:
-                        self.gen.fact(fn.pkg_fact(pkg_name, fn.version_needs_commit(v)))
+                        self.gen.pkg_fact(pkg_name, fn.version_needs_commit(v))
             self.gen.newline()
         self.gen.newline()
 
@@ -2406,13 +2396,13 @@ class SpackSolverSetup:
                     elif start_idx is not None:
                         # End of a contiguous satisfying range found
                         version_range = fn.version_range(versions, start_idx, current_idx - 1)
-                        self.gen.fact(fn.pkg_fact(pkg_name, version_range))
+                        self.gen.pkg_fact(pkg_name, version_range)
                         start_idx = None
                 if start_idx is not None:
                     version_range = fn.version_range(
                         versions, start_idx, len(possible_versions) - 1
                     )
-                    self.gen.fact(fn.pkg_fact(pkg_name, version_range))
+                    self.gen.pkg_fact(pkg_name, version_range)
             self.gen.newline()
 
     def collect_virtual_constraints(self):
@@ -2500,7 +2490,7 @@ class SpackSolverSetup:
 
         # Tell the concretizer about possible values from specs seen in spec_clauses().
         for pkg_name, vid, value in sorted(def_info):
-            self.gen.fact(fn.pkg_fact(pkg_name, fn.variant_possible_value(vid, value)))
+            self.gen.pkg_fact(pkg_name, fn.variant_possible_value(vid, value))
 
     def register_concrete_spec(self, spec, possible: set, *, selectable: bool = True):
         # tell the solver about any installed packages that could
@@ -2928,7 +2918,7 @@ class SpackSolverSetup:
 
             # Special condition triggered by "literal_solved"
             self.gen.fact(fn.literal(trigger_id))
-            self.gen.fact(fn.pkg_fact(spec.name, fn.condition_trigger(condition_id, trigger_id)))
+            self.gen.pkg_fact(spec.name, fn.condition_trigger(condition_id, trigger_id))
             self.gen.fact(fn.condition_reason(condition_id, f"{spec} requested explicitly"))
 
             imposed_spec_key = str(spec), None
@@ -2959,7 +2949,7 @@ class SpackSolverSetup:
             )
             requirements = [x for x in requirements if x.args[0] != "depends_on"]
             cache[imposed_spec_key] = (effect_id, requirements)
-            self.gen.fact(fn.pkg_fact(spec.name, fn.condition_effect(condition_id, effect_id)))
+            self.gen.pkg_fact(spec.name, fn.condition_effect(condition_id, effect_id))
 
             # Create subcondition with any conditional dependencies
             # spec_clauses() does not do anything with conditional dependencies
@@ -3102,6 +3092,13 @@ class ProblemInstanceBuilder:
 
     def fact(self, atom: AspFunction) -> None:
         self.asp_problem.append(f"{atom}.")
+
+    def pkg_fact(self, pkg_name: str, atom: AspFunction) -> None:
+        """Add ``pkg_fact(<pkg_name>, <atom>)``, the most common fact of the problem by far.
+
+        It is written out here, so that the wrapping ``AspFunction`` is never built.
+        """
+        self.asp_problem.append(f"pkg_fact({quote(pkg_name)},{atom}).")
 
     def append(self, rule: str) -> None:
         self.asp_problem.append(rule)

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -1540,19 +1540,9 @@ class SpackSolverSetup:
             return
 
         self.gen.h2("Trigger conditions")
-        # We avoid high-level fn.* calls for performance reasons here.
-        problem, quoted = self.gen.asp_problem, self.gen.quoted
-        for name in self._trigger_cache:
-            cache = self._trigger_cache[name]
-            quoted_name = quote(name, quoted)
+        for name, cache in self._trigger_cache.items():
             for (spec_str, _), (trigger_id, requirements) in cache.items():
-                problem.append(f"pkg_fact({quoted_name},trigger_id({trigger_id})).")
-                problem.append(f"pkg_fact({quoted_name},trigger_msg({quote_once(spec_str)})).")
-                for predicate in requirements:
-                    problem.append(
-                        f"condition_requirement({trigger_id},{predicate.args_str(quoted)})."
-                    )
-                problem.append("")
+                self.gen.trigger_facts(name, trigger_id, spec_str, requirements)
         self._trigger_cache.clear()
 
     def effect_rules(self):
@@ -1561,19 +1551,9 @@ class SpackSolverSetup:
             return
 
         self.gen.h2("Imposed requirements")
-        # We avoid high-level fn.* calls for performance reasons here.
-        problem, quoted = self.gen.asp_problem, self.gen.quoted
         for name in sorted(self._effect_cache):
-            cache = self._effect_cache[name]
-            quoted_name = quote(name, quoted)
-            for (spec_str, _), (effect_id, requirements) in cache.items():
-                problem.append(f"pkg_fact({quoted_name},effect_id({effect_id})).")
-                problem.append(f"pkg_fact({quoted_name},effect_msg({quote_once(spec_str)})).")
-                for predicate in requirements:
-                    problem.append(
-                        f"imposed_constraint({effect_id},{predicate.args_str(quoted)})."
-                    )
-                problem.append("")
+            for (spec_str, _), (effect_id, requirements) in self._effect_cache[name].items():
+                self.gen.effect_facts(name, effect_id, spec_str, requirements)
         self._effect_cache.clear()
 
     def define_variant(
@@ -1733,63 +1713,6 @@ class SpackSolverSetup:
 
         return cond_id
 
-    def _condition_clauses(
-        self,
-        required_spec: spack.spec.Spec,
-        imposed_spec: Optional[spack.spec.Spec] = None,
-        *,
-        required_name: Optional[str] = None,
-        imposed_name: Optional[str] = None,
-        msg: Optional[str] = None,
-        context: Optional[ConditionContext] = None,
-    ) -> Tuple[List[str], int]:
-        required_name = required_spec.name or required_name
-        if not required_name:
-            raise ValueError(f"Must provide a name for anonymous condition: '{required_spec}'")
-
-        if not context:
-            context = ConditionContext()
-            context.transform_imposed = remove_facts("node", "virtual_node")
-
-        # Check if we can emit the requirements before updating the condition ID counter.
-        # In this way, if a condition can't be emitted but the exception is handled in the
-        # caller, we won't emit partial facts.
-        condition_id = next(self._id_counter)
-        requirement_context = context.requirement_context()
-        trigger_id = self._get_condition_id(
-            required_name,
-            required_spec,
-            cache=self._trigger_cache,
-            body=True,
-            context=requirement_context,
-        )
-        quoted = self.gen.quoted
-        quoted_name = quote(required_name, quoted)
-        quoted_msg = quote_once(msg) if type(msg) is str else asp_argument(msg, quoted)
-        clauses = [
-            f"pkg_fact({quoted_name},condition({condition_id})).",
-            f"condition_reason({condition_id},{quoted_msg}).",
-            f"pkg_fact({quoted_name},condition_trigger({condition_id},{trigger_id})).",
-        ]
-        if not imposed_spec:
-            return clauses, condition_id
-
-        imposed_name = imposed_spec.name or imposed_name
-        if not imposed_name:
-            raise ValueError(f"Must provide a name for imposed constraint: '{imposed_spec}'")
-
-        impose_context = context.impose_context()
-        effect_id = self._get_condition_id(
-            imposed_name,
-            imposed_spec,
-            cache=self._effect_cache,
-            body=False,
-            context=impose_context,
-        )
-        clauses.append(f"pkg_fact({quoted_name},condition_effect({condition_id},{effect_id})).")
-
-        return clauses, condition_id
-
     def condition(
         self,
         required_spec: spack.spec.Spec,
@@ -1815,16 +1738,40 @@ class SpackSolverSetup:
         Returns:
             int: id of the condition created by this function
         """
-        clauses, condition_id = self._condition_clauses(
-            required_spec=required_spec,
-            imposed_spec=imposed_spec,
-            required_name=required_name,
-            imposed_name=imposed_name,
-            msg=msg,
-            context=context,
-        )
-        self.gen.asp_problem.extend(clauses)
+        required_name = required_spec.name or required_name
+        if not required_name:
+            raise ValueError(f"Must provide a name for anonymous condition: '{required_spec}'")
 
+        if not context:
+            context = ConditionContext()
+            context.transform_imposed = remove_facts("node", "virtual_node")
+
+        # Settle the trigger and the effect before emitting anything: if one of them cannot be
+        # emitted but the exception is handled in the caller, we won't have emitted partial facts.
+        condition_id = next(self._id_counter)
+        trigger_id = self._get_condition_id(
+            required_name,
+            required_spec,
+            cache=self._trigger_cache,
+            body=True,
+            context=context.requirement_context(),
+        )
+
+        effect_id = None
+        if imposed_spec:
+            imposed_name = imposed_spec.name or imposed_name
+            if not imposed_name:
+                raise ValueError(f"Must provide a name for imposed constraint: '{imposed_spec}'")
+
+            effect_id = self._get_condition_id(
+                imposed_name,
+                imposed_spec,
+                cache=self._effect_cache,
+                body=False,
+                context=context.impose_context(),
+            )
+
+        self.gen.condition_facts(required_name, condition_id, trigger_id, msg, effect_id)
         return condition_id
 
     def package_provider_rules(self, pkg: Type[spack.package_base.PackageBase]) -> None:
@@ -3109,6 +3056,10 @@ class ProblemInstanceBuilder:
 
     The problem instance can be added directly to the "control" structure of clingo.
 
+    Facts are usually added as ``AspFunction`` objects, see :meth:`fact`. The facts that a solve
+    writes out by the ten thousands, those of its conditions, have a writer of their own here
+    instead: they are written out once and never looked at again, so there is no point in
+    building the objects, and the writers are the one place that spells out their ASP form.
     """
 
     def __init__(self) -> None:
@@ -3123,6 +3074,70 @@ class ProblemInstanceBuilder:
         """Fast helper for ``pkg_fact(<pkg_name>, <atom>)``"""
         quoted = self.quoted
         self.asp_problem.append(f"pkg_fact({quote(pkg_name, quoted)},{atom.to_str(quoted)}).")
+
+    def condition_facts(
+        self,
+        pkg_name: str,
+        condition_id: int,
+        trigger_id: int,
+        msg: Optional[str],
+        effect_id: Optional[int] = None,
+    ) -> None:
+        """Add the facts of a condition: the package that declares it, the reason for it, what
+        triggers it and, if there is one, the effect it has::
+
+            pkg_fact(P,condition(C)).
+            condition_reason(C,M).
+            pkg_fact(P,condition_trigger(C,T)).
+            pkg_fact(P,condition_effect(C,E)).
+        """
+        quoted = self.quoted
+        name = quote(pkg_name, quoted)
+        reason = quote_once(msg) if type(msg) is str else asp_argument(msg, quoted)
+        problem = self.asp_problem
+        problem.append(f"pkg_fact({name},condition({condition_id})).")
+        problem.append(f"condition_reason({condition_id},{reason}).")
+        problem.append(f"pkg_fact({name},condition_trigger({condition_id},{trigger_id})).")
+        if effect_id is not None:
+            problem.append(f"pkg_fact({name},condition_effect({condition_id},{effect_id})).")
+
+    def trigger_facts(
+        self, pkg_name: str, trigger_id: int, spec_str: str, requirements: List[AspFunction]
+    ) -> None:
+        """Add the facts of a trigger: its id, the spec it stands for, and the clauses of that
+        spec as its requirements, followed by a blank line::
+
+            pkg_fact(P,trigger_id(T)).
+            pkg_fact(P,trigger_msg(S)).
+            condition_requirement(T,<the arguments of a clause>).
+        """
+        quoted = self.quoted
+        name = quote(pkg_name, quoted)
+        problem = self.asp_problem
+        problem.append(f"pkg_fact({name},trigger_id({trigger_id})).")
+        problem.append(f"pkg_fact({name},trigger_msg({quote_once(spec_str)})).")
+        for clause in requirements:
+            problem.append(f"condition_requirement({trigger_id},{clause.args_str(quoted)}).")
+        problem.append("")
+
+    def effect_facts(
+        self, pkg_name: str, effect_id: int, spec_str: str, requirements: List[AspFunction]
+    ) -> None:
+        """Add the facts of an effect: its id, the spec it stands for, and the clauses of that
+        spec as the constraints it imposes, followed by a blank line::
+
+            pkg_fact(P,effect_id(E)).
+            pkg_fact(P,effect_msg(S)).
+            imposed_constraint(E,<the arguments of a clause>).
+        """
+        quoted = self.quoted
+        name = quote(pkg_name, quoted)
+        problem = self.asp_problem
+        problem.append(f"pkg_fact({name},effect_id({effect_id})).")
+        problem.append(f"pkg_fact({name},effect_msg({quote_once(spec_str)})).")
+        for clause in requirements:
+            problem.append(f"imposed_constraint({effect_id},{clause.args_str(quoted)}).")
+        problem.append("")
 
     def append(self, rule: str) -> None:
         self.asp_problem.append(rule)

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -1540,6 +1540,7 @@ class SpackSolverSetup:
             return
 
         self.gen.h2("Trigger conditions")
+        # We avoid high-level fn.* calls for performance reasons here.
         problem, quoted = self.gen.asp_problem, self.gen.quoted
         for name in self._trigger_cache:
             cache = self._trigger_cache[name]
@@ -1547,7 +1548,6 @@ class SpackSolverSetup:
             for (spec_str, _), (trigger_id, requirements) in cache.items():
                 problem.append(f"pkg_fact({quoted_name},trigger_id({trigger_id})).")
                 problem.append(f"pkg_fact({quoted_name},trigger_msg({quote_once(spec_str)})).")
-                # the requirements are written out as they are, with the trigger id prepended
                 for predicate in requirements:
                     problem.append(
                         f"condition_requirement({trigger_id},{predicate.args_str(quoted)})."
@@ -1561,6 +1561,7 @@ class SpackSolverSetup:
             return
 
         self.gen.h2("Imposed requirements")
+        # We avoid high-level fn.* calls for performance reasons here.
         problem, quoted = self.gen.asp_problem, self.gen.quoted
         for name in sorted(self._effect_cache):
             cache = self._effect_cache[name]
@@ -1568,7 +1569,6 @@ class SpackSolverSetup:
             for (spec_str, _), (effect_id, requirements) in cache.items():
                 problem.append(f"pkg_fact({quoted_name},effect_id({effect_id})).")
                 problem.append(f"pkg_fact({quoted_name},effect_msg({quote_once(spec_str)})).")
-                # see the note in trigger_rules()
                 for predicate in requirements:
                     problem.append(
                         f"imposed_constraint({effect_id},{predicate.args_str(quoted)})."
@@ -3113,17 +3113,14 @@ class ProblemInstanceBuilder:
 
     def __init__(self) -> None:
         self.asp_problem: List[str] = []
-        #: ASP literals of the strings written out for this problem, see core.quote()
+        #: Cache of quoted Python strings for use in ASP
         self.quoted: QuotedStrings = {}
 
     def fact(self, atom: AspFunction) -> None:
         self.asp_problem.append(f"{atom.to_str(self.quoted)}.")
 
     def pkg_fact(self, pkg_name: str, atom: AspFunction) -> None:
-        """Add ``pkg_fact(<pkg_name>, <atom>)``, the most common fact of the problem by far.
-
-        It is written out here, so that the wrapping ``AspFunction`` is never built.
-        """
+        """Fast helper for ``pkg_fact(<pkg_name>, <atom>)``"""
         quoted = self.quoted
         self.asp_problem.append(f"pkg_fact({quote(pkg_name, quoted)},{atom.to_str(quoted)}).")
 

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -79,6 +79,7 @@ from .core import (
     AspFunction,
     AspVar,
     NodeId,
+    QuotedStrings,
     SourceContext,
     asp_argument,
     extract_args,
@@ -1539,16 +1540,18 @@ class SpackSolverSetup:
             return
 
         self.gen.h2("Trigger conditions")
-        problem = self.gen.asp_problem
+        problem, quoted = self.gen.asp_problem, self.gen.quoted
         for name in self._trigger_cache:
             cache = self._trigger_cache[name]
-            quoted_name = quote(name)
+            quoted_name = quote(name, quoted)
             for (spec_str, _), (trigger_id, requirements) in cache.items():
                 problem.append(f"pkg_fact({quoted_name},trigger_id({trigger_id})).")
                 problem.append(f"pkg_fact({quoted_name},trigger_msg({quote_once(spec_str)})).")
                 # the requirements are written out as they are, with the trigger id prepended
                 for predicate in requirements:
-                    problem.append(f"condition_requirement({trigger_id},{predicate.args_str()}).")
+                    problem.append(
+                        f"condition_requirement({trigger_id},{predicate.args_str(quoted)})."
+                    )
                 problem.append("")
         self._trigger_cache.clear()
 
@@ -1558,16 +1561,18 @@ class SpackSolverSetup:
             return
 
         self.gen.h2("Imposed requirements")
-        problem = self.gen.asp_problem
+        problem, quoted = self.gen.asp_problem, self.gen.quoted
         for name in sorted(self._effect_cache):
             cache = self._effect_cache[name]
-            quoted_name = quote(name)
+            quoted_name = quote(name, quoted)
             for (spec_str, _), (effect_id, requirements) in cache.items():
                 problem.append(f"pkg_fact({quoted_name},effect_id({effect_id})).")
                 problem.append(f"pkg_fact({quoted_name},effect_msg({quote_once(spec_str)})).")
                 # see the note in trigger_rules()
                 for predicate in requirements:
-                    problem.append(f"imposed_constraint({effect_id},{predicate.args_str()}).")
+                    problem.append(
+                        f"imposed_constraint({effect_id},{predicate.args_str(quoted)})."
+                    )
                 problem.append("")
         self._effect_cache.clear()
 
@@ -1758,8 +1763,9 @@ class SpackSolverSetup:
             body=True,
             context=requirement_context,
         )
-        quoted_name = quote(required_name)
-        quoted_msg = quote_once(msg) if type(msg) is str else asp_argument(msg)
+        quoted = self.gen.quoted
+        quoted_name = quote(required_name, quoted)
+        quoted_msg = quote_once(msg) if type(msg) is str else asp_argument(msg, quoted)
         clauses = [
             f"pkg_fact({quoted_name},condition({condition_id})).",
             f"condition_reason({condition_id},{quoted_msg}).",
@@ -3107,16 +3113,19 @@ class ProblemInstanceBuilder:
 
     def __init__(self) -> None:
         self.asp_problem: List[str] = []
+        #: ASP literals of the strings written out for this problem, see core.quote()
+        self.quoted: QuotedStrings = {}
 
     def fact(self, atom: AspFunction) -> None:
-        self.asp_problem.append(f"{atom}.")
+        self.asp_problem.append(f"{atom.to_str(self.quoted)}.")
 
     def pkg_fact(self, pkg_name: str, atom: AspFunction) -> None:
         """Add ``pkg_fact(<pkg_name>, <atom>)``, the most common fact of the problem by far.
 
         It is written out here, so that the wrapping ``AspFunction`` is never built.
         """
-        self.asp_problem.append(f"pkg_fact({quote(pkg_name)},{atom}).")
+        quoted = self.quoted
+        self.asp_problem.append(f"pkg_fact({quote(pkg_name, quoted)},{atom.to_str(quoted)}).")
 
     def append(self, rule: str) -> None:
         self.asp_problem.append(rule)

--- a/lib/spack/spack/solver/clauses.py
+++ b/lib/spack/spack/solver/clauses.py
@@ -251,6 +251,10 @@ class SpecClauseGenerator:
         self, spec: spack.spec.Spec, *, name: str, body: bool
     ) -> List[AspFunction]:
         """Return clauses for the virtuals a spec provides on its incoming edges."""
+        # without incoming edges there are no virtuals to report
+        if not spec._dependents:
+            return []
+
         # TODO: a loop over `edges_to_dependencies` is preferred over `edges_from_dependents`
         # since dependents can point to specs out of scope for the solver.
         edges = spec.edges_from_dependents()
@@ -417,9 +421,13 @@ class SpecClauseGenerator:
             clauses.append(f.namespace(name, spec.namespace))
 
         clauses.extend(self.spec_versions(spec, name=name))
-        clauses.extend(self._arch_clauses(spec, f, name=name))
-        clauses.extend(self._variant_clauses(spec, f, name=name, body=body))
-        clauses.extend(self._flag_clauses(spec, f, name=name, context=context))
+        # an absent part contributes no clauses
+        if spec.architecture:
+            clauses.extend(self._arch_clauses(spec, f, name=name))
+        if spec.variants:
+            clauses.extend(self._variant_clauses(spec, f, name=name, body=body))
+        if spec.compiler_flags:
+            clauses.extend(self._flag_clauses(spec, f, name=name, context=context))
 
         # Hash for concrete specs
         if spec.concrete:
@@ -431,7 +439,8 @@ class SpecClauseGenerator:
             if spec.external:
                 clauses.append(fn.attr("external", name))
 
-        clauses.extend(self._virtuals_from_dependents(spec, name=name, body=body))
+        if spec._dependents:
+            clauses.extend(self._virtuals_from_dependents(spec, name=name, body=body))
 
         # If the spec is external and concrete, we allow all the libcs on the system
         if spec.external and spec.concrete and spack.platforms.using_libc_compatibility():

--- a/lib/spack/spack/solver/clauses.py
+++ b/lib/spack/spack/solver/clauses.py
@@ -84,6 +84,10 @@ class SpecClauseGenerator:
         self.version_constraints: Dict[str, Set] = collections.defaultdict(set)
         self.target_constraints: Set = set()
         self.variant_values_from_specs: Set = set()
+        #: Package classes by name, see pkg_class()
+        self._pkg_classes: Dict[str, Type[spack.package_base.PackageBase]] = {}
+        #: Whether a name is virtual, see is_virtual()
+        self._virtual_names: Dict[str, bool] = {}
 
     def record_version_constraint(self, name: str, versions) -> None:
         """Record that `versions` was requested for package `name`."""
@@ -197,7 +201,7 @@ class SpecClauseGenerator:
 
             for value in variant.values:
                 # ensure that the value *can* be valid for the spec
-                if name and not spec.concrete and not spack.repo.PATH.is_virtual(name):
+                if name and not spec.concrete and not self.is_virtual(name):
                     variant_defs = vt.prevalidate_variant_value(
                         self.pkg_class(name), variant, spec
                     )
@@ -414,9 +418,7 @@ class SpecClauseGenerator:
         f: Union[Type[_Head], Type[_Body]] = _Body if body else _Head
 
         if name:
-            clauses.append(
-                f.node(name) if not spack.repo.PATH.is_virtual(name) else f.virtual_node(name)
-            )
+            clauses.append(f.node(name) if not self.is_virtual(name) else f.virtual_node(name))
         if spec.namespace:
             clauses.append(f.namespace(name, spec.namespace))
 
@@ -492,9 +494,26 @@ class SpecClauseGenerator:
         clauses.extend(edge_clauses)
         return clauses
 
+    def is_virtual(self, name: str) -> bool:
+        """Whether ``name`` is the name of a virtual package.
+
+        The answer is kept: this generator lives for a single setup, and the set of virtuals
+        does not change during one.
+        """
+        result = self._virtual_names.get(name)
+        if result is None:
+            result = self._virtual_names[name] = spack.repo.PATH.is_virtual(name)
+        return result
+
     def pkg_class(self, pkg_name: str) -> Type[spack.package_base.PackageBase]:
+        # This generator lives for a single setup, so a class it hands out cannot go stale.
+        cls = self._pkg_classes.get(pkg_name)
+        if cls is not None:
+            return cls
+
         request = pkg_name
         if pkg_name in self.explicitly_required_namespaces:
             namespace = self.explicitly_required_namespaces[pkg_name]
             request = f"{namespace}.{pkg_name}"
-        return spack.repo.PATH.get_pkg_class(request)
+        cls = self._pkg_classes[pkg_name] = spack.repo.PATH.get_pkg_class(request)
+        return cls

--- a/lib/spack/spack/solver/clauses.py
+++ b/lib/spack/spack/solver/clauses.py
@@ -84,9 +84,9 @@ class SpecClauseGenerator:
         self.version_constraints: Dict[str, Set] = collections.defaultdict(set)
         self.target_constraints: Set = set()
         self.variant_values_from_specs: Set = set()
-        #: Package classes by name, see pkg_class()
+        #: Cache for pkg_class()
         self._pkg_classes: Dict[str, Type[spack.package_base.PackageBase]] = {}
-        #: Whether a name is virtual, see is_virtual()
+        #: Cache for is_virtual()
         self._virtual_names: Dict[str, bool] = {}
 
     def record_version_constraint(self, name: str, versions) -> None:
@@ -255,7 +255,6 @@ class SpecClauseGenerator:
         self, spec: spack.spec.Spec, *, name: str, body: bool
     ) -> List[AspFunction]:
         """Return clauses for the virtuals a spec provides on its incoming edges."""
-        # without incoming edges there are no virtuals to report
         if not spec._dependents:
             return []
 
@@ -423,7 +422,6 @@ class SpecClauseGenerator:
             clauses.append(f.namespace(name, spec.namespace))
 
         clauses.extend(self.spec_versions(spec, name=name))
-        # an absent part contributes no clauses
         if spec.architecture:
             clauses.extend(self._arch_clauses(spec, f, name=name))
         if spec.variants:
@@ -495,18 +493,12 @@ class SpecClauseGenerator:
         return clauses
 
     def is_virtual(self, name: str) -> bool:
-        """Whether ``name`` is the name of a virtual package.
-
-        The answer is kept: this generator lives for a single setup, and the set of virtuals
-        does not change during one.
-        """
         result = self._virtual_names.get(name)
         if result is None:
             result = self._virtual_names[name] = spack.repo.PATH.is_virtual(name)
         return result
 
     def pkg_class(self, pkg_name: str) -> Type[spack.package_base.PackageBase]:
-        # This generator lives for a single setup, so a class it hands out cannot go stale.
         cls = self._pkg_classes.get(pkg_name)
         if cls is not None:
             return cls

--- a/lib/spack/spack/solver/core.py
+++ b/lib/spack/spack/solver/core.py
@@ -99,9 +99,18 @@ def quote_once(arg: str) -> str:
     return '"' + arg.replace("\\", r"\\").replace("\n", r"\n").replace('"', r"\"") + '"'
 
 
+#: Strings up to this long are kept, longer ones are written out and forgotten. Names of
+#: packages, variants, versions, targets, ... are short and come up over and over; the long
+#: arguments are the messages that explain a condition or a conflict, and those are written
+#: once each, so keeping them only costs memory.
+MAX_QUOTED_LENGTH = 32
+
+
 def _quote(arg: str, quoted: QuotedStrings) -> str:
-    """Compute and keep the ASP literal for ``arg``; see :func:`quote`."""
-    result = quoted[arg] = quote_once(arg)
+    """Compute the ASP literal for ``arg``, and keep it if it is short; see :func:`quote`."""
+    result = quote_once(arg)
+    if len(arg) <= MAX_QUOTED_LENGTH:
+        quoted[arg] = result
     return result
 
 

--- a/lib/spack/spack/solver/core.py
+++ b/lib/spack/spack/solver/core.py
@@ -60,22 +60,19 @@ class AspFunction:
         return AspFunction(self.name, args if not self.args else self.args + args)
 
     def __str__(self) -> str:
-        return f"{self.name}({','.join([asp_argument(arg) for arg in self.args])})"
+        return self.to_str({})
 
-    def args_str(self) -> str:
+    def to_str(self, quoted: "QuotedStrings") -> str:
+        """The ASP representation of this function, reusing the literals in ``quoted``."""
+        return f"{self.name}({','.join([asp_argument(arg, quoted) for arg in self.args])})"
+
+    def args_str(self, quoted: "QuotedStrings") -> str:
         """The arguments as they appear between the parentheses of this function.
 
         The trigger and effect rules write the arguments of a clause out under a head of
-        their own, which is what needs this separately from :meth:`__str__`.
+        their own, which is what needs this separately from :meth:`to_str`.
         """
-        # a string that has been written out before needs no further work
-        quoted = _QUOTED
-        return ",".join(
-            [
-                quoted[arg] if type(arg) is str and arg in quoted else asp_argument(arg)
-                for arg in self.args
-            ]
-        )
+        return ",".join([asp_argument(arg, quoted) for arg in self.args])
 
     def __repr__(self) -> str:
         return str(self)
@@ -83,17 +80,18 @@ class AspFunction:
 
 #: ASP literals of the strings that have been written out, by string. String arguments are
 #: package, variant, version, ... names, of which a solve writes the same handful out over and
-#: over, and escaping one means scanning it three times.
-_QUOTED: Dict[str, str] = {}
+#: over, and escaping one means scanning it three times. A problem instance owns one of these,
+#: so that the literals it collects are released together with it.
+QuotedStrings = Dict[str, str]
 
 
-def quote(arg: str) -> str:
+def quote(arg: str, quoted: QuotedStrings) -> str:
     """The ASP literal for the string ``arg``: escaped, in double quotes, and kept for reuse.
 
     Use :func:`quote_once` for the strings that are written out once, such as the messages that
-    explain a condition, so that they do not fill the cache.
+    explain a condition, so that they do not fill ``quoted``.
     """
-    return _QUOTED.get(arg) or _quote(arg)
+    return quoted.get(arg) or _quote(arg, quoted)
 
 
 def quote_once(arg: str) -> str:
@@ -101,25 +99,27 @@ def quote_once(arg: str) -> str:
     return '"' + arg.replace("\\", r"\\").replace("\n", r"\n").replace('"', r"\"") + '"'
 
 
-def _quote(arg: str) -> str:
+def _quote(arg: str, quoted: QuotedStrings) -> str:
     """Compute and keep the ASP literal for ``arg``; see :func:`quote`."""
-    result = _QUOTED[arg] = quote_once(arg)
+    result = quoted[arg] = quote_once(arg)
     return result
 
 
-def asp_argument(arg: Any) -> str:
+def asp_argument(arg: Any, quoted: QuotedStrings) -> str:
     """The ASP representation of a single argument of a function."""
     # exact type checks first, ordered by frequency
     if type(arg) is str:
-        return _QUOTED.get(arg) or _quote(arg)
-    if type(arg) is AspFunction or type(arg) is int or type(arg) is AspVar:
+        return quoted.get(arg) or _quote(arg, quoted)
+    if type(arg) is AspFunction:
+        return arg.to_str(quoted)
+    if type(arg) is int or type(arg) is AspVar:
         return str(arg)
     # subclasses miss the checks above: config values are syaml_str / syaml_int. bool is
     # an int subclass, but is not a number in ASP, so it is quoted below.
     if isinstance(arg, int) and not isinstance(arg, bool):
         return str(arg)
     if isinstance(arg, str):
-        return _QUOTED.get(arg) or _quote(arg)
+        return quoted.get(arg) or _quote(arg, quoted)
     return f'"{arg}"'
 
 

--- a/lib/spack/spack/solver/core.py
+++ b/lib/spack/spack/solver/core.py
@@ -9,6 +9,8 @@ from spack.util import lang
 
 from .compat import symbol_name, symbol_string
 
+#: Type used for quoted string cache
+QuotedStrings = Dict[str, str]
 
 class AspVar:
     """Represents a variable in an ASP rule, allows for conditionally generating
@@ -62,27 +64,16 @@ class AspFunction:
     def __str__(self) -> str:
         return self.to_str({})
 
-    def to_str(self, quoted: "QuotedStrings") -> str:
+    def to_str(self, quoted: QuotedStrings) -> str:
         """The ASP representation of this function, reusing the literals in ``quoted``."""
         return f"{self.name}({','.join([asp_argument(arg, quoted) for arg in self.args])})"
 
-    def args_str(self, quoted: "QuotedStrings") -> str:
-        """The arguments as they appear between the parentheses of this function.
-
-        The trigger and effect rules write the arguments of a clause out under a head of
-        their own, which is what needs this separately from :meth:`to_str`.
-        """
+    def args_str(self, quoted: QuotedStrings) -> str:
+        """The arguments as they appear between the parentheses of this function."""
         return ",".join([asp_argument(arg, quoted) for arg in self.args])
 
     def __repr__(self) -> str:
         return str(self)
-
-
-#: ASP literals of the strings that have been written out, by string. String arguments are
-#: package, variant, version, ... names, of which a solve writes the same handful out over and
-#: over, and escaping one means scanning it three times. A problem instance owns one of these,
-#: so that the literals it collects are released together with it.
-QuotedStrings = Dict[str, str]
 
 
 def quote(arg: str, quoted: QuotedStrings) -> str:
@@ -99,10 +90,7 @@ def quote_once(arg: str) -> str:
     return '"' + arg.replace("\\", r"\\").replace("\n", r"\n").replace('"', r"\"") + '"'
 
 
-#: Strings up to this long are kept, longer ones are written out and forgotten. Names of
-#: packages, variants, versions, targets, ... are short and come up over and over; the long
-#: arguments are the messages that explain a condition or a conflict, and those are written
-#: once each, so keeping them only costs memory.
+#: Constant that determines the maximum length of a string that's kept in the quoted cache
 MAX_QUOTED_LENGTH = 32
 
 

--- a/lib/spack/spack/solver/core.py
+++ b/lib/spack/spack/solver/core.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 """Low-level wrappers around clingo API and other basic functionality related to ASP"""
 
-from typing import Any, NamedTuple, Optional, Tuple
+from typing import Any, Dict, NamedTuple, Optional, Tuple
 
 from spack.util import lang
 
@@ -60,27 +60,45 @@ class AspFunction:
         return AspFunction(self.name, args if not self.args else self.args + args)
 
     def __str__(self) -> str:
-        parts = []
-        for arg in self.args:
-            # exact type checks first, ordered by frequency
-            if type(arg) is str:
-                arg = arg.replace("\\", r"\\").replace("\n", r"\n").replace('"', r"\"")
-                parts.append(f'"{arg}"')
-            elif type(arg) is AspFunction or type(arg) is int or type(arg) is AspVar:
-                parts.append(str(arg))
-            # subclasses miss the checks above: config values are syaml_str / syaml_int. bool is
-            # an int subclass, but is not a number in ASP, so it is quoted below.
-            elif isinstance(arg, int) and not isinstance(arg, bool):
-                parts.append(str(arg))
-            elif isinstance(arg, str):
-                arg = arg.replace("\\", r"\\").replace("\n", r"\n").replace('"', r"\"")
-                parts.append(f'"{arg}"')
-            else:
-                parts.append(f'"{arg}"')
-        return f"{self.name}({','.join(parts)})"
+        return f"{self.name}({','.join([asp_argument(arg) for arg in self.args])})"
 
     def __repr__(self) -> str:
         return str(self)
+
+
+#: ASP literals of the strings that have been written out, by string. String arguments are
+#: package, variant, version, ... names, of which a solve writes the same handful out over and
+#: over, and escaping one means scanning it three times.
+_QUOTED: Dict[str, str] = {}
+
+
+def quote(arg: str) -> str:
+    """The ASP literal for the string ``arg``: escaped, in double quotes, and kept for reuse."""
+    return _QUOTED.get(arg) or _quote(arg)
+
+
+def _quote(arg: str) -> str:
+    """Compute and keep the ASP literal for ``arg``; see :func:`quote`."""
+    result = _QUOTED[arg] = (
+        '"' + arg.replace("\\", r"\\").replace("\n", r"\n").replace('"', r"\"") + '"'
+    )
+    return result
+
+
+def asp_argument(arg: Any) -> str:
+    """The ASP representation of a single argument of a function."""
+    # exact type checks first, ordered by frequency
+    if type(arg) is str:
+        return _QUOTED.get(arg) or _quote(arg)
+    if type(arg) is AspFunction or type(arg) is int or type(arg) is AspVar:
+        return str(arg)
+    # subclasses miss the checks above: config values are syaml_str / syaml_int. bool is
+    # an int subclass, but is not a number in ASP, so it is quoted below.
+    if isinstance(arg, int) and not isinstance(arg, bool):
+        return str(arg)
+    if isinstance(arg, str):
+        return _QUOTED.get(arg) or _quote(arg)
+    return f'"{arg}"'
 
 
 class _AspFunctionBuilder:

--- a/lib/spack/spack/solver/core.py
+++ b/lib/spack/spack/solver/core.py
@@ -88,15 +88,22 @@ _QUOTED: Dict[str, str] = {}
 
 
 def quote(arg: str) -> str:
-    """The ASP literal for the string ``arg``: escaped, in double quotes, and kept for reuse."""
+    """The ASP literal for the string ``arg``: escaped, in double quotes, and kept for reuse.
+
+    Use :func:`quote_once` for the strings that are written out once, such as the messages that
+    explain a condition, so that they do not fill the cache.
+    """
     return _QUOTED.get(arg) or _quote(arg)
+
+
+def quote_once(arg: str) -> str:
+    """The ASP literal for a string that is not expected to come up again."""
+    return '"' + arg.replace("\\", r"\\").replace("\n", r"\n").replace('"', r"\"") + '"'
 
 
 def _quote(arg: str) -> str:
     """Compute and keep the ASP literal for ``arg``; see :func:`quote`."""
-    result = _QUOTED[arg] = (
-        '"' + arg.replace("\\", r"\\").replace("\n", r"\n").replace('"', r"\"") + '"'
-    )
+    result = _QUOTED[arg] = quote_once(arg)
     return result
 
 

--- a/lib/spack/spack/solver/core.py
+++ b/lib/spack/spack/solver/core.py
@@ -12,6 +12,7 @@ from .compat import symbol_name, symbol_string
 #: Type used for quoted string cache
 QuotedStrings = Dict[str, str]
 
+
 class AspVar:
     """Represents a variable in an ASP rule, allows for conditionally generating
     rules"""

--- a/lib/spack/spack/solver/core.py
+++ b/lib/spack/spack/solver/core.py
@@ -67,7 +67,13 @@ class AspFunction:
 
     def to_str(self, quoted: QuotedStrings) -> str:
         """The ASP representation of this function, reusing the literals in ``quoted``."""
-        return f"{self.name}({','.join([asp_argument(arg, quoted) for arg in self.args])})"
+        args = self.args
+        # nearly every function takes one or two arguments; those need neither list nor join
+        if len(args) == 1:
+            return f"{self.name}({asp_argument(args[0], quoted)})"
+        if len(args) == 2:
+            return f"{self.name}({asp_argument(args[0], quoted)},{asp_argument(args[1], quoted)})"
+        return f"{self.name}({','.join([asp_argument(arg, quoted) for arg in args])})"
 
     def args_str(self, quoted: QuotedStrings) -> str:
         """The arguments as they appear between the parentheses of this function."""

--- a/lib/spack/spack/solver/core.py
+++ b/lib/spack/spack/solver/core.py
@@ -62,6 +62,21 @@ class AspFunction:
     def __str__(self) -> str:
         return f"{self.name}({','.join([asp_argument(arg) for arg in self.args])})"
 
+    def args_str(self) -> str:
+        """The arguments as they appear between the parentheses of this function.
+
+        The trigger and effect rules write the arguments of a clause out under a head of
+        their own, which is what needs this separately from :meth:`__str__`.
+        """
+        # a string that has been written out before needs no further work
+        quoted = _QUOTED
+        return ",".join(
+            [
+                quoted[arg] if type(arg) is str and arg in quoted else asp_argument(arg)
+                for arg in self.args
+            ]
+        )
+
     def __repr__(self) -> str:
         return str(self)
 

--- a/lib/spack/spack/solver/core.py
+++ b/lib/spack/spack/solver/core.py
@@ -77,11 +77,7 @@ class AspFunction:
 
 
 def quote(arg: str, quoted: QuotedStrings) -> str:
-    """The ASP literal for the string ``arg``: escaped, in double quotes, and kept for reuse.
-
-    Use :func:`quote_once` for the strings that are written out once, such as the messages that
-    explain a condition, so that they do not fill ``quoted``.
-    """
+    """The ASP literal for the string ``arg``: escaped, in double quotes, and kept for reuse."""
     return quoted.get(arg) or _quote(arg, quoted)
 
 

--- a/lib/spack/spack/solver/input_analysis.py
+++ b/lib/spack/spack/solver/input_analysis.py
@@ -71,6 +71,9 @@ class NoStaticAnalysis(PossibleDependencyGraph):
     def __init__(self, *, configuration: spack.config.Configuration, repo: spack.repo.RepoPath):
         self.configuration = configuration
         self.repo = repo
+        #: Whether a name is virtual, by name. This object lives for a single solve, and the
+        #: set of virtuals does not change during one.
+        self._virtuals: Dict[str, bool] = {}
         self._platform_condition = spack.spec.Spec(
             f"platform={spack.platforms.host()} target={spack.vendor.archspec.cpu.host().family}:"
         )
@@ -81,7 +84,10 @@ class NoStaticAnalysis(PossibleDependencyGraph):
             self.libc_pkgs = []
 
     def is_virtual(self, name: str) -> bool:
-        return self.repo.is_virtual(name)
+        result = self._virtuals.get(name)
+        if result is None:
+            result = self._virtuals[name] = self.repo.is_virtual(name)
+        return result
 
     @lang.memoized
     def is_allowed_on_this_platform(self, *, pkg_name: str) -> bool:

--- a/lib/spack/spack/solver/input_analysis.py
+++ b/lib/spack/spack/solver/input_analysis.py
@@ -71,8 +71,6 @@ class NoStaticAnalysis(PossibleDependencyGraph):
     def __init__(self, *, configuration: spack.config.Configuration, repo: spack.repo.RepoPath):
         self.configuration = configuration
         self.repo = repo
-        #: Whether a name is virtual, by name. This object lives for a single solve, and the
-        #: set of virtuals does not change during one.
         self._virtuals: Dict[str, bool] = {}
         self._platform_condition = spack.spec.Spec(
             f"platform={spack.platforms.host()} target={spack.vendor.archspec.cpu.host().family}:"


### PR DESCRIPTION
These are some low-hanging fruit type of improvements to speed up the setup phase of the solver.

On my desktop about 15% reduction of setup of `spack spec trilinos` (with/without reuse).

On my macbook it's 21% reduction of setup time, and a 15% reduction in python process runtime when getting a cache hit.
