### PR TITLE
externals: use variant values allowed by the external version

### DIFF
--- a/lib/spack/spack/externals.py
+++ b/lib/spack/spack/externals.py
@@ -116,7 +116,9 @@ def complete_variants_and_architecture(node: spack.spec.Spec) -> None:
     """Completes a node with variants and architecture information.
 
     Architecture is completed first, delegating to ``complete_architecture``.
-    Variants are then added to the node, using their default value.
+    Variants are then added to the node, using their default value where possible.
+    For conditional variant values, the evaluation is greedy and may currently fail if the
+    conditional value is gated on another variant.
     """
     complete_architecture(node)
     pkg_class = spack.repo.PATH.get_pkg_class(node.name)

--- a/lib/spack/spack/externals.py
+++ b/lib/spack/spack/externals.py
@@ -18,7 +18,7 @@ into the intermediate representation.
 import re
 import uuid
 import warnings
-from typing import Any, Callable, Dict, List, NamedTuple, Tuple, Union
+from typing import Any, Callable, Dict, List, NamedTuple, Optional, Tuple, Union
 
 from spack.vendor.typing_extensions import TypedDict
 
@@ -26,6 +26,7 @@ import spack.archspec
 import spack.deptypes
 import spack.repo
 import spack.spec
+import spack.variant as vt
 from spack.error import SpackError
 from spack.util import tty
 
@@ -93,6 +94,24 @@ def complete_architecture(node: spack.spec.Spec) -> None:
         node.compiler_flags.setdefault(flag_type, [])
 
 
+def _default_variant_value(node: spack.spec.Spec, vdef: vt.Variant) -> Optional[vt.VariantValue]:
+    """Returns the default value of a variant definition, restricted to the values that are
+    available for this node, or None if no value is available.
+    """
+    default, available = vdef.make_default(), vdef.possible_values(when=node)
+    if available is None:
+        return default
+
+    selected = tuple(value for value in default.values if value in available)
+    if len(selected) == len(default.values):
+        return default
+    elif selected:
+        return vdef.make_variant(*selected)
+    elif vdef.multi or not available:
+        return None
+    return vdef.make_variant(available[0])
+
+
 def complete_variants_and_architecture(node: spack.spec.Spec) -> None:
     """Completes a node with variants and architecture information.
 
@@ -114,8 +133,11 @@ def complete_variants_and_architecture(node: spack.spec.Spec) -> None:
             variants_dict.pop(when)
             for name, vdef in variants_by_name.items():
                 if name not in node.variants:
+                    default = _default_variant_value(node, vdef)
+                    if default is None:
+                        continue
                     # Cannot use Spec.constrain, because we lose information on the variant type
-                    node.variants[name] = vdef.make_default()
+                    node.variants[name] = default
                 elif (
                     node.variants[name].type != vdef.variant_type
                     and len(node.variants[name].values) == 1

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -1642,13 +1642,14 @@ class SpackSolverSetup:
                 # the conditional value is always "possible", but it imposes its when condition as
                 # a constraint if the conditional value is taken. This may seem backwards, but it
                 # ensures that the conditional can only occur when its condition holds.
-                self.condition(
+                condition_id = self.condition(
                     required_spec=variant_has_value,
                     imposed_spec=value.when,
                     required_name=pkg.name,
                     imposed_name=pkg.name,
                     msg=f"{pkg.name} variant {name} has value '{value.value}' when {value.when}",
                 )
+                pkg_fact(fn.conditional_value_condition(condition_id))
             else:
                 vstring = f"{name}='{value.value}'"
 

--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -1598,6 +1598,13 @@ error(10, "'Spec({1}={2})' is not a valid value for '{0}' variant '{1}'", Packag
     not variant_possible_value(node(ID, Package), Variant, Value),
     build(node(ID, Package)).
 
+% Taking a conditional value imposes the condition attached to it.
+% The condition should not be imposed on concrete packages.
+do_not_impose(EffectID, node(ID, Package))
+  :- pkg_fact(Package, conditional_value_condition(ConditionID)),
+     pkg_fact(Package, condition_effect(ConditionID, EffectID)),
+     concrete(node(ID, Package)).
+
 % Some multi valued variants accept multiple values from disjoint sets. Ensure that we
 % respect that constraint and we don't pick values from more than one set at once
 error(100, "{0} variant '{1}' cannot have values '{2}' and '{3}' as they come from disjoint value sets", Package, Variant, Value1, Value2)

--- a/lib/spack/spack/test/externals.py
+++ b/lib/spack/spack/test/externals.py
@@ -468,3 +468,22 @@ def test_external_with_unavailable_default_value_is_usable(mutable_config: Confi
     assert s.external
     assert s.satisfies("build_system=mock_autotools")
     assert s.satisfies("flavor=old")
+
+
+@pytest.mark.regression("52943")
+def test_external_with_value_conditional_on_another_version(mutable_config: Configuration):
+    """Tests that an external declared with a variant value that is conditional on a version the
+    external doesn't have is still used, since the external spec is concrete.
+    """
+    packages_config = {
+        "conditional-build-system": {
+            # 'flavor=new' is declared 'when="@2:"', so it is not available at v1.0
+            "externals": [{"spec": "conditional-build-system@1.0 flavor=new", "prefix": "/usr"}],
+            "buildable": False,
+        }
+    }
+    with mutable_config.override("packages", packages_config):
+        s = spack.concretize.concretize_one("conditional-build-system@1.0")
+
+    assert s.external
+    assert s.satisfies("flavor=new")

--- a/lib/spack/spack/test/externals.py
+++ b/lib/spack/spack/test/externals.py
@@ -8,6 +8,7 @@ import pytest
 from spack.vendor.archspec.cpu import TARGETS
 
 import spack.archspec
+import spack.concretize
 import spack.traverse
 from spack.compilers.config import CompilerFactory
 from spack.config import Configuration
@@ -407,3 +408,63 @@ def test_external_compiler_with_non_compiler_dependency(mutable_config: Configur
             if c.name == "compiler-with-deps":
                 assert c.external
                 assert c["binutils-for-test"].external
+
+
+@pytest.mark.regression("52943")
+@pytest.mark.parametrize(
+    "external_spec,expected,not_expected",
+    [
+        # The declared defaults, 'mock_cmake' and 'new', are available on this version
+        (
+            "conditional-build-system@2.0",
+            ["build_system=mock_cmake", "flavor=new"],
+            ["build_system=mock_autotools", "flavor=old", "+static", "~static"],
+        ),
+        # The declared defaults are not available on this version
+        (
+            "conditional-build-system@1.0",
+            ["build_system=mock_autotools", "flavor=old", "~static"],
+            ["build_system=mock_cmake", "flavor=new"],
+        ),
+        # A value given by the user is never overridden
+        (
+            "conditional-build-system@1.0 flavor=old",
+            ["build_system=mock_autotools", "flavor=old"],
+            ["flavor=new"],
+        ),
+    ],
+)
+def test_external_completion_skips_unavailable_default_values(
+    config, external_spec, expected, not_expected
+):
+    """Tests that completing an external spec doesn't use variant values that are conditional on
+    a version the external doesn't have.
+    """
+    externals_dict: List[ExternalDict] = [{"spec": external_spec, "prefix": "/usr"}]
+    parser = ExternalSpecsParser(externals_dict, complete_node=complete_variants_and_architecture)
+
+    specs = parser.all_specs()
+    assert len(specs) == 1
+    for constraint in expected:
+        assert specs[0].satisfies(constraint), f"{specs[0]} does not satisfy {constraint}"
+    for constraint in not_expected:
+        assert not specs[0].satisfies(constraint), f"{specs[0]} satisfies {constraint}"
+
+
+@pytest.mark.regression("52943")
+def test_external_with_unavailable_default_value_is_usable(mutable_config: Configuration):
+    """Tests that an external can be used when the default value of one of its variants is
+    conditional on a version the external doesn't have.
+    """
+    packages_config = {
+        "conditional-build-system": {
+            "externals": [{"spec": "conditional-build-system@1.0", "prefix": "/usr"}],
+            "buildable": False,
+        }
+    }
+    with mutable_config.override("packages", packages_config):
+        s = spack.concretize.concretize_one("conditional-build-system@1.0")
+
+    assert s.external
+    assert s.satisfies("build_system=mock_autotools")
+    assert s.satisfies("flavor=old")

--- a/lib/spack/spack/test/variant.py
+++ b/lib/spack/spack/test/variant.py
@@ -13,6 +13,7 @@ from spack.repo import RepoPath
 from spack.spec import Spec, VariantMap
 from spack.variant import (
     BoolValuedVariant,
+    ConditionalValue,
     DuplicateVariantError,
     InconsistentValidationError,
     InvalidVariantValueError,
@@ -913,3 +914,36 @@ def test_constrain_narrowing():
     s.constrain("+foo")
     assert s.variants["foo"].type == spack.variant.VariantType.BOOL
     assert s.variants["foo"].concrete
+
+
+@pytest.mark.parametrize(
+    "when,expected",
+    [
+        # No constraint: every value that is not statically disabled
+        (None, ("always", "old", "new")),
+        # Constraints selecting one of the two conditional values
+        (Spec("@1.0"), ("always", "old")),
+        (Spec("@2.0"), ("always", "new")),
+        # A constraint that doesn't decide the condition either way
+        (Spec("+foo"), ("always",)),
+    ],
+)
+def test_possible_values_unwraps_conditional_values(when, expected):
+    vdef = Variant(
+        "flavor",
+        default="new",
+        description="",
+        values=(
+            "always",
+            ConditionalValue("old", when=Spec("@:1")),
+            ConditionalValue("new", when=Spec("@2:")),
+            ConditionalValue("never", when=None),
+        ),
+    )
+    assert vdef.possible_values(when=when) == expected
+
+
+def test_possible_values_when_checked_by_a_validator():
+    vdef = Variant("flavor", default="1", description="", values=int)
+    assert vdef.values_defined_by_validator()
+    assert vdef.possible_values() is None

--- a/lib/spack/spack/variant.py
+++ b/lib/spack/spack/variant.py
@@ -157,6 +157,32 @@ class Variant:
     def values_defined_by_validator(self) -> bool:
         return self.values is None
 
+    def possible_values(
+        self, *, when: Optional["spack.spec.Spec"] = None
+    ) -> Optional["ValueType"]:
+        """Returns the values this variant can take, with conditional values unwrapped.
+
+        Values are returned in the order they are declared in the package. Values that are
+        statically disabled are never returned.
+
+        Args:
+            when: if given, a conditional value is returned only if this spec satisfies the
+                condition attached to it
+
+        Returns:
+            the values, or None if they are checked by a validator instead of being listed
+        """
+        if self.values is None:
+            return None
+
+        result: List[Union[bool, str]] = []
+        for value in self.values:
+            if not isinstance(value, ConditionalValue):
+                result.append(value)
+            elif value.when is not None and (when is None or when.satisfies(value.when)):
+                result.append(value.value)
+        return tuple(result)
+
     def validate_or_raise(self, vspec: "VariantValue", pkg_name: str):
         """Validate a variant spec against this package variant. Raises an
         exception if any error is found.

--- a/var/spack/test_repos/spack_repo/builtin_mock/packages/conditional_build_system/package.py
+++ b/var/spack/test_repos/spack_repo/builtin_mock/packages/conditional_build_system/package.py
@@ -1,0 +1,41 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+from spack_repo.builtin_mock.build_systems.autotools import AutotoolsPackage
+from spack_repo.builtin_mock.build_systems.cmake import CMakePackage
+
+from spack.package import *
+
+
+class ConditionalBuildSystem(AutotoolsPackage, CMakePackage):
+    """Package with two build systems, each available on a different range of versions.
+
+    The default build system is available only on the most recent versions.
+    """
+
+    homepage = "http://www.example.com"
+    url = "http://www.example.com/conditional-build-system-1.0.tar.gz"
+
+    version("2.0")
+    version("1.0")
+
+    build_system(
+        conditional("mock_cmake", when="@2:"),
+        conditional("mock_autotools", when="@:1"),
+        default="mock_cmake",
+    )
+
+    variant(
+        "flavor",
+        default="new",
+        values=(conditional("new", when="@2:"), conditional("old", when="@:1")),
+        multi=False,
+        description="Variant whose default value is not available on all versions",
+    )
+
+    variant(
+        "static",
+        default=False,
+        description="Variant tied to the build system, and not to the version",
+        when="build_system=mock_autotools",
+    )


### PR DESCRIPTION
fixes #52943

**Bugfix 1: better heuristic for completing an external spec**

Completing an external spec used the declared default of every variant, even when that default is a conditional value gated on a version the external does not have.

The default is now restricted to the values available for the node, falling back to the first available value in order of declaration. If no value is available the variant is omitted.

**Bugfix 2: don't reject a concrete spec if it uses a conditional variant value the recipe doesn't allow**

Taking a conditional variant value imposes the value's `when` condition on the node, which is what restricts the value to the versions that allow it. This condition should not be imposed on concrete specs.