### PR TITLE
spec parser: str-roundtrip, when=, quoting

### DIFF
--- a/lib/spack/docs/conf.py
+++ b/lib/spack/docs/conf.py
@@ -200,7 +200,10 @@ class SpecLexer(RegexLexer):
         ],
         "edge_properties": [
             (SPEC_TOKENS["KEY_VALUE_PAIR"], Name.Function),
+            # An unquoted when= condition is a spec up to the closing bracket
+            (SPEC_TOKENS["WHEN"], Name.Function, "spec"),
             (SPEC_TOKENS["END_EDGE_PROPERTIES"], Name.Variable, "#pop"),
+            (r"\s+", Text),
         ],
     }
 

--- a/lib/spack/docs/spec_syntax.rst
+++ b/lib/spack/docs/spec_syntax.rst
@@ -604,6 +604,9 @@ Concretizing the spec above produces the following DAG:
 where ``intel-parallel-studio`` *could* provide ``mpi``, ``lapack``, and ``blas`` but is used only for the former.
 The ``lapack`` and ``blas`` dependencies are satisfied by ``openblas``.
 
+Note that ``^foo=bar`` binds the virtual ``foo`` to the package ``bar``.
+To constrain a variant of an unnamed dependency instead, use ``*`` as the name: ``^* foo=bar`` means "some dependency has the variant ``foo`` set to ``bar``".
+
 .. index:: edge attribute
 
 Dependency edge attributes

--- a/lib/spack/docs/spec_syntax.rst
+++ b/lib/spack/docs/spec_syntax.rst
@@ -653,6 +653,14 @@ We can express conditional constraints by specifying the ``when`` edge attribute
 
 This tells Spack that hdf5 should depend on ``mpich@3.1`` if it is configured with MPI support.
 
+The value of ``when`` is a spec, which extends up to the closing bracket.
+It is therefore the last edge attribute, unless it is quoted:
+
+.. code-block:: spec
+
+   $ spack install hdf5 ^[virtuals=mpi when=+mpi] mpich@3.1
+   $ spack install hdf5 ^[when='+mpi' virtuals=mpi] mpich@3.1
+
 Dependency propagation
 ^^^^^^^^^^^^^^^^^^^^^^
 

--- a/lib/spack/spack/cmd/__init__.py
+++ b/lib/spack/spack/cmd/__init__.py
@@ -154,26 +154,33 @@ def get_command(cmd_name):
     return getattr(get_module(cmd_name), pname)
 
 
+#: A key=value argument needs quotes only if its value cannot be parsed as it is: it is empty, it
+#: starts with a character that cannot start a value, like the ``@`` of ``when=@1.0``, or it has a
+#: character that no spec token can hold, like the whitespace, quotes or ``$`` the shell quoting
+#: was needed for. A value like ``gcc@14`` parses as a name followed by a version.
+_NEEDS_QUOTES = re.compile(r"^[^a-zA-Z_0-9\-+*.,:=%^~/\\]|[^a-zA-Z_0-9\-+*.,:=%^~/\\@]")
+
+
 def quote_kvp(string: str) -> str:
     """For strings like ``name=value`` or ``name==value``, quote and escape the value if needed.
 
     This is a compromise to respect quoting of key-value pairs on the CLI. The shell
     strips quotes from quoted arguments, so we cannot know *exactly* how CLI arguments
-    were quoted. To compensate, we re-add quotes around anything staritng with ``name=``
-    or ``name==``, and we assume the rest of the argument is the value. This covers the
-    common cases of passing flags, e.g., ``cflags="-O2 -g"`` on the command line.
+    were quoted. To compensate, we re-add quotes around anything starting with ``name=``
+    or ``name==`` whose value cannot be parsed as it is, and we assume the rest of the
+    argument is the value. This covers the common cases of passing flags, e.g.,
+    ``cflags="-O2 -g"`` on the command line, while ``c=gcc@14`` stays a virtual assignment.
 
     A trailing ``]`` closes the edge attributes when the shell splits an argument like
-    ``%[virtuals=c deptypes=build]``, it is never part of the value. Quoting turns a virtual
-    assignment whose substitute needs quotes into a variant of an anonymous dependency: the
-    arguments ``%[when=+x]`` ``c=gcc@14`` become ``c='gcc@14'``. Use the edge attribute
-    ``%[when=+x virtuals=c] gcc@14`` or quote the whole spec instead.
+    ``%[virtuals=c deptypes=build]``, it is never part of the value.
     """
     match = spack.spec_parser.SPLIT_KVP.match(string)
     if not match:
         return string
 
     key, delim, value, brackets = match.groups()
+    if value and not _NEEDS_QUOTES.search(value):
+        return string
     return f"{key}{delim}{spack.spec_parser.quote_if_needed(value)}{brackets}"
 
 

--- a/lib/spack/spack/cmd/__init__.py
+++ b/lib/spack/spack/cmd/__init__.py
@@ -158,7 +158,7 @@ def get_command(cmd_name):
 #: starts with a character that cannot start a value, like the ``@`` of ``when=@1.0``, or it has a
 #: character that no spec token can hold, like the whitespace, quotes or ``$`` the shell quoting
 #: was needed for. A value like ``gcc@14`` parses as a name followed by a version.
-_NEEDS_QUOTES = re.compile(r"^[^a-zA-Z_0-9\-+*.,:=%^~/\\]|[^a-zA-Z_0-9\-+*.,:=%^~/\\@]")
+_PARSES_BARE = re.compile(rf"{spack.spec_parser.VALUE}(?:@{spack.spec_parser.VALUE}?)*")
 
 
 def quote_kvp(string: str) -> str:
@@ -179,7 +179,7 @@ def quote_kvp(string: str) -> str:
         return string
 
     key, delim, value, brackets = match.groups()
-    if value and not _NEEDS_QUOTES.search(value):
+    if _PARSES_BARE.fullmatch(value):
         return string
     return f"{key}{delim}{spack.spec_parser.quote_if_needed(value)}{brackets}"
 

--- a/lib/spack/spack/cmd/__init__.py
+++ b/lib/spack/spack/cmd/__init__.py
@@ -162,7 +162,7 @@ _NEEDS_QUOTES = re.compile(r"^[^a-zA-Z_0-9\-+*.,:=%^~/\\]|[^a-zA-Z_0-9\-+*.,:=%^
 
 
 def quote_kvp(string: str) -> str:
-    """For strings like ``name=value`` or ``name==value``, quote and escape the value if needed.
+    """For strings like ``name=value`` or ``name==value``, quote the value if needed.
 
     This is a compromise to respect quoting of key-value pairs on the CLI. The shell
     strips quotes from quoted arguments, so we cannot know *exactly* how CLI arguments

--- a/lib/spack/spack/cmd/__init__.py
+++ b/lib/spack/spack/cmd/__init__.py
@@ -154,13 +154,6 @@ def get_command(cmd_name):
     return getattr(get_module(cmd_name), pname)
 
 
-#: A key=value argument needs quotes only if its value cannot be parsed as it is: it is empty, it
-#: starts with a character that cannot start a value, like the ``@`` of ``when=@1.0``, or it has a
-#: character that no spec token can hold, like the whitespace, quotes or ``$`` the shell quoting
-#: was needed for. A value like ``gcc@14`` parses as a name followed by a version.
-_PARSES_BARE = re.compile(rf"{spack.spec_parser.VALUE}(?:@{spack.spec_parser.VALUE}?)*")
-
-
 def quote_kvp(string: str) -> str:
     """For strings like ``name=value`` or ``name==value``, quote the value if needed.
 
@@ -169,19 +162,27 @@ def quote_kvp(string: str) -> str:
     were quoted. To compensate, we re-add quotes around anything starting with ``name=``
     or ``name==`` whose value cannot be parsed as it is, and we assume the rest of the
     argument is the value. This covers the common cases of passing flags, e.g.,
-    ``cflags="-O2 -g"`` on the command line, while ``c=gcc@14`` stays a virtual assignment.
+    ``cflags="-O2 -g"`` on the command line.
 
-    A trailing ``]`` closes the edge attributes when the shell splits an argument like
-    ``%[virtuals=c deptypes=build]``, it is never part of the value.
+    An argument is parsed as it is if the tokenizer reads it without unexpected characters
+    and without whitespace between tokens, so ``c=gcc@14`` stays a virtual assignment,
+    ``when=@1.0`` a condition, ``deptypes=build]gcc`` closes the edge attributes the shell
+    split off, and ``x=' a b'`` keeps its quotes. Otherwise the value holds the whitespace,
+    quotes or other characters the shell quoting was needed for, or is empty.
     """
     match = spack.spec_parser.SPLIT_KVP.match(string)
     if not match:
         return string
 
-    key, delim, value, brackets = match.groups()
-    if _PARSES_BARE.fullmatch(value):
-        return string
-    return f"{key}{delim}{spack.spec_parser.quote_if_needed(value)}{brackets}"
+    key, delim, value = match.groups()
+    try:
+        tokens = spack.spec_parser.SpecParser(string).tokens()
+    except spack.error.SpecSyntaxError:
+        pass
+    else:
+        if "".join(text for _, text, _ in tokens) == string:
+            return string
+    return f"{key}{delim}{spack.spec_parser.quote_if_needed(value)}"
 
 
 def parse_specs(

--- a/lib/spack/spack/cmd/__init__.py
+++ b/lib/spack/spack/cmd/__init__.py
@@ -168,7 +168,11 @@ def quote_kvp(string: str) -> str:
         return string
 
     key, delim, value = match.groups()
-    return f"{key}{delim}{spack.spec_parser.quote_if_needed(value)}"
+    # A closing bracket ends a list of edge attributes, it is never part of the value. It ends up
+    # here because the shell splits e.g. "%[virtuals=c deptypes=build]" into separate arguments.
+    unbracketed = value.rstrip("]")
+    brackets = value[len(unbracketed) :]
+    return f"{key}{delim}{spack.spec_parser.quote_if_needed(unbracketed)}{brackets}"
 
 
 def parse_specs(

--- a/lib/spack/spack/cmd/__init__.py
+++ b/lib/spack/spack/cmd/__init__.py
@@ -161,18 +161,20 @@ def quote_kvp(string: str) -> str:
     strips quotes from quoted arguments, so we cannot know *exactly* how CLI arguments
     were quoted. To compensate, we re-add quotes around anything staritng with ``name=``
     or ``name==``, and we assume the rest of the argument is the value. This covers the
-    common cases of passign flags, e.g., ``cflags="-O2 -g"`` on the command line.
+    common cases of passing flags, e.g., ``cflags="-O2 -g"`` on the command line.
+
+    A trailing ``]`` closes the edge attributes when the shell splits an argument like
+    ``%[virtuals=c deptypes=build]``, it is never part of the value. Quoting turns a virtual
+    assignment whose substitute needs quotes into a variant of an anonymous dependency: the
+    arguments ``%[when=+x]`` ``c=gcc@14`` become ``c='gcc@14'``. Use the edge attribute
+    ``%[when=+x virtuals=c] gcc@14`` or quote the whole spec instead.
     """
     match = spack.spec_parser.SPLIT_KVP.match(string)
     if not match:
         return string
 
-    key, delim, value = match.groups()
-    # A closing bracket ends a list of edge attributes, it is never part of the value. It ends up
-    # here because the shell splits e.g. "%[virtuals=c deptypes=build]" into separate arguments.
-    unbracketed = value.rstrip("]")
-    brackets = value[len(unbracketed) :]
-    return f"{key}{delim}{spack.spec_parser.quote_if_needed(unbracketed)}{brackets}"
+    key, delim, value, brackets = match.groups()
+    return f"{key}{delim}{spack.spec_parser.quote_if_needed(value)}{brackets}"
 
 
 def parse_specs(

--- a/lib/spack/spack/cmd/__init__.py
+++ b/lib/spack/spack/cmd/__init__.py
@@ -164,12 +164,9 @@ def quote_kvp(string: str) -> str:
     argument is the value. This covers the common cases of passing flags, e.g.,
     ``cflags="-O2 -g"`` on the command line.
 
-    An argument is parsed as it is if the tokenizer reads it without unexpected characters
-    and without whitespace between tokens, so ``c=gcc@14`` stays a virtual assignment,
-    ``when=@1.0`` a condition, ``deptypes=build]gcc`` closes the edge attributes the shell
-    split off, and ``x=' a b'`` keeps its quotes. Otherwise the value holds the whitespace,
-    quotes or other characters the shell quoting was needed for, or is empty.
-    """
+    There are many edge cases here, e.g. `when=@1.0` should not be quoted, cause it can be part
+    of a when condition instead of a key-value pair `when='@1.0'`. Therefore, use the parser to
+    decide if the value needs quoting."""
     match = spack.spec_parser.SPLIT_KVP.match(string)
     if not match:
         return string

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -1688,23 +1688,25 @@ def _format_edge(
         deptypes: whether to include the deptypes of the edge
         when: whether to include the condition of the edge
     """
-    # The virtual assignment shorthand substitutes a package name, so an anonymous node keeps its
-    # virtuals in the edge attributes, and is named * where its options could otherwise be read
-    # as a name: %[virtuals=c] * foo=bar, ^*. The when= condition extends up to the closing
-    # bracket, so it comes last.
     anonymous = not edge.spec.name
     attrs = []
     if deptypes and edge.depflag:
         attrs.append(f"deptypes={','.join(dt.flag_to_tuple(edge.depflag))}")
     if anonymous and edge.virtuals:
         attrs.append(f"virtuals={','.join(edge.virtuals)}")
+    # When condition comes last so that it can be parsed back as a spec until the closing bracket.
     if when and edge.when != EMPTY_SPEC:
         attrs.append(f"when={edge.when}")
     attributes = f"[{' '.join(attrs)}] " if attrs else ""
+    # Use virtual assignemnt syntax ^c,cxx=gcc, but not for anonymous nodes (^cxx=* parses as a
+    # variant). For anonymous nodes, use ^[virtuals=c,cxx] * foo=bar.
     virtuals = f"{','.join(edge.virtuals)}=" if edge.virtuals and not anonymous else ""
-    star = anonymous and (not dep_format or dep_format[:1].isalnum() or dep_format[:1] == "_")
-    node = " ".join(s for s in ("*" if star else "", dep_format) if s)
-    return f"{sigil}{attributes}{virtuals}{node}"
+    if anonymous and not dep_format:
+        dep_format = "*"
+    elif anonymous and (dep_format[0].isalnum() or dep_format[0] == "_"):
+        # `^foo=bar` is virtual assignment, `^* foo=bar` is an anonymous dep with a variant.
+        dep_format = f"* {dep_format}"
+    return f"{sigil}{attributes}{virtuals}{dep_format}"
 
 
 def _satisfying_edges(

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -1068,22 +1068,15 @@ class DependencySpec:
             unconditional: if True, removes any condition statement from the representation
         """
 
-        parent_str, child_str = self.parent.format(), self.spec.format()
-        virtuals_str = f"virtuals={','.join(self.virtuals)}" if self.virtuals else ""
-
-        when_str = ""
-        if not unconditional and self.when != Spec():
-            when_str = f"when='{self.when}'"
-
-        dep_sigil = "%" if self.direct else "^"
+        sigil = "%" if self.direct else "^"
         if self.propagation == PropagationPolicy.PREFERENCE:
-            dep_sigil = "%%"
+            sigil = "%%"
 
-        edge_attrs = [x for x in (virtuals_str, when_str) if x]
-
-        if edge_attrs:
-            return f"{parent_str} {dep_sigil}[{' '.join(edge_attrs)}] {child_str}"
-        return f"{parent_str} {dep_sigil}{child_str}"
+        # deptypes are not part of the string, since it is used as a constraint in the solver
+        edge_str = _format_edge(
+            self, sigil, self.spec.format(), deptypes=False, when=not unconditional
+        )
+        return f"{self.parent.format()} {edge_str}"
 
     def flip(self) -> "DependencySpec":
         """Flips the dependency and keeps its type. Drops all other information."""
@@ -1676,35 +1669,55 @@ class SpecAnnotations:
         return result
 
 
-def _anonymous_star(dep: DependencySpec, dep_format: str) -> str:
-    """Determine if a spec needs a star to disambiguate it from an anonymous spec w/variants.
+def _format_edge_attributes(
+    edge: DependencySpec, *, deptypes: bool = True, when: bool = True, virtuals: bool = False
+) -> str:
+    """Format the ``[key=value ...] `` edge attributes of an edge, or return an empty string."""
+    when_str = f"when='{edge.when}'" if when and edge.when != EMPTY_SPEC else ""
+    deptypes_str = (
+        f"deptypes={','.join(dt.flag_to_tuple(edge.depflag))}" if deptypes and edge.depflag else ""
+    )
+    virtuals_str = f"virtuals={','.join(edge.virtuals)}" if virtuals and edge.virtuals else ""
+    attrs = " ".join(s for s in (when_str, deptypes_str, virtuals_str) if s)
+    return f"[{attrs}] " if attrs else ""
 
-    Returns:
-        "*" if a star is needed, "" otherwise
+
+def _format_edge(
+    edge: DependencySpec,
+    sigil: str,
+    dep_format: str,
+    *,
+    deptypes: bool = True,
+    when: bool = True,
+    anonymous: Optional[bool] = None,
+) -> str:
+    """Format an edge and its child node in spec syntax, e.g. ``%[when=+foo] c,cxx=gcc@14``.
+
+    Args:
+        edge: the edge to format
+        sigil: ``^``, ``%`` or ``%%``
+        dep_format: the formatted child node, without name for an anonymous node
+        deptypes: whether to include the deptypes of the edge
+        when: whether to include the condition of the edge
+        anonymous: whether the child node is anonymous; defaults to it having no name. An
+            anonymous node is named ``*`` where its options could otherwise be read as a name
     """
-    # named spec never needs star
-    if dep.spec.name:
-        return ""
+    if anonymous is None:
+        anonymous = not edge.spec.name
 
-    # virtuals without a name always need *: %[virtuals=c] *@4.0 foo=bar
-    if dep.virtuals:
-        return "*"
-
-    # versions are first so checking for @ is faster than != VersionList(':')
-    if dep_format.startswith("@"):
-        return ""
-
-    # compiler flags are key-value pairs and can be ambiguous with virtual assignment
-    if dep.spec.compiler_flags:
-        return "*"
-
-    # booleans come first, and they don't need a star. key-value pairs do. If there are
-    # no key value pairs, we're left with either an empty spec, which needs * as in
-    # '^*', or we're left with arch, which is a key value pair, and needs a star.
-    if not any(v.type == vt.VariantType.BOOL for v in dep.spec.variants.values()):
-        return "*"
-
-    return "*" if dep.spec.architecture else ""
+    # The virtual assignment shorthand substitutes a package name. An anonymous node is named *,
+    # and keeps its virtuals in the edge attributes: %[virtuals=c] * foo=bar
+    attributes = _format_edge_attributes(edge, deptypes=deptypes, when=when, virtuals=anonymous)
+    virtuals = f"{','.join(edge.virtuals)}=" if edge.virtuals and not anonymous else ""
+    name = ""
+    if anonymous:
+        # Only a leading key=value pair, or an empty node, is ambiguous: `^* foo=bar`, `^*`. Other
+        # options start with a sigil that cannot start a name: `^+foo`, `^@1.0`.
+        if dep_format[:1].isalnum() or dep_format[:1] == "_":
+            name = "* "
+        elif not dep_format:
+            name = "*"
+    return f"{sigil}{attributes}{virtuals}{name}{dep_format}"
 
 
 def _satisfying_edges(
@@ -4640,21 +4653,6 @@ class Spec:
         ]
         return str(path_ctor(*output_path_components))
 
-    def _format_edge_attributes(self, dep: DependencySpec, deptypes=True, virtuals=True):
-        deptypes_str = (
-            f"deptypes={','.join(dt.flag_to_tuple(dep.depflag))}"
-            if deptypes and dep.depflag
-            else ""
-        )
-        when_str = f"when='{(dep.when)}'" if dep.when != EMPTY_SPEC else ""
-        virtuals_str = f"virtuals={','.join(dep.virtuals)}" if virtuals and dep.virtuals else ""
-
-        attrs = " ".join(s for s in (when_str, deptypes_str, virtuals_str) if s)
-        if attrs:
-            attrs = f"[{attrs}] "
-
-        return attrs
-
     def _format_dependencies(
         self,
         format_string: str = DEFAULT_FORMAT,
@@ -4686,22 +4684,13 @@ class Spec:
         # helper for direct and transitive loops below
         def format_edge(edge: DependencySpec, sigil: str, dep_spec: Optional[Spec] = None) -> str:
             dep_spec = dep_spec or edge.spec
-            dep_format = dep_spec.format(format_string, color=color)
-
-            # the virtuals=substitute shorthand substitutes a package name, which an anonymous
-            # spec does not have, so its virtuals go in the edge attributes: %[virtuals=c] *
-            anonymous_virtuals = bool(edge.virtuals) and not dep_spec.name
-            edge_attributes = (
-                self._format_edge_attributes(edge, deptypes=deptypes, virtuals=anonymous_virtuals)
-                if edge.depflag or edge.when != EMPTY_SPEC or anonymous_virtuals
-                else ""
+            return _format_edge(
+                edge,
+                sigil,
+                dep_spec.format(format_string, color=color),
+                deptypes=deptypes,
+                anonymous=not dep_spec.name,
             )
-            virtuals = (
-                f"{','.join(edge.virtuals)}=" if edge.virtuals and not anonymous_virtuals else ""
-            )
-            star = _anonymous_star(edge, dep_format)
-
-            return f"{sigil}{edge_attributes}{virtuals}{star}{dep_format}"
 
         # direct dependencies
         for edge in sorted(direct, key=lambda x: x.spec.name):

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -1686,7 +1686,7 @@ def _anonymous_star(dep: DependencySpec, dep_format: str) -> str:
     if dep.spec.name:
         return ""
 
-    # virtuals without a name always need *: %c=* @4.0 foo=bar
+    # virtuals without a name always need *: %[virtuals=c] *@4.0 foo=bar
     if dep.virtuals:
         return "*"
 
@@ -4718,15 +4718,20 @@ class Spec:
             dep_spec = dep_spec or edge.spec
             dep_format = dep_spec.format(format_string, color=color)
 
+            # the virtuals=substitute shorthand substitutes a package name, which an anonymous
+            # spec does not have, so its virtuals go in the edge attributes: %[virtuals=c] *
+            anonymous_virtuals = bool(edge.virtuals) and not dep_spec.name
             edge_attributes = (
-                self._format_edge_attributes(edge, deptypes=deptypes, virtuals=False)
-                if edge.depflag or edge.when != EMPTY_SPEC
+                self._format_edge_attributes(edge, deptypes=deptypes, virtuals=anonymous_virtuals)
+                if edge.depflag or edge.when != EMPTY_SPEC or anonymous_virtuals
                 else ""
             )
-            virtuals = f"{','.join(edge.virtuals)}=" if edge.virtuals else ""
+            virtuals = (
+                f"{','.join(edge.virtuals)}=" if edge.virtuals and not anonymous_virtuals else ""
+            )
             star = _anonymous_star(edge, dep_format)
 
-            return f"{sigil}{edge_attributes}{star}{virtuals}{dep_format}"
+            return f"{sigil}{edge_attributes}{virtuals}{star}{dep_format}"
 
         # direct dependencies
         for edge in sorted(direct, key=lambda x: x.spec.name):

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -146,9 +146,7 @@ _STRING_ATTRIBUTES = frozenset(
     ("arch", "architecture", "platform", "os", "operating_system", "target", "namespace")
 )
 _BARE_VALUE = re.compile(spack.spec_parser.VALUE)
-_NAMESPACE_VALUE = re.compile(
-    rf"{spack.spec_parser.IDENTIFIER}(?:\.{spack.spec_parser.IDENTIFIER})*"
-)
+_NAMESPACE_VALUE = re.compile(spack.spec_parser.PACKAGE_NAME)
 
 # Coloring of specs when using color output. Fields are printed with
 # different colors to enhance readability.
@@ -1678,28 +1676,8 @@ class SpecAnnotations:
         return result
 
 
-def _format_edge_attributes(
-    edge: DependencySpec, *, deptypes: bool = True, when: bool = True, virtuals: bool = False
-) -> str:
-    """Format the ``[key=value ...] `` edge attributes of an edge, or return an empty string.
-    The ``when=`` condition is a spec that extends up to the closing bracket, so it comes last."""
-    deptypes_str = (
-        f"deptypes={','.join(dt.flag_to_tuple(edge.depflag))}" if deptypes and edge.depflag else ""
-    )
-    virtuals_str = f"virtuals={','.join(edge.virtuals)}" if virtuals and edge.virtuals else ""
-    when_str = f"when={edge.when}" if when and edge.when != EMPTY_SPEC else ""
-    attrs = " ".join(s for s in (deptypes_str, virtuals_str, when_str) if s)
-    return f"[{attrs}] " if attrs else ""
-
-
 def _format_edge(
-    edge: DependencySpec,
-    sigil: str,
-    dep_format: str,
-    *,
-    deptypes: bool = True,
-    when: bool = True,
-    anonymous: Optional[bool] = None,
+    edge: DependencySpec, sigil: str, dep_format: str, *, deptypes: bool = True, when: bool = True
 ) -> str:
     """Format an edge and its child node in spec syntax, e.g. ``%[when=+foo] c,cxx=gcc@14``.
 
@@ -1709,25 +1687,24 @@ def _format_edge(
         dep_format: the formatted child node, without name for an anonymous node
         deptypes: whether to include the deptypes of the edge
         when: whether to include the condition of the edge
-        anonymous: whether the child node is anonymous; defaults to it having no name. An
-            anonymous node is named ``*`` where its options could otherwise be read as a name
     """
-    if anonymous is None:
-        anonymous = not edge.spec.name
-
-    # The virtual assignment shorthand substitutes a package name. An anonymous node is named *,
-    # and keeps its virtuals in the edge attributes: %[virtuals=c] * foo=bar
-    attributes = _format_edge_attributes(edge, deptypes=deptypes, when=when, virtuals=anonymous)
+    # The virtual assignment shorthand substitutes a package name, so an anonymous node keeps its
+    # virtuals in the edge attributes, and is named * where its options could otherwise be read
+    # as a name: %[virtuals=c] * foo=bar, ^*. The when= condition extends up to the closing
+    # bracket, so it comes last.
+    anonymous = not edge.spec.name
+    attrs = []
+    if deptypes and edge.depflag:
+        attrs.append(f"deptypes={','.join(dt.flag_to_tuple(edge.depflag))}")
+    if anonymous and edge.virtuals:
+        attrs.append(f"virtuals={','.join(edge.virtuals)}")
+    if when and edge.when != EMPTY_SPEC:
+        attrs.append(f"when={edge.when}")
+    attributes = f"[{' '.join(attrs)}] " if attrs else ""
     virtuals = f"{','.join(edge.virtuals)}=" if edge.virtuals and not anonymous else ""
-    name = ""
-    if anonymous:
-        # Only a leading key=value pair, or an empty node, is ambiguous: `^* foo=bar`, `^*`. Other
-        # options start with a sigil that cannot start a name: `^+foo`, `^@1.0`.
-        if dep_format[:1].isalnum() or dep_format[:1] == "_":
-            name = "* "
-        elif not dep_format:
-            name = "*"
-    return f"{sigil}{attributes}{virtuals}{name}{dep_format}"
+    star = anonymous and (not dep_format or dep_format[:1].isalnum() or dep_format[:1] == "_")
+    node = " ".join(s for s in ("*" if star else "", dep_format) if s)
+    return f"{sigil}{attributes}{virtuals}{node}"
 
 
 def _satisfying_edges(
@@ -4703,11 +4680,7 @@ class Spec:
         def format_edge(edge: DependencySpec, sigil: str, dep_spec: Optional[Spec] = None) -> str:
             dep_spec = dep_spec or edge.spec
             return _format_edge(
-                edge,
-                sigil,
-                dep_spec.format(format_string, color=color),
-                deptypes=deptypes,
-                anonymous=not dep_spec.name,
+                edge, sigil, dep_spec.format(format_string, color=color), deptypes=deptypes
             )
 
         # direct dependencies

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -1681,13 +1681,14 @@ class SpecAnnotations:
 def _format_edge_attributes(
     edge: DependencySpec, *, deptypes: bool = True, when: bool = True, virtuals: bool = False
 ) -> str:
-    """Format the ``[key=value ...] `` edge attributes of an edge, or return an empty string."""
-    when_str = f"when='{edge.when}'" if when and edge.when != EMPTY_SPEC else ""
+    """Format the ``[key=value ...] `` edge attributes of an edge, or return an empty string.
+    The ``when=`` condition is a spec that extends up to the closing bracket, so it comes last."""
     deptypes_str = (
         f"deptypes={','.join(dt.flag_to_tuple(edge.depflag))}" if deptypes and edge.depflag else ""
     )
     virtuals_str = f"virtuals={','.join(edge.virtuals)}" if virtuals and edge.virtuals else ""
-    attrs = " ".join(s for s in (when_str, deptypes_str, virtuals_str) if s)
+    when_str = f"when={edge.when}" if when and edge.when != EMPTY_SPEC else ""
+    attrs = " ".join(s for s in (deptypes_str, virtuals_str, when_str) if s)
     return f"[{attrs}] " if attrs else ""
 
 

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -141,6 +141,15 @@ SPEC_FORMAT_RE = re.compile(
 
 IDENTIFIER_RE = r"\w[\w-]*"
 
+#: Attributes set through ``name=value`` that print unquoted, so their value must parse bare
+_STRING_ATTRIBUTES = frozenset(
+    ("arch", "architecture", "platform", "os", "operating_system", "target", "namespace")
+)
+_BARE_VALUE = re.compile(spack.spec_parser.VALUE)
+_NAMESPACE_VALUE = re.compile(
+    rf"{spack.spec_parser.IDENTIFIER}(?:\.{spack.spec_parser.IDENTIFIER})*"
+)
+
 # Coloring of specs when using color output. Fields are printed with
 # different colors to enhance readability.
 # See spack.util.tty.color for descriptions of the color codes.
@@ -2150,8 +2159,16 @@ class Spec:
                 f"Propagation with '==' is not supported for '{name}'."
             )
 
+        if name in _STRING_ATTRIBUTES:
+            # These print unquoted, so they must be values that parse without quotes
+            if type(value) is not str:
+                raise ValueError(f"{name} must have a string value")
+            pattern = _NAMESPACE_VALUE if name == "namespace" else _BARE_VALUE
+            if not pattern.fullmatch(value):
+                raise ValueError(f"invalid value {value!r} for {name}")
+
         if name == "arch" or name == "architecture":
-            assert type(value) is str, "architecture have a string value"
+            assert isinstance(value, str)  # checked above, for mypy
             parts = tuple(value.split("-"))
             plat, os, tgt = parts if len(parts) == 3 else (None, None, value)
             self._set_architecture(platform=plat, os=os, target=tgt)

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -2075,36 +2075,6 @@ class Spec:
         """
         return _select_edges(self._dependencies, child=name, depflag=depflag, virtuals=virtuals)
 
-    @property
-    def edge_attributes(self) -> str:
-        """Helper method to print edge attributes in spec strings."""
-        edges = self.edges_from_dependents()
-        if not edges:
-            return ""
-
-        union = DependencySpec(parent=Spec(), spec=self, depflag=0, virtuals=())
-        all_direct_edges = all(x.direct for x in edges)
-        dep_conditions = set()
-
-        for edge in edges:
-            union.update_deptypes(edge.depflag)
-            union.update_virtuals(edge.virtuals)
-            dep_conditions.add(edge.when)
-
-        deptypes_str = ""
-        if not all_direct_edges and union.depflag:
-            deptypes_str = f"deptypes={','.join(dt.flag_to_tuple(union.depflag))}"
-
-        virtuals_str = f"virtuals={','.join(union.virtuals)}" if union.virtuals else ""
-
-        conditions = [str(c) for c in dep_conditions if c != Spec()]
-        when_str = f"when='{','.join(conditions)}'" if conditions else ""
-
-        result = " ".join(filter(lambda x: bool(x), (when_str, deptypes_str, virtuals_str)))
-        if result:
-            result = f"[{result}]"
-        return result
-
     def dependencies(
         self,
         name: Optional[str] = None,

--- a/lib/spack/spack/spec_parser.py
+++ b/lib/spack/spack/spec_parser.py
@@ -122,7 +122,7 @@ FILENAME = WINDOWS_FILENAME if sys.platform == "win32" else UNIX_FILENAME
 STRIP_QUOTES = re.compile(r"^(['\"])(.*)\1$")
 
 #: Values that match this (e.g., variants, flags) can be left unquoted in Spack output
-NO_QUOTES_NEEDED = re.compile(r"^[a-zA-Z0-9,/_.\-\[\]]+$")
+NO_QUOTES_NEEDED = re.compile(r"^[a-zA-Z0-9,/_.\-]+$")
 
 
 class SpecTokenizationError(spack.error.SpecSyntaxError):

--- a/lib/spack/spack/spec_parser.py
+++ b/lib/spack/spack/spec_parser.py
@@ -118,7 +118,8 @@ GIT_VERSION_ITEM = rf"(?:{GIT_VERSION_PATTERN}(?:={VERSION_OR_RANGE})?)"
 VERSION_LIST_ITEM = rf"(?:{GIT_VERSION_ITEM}|={VERSION}|{VERSION_OR_RANGE})"
 VERSION_LIST = rf"{VERSION_LIST_ITEM}(?:\s*,\s*{VERSION_LIST_ITEM})*"
 
-SPLIT_KVP = re.compile(rf"^({NAME})(:?==?)(.*)$")
+#: Split ``key=value]]`` into key, delimiter, value and closing brackets of edge attributes
+SPLIT_KVP = re.compile(rf"^({NAME})(:?==?)(.*?)(\]*)$")
 
 #: A filename starts either with a ``.`` or a ``/`` or a ``{name}/``, or on Windows, a drive letter
 #: followed by a colon and ``\`` or ``.`` or ``{name}\``

--- a/lib/spack/spack/spec_parser.py
+++ b/lib/spack/spack/spec_parser.py
@@ -126,8 +126,7 @@ GIT_VERSION_ITEM = rf"(?:{GIT_VERSION_PATTERN}(?:={VERSION_OR_RANGE})?)"
 VERSION_LIST_ITEM = rf"(?:{GIT_VERSION_ITEM}|={VERSION}|{VERSION_OR_RANGE})"
 VERSION_LIST = rf"{VERSION_LIST_ITEM}(?:\s*,\s*{VERSION_LIST_ITEM})*"
 
-#: Split ``key=value]]`` into key, delimiter, value and closing brackets of edge attributes
-SPLIT_KVP = re.compile(rf"^({NAME})(:?==?)(.*?)(\]*)$")
+SPLIT_KVP = re.compile(rf"^({NAME})(:?==?)(.*)$")
 
 #: A filename starts either with a ``.`` or a ``/`` or a ``{name}/``, or on Windows, a drive letter
 #: followed by a colon and ``\`` or ``.`` or ``{name}\``

--- a/lib/spack/spack/spec_parser.py
+++ b/lib/spack/spack/spec_parser.py
@@ -571,6 +571,7 @@ class SpecParser:
                                 continue
 
                             value = strip_quotes(value)
+                            token = self.curr
                             self.curr, self.next = self.next, self.scanner.match()
 
                             # A quoted when value is one spec string, where a comma is part of
@@ -578,7 +579,16 @@ class SpecParser:
                             # comma-separated lists. Repeated attributes combine: a second
                             # when= constrains the condition, like virtuals accumulate.
                             if name == "when":
-                                condition = parse_one_or_raise(value)
+                                try:
+                                    condition = parse_one_or_raise(value)
+                                except ValueError as e:
+                                    # e.g. when='a b' or when='': a syntax error of the spec, not
+                                    # a ValueError that a SpecSyntaxError handler would miss
+                                    raise SpecParsingError(
+                                        "expected a single spec as the when= condition",
+                                        token,
+                                        self.literal_str,
+                                    ) from e
                                 if conditions is None:
                                     conditions = condition
                                 else:

--- a/lib/spack/spack/spec_parser.py
+++ b/lib/spack/spack/spec_parser.py
@@ -118,8 +118,10 @@ QUOTED_VALUE = r"(?:'[^']*'|\"[^\"]*\")"
 VERSION = r"[a-zA-Z0-9_][a-zA-Z_0-9\-\.]*(?<![\-\.])(?![a-zA-Z_0-9\-\.])"
 #: The upper bound of a range is not the key of a key-value pair, so ``@1.2:develop=foo`` is
 #: ``@1.2:`` and a variant.
-VERSION_RANGE = rf"(?:(?:{VERSION})?:(?:{VERSION}(?!\s*=))?)"
-VERSION_OR_RANGE = rf"(?:{VERSION_RANGE}|{VERSION})"
+_RANGE_END = rf"(?::(?:{VERSION}(?!\s*=))?)"
+#: A version or a range, with the lower bound factored out so that a plain version is matched
+#: once, instead of as a failed range first and then again as a version
+VERSION_OR_RANGE = rf"(?:{VERSION}{_RANGE_END}?|{_RANGE_END})"
 #: A git ref, optionally assigned a version or constrained to a range, e.g. ``git.main=1.2:``
 GIT_VERSION_ITEM = rf"(?:{GIT_VERSION_PATTERN}(?:={VERSION_OR_RANGE})?)"
 #: Either a git version, an exact version, or a version range.

--- a/lib/spack/spack/spec_parser.py
+++ b/lib/spack/spack/spec_parser.py
@@ -546,7 +546,7 @@ class SpecParser:
                     substitute = None
                     while True:
                         if not self.curr:
-                            self._raise_parsing_error("unexpected token in edge attributes")
+                            self._raise_parsing_error("expected `]` to close the edge attributes")
 
                         kind = self.curr.lastgroup
                         if kind == _KEY_VALUE_PAIR and self.curr.group(_KV_NAME) != "when":
@@ -610,7 +610,7 @@ class SpecParser:
                             break
                         else:
                             # Only key=value pairs can occur between brackets
-                            self._raise_parsing_error("unexpected token in edge attributes")
+                            self._raise_parsing_error("expected an edge attribute or `]`")
 
                     depflag = 0
                     if "deptypes" in attributes:

--- a/lib/spack/spack/spec_parser.py
+++ b/lib/spack/spack/spec_parser.py
@@ -5,21 +5,24 @@
 
 Here is the EBNF grammar for a spec::
 
-    spec          = [name] [node_options] { ^[edge_properties] node } |
+    spec          = [name] [node_options] { sigil [edge_properties] dependency } |
                     [name] [node_options] hash |
                     filename
 
+    sigil         = ^ | % | %%
+    dependency    = virtual_assignment [node_options] | node
     node          =  name [node_options] |
                      [name] [node_options] hash |
                      filename
 
-    node_options    = [@version_list] [%compiler] { variant }
-    edge_properties = [ { bool_variant | key_value } ]
+    node_options    = [@version_list] { variant } [hash]
+    edge_properties = [ { key_value } ]
 
+    virtual_assignment = id { , id } = name
     hash          = / id
     filename      = (.|/|[a-zA-Z0-9-_]*/)([a-zA-Z0-9-_./]*)(.json|.yaml)
 
-    name          = id | namespace id
+    name          = id | namespace id | *
     namespace     = { id . }
 
     variant       = bool_variant | key_value | propagated_bv | propagated_kv
@@ -27,8 +30,6 @@ Here is the EBNF grammar for a spec::
     propagated_bv = ++id | ~~id | --id
     key_value     =  id=id |  id=quoted_id
     propagated_kv = id==id | id==quoted_id
-
-    compiler      = id [@version_list]
 
     version_list  = version_item [ { , version_item } ]
     version_item  = version | =version | version_range | git_version [= (version|version_range)]
@@ -46,8 +47,11 @@ Here is the EBNF grammar for a spec::
 Identifiers using the ``<name>=<value>`` command, such as architectures and
 compiler flags, require a space before the name.
 
-There is one context-sensitive part: ids in versions may contain ``.``, while
-other ids may not.
+There are two context-sensitive parts: ids in versions may contain ``.``, while other ids may
+not; and a ``key=value`` pair directly after a dependency sigil or edge properties, where the
+value is a package name, is a virtual assignment ``%c,cxx=gcc`` rather than a variant of an
+anonymous dependency (write ``%* foo=bar`` for the latter). ``*`` is the name of an anonymous
+node.
 
 There is one ambiguity: since ``-`` is allowed in an id, you need to put
 whitespace space before ``-variant`` for it to be tokenized properly.  You can
@@ -362,9 +366,18 @@ _KV_VALUE = "kv_value"
 
 # The virtual assignment ``c,cxx=gcc`` substitutes a package for one or more virtuals. Both
 # END_EDGE_PROPERTIES and DEPENDENCY embed it, each with its own group names; only that context
-# distinguishes it from KEY_VALUE_PAIR.
+# distinguishes it from KEY_VALUE_PAIR. It applies only if the whole value is a package name,
+# i.e. the substitute is followed by whitespace, a variant, version or hash of the node, a sigil,
+# a closing bracket, or the end of the input. Otherwise the pair is a variant of an anonymous
+# node, e.g. ``^foo=bar:baz``, and the sigil is a token of its own.
 _VIRTUALS_LIST = rf"{IDENTIFIER}(?:,{IDENTIFIER})*"  # comma-separated virtuals
-_SUBSTITUTE = rf"{DOTTED_IDENTIFIER}|{IDENTIFIER}"  # package to substitute for them
+_SUBSTITUTE_END = r"(?=\s|[+~]{1,2}\s*[a-zA-Z_0-9]|[@/^%\]]|$)"
+_SUBSTITUTE = rf"(?:{DOTTED_IDENTIFIER}|{IDENTIFIER}){_SUBSTITUTE_END}"  # package to substitute
+
+#: A virtual assignment of several virtuals that does not follow a dependency sigil or edge
+#: properties, e.g. ``zlib c,cxx=gcc``, fails to tokenize at the comma. It is only matched on that
+#: error path, to point out the mistake, so that it costs nothing in the token regex.
+_MISPLACED_VIRTUAL_ASSIGNMENT = re.compile(rf"{_VIRTUALS_LIST}={_SUBSTITUTE}")
 
 #: Token kind -> regex. FAST_SPEC_REGEX is the ``|``-alternation of these in order: tokens are
 #: tried top to bottom, so more specific tokens come first (e.g. FILENAME before package names).
@@ -462,6 +475,22 @@ class SpecParser:
         return tokens
 
     def _raise_tokenization_error(self) -> None:
+        # A virtual assignment of several virtuals outside a dependency, `zlib c,cxx=gcc`, fails
+        # at the comma: point out the mistake instead of underlining the comma
+        if self.curr is not None and self.curr.group(_UNEXPECTED) == ",":
+            start = self.curr.start(_UNEXPECTED)
+            while start > 0 and (
+                self.literal_str[start - 1].isalnum() or self.literal_str[start - 1] in "_-"
+            ):
+                start -= 1
+            assignment = _MISPLACED_VIRTUAL_ASSIGNMENT.match(self.literal_str, start)
+            if assignment:
+                raise SpecParsingError(
+                    "a virtual assignment such as c,cxx=gcc must directly follow a dependency "
+                    "sigil (^ or %) or edge properties",
+                    assignment,
+                    self.literal_str,
+                )
         raise SpecTokenizationError(self.literal_str)
 
     def _raise_parsing_error(self, message: str) -> None:
@@ -485,6 +514,7 @@ class SpecParser:
         if self.curr.lastgroup == _UNEXPECTED:
             self._raise_tokenization_error()
 
+        first_token = self.curr
         root_spec = self._parse_node(initial_spec)
         current_spec = root_spec
 
@@ -618,6 +648,10 @@ class SpecParser:
 
         self._attach_pending(root_spec, pending)
 
+        if self.curr is not None and self.curr is first_token:
+            # Nothing was consumed, e.g. a stray ] in `zlib ]`: raise instead of looping forever
+            self._raise_parsing_error("unexpected token")
+
         return root_spec
 
     def _attach_pending(self, root_spec: "spack.spec.Spec", pending: Optional[tuple]) -> None:
@@ -653,34 +687,34 @@ class SpecParser:
         # 1. Package name (or spec file). A missing name is fine: anonymous specs like
         # `@1.2 +debug` are valid.
         if initial_name:
-            # Name came from a virtual assignment on the incoming edge, e.g. %c,cxx=gcc
+            # Name came from a virtual assignment on the incoming edge, e.g. %c,cxx=gcc: only
+            # node options can follow, a package name starts the next spec (`zlib %c=gcc gcc`)
             if "." in initial_name:
                 spec.namespace, spec.name = initial_name.rsplit(".", 1)
             else:
                 spec.name = initial_name
-        if not curr:
-            return spec
-        kind = curr.lastgroup
-        value = curr.group(kind)
-        if kind == _UNQUALIFIED_PACKAGE_NAME:
-            if value != "*":  # `*` is an anonymous node, as in `%*+shared`
-                spec.name = value
-            curr = next
-            next = scanner.match() if curr is not None else None
-        elif kind == _FULLY_QUALIFIED_PACKAGE_NAME:
-            spec.namespace, spec.name = value.rsplit(".", 1)
-            curr = next
-            next = scanner.match() if curr is not None else None
-        elif kind == _FILENAME:
-            # A spec file is a complete node: read it and return
-            if not os.path.exists(value):
-                raise spack.error.NoSuchSpecFileError(f"No such spec file: '{value}'")
-            spec._dup(spack.spec.Spec.from_specfile(value))
-            self.curr, self.next = next, scanner.match()
-            return spec
-        elif kind == _UNEXPECTED:
-            self._raise_tokenization_error()
-        # else: no name; fall through to attributes of an anonymous node
+        elif curr:
+            kind = curr.lastgroup
+            value = curr.group(kind)
+            if kind == _UNQUALIFIED_PACKAGE_NAME:
+                if value != "*":  # `*` is an anonymous node, as in `%*+shared`
+                    spec.name = value
+                curr = next
+                next = scanner.match() if curr is not None else None
+            elif kind == _FULLY_QUALIFIED_PACKAGE_NAME:
+                spec.namespace, spec.name = value.rsplit(".", 1)
+                curr = next
+                next = scanner.match() if curr is not None else None
+            elif kind == _FILENAME:
+                # A spec file is a complete node: read it and return
+                if not os.path.exists(value):
+                    raise spack.error.NoSuchSpecFileError(f"No such spec file: '{value}'")
+                spec._dup(spack.spec.Spec.from_specfile(value))
+                self.curr, self.next = next, scanner.match()
+                return spec
+            elif kind == _UNEXPECTED:
+                self._raise_tokenization_error()
+            # else: no name; fall through to attributes of an anonymous node
 
         # 2. Node attributes: version, variants, flags, and abstract hash, in any order
         has_version = False

--- a/lib/spack/spack/spec_parser.py
+++ b/lib/spack/spack/spec_parser.py
@@ -98,6 +98,8 @@ GIT_HASH = r"(?:[a-f0-9]{40})"
 #: Git refs include branch names, and can contain ``.`` and ``/``
 GIT_REF = r"(?:[a-zA-Z_0-9][a-zA-Z_0-9./\-]*)"
 GIT_VERSION_PATTERN = rf"(?:(?:git\.(?:{GIT_REF}))|(?:{GIT_HASH}))"
+#: A package name, optionally with a namespace
+PACKAGE_NAME = rf"(?:{IDENTIFIER}(?:\.{IDENTIFIER})*)"
 
 STAR = r"\*"
 
@@ -373,11 +375,10 @@ _KV_VALUE = "kv_value"
 # node, e.g. ``^foo=bar:baz``, and the sigil is a token of its own.
 _VIRTUALS_LIST = rf"{IDENTIFIER}(?:,{IDENTIFIER})*"  # comma-separated virtuals
 _SUBSTITUTE_END = r"(?=\s|[+~]{1,2}\s*[a-zA-Z_0-9]|[@/^%\]]|$)"
-_SUBSTITUTE = rf"(?:{DOTTED_IDENTIFIER}|{IDENTIFIER}){_SUBSTITUTE_END}"  # package to substitute
+_SUBSTITUTE = rf"{PACKAGE_NAME}{_SUBSTITUTE_END}"  # package to substitute for them
 
-#: A virtual assignment of several virtuals that does not follow a dependency sigil or edge
-#: properties, e.g. ``zlib c,cxx=gcc``, fails to tokenize at the comma. It is only matched on that
-#: error path, to point out the mistake, so that it costs nothing in the token regex.
+#: A virtual assignment outside a dependency, ``zlib c,cxx=gcc``, fails to tokenize at the comma:
+#: matched on that error path only, so that it costs nothing in the token regex
 _MISPLACED_VIRTUAL_ASSIGNMENT = re.compile(rf"{_VIRTUALS_LIST}={_SUBSTITUTE}")
 
 #: Token kind -> regex. FAST_SPEC_REGEX is the ``|``-alternation of these in order: tokens are
@@ -411,10 +412,8 @@ SPEC_TOKENS: Dict[str, str] = {
         rf"(?P<{_KV_SEP}>:?==?)"  # separator: ``=``, ``==``, ``:=`` or ``:==``
         rf"(?P<{_KV_VALUE}>{VALUE}|{QUOTED_VALUE})"  # bare or quoted value
     ),
-    # the when= condition of edge properties whose spec does not start with a value character,
-    # e.g. ``^[when=@1.2] dep``. Otherwise ``when=+foo`` is a key-value pair like any other, which
-    # the edge properties parser reads as the start of a condition, so ``when`` is still a
-    # variant name elsewhere.
+    # ``when=`` of edge properties whose spec is not a value, e.g. ``^[when=@1.2] dep``; otherwise
+    # ``when=+foo`` is a key-value pair like any other, and ``when`` a variant name elsewhere
     _WHEN: r"when=",
     # path to a spec file, e.g. ``./foo/bar.json``
     _FILENAME: FILENAME,
@@ -481,22 +480,18 @@ class SpecParser:
         return tokens
 
     def _raise_tokenization_error(self) -> None:
-        # A virtual assignment of several virtuals outside a dependency, `zlib c,cxx=gcc`, fails
-        # at the comma: point out the mistake instead of underlining the comma
+        # A virtual assignment outside a dependency, `zlib c,cxx=gcc`, fails at the comma: point
+        # out the mistake instead of underlining the comma
         if self.curr is not None and self.curr.group(_UNEXPECTED) == ",":
-            start = self.curr.start(_UNEXPECTED)
-            while start > 0 and (
-                self.literal_str[start - 1].isalnum() or self.literal_str[start - 1] in "_-"
-            ):
-                start -= 1
-            assignment = _MISPLACED_VIRTUAL_ASSIGNMENT.match(self.literal_str, start)
-            if assignment:
-                raise SpecParsingError(
-                    "a virtual assignment such as c,cxx=gcc must directly follow a dependency "
-                    "sigil (^ or %) or edge properties",
-                    assignment,
-                    self.literal_str,
-                )
+            comma = self.curr.start(_UNEXPECTED)
+            for assignment in _MISPLACED_VIRTUAL_ASSIGNMENT.finditer(self.literal_str):
+                if assignment.start() <= comma < assignment.end():
+                    raise SpecParsingError(
+                        "a virtual assignment such as c,cxx=gcc must directly follow a "
+                        "dependency sigil (^ or %) or edge properties",
+                        assignment,
+                        self.literal_str,
+                    )
         raise SpecTokenizationError(self.literal_str)
 
     def _raise_parsing_error(self, message: str) -> None:
@@ -552,62 +547,52 @@ class SpecParser:
                         if not self.curr:
                             self._raise_parsing_error("unexpected token in edge attributes")
 
-                        if self.curr.lastgroup == _KEY_VALUE_PAIR:
+                        kind = self.curr.lastgroup
+                        if kind == _KEY_VALUE_PAIR and self.curr.group(_KV_NAME) != "when":
                             name = self.curr.group(_KV_NAME)
-                            if name not in ("deptypes", "virtuals", "when"):
+                            if name not in ("deptypes", "virtuals"):
                                 msg = (
                                     "the only edge attributes that are currently accepted are "
                                     '"deptypes", "virtuals", and a "when=<spec>" condition, '
                                     "which must be the last unless quoted"
                                 )
                                 self._raise_parsing_error(msg)
-                            value = self.curr.group(_KV_VALUE)
-                            if name == "when" and value[0] not in "'\"":
-                                # An unquoted condition is a spec that starts at the value and
-                                # extends up to the closing bracket, e.g. when=+mpi %c=gcc: the
-                                # tokenizer is context free, so rescan from the value
-                                self._rescan(self.curr.start(_KV_VALUE))
-                                conditions = self._parse_condition(conditions)
-                                continue
-
-                            value = strip_quotes(value)
-                            token = self.curr
+                            value = strip_quotes(self.curr.group(_KV_VALUE))
+                            attributes[name] = [v.strip() for v in value.split(",")]
                             self.curr, self.next = self.next, self.scanner.match()
 
-                            # A quoted when value is one spec string, where a comma is part of
-                            # the syntax, e.g. when='@1,2'; deptypes and virtuals values are
-                            # comma-separated lists. Repeated attributes combine: a second
-                            # when= constrains the condition, like virtuals accumulate.
-                            if name == "when":
+                        elif kind == _KEY_VALUE_PAIR or kind == _WHEN:
+                            # The condition is a spec. Quoted, it is a value like any other pair.
+                            # Unquoted, it extends up to the closing bracket: the tokenizer is
+                            # context free, so restart the scanner at the value, which is either
+                            # that of the pair or what follows a bare WHEN token (when=@1.2).
+                            value = self.curr.group(_KV_VALUE) if kind == _KEY_VALUE_PAIR else ""
+                            if value[:1] in ("'", '"'):
                                 try:
-                                    condition = parse_one_or_raise(value)
-                                except ValueError as e:
-                                    # e.g. when='a b' or when='': a syntax error of the spec, not
-                                    # a ValueError that a SpecSyntaxError handler would miss
-                                    raise SpecParsingError(
-                                        "expected a single spec as the when= condition",
-                                        token,
-                                        self.literal_str,
-                                    ) from e
-                                if conditions is None:
-                                    conditions = condition
-                                else:
-                                    conditions.constrain(condition)
+                                    condition = parse_one_or_raise(strip_quotes(value))
+                                except ValueError:
+                                    msg = "expected a single spec as the when= condition"
+                                    self._raise_parsing_error(msg)
+                                self.curr, self.next = self.next, self.scanner.match()
                             else:
-                                attributes[name] = [v.strip() for v in value.split(",")]
-
-                        elif self.curr.lastgroup == _WHEN:
-                            # when= followed by a spec that does not start with a value
-                            # character, e.g. when=@1.2
-                            when_token = self.curr
-                            self.curr, self.next = self.next, self.scanner.match()
-                            if not self.curr or self.curr.lastgroup == _END_EDGE_PROPERTIES:
-                                raise SpecParsingError(
-                                    "expected a spec after when=", when_token, self.literal_str
+                                if not value and (
+                                    not self.next or self.next.lastgroup == _END_EDGE_PROPERTIES
+                                ):
+                                    self._raise_parsing_error("expected a spec after when=")
+                                self._rescan(
+                                    self.curr.start(_KV_VALUE) if value else self.curr.end()
                                 )
-                            conditions = self._parse_condition(conditions)
+                                parsed = self.next_spec()
+                                assert parsed is not None  # there is a token, so there is a spec
+                                condition = parsed
+                            # Repeated attributes combine: conditions are constrained, like
+                            # virtuals accumulate and deptypes are or-ed
+                            if conditions is None:
+                                conditions = condition
+                            else:
+                                conditions.constrain(condition)
 
-                        elif self.curr.lastgroup == _END_EDGE_PROPERTIES:
+                        elif kind == _END_EDGE_PROPERTIES:
                             # Closing ], optionally fused with a virtual assignment, as in
                             # ^[deptypes=link] mpi=openmpi
                             virtuals_str = self.curr.group(_END_EDGE_VIRTUALS)
@@ -695,23 +680,10 @@ class SpecParser:
         return root_spec
 
     def _rescan(self, pos: int) -> None:
-        """Restart the scanner at ``pos`` in the input, e.g. at the value of a ``key=value`` pair
-        that turns out to be the start of an unquoted ``when=`` condition"""
+        """Restart the scanner at ``pos`` in the input, the value of an unquoted when= condition"""
         self.scanner = FAST_SPEC_REGEX.scanner(self.literal_str, pos)  # type: ignore[attr-defined]
         self.curr = self.scanner.match()
         self.next = self.scanner.match()
-
-    def _parse_condition(
-        self, conditions: Optional["spack.spec.Spec"]
-    ) -> Optional["spack.spec.Spec"]:
-        """Parse the unquoted ``when=`` condition of edge properties, which is a spec that extends
-        up to the closing bracket, and constrain the condition ``conditions`` so far with it"""
-        condition = self.next_spec()
-        assert condition is not None  # there is a token, so there is a spec
-        if conditions is None:
-            return condition
-        conditions.constrain(condition)
-        return conditions
 
     def _attach_pending(self, root_spec: "spack.spec.Spec", pending: Optional[tuple]) -> None:
         """Attach the pending ^ dependency, whose sub-dag is complete now."""

--- a/lib/spack/spack/spec_parser.py
+++ b/lib/spack/spack/spec_parser.py
@@ -108,14 +108,14 @@ HASH = r"[a-zA-Z_0-9]+"
 #: These are legal values that *can* be parsed bare, without quotes on the command line.
 VALUE = r"(?:[a-zA-Z_0-9\-+\*.,:=%^\~\/\\]+)"
 
-#: Quoted values can be anything in between quotes, except the quote itself: there is no escaping
+#: Quoted values can be anything in between quotes, except the quote itself. There is no escaping.
 QUOTED_VALUE = r"(?:'[^']*'|\"[^\"]*\")"
 
 #: A version is the whole run of version characters, not ending in ``-`` or ``.``, so a
 #: following ``=`` cannot be satisfied by backtracking into a shorter version.
 VERSION = r"[a-zA-Z0-9_][a-zA-Z_0-9\-\.]*(?<![\-\.])(?![a-zA-Z_0-9\-\.])"
-#: The upper bound of a range is not the key of a key-value pair: ``@1.2:develop=foo`` is ``@1.2:``
-#: and a variant.
+#: The upper bound of a range is not the key of a key-value pair, so ``@1.2:develop=foo`` is
+#: ``@1.2:`` and a variant.
 VERSION_RANGE = rf"(?:(?:{VERSION})?:(?:{VERSION}(?!\s*=))?)"
 VERSION_OR_RANGE = rf"(?:{VERSION_RANGE}|{VERSION})"
 #: A git ref, optionally assigned a version or constrained to a range, e.g. ``git.main=1.2:``

--- a/lib/spack/spack/spec_parser.py
+++ b/lib/spack/spack/spec_parser.py
@@ -101,7 +101,11 @@ VALUE = r"(?:[a-zA-Z_0-9\-+\*.,:=%^\~\/\\]+)"
 #: Quoted values can be *anything* in between quotes, including escaped quotes.
 QUOTED_VALUE = r"(?:'(?:[^']|(?<=\\)')*'|\"(?:[^\"]|(?<=\\)\")*\")"
 
-VERSION = r"[a-zA-Z0-9_][a-zA-Z_0-9\-\.]*\b"
+#: A version is the whole run of version characters, not ending in ``-`` or ``.``, so a
+#: following ``=`` cannot be satisfied by backtracking into a shorter version.
+VERSION = r"[a-zA-Z0-9_][a-zA-Z_0-9\-\.]*(?<![\-\.])(?![a-zA-Z_0-9\-\.])"
+#: The upper bound of a range is not the key of a key-value pair: ``@1.2:develop=foo`` is ``@1.2:``
+#: and a variant.
 VERSION_RANGE = rf"(?:(?:{VERSION})?:(?:{VERSION}(?!\s*=))?)"
 VERSION_OR_RANGE = rf"(?:{VERSION_RANGE}|{VERSION})"
 #: A git ref, optionally assigned a version or constrained to a range, e.g. ``git.main=1.2:``

--- a/lib/spack/spack/spec_parser.py
+++ b/lib/spack/spack/spec_parser.py
@@ -29,7 +29,7 @@ Here is the EBNF grammar for a spec::
     propagated_kv = id==value | id:==value
     value         = bare_value | quoted_value
     bare_value    = [a-zA-Z0-9_\\-+*.,:=%^~/\\\\]+
-    quoted_value  = " { char | \\" } " | ' { char | \\' } '
+    quoted_value  = " [^"]* " | ' [^']* '
 
     version_list  = version_item { , version_item }
     version_item  = version | =version | version_range | git_version [= (version|version_range)]
@@ -68,7 +68,6 @@ specs to avoid ambiguity.  Both are provided because ``~`` can cause shell
 expansion when it is the first character in an id typed on the command line.
 """
 
-import json
 import os
 import re
 import sys
@@ -109,8 +108,8 @@ HASH = r"[a-zA-Z_0-9]+"
 #: These are legal values that *can* be parsed bare, without quotes on the command line.
 VALUE = r"(?:[a-zA-Z_0-9\-+\*.,:=%^\~\/\\]+)"
 
-#: Quoted values can be *anything* in between quotes, including escaped quotes.
-QUOTED_VALUE = r"(?:'(?:[^']|(?<=\\)')*'|\"(?:[^\"]|(?<=\\)\")*\")"
+#: Quoted values can be anything in between quotes, except the quote itself: there is no escaping
+QUOTED_VALUE = r"(?:'[^']*'|\"[^\"]*\")"
 
 #: A version is the whole run of version characters, not ending in ``-`` or ``.``, so a
 #: following ``=`` cannot be satisfied by backtracking into a shorter version.
@@ -133,9 +132,6 @@ SPLIT_KVP = re.compile(rf"^({NAME})(:?==?)(.*?)(\]*)$")
 WINDOWS_FILENAME = r"(?:\.|[a-zA-Z0-9-_]*\\|[a-zA-Z]:\\)(?:[a-zA-Z0-9-_\.\\]*)(?:\.json|\.yaml)"
 UNIX_FILENAME = r"(?:\.|\/|[a-zA-Z0-9-_]*\/)(?:[a-zA-Z0-9-_\.\/]*)(?:\.json|\.yaml)"
 FILENAME = WINDOWS_FILENAME if sys.platform == "win32" else UNIX_FILENAME
-
-#: Regex to strip quotes. Group 2 will be the unquoted string.
-STRIP_QUOTES = re.compile(r"^(['\"])(.*)\1$")
 
 #: Values that match this (e.g., variants, flags) can be left unquoted in Spack output
 NO_QUOTES_NEEDED = re.compile(r"^[a-zA-Z0-9,/_.\-]+$")
@@ -314,35 +310,31 @@ class SpecParsingError(spack.error.SpecSyntaxError):
         super().__init__(message)
 
 
-def strip_quotes_and_unescape(string: str) -> str:
+def strip_quotes(string: str) -> str:
     """Remove surrounding single or double quotes from string, if present."""
-    match = STRIP_QUOTES.match(string)
-    if not match:
-        return string
-
-    # replace any escaped quotes with bare quotes
-    quote, result = match.groups()
-    return result.replace(rf"\{quote}", quote)
+    if len(string) >= 2 and string[0] in "'\"" and string[-1] == string[0]:
+        return string[1:-1]
+    return string
 
 
 def quote_if_needed(value: str) -> str:
-    """Add quotes around the value if it requires quotes.
+    """Add quotes around the value if it requires quotes, i.e. unless it matches
+    :data:`NO_QUOTES_NEEDED`. Single quotes are used, or double quotes around a value that
+    contains single quotes. There is no escaping: a value that contains both kinds of quotes
+    cannot be written in a spec string.
 
-    This will add quotes around the value unless it matches :data:`NO_QUOTES_NEEDED`.
-
-    This adds:
-
-    * single quotes by default
-    * double quotes around any value that contains single quotes
-
-    If double quotes are used, we json-escape the string. That is, we escape ``\\``,
-    ``"``, and control codes.
-
+    Raises:
+        spack.error.SpecSyntaxError: if the value contains both single and double quotes
     """
     if NO_QUOTES_NEEDED.match(value):
         return value
-
-    return json.dumps(value) if "'" in value else f"'{value}'"
+    if "'" not in value:
+        return f"'{value}'"
+    if '"' not in value:
+        return f'"{value}"'
+    raise spack.error.SpecSyntaxError(
+        f"cannot quote the value {value!r}: it contains both single and double quotes"
+    )
 
 
 # Token kinds: names of the top-level capture groups in FAST_SPEC_REGEX, compared against
@@ -578,7 +570,7 @@ class SpecParser:
                                 conditions = self._parse_condition(conditions)
                                 continue
 
-                            value = strip_quotes_and_unescape(value)
+                            value = strip_quotes(value)
                             self.curr, self.next = self.next, self.scanner.match()
 
                             # A quoted when value is one spec string, where a comma is part of
@@ -804,7 +796,7 @@ class SpecParser:
                 propagate = "==" in sep
                 concrete = sep.startswith(":")
                 try:
-                    spec._add_flag(name, strip_quotes_and_unescape(value), propagate, concrete)
+                    spec._add_flag(name, strip_quotes(value), propagate, concrete)
                 except Exception as e:
                     self.curr = curr
                     self._raise_parsing_error(str(e))

--- a/lib/spack/spack/spec_parser.py
+++ b/lib/spack/spack/spec_parser.py
@@ -5,44 +5,46 @@
 
 Here is the EBNF grammar for a spec::
 
-    spec          = [name] [node_options] { sigil [edge_properties] dependency } |
-                    [name] [node_options] hash |
-                    filename
+    spec          = node { sigil [edge_properties] dependency }
 
     sigil         = ^ | % | %%
-    dependency    = virtual_assignment [node_options] | node
-    node          =  name [node_options] |
-                     [name] [node_options] hash |
-                     filename
+    dependency    = virtual_assignment { node_option } | node
+    node          = [name] { node_option } | filename
+    node_option   = @version_list | variant | hash
 
-    node_options    = [@version_list] { variant } [hash]
-    edge_properties = [ { key_value } ]
+    edge_properties = [ { key_value | when=quoted_spec } [ when=spec ] ]
+    quoted_spec     = " spec " | ' spec '
 
-    virtual_assignment = id { , id } = name
-    hash          = / id
+    virtual_assignment = id { , id } = (id | namespace id)
+    hash          = / [a-zA-Z0-9_]+
     filename      = (.|/|[a-zA-Z0-9-_]*/)([a-zA-Z0-9-_./]*)(.json|.yaml)
 
     name          = id | namespace id | *
-    namespace     = { id . }
+    namespace     = id . { id . }
 
     variant       = bool_variant | key_value | propagated_bv | propagated_kv
-    bool_variant  =  +id |  ~id |  -id
+    bool_variant  = +id | ~id | -id
     propagated_bv = ++id | ~~id | --id
-    key_value     =  id=id |  id=quoted_id
-    propagated_kv = id==id | id==quoted_id
+    key_value     = id=value | id:=value
+    propagated_kv = id==value | id:==value
+    value         = bare_value | quoted_value
+    bare_value    = [a-zA-Z0-9_\\-+*.,:=%^~/\\\\]+
+    quoted_value  = " { char | \\" } " | ' { char | \\' } '
 
-    version_list  = version_item [ { , version_item } ]
+    version_list  = version_item { , version_item }
     version_item  = version | =version | version_range | git_version [= (version|version_range)]
-    version_range = vid:vid | vid: | :vid | :
+    version_range = [vid] : [vid]
     version       = vid
 
-    git_version   = git.(vid) | git_hash
-    git_hash      = [a-f0-9]{40}
-
-    quoted_id     = " id_with_ws " | ' id_with_ws '
-    id_with_ws    = [a-zA-Z0-9_][a-zA-Z_0-9-.\\s]*
-    vid           = [a-zA-Z0-9_][a-zA-Z_0-9-.]*
+    git_version   = git.(ref) | git_hash
+    git_hash      = [A-Fa-f0-9]{40}
+    ref           = [a-zA-Z0-9_][a-zA-Z_0-9-./]*
+    vid           = [a-zA-Z0-9_] [ [a-zA-Z_0-9-.]* [a-zA-Z0-9_] ]
     id            = [a-zA-Z0-9_][a-zA-Z_0-9-]*
+
+The options of a node come in any order, with at most one version and one hash: a second hash
+starts the next spec, as in ``spack find /abc /def``. ``:=`` marks a concrete variant value, and
+``==`` or ``:==`` propagate the value to dependencies.
 
 Identifiers using the ``<name>=<value>`` command, such as architectures and
 compiler flags, require a space before the name.
@@ -52,6 +54,11 @@ not; and a ``key=value`` pair directly after a dependency sigil or edge properti
 value is a package name, is a virtual assignment ``%c,cxx=gcc`` rather than a variant of an
 anonymous dependency (write ``%* foo=bar`` for the latter). ``*`` is the name of an anonymous
 node.
+
+The ``when=`` edge property is a condition on the edge, and its value is a spec that extends up
+to the closing bracket, so it must be the last edge property: ``^[virtuals=mpi when=+mpi] mpich``.
+A quoted condition, ``^[when='+mpi' virtuals=mpi] mpich``, is a value like any other and can
+precede other edge properties.
 
 There is one ambiguity: since ``-`` is allowed in an id, you need to put
 whitespace space before ``-variant`` for it to be tokenized properly.  You can
@@ -345,6 +352,7 @@ _DEPENDENCY = "DEPENDENCY"
 _VERSION = "VERSION"
 _BOOL_VARIANT = "BOOL_VARIANT"
 _KEY_VALUE_PAIR = "KEY_VALUE_PAIR"
+_WHEN = "WHEN"
 _FILENAME = "FILENAME"
 _FULLY_QUALIFIED_PACKAGE_NAME = "FULLY_QUALIFIED_PACKAGE_NAME"
 _UNQUALIFIED_PACKAGE_NAME = "UNQUALIFIED_PACKAGE_NAME"
@@ -411,6 +419,11 @@ SPEC_TOKENS: Dict[str, str] = {
         rf"(?P<{_KV_SEP}>:?==?)"  # separator: ``=``, ``==``, ``:=`` or ``:==``
         rf"(?P<{_KV_VALUE}>{VALUE}|{QUOTED_VALUE})"  # bare or quoted value
     ),
+    # the when= condition of edge properties whose spec does not start with a value character,
+    # e.g. ``^[when=@1.2] dep``. Otherwise ``when=+foo`` is a key-value pair like any other, which
+    # the edge properties parser reads as the start of a condition, so ``when`` is still a
+    # variant name elsewhere.
+    _WHEN: r"when=",
     # path to a spec file, e.g. ``./foo/bar.json``
     _FILENAME: FILENAME,
     # package name with namespace, e.g. ``builtin.mpich``
@@ -543,19 +556,33 @@ class SpecParser:
                     attributes: Dict[str, List[str]] = {}
                     conditions: Optional["spack.spec.Spec"] = None
                     substitute = None
-                    while self.curr:
+                    while True:
+                        if not self.curr:
+                            self._raise_parsing_error("unexpected token in edge attributes")
+
                         if self.curr.lastgroup == _KEY_VALUE_PAIR:
                             name = self.curr.group(_KV_NAME)
                             if name not in ("deptypes", "virtuals", "when"):
                                 msg = (
-                                    "the only edge attributes that are currently accepted "
-                                    'are "deptypes", "virtuals", and "when"'
+                                    "the only edge attributes that are currently accepted are "
+                                    '"deptypes", "virtuals", and a "when=<spec>" condition, '
+                                    "which must be the last unless quoted"
                                 )
                                 self._raise_parsing_error(msg)
                             value = self.curr.group(_KV_VALUE)
+                            if name == "when" and value[0] not in "'\"":
+                                # An unquoted condition is a spec that starts at the value and
+                                # extends up to the closing bracket, e.g. when=+mpi %c=gcc: the
+                                # tokenizer is context free, so rescan from the value
+                                self._rescan(self.curr.start(_KV_VALUE))
+                                conditions = self._parse_condition(conditions)
+                                continue
+
                             value = strip_quotes_and_unescape(value)
-                            # A when value is one spec string, where a comma is part of the
-                            # syntax, e.g. when='@1,2'; deptypes and virtuals values are
+                            self.curr, self.next = self.next, self.scanner.match()
+
+                            # A quoted when value is one spec string, where a comma is part of
+                            # the syntax, e.g. when='@1,2'; deptypes and virtuals values are
                             # comma-separated lists. Repeated attributes combine: a second
                             # when= constrains the condition, like virtuals accumulate.
                             if name == "when":
@@ -567,7 +594,16 @@ class SpecParser:
                             else:
                                 attributes[name] = [v.strip() for v in value.split(",")]
 
+                        elif self.curr.lastgroup == _WHEN:
+                            # when= followed by a spec that does not start with a value
+                            # character, e.g. when=@1.2
+                            when_token = self.curr
                             self.curr, self.next = self.next, self.scanner.match()
+                            if not self.curr or self.curr.lastgroup == _END_EDGE_PROPERTIES:
+                                raise SpecParsingError(
+                                    "expected a spec after when=", when_token, self.literal_str
+                                )
+                            conditions = self._parse_condition(conditions)
 
                         elif self.curr.lastgroup == _END_EDGE_PROPERTIES:
                             # Closing ], optionally fused with a virtual assignment, as in
@@ -586,7 +622,7 @@ class SpecParser:
                             break
                         else:
                             # Only key=value pairs can occur between brackets
-                            self._raise_parsing_error("Unexpected token in edge attributes")
+                            self._raise_parsing_error("unexpected token in edge attributes")
 
                     depflag = 0
                     if "deptypes" in attributes:
@@ -655,6 +691,25 @@ class SpecParser:
             self._raise_parsing_error("unexpected token")
 
         return root_spec
+
+    def _rescan(self, pos: int) -> None:
+        """Restart the scanner at ``pos`` in the input, e.g. at the value of a ``key=value`` pair
+        that turns out to be the start of an unquoted ``when=`` condition"""
+        self.scanner = FAST_SPEC_REGEX.scanner(self.literal_str, pos)  # type: ignore[attr-defined]
+        self.curr = self.scanner.match()
+        self.next = self.scanner.match()
+
+    def _parse_condition(
+        self, conditions: Optional["spack.spec.Spec"]
+    ) -> Optional["spack.spec.Spec"]:
+        """Parse the unquoted ``when=`` condition of edge properties, which is a spec that extends
+        up to the closing bracket, and constrain the condition ``conditions`` so far with it"""
+        condition = self.next_spec()
+        assert condition is not None  # there is a token, so there is a spec
+        if conditions is None:
+            return condition
+        conditions.constrain(condition)
+        return conditions
 
     def _attach_pending(self, root_spec: "spack.spec.Spec", pending: Optional[tuple]) -> None:
         """Attach the pending ^ dependency, whose sub-dag is complete now."""

--- a/lib/spack/spack/spec_parser.py
+++ b/lib/spack/spack/spec_parser.py
@@ -541,7 +541,7 @@ class SpecParser:
 
                     # Collect edge attributes (key=value pairs) up to the closing bracket
                     attributes: Dict[str, List[str]] = {}
-                    when_string: Optional[str] = None
+                    conditions: Optional["spack.spec.Spec"] = None
                     substitute = None
                     while self.curr:
                         if self.curr.lastgroup == _KEY_VALUE_PAIR:
@@ -556,9 +556,14 @@ class SpecParser:
                             value = strip_quotes_and_unescape(value)
                             # A when value is one spec string, where a comma is part of the
                             # syntax, e.g. when='@1,2'; deptypes and virtuals values are
-                            # comma-separated lists.
+                            # comma-separated lists. Repeated attributes combine: a second
+                            # when= constrains the condition, like virtuals accumulate.
                             if name == "when":
-                                when_string = value
+                                condition = parse_one_or_raise(value)
+                                if conditions is None:
+                                    conditions = condition
+                                else:
+                                    conditions.constrain(condition)
                             else:
                                 attributes[name] = [v.strip() for v in value.split(",")]
 
@@ -588,10 +593,6 @@ class SpecParser:
                         depflag = spack.deptypes.canonicalize(attributes["deptypes"])
 
                     virtuals_tuple = tuple(attributes.get("virtuals", ()))
-
-                    conditions = None
-                    if when_string is not None:
-                        conditions = SpecParser(when_string).next_spec()
 
                     dep_spec = self._parse_node(initial_name=substitute)
 

--- a/lib/spack/spack/test/spec_semantics.py
+++ b/lib/spack/spack/test/spec_semantics.py
@@ -1658,19 +1658,19 @@ class TestSpecSemantics:
             # Ensure the 'when=+debug' is referred to 'callpath', and not to 'mpileaks',
             # and that we can concretize the spec despite 'callpath' has no debug variant
             (
-                "mpileaks+debug ^callpath %[when=+debug virtuals=mpi] zmpi",
+                "mpileaks+debug ^callpath %[virtuals=mpi when=+debug] zmpi",
                 [
                     ("^zmpi", False),
                     ("^mpich", False),
-                    ("mpileaks+debug  %[when=+debug virtuals=mpi] zmpi", False),
+                    ("mpileaks+debug  %[virtuals=mpi when=+debug] zmpi", False),
                 ],
                 [("^zmpi", False), ("^[virtuals=mpi] mpich", True)],
             ),
             # Ensure we don't skip conditional edges when testing because we associate them
             # with the wrong node (e.g. mpileaks instead of mpich)
             (
-                "mpileaks~debug ^mpich+debug %[when=+debug virtuals=c] llvm",
-                [("^mpich+debug %[when=+debug virtuals=c] gcc", False)],
+                "mpileaks~debug ^mpich+debug %[virtuals=c when=+debug] llvm",
+                [("^mpich+debug %[virtuals=c when=+debug] gcc", False)],
                 [("^mpich %[virtuals=c] gcc", False), ("^mpich %[virtuals=c] llvm", True)],
             ),
         ],

--- a/lib/spack/spack/test/spec_semantics.py
+++ b/lib/spack/spack/test/spec_semantics.py
@@ -2803,14 +2803,14 @@ def test_copy_does_not_share_flag_instances(mock_packages):
             "mpileaks",
             "callpath",
             {"virtuals": ("mpi", "lapack")},
-            "mpileaks ^[virtuals=lapack,mpi] callpath",
+            "mpileaks ^lapack,mpi=callpath",
             "DependencySpec('mpileaks', 'callpath', depflag=0, virtuals=('lapack', 'mpi'))",
         ),
         (
             "",
             "callpath",
             {"virtuals": ("mpi", "lapack"), "direct": True},
-            " %[virtuals=lapack,mpi] callpath",
+            " %lapack,mpi=callpath",
             "DependencySpec('', 'callpath', depflag=0, virtuals=('lapack', 'mpi'), direct=True)",
         ),
         (
@@ -2821,7 +2821,7 @@ def test_copy_does_not_share_flag_instances(mock_packages):
                 "direct": True,
                 "propagation": PropagationPolicy.PREFERENCE,
             },
-            " %%[virtuals=lapack,mpi] callpath",
+            " %%lapack,mpi=callpath",
             "DependencySpec('', 'callpath', depflag=0, virtuals=('lapack', 'mpi'), direct=True,"
             " propagation=PropagationPolicy.PREFERENCE)",
         ),
@@ -2841,6 +2841,21 @@ def test_copy_does_not_share_flag_instances(mock_packages):
             "DependencySpec('mpileaks+foo', 'callpath+bar', depflag=0, virtuals=(), direct=True,"
             " propagation=PropagationPolicy.PREFERENCE)",
         ),
+        # an anonymous child is named *, so that foo=bar is not read as a virtual assignment
+        (
+            "mpileaks",
+            "foo=bar",
+            {"virtuals": ()},
+            "mpileaks ^* foo=bar",
+            "DependencySpec('mpileaks', 'foo=bar', depflag=0, virtuals=())",
+        ),
+        (
+            "mpileaks",
+            "@4.0",
+            {"virtuals": ("c",), "direct": True},
+            "mpileaks %[virtuals=c] @4.0",
+            "DependencySpec('mpileaks', '@4.0', depflag=0, virtuals=('c',), direct=True)",
+        ),
     ],
 )
 def test_edge_representation(parent_str, child_str, kwargs, expected_str, expected_repr):
@@ -2850,6 +2865,10 @@ def test_edge_representation(parent_str, child_str, kwargs, expected_str, expect
     edge = DependencySpec(parent, child, depflag=0, **kwargs)
     assert str(edge) == expected_str
     assert repr(edge) == expected_repr
+    # the string is used as a constraint, so it must parse back to the same edge
+    parsed = Spec(str(edge)).edges_to_dependencies()[0]
+    assert parsed.spec == child and parsed.virtuals == edge.virtuals
+    assert parsed.direct == edge.direct and parsed.propagation == edge.propagation
 
 
 def test_parallel_edges_sort_with_differing_propagation(mock_packages):

--- a/lib/spack/spack/test/spec_syntax.py
+++ b/lib/spack/spack/test/spec_syntax.py
@@ -1662,7 +1662,7 @@ def test_disambiguate_hash_by_spec(spec1, spec2, constraint, mock_packages, monk
         ("x os=debian6 platform=test target=default_target os=redhat6", "two architectures"),
         ("x target=default_target platform=test os=redhat6 os=debian6", "'platform'"),
         # Dependencies
-        ("^[@foo] zlib", "edge attributes"),
+        ("^[@foo] zlib", "expected an edge attribute or `]`"),
         # TODO: Remove this as soon as use variants are added and we can parse custom attributes
         ("^[foo=bar] zlib", "edge attributes"),
         # Propagating reserved names generates a parse error
@@ -1677,8 +1677,8 @@ def test_disambiguate_hash_by_spec(spec1, spec2, constraint, mock_packages, monk
         # a when= condition is a spec, which extends up to the closing bracket
         ("foo ^[when=] bar", "expected a spec after when="),
         ("foo ^[when=", "expected a spec after when="),
-        ("foo ^[when=bar baz] qux", "unexpected token in edge attributes"),
-        ("foo ^[when=bar ^baz", "unexpected token in edge attributes"),
+        ("foo ^[when=bar baz] qux", "expected an edge attribute or `]`"),
+        ("foo ^[when=bar ^baz", "expected `]` to close the edge attributes"),
         # a quoted condition is a single spec: neither two specs nor none
         ("foo ^[when='bar baz'] qux", "expected a single spec as the when= condition"),
         ("foo ^[when=''] qux", "expected a single spec as the when= condition"),

--- a/lib/spack/spack/test/spec_syntax.py
+++ b/lib/spack/spack/test/spec_syntax.py
@@ -1216,6 +1216,8 @@ def test_parse_multiple_specs(text, tokens, expected_specs):
         (["zlib ldflags='' +pic"], "zlib+pic"),
         # Ensure that $ORIGIN is handled correctly
         (["zlib", "ldflags=-Wl,-rpath=$ORIGIN/_libs"], "zlib ldflags='-Wl,-rpath=$ORIGIN/_libs'"),
+        # A closing bracket ends the edge attribute list, it is never part of the value
+        (["mpileaks", "%[", "when=@1.0]", "gcc"], "mpileaks %[when='@1.0'] gcc"),
         # Ensure that passing escaped quotes on the CLI raises a tokenization error
         (["zlib", '"-g', '-O2"'], SpecTokenizationError),
     ],
@@ -1954,6 +1956,80 @@ def test_when_edge_attribute_keeps_commas():
     comma-separated deptypes and virtuals lists."""
     edge = spack.spec.Spec("foo ^[when='@1,2'] bar").edges_to_dependencies(name="bar")[0]
     assert edge.when == spack.spec.Spec("@1,2")
+
+
+@pytest.mark.parametrize(
+    "spec_str,expected",
+    [
+        # square brackets are not valid characters in an unquoted value
+        ("a=']'", "a=']'"),
+        ("a='['", "a='['"),
+        # virtuals of an anonymous spec stay in the edge attributes, there is no name to
+        # substitute them with
+        ("%[virtuals=c] *", "%[virtuals=c] *"),
+        ("%[deptypes=build virtuals=c] *", "%[deptypes=build virtuals=c] *"),
+        ("^[virtuals=c,cxx] *", "^[virtuals=c,cxx] *"),
+        ("%[virtuals=c] @4.0 foo=bar", "%[virtuals=c] *@4.0 foo=bar"),
+        # a star is a package name, so name=* is a variant value, not a substitute
+        ("^dev_path=*", "^*dev_path='*'"),
+        # a version bound is never truncated at a "." to make room for a key=value pair
+        ("@:a.a=''", "a.a=''"),
+        ("@1.2:2.0=x", "@1.2: 2.0=x"),
+        # a key=value pair after a sigil is a virtual assignment only if the whole value is a
+        # package name, otherwise it is a variant of an anonymous dependency
+        ("^foo=bar:baz", "^* foo='bar:baz'"),
+        ("^foo=bar,baz", "^* foo=bar,baz"),
+        ("^foo=bar=baz", "^* foo='bar=baz'"),
+        ("%x=y~", "%* x='y~'"),
+    ],
+)
+def test_spec_str_round_trips(spec_str, expected):
+    """The string of a spec must be parseable, and parse back to the same spec."""
+    spec = spack.spec.Spec(spec_str)
+    assert str(spec) == expected
+    assert spack.spec.Spec(str(spec)) == spec
+
+
+@pytest.mark.parametrize(
+    "spec_str", ["x os='a b'", "x target='x?y'", "x platform=''", "x os=''", "x arch='a b'"]
+)
+def test_architecture_parts_must_be_bare_values(spec_str):
+    """The parts of an architecture print unquoted, so anything that needs quotes cannot
+    round-trip and is rejected"""
+    with pytest.raises(SpecParsingError):
+        spack.spec.Spec(spec_str)
+
+
+@pytest.mark.parametrize("spec_str", ["x namespace=a+b", "x namespace=','", "x namespace=''"])
+def test_namespace_must_be_dotted_identifier(spec_str):
+    """A namespace prints as a prefix of the package name, so anything else cannot round-trip"""
+    with pytest.raises(SpecParsingError):
+        spack.spec.Spec(spec_str)
+
+
+@pytest.mark.parametrize(
+    "spec_str", ["x ~os", "x ~platform", "x ~target", "x ~namespace", "x +os"]
+)
+def test_bool_variant_form_of_string_attributes_raises(spec_str):
+    """The parts of an architecture and the namespace have a string value, like ``arch`` itself,
+    so the bool variant form is an error rather than silently dropped"""
+    with pytest.raises(SpecParsingError):
+        spack.spec.Spec(spec_str)
+
+
+def test_duplicate_when_edge_attribute_constrains():
+    """Repeated edge attributes combine: virtuals accumulate, deptypes are or-ed, and conditions
+    are constrained, rather than the last one silently replacing the others"""
+    edge = spack.spec.Spec("x ^[when='+a' when='+b'] y").edges_to_dependencies(name="y")[0]
+    assert edge.when == spack.spec.Spec("+a+b")
+
+
+@pytest.mark.parametrize("spec_str", ["x @=1:2", "x @1:=2"])
+def test_exact_version_in_range_is_a_syntax_error(spec_str):
+    """``=`` marks an exact version, which cannot be a bound of a range: that is a syntax error
+    of the spec, not a ValueError from the version list"""
+    with pytest.raises(spack.error.SpecSyntaxError):
+        spack.spec.Spec(spec_str)
 
 
 @pytest.mark.regression("52375")

--- a/lib/spack/spack/test/spec_syntax.py
+++ b/lib/spack/spack/test/spec_syntax.py
@@ -18,6 +18,7 @@ import spack.platforms.test
 import spack.repo
 import spack.solver.asp
 import spack.spec
+import spack.spec_parser
 import spack.util.filesystem as fs
 import spack.version
 from spack.externals import (
@@ -315,24 +316,35 @@ def specfile_for(config, mock_packages):
         # TODO: consider making these format to "*" instead of ""
         ("@:", [Token("VERSION", value="@:")], r""),
         ("*", [Token("UNQUALIFIED_PACKAGE_NAME", value="*")], r""),
+        # virtual assignment on a dep of an anonymous spec (more of these later)
+        (
+            "%foo=bar",
+            [Token("DEPENDENCY", value="%foo=bar", edge_virtuals="foo", edge_substitute="bar")],
+            "%foo=bar",
+        ),
+        (
+            "^foo=bar",
+            [Token("DEPENDENCY", value="^foo=bar", edge_virtuals="foo", edge_substitute="bar")],
+            "^foo=bar",
+        ),
         # anonymous dependencies with variants
         (
-            "^*foo=bar",
+            "^* foo=bar",
             [
                 Token("DEPENDENCY", value="^"),
                 Token("UNQUALIFIED_PACKAGE_NAME", value="*"),
                 Token("KEY_VALUE_PAIR", value="foo=bar"),
             ],
-            "^*foo=bar",
+            "^* foo=bar",
         ),
         (
-            "%*foo=bar",
+            "%* foo=bar",
             [
                 Token("DEPENDENCY", value="%"),
                 Token("UNQUALIFIED_PACKAGE_NAME", value="*"),
                 Token("KEY_VALUE_PAIR", value="foo=bar"),
             ],
-            "%*foo=bar",
+            "%* foo=bar",
         ),
         (
             "^*+foo",
@@ -1085,6 +1097,42 @@ def specfile_for(config, mock_packages):
             ],
             "foo %%[when='%c'] c=gcc",
         ),
+        # whitespace between a dependency sigil or edge properties and a virtual assignment
+        (
+            "zlib % c=gcc",
+            [
+                Token("UNQUALIFIED_PACKAGE_NAME", value="zlib"),
+                Token("DEPENDENCY", value="% c=gcc", edge_virtuals="c", edge_substitute="gcc"),
+            ],
+            "zlib %c=gcc",
+        ),
+        (
+            "foo ^[when='%c']   c,cxx=builtin.gcc@14+bar",
+            [
+                Token("UNQUALIFIED_PACKAGE_NAME", value="foo"),
+                Token("DEPENDENCY", value="^[", edge_bracket="["),
+                Token("KEY_VALUE_PAIR", "when='%c'", kv_name="when", kv_sep="=", kv_value="'%c'"),
+                Token(
+                    "END_EDGE_PROPERTIES",
+                    "]   c,cxx=builtin.gcc",
+                    end_edge_virtuals="c,cxx",
+                    end_edge_substitute="builtin.gcc",
+                ),
+                Token("VERSION", value="@14", version_list="14"),
+                Token("BOOL_VARIANT", value="+bar", bv_prefix="+", bv_name="bar"),
+            ],
+            "foo ^[when='%c'] c,cxx=builtin.gcc@14+bar",
+        ),
+        # a value that is not a package name is a variant of an anonymous dependency
+        (
+            "zlib ^cflags=-O2",
+            [
+                Token("UNQUALIFIED_PACKAGE_NAME", value="zlib"),
+                Token("DEPENDENCY", value="^"),
+                Token("KEY_VALUE_PAIR", value="cflags=-O2"),
+            ],
+            "zlib ^* cflags=-O2",
+        ),
     ],
 )
 def test_parse_single_spec(spec_str, tokens, expected_roundtrip, mock_git_test_package):
@@ -1164,6 +1212,15 @@ def test_parse_single_spec(spec_str, tokens, expected_roundtrip, mock_git_test_p
             ],
             ["mvapich %gcc languages=c,c++", "emacs ^ncurses%gcc languages:=c"],
         ),
+        (
+            "zlib %c=gcc gcc",
+            [
+                Token("UNQUALIFIED_PACKAGE_NAME", value="zlib"),
+                Token("DEPENDENCY", value="%c=gcc"),
+                Token("UNQUALIFIED_PACKAGE_NAME", value="gcc"),
+            ],
+            ["zlib %c=gcc", "gcc"],
+        ),
     ],
 )
 def test_parse_multiple_specs(text, tokens, expected_specs):
@@ -1218,6 +1275,8 @@ def test_parse_multiple_specs(text, tokens, expected_specs):
         (["zlib", "ldflags=-Wl,-rpath=$ORIGIN/_libs"], "zlib ldflags='-Wl,-rpath=$ORIGIN/_libs'"),
         # A closing bracket ends the edge attribute list, it is never part of the value
         (["mpileaks", "%[", "when=@1.0]", "gcc"], "mpileaks %[when='@1.0'] gcc"),
+        (["mpileaks", "%[when=+x]", "c=gcc"], "mpileaks %[when='+x'] c=gcc"),
+        (["mpileaks", "%c,cxx=gcc"], "mpileaks %c,cxx=gcc"),
         # Ensure that passing escaped quotes on the CLI raises a tokenization error
         (["zlib", '"-g', '-O2"'], SpecTokenizationError),
     ],
@@ -1964,14 +2023,24 @@ def test_when_edge_attribute_keeps_commas():
         # square brackets are not valid characters in an unquoted value
         ("a=']'", "a=']'"),
         ("a='['", "a='['"),
+        # an anonymous dependency is named * only where its options could be read as a name
+        ("foo ^", "foo ^*"),
+        ("pkg-a %*+foo ^*@1.0", "pkg-a %+foo ^@1.0"),
+        ("^cflags=-O2", "^* cflags=-O2"),
+        ("^* foo=bar,baz", "^* foo=bar,baz"),
+        # a virtual assignment is one token, the node options follow
+        ("zlib % c=gcc", "zlib %c=gcc"),
+        ("^mpi=intel-parallel-studio+mkl", "^mpi=intel-parallel-studio+mkl"),
+        ("%c=builtin.gcc@14", "%c=builtin.gcc@14"),
+        ("%[when=+x] c=gcc", "%[when='+x'] c=gcc"),
         # virtuals of an anonymous spec stay in the edge attributes, there is no name to
         # substitute them with
         ("%[virtuals=c] *", "%[virtuals=c] *"),
         ("%[deptypes=build virtuals=c] *", "%[deptypes=build virtuals=c] *"),
         ("^[virtuals=c,cxx] *", "^[virtuals=c,cxx] *"),
-        ("%[virtuals=c] @4.0 foo=bar", "%[virtuals=c] *@4.0 foo=bar"),
+        ("%[virtuals=c] *@4.0 foo=bar", "%[virtuals=c] @4.0 foo=bar"),
         # a star is a package name, so name=* is a variant value, not a substitute
-        ("^dev_path=*", "^*dev_path='*'"),
+        ("^dev_path=*", "^* dev_path='*'"),
         # a version bound is never truncated at a "." to make room for a key=value pair
         ("@:a.a=''", "a.a=''"),
         ("@1.2:2.0=x", "@1.2: 2.0=x"),
@@ -2030,6 +2099,21 @@ def test_exact_version_in_range_is_a_syntax_error(spec_str):
     of the spec, not a ValueError from the version list"""
     with pytest.raises(spack.error.SpecSyntaxError):
         spack.spec.Spec(spec_str)
+
+
+@pytest.mark.parametrize(
+    "spec_str,expected_in_error",
+    [
+        ("c,cxx=gcc", "virtual assignment"),
+        ("zlib c,cxx=gcc", "virtual assignment"),
+        ("zlib %[c=gcc]", "edge attributes"),
+        # regression: an unconsumed token used to make the parser loop forever
+        ("zlib ]", "unexpected token"),
+    ],
+)
+def test_misplaced_tokens_raise(spec_str, expected_in_error):
+    with pytest.raises(SpecParsingError, match=expected_in_error):
+        spack.spec_parser.parse(spec_str)
 
 
 @pytest.mark.regression("52375")

--- a/lib/spack/spack/test/spec_syntax.py
+++ b/lib/spack/spack/test/spec_syntax.py
@@ -1251,8 +1251,10 @@ def test_parse_multiple_specs(text, tokens, expected_specs):
         (["zlib", 'cflags="-O3 -g" +bar baz'], """zlib cflags='"-O3 -g" +bar baz'"""),
         # Use double quotes if internal single quotes are present
         (["zlib", "cflags='-O3 -g' +bar baz"], '''zlib cflags="'-O3 -g' +bar baz"'''),
-        # Use single quotes and escape single quotes with internal single and double quotes
-        (["zlib", "cflags='-O3 -g' \"+bar baz\""], 'zlib cflags="\'-O3 -g\' \\"+bar baz\\""'),
+        # There is no escaping: a value cannot contain both kinds of quotes
+        (["zlib", '''cflags='-O3 -g' "+bar baz"'''], spack.error.SpecSyntaxError),
+        # and a backslash is a character like any other: the compiler gets the define as typed
+        (["zlib", r"cflags=-DCHAR=\'x\'"], r'''zlib cflags="-DCHAR=\'x\'"'''),
         # Ensure that empty strings are handled correctly on CLI
         (["zlib", "ldflags=", "+pic"], "zlib+pic"),
         # These flags are assumed to be quoted by the shell, but the space doesn't matter because
@@ -2044,9 +2046,20 @@ def test_when_edge_attribute_keeps_commas():
         ("%[virtuals=c] *@4.0 foo=bar", "%[virtuals=c] @4.0 foo=bar"),
         # a star is a package name, so name=* is a variant value, not a substitute
         ("^dev_path=*", "^* dev_path='*'"),
+        # a when= value is a spec, whose own quotes cannot be nested in a quoted value
+        ('%[when="a=*"]', "%[when=a='*'] *"),
+        ("""x %[when="a=']'"] gcc""", "x %[when=a=']'] gcc"),
+        ("%[when='@1,2' virtuals=c] *", "%[virtuals=c when=@1:2] *"),
         # a version bound is never truncated at a "." to make room for a key=value pair
         ("@:a.a=''", "a.a=''"),
         ("@1.2:2.0=x", "@1.2: 2.0=x"),
+        # there is no escaping in quoted values: a backslash is a character like any other, and a
+        # value that contains one kind of quote is quoted with the other
+        (r"a='x\' b='y'", r"a='x\' b=y"),
+        (r"""a="it's\"""", r"""a="it's\""""),
+        # nor is there json-style escaping of non-ASCII or control characters on output
+        ('a="café\'s"', 'a="café\'s"'),
+        ('a="x\'\ty"', 'a="x\'\ty"'),
         # a key=value pair after a sigil is a virtual assignment only if the whole value is a
         # package name, otherwise it is a variant of an anonymous dependency
         ("^foo=bar:baz", "^* foo='bar:baz'"),

--- a/lib/spack/spack/test/spec_syntax.py
+++ b/lib/spack/spack/test/spec_syntax.py
@@ -18,7 +18,6 @@ import spack.platforms.test
 import spack.repo
 import spack.solver.asp
 import spack.spec
-import spack.spec_parser
 import spack.util.filesystem as fs
 import spack.version
 from spack.externals import (
@@ -316,17 +315,6 @@ def specfile_for(config, mock_packages):
         # TODO: consider making these format to "*" instead of ""
         ("@:", [Token("VERSION", value="@:")], r""),
         ("*", [Token("UNQUALIFIED_PACKAGE_NAME", value="*")], r""),
-        # virtual assignment on a dep of an anonymous spec (more of these later)
-        (
-            "%foo=bar",
-            [Token("DEPENDENCY", value="%foo=bar", edge_virtuals="foo", edge_substitute="bar")],
-            "%foo=bar",
-        ),
-        (
-            "^foo=bar",
-            [Token("DEPENDENCY", value="^foo=bar", edge_virtuals="foo", edge_substitute="bar")],
-            "^foo=bar",
-        ),
         # anonymous dependencies with variants
         (
             "^* foo=bar",
@@ -1097,15 +1085,7 @@ def specfile_for(config, mock_packages):
             ],
             "foo %%[when=%c] c=gcc",
         ),
-        # whitespace between a dependency sigil or edge properties and a virtual assignment
-        (
-            "zlib % c=gcc",
-            [
-                Token("UNQUALIFIED_PACKAGE_NAME", value="zlib"),
-                Token("DEPENDENCY", value="% c=gcc", edge_virtuals="c", edge_substitute="gcc"),
-            ],
-            "zlib %c=gcc",
-        ),
+        # whitespace between edge properties and a virtual assignment
         (
             "foo ^[when=%c]   c,cxx=builtin.gcc@14+bar",
             [
@@ -1122,16 +1102,6 @@ def specfile_for(config, mock_packages):
                 Token("BOOL_VARIANT", value="+bar", bv_prefix="+", bv_name="bar"),
             ],
             "foo ^[when=%c] c,cxx=builtin.gcc@14+bar",
-        ),
-        # a value that is not a package name is a variant of an anonymous dependency
-        (
-            "zlib ^cflags=-O2",
-            [
-                Token("UNQUALIFIED_PACKAGE_NAME", value="zlib"),
-                Token("DEPENDENCY", value="^"),
-                Token("KEY_VALUE_PAIR", value="cflags=-O2"),
-            ],
-            "zlib ^* cflags=-O2",
         ),
     ],
 )
@@ -1277,11 +1247,8 @@ def test_parse_multiple_specs(text, tokens, expected_specs):
         (["zlib", "ldflags=-Wl,-rpath=$ORIGIN/_libs"], "zlib ldflags='-Wl,-rpath=$ORIGIN/_libs'"),
         # A closing bracket ends the edge attribute list, it is never part of the value
         (["mpileaks", "%[", "when=@1.0]", "gcc"], "mpileaks %[when=@1.0] gcc"),
-        (["mpileaks", "%[when=+x]", "c=gcc"], "mpileaks %[when=+x] c=gcc"),
         # a value that parses as it is stays unquoted: c=gcc@14 is a virtual assignment
         (["mpileaks", "%[when=+x]", "c=gcc@14"], "mpileaks %[when=+x] c=gcc@14"),
-        (["mpileaks", "%c=gcc@14"], "mpileaks %c=gcc@14"),
-        (["mpileaks", "%c,cxx=gcc"], "mpileaks %c,cxx=gcc"),
         # Ensure that passing escaped quotes on the CLI raises a tokenization error
         (["zlib", '"-g', '-O2"'], SpecTokenizationError),
     ],
@@ -1691,11 +1658,42 @@ def test_disambiguate_hash_by_spec(spec1, spec2, constraint, mock_packages, monk
         ("x target==x86_64", "Propagation"),
         ("x dev_path==/foo/bar/baz", "Propagation"),
         ("x patches==abcde12345,12345abcde", "Propagation"),
+        # a when= condition is a spec, which extends up to the closing bracket
+        ("foo ^[when=] bar", "expected a spec after when="),
+        ("foo ^[when=", "expected a spec after when="),
+        ("foo ^[when=bar baz] qux", "unexpected token in edge attributes"),
+        ("foo ^[when=bar ^baz", "unexpected token in edge attributes"),
+        # a quoted condition is a single spec: neither two specs nor none
+        ("foo ^[when='bar baz'] qux", "expected a single spec as the when= condition"),
+        ("foo ^[when=''] qux", "expected a single spec as the when= condition"),
+        # the parts of an architecture and the namespace print unquoted, so they must be values
+        # that parse without quotes, and a namespace a dotted identifier
+        ("x os='a b'", "invalid value"),
+        ("x target='x?y'", "invalid value"),
+        ("x platform=''", "invalid value"),
+        ("x os=''", "invalid value"),
+        ("x arch='a b'", "invalid value"),
+        ("x namespace=a+b", "invalid value"),
+        ("x namespace=','", "invalid value"),
+        ("x namespace=''", "invalid value"),
+        # they have a string value like arch, so the bool variant form is an error rather than
+        # silently dropped
+        ("x ~os", "must have a string value"),
+        ("x ~platform", "must have a string value"),
+        ("x ~target", "must have a string value"),
+        ("x ~namespace", "must have a string value"),
+        ("x +os", "must have a string value"),
+        # a virtual assignment must directly follow a dependency sigil or edge properties
+        ("c,cxx=gcc", "virtual assignment"),
+        ("zlib c,cxx=gcc", "virtual assignment"),
+        ("zlib %[c=gcc]", "edge attributes"),
+        # regression: an unconsumed token used to make the parser loop forever
+        ("zlib ]", "unexpected token"),
     ],
 )
 def test_error_conditions(text, match_string):
     with pytest.raises(SpecParsingError, match=match_string):
-        SpecParser(text).next_spec()
+        SpecParser(text).all_specs()
 
 
 @pytest.mark.parametrize(
@@ -2016,61 +2014,10 @@ def test_parse_multiple_edge_attributes(input_args, expected):
 
 
 def test_when_edge_attribute_keeps_commas():
-    """A when value is one spec, where a comma is part of the syntax, unlike the
+    """A when value is one spec string, where a comma is part of the syntax, unlike the
     comma-separated deptypes and virtuals lists."""
     edge = spack.spec.Spec("foo ^[when='@1,2'] bar").edges_to_dependencies(name="bar")[0]
     assert edge.when == spack.spec.Spec("@1,2")
-    edge = spack.spec.Spec("foo ^[when=@1,2] bar").edges_to_dependencies(name="bar")[0]
-    assert edge.when == spack.spec.Spec("@1,2")
-
-
-def test_when_edge_attribute_extends_to_closing_bracket():
-    """The when condition is a spec that extends up to the closing bracket: what follows it are
-    node options of the condition, not further edge attributes."""
-    edge = spack.spec.Spec("foo ^[when=bar virtuals=c] baz").edges_to_dependencies(name="baz")[0]
-    assert edge.when == spack.spec.Spec("bar virtuals=c")
-    assert edge.virtuals == ()
-
-    edge = spack.spec.Spec("foo ^[virtuals=c when=bar] baz").edges_to_dependencies(name="baz")[0]
-    assert edge.when == spack.spec.Spec("bar")
-    assert edge.virtuals == ("c",)
-
-
-@pytest.mark.parametrize(
-    "spec_str,expected_in_error",
-    [
-        ("foo ^[when=] bar", "expected a spec after when="),
-        ("foo ^[when=", "expected a spec after when="),
-        ("foo ^[when=bar baz] qux", "unexpected token in edge attributes"),
-        ("foo ^[when=bar ^baz", "unexpected token in edge attributes"),
-        # a quoted condition is a single spec: neither two specs nor none
-        ("foo ^[when='bar baz'] qux", "expected a single spec as the when= condition"),
-        ("foo ^[when=''] qux", "expected a single spec as the when= condition"),
-    ],
-)
-def test_when_edge_attribute_errors(spec_str, expected_in_error):
-    with pytest.raises(SpecParsingError, match=expected_in_error):
-        SpecParser(spec_str).all_specs()
-
-
-def test_when_is_a_variant_name_outside_edge_attributes():
-    spec = spack.spec.Spec("foo when=bar")
-    assert str(spec) == "foo when=bar"
-
-
-@pytest.mark.parametrize(
-    "spec_str",
-    [
-        "foo ^[when='+x' virtuals=c] bar",
-        'foo ^[when="+x" virtuals=c] bar',
-        "foo ^[when='+x']c=bar",
-    ],
-)
-def test_when_edge_attribute_quoted_precedes_other_attributes(spec_str):
-    """A quoted condition is a value like any other edge attribute, so it can come first"""
-    edge = spack.spec.Spec(spec_str).edges_to_dependencies(name="bar")[0]
-    assert edge.when == spack.spec.Spec("+x")
-    assert edge.virtuals == ("c",)
 
 
 @pytest.mark.parametrize(
@@ -2083,12 +2030,10 @@ def test_when_edge_attribute_quoted_precedes_other_attributes(spec_str):
         ("foo ^", "foo ^*"),
         ("pkg-a %*+foo ^*@1.0", "pkg-a %+foo ^@1.0"),
         ("^cflags=-O2", "^* cflags=-O2"),
-        ("^* foo=bar,baz", "^* foo=bar,baz"),
         # a virtual assignment is one token, the node options follow
         ("zlib % c=gcc", "zlib %c=gcc"),
         ("^mpi=intel-parallel-studio+mkl", "^mpi=intel-parallel-studio+mkl"),
         ("%c=builtin.gcc@14", "%c=builtin.gcc@14"),
-        ("%[when=+x] c=gcc", "%[when=+x] c=gcc"),
         # virtuals of an anonymous spec stay in the edge attributes, there is no name to
         # substitute them with
         ("%[virtuals=c] *", "%[virtuals=c] *"),
@@ -2099,8 +2044,15 @@ def test_when_edge_attribute_quoted_precedes_other_attributes(spec_str):
         ("^dev_path=*", "^* dev_path='*'"),
         # a when= value is a spec, which extends to the closing bracket and is printed unquoted
         ("%[when=a=*]", "%[when=a='*'] *"),
-        ("x %[when=a=']'] gcc", "x %[when=a=']'] gcc"),
         ("""x %[when="a=']'"] gcc""", "x %[when=a=']'] gcc"),
+        ("foo ^[when=bar virtuals=c] baz", "foo ^[when=bar virtuals=c] baz"),
+        ("foo when=bar", "foo when=bar"),
+        # a quoted when= is a value like any other, so it can precede other edge attributes
+        ("foo ^[when='+x' virtuals=c] bar", "foo ^[when=+x] c=bar"),
+        ('foo ^[when="+x" virtuals=c] bar', "foo ^[when=+x] c=bar"),
+        ("foo ^[when='+x']c=bar", "foo ^[when=+x] c=bar"),
+        # repeated edge attributes combine: conditions are constrained, like virtuals accumulate
+        ("x ^[when='+a' when='+b'] y", "x ^[when=+a+b] y"),
         ("%[when='@1,2' virtuals=c] *", "%[virtuals=c when=@1:2] *"),
         ("%[virtuals=c when=@1,2] *", "%[virtuals=c when=@1:2] *"),
         ("%[deptypes=build virtuals=c when=@1,2] *", "%[deptypes=build virtuals=c when=@1:2] *"),
@@ -2128,63 +2080,6 @@ def test_spec_str_round_trips(spec_str, expected):
     spec = spack.spec.Spec(spec_str)
     assert str(spec) == expected
     assert spack.spec.Spec(str(spec)) == spec
-
-
-@pytest.mark.parametrize(
-    "spec_str", ["x os='a b'", "x target='x?y'", "x platform=''", "x os=''", "x arch='a b'"]
-)
-def test_architecture_parts_must_be_bare_values(spec_str):
-    """The parts of an architecture print unquoted, so anything that needs quotes cannot
-    round-trip and is rejected"""
-    with pytest.raises(SpecParsingError):
-        spack.spec.Spec(spec_str)
-
-
-@pytest.mark.parametrize("spec_str", ["x namespace=a+b", "x namespace=','", "x namespace=''"])
-def test_namespace_must_be_dotted_identifier(spec_str):
-    """A namespace prints as a prefix of the package name, so anything else cannot round-trip"""
-    with pytest.raises(SpecParsingError):
-        spack.spec.Spec(spec_str)
-
-
-@pytest.mark.parametrize(
-    "spec_str", ["x ~os", "x ~platform", "x ~target", "x ~namespace", "x +os"]
-)
-def test_bool_variant_form_of_string_attributes_raises(spec_str):
-    """The parts of an architecture and the namespace have a string value, like ``arch`` itself,
-    so the bool variant form is an error rather than silently dropped"""
-    with pytest.raises(SpecParsingError):
-        spack.spec.Spec(spec_str)
-
-
-def test_duplicate_when_edge_attribute_constrains():
-    """Repeated edge attributes combine: virtuals accumulate, deptypes are or-ed, and conditions
-    are constrained, rather than the last one silently replacing the others"""
-    edge = spack.spec.Spec("x ^[when='+a' when='+b'] y").edges_to_dependencies(name="y")[0]
-    assert edge.when == spack.spec.Spec("+a+b")
-
-
-@pytest.mark.parametrize("spec_str", ["x @=1:2", "x @1:=2"])
-def test_exact_version_in_range_is_a_syntax_error(spec_str):
-    """``=`` marks an exact version, which cannot be a bound of a range: that is a syntax error
-    of the spec, not a ValueError from the version list"""
-    with pytest.raises(spack.error.SpecSyntaxError):
-        spack.spec.Spec(spec_str)
-
-
-@pytest.mark.parametrize(
-    "spec_str,expected_in_error",
-    [
-        ("c,cxx=gcc", "virtual assignment"),
-        ("zlib c,cxx=gcc", "virtual assignment"),
-        ("zlib %[c=gcc]", "edge attributes"),
-        # regression: an unconsumed token used to make the parser loop forever
-        ("zlib ]", "unexpected token"),
-    ],
-)
-def test_misplaced_tokens_raise(spec_str, expected_in_error):
-    with pytest.raises(SpecParsingError, match=expected_in_error):
-        spack.spec_parser.parse(spec_str)
 
 
 @pytest.mark.regression("52375")

--- a/lib/spack/spack/test/spec_syntax.py
+++ b/lib/spack/spack/test/spec_syntax.py
@@ -1276,6 +1276,9 @@ def test_parse_multiple_specs(text, tokens, expected_specs):
         # A closing bracket ends the edge attribute list, it is never part of the value
         (["mpileaks", "%[", "when=@1.0]", "gcc"], "mpileaks %[when='@1.0'] gcc"),
         (["mpileaks", "%[when=+x]", "c=gcc"], "mpileaks %[when='+x'] c=gcc"),
+        # a value that parses as it is stays unquoted: c=gcc@14 is a virtual assignment
+        (["mpileaks", "%[when=+x]", "c=gcc@14"], "mpileaks %[when='+x'] c=gcc@14"),
+        (["mpileaks", "%c=gcc@14"], "mpileaks %c=gcc@14"),
         (["mpileaks", "%c,cxx=gcc"], "mpileaks %c,cxx=gcc"),
         # Ensure that passing escaped quotes on the CLI raises a tokenization error
         (["zlib", '"-g', '-O2"'], SpecTokenizationError),

--- a/lib/spack/spack/test/spec_syntax.py
+++ b/lib/spack/spack/test/spec_syntax.py
@@ -1247,6 +1247,22 @@ def test_parse_multiple_specs(text, tokens, expected_specs):
         (["zlib", "ldflags=-Wl,-rpath=$ORIGIN/_libs"], "zlib ldflags='-Wl,-rpath=$ORIGIN/_libs'"),
         # A closing bracket ends the edge attribute list, it is never part of the value
         (["mpileaks", "%[", "when=@1.0]", "gcc"], "mpileaks %[when=@1.0] gcc"),
+        # but a bracket that has its opening one in the value is part of the value
+        (["zlib", "cflags=-DFOO=[1]"], "zlib cflags='-DFOO=[1]'"),
+        (["zlib", "cflags=-DX=']'"], "zlib cflags=\"-DX=']'\""),
+        # what follows the closing bracket is the dependency, and not part of the value either
+        (["x", "%[virtuals=c", "deptypes=build]gcc@14"], "x %[deptypes=build] c=gcc@14"),
+        (
+            ["x", "%[virtuals=c", "when=+a]gcc", "^[virtuals=mpi", "when=~b]mpich"],
+            "x %[when=+a] c=gcc ^[when=~b] mpi=mpich",
+        ),
+        # a when= value is a spec, which is not quoted even if it starts with a non-value character
+        (["x", "%[virtuals=c", "when=@1.0", "+debug]", "gcc"], "x %[when=@1.0+debug] c=gcc"),
+        # a value that is still quoted is left alone, the user quoted the whole argument
+        (["x", "cflags=' a b'"], "x cflags='a b'"),
+        # the limit: a when= condition with a quoted value only tokenizes inside brackets, so as
+        # one argument it is quoted as a whole and its bracket ends up in the condition
+        (["x", "%[virtuals=c", "when=a=']']", "gcc"], SpecParsingError),
         # a value that parses as it is stays unquoted: c=gcc@14 is a virtual assignment
         (["mpileaks", "%[when=+x]", "c=gcc@14"], "mpileaks %[when=+x] c=gcc@14"),
         # Ensure that passing escaped quotes on the CLI raises a tokenization error

--- a/lib/spack/spack/test/spec_syntax.py
+++ b/lib/spack/spack/test/spec_syntax.py
@@ -1023,7 +1023,7 @@ def specfile_for(config, mock_packages):
                 Token("END_EDGE_PROPERTIES", "]"),
                 Token("UNQUALIFIED_PACKAGE_NAME", "gcc"),
             ],
-            "foo ^[when='%c'] c=gcc",
+            "foo ^[when=%c] c=gcc",
         ),
         (
             "foo ^[when='%c' virtuals=c]gcc",
@@ -1035,14 +1035,14 @@ def specfile_for(config, mock_packages):
                 Token("END_EDGE_PROPERTIES", "]"),
                 Token("UNQUALIFIED_PACKAGE_NAME", "gcc"),
             ],
-            "foo ^[when='%c'] c=gcc",
+            "foo ^[when=%c] c=gcc",
         ),
         (
-            "foo ^[when='%c'] c=gcc",
+            "foo ^[when=%c] c=gcc",
             [
                 Token("UNQUALIFIED_PACKAGE_NAME", "foo"),
                 Token("DEPENDENCY", "^[", edge_bracket="["),
-                Token("KEY_VALUE_PAIR", "when='%c'", kv_name="when", kv_sep="=", kv_value="'%c'"),
+                Token("KEY_VALUE_PAIR", "when=%c", kv_name="when", kv_sep="=", kv_value="%c"),
                 Token(
                     "END_EDGE_PROPERTIES",
                     "] c=gcc",
@@ -1050,7 +1050,7 @@ def specfile_for(config, mock_packages):
                     end_edge_substitute="gcc",
                 ),
             ],
-            "foo ^[when='%c'] c=gcc",
+            "foo ^[when=%c] c=gcc",
         ),
         # Test dependency propagation
         (
@@ -1071,11 +1071,11 @@ def specfile_for(config, mock_packages):
             "foo %%c,cxx=gcc",
         ),
         (
-            "foo %%[when='%c'] c=gcc",
+            "foo %%[when=%c] c=gcc",
             [
                 Token("UNQUALIFIED_PACKAGE_NAME", "foo"),
                 Token("DEPENDENCY", "%%[", edge_bracket="["),
-                Token("KEY_VALUE_PAIR", "when='%c'", kv_name="when", kv_sep="=", kv_value="'%c'"),
+                Token("KEY_VALUE_PAIR", "when=%c", kv_name="when", kv_sep="=", kv_value="%c"),
                 Token(
                     "END_EDGE_PROPERTIES",
                     "] c=gcc",
@@ -1083,7 +1083,7 @@ def specfile_for(config, mock_packages):
                     end_edge_substitute="gcc",
                 ),
             ],
-            "foo %%[when='%c'] c=gcc",
+            "foo %%[when=%c] c=gcc",
         ),
         (
             "foo %%[when='%c' virtuals=c] gcc",
@@ -1095,7 +1095,7 @@ def specfile_for(config, mock_packages):
                 Token("END_EDGE_PROPERTIES", "]"),
                 Token("UNQUALIFIED_PACKAGE_NAME", "gcc"),
             ],
-            "foo %%[when='%c'] c=gcc",
+            "foo %%[when=%c] c=gcc",
         ),
         # whitespace between a dependency sigil or edge properties and a virtual assignment
         (
@@ -1107,11 +1107,11 @@ def specfile_for(config, mock_packages):
             "zlib %c=gcc",
         ),
         (
-            "foo ^[when='%c']   c,cxx=builtin.gcc@14+bar",
+            "foo ^[when=%c]   c,cxx=builtin.gcc@14+bar",
             [
                 Token("UNQUALIFIED_PACKAGE_NAME", value="foo"),
                 Token("DEPENDENCY", value="^[", edge_bracket="["),
-                Token("KEY_VALUE_PAIR", "when='%c'", kv_name="when", kv_sep="=", kv_value="'%c'"),
+                Token("KEY_VALUE_PAIR", "when=%c", kv_name="when", kv_sep="=", kv_value="%c"),
                 Token(
                     "END_EDGE_PROPERTIES",
                     "]   c,cxx=builtin.gcc",
@@ -1121,7 +1121,7 @@ def specfile_for(config, mock_packages):
                 Token("VERSION", value="@14", version_list="14"),
                 Token("BOOL_VARIANT", value="+bar", bv_prefix="+", bv_name="bar"),
             ],
-            "foo ^[when='%c'] c,cxx=builtin.gcc@14+bar",
+            "foo ^[when=%c] c,cxx=builtin.gcc@14+bar",
         ),
         # a value that is not a package name is a variant of an anonymous dependency
         (
@@ -1276,10 +1276,10 @@ def test_parse_multiple_specs(text, tokens, expected_specs):
         # Ensure that $ORIGIN is handled correctly
         (["zlib", "ldflags=-Wl,-rpath=$ORIGIN/_libs"], "zlib ldflags='-Wl,-rpath=$ORIGIN/_libs'"),
         # A closing bracket ends the edge attribute list, it is never part of the value
-        (["mpileaks", "%[", "when=@1.0]", "gcc"], "mpileaks %[when='@1.0'] gcc"),
-        (["mpileaks", "%[when=+x]", "c=gcc"], "mpileaks %[when='+x'] c=gcc"),
+        (["mpileaks", "%[", "when=@1.0]", "gcc"], "mpileaks %[when=@1.0] gcc"),
+        (["mpileaks", "%[when=+x]", "c=gcc"], "mpileaks %[when=+x] c=gcc"),
         # a value that parses as it is stays unquoted: c=gcc@14 is a virtual assignment
-        (["mpileaks", "%[when=+x]", "c=gcc@14"], "mpileaks %[when='+x'] c=gcc@14"),
+        (["mpileaks", "%[when=+x]", "c=gcc@14"], "mpileaks %[when=+x] c=gcc@14"),
         (["mpileaks", "%c=gcc@14"], "mpileaks %c=gcc@14"),
         (["mpileaks", "%c,cxx=gcc"], "mpileaks %c,cxx=gcc"),
         # Ensure that passing escaped quotes on the CLI raises a tokenization error
@@ -1303,28 +1303,28 @@ def test_cli_spec_roundtrip(args, expected):
         (
             "foo%my_toolchain",
             {"my_toolchain": "%[when='%c' virtuals=c]gcc"},
-            ["foo %[when='%c'] c=gcc"],
+            ["foo %[when=%c] c=gcc"],
         ),
-        ("foo%my_toolchain", {"my_toolchain": "%[when='%c'] c=gcc"}, ["foo %[when='%c'] c=gcc"]),
+        ("foo%my_toolchain", {"my_toolchain": "%[when=%c] c=gcc"}, ["foo %[when=%c] c=gcc"]),
         (
             "foo%my_toolchain",
             {"my_toolchain": "+bar cflags=baz %[when='%c' virtuals=c]gcc"},
-            ["foo cflags=baz +bar %[when='%c'] c=gcc"],
+            ["foo cflags=baz +bar %[when=%c] c=gcc"],
         ),
         (
             "foo%my_toolchain",
-            {"my_toolchain": "+bar cflags=baz %[when='%c']c=gcc"},
-            ["foo cflags=baz +bar %[when='%c'] c=gcc"],
+            {"my_toolchain": "+bar cflags=baz %[when=%c]c=gcc"},
+            ["foo cflags=baz +bar %[when=%c] c=gcc"],
         ),
         (
             "foo%my_toolchain2",
             {"my_toolchain2": "%[when='%c' virtuals=c]gcc %[when='+mpi' virtuals=mpi]mpich"},
-            ["foo %[when='%c'] c=gcc %[when='+mpi'] mpi=mpich"],
+            ["foo %[when=%c] c=gcc %[when=+mpi] mpi=mpich"],
         ),
         (
             "foo%my_toolchain2",
-            {"my_toolchain2": "%[when='%c'] c=gcc %[when='+mpi'] mpi=mpich"},
-            ["foo %[when='%c'] c=gcc %[when='+mpi'] mpi=mpich"],
+            {"my_toolchain2": "%[when=%c] c=gcc %[when=+mpi] mpi=mpich"},
+            ["foo %[when=%c] c=gcc %[when=+mpi] mpi=mpich"],
         ),
         (
             "foo%my_toolchain bar%my_toolchain2",
@@ -1332,15 +1332,15 @@ def test_cli_spec_roundtrip(args, expected):
                 "my_toolchain": "%[when='%c' virtuals=c]gcc",
                 "my_toolchain2": "%[when='%c' virtuals=c]gcc %[when='+mpi' virtuals=mpi]mpich",
             },
-            ["foo %[when='%c'] c=gcc", "bar %[when='%c'] c=gcc %[when='+mpi'] mpi=mpich"],
+            ["foo %[when=%c] c=gcc", "bar %[when=%c] c=gcc %[when=+mpi] mpi=mpich"],
         ),
         (
             "foo%my_toolchain bar%my_toolchain2",
             {
-                "my_toolchain": "%[when='%c'] c=gcc",
-                "my_toolchain2": "%[when='%c'] c=gcc %[when='+mpi']mpi=mpich",
+                "my_toolchain": "%[when=%c] c=gcc",
+                "my_toolchain2": "%[when=%c] c=gcc %[when=+mpi]mpi=mpich",
             },
-            ["foo %[when='%c'] c=gcc", "bar %[when='%c'] c=gcc %[when='+mpi'] mpi=mpich"],
+            ["foo %[when=%c] c=gcc", "bar %[when=%c] c=gcc %[when=+mpi] mpi=mpich"],
         ),
         (
             "foo%my_toolchain2",
@@ -1350,7 +1350,7 @@ def test_cli_spec_roundtrip(args, expected):
                     {"spec": "%[virtuals=mpi]mpich", "when": "+mpi"},
                 ]
             },
-            ["foo %[when='%c'] c=gcc %[when='+mpi'] mpi=mpich"],
+            ["foo %[when=%c] c=gcc %[when=+mpi] mpi=mpich"],
         ),
         (
             "foo%my_toolchain2",
@@ -1360,17 +1360,17 @@ def test_cli_spec_roundtrip(args, expected):
                     {"spec": "%mpi=mpich", "when": "+mpi"},
                 ]
             },
-            ["foo %[when='%c'] c=gcc %[when='+mpi'] mpi=mpich"],
+            ["foo %[when=%c] c=gcc %[when=+mpi] mpi=mpich"],
         ),
         (
             "foo%my_toolchain2",
             {"my_toolchain2": [{"spec": "%[virtuals=c]gcc %[virtuals=mpi]mpich", "when": "%c"}]},
-            ["foo %[when='%c'] c=gcc %[when='%c'] mpi=mpich"],
+            ["foo %[when=%c] c=gcc %[when=%c] mpi=mpich"],
         ),
         (
             "foo%my_toolchain2",
             {"my_toolchain2": [{"spec": "%c=gcc %mpi=mpich", "when": "%c"}]},
-            ["foo %[when='%c'] c=gcc %[when='%c'] mpi=mpich"],
+            ["foo %[when=%c] c=gcc %[when=%c] mpi=mpich"],
         ),
         # Test that we don't get caching wrong in the parser
         (
@@ -1382,8 +1382,8 @@ def test_cli_spec_roundtrip(args, expected):
                 ]
             },
             [
-                "foo %[when='%c'] c=gcc %[when='%mpi'] mpi=mpich "
-                "^bar %[when='%c'] c=gcc %[when='%mpi'] mpi=mpich"
+                "foo %[when=%c] c=gcc %[when=%mpi] mpi=mpich "
+                "^bar %[when=%c] c=gcc %[when=%mpi] mpi=mpich"
             ],
         ),
         (
@@ -1395,8 +1395,8 @@ def test_cli_spec_roundtrip(args, expected):
                 ]
             },
             [
-                "foo %[when='%c'] c=gcc %[when='%mpi'] mpi=mpich "
-                "^bar %[when='%c'] c=gcc %[when='%mpi'] mpi=mpich"
+                "foo %[when=%c] c=gcc %[when=%mpi] mpi=mpich "
+                "^bar %[when=%c] c=gcc %[when=%mpi] mpi=mpich"
             ],
         ),
     ],
@@ -2016,10 +2016,58 @@ def test_parse_multiple_edge_attributes(input_args, expected):
 
 
 def test_when_edge_attribute_keeps_commas():
-    """A when value is one spec string, where a comma is part of the syntax, unlike the
+    """A when value is one spec, where a comma is part of the syntax, unlike the
     comma-separated deptypes and virtuals lists."""
     edge = spack.spec.Spec("foo ^[when='@1,2'] bar").edges_to_dependencies(name="bar")[0]
     assert edge.when == spack.spec.Spec("@1,2")
+    edge = spack.spec.Spec("foo ^[when=@1,2] bar").edges_to_dependencies(name="bar")[0]
+    assert edge.when == spack.spec.Spec("@1,2")
+
+
+def test_when_edge_attribute_extends_to_closing_bracket():
+    """The when condition is a spec that extends up to the closing bracket: what follows it are
+    node options of the condition, not further edge attributes."""
+    edge = spack.spec.Spec("foo ^[when=bar virtuals=c] baz").edges_to_dependencies(name="baz")[0]
+    assert edge.when == spack.spec.Spec("bar virtuals=c")
+    assert edge.virtuals == ()
+
+    edge = spack.spec.Spec("foo ^[virtuals=c when=bar] baz").edges_to_dependencies(name="baz")[0]
+    assert edge.when == spack.spec.Spec("bar")
+    assert edge.virtuals == ("c",)
+
+
+@pytest.mark.parametrize(
+    "spec_str,expected_in_error",
+    [
+        ("foo ^[when=] bar", "expected a spec after when="),
+        ("foo ^[when=", "expected a spec after when="),
+        ("foo ^[when=bar baz] qux", "unexpected token in edge attributes"),
+        ("foo ^[when=bar ^baz", "unexpected token in edge attributes"),
+    ],
+)
+def test_when_edge_attribute_errors(spec_str, expected_in_error):
+    with pytest.raises(SpecParsingError, match=expected_in_error):
+        SpecParser(spec_str).all_specs()
+
+
+def test_when_is_a_variant_name_outside_edge_attributes():
+    spec = spack.spec.Spec("foo when=bar")
+    assert str(spec) == "foo when=bar"
+
+
+@pytest.mark.parametrize(
+    "spec_str",
+    [
+        "foo ^[when='+x' virtuals=c] bar",
+        'foo ^[when="+x" virtuals=c] bar',
+        "foo ^[when='+x']c=bar",
+    ],
+)
+def test_when_edge_attribute_quoted_precedes_other_attributes(spec_str):
+    """A quoted condition is a value like any other edge attribute, so it can come first"""
+    edge = spack.spec.Spec(spec_str).edges_to_dependencies(name="bar")[0]
+    assert edge.when == spack.spec.Spec("+x")
+    assert edge.virtuals == ("c",)
 
 
 @pytest.mark.parametrize(
@@ -2037,7 +2085,7 @@ def test_when_edge_attribute_keeps_commas():
         ("zlib % c=gcc", "zlib %c=gcc"),
         ("^mpi=intel-parallel-studio+mkl", "^mpi=intel-parallel-studio+mkl"),
         ("%c=builtin.gcc@14", "%c=builtin.gcc@14"),
-        ("%[when=+x] c=gcc", "%[when='+x'] c=gcc"),
+        ("%[when=+x] c=gcc", "%[when=+x] c=gcc"),
         # virtuals of an anonymous spec stay in the edge attributes, there is no name to
         # substitute them with
         ("%[virtuals=c] *", "%[virtuals=c] *"),
@@ -2046,10 +2094,14 @@ def test_when_edge_attribute_keeps_commas():
         ("%[virtuals=c] *@4.0 foo=bar", "%[virtuals=c] @4.0 foo=bar"),
         # a star is a package name, so name=* is a variant value, not a substitute
         ("^dev_path=*", "^* dev_path='*'"),
-        # a when= value is a spec, whose own quotes cannot be nested in a quoted value
-        ('%[when="a=*"]', "%[when=a='*'] *"),
+        # a when= value is a spec, which extends to the closing bracket and is printed unquoted
+        ("%[when=a=*]", "%[when=a='*'] *"),
+        ("x %[when=a=']'] gcc", "x %[when=a=']'] gcc"),
         ("""x %[when="a=']'"] gcc""", "x %[when=a=']'] gcc"),
         ("%[when='@1,2' virtuals=c] *", "%[virtuals=c when=@1:2] *"),
+        ("%[virtuals=c when=@1,2] *", "%[virtuals=c when=@1:2] *"),
+        ("%[deptypes=build virtuals=c when=@1,2] *", "%[deptypes=build virtuals=c when=@1:2] *"),
+        ("x %[when=%c=gcc] y", "x %[when=%c=gcc] y"),
         # a version bound is never truncated at a "." to make room for a key=value pair
         ("@:a.a=''", "a.a=''"),
         ("@1.2:2.0=x", "@1.2: 2.0=x"),

--- a/lib/spack/spack/test/spec_syntax.py
+++ b/lib/spack/spack/test/spec_syntax.py
@@ -2043,6 +2043,9 @@ def test_when_edge_attribute_extends_to_closing_bracket():
         ("foo ^[when=", "expected a spec after when="),
         ("foo ^[when=bar baz] qux", "unexpected token in edge attributes"),
         ("foo ^[when=bar ^baz", "unexpected token in edge attributes"),
+        # a quoted condition is a single spec: neither two specs nor none
+        ("foo ^[when='bar baz'] qux", "expected a single spec as the when= condition"),
+        ("foo ^[when=''] qux", "expected a single spec as the when= condition"),
     ],
 )
 def test_when_edge_attribute_errors(spec_str, expected_in_error):


### PR DESCRIPTION
This PR fixes `str(Spec(<str>))` round-trip issues of abstract specs found by a grammar-based fuzzer, and changes the spec syntax in two places so that every spec has a string that parses back:

* `[when=<spec>]` takes an unquoted spec that extends up to the closing bracket, so a condition never needs nested quotes.
* Quoted values are literal: so no escaping with `\`.

Performance is identical to `develop` (https://github.com/spack/spack/pull/51836#issuecomment-4960953899). Multiple blocks of edge properties, `%[virtuals=c] [when=...] gcc`, are out of scope; #52977 adds a second edge property with a spec value, so `[when=<spec>] [usage=<spec>]` could be a solution there.

### Spec strings

| input | `develop` | this PR |
| --- | --- | --- |
| `a=']'` | `a=]`, unparseable | `a=']'` |
| `%[virtuals=c] *` | `%*c=`, unparseable | `%[virtuals=c] *` |
| `@:a.a=''` | `@:a. a=''` | `a.a=''` |
| `str(edge)` of `x ^* foo=bar` | `x ^foo=bar`, a virtual assignment | `x ^* foo=bar` |
| `^foo=bar:baz`, `^foo=bar=baz`, `%x=y~` | tokenization error | `^* foo='bar:baz'`, ... |
| `zlib %c=gcc gcc` | one spec, the dependency renamed `gcc` | two specs |
| `zlib ]` | hangs forever | parse error |
| `x ^[virtuals=c` | edge to an empty node | parse error |
| `zlib c,cxx=gcc` | "unexpected characters" at the comma | error naming the misplaced virtual assignment |
| `x os='a b'`, `x target=''`, `x namespace=a+b` | `x os=a b`, `x`, `a+b.x` | parse error |
| `x ~os` | `x` | parse error |
| `x @=1:2` | `ValueError` from `VersionList` | parse error |
| `x ^[when='+a' when='+b'] y` | condition `+b` | condition `+a+b` |
| `x ^[when='a b'] y` | condition `a`, `b` dropped | parse error |
| `%[when="a=*"]` | `%[when='a='*''] *`, unparseable | `%[when=a='*'] *` |
| `a='x\' b='y'` | parse error, `\'` swallows up to the next quote | `a='x\' b=y` |
| `a="it's\"` | `a="it's\\"`, doubling on every round-trip | `a="it's\"` |
| `a="café's"`, `a="x'<TAB>y"` | `\u00e9`, `\t`, read back as literals | unchanged |

### Command line

The shell strips quotes and splits on whitespace, and `quote_kvp()` puts quotes back around the value of a `name=value` argument. It now does so only if the tokenizer cannot read the argument as it is, i.e. it has unexpected characters or whitespace between tokens.

| typed in the shell | `develop` | this PR |
| --- | --- | --- |
| `%[when=+x] c=gcc@14` | `c='gcc@14'`, a variant | `c=gcc@14`, a virtual assignment |
| `%[virtuals=c when=@1.0 +debug] gcc` | `when='@1.0'`, then `+debug` is an unknown edge attribute | condition `@1.0+debug` |
| `"cflags=' a b'"` | `cflags="' a b'"`, quotes in the flags | `cflags='a b'` |
| `cflags=-DCHAR=\'x\'` | the compiler gets `-DCHAR=\\'x\\'` | `-DCHAR=\'x\'` |
| `cflags='-O3 -g' "+bar baz"` | `cflags="'-O3 -g' \"+bar baz\""` | error: a value cannot contain both kinds of quotes |
| `"%[virtuals=c" "when=a=']']" gcc` | error | error: a `when=` with a quoted value only tokenizes inside brackets |

### Any spec in `when=`

`when=` used to be a quoted value like any other, `%[when='+x'] gcc`, so a condition with a quoted value in it had to nest quotes and escape: `%[when="a='*'"] x`. Now an unquoted `when=` is parsed as a spec up to the closing bracket, which makes it the last edge attribute:

```
edge_properties = [ { key_value | when=quoted_spec } [ when=spec ] ]
```

`[when=foo virtuals=c]` is a condition `foo virtuals=c`, `[virtuals=c when=foo]` is two attributes, and the quoted form `[when='+mpi' virtuals=mpi]` still works and is the way to put a condition first. Since `when=+x` tokenizes as a key-value pair, `when` stays a variant name outside edge attributes; the edge attribute parser restarts the scanner at the value and recurses into `next_spec()`, and a `WHEN` token covers `when=` before a character that cannot start a value, e.g. `when=@1.2`. `str()` prints `deptypes`, `virtuals`, then `when=<spec>` unquoted.

### Literal quoted values

#41529 set out to "allow any character to appear in the quoted values of variants and flags", treating quotes inside a value as content; it also let the tokenizer accept `\'` and `\"`. #48063 then made the formatter `json.dumps()` a value containing a single quote, which escapes `\\`, control characters and non-ASCII, none of which the parser ever decoded, so such values changed on every round-trip (table above). No spec string in the builtin repository uses an escaped quote.

Now a quoted value is anything up to the next quote of the same kind, a value with one kind of quote is printed with the other, and a value with both kinds cannot be written in a spec string: `quote_if_needed()` raises. That is the only input that worked before and does not now, and it fails loudly instead of corrupting the value.

### Behaviour changes

- An unquoted `when=` extends to the closing bracket: `%[when=+x virtuals=c] gcc` is a condition `+x virtuals=c`. Write `%[virtuals=c when=+x] gcc` or `%[when='+x' virtuals=c] gcc`. No package in the builtin repository uses `[when=` in a spec string.
- A value with both kinds of quotes is an error, also on the command line: the command line must not express more than a spec string in `spack.yaml` or a `depends_on()` can.
- `str()` of an anonymous dependency with a key-value variant is `^* foo=bar` instead of `^*foo=bar`; both parse.
