### PR TITLE
version: reject ranges whose bounds are one component apart

### DIFF
--- a/lib/spack/spack/test/versions.py
+++ b/lib/spack/spack/test/versions.py
@@ -799,6 +799,10 @@ def test_empty_version_range_raises():
         assert VersionRange("2", "1.0")
     with pytest.raises(EmptyRangeError, match="2:1.0 is an empty range"):
         assert ver("2:1.0")
+    with pytest.raises(EmptyRangeError, match="2:1 is an empty range"):
+        assert ver("2:1")
+    with pytest.raises(EmptyRangeError, match="1.21:1.20 is an empty range"):
+        assert ver("1.21:1.20")
 
 
 def test_version_empty_slice():

--- a/lib/spack/spack/version/version_types.py
+++ b/lib/spack/spack/version/version_types.py
@@ -793,7 +793,7 @@ class ClosedOpenRange(VersionType):
     __slots__ = ("lo", "hi", "_string", "_hash")
 
     def __init__(self, lo: StandardVersion, hi: StandardVersion):
-        if hi < lo:
+        if hi <= lo:
             raise EmptyRangeError(f"{lo}..{hi} is an empty range")
         self.lo: StandardVersion = lo
         self.hi: StandardVersion = hi


### PR DESCRIPTION
`ClosedOpenRange.hi` is the *exclusive* upper bound -- `from_version_range` builds it as `_next_version(hi)` -- so `[lo, hi)` is empty whenever `lo >= hi`, not only when `hi < lo`. The strict `<` accepted the degenerate `lo == hi` case.

That admits inverted ranges of the common `@X.(n+1):X.n` form. On `develop`:

```python
>>> r = ver("2:1"); r.lo, r.hi
(Version('2'), Version('2'))
>>> r.intersects(r), r.satisfies(r)
(False, True)          # does not overlap itself
>>> Version("2") in r
False                  # and contains nothing
```

`zlib@1.21:1.20` parses and matches nothing; the one-character-different `zlib@1.21:1.2` correctly raises.

The `<` looks like a holdover from the pre-0.20 code, where bounds were *inclusive* and it was right (`version.py:740`); that version rejects both cases above. The prefix case its comment protects, `1.2.3:1.2`, is unaffected -- its exclusive `hi` exceeds `lo`. The other two `ClosedOpenRange(...)` sites are safe: `intersection` already guards with `max_lo < min_hi`, and a union of non-empty ranges cannot degenerate.

Narrow scope: across 9,080 `package.py` / 58,812 `@` constraints, **zero** shipped recipes are affected. This is an invariant fix that turns a silently-ignored inverted-bound typo into an error.

`test/versions.py`: 100 passed / 6 failed, identical to pristine `develop` here (the 6 are `ImportError`, no packages repo). Reverting only the source change fails the new assertions.

AI-assisted (claude-opus-5).
