### PR TITLE
parser: disallow `=version` in range

### DIFF
--- a/lib/spack/spack/spec_parser.py
+++ b/lib/spack/spack/spec_parser.py
@@ -31,7 +31,7 @@ Here is the EBNF grammar for a spec::
     compiler      = id [@version_list]
 
     version_list  = version_item [ { , version_item } ]
-    version_item  = version | version_range | git_version [= (version|version_range)]
+    version_item  = version | =version | version_range | git_version [= (version|version_range)]
     version_range = vid:vid | vid: | :vid | :
     version       = vid
 
@@ -100,12 +100,13 @@ VALUE = r"(?:[a-zA-Z_0-9\-+\*.,:=%^\~\/\\]+)"
 #: Quoted values can be *anything* in between quotes, including escaped quotes.
 QUOTED_VALUE = r"(?:'(?:[^']|(?<=\\)')*'|\"(?:[^\"]|(?<=\\)\")*\")"
 
-VERSION = r"=?(?:[a-zA-Z0-9_][a-zA-Z_0-9\-\.]*\b)"
+VERSION = r"[a-zA-Z0-9_][a-zA-Z_0-9\-\.]*\b"
 VERSION_RANGE = rf"(?:(?:{VERSION})?:(?:{VERSION}(?!\s*=))?)"
 VERSION_OR_RANGE = rf"(?:{VERSION_RANGE}|{VERSION})"
 #: A git ref, optionally assigned a version or constrained to a range, e.g. ``git.main=1.2:``
 GIT_VERSION_ITEM = rf"(?:{GIT_VERSION_PATTERN}(?:={VERSION_OR_RANGE})?)"
-VERSION_LIST_ITEM = rf"(?:{GIT_VERSION_ITEM}|{VERSION_OR_RANGE})"
+#: Either a git version, an exact version, or a version range.
+VERSION_LIST_ITEM = rf"(?:{GIT_VERSION_ITEM}|={VERSION}|{VERSION_OR_RANGE})"
 VERSION_LIST = rf"{VERSION_LIST_ITEM}(?:\s*,\s*{VERSION_LIST_ITEM})*"
 
 SPLIT_KVP = re.compile(rf"^({NAME})(:?==?)(.*)$")

--- a/lib/spack/spack/test/spec_syntax.py
+++ b/lib/spack/spack/test/spec_syntax.py
@@ -1353,6 +1353,11 @@ def test_parse_toolchain(spec_str, toolchain, expected_roundtrip, mutable_config
         ("cflags=''-Wl,a,b,c''", r"cflags=''-Wl,a,b,c''\n            ^ ^ ^ ^^"),
         ("@1.2:   develop   = foo", r"@1.2:   develop   = foo\n                  ^"),
         ("@1.2:develop   = foo", r"@1.2:develop   = foo\n               ^"),
+        # = marks an exact version: neither a bound of a range nor the constraint of a git ref
+        ("x@=1:2", r"x@=1:2\n    ^"),
+        ("x@1:=2", r"x@1:=2\n    ^"),
+        ("x@git.foo==1.2", r"x@git.foo==1.2\n         ^^"),
+        ("x@git.foo=1:=2", r"x@git.foo=1:=2\n            ^"),
     ],
 )
 def test_error_reporting(text, expected_in_error):

--- a/lib/spack/spack/test/versions.py
+++ b/lib/spack/spack/test/versions.py
@@ -837,7 +837,6 @@ def test_version_git_vs_base(string, git):
     ],
 )
 def test_invalid_version_strings(string, error):
-    """A malformed version is a ValueError naming what is wrong, not an internal error."""
     with pytest.raises(ValueError, match=re.escape(error)):
         ver(string)
 

--- a/lib/spack/spack/test/versions.py
+++ b/lib/spack/spack/test/versions.py
@@ -9,6 +9,7 @@ where it makes sense.
 
 import os
 import pathlib
+import re
 
 import pytest
 
@@ -814,11 +815,31 @@ def test_git_branch_with_slash(monkeypatch):
         ("git.foo", True),
         ("git.abcdabcdabcdabcdabcdabcdabcdabcdabcdabcd", True),
         ("abcdabcdabcdabcdabcdabcdabcdabcdabcdabcd", True),
+        ("abcdabcdabcdabcdabcdabcdabcdabcdabcdabcd=1.2", True),
     ],
 )
 def test_version_git_vs_base(string, git):
     assert is_git_version(string) == git
     assert isinstance(Version(string), GitVersion) == git
+
+
+@pytest.mark.parametrize(
+    "string,error",
+    [
+        # the constraint on a ref can only be a version or a version range
+        ("git.foo==1.2", "Bad characters in version string: =1.2"),
+        ("git.foo=1:=2", "Bad characters in version string: =2"),
+        ("git.foo=1:2:3", "Bad characters in version string: 2:3"),
+        ("git.foo=1=2", "Bad characters in version string: 1=2"),
+        ("1:2:3", "Bad characters in version string: 2:3"),
+        # not a ref because `:` is not allowed, not a range because `=` is not allowed
+        ("1:=2", "Bad characters in version string: =2"),
+    ],
+)
+def test_invalid_version_strings(string, error):
+    """A malformed version is a ValueError naming what is wrong, not an internal error."""
+    with pytest.raises(ValueError, match=re.escape(error)):
+        ver(string)
 
 
 def test_version_range_nonempty():

--- a/lib/spack/spack/version/common.py
+++ b/lib/spack/spack/version/common.py
@@ -20,7 +20,11 @@ STRING_TO_PRERELEASE = {"alpha": ALPHA, "beta": BETA, "rc": RC, "final": FINAL}
 
 
 def is_git_version(string: str) -> bool:
-    return string.startswith("git.") or is_git_commit_sha(string) or "=" in string[1:]
+    """``git.<ref>``, ``<sha>`` or ``<ref>=<version or range>``"""
+    if string.startswith("git."):
+        return True
+    ref, sep, _ = string.partition("=")
+    return bool(ref) and ":" not in ref if sep else is_git_commit_sha(ref)
 
 
 class VersionError(spack.error.SpackError):

--- a/lib/spack/spack/version/common.py
+++ b/lib/spack/spack/version/common.py
@@ -24,7 +24,9 @@ def is_git_version(string: str) -> bool:
     if string.startswith("git."):
         return True
     ref, sep, _ = string.partition("=")
-    return bool(ref) and ":" not in ref if sep else is_git_commit_sha(ref)
+    if not sep:
+        return is_git_commit_sha(ref)
+    return bool(ref) and ":" not in ref
 
 
 class VersionError(spack.error.SpackError):

--- a/lib/spack/spack/version/version_types.py
+++ b/lib/spack/spack/version/version_types.py
@@ -23,7 +23,7 @@ from .common import (
 )
 
 # Valid version characters
-VALID_VERSION = re.compile(r"^[A-Za-z0-9_.-][=A-Za-z0-9_.-]*$")
+VALID_VERSION = re.compile(r"^[A-Za-z0-9_.-]+$")
 
 # regex for version segments
 SEGMENT_REGEX = re.compile(r"(?:(?P<num>[0-9]+)|(?P<str>[a-zA-Z]+))(?P<sep>[_.-]*)")
@@ -546,16 +546,14 @@ class GitVersion(ConcreteVersion):
         # Drop `git.` prefix
         normalized_string = string[4:] if self.has_git_prefix else string
 
-        if "=" in normalized_string:
-            # Store the git reference, and parse the user provided version or range.
-            self.ref, constraint = normalized_string.split("=")
-            if ":" in constraint:
-                self.constraint = _parse_range(constraint)
-            else:
-                self.constraint = StandardVersion.from_string(constraint)
-        else:
-            self.ref = normalized_string
+        # Store the git reference, and parse the user provided version or range.
+        self.ref, sep, constraint = normalized_string.partition("=")
+        if not sep:
             self.constraint = _UNBOUNDED_RANGE
+        elif ":" in constraint:
+            self.constraint = _parse_range(constraint)
+        else:
+            self.constraint = StandardVersion.from_string(constraint)
 
         # Used by fetcher
         self.is_commit: bool = is_git_commit_sha(self.ref)
@@ -1334,7 +1332,7 @@ def VersionRange(lo: Union[str, StandardVersion], hi: Union[str, StandardVersion
 
 def _parse_range(string: str) -> ClosedOpenRange:
     """Parse ``lo:hi``, ``lo:``, ``:hi`` or ``:`` into a range."""
-    s, e = string.split(":")
+    s, _, e = string.partition(":")
     lo = _STANDARD_VERSION_TYPEMIN if s == "" else StandardVersion.from_string(s)
     hi = _STANDARD_VERSION_TYPEMAX if e == "" else StandardVersion.from_string(e)
     return VersionRange(lo, hi)


### PR DESCRIPTION
Follow-up to #52990.

Previously the `VERSION` token included the optional `=` prefix that signals "exact version". It was used on either side of a range, which is wrong, because `1:=2` is not allowed in our grammar.

So, make `VERSION` a standalone token and add `={VERSION}` as a version list entry. That way, `1:=2` does not parse, and also `=` in the middle is unambiguously a git version assignment.

Our grammar specification already got it *almost* right, it was just missing `=version` as a version list entry.

Also fix a `ValueError: too many values to unpack issue` instead of a parser error (I think not reachable assuming parsed input, but still good).
