### PR TITLE
parser: a git hash is lowercase

### DIFF
--- a/lib/spack/spack/spec_parser.py
+++ b/lib/spack/spack/spec_parser.py
@@ -36,7 +36,7 @@ Here is the EBNF grammar for a spec::
     version       = vid
 
     git_version   = git.(vid) | git_hash
-    git_hash      = [A-Fa-f0-9]{40}
+    git_hash      = [a-f0-9]{40}
 
     quoted_id     = " id_with_ws " | ' id_with_ws '
     id_with_ws    = [a-zA-Z0-9_][a-zA-Z_0-9-.\\s]*
@@ -83,7 +83,8 @@ Spec: Optional[Type["spack.spec.Spec"]] = None
 #: characters that can be part of a word in any language
 IDENTIFIER = r"(?:[a-zA-Z_0-9][a-zA-Z_0-9\-]*)"
 DOTTED_IDENTIFIER = rf"(?:{IDENTIFIER}(?:\.{IDENTIFIER})+)"
-GIT_HASH = r"(?:[A-Fa-f0-9]{40})"
+#: Git commits are 40-character lowercase hex strings
+GIT_HASH = r"(?:[a-f0-9]{40})"
 #: Git refs include branch names, and can contain ``.`` and ``/``
 GIT_REF = r"(?:[a-zA-Z_0-9][a-zA-Z_0-9./\-]*)"
 GIT_VERSION_PATTERN = rf"(?:(?:git\.(?:{GIT_REF}))|(?:{GIT_HASH}))"

--- a/lib/spack/spack/test/spec_syntax.py
+++ b/lib/spack/spack/test/spec_syntax.py
@@ -19,6 +19,7 @@ import spack.repo
 import spack.solver.asp
 import spack.spec
 import spack.util.filesystem as fs
+import spack.version
 from spack.externals import (
     ExternalSpecsParser,
     complete_variants_and_architecture,
@@ -1876,6 +1877,17 @@ def test_git_ref_spec_equivalences(mock_packages, lhs_str, rhs_str, expected):
     assert rhs.intersects(lhs) is intersect
     assert lhs.satisfies(rhs) is lhs_sat_rhs
     assert rhs.satisfies(lhs) is rhs_sat_lhs
+
+
+def test_uppercase_hash_is_not_a_git_version():
+    """A git commit hash can only be written in lowercase. With mixed case it's a version range."""
+    mixed = "894CaF3Ce2AE06Abe360C0FB39EF0dEB5BDD8510"
+    spec = spack.spec.Spec(f"x@{mixed}")
+    assert not isinstance(spec.versions[0], spack.version.GitVersion)
+    assert spack.spec.Spec(str(spec)) == spec
+    with pytest.raises(SpecTokenizationError):
+        spack.spec.Spec(f"x@{mixed}=1.2")
+    assert isinstance(spack.spec.Spec(f"x@{mixed.lower()}").versions[0], spack.version.GitVersion)
 
 
 @pytest.mark.regression("32471")


### PR DESCRIPTION
Bit of a curiosity: when you write `@Abcd...` exactly 40 hexadecimal characters long with mixed case, it parses as a version range. If you use all lowercase, it parses as a git version (or git commit).

The new syntax `@<ref>=<range>` allows you to write

```
@Abcd...9=:
```

which canonicalizes as string to

```
@Abcd..9
```

which then parses back as a version range instead of a git version, because it includes mixed case.

I think the most sensible solution to consistently allow lowercase `a-f` in git commit versions only then. That is consistent with `is_git_commit_sha` which has the final say in what qualifies as a git commit sha, the parser was just more generic than that function. Now they are both the same.

