### PR TITLE
Sbang support encodings comments

### DIFF
--- a/bin/sbang
+++ b/bin/sbang
@@ -1,6 +1,7 @@
 #!/bin/sh
 #
-# Copyright sbang project developers. See COPYRIGHT file for details.
+# Copyright 2013-2020 Lawrence Livermore National Security, LLC and other
+# sbang project developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
@@ -20,6 +21,14 @@
 # `sbang` will run the real interpreter with the script as its argument.
 #
 # See https://github.com/spack/sbang for more details.
+#
+# If using python- or ruby- style source code encoding, put that on the second
+# line of the file and the shebang line for the long path to the real
+# interpreter on the third line, like this:
+#
+#     #!/bin/sh /path/to/sbang
+#     # -*- coding: utf-8 -*-
+#     #!/long/path/to/real/interpreter with arguments
 #
 
 # Generic error handling
@@ -45,19 +54,39 @@ elif [ ! -f "$script" ]; then
 fi
 
 # Search the first two lines of script for interpreters.
+# Search the third line if one of the first two is an encoding declaration
 lines=0
 while read -r line && [ $lines -ne 2 ]; do
     if [ "${line#\#!}" != "$line" ]; then
         shebang_line="${line#\#!}"
+        lines=$((lines+1))
     elif [ "${line#//!}" != "$line" ]; then      # // comments
         shebang_line="${line#//!}"
+        lines=$((lines+1))
     elif [ "${line#--!}" != "$line" ]; then      # -- lua comments
         shebang_line="${line#--!}"
+        lines=$((lines+1))
     elif [ "${line#<?php\ }" != "$line" ]; then  # php comments
         shebang_line="${line#<?php\ \#!}"
         shebang_line="${shebang_line%\ ?>}"
+        lines=$((lines+1))
+    else
+        # Check whether this is a python/ruby encoding line
+        # Strip leading whitespace, whitespace is allowed before encoding
+        leading_whitespace=${line%%[![:space:]]*}
+        line=${line#"$leading_whitespace"}
+
+        # encoding declaration starts with comment character
+        if [ "${line#\#}" != "$line" ]; then
+            case "$line" in
+                *"coding:"* | *"coding="*)
+                    ;;  # skip encoding line
+                *)
+                    lines=$((lines+1))
+                    ;;
+            esac
+        fi
     fi
-    lines=$((lines+1))
 done < "$script"
 
 # error if we did not find any interpreter
@@ -77,13 +106,17 @@ EOF
 #
 # will be true for '#!/usr/bin/perl' and '#!/usr/bin/env perl'
 interpreter_is() {
-    if [ "${interpreter##*/}" = "$1" ]; then
-        return 0
-    elif [ "$interpreter" = "/usr/bin/env" ] && [ "$arg1" = "$1" ]; then
-        return 0
-    else
-        return 1
+    case "${interpreter##*/}" in
+        "$1"*) return 0 ;;
+    esac
+
+    if [ "$interpreter" = "/usr/bin/env" ]; then
+        case "$arg1" in
+            "$1"*) return 0 ;;
+        esac
     fi
+
+    return 1
 }
 
 if interpreter_is "sbang"; then

--- a/bin/sbang
+++ b/bin/sbang
@@ -1,7 +1,7 @@
 #!/bin/sh
 #
-# Copyright 2013-2020 Lawrence Livermore National Security, LLC and other
-# sbang project developers. See the top-level COPYRIGHT file for details.
+# Copyright sbang project developers. See the top-level COPYRIGHT file
+# for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 

--- a/bin/sbang
+++ b/bin/sbang
@@ -1,7 +1,6 @@
 #!/bin/sh
 #
-# Copyright sbang project developers. See the top-level COPYRIGHT file
-# for details.
+# Copyright sbang project developers. See COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 

--- a/lib/spack/spack/hooks/sbang.py
+++ b/lib/spack/spack/hooks/sbang.py
@@ -125,6 +125,13 @@ def filter_shebang(path):
         patched = tempfile.NamedTemporaryFile("wb", delete=False)
         patched.write(new_sbang_line)
 
+        # If the second line is an encoding, we need to keep it second and swap
+        # the old shebang line to third
+        line_two = original.readline()
+        using_encoding = re.match(rb"^[ \t\f]*#.*?coding[:=][ \t]*([-_.a-zA-Z0-9]+)", line_two)
+        if using_encoding:
+            patched.write(line_two)
+
         # Note that in Python this does not go out of bounds even if interpreter is a
         # short byte array.
         # Note: if the interpreter string was encoded with UTF-16, there would have
@@ -142,6 +149,10 @@ def filter_shebang(path):
             patched.write(b"<?php " + old_shebang_line + b" ?>")
         else:
             patched.write(old_shebang_line)
+
+        # Line two goes after the original shebang if it's not an encoding
+        if not using_encoding:
+            patched.write(line_two)
 
         # After copying the remainder of the file, we can close the original
         shutil.copyfileobj(original, patched)

--- a/lib/spack/spack/test/sbang.py
+++ b/lib/spack/spack/test/sbang.py
@@ -37,6 +37,9 @@ too_long = sbang.system_shebang_limit + 1
 short_line = "#!/this/is/short/bin/bash\n"
 long_line = "#!/this/" + ("x" * too_long) + "/is/long\n"
 
+python_line = "#!/this/" + ("x" * too_long) + "/is/python\n"
+python_encoding_line = "# coding: utf-8\n"
+
 lua_line = "#!/this/" + ("x" * too_long) + "/is/lua\n"
 lua_in_text = ("line\n") * 100 + "lua\n" + ("line\n" * 100)
 lua_line_patched = "--!/this/" + ("x" * too_long) + "/is/lua\n"
@@ -90,6 +93,14 @@ class ScriptDirectory:
         with open(self.nonexec_long_shebang, "w", encoding="utf-8") as f:
             f.write(long_line)
             f.write(last_line)
+
+        # python using an encoding comment
+        self.python_shebang = os.path.join(self.tempdir, "python")
+        with open(self.python_shebang, "w", encoding="utf-8") as f:
+            f.write(python_line)
+            f.write(python_encoding_line)
+            f.write(last_line)
+        self.make_executable(self.python_shebang)
 
         # Lua script with long shebang
         self.lua_shebang = os.path.join(self.tempdir, "lua")
@@ -220,6 +231,13 @@ def test_shebang_handling(script_dir, sbang_line):
     # Make sure this is untouched
     with open(script_dir.nonexec_long_shebang, "r", encoding="utf-8") as f:
         assert f.readline() == long_line
+        assert f.readline() == last_line
+
+    # Make sure this got patched and didn't move the encoding line
+    with open(script_dir.python_shebang, "r", encoding="utf-8") as f:
+        assert f.readline() == sbang_line
+        assert f.readline() == python_encoding_line
+        assert f.readline() == python_line
         assert f.readline() == last_line
 
     # Make sure this got patched.


### PR DESCRIPTION
Prior to sbang version 1.1.0, sbang did not handle comments like `# -*- coding: utf-8 -*-` in python scripts, which are required to be in the first two lines of the file. It would push those lines to the third line by placing the sbang shebang line above the original shebang line.

This PR updates Spack to use sbang version 1.1.0 and updates the Spack sbang hook to take advantage of the new feature by keeping encoding comments on the second line and pushing the original shebang to the third line if necessary.