### PR TITLE
spack_yaml: count line numbers from 1

### DIFF
--- a/lib/spack/spack/solver/requirements.py
+++ b/lib/spack/spack/solver/requirements.py
@@ -17,17 +17,13 @@ import spack.traverse
 import spack.util.spack_yaml
 from spack.enums import PropagationPolicy
 from spack.util import tty
-from spack.util.spack_yaml import get_mark_from_yaml_data
+from spack.util.spack_yaml import source_location
 
 
 def _mark_str(raw) -> str:
     """Return a 'file:line: ' prefix from the YAML mark on *raw*, or empty string."""
-    mark = get_mark_from_yaml_data(raw)
-    if not mark:
-        return ""
-    if mark.line is None:
-        return f"{mark.name}: "
-    return f"{mark.name}:{mark.line + 1}: "
+    location = source_location(raw)
+    return f"{location}: " if location else ""
 
 
 def _check_unknown_virtuals_on_edges(raw_strs: List[str], specs: List["spack.spec.Spec"]) -> None:
@@ -479,23 +475,20 @@ def parse_spec_from_yaml_string(string: str, *, named: bool = False) -> spack.sp
     try:
         result = spack.spec.Spec(string)
     except spack.error.SpecSyntaxError as e:
-        mark = get_mark_from_yaml_data(string)
-        if mark:
-            msg = f"{mark.name}:{mark.line + 1}: {str(e)}"
-            raise spack.error.SpecSyntaxError(msg) from e
+        prefix = _mark_str(string)
+        if prefix:
+            raise spack.error.SpecSyntaxError(f"{prefix}{e}") from e
         raise e
 
     if named is True and not result.name:
         msg = f"expected a named spec, but got '{string}' instead"
-        mark = get_mark_from_yaml_data(string)
 
         # Add a hint in case it's dependencies
         deps = result.dependencies()
         if len(deps) == 1:
             msg = f"{msg}. Did you mean '{deps[0]}'?"
 
-        if mark:
-            msg = f"{mark.name}:{mark.line + 1}: {msg}"
+        msg = f"{_mark_str(string)}{msg}"
 
         raise spack.error.SpackError(msg)
 

--- a/lib/spack/spack/test/config.py
+++ b/lib/spack/spack/test/config.py
@@ -1693,6 +1693,10 @@ def test_deepcopy_as_builtin(env_yaml):
     assert type(packages_copy["all"]["compiler"]) is list
     assert type(packages_copy["all"]["compiler"][0]) is str
 
+    line_info = cfg.deepcopy_as_builtin("packages", line_info=True)
+    assert line_info.line_info == f"{env_yaml}:6"
+    assert line_info["all"].line_info == f"{env_yaml}:7"
+
 
 def test_included_optional_include_scopes():
     with pytest.raises(NotImplementedError):

--- a/lib/spack/spack/util/spack_yaml.py
+++ b/lib/spack/spack/util/spack_yaml.py
@@ -96,7 +96,7 @@ def deepcopy_as_builtin(obj: Any, *, line_info: bool = False) -> Any:
             }
         )
         if line_info:
-            result.line_info = _line_info(obj)
+            result.line_info = source_location(obj)
         return result
     elif isinstance(obj, list):
         return [deepcopy_as_builtin(x, line_info=line_info) for x in obj]
@@ -277,14 +277,14 @@ def dump(data, stream=None, default_flow_style=False):
     return handler.dump(data, stream=stream)
 
 
-def _line_info(obj):
-    """Format a mark as <file>:<line> information."""
+def source_location(obj) -> str:
+    """Return the source location "<file>:<line>" of a YAML object as a string."""
     m = get_mark_from_yaml_data(obj)
     if m is None:
         return ""
-    if m.line:
-        return f"{m.name}:{m.line:d}"
-    return m.name
+    if m.line is None:
+        return m.name
+    return f"{m.name}:{m.line + 1:d}"
 
 
 #: Global for interactions between LineAnnotationDumper and dump_annotated().


### PR DESCRIPTION
Extract some line number logic to ensure there aren't off by one errors; lines are counted from 1.

Also fix a bug where line number 1 was not shown because of a falsy check that triggered for `line == 0` instead of just `line is None`.