### PR TITLE
error messages: mention the parent when dep is rejected

### DIFF
--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -674,6 +674,31 @@ def _make_cache_key(asp_problem: str, control_file_paths: List[str]) -> str:
     return "\n".join(components)
 
 
+def _excluded_by_provider_requirement(name: str, parser: RequirementParser) -> str:
+    """Explain a rejected `^dep` that a virtual requirement rules out.
+
+    Asking for `^jdk` where packages.yaml says `java: require: openjdk` leaves jdk out of the
+    possible dependencies entirely, and the bare "not a possible dependency" says nothing about
+    the requirement that put it there.
+    """
+    try:
+        pkg_cls = spack.repo.PATH.get_pkg_class(name)
+    except spack.repo.UnknownPackageError:
+        return ""
+    for virtual in pkg_cls.provided_virtual_names():
+        for rule in parser.rules_from_virtual(virtual):
+            if rule.origin != RequirementOrigin.REQUIRE_YAML or rule.condition != EMPTY_SPEC:
+                continue
+            required = {s.name for s in rule.requirements if s.name}
+            if required and name not in required:
+                text = "'" + "' or '".join(str(s) for s in rule.requirements) + "'"
+                return (
+                    f": the '{virtual}' virtual it provides is required to be {text}, "
+                    f"which '{name}' is not"
+                )
+    return ""
+
+
 class PyclingoDriver:
     def __init__(self, conc_cache: Optional[ConcretizationCache] = None) -> None:
         """Driver for the Python clingo interface.
@@ -2238,9 +2263,11 @@ class SpackSolverSetup:
                 # name what it was asked of, not just what was asked for
                 parent = edge.parent.name if edge.parent is not None else None
                 of = f"'{parent}'" if parent else "any root spec"
-                raise InvalidDependencyError(
-                    f"'{edge.spec.name}' is not a possible dependency of {of}"
+                message = f"'{edge.spec.name}' is not a possible dependency of {of}"
+                because = _excluded_by_provider_requirement(
+                    edge.spec.name, self.requirement_parser
                 )
+                raise InvalidDependencyError(f"{message}{because}")
 
     def input_spec_version_check(self, specs, allow_deprecated: bool) -> None:
         """Raise an error early if no versions available in the solve can satisfy the inputs."""

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -2235,8 +2235,11 @@ class SpackSolverSetup:
             if spack.repo.PATH.is_virtual(edge.spec.name):
                 possible_deps = self.possible_virtuals
             if edge.spec.name not in possible_deps and not str(edge.when):
+                # name what it was asked of, not just what was asked for
+                parent = edge.parent.name if edge.parent is not None else None
+                of = f"'{parent}'" if parent else "any root spec"
                 raise InvalidDependencyError(
-                    f"'{edge.spec.name}' is not a possible dependency of any root spec"
+                    f"'{edge.spec.name}' is not a possible dependency of {of}"
                 )
 
     def input_spec_version_check(self, specs, allow_deprecated: bool) -> None:

--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -282,7 +282,7 @@ condition_set(LiteralNode, BuildNode) :- build_dependency_of_literal_node(Litera
 
 % Generate a comprehensible error for cases like 'foo ^bar' where 'bar' is a build dependency
 % of a transitive dependency of 'foo'
-error(1, "{0} is not a direct 'build' or 'test' dependency, or transitive 'link' or 'run' dependency of any root", Literal)
+error(1, "'{0}' is not a direct 'build' or 'test' dependency of '{1}', nor a transitive 'link' or 'run' dependency of it", Literal, RootPackage)
   :- literal_node(RootPackage, node(X, Literal)),
      not depends_on(node(min_dupe_id, RootPackage), node(X, Literal)),
      not unification_set("root", node(X, Literal)).

--- a/lib/spack/spack/test/concretization/errors.py
+++ b/lib/spack/spack/test/concretization/errors.py
@@ -20,6 +20,7 @@ import spack.concretize
 import spack.error
 import spack.main
 import spack.solver.asp
+import spack.solver.error
 import spack.spec
 from spack.config import Configuration
 
@@ -109,6 +110,20 @@ def test_virtual_constrained_beyond_versions_error(spec, mock_packages, mutable_
         _ = spack.concretize.concretize_one(spec)
 
     assert "cannot concretize" in str(e.value)
+
+
+def test_provider_excluded_by_requirement_names_both(mock_packages, mutable_config: Configuration):
+    """Asking for a provider that a virtual requirement rules out must name the provider that is
+    required, not just say the one asked for is impossible."""
+    mutable_config.set("concretizer:static_analysis", True)
+    mutable_config.set("packages:mpi", {"require": ["mpich"]})
+    with pytest.raises(spack.solver.error.InvalidDependencyError) as exc_info:
+        spack.concretize.concretize_one("mpileaks ^zmpi")
+    assert_actionable_error(
+        exc_info,
+        "'zmpi' is not a possible dependency of 'mpileaks'",
+        "the 'mpi' virtual it provides is required to be 'mpich', which 'zmpi' is not",
+    )
 
 
 def test_internal_error_handling_formatting(tmp_path: pathlib.Path):

--- a/lib/spack/spack/test/concretization/errors.py
+++ b/lib/spack/spack/test/concretization/errors.py
@@ -187,7 +187,7 @@ def assert_actionable_error(exc_info, *required_part: str) -> None:
         # via link/run from multivalue-variant.
         pytest.param(
             "multivalue-variant ^gmake",
-            ["gmake is not a direct 'build' or"],
+            ["'gmake' is not a direct 'build' or 'test' dependency of 'multivalue-variant'"],
             id="literal_not_in_dag",
         ),
         # mvapich2 file_systems uses auto_or_any_combination_of, but "auto" and "lustre"


### PR DESCRIPTION
(note: unfiltered llm content)

- **solver: name the package a rejected dependency was asked of**
  Two messages named what the user asked for but not what it conflicts
  with. "is not a direct dependency" never said of what:
  
      -  gmake is not a direct 'build' or 'test' dependency, or transitive
      -  'link' or 'run' dependency of any root
      +  'gmake' is not a direct 'build' or 'test' dependency of
      +  'multivalue-variant', nor a transitive 'link' or 'run' dependency of it
  
  Same for the pre-solve check, which had the parent in hand already:
  
      -  'cray-mpich' is not a possible dependency of any root spec
      +  'cray-mpich' is not a possible dependency of 'grackle'
  

- **solver: say which requirement ruled out a provider**
  With static analysis on, a provider that a virtual requirement excludes
  is not a possible dependency at all, and the pre-solve check said only
  that:
  
      packages: {java: {require: openjdk}}
      $ spack spec 'kibana ^jdk'
      -  'jdk' is not a possible dependency of 'kibana'
      +  'jdk' is not a possible dependency of 'kibana': the 'java' virtual it
      +  provides is required to be 'openjdk', which 'jdk' is not
  
  Package names are compared rather than substrings: "jdk" occurs inside
  "openjdk", and a substring test says the requirement is already met.
 
  