### PR TITLE
solver: move `Result` and the solver errors out of asp.py

### DIFF
--- a/lib/spack/spack/cmd/solve.py
+++ b/lib/spack/spack/cmd/solve.py
@@ -16,6 +16,8 @@ import spack.package_base
 import spack.spec
 from spack.active_environment import active_environment
 from spack.solver import asp
+from spack.solver.error import format_unsolved
+from spack.solver.result import OptimizationKind
 from spack.util import tty
 from spack.util.tty import color
 
@@ -85,9 +87,9 @@ def _process_result(result, show, required_format, kwargs):
 
             if grey_out:
                 lc = "@K"
-            elif criterion.kind == asp.OptimizationKind.CONCRETE:
+            elif criterion.kind == OptimizationKind.CONCRETE:
                 lc = "@b"
-            elif criterion.kind == asp.OptimizationKind.BUILD:
+            elif criterion.kind == OptimizationKind.BUILD:
                 lc = "@g"
             else:
                 lc = "@y"
@@ -121,7 +123,7 @@ def _process_result(result, show, required_format, kwargs):
         print()
 
     if result.unsolved_specs and "solutions" in show:
-        tty.msg(asp.Result.format_unsolved(result.unsolved_specs))
+        tty.msg(format_unsolved(result.unsolved_specs))
 
 
 def solve(parser, args):

--- a/lib/spack/spack/concretize.py
+++ b/lib/spack/spack/concretize.py
@@ -15,6 +15,7 @@ import spack.config
 import spack.error
 import spack.hash_lookup
 import spack.repo
+import spack.solver.core
 import spack.traverse
 import spack.util.parallel
 from spack.concretize_ui import ConcretizerUI, HeadlessUI, SolveKind
@@ -254,7 +255,7 @@ def concretize_one(
         tests: if False disregard test dependencies, if a list of names activate them for
             the packages in the list, if True activate test dependencies for all packages.
     """
-    from spack.solver.asp import Solver, SpecBuilder
+    from spack.solver.asp import Solver
 
     if isinstance(spec, str):
         spec = Spec(spec)
@@ -282,7 +283,7 @@ def concretize_one(
         providers = [s.name for s in answer.values() if s.package.provides(name)]
         name = providers[0]
 
-    node = SpecBuilder.make_node(pkg=name)
+    node = spack.solver.core.min_dupe_node(pkg=name)
     assert node in answer, (
         f"cannot find {name} in the list of specs {','.join([n.pkg for n in answer.keys()])}"
     )

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -48,7 +48,6 @@ import spack.deptypes as dt
 import spack.error
 import spack.externals_config
 import spack.hash_lookup
-import spack.hash_types as ht
 import spack.package_base
 import spack.package_prefs
 import spack.platforms
@@ -74,21 +73,32 @@ from spack.util import tty
 from spack.util.lang import elide_list
 
 from .clauses import SpecClauseGenerator
-from .compat import default_clingo_control, make_error_control
+from .compat import default_clingo_control, make_error_control, symbol_name, symbol_string
 from .core import (
     AspFunction,
     AspVar,
+    NodeFlag,
     NodeId,
     QuotedStrings,
     SourceContext,
     asp_argument,
-    extract_args,
     fn,
     quote,
     quote_once,
 )
+from .error import (
+    DeprecatedVersionError,
+    InternalConcretizerError,
+    InvalidDependencyError,
+    InvalidSpliceError,
+    InvalidVersionError,
+    OutputDoesNotSatisfyInputError,
+    SpliceSerializationError,
+    UnsatisfiableSpecError,
+)
 from .input_analysis import create_counter, create_graph_analyzer
 from .requirements import RequirementKind, RequirementOrigin, RequirementParser, RequirementRule
+from .result import Result, SpecDict, build_criteria_names
 from .reuse import ReusableSpecsSelector, SpecFiltersFactory
 from .runtimes import COMPILER_WRAPPER_LANGUAGES, RuntimePropertyRecorder, all_libcs
 from .versions import Provenance
@@ -117,80 +127,44 @@ DEFAULT_OUTPUT_CONFIGURATION = OutputConfiguration(
 )
 
 
-# type aliases for the data structures we get back from the solver
-SpecDict = Dict[NodeId, spack.spec.Spec]
 SpliceDict = Dict[spack.spec.Spec, List[spack.solver.splicing.Splice]]
 
 
-class OptimizationKind:
-    """Enum for the optimization KIND of a criteria.
+def intermediate_repr(sym):
+    """Returns an intermediate representation of clingo models for Spack's spec builder.
 
-    It's not using enum.Enum since it must be serializable.
+    Currently, transforms symbols from clingo models either to strings or to NodeId objects.
+
+    Returns:
+        This will turn a ``clingo.Symbol`` into a string or NodeId, or a sequence of
+        ``clingo.Symbol`` objects into a tuple of those objects.
     """
+    if isinstance(sym, (list, tuple)):
+        return tuple(intermediate_repr(a) for a in sym)
 
-    BUILD = 0
-    CONCRETE = 1
-    OTHER = 2
-
-
-class OptimizationBand(enum.Enum):
-    """Grouping for optimization criteria by their priority range."""
-
-    LOW = "Lowest priority"
-    REUSED = "Reused nodes"
-    FIXED = "Fixed (reuse vs build)"
-    BUILD = "Built nodes"
-    HIGHEST = "Highest priority"
-
-
-class OptimizationCriteria(NamedTuple):
-    """A named tuple describing an optimization criteria."""
-
-    priority: int
-    value: int
-    name: str
-    band: str
-    kind: OptimizationKind
+    name = symbol_name(sym)
+    if name == "node":
+        return NodeId(
+            id=intermediate_repr(sym.arguments[0]), pkg=intermediate_repr(sym.arguments[1])
+        )
+    if name == "node_flag":
+        return NodeFlag(
+            flag_type=intermediate_repr(sym.arguments[0]),
+            flag=intermediate_repr(sym.arguments[1]),
+            flag_group=intermediate_repr(sym.arguments[2]),
+            source=intermediate_repr(sym.arguments[3]),
+        )
+    return symbol_string(sym)
 
 
-def build_criteria_names(costs, arg_tuples):
-    """Construct an ordered mapping from criteria names to costs."""
-    # pull optimization criteria names out of the solution
-    priorities_names = []
+def extract_args(model, predicate_name):
+    """Extract the arguments to predicates with the provided name from a model.
 
-    # translate ASP band names into display names
-    band_names = {
-        "low": OptimizationBand.LOW,
-        "concr": OptimizationBand.REUSED,
-        "hinge": OptimizationBand.FIXED,
-        "built": OptimizationBand.BUILD,
-        "high": OptimizationBand.HIGHEST,
-    }
-
-    for args in arg_tuples:
-        priority, band, name = args[0], band_names[args[2]].value, args[4]
-        priority = int(priority)
-
-        if band == OptimizationBand.REUSED.value:
-            # Reused/concrete criterion
-            priorities_names.append((priority, name, band, OptimizationKind.CONCRETE))
-        elif band == OptimizationBand.BUILD.value:
-            # Build criterion
-            priorities_names.append((priority, name, band, OptimizationKind.BUILD))
-        else:
-            priorities_names.append((priority, name, band, OptimizationKind.OTHER))
-
-    # sort the criteria by priority
-    priorities_names = sorted(priorities_names, reverse=True)
-
-    # We only have opt-criterion values for non-error types
-    # error type criteria are excluded (they come first)
-    error_criteria = len(costs) - len(priorities_names)
-    costs = costs[error_criteria:]
-
+    Pull out all the predicates with name ``predicate_name`` from the model, and
+    return their intermediate representation.
+    """
     return [
-        OptimizationCriteria(priority, value, name, band, status)
-        for (priority, name, band, status), value in zip(priorities_names, costs)
+        intermediate_repr(sym.arguments) for sym in model if symbol_name(sym) == predicate_name
     ]
 
 
@@ -292,261 +266,6 @@ def _reorder_flags(flag_list: List[spack.spec.CompilerFlag]) -> List[spack.spec.
             flag_group, propagate=flag_propagate
         )
     ]
-
-
-# We have to take some care with how we serialize a `SpecDict` fresh from a solve,
-# because it contains specs that are in between concrete and abstract. The hash is not
-# yet final, because there are spec changes yet to be made in post-processing that will
-# change the hashes. We still need an identifier for the nodes in the spec DAG, though.
-# So, we use hashes as ids during serialization, but we must clear them afterwards so
-# that they are not cached, and they can be set again when the final changes are made.
-
-
-def spec_dict_to_json(spec_dict: SpecDict) -> Dict:
-    """Serialize a SpecDict to JSON, taking care to preserve node structure in serialized specs.
-
-    Note: this does not yet handle spliced specs and will raise an error if they're passed in.
-
-    Raises:
-        SpliceSerializationError: if any node in ``spec_dict`` has a ``build_spec``.
-    """
-    # Specs are keyed in spec_dict by their solver-assigned NodeId, but reused concrete
-    # specs may have transitive dependencies that do not have a NodeId.
-    # Make a dictionary preserving the NodeIds from input.
-    node_id_for: Dict[int, NodeId] = {id(spec): nid for nid, spec in spec_dict.items()}
-
-    specs = list(spec_dict.values())
-
-    try:
-        # A SpecDict has one entry for each spec in a solution, but some are abstract and some
-        # are concrete. We need DAG hashes for the abstract specs to serialize them, so
-        # force-cache them, taking care to do so bottom-up, to avoid exponential recomputation.
-        # TODO: spec serialization was really designed for concrete and small abstract specs.
-        # This should really be handled by Spec, but it will take some work to adjust the format.
-        for spec in spack.traverse.traverse_nodes(specs, key=id, order="post"):
-            if spec.build_spec is not spec:
-                raise SpliceSerializationError(
-                    f"cannot serialize spliced spec {spec.name}; SpecDicts with spliced "
-                    "specs are not serializable."
-                )
-            if not spec.concrete:
-                spec._cached_hash(ht.dag_hash, force=True)
-
-        # Traverse every spec reachable from spec_dict's values, deduped by hash, and add them
-        # to the serialized entries either a) with their original NodeId, or b) with None if they
-        # don't have a NodeId. This ensures that all nodes are added and NodeIds are preserved.
-        entries = []
-        for dep in spack.traverse.traverse_nodes(specs, key=lambda s: s.dag_hash()):
-            node = dep.to_node_dict()
-            node["hash"] = dep.dag_hash()
-            entries.append((node_id_for.get(id(dep)), node))
-
-    finally:
-        # Clear hashes cached above, which must be recomputed in post-concretization
-        # They're only used here as keys for reading and writing spec DAGs.
-        for spec in spack.traverse.traverse_nodes(specs, key=id):
-            if not spec.concrete:
-                spec.clear_caches()
-
-    return {"_meta": {"spec_version": spack.spec.SpecfileLatest.SPEC_VERSION}, "specs": entries}
-
-
-def spec_dict_from_json(data: Dict) -> SpecDict:
-    """Deserialize a SpecDict from JSON, taking care not to duplicate nodes."""
-    try:
-        spec_version = int(data["_meta"]["spec_version"])
-        entries = data["specs"]
-    except (KeyError, ValueError):
-        raise ValueError(f"Invalid spec dict data: {data}")
-
-    reader = spack.spec.specfile_reader_for_version(spec_version)
-    nodes = [node for _, node in entries]
-    specs_by_hash = spack.spec.wire_spec_nodes(nodes, "hash", reader)
-
-    # clear the hashes we cached on any abstract specs, so that they can be recomputed later
-    for spec in spack.traverse.traverse_nodes(list(specs_by_hash.values()), key=id):
-        if not spec.concrete:
-            spec.clear_caches()
-
-    # Anonymous nodes (nid=None) are reachable transitively through named roots' edges, and
-    # are handled by wire_spec_nodes() above. Skip them here to preserve SpecDict on round-trip.
-    return {NodeId(*nid): specs_by_hash[node["hash"]] for nid, node in entries if nid is not None}
-
-
-class Result:
-    """Result of an ASP solve."""
-
-    def __init__(self, specs):
-        self.satisfiable = None
-        self.optimal = None
-        self.warnings = None
-        self.nmodels = 0
-
-        # specs ordered by optimization level
-        self.answers = []
-
-        # names of optimization criteria
-        self.criteria = []
-
-        # Abstract user requests
-        self.abstract_specs = specs
-
-        # possible dependencies
-        self.possible_dependencies = None
-
-        # Concrete specs
-        self._concrete_specs_by_input = None
-        self._concrete_specs = None
-        self._unsolved_specs = None
-
-    def raise_if_unsat(self):
-        """Raise a generic internal error if the result is unsatisfiable."""
-        if self.satisfiable:
-            return
-
-        constraints = self.abstract_specs
-        if len(constraints) == 1:
-            constraints = constraints[0]
-
-        raise SolverError(constraints)
-
-    @property
-    def specs(self):
-        """List of concretized specs satisfying the initial
-        abstract request.
-        """
-        if self._concrete_specs is None:
-            self._compute_specs_from_answer_set()
-        return self._concrete_specs
-
-    @property
-    def unsolved_specs(self):
-        """List of tuples pairing abstract input specs that were not
-        solved with their associated candidate spec from the solver
-        (if the solve completed).
-        """
-        if self._unsolved_specs is None:
-            self._compute_specs_from_answer_set()
-        return self._unsolved_specs
-
-    @property
-    def specs_by_input(self) -> Dict[spack.spec.Spec, spack.spec.Spec]:
-        if self._concrete_specs_by_input is None:
-            self._compute_specs_from_answer_set()
-        return self._concrete_specs_by_input  # type: ignore
-
-    def _compute_specs_from_answer_set(self):
-        if not self.satisfiable:
-            self._concrete_specs = []
-            self._unsolved_specs = [(x, None) for x in self.abstract_specs]
-            self._concrete_specs_by_input = {}
-            return
-
-        self._concrete_specs, self._unsolved_specs = [], []
-        self._concrete_specs_by_input = {}
-        best = min(self.answers)
-        opt, _, answer = best
-        for input_spec in self.abstract_specs:
-            # The specs must be unified to get here, so it is safe to associate any satisfying spec
-            # with the input. Multiple inputs may be matched to the same concrete spec
-            node = SpecBuilder.make_node(pkg=input_spec.name)
-            if spack.repo.PATH.is_virtual(input_spec.name):
-                providers = [
-                    spec.name for spec in answer.values() if spec.package.provides(input_spec.name)
-                ]
-                node = SpecBuilder.make_node(pkg=providers[0])
-            candidate = answer.get(node)
-
-            if candidate and candidate.satisfies(input_spec):
-                self._concrete_specs.append(answer[node])
-                self._concrete_specs_by_input[input_spec] = answer[node]
-            elif candidate and candidate.build_spec.satisfies(input_spec):
-                tty.warn(
-                    "explicit splice configuration has caused the concretized spec"
-                    f" {candidate} not to satisfy the input spec {input_spec}"
-                )
-                self._concrete_specs.append(answer[node])
-                self._concrete_specs_by_input[input_spec] = answer[node]
-            else:
-                self._unsolved_specs.append((input_spec, candidate))
-
-    @staticmethod
-    def format_unsolved(unsolved_specs):
-        """Create a message providing info on unsolved user specs and for
-        each one show the associated candidate spec from the solver (if
-        there is one).
-        """
-        msg = "Unsatisfied input specs:"
-        for input_spec, candidate in unsolved_specs:
-            msg += f"\n\tInput spec: {str(input_spec)}"
-            if candidate:
-                msg += f"\n\tCandidate spec: {candidate.long_spec}"
-            else:
-                msg += "\n\t(No candidate specs from solver)"
-        return msg
-
-    def to_dict(self) -> dict:
-        """Produces dict representation of Result object
-
-        Does not include anything related to unsatisfiability as we
-        are only interested in storing satisfiable results
-        """
-
-        # NOTE: _unsolved_specs, _concrete_specs_by_input, and _concrete_specs are all
-        # computed dynamically from self.answers, so they're not serialized.
-        return {
-            "criteria": self.criteria,
-            "optimal": self.optimal,
-            "warnings": self.warnings,
-            "nmodels": self.nmodels,
-            # abstract specs are not used for deserialization, but dropping them is
-            # forward-incompatible with Spack 1.2 and earlier.
-            "abstract_specs": [s.to_dict() for s in self.abstract_specs],
-            "satisfiable": self.satisfiable,
-            "answers": [
-                (opt, i, spec_dict_to_json(spec_dict)) for opt, i, spec_dict in self.answers
-            ],
-        }
-
-    @staticmethod
-    def from_dict(obj: dict, specs: List[spack.spec.Spec]):
-        """Returns Result object from compatible dictionary, for the given input specs.
-
-        The stored abstract specs are troubleshooting metadata and are deliberately not
-        deserialized: the caller's input specs are authoritative. This also keeps cache
-        entries with unreadable abstract spec data usable.
-        """
-        result = Result(specs)
-        result.criteria = [OptimizationCriteria(*t) for t in obj["criteria"]]
-        result.optimal = obj["optimal"]
-        result.warnings = obj["warnings"]
-        result.nmodels = obj["nmodels"]
-        result.satisfiable = obj["satisfiable"]
-        result.answers = [
-            (opt, i, spec_dict_from_json(spec_dict)) for opt, i, spec_dict in obj["answers"]
-        ]
-        # NOTE: _unsolved_specs, _concrete_specs_by_input, and _concrete_specs are all
-        # computed dynamically from self.answers, so they're not serialized.
-
-        return result
-
-    def __eq__(self, other):
-        eq = (
-            self.satisfiable == other.satisfiable,
-            self.optimal == other.optimal,
-            self.warnings == other.warnings,
-            self.nmodels == other.nmodels,
-            self.criteria == other.criteria,
-            self.answers == other.answers,
-            self.abstract_specs == other.abstract_specs,
-            # Not considered for equality
-            # self._concrete_specs_by_input   # These three are computed
-            # self._concrete_specs
-            # self._unsolved_specs
-            # self.control                    # Currently we just don't serialize these
-            # self.possible_dependencies
-        )
-        return all(eq)
 
 
 class ConcretizationCache:
@@ -3232,16 +2951,6 @@ class SpecBuilder:
         )
     )
 
-    @staticmethod
-    def make_node(*, pkg: str) -> NodeId:
-        """Given a package name, returns the string representation of the "min_dupe_id" node in
-        the ASP encoding.
-
-        Args:
-            pkg: name of a package
-        """
-        return NodeId(id="0", pkg=pkg)
-
     def __init__(self, specs, hash_lookup=None):
         self._specs: Dict[NodeId, spack.spec.Spec] = {}
 
@@ -3881,79 +3590,3 @@ def _check_unknown_virtuals_in_input_specs(specs: Sequence[spack.spec.Spec]) -> 
     raise spack.error.InvalidVirtualOnEdgeError(
         f"unknown virtuals have been found in input specs:\n{details}"
     )
-
-
-class UnsatisfiableSpecError(spack.error.UnsatisfiableSpecError):
-    """There was an issue with the spec that was requested (i.e. a user error)."""
-
-    def __init__(self, msg):
-        super(spack.error.UnsatisfiableSpecError, self).__init__(msg)
-        self.provided = None
-        self.required = None
-        self.constraint_type = None
-
-
-class InternalConcretizerError(spack.error.UnsatisfiableSpecError):
-    """Errors that indicate a bug in Spack."""
-
-    def __init__(self, msg):
-        super(spack.error.UnsatisfiableSpecError, self).__init__(msg)
-        self.provided = None
-        self.required = None
-        self.constraint_type = None
-
-
-class OutputDoesNotSatisfyInputError(InternalConcretizerError):
-    def __init__(
-        self, input_to_output: List[Tuple[spack.spec.Spec, Optional[spack.spec.Spec]]]
-    ) -> None:
-        self.input_to_output = input_to_output
-        super().__init__(
-            "internal solver error: the solver completed but produced specs"
-            " that do not satisfy the request. Please report a bug at "
-            f"https://github.com/spack/spack/issues\n\t{Result.format_unsolved(input_to_output)}"
-        )
-
-
-class SolverError(InternalConcretizerError):
-    """For cases where the solver is unable to produce a solution.
-
-    Such cases are unexpected because we allow for solutions with errors,
-    so for example user specs that are over-constrained should still
-    get a solution.
-    """
-
-    def __init__(self, provided):
-        msg = (
-            "Spack concretizer internal error. Please submit a bug report at "
-            "https://github.com/spack/spack and include the command and environment "
-            "if applicable."
-            f"\n    {provided} is unsatisfiable"
-        )
-
-        super().__init__(msg)
-
-        # Add attribute expected of the superclass interface
-        self.required = None
-        self.constraint_type = None
-        self.provided = provided
-
-
-class InvalidSpliceError(spack.error.SpackError):
-    """For cases in which the splice configuration is invalid."""
-
-
-class SpliceSerializationError(spack.error.SpackError):
-    """Attempt to serialize a SpecDict that contains spliced specs (currently unsupported)."""
-
-
-class DeprecatedVersionError(spack.error.SpackError):
-    """Raised when user directly requests a deprecated version."""
-
-
-class InvalidVersionError(spack.error.SpackError):
-    """Raised when a version can't be satisfied by any possible versions."""
-
-
-class InvalidDependencyError(spack.error.SpackError):
-    """Raised when an explicit dependency is not a possible dependency."""

--- a/lib/spack/spack/solver/core.py
+++ b/lib/spack/spack/solver/core.py
@@ -1,13 +1,11 @@
 # Copyright Spack Project Developers. See COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
-"""Low-level wrappers around clingo API and other basic functionality related to ASP"""
+"""Basic data structures used to build Spack's ASP program"""
 
 from typing import Any, Dict, NamedTuple, Optional, Tuple
 
 from spack.util import lang
-
-from .compat import symbol_name, symbol_string
 
 #: Type used for quoted string cache
 QuotedStrings = Dict[str, str]
@@ -144,49 +142,20 @@ class NodeId(NamedTuple):
     pkg: str
 
 
+def min_dupe_node(*, pkg: str) -> NodeId:
+    """Given a package name, returns the "min_dupe_id" node in the ASP encoding.
+
+    Args:
+        pkg: name of a package
+    """
+    return NodeId(id="0", pkg=pkg)
+
+
 class NodeFlag(NamedTuple):
     flag_type: str
     flag: str
     flag_group: str
     source: str
-
-
-def intermediate_repr(sym):
-    """Returns an intermediate representation of clingo models for Spack's spec builder.
-
-    Currently, transforms symbols from clingo models either to strings or to NodeId objects.
-
-    Returns:
-        This will turn a ``clingo.Symbol`` into a string or NodeId, or a sequence of
-        ``clingo.Symbol`` objects into a tuple of those objects.
-    """
-    if isinstance(sym, (list, tuple)):
-        return tuple(intermediate_repr(a) for a in sym)
-
-    name = symbol_name(sym)
-    if name == "node":
-        return NodeId(
-            id=intermediate_repr(sym.arguments[0]), pkg=intermediate_repr(sym.arguments[1])
-        )
-    if name == "node_flag":
-        return NodeFlag(
-            flag_type=intermediate_repr(sym.arguments[0]),
-            flag=intermediate_repr(sym.arguments[1]),
-            flag_group=intermediate_repr(sym.arguments[2]),
-            source=intermediate_repr(sym.arguments[3]),
-        )
-    return symbol_string(sym)
-
-
-def extract_args(model, predicate_name):
-    """Extract the arguments to predicates with the provided name from a model.
-
-    Pull out all the predicates with name ``predicate_name`` from the model, and
-    return their intermediate representation.
-    """
-    return [
-        intermediate_repr(sym.arguments) for sym in model if symbol_name(sym) == predicate_name
-    ]
 
 
 class SourceContext:

--- a/lib/spack/spack/solver/error.py
+++ b/lib/spack/spack/solver/error.py
@@ -1,0 +1,105 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+"""Errors raised by the concretizer.
+
+This module holds no solver state, so that both the solver and the types it produces can
+depend on it without importing each other.
+"""
+
+from typing import List, Optional, Tuple
+
+import spack.error
+import spack.spec
+
+
+def format_unsolved(
+    unsolved_specs: List[Tuple[spack.spec.Spec, Optional[spack.spec.Spec]]],
+) -> str:
+    """Create a message providing info on unsolved user specs and for each one show the
+    associated candidate spec from the solver (if there is one).
+    """
+    msg = "Unsatisfied input specs:"
+    for input_spec, candidate in unsolved_specs:
+        msg += f"\n\tInput spec: {str(input_spec)}"
+        if candidate:
+            msg += f"\n\tCandidate spec: {candidate.long_spec}"
+        else:
+            msg += "\n\t(No candidate specs from solver)"
+    return msg
+
+
+class UnsatisfiableSpecError(spack.error.UnsatisfiableSpecError):
+    """There was an issue with the spec that was requested (i.e. a user error)."""
+
+    def __init__(self, msg):
+        super(spack.error.UnsatisfiableSpecError, self).__init__(msg)
+        self.provided = None
+        self.required = None
+        self.constraint_type = None
+
+
+class InternalConcretizerError(spack.error.UnsatisfiableSpecError):
+    """Errors that indicate a bug in Spack."""
+
+    def __init__(self, msg):
+        super(spack.error.UnsatisfiableSpecError, self).__init__(msg)
+        self.provided = None
+        self.required = None
+        self.constraint_type = None
+
+
+class OutputDoesNotSatisfyInputError(InternalConcretizerError):
+    def __init__(
+        self, input_to_output: List[Tuple[spack.spec.Spec, Optional[spack.spec.Spec]]]
+    ) -> None:
+        self.input_to_output = input_to_output
+        super().__init__(
+            "internal solver error: the solver completed but produced specs"
+            " that do not satisfy the request. Please report a bug at "
+            f"https://github.com/spack/spack/issues\n\t{format_unsolved(input_to_output)}"
+        )
+
+
+class SolverError(InternalConcretizerError):
+    """For cases where the solver is unable to produce a solution.
+
+    Such cases are unexpected because we allow for solutions with errors,
+    so for example user specs that are over-constrained should still
+    get a solution.
+    """
+
+    def __init__(self, provided):
+        msg = (
+            "Spack concretizer internal error. Please submit a bug report at "
+            "https://github.com/spack/spack and include the command and environment "
+            "if applicable."
+            f"\n    {provided} is unsatisfiable"
+        )
+
+        super().__init__(msg)
+
+        # Add attribute expected of the superclass interface
+        self.required = None
+        self.constraint_type = None
+        self.provided = provided
+
+
+class InvalidSpliceError(spack.error.SpackError):
+    """For cases in which the splice configuration is invalid."""
+
+
+class SpliceSerializationError(spack.error.SpackError):
+    """Attempt to serialize a SpecDict that contains spliced specs (currently unsupported)."""
+
+
+class DeprecatedVersionError(spack.error.SpackError):
+    """Raised when user directly requests a deprecated version."""
+
+
+class InvalidVersionError(spack.error.SpackError):
+    """Raised when a version can't be satisfied by any possible versions."""
+
+
+class InvalidDependencyError(spack.error.SpackError):
+    """Raised when an explicit dependency is not a possible dependency."""

--- a/lib/spack/spack/solver/result.py
+++ b/lib/spack/spack/solver/result.py
@@ -1,0 +1,336 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+"""The result of an ASP solve, and the types needed to read and serialize it.
+
+This module is importable without pulling in the solver itself, so that frontends can be
+typed against a result without depending on how it is produced.
+"""
+
+import enum
+from typing import Dict, List, NamedTuple
+
+import spack.hash_types as ht
+import spack.repo
+import spack.spec
+import spack.traverse
+from spack.util import tty
+
+from .core import NodeId, min_dupe_node
+from .error import SolverError, SpliceSerializationError
+
+# type aliases for the data structures we get back from the solver
+SpecDict = Dict[NodeId, spack.spec.Spec]
+
+
+class OptimizationKind:
+    """Enum for the optimization KIND of a criteria.
+
+    It's not using enum.Enum since it must be serializable.
+    """
+
+    BUILD = 0
+    CONCRETE = 1
+    OTHER = 2
+
+
+class OptimizationBand(enum.Enum):
+    """Grouping for optimization criteria by their priority range."""
+
+    LOW = "Lowest priority"
+    REUSED = "Reused nodes"
+    FIXED = "Fixed (reuse vs build)"
+    BUILD = "Built nodes"
+    HIGHEST = "Highest priority"
+
+
+class OptimizationCriteria(NamedTuple):
+    """A named tuple describing an optimization criteria."""
+
+    priority: int
+    value: int
+    name: str
+    band: str
+    kind: OptimizationKind
+
+
+def build_criteria_names(costs, arg_tuples):
+    """Construct an ordered mapping from criteria names to costs."""
+    # pull optimization criteria names out of the solution
+    priorities_names = []
+
+    # translate ASP band names into display names
+    band_names = {
+        "low": OptimizationBand.LOW,
+        "concr": OptimizationBand.REUSED,
+        "hinge": OptimizationBand.FIXED,
+        "built": OptimizationBand.BUILD,
+        "high": OptimizationBand.HIGHEST,
+    }
+
+    for args in arg_tuples:
+        priority, band, name = args[0], band_names[args[2]].value, args[4]
+        priority = int(priority)
+
+        if band == OptimizationBand.REUSED.value:
+            # Reused/concrete criterion
+            priorities_names.append((priority, name, band, OptimizationKind.CONCRETE))
+        elif band == OptimizationBand.BUILD.value:
+            # Build criterion
+            priorities_names.append((priority, name, band, OptimizationKind.BUILD))
+        else:
+            priorities_names.append((priority, name, band, OptimizationKind.OTHER))
+
+    # sort the criteria by priority
+    priorities_names = sorted(priorities_names, reverse=True)
+
+    # We only have opt-criterion values for non-error types
+    # error type criteria are excluded (they come first)
+    error_criteria = len(costs) - len(priorities_names)
+    costs = costs[error_criteria:]
+
+    return [
+        OptimizationCriteria(priority, value, name, band, status)
+        for (priority, name, band, status), value in zip(priorities_names, costs)
+    ]
+
+
+# We have to take some care with how we serialize a `SpecDict` fresh from a solve,
+# because it contains specs that are in between concrete and abstract. The hash is not
+# yet final, because there are spec changes yet to be made in post-processing that will
+# change the hashes. We still need an identifier for the nodes in the spec DAG, though.
+# So, we use hashes as ids during serialization, but we must clear them afterwards so
+# that they are not cached, and they can be set again when the final changes are made.
+
+
+def spec_dict_to_json(spec_dict: SpecDict) -> Dict:
+    """Serialize a SpecDict to JSON, taking care to preserve node structure in serialized specs.
+
+    Note: this does not yet handle spliced specs and will raise an error if they're passed in.
+
+    Raises:
+        spack.solver.error.SpliceSerializationError: if any node in ``spec_dict`` has a
+            ``build_spec``.
+    """
+    # Specs are keyed in spec_dict by their solver-assigned NodeId, but reused concrete
+    # specs may have transitive dependencies that do not have a NodeId.
+    # Make a dictionary preserving the NodeIds from input.
+    node_id_for: Dict[int, NodeId] = {id(spec): nid for nid, spec in spec_dict.items()}
+
+    specs = list(spec_dict.values())
+
+    try:
+        # A SpecDict has one entry for each spec in a solution, but some are abstract and some
+        # are concrete. We need DAG hashes for the abstract specs to serialize them, so
+        # force-cache them, taking care to do so bottom-up, to avoid exponential recomputation.
+        # TODO: spec serialization was really designed for concrete and small abstract specs.
+        # This should really be handled by Spec, but it will take some work to adjust the format.
+        for spec in spack.traverse.traverse_nodes(specs, key=id, order="post"):
+            if spec.build_spec is not spec:
+                raise SpliceSerializationError(
+                    f"cannot serialize spliced spec {spec.name}; SpecDicts with spliced "
+                    "specs are not serializable."
+                )
+            if not spec.concrete:
+                spec._cached_hash(ht.dag_hash, force=True)
+
+        # Traverse every spec reachable from spec_dict's values, deduped by hash, and add them
+        # to the serialized entries either a) with their original NodeId, or b) with None if they
+        # don't have a NodeId. This ensures that all nodes are added and NodeIds are preserved.
+        entries = []
+        for dep in spack.traverse.traverse_nodes(specs, key=lambda s: s.dag_hash()):
+            node = dep.to_node_dict()
+            node["hash"] = dep.dag_hash()
+            entries.append((node_id_for.get(id(dep)), node))
+
+    finally:
+        # Clear hashes cached above, which must be recomputed in post-concretization
+        # They're only used here as keys for reading and writing spec DAGs.
+        for spec in spack.traverse.traverse_nodes(specs, key=id):
+            if not spec.concrete:
+                spec.clear_caches()
+
+    return {"_meta": {"spec_version": spack.spec.SpecfileLatest.SPEC_VERSION}, "specs": entries}
+
+
+def spec_dict_from_json(data: Dict) -> SpecDict:
+    """Deserialize a SpecDict from JSON, taking care not to duplicate nodes."""
+    try:
+        spec_version = int(data["_meta"]["spec_version"])
+        entries = data["specs"]
+    except (KeyError, ValueError):
+        raise ValueError(f"Invalid spec dict data: {data}")
+
+    reader = spack.spec.specfile_reader_for_version(spec_version)
+    nodes = [node for _, node in entries]
+    specs_by_hash = spack.spec.wire_spec_nodes(nodes, "hash", reader)
+
+    # clear the hashes we cached on any abstract specs, so that they can be recomputed later
+    for spec in spack.traverse.traverse_nodes(list(specs_by_hash.values()), key=id):
+        if not spec.concrete:
+            spec.clear_caches()
+
+    # Anonymous nodes (nid=None) are reachable transitively through named roots' edges, and
+    # are handled by wire_spec_nodes() above. Skip them here to preserve SpecDict on round-trip.
+    return {NodeId(*nid): specs_by_hash[node["hash"]] for nid, node in entries if nid is not None}
+
+
+class Result:
+    """Result of an ASP solve."""
+
+    def __init__(self, specs):
+        self.satisfiable = None
+        self.optimal = None
+        self.warnings = None
+        self.nmodels = 0
+
+        # specs ordered by optimization level
+        self.answers = []
+
+        # names of optimization criteria
+        self.criteria = []
+
+        # Abstract user requests
+        self.abstract_specs = specs
+
+        # possible dependencies
+        self.possible_dependencies = None
+
+        # Concrete specs
+        self._concrete_specs_by_input = None
+        self._concrete_specs = None
+        self._unsolved_specs = None
+
+    def raise_if_unsat(self):
+        """Raise a generic internal error if the result is unsatisfiable."""
+        if self.satisfiable:
+            return
+
+        constraints = self.abstract_specs
+        if len(constraints) == 1:
+            constraints = constraints[0]
+
+        raise SolverError(constraints)
+
+    @property
+    def specs(self):
+        """List of concretized specs satisfying the initial
+        abstract request.
+        """
+        if self._concrete_specs is None:
+            self._compute_specs_from_answer_set()
+        return self._concrete_specs
+
+    @property
+    def unsolved_specs(self):
+        """List of tuples pairing abstract input specs that were not
+        solved with their associated candidate spec from the solver
+        (if the solve completed).
+        """
+        if self._unsolved_specs is None:
+            self._compute_specs_from_answer_set()
+        return self._unsolved_specs
+
+    @property
+    def specs_by_input(self) -> Dict[spack.spec.Spec, spack.spec.Spec]:
+        if self._concrete_specs_by_input is None:
+            self._compute_specs_from_answer_set()
+        return self._concrete_specs_by_input  # type: ignore
+
+    def _compute_specs_from_answer_set(self):
+        if not self.satisfiable:
+            self._concrete_specs = []
+            self._unsolved_specs = [(x, None) for x in self.abstract_specs]
+            self._concrete_specs_by_input = {}
+            return
+
+        self._concrete_specs, self._unsolved_specs = [], []
+        self._concrete_specs_by_input = {}
+        best = min(self.answers)
+        opt, _, answer = best
+        for input_spec in self.abstract_specs:
+            # The specs must be unified to get here, so it is safe to associate any satisfying spec
+            # with the input. Multiple inputs may be matched to the same concrete spec
+            node = min_dupe_node(pkg=input_spec.name)
+            if spack.repo.PATH.is_virtual(input_spec.name):
+                providers = [
+                    spec.name for spec in answer.values() if spec.package.provides(input_spec.name)
+                ]
+                node = min_dupe_node(pkg=providers[0])
+            candidate = answer.get(node)
+
+            if candidate and candidate.satisfies(input_spec):
+                self._concrete_specs.append(answer[node])
+                self._concrete_specs_by_input[input_spec] = answer[node]
+            elif candidate and candidate.build_spec.satisfies(input_spec):
+                tty.warn(
+                    "explicit splice configuration has caused the concretized spec"
+                    f" {candidate} not to satisfy the input spec {input_spec}"
+                )
+                self._concrete_specs.append(answer[node])
+                self._concrete_specs_by_input[input_spec] = answer[node]
+            else:
+                self._unsolved_specs.append((input_spec, candidate))
+
+    def to_dict(self) -> dict:
+        """Produces dict representation of Result object
+
+        Does not include anything related to unsatisfiability as we
+        are only interested in storing satisfiable results
+        """
+
+        # NOTE: _unsolved_specs, _concrete_specs_by_input, and _concrete_specs are all
+        # computed dynamically from self.answers, so they're not serialized.
+        return {
+            "criteria": self.criteria,
+            "optimal": self.optimal,
+            "warnings": self.warnings,
+            "nmodels": self.nmodels,
+            # abstract specs are not used for deserialization, but dropping them is
+            # forward-incompatible with Spack 1.2 and earlier.
+            "abstract_specs": [s.to_dict() for s in self.abstract_specs],
+            "satisfiable": self.satisfiable,
+            "answers": [
+                (opt, i, spec_dict_to_json(spec_dict)) for opt, i, spec_dict in self.answers
+            ],
+        }
+
+    @staticmethod
+    def from_dict(obj: dict, specs: List[spack.spec.Spec]):
+        """Returns Result object from compatible dictionary, for the given input specs.
+
+        The stored abstract specs are troubleshooting metadata and are deliberately not
+        deserialized: the caller's input specs are authoritative. This also keeps cache
+        entries with unreadable abstract spec data usable.
+        """
+        result = Result(specs)
+        result.criteria = [OptimizationCriteria(*t) for t in obj["criteria"]]
+        result.optimal = obj["optimal"]
+        result.warnings = obj["warnings"]
+        result.nmodels = obj["nmodels"]
+        result.satisfiable = obj["satisfiable"]
+        result.answers = [
+            (opt, i, spec_dict_from_json(spec_dict)) for opt, i, spec_dict in obj["answers"]
+        ]
+        # NOTE: _unsolved_specs, _concrete_specs_by_input, and _concrete_specs are all
+        # computed dynamically from self.answers, so they're not serialized.
+
+        return result
+
+    def __eq__(self, other):
+        eq = (
+            self.satisfiable == other.satisfiable,
+            self.optimal == other.optimal,
+            self.warnings == other.warnings,
+            self.nmodels == other.nmodels,
+            self.criteria == other.criteria,
+            self.answers == other.answers,
+            self.abstract_specs == other.abstract_specs,
+            # Not considered for equality
+            # self._concrete_specs_by_input   # These three are computed
+            # self._concrete_specs
+            # self._unsolved_specs
+            # self.control                    # Currently we just don't serialize these
+            # self.possible_dependencies
+        )
+        return all(eq)

--- a/lib/spack/spack/test/concretization/core.py
+++ b/lib/spack/spack/test/concretization/core.py
@@ -37,6 +37,7 @@ import spack.solver.asp
 import spack.solver.clauses
 import spack.solver.core
 import spack.solver.input_analysis
+import spack.solver.result
 import spack.solver.reuse
 import spack.spec
 import spack.spec_filter
@@ -327,9 +328,9 @@ def gcc11_with_flags(compiler_factory):
 def weights_from_result(result: Result, *, name: str) -> Dict[str, int]:
     weights = {}
     for x in result.criteria:
-        if x.name == name and x.kind == spack.solver.asp.OptimizationKind.CONCRETE:
+        if x.name == name and x.kind == spack.solver.result.OptimizationKind.CONCRETE:
             weights["reused"] = x.value
-        elif x.name == name and x.kind == spack.solver.asp.OptimizationKind.BUILD:
+        elif x.name == name and x.kind == spack.solver.result.OptimizationKind.BUILD:
             weights["built"] = x.value
     return weights
 
@@ -4545,7 +4546,7 @@ def test_result_roundtrip(mock_packages, config, specs):
     """Test that a solve result can be serialized and brought back."""
     solver = spack.solver.asp.Solver()
     result = solver.solve(specs)
-    roundtrip = spack.solver.asp.Result.from_dict(result.to_dict(), specs)
+    roundtrip = spack.solver.result.Result.from_dict(result.to_dict(), specs)
 
     # ensure that we didn't duplicate spec objects during the round trip -- specs need
     # to come back as exactly the same graph they were before.
@@ -4571,10 +4572,12 @@ def test_spec_dict_roundtrip(mock_packages, config, spec_str):
     dangling-hash bug in wire_spec_nodes.
     """
     spec = spack.concretize.concretize_one(spec_str)
-    nid = spack.solver.asp.SpecBuilder.make_node(pkg=spec.name)
+    nid = spack.solver.core.min_dupe_node(pkg=spec.name)
     spec_dict = {nid: spec}
 
-    roundtrip = spack.solver.asp.spec_dict_from_json(spack.solver.asp.spec_dict_to_json(spec_dict))
+    roundtrip = spack.solver.result.spec_dict_from_json(
+        spack.solver.result.spec_dict_to_json(spec_dict)
+    )
 
     # SpecDict shape is preserved exactly (no synthetic NodeIds leak into the dict)
     assert list(roundtrip.keys()) == [nid]
@@ -4611,11 +4614,11 @@ def test_concretization_cache_store_skips_spliced_results(mock_packages, use_con
     abstract_dep = Spec("pkg-b")
     root._add_dependency(abstract_dep, depflag=dt.LINK, virtuals=())
     root._add_dependency(spliced, depflag=dt.LINK, virtuals=())
-    nid = spack.solver.asp.SpecBuilder.make_node(pkg=root.name)
+    nid = spack.solver.core.min_dupe_node(pkg=root.name)
 
     # serialization refuses spliced specs, and must clean up any force-cached hashes
     with pytest.raises(spack.solver.asp.SpliceSerializationError):
-        spack.solver.asp.spec_dict_to_json({nid: root})
+        spack.solver.result.spec_dict_to_json({nid: root})
     assert abstract_dep._hash is None
     assert root._hash is None
 
@@ -5409,7 +5412,7 @@ def test_specs_from_mirror_warns_when_index_missing(monkeypatch):
 def test_spec_dict_from_json_invalid_data(data):
     """spec_dict_from_json raises ValueError on missing or malformed input."""
     with pytest.raises(ValueError, match="Invalid spec dict data"):
-        spack.solver.asp.spec_dict_from_json(data)
+        spack.solver.result.spec_dict_from_json(data)
 
 
 def test_concretization_cache_remove_entry_oserror(tmp_path):

--- a/lib/spack/spack/test/concretization/splicing.py
+++ b/lib/spack/spack/test/concretization/splicing.py
@@ -11,7 +11,8 @@ import spack.concretize
 import spack.config
 import spack.deptypes as dt
 from spack.old_installer import PackageInstaller
-from spack.solver.asp import SolverError, UnsatisfiableSpecError
+from spack.solver.asp import UnsatisfiableSpecError
+from spack.solver.error import SolverError
 
 
 def _make_specs_non_buildable(specs: List[str]):

--- a/lib/spack/spack/test/error.py
+++ b/lib/spack/spack/test/error.py
@@ -8,7 +8,7 @@ import pickle
 import pytest
 
 import spack.error
-import spack.solver.asp
+import spack.solver.error
 from spack.spec import Spec
 
 
@@ -28,10 +28,10 @@ def test_error_keeps_its_state_through_a_pipe():
 @pytest.mark.parametrize(
     "factory",
     [
-        lambda: spack.solver.asp.UnsatisfiableSpecError("boom"),
-        lambda: spack.solver.asp.InternalConcretizerError("boom"),
-        lambda: spack.solver.asp.SolverError(Spec("pkg-a")),
-        lambda: spack.solver.asp.OutputDoesNotSatisfyInputError(
+        lambda: spack.solver.error.UnsatisfiableSpecError("boom"),
+        lambda: spack.solver.error.InternalConcretizerError("boom"),
+        lambda: spack.solver.error.SolverError(Spec("pkg-a")),
+        lambda: spack.solver.error.OutputDoesNotSatisfyInputError(
             [(Spec("pkg-a"), Spec("pkg-b")), (Spec("pkg-c"), None)]
         ),
     ],
@@ -52,7 +52,7 @@ def test_errors_with_their_own_constructor_survive_a_pipe(factory):
 def test_output_does_not_satisfy_input_keeps_its_specs():
     """Tests that OutputDoesNotSatisfyInputError keeps its specs over a pickle round-trip."""
     unsolved = [(Spec("pkg-a"), Spec("pkg-b")), (Spec("pkg-c"), None)]
-    error = spack.solver.asp.OutputDoesNotSatisfyInputError(unsolved)
+    error = spack.solver.error.OutputDoesNotSatisfyInputError(unsolved)
 
     replayed = pickle.loads(pickle.dumps(error))
 


### PR DESCRIPTION
Extracted from #52891

This PR splits the error and result types from `asp.py` and puts them in their own module. More specifically:

* `spack.solver.result` carries `Result`, the optimization criteria types and the `SpecDict` serializers.
* `spack.solver.error` carries the exceptions and `format_unsolved`.

Neither imports the solver, so a caller can be typed against a result without pulling in how it is produced. This last property will be used to add more UI callbacks without introducing circular imports.