### PR TITLE
solver: show what platform/target can't be targeted

### DIFF
--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -331,6 +331,7 @@ error(10000, no_value_error, Attribute, Package)
 % Error when multiple attr need to be selected
 error(100, multiple_values_error, Attribute, Package)
   :- attr("node", node(ID, Package)),
+     not multiple_values_explained(node(ID, Package), Attribute),
      attr_single_value(Attribute),
      2 { attr(Attribute, node(ID, Package), Value) }.
 
@@ -1909,6 +1910,15 @@ will_build_packages() :- build(X).
 1 { attr("node_platform", PackageNode, Platform) : allowed_platform(Platform) } 1
   :- attr("node", PackageNode).
 
+error(100, "'{0} platform={1}' is not compatible with this machine (platform={2})", Package, Platform, Allowed)
+  :- attr("node_platform", node(X, Package), Platform),
+     not allowed_platform(Platform),
+     allowed_platform(Allowed).
+
+% The error above explains the situation; the generic multiple-values error would only add noise.
+multiple_values_explained(node(X, Package), "node_platform")
+  :- attr("node_platform", node(X, Package), Platform), not allowed_platform(Platform).
+
 % setting platform on a node is a hard constraint
 attr("node_platform", PackageNode, Platform)
  :- attr("node", PackageNode), attr("node_platform_set", PackageNode, Platform).
@@ -1949,11 +1959,13 @@ attr("node_os", PackageNode, OS) :- attr("node_os_set", PackageNode, OS), attr("
 % Each node has only one target chosen among the known targets
 1 { attr("node_target", PackageNode, Target) : target(Target) } 1 :- attr("node", PackageNode).
 
-% If a node must satisfy a target constraint, enforce it
+% If a node must satisfy a target constraint, enforce it. A target unknown to this machine is
+% reported by a dedicated error below, so don't repeat the mismatch for it here.
 error(10, "'{0} target={1}' cannot satisfy constraint 'target={2}'", Package, Target, Constraint)
   :- attr("node_target", node(X, Package), Target),
      attr("node_target_satisfies", node(X, Package), Constraint),
-     not target_satisfies(Constraint, Target).
+     not target_satisfies(Constraint, Target),
+     not multiple_values_explained(node(X, Package), "node_target").
 
 % If a node has a target and the target satisfies a constraint, then the target
 % associated with the node satisfies the same constraint
@@ -2026,6 +2038,10 @@ error(100, "'{0} target={1}' is not compatible with this machine", Package, Targ
   :- attr("node", node(X, Package)),
      attr("node_target", node(X, Package), Target),
      not target(Target).
+
+% The error above explains the situation; the generic multiple-values error would only add noise.
+multiple_values_explained(node(X, Package), "node_target")
+  :- attr("node_target", node(X, Package), Target), not target(Target).
 
 %-----------------------------------------------------------------------------
 % Compiler flags

--- a/lib/spack/spack/test/concretization/errors.py
+++ b/lib/spack/spack/test/concretization/errors.py
@@ -197,6 +197,12 @@ def assert_actionable_error(exc_info, *required_part: str) -> None:
             ["mvapich2", "file_systems", "the value 'auto' is mutually exclusive"],
             id="variant_disjoint_sets",
         ),
+        # The requested platform is not the one Spack runs on. The error must name both.
+        pytest.param(
+            "libelf platform=linux",
+            ["'libelf platform=linux' is not compatible with this machine (platform=test)"],
+            id="platform_mismatch",
+        ),
         # "fortan" is not a known virtual (typo of "fortran"). The error must name the
         # unknown virtual and quote the originating spec, and must not be a generic internal error.
         pytest.param(
@@ -221,6 +227,19 @@ def test_input_spec_driven_errors(
     with pytest.raises(spack.error.SpackError) as exc_info:
         spack.concretize.concretize_one(input_spec)
     assert_actionable_error(exc_info, *expected_parts)
+
+
+def test_target_not_compatible_with_host_error(mock_packages, mutable_config: Configuration):
+    """With host-compatible targets only, requesting a target from another family must name the
+    spec and say the machine cannot build for it, without a generic "conflicting values" message.
+    """
+    mutable_config.set("concretizer:targets:host_compatible", True)
+    with pytest.raises(spack.error.SpackError) as exc_info:
+        spack.concretize.concretize_one("libelf target=ppc64le")
+    assert_actionable_error(
+        exc_info, "'libelf target=ppc64le' is not compatible with this machine"
+    )
+    assert "Conflicting target values" not in str(exc_info.value)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
A platform Spack cannot target produced "Cannot select a single
node_platform". It now errors as follows:

    'zlib-ng platform=linux' is not compatible with this machine (platform=darwin)

A target from another family produced four messages, only one of them would
do:

    'zlib-ng target=x86_64' is not compatible with this machine

