### PR TITLE
correct error message for bootstrap DB migration

### DIFF
--- a/lib/spack/spack/bootstrap/config.py
+++ b/lib/spack/spack/bootstrap/config.py
@@ -101,6 +101,13 @@ def ensure_bootstrap_configuration() -> Generator:
         else:
             with _ensure_bootstrap_configuration():
                 yield
+    except Exception as e:
+        # Adjust database upgrade error messages to include -b flag when in bootstrap mode
+        from spack.database import ExplicitDatabaseUpgradeError
+
+        if isinstance(e, ExplicitDatabaseUpgradeError) and e._long_message:
+            e._long_message = e._long_message.replace("spack reindex", "spack -b reindex")
+        raise
     finally:
         _REF_COUNT -= 1
 

--- a/lib/spack/spack/bootstrap/config.py
+++ b/lib/spack/spack/bootstrap/config.py
@@ -15,6 +15,7 @@ import spack.paths
 import spack.platforms
 import spack.repo
 import spack.store
+from spack.error import ExplicitDatabaseUpgradeError
 from spack.util import tty
 
 #: Reference counter for the bootstrapping configuration context manager
@@ -101,11 +102,9 @@ def ensure_bootstrap_configuration() -> Generator:
         else:
             with _ensure_bootstrap_configuration():
                 yield
-    except Exception as e:
+    except ExplicitDatabaseUpgradeError as e:
         # Adjust database upgrade error messages to include -b flag when in bootstrap mode
-        from spack.database import ExplicitDatabaseUpgradeError
-
-        if isinstance(e, ExplicitDatabaseUpgradeError) and e._long_message:
+        if e._long_message:
             e._long_message = e._long_message.replace("spack reindex", "spack -b reindex")
         raise
     finally:

--- a/lib/spack/spack/database.py
+++ b/lib/spack/spack/database.py
@@ -945,28 +945,8 @@ class Database:
         return (self.db_version, _DB_VERSION) in _REINDEX_NOT_NEEDED_ON_READ
 
     def raise_explicit_database_upgrade_error(self):
-        """Raises an ExplicitDatabaseUpgradeError with an appropriate message"""
-        raise ExplicitDatabaseUpgradeError(
-            f"database is v{self.db_version}, but Spack v{spack.__version__} needs v{_DB_VERSION}",
-            long_message=(
-                f"You will need to either:"
-                f"\n"
-                f"\n  1. Migrate the database to v{_DB_VERSION}, or"
-                f"\n  2. Use a new database by changing config:install_tree:root."
-                f"\n"
-                f"\nTo migrate the database at {self.root} "
-                f"\nto version {_DB_VERSION}, run:"
-                f"\n"
-                f"\n    spack reindex"
-                f"\n"
-                f"\nNOTE that if you do this, older Spack versions will no longer"
-                f"\nbe able to read the database. However, `spack reindex` will create a backup,"
-                f"\nin case you want to revert."
-                f"\n"
-                f"\nIf you still need your old database, you can instead run"
-                f"\n`spack config edit config` and set install_tree:root to a new location."
-            ),
-        )
+        """Raises an ExplicitDatabaseUpgradeError with version and path info"""
+        raise ExplicitDatabaseUpgradeError(self.db_version, _DB_VERSION, self.root)
 
     def reindex(self):
         """Build database index from scratch based on a directory layout.
@@ -1981,6 +1961,33 @@ class InvalidDatabaseVersionError(SpackError):
 
 class ExplicitDatabaseUpgradeError(SpackError):
     """Raised to request an explicit DB upgrade to the user"""
+
+    def __init__(self, db_version, expected_version, root):
+        self.db_version = db_version
+        self.expected_version = expected_version
+        self.root = root
+        long_message = (
+            f"You will need to either:"
+            f"\n"
+            f"\n  1. Migrate the database to v{expected_version}, or"
+            f"\n  2. Use a new database by changing config:install_tree:root."
+            f"\n"
+            f"\nTo migrate the database at {root} "
+            f"\nto version {expected_version}, run:"
+            f"\n"
+            f"\n    spack reindex"
+            f"\n"
+            f"\nNOTE that if you do this, older Spack versions will no longer"
+            f"\nbe able to read the database. However, `spack reindex` will create a"
+            f"\nbackup, in case you want to revert."
+            f"\n"
+            f"\nIf you still need your old database, you can instead run"
+            f"\n`spack config edit config` and set install_tree:root to a new location."
+        )
+        super().__init__(
+            f"database is v{db_version}, but Spack v{spack.__version__} needs v{expected_version}",
+            long_message=long_message,
+        )
 
 
 class DatabaseNotReadableError(SpackError):

--- a/lib/spack/spack/database.py
+++ b/lib/spack/spack/database.py
@@ -946,7 +946,9 @@ class Database:
 
     def raise_explicit_database_upgrade_error(self):
         """Raises an ExplicitDatabaseUpgradeError with version and path info"""
-        raise ExplicitDatabaseUpgradeError(self.db_version, _DB_VERSION, self.root)
+        raise ExplicitDatabaseUpgradeError(
+            self.db_version, _DB_VERSION, self.root, spack.spack_version
+        )
 
     def reindex(self):
         """Build database index from scratch based on a directory layout.

--- a/lib/spack/spack/database.py
+++ b/lib/spack/spack/database.py
@@ -65,7 +65,7 @@ from spack.directory_layout import (
     DirectoryLayoutError,
     InconsistentInstallDirectoryError,
 )
-from spack.error import SpackError
+from spack.error import ExplicitDatabaseUpgradeError, SpackError
 from spack.util import tty
 from spack.util.crypto import bit_length
 from spack.util.socket import _gethostname
@@ -1957,37 +1957,6 @@ class InvalidDatabaseVersionError(SpackError):
     @property
     def database_version_message(self):
         return f"The expected DB version is '{self.expected}', but '{self.found}' was found."
-
-
-class ExplicitDatabaseUpgradeError(SpackError):
-    """Raised to request an explicit DB upgrade to the user"""
-
-    def __init__(self, db_version, expected_version, root):
-        self.db_version = db_version
-        self.expected_version = expected_version
-        self.root = root
-        long_message = (
-            f"You will need to either:"
-            f"\n"
-            f"\n  1. Migrate the database to v{expected_version}, or"
-            f"\n  2. Use a new database by changing config:install_tree:root."
-            f"\n"
-            f"\nTo migrate the database at {root} "
-            f"\nto version {expected_version}, run:"
-            f"\n"
-            f"\n    spack reindex"
-            f"\n"
-            f"\nNOTE that if you do this, older Spack versions will no longer"
-            f"\nbe able to read the database. However, `spack reindex` will create a"
-            f"\nbackup, in case you want to revert."
-            f"\n"
-            f"\nIf you still need your old database, you can instead run"
-            f"\n`spack config edit config` and set install_tree:root to a new location."
-        )
-        super().__init__(
-            f"database is v{db_version}, but Spack v{spack.__version__} needs v{expected_version}",
-            long_message=long_message,
-        )
 
 
 class DatabaseNotReadableError(SpackError):

--- a/lib/spack/spack/error.py
+++ b/lib/spack/spack/error.py
@@ -228,3 +228,36 @@ class SpecFilenameError(SpecError):
 
 class NoSuchSpecFileError(SpecFilenameError):
     """Raised when a spec file doesn't exist."""
+
+
+class ExplicitDatabaseUpgradeError(SpackError):
+    """Raised to request an explicit DB upgrade to the user"""
+
+    def __init__(self, db_version, expected_version, root):
+        import spack
+
+        self.db_version = db_version
+        self.expected_version = expected_version
+        self.root = root
+        long_message = (
+            f"You will need to either:"
+            f"\n"
+            f"\n  1. Migrate the database to v{expected_version}, or"
+            f"\n  2. Use a new database by changing config:install_tree:root."
+            f"\n"
+            f"\nTo migrate the database at {root} "
+            f"\nto version {expected_version}, run:"
+            f"\n"
+            f"\n    spack reindex"
+            f"\n"
+            f"\nNOTE that if you do this, older Spack versions will no longer"
+            f"\nbe able to read the database. However, `spack reindex` will create a"
+            f"\nbackup, in case you want to revert."
+            f"\n"
+            f"\nIf you still need your old database, you can instead run"
+            f"\n`spack config edit config` and set install_tree:root to a new location."
+        )
+        super().__init__(
+            f"database is v{db_version}, but Spack v{spack.__version__} needs v{expected_version}",
+            long_message=long_message,
+        )

--- a/lib/spack/spack/error.py
+++ b/lib/spack/spack/error.py
@@ -233,9 +233,7 @@ class NoSuchSpecFileError(SpecFilenameError):
 class ExplicitDatabaseUpgradeError(SpackError):
     """Raised to request an explicit DB upgrade to the user"""
 
-    def __init__(self, db_version, expected_version, root):
-        import spack
-
+    def __init__(self, db_version, expected_version, root, spack_version):
         self.db_version = db_version
         self.expected_version = expected_version
         self.root = root
@@ -258,6 +256,6 @@ class ExplicitDatabaseUpgradeError(SpackError):
             f"\n`spack config edit config` and set install_tree:root to a new location."
         )
         super().__init__(
-            f"database is v{db_version}, but Spack v{spack.__version__} needs v{expected_version}",
+            f"database is v{db_version}, but Spack v{spack_version} needs v{expected_version}",
             long_message=long_message,
         )

--- a/lib/spack/spack/test/bootstrap.py
+++ b/lib/spack/spack/test/bootstrap.py
@@ -153,6 +153,33 @@ def test_bootstrap_deactivates_environments(active_mock_environment):
     assert active_environment() == active_mock_environment
 
 
+def test_bootstrap_db_upgrade_error_points_at_b_flag(mutable_config, monkeypatch):
+    """An outdated bootstrap store database must raise ExplicitDatabaseUpgradeError, and,
+    because the store being read is the bootstrap store, the migration hint must be
+    ``spack -b reindex`` rather than plain ``spack reindex``.
+    """
+    import spack.database
+    import spack.version as vn
+    from spack.database import Database, ExplicitDatabaseUpgradeError
+
+    with pytest.raises(ExplicitDatabaseUpgradeError) as exc_info:
+        with spack.bootstrap.ensure_bootstrap_configuration():
+            db_dir = pathlib.Path(spack.store.STORE.root) / ".spack-db"
+            db_dir.mkdir(parents=True, exist_ok=True)
+            (db_dir / "index.json").write_text(
+                json.dumps(
+                    {"database": {"version": str(spack.database._DB_VERSION), "installs": {}}}
+                )
+            )
+            next_version = vn.Version(f"{spack.database._DB_VERSION[0] + 1}")
+            monkeypatch.setattr(spack.database, "_DB_VERSION", next_version)
+            Database(spack.store.STORE.root)._read()
+
+    long_message = exc_info.value.long_message
+    assert "spack -b reindex" in long_message
+    assert "spack reindex" not in long_message
+
+
 @pytest.mark.regression("25805")
 def test_bootstrap_disables_modulefile_generation(mutable_config):
     # Be sure to enable both lmod and tcl in modules.yaml

--- a/lib/spack/spack/test/bootstrap.py
+++ b/lib/spack/spack/test/bootstrap.py
@@ -17,6 +17,7 @@ import spack.bootstrap.status
 import spack.compilers.config
 import spack.concretize
 import spack.config
+import spack.database
 import spack.environment
 import spack.error
 import spack.installer_dispatch
@@ -24,6 +25,7 @@ import spack.paths
 import spack.spec
 import spack.store
 import spack.util.executable
+import spack.version
 from spack.active_environment import active_environment
 
 CLINGO_METADATA = sorted(pathlib.Path(spack.paths.share_path).glob("bootstrap/*/clingo.json"))
@@ -158,11 +160,7 @@ def test_bootstrap_db_upgrade_error_points_at_b_flag(mutable_config, monkeypatch
     because the store being read is the bootstrap store, the migration hint must be
     ``spack -b reindex`` rather than plain ``spack reindex``.
     """
-    import spack.database
-    import spack.version as vn
-    from spack.database import Database, ExplicitDatabaseUpgradeError
-
-    with pytest.raises(ExplicitDatabaseUpgradeError) as exc_info:
+    with pytest.raises(spack.error.ExplicitDatabaseUpgradeError) as exc_info:
         with spack.bootstrap.ensure_bootstrap_configuration():
             db_dir = pathlib.Path(spack.store.STORE.root) / ".spack-db"
             db_dir.mkdir(parents=True, exist_ok=True)
@@ -171,9 +169,9 @@ def test_bootstrap_db_upgrade_error_points_at_b_flag(mutable_config, monkeypatch
                     {"database": {"version": str(spack.database._DB_VERSION), "installs": {}}}
                 )
             )
-            next_version = vn.Version(f"{spack.database._DB_VERSION[0] + 1}")
+            next_version = spack.version.Version(f"{spack.database._DB_VERSION[0] + 1}")
             monkeypatch.setattr(spack.database, "_DB_VERSION", next_version)
-            Database(spack.store.STORE.root)._read()
+            spack.database.Database(spack.store.STORE.root)._read()
 
     long_message = exc_info.value.long_message
     assert "spack -b reindex" in long_message

--- a/lib/spack/spack/test/database.py
+++ b/lib/spack/spack/test/database.py
@@ -1201,6 +1201,22 @@ def test_error_message_when_using_too_new_db(database: Database, monkeypatch):
         Database(database.root)._read()
 
 
+def test_explicit_upgrade_error_when_using_too_old_db(database: Database, monkeypatch):
+    """When the on-disk database is older than what Spack expects and a reindex is not
+    requested, reading it should raise ExplicitDatabaseUpgradeError telling the user to
+    run `spack reindex`.
+    """
+    next_version = vn.Version(f"{spack.database._DB_VERSION[0] + 1}")
+    monkeypatch.setattr(spack.database, "_DB_VERSION", next_version)
+    with pytest.raises(spack.database.ExplicitDatabaseUpgradeError) as exc_info:
+        Database(database.root)._read()
+
+    err = exc_info.value
+    assert err.expected_version == next_version
+    assert str(err.root) == str(database.root)
+    assert "spack reindex" in err.long_message
+
+
 @pytest.mark.parametrize(
     "lock_cfg",
     [spack.database.NO_LOCK, spack.database.NO_TIMEOUT, spack.database.DEFAULT_LOCK_CFG, None],


### PR DESCRIPTION
Users can get confused by error message instructing them to migrate DB via `spack reindex`, even though the DB is the bootstrap DB.