### PR TITLE
error messages: explain why external isn't chosen

### DIFF
--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -1801,6 +1801,19 @@ class SpackSolverSetup:
             if not data.get("buildable", True):
                 self.gen.h2(f"External package: {pkg_name}")
                 self.gen.fact(fn.buildable_false(pkg_name))
+                # Record what is on offer, so that a failure can name the external that was
+                # rejected instead of only "no externals satisfy the request": the spec as
+                # written, and its versions as written for the version-mismatch message.
+                for entry in data.get("externals", []):
+                    try:
+                        versions = spack.spec.Spec(entry["spec"]).versions
+                    except Exception:  # noqa: BLE001
+                        continue
+                    # packages_with_externals is deepcopy_as_builtin(..., line_info=True), so
+                    # each entry carries its YAML mark as line_info
+                    location = getattr(entry, "line_info", "")
+                    as_written = f"'{entry['spec']}'" + (f" from {location}" if location else "")
+                    self.gen.pkg_fact(pkg_name, fn.external_declared(as_written, str(versions)))
 
     def preferred_variants(self, pkg_name):
         """Facts on concretization preferences, as read from packages.yaml"""

--- a/lib/spack/spack/solver/display.lp
+++ b/lib/spack/spack/solver/display.lp
@@ -49,5 +49,6 @@
 #show imposed_nodes/2.
 #show variant_single_value/2.
 #show has_provider/1.
+#show buildable_false/1.
 
 % debug

--- a/lib/spack/spack/solver/error_messages.lp
+++ b/lib/spack/spack/solver/error_messages.lp
@@ -147,6 +147,29 @@ error(0, "'{0}' requires conflicting variant values 'Spec({1}={2})' and 'Spec({1
      condition_holds(Cause2, node(X, TriggerPkg2)),
      Value1 < Value2. % see[1] in concretize.lp
 
+% A `buildable:false` package that has to be built: name what is on offer. This line is true
+% whatever the mismatch turns out to be -- a variant or a target just as easily as a version.
+error(0, "Cannot build {0}, since it is configured `buildable:false`; the external declared for it is {1}", Package, ExternalSpec)
+  :- buildable_false(Package),
+     attr("node", node(ID, Package)),
+     build(node(ID, Package)),
+     pkg_fact(Package, external_declared(ExternalSpec, _)).
+
+% ... and when its version is the mismatch, say which constraint it failed. The version check is
+% what keeps this from blaming the version for a variant mismatch. ":" is an external declared
+% without a version, which cannot fail on it.
+error(0, "Cannot build {0}, since it is configured `buildable:false` and the external {0}@{1} does not satisfy '{0}@{2}'", Package, ExternalVersion, Constraint, startcauses, Cause, CauseID)
+  :- buildable_false(Package),
+     attr("node", node(ID, Package)),
+     build(node(ID, Package)),
+     pkg_fact(Package, external_declared(_, ExternalVersion)),
+     ExternalVersion != ":",
+     attr("node_version_satisfies", node(ID, Package), Constraint),
+     not pkg_fact(Package, version_satisfies(Constraint, ExternalVersion)),
+     pkg_fact(TriggerPkg, condition_effect(Cause, EffectID)),
+     imposed_constraint(EffectID, "node_version_satisfies", Package, Constraint),
+     condition_holds(Cause, node(CauseID, TriggerPkg)).
+
 % error message with causes for conflicts
 error(0, Msg, startcauses, TriggerID, ID1, ConstraintID, ID2)
   :- attr("node", node(ID, Package)),
@@ -209,6 +232,7 @@ pkg_fact(Package, version_satisfies(Constraint, Version)) :-
 #defined external/1.
 #defined trigger_and_effect/3.
 #defined build/1.
+#defined buildable_false/1.
 #defined node_has_variant/3.
 #defined provider/2.
 #defined variant_single_value/2.

--- a/lib/spack/spack/test/concretization/errors.py
+++ b/lib/spack/spack/test/concretization/errors.py
@@ -316,6 +316,38 @@ def test_config_driven_errors(
     assert_actionable_error(exc_info, *expected_parts)
 
 
+def test_buildable_false_names_the_external_and_the_constraint(
+    mock_packages, mutable_config: Configuration
+):
+    """`buildable: false` with an external that is too old must name the external on offer and
+    the constraint it failed, not just "no externals satisfy the request"."""
+    mutable_config.set(
+        "packages:libelf",
+        {"buildable": False, "externals": [{"spec": "libelf@0.8.10", "prefix": "/usr"}]},
+    )
+    with pytest.raises(spack.error.SpackError) as exc_info:
+        spack.concretize.concretize_one("libelf@0.8.13:")
+    assert_actionable_error(exc_info, "libelf@0.8.10", "0.8.13:")
+
+
+def test_buildable_false_names_the_external_on_a_variant_mismatch(
+    mock_packages, mutable_config: Configuration
+):
+    """When the external fails on something other than its version, the message must still name
+    it, and must not claim the version is at fault."""
+    mutable_config.set(
+        "packages:quantum-espresso",
+        {
+            "buildable": False,
+            "externals": [{"spec": "quantum-espresso@1.0~veritas", "prefix": "/u"}],
+        },
+    )
+    with pytest.raises(spack.error.SpackError) as exc_info:
+        spack.concretize.concretize_one("quantum-espresso+veritas")
+    assert_actionable_error(exc_info, "quantum-espresso@1.0~veritas")
+    assert "does not satisfy" not in str(exc_info.value)
+
+
 @pytest.mark.parametrize(
     "input_spec,expected_handles",
     [


### PR DESCRIPTION
(note: unfiltered llm content)

- **solver: name the external on offer when a buildable:false package cannot be used**
  The only message was
  
      Cannot build cmake, since it is configured `buildable:false` and no externals satisfy the request
  
  which does not say what external was considered, nor why it was rejected.
  Two lines are added in the causation pass: one naming the external as
  written in packages.yaml, whatever the mismatch is, and one for a version
  mismatch that quotes the constraint that failed and where it came from:
  
      Cannot build cmake, since it is configured `buildable:false`; the external declared for it is 'cmake@2.8.10.2' from packages.yaml:5
      Cannot build cmake, since it is configured `buildable:false` and the external cmake@2.8.10.2 does not satisfy 'cmake@3.18:'
         required because hdf5 depends on cmake@3.18: when @1.14:
  
  The version check is what keeps the second line from blaming the version
  when the real mismatch is a variant.
  