### PR TITLE
error messages: conditional variants

### DIFF
--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -1543,16 +1543,35 @@ attr("variant_selected", PackageNode, Variant, Value, VariantType, VariantID) :-
   node_has_variant(PackageNode, Variant, VariantID),
   variant_type(VariantID, VariantType).
 
-% a variant cannot be set if it is not a variant on the package
+variant_set_but_missing(PackageNode, Variant)
+  :- attr("variant_set", PackageNode, Variant),
+     not pkg_has_variant(PackageNode, Variant),
+     build(PackageNode).
+
+variant_has_condition(Package, Variant) :- pkg_fact(Package, variant_condition(Variant, _, _)).
+
+% error when a variant has to be set, but its when condition cannot hold
+% "Cannot set variant 'java' for 'hdf5@1.8.19': Package hdf5 has variant 'java' when @1.10:"
+error(100, "Cannot set variant '{0}' for '{1}@{2}': {3}", Variant, Package, Version, Reason)
+  :- variant_set_but_missing(node(ID, Package), Variant),
+     attr("version", node(ID, Package), Version),
+     pkg_fact(Package, variant_condition(Variant, _, ConditionID)),
+     condition_reason(ConditionID, Reason).
+
 error(100, "Cannot set variant '{0}' for package '{1}' because the variant condition cannot be satisfied for the given spec", Variant, Package)
-  :- attr("variant_set", node(ID, Package), Variant),
-     not pkg_has_variant(node(ID, Package), Variant),
-     build(node(ID, Package)).
+  :- variant_set_but_missing(node(ID, Package), Variant),
+     not variant_has_condition(Package, Variant).
+
+% together with the errors above, this ensures every variant that is set has a value
+:- attr("variant_set", PackageNode, Variant, Value),
+   not attr("variant_value", PackageNode, Variant, Value),
+   not variant_set_but_missing(PackageNode, Variant).
 
 % a variant cannot take on a value if it is not a variant of the package
 error(100, "Cannot set variant '{0}' for package '{1}' because the variant condition cannot be satisfied for the given spec", Variant, Package)
   :- attr("variant_value", node(ID, Package), Variant, _),
      not pkg_has_variant(node(ID, Package), Variant),
+     not attr("variant_set", node(ID, Package), Variant),
      build(node(ID, Package)).
 
 % at most one variant value for single-valued variants.
@@ -1614,9 +1633,6 @@ error(100, "{0} variant '{1}' cannot have values '{2}' and '{3}' as they come fr
      variant_value_from_disjoint_sets(node(ID, Package), Variant, Value2, Set2),
      Set1 < Set2, % see[1]
      build(node(ID, Package)).
-
-:- attr("variant_set", node(ID, Package), Variant, Value),
-   not attr("variant_value", node(ID, Package), Variant, Value).
 
 % In a case with `variant("foo", when="+bar")` and a user request for +foo or ~foo,
 % force +bar to be set too. This gives no penalty if `+bar` is not the default value, and

--- a/lib/spack/spack/test/concretization/errors.py
+++ b/lib/spack/spack/test/concretization/errors.py
@@ -164,6 +164,13 @@ def assert_actionable_error(exc_info, *required_part: str) -> None:
             ["quantum-espresso", "nonexistent", "No such variant"],
             id="variant_undefined",
         ),
+        # The variant exists only when @2.0:, but the user pinned @1.0. The error must name the
+        # variant and its condition, instead of saying it cannot pick a version.
+        pytest.param(
+            "conditional-variant-pkg@1.0+version_based",
+            ["Cannot set variant 'version_based' for 'conditional-variant-pkg@1.0'", "when @2.0:"],
+            id="conditional_variant_unsatisfied",
+        ),
         # quantum-espresso has only version 1.0; @:0.1 cannot be satisfied.
         pytest.param(
             "quantum-espresso@:0.1",


### PR DESCRIPTION
A user-set variant that does not exist on the requested version was a hard
constraint, so the only feasible models changed the version, resulting
in a curious error message:

    $ spack spec hdf5@1.8.19+java
    Cannot satisfy 'hdf5@1.8.19' (version 1.14.6 does not match)

The constraint now applies only when the node actually has the variant,
and the error shows the variant and every definition condition the node
does not satisfy:

    Cannot set variant 'java' for 'hdf5@1.8.19': Package hdf5 has variant 'java' when @1.10:

Unconditional variants keep the previous generic message, and the
variant_value rule no longer duplicates it for variants the user set
explicitly.

