### PR TITLE
error messages: show conflicting values for single-value attribute and provider

### DIFF
--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -776,11 +776,21 @@ class ErrorHandler:
         self.input_specs = input_specs
         self.full_model = None
 
-    def multiple_values_error(self, attribute, pkg):
-        return f'Cannot select a single "{attribute}" for package "{pkg}"'
+    #: User-facing names for attributes that must have a single value
+    _single_value_attribute_names = {
+        "node_platform": "platform",
+        "node_os": "os",
+        "node_target": "target",
+    }
+
+    def multiple_values_error(self, attribute, pkg, *values):
+        name = self._single_value_attribute_names.get(attribute, attribute)
+        listed = " and ".join(f"'{v}'" for v in values)
+        return f"Conflicting {name} values are required for package '{pkg}': {listed}"
 
     def no_value_error(self, attribute, pkg):
-        return f'Cannot select a single "{attribute}" for package "{pkg}"'
+        name = self._single_value_attribute_names.get(attribute, attribute)
+        return f"No {name} value could be selected for package '{pkg}'"
 
     def _get_cause_tree(
         self,

--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -332,7 +332,15 @@ error(10000, no_value_error, Attribute, Package)
 error(100, multiple_values_error, Attribute, Package)
   :- attr("node", node(ID, Package)),
      attr_single_value(Attribute),
-     2 { attr(Attribute, node(ID, Package), Value) }.
+     2 { attr(Attribute, node(ID, Package), Value) },
+     Attribute != "node_os".
+
+% For the os the message includes the conflicting values, which is cheap enough to ground.
+error(100, multiple_values_error, "node_os", Package, OS1, OS2)
+  :- attr("node", node(ID, Package)),
+     attr("node_os", node(ID, Package), OS1),
+     attr("node_os", node(ID, Package), OS2),
+     OS1 < OS2.
 
 %-----------------------------------------------------------------------------
 % Version semantics
@@ -1140,9 +1148,11 @@ error(100, "Cannot find valid provider for virtual {0}", Virtual)
   :- attr("virtual_node", node(X, Virtual)),
      not has_provider(node(X, Virtual)).
 
-error(100, "Multiple providers are required for the same '{0}' virtual", Virtual)
+error(100, "Multiple providers are required for the same '{0}' virtual: '{1}' and '{2}'", Virtual, Provider1, Provider2)
   :- attr("virtual_node", node(X, Virtual)),
-     2 { provider(P, node(X, Virtual)) }.
+     provider(node(_, Provider1), node(X, Virtual)),
+     provider(node(_, Provider2), node(X, Virtual)),
+     Provider1 < Provider2.
 
 % virtual roots imply virtual nodes, and that one provider is a root
 attr("virtual_node", VirtualNode) :- attr("virtual_root", VirtualNode).

--- a/lib/spack/spack/solver/error_messages.lp
+++ b/lib/spack/spack/solver/error_messages.lp
@@ -212,3 +212,4 @@ pkg_fact(Package, version_satisfies(Constraint, Version)) :-
 #defined node_has_variant/3.
 #defined provider/2.
 #defined variant_single_value/2.
+#defined has_provider/1.

--- a/lib/spack/spack/test/concretization/errors.py
+++ b/lib/spack/spack/test/concretization/errors.py
@@ -210,6 +210,12 @@ def assert_actionable_error(exc_info, *required_part: str) -> None:
             ["fortan", "cxxxx", "zlib %c,cxxxx,fortan=gcc"],
             id="two_unknown_virtuals_on_edge",
         ),
+        # Two providers requested for the same virtual: the error must name both.
+        pytest.param(
+            "mpileaks ^mpich ^zmpi",
+            ["Multiple providers are required for the same 'mpi' virtual: 'mpich' and 'zmpi'"],
+            id="two_providers_for_virtual",
+        ),
     ],
 )
 def test_input_spec_driven_errors(


### PR DESCRIPTION
The "no value" and "multiple values" error messages for platform, os and
target were identical ('Cannot select a single "node_os" for package
"zlib-ng"'), used internal attribute names, and did not say what values
were in conflict.

They are now distinct, use the user-facing name, and for the os list the
values:

    Conflicting os values are required for package 'zlib-ng': 'sequoia' and 'ubuntu22.04'

Only the os is enumerated pairwise: there are a handful of candidates per node,
whereas grounding pairs of versions or targets would be expensive.

"Multiple providers are required for the same 'mpi' virtual" now shows the
providers: "...: 'mpich' and 'openmpi'".

The causation program declares `has_provider/1` so clingo stops printing an
"atom does not occur in any rule head" info line on models without virtuals.

