### PR TITLE
error messages: mention the requirement on failure

### DIFF
--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -1724,8 +1724,22 @@ class SpackSolverSetup:
 
             self.gen.fact(fn.requirement_group(pkg_name, requirement_grp_id))
             self.gen.fact(fn.requirement_policy(pkg_name, requirement_grp_id, policy))
+            # What the requirement actually says, so a failure can quote it. Without this the
+            # only thing reported is "cannot satisfy a requirement for package 'X'".
+            requirement_text = "'" + "' or '".join(str(s) for s in requirement_grp) + "'"
+            location_prefix = ""
+            if rule.location:
+                requirement_text += f" from {rule.location}"
+                location_prefix = f"{rule.location}: "
+            self.gen.fact(
+                fn.requirement_group_spec(pkg_name, requirement_grp_id, requirement_text)
+            )
             if rule.message:
-                self.gen.fact(fn.requirement_message(pkg_name, requirement_grp_id, rule.message))
+                self.gen.fact(
+                    fn.requirement_message(
+                        pkg_name, requirement_grp_id, f"{location_prefix}{rule.message}"
+                    )
+                )
             self.gen.newline()
 
             for input_spec in requirement_grp:
@@ -1754,7 +1768,9 @@ class SpackSolverSetup:
                     # else: for virtuals we want to emit "node" and
                     # "virtual_node" in imposed specs
 
-                    info_msg = f"{input_spec} is a requirement for package {pkg_name}"
+                    info_msg = (
+                        f"{location_prefix}{input_spec} is a requirement for package {pkg_name}"
+                    )
                     if rule.condition != EMPTY_SPEC:
                         info_msg += f" when {rule.condition}"
                     if rule.message:

--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -1403,9 +1403,10 @@ requirement_penalty(PackageNode, Language, Group, W) :-
   attr("concrete_build_dependency", PackageNode, CompilerName, CompilerHash),
   attr("virtual_on_build_edge", PackageNode, CompilerName, Language).
 
-error(60000, "cannot satisfy a requirement for package '{0}'.", Package) :-
+error(60000, "cannot satisfy requirement {1} for package '{0}'", Package, Requirement) :-
   activate_requirement(node(ID, Package), X),
   requirement_group(Package, X),
+  requirement_group_spec(Package, X, Requirement),
   not has_requirement_message(Package, X),
   not requirement_group_satisfied(node(ID, Package), X).
 
@@ -1423,6 +1424,7 @@ error(50000, Message) :-
 #defined requirement_group_member/3.
 #defined requirement_has_weight/2.
 #defined requirement_policy/3.
+#defined requirement_group_spec/3.
 
 %-----------------------------------------------------------------------------
 % Variant semantics

--- a/lib/spack/spack/solver/requirements.py
+++ b/lib/spack/spack/solver/requirements.py
@@ -114,6 +114,9 @@ class RequirementRule(NamedTuple):
     condition: spack.spec.Spec
     kind: RequirementKind
     message: Optional[str]
+    #: "file:line" where this rule was written, or "" if it did not come from YAML. Specs lose
+    #: the mark when parsed, so it is recorded here for error messages to quote.
+    location: str = ""
 
 
 def preference(
@@ -123,6 +126,7 @@ def preference(
     origin: RequirementOrigin = RequirementOrigin.PREFER_YAML,
     kind: RequirementKind = RequirementKind.PACKAGE,
     message: Optional[str] = None,
+    location: str = "",
 ) -> RequirementRule:
     """Returns a preference rule"""
     # A strong preference is defined as:
@@ -137,6 +141,7 @@ def preference(
         condition=condition,
         origin=origin,
         message=message,
+        location=location,
     )
 
 
@@ -147,6 +152,7 @@ def conflict(
     origin: RequirementOrigin = RequirementOrigin.CONFLICT_YAML,
     kind: RequirementKind = RequirementKind.PACKAGE,
     message: Optional[str] = None,
+    location: str = "",
 ) -> RequirementRule:
     """Returns a conflict rule"""
     # A conflict is defined as:
@@ -161,6 +167,7 @@ def conflict(
         condition=condition,
         origin=origin,
         message=message,
+        location=location,
     )
 
 
@@ -255,9 +262,16 @@ class RequirementParser:
             if kind == RequirementKind.DEFAULT:
                 # Warn about %gcc type of preferences under `all`.
                 self._maybe_warn_compiler_in_all(item, "prefer")
-            spec, condition, msg = self._parse_prefer_conflict_item(item)
+            spec, condition, msg, location = self._parse_prefer_conflict_item(item)
             result.append(
-                preference(pkg_name, constraint=spec, condition=condition, kind=kind, message=msg)
+                preference(
+                    pkg_name,
+                    constraint=spec,
+                    condition=condition,
+                    kind=kind,
+                    message=msg,
+                    location=location,
+                )
             )
         return result
 
@@ -270,9 +284,16 @@ class RequirementParser:
     ) -> List[RequirementRule]:
         result = []
         for item in conflicts:
-            spec, condition, msg = self._parse_prefer_conflict_item(item)
+            spec, condition, msg, location = self._parse_prefer_conflict_item(item)
             result.append(
-                conflict(pkg_name, constraint=spec, condition=condition, kind=kind, message=msg)
+                conflict(
+                    pkg_name,
+                    constraint=spec,
+                    condition=condition,
+                    kind=kind,
+                    message=msg,
+                    location=location,
+                )
             )
         return result
 
@@ -289,7 +310,7 @@ class RequirementParser:
             message = item.get("message")
         raw_key = item if isinstance(item, str) else item.get("spec", item)
         _check_unknown_targets([raw_key], [spec], always_warn=True)
-        return spec, condition, message
+        return spec, condition, message, source_location(raw_key)
 
     def _raw_yaml_data(self, pkg_name: str, *, section: str, virtual: bool = False):
         config = self.config.get_config("packages")
@@ -315,6 +336,8 @@ class RequirementParser:
 
         rules = []
         for requirement in requirements:
+            # Take the mark before wrapping a bare string below in a plain dict that has none
+            location = source_location(requirement)
             # A string is equivalent to a one_of group with a single element
             if isinstance(requirement, str):
                 requirement = {"one_of": [requirement]}
@@ -361,6 +384,7 @@ class RequirementParser:
                         message=requirement.get("message"),
                         condition=when,
                         origin=RequirementOrigin.REQUIRE_YAML,
+                        location=location,
                     )
                 )
         return rules

--- a/lib/spack/spack/test/concretization/errors.py
+++ b/lib/spack/spack/test/concretization/errors.py
@@ -242,6 +242,19 @@ def test_target_not_compatible_with_host_error(mock_packages, mutable_config: Co
     assert "Conflicting target values" not in str(exc_info.value)
 
 
+def test_requirement_error_names_config_location(mock_packages, concretize_scope):
+    """A requirement that cannot be satisfied must say which config file and line it came from,
+    so the user knows what to edit."""
+    pathlib.Path(concretize_scope, "packages.yaml").write_text(
+        "packages:\n  mpileaks:\n    require:\n    - '@2.3'\n", encoding="utf-8"
+    )
+    with pytest.raises(spack.error.SpackError) as exc_info:
+        spack.concretize.concretize_one("mpileaks@2.1")
+    assert_actionable_error(
+        exc_info, "@2.3 is a requirement for package mpileaks", "packages.yaml:4: "
+    )
+
+
 @pytest.mark.parametrize(
     "packages_config,input_spec,expected_parts",
     [
@@ -273,11 +286,12 @@ def test_target_not_compatible_with_host_error(mock_packages, mutable_config: Co
             ["libelf", "must be compiled with clang"],
             id="requirement_unsatisfied_custom_message",
         ),
-        # Generic message must still name the package so the user knows which entry to look at
+        # With no custom message the error must still quote the requirement itself, not just
+        # say that "a requirement" for the package could not be satisfied
         pytest.param(
             {"packages:libelf": {"require": ["%clang"]}},
             "libelf%gcc",
-            ["libelf"],
+            ["libelf", "cannot satisfy requirement '%clang'"],
             id="requirement_unsatisfied_generic",
         ),
         # A `require:` entry names a virtual that does not exist. The error must name the


### PR DESCRIPTION
(note: unfiltered llm content)

  Without a custom message, an unsatisfied requirement only reported
  
      cannot satisfy a requirement for package 'zlib-ng'.
  
  It now quotes the requirement and the config file it came from:
  
      cannot satisfy requirement 'os=ubuntu22.04' from ~/.spack/packages.yaml:3 for package 'zlib-ng'
  
  and the cause tree carries the same location:
  
      required because ~/.spack/packages.yaml:4: @1.14.6 is a requirement for package hdf5
  
  RequirementRule records the YAML mark as `location`, since specs lose it
  when parsed.
  