### PR TITLE
spec parser: make it pure

### DIFF
--- a/lib/spack/spack/cmd/__init__.py
+++ b/lib/spack/spack/cmd/__init__.py
@@ -194,8 +194,8 @@ def parse_specs(
     args = [args] if isinstance(args, str) else args
     arg_string = " ".join([quote_kvp(arg) for arg in args])
 
-    toolchains = spack.config.CONFIG.get("toolchains", {})
-    specs = spack.spec_parser.parse(arg_string, toolchains=toolchains)
+    user_input = spack.spec_parser.UserInput.from_config(spack.config.CONFIG, specfiles=True)
+    specs = spack.spec_parser.parse(arg_string, user_input=user_input)
     if not concretize:
         return specs
 

--- a/lib/spack/spack/cmd/__init__.py
+++ b/lib/spack/spack/cmd/__init__.py
@@ -194,8 +194,8 @@ def parse_specs(
     args = [args] if isinstance(args, str) else args
     arg_string = " ".join([quote_kvp(arg) for arg in args])
 
-    user_input = spack.spec_parser.UserInput.from_config(spack.config.CONFIG, specfiles=True)
-    specs = spack.spec_parser.parse(arg_string, user_input=user_input)
+    context = spack.spec_parser.ParseContext.from_config(spack.config.CONFIG, specfiles=True)
+    specs = spack.spec_parser.parse(arg_string, context=context)
     if not concretize:
         return specs
 

--- a/lib/spack/spack/cmd/common/arguments.py
+++ b/lib/spack/spack/cmd/common/arguments.py
@@ -13,7 +13,6 @@ import spack.deptypes as dt
 import spack.mirrors.mirror
 import spack.mirrors.utils
 import spack.reporters
-import spack.spec
 import spack.store
 from spack.active_environment import active_environment
 from spack.util import tty
@@ -230,7 +229,7 @@ def _cdash_reporter(namespace):
                 # Ensure CI 'spack test run' can output CDash results
                 packages = args.package
 
-            return [str(spack.spec.Spec(s)) for s in packages]
+            return [str(s) for s in spack.cmd.parse_specs(packages)]
 
         configuration = spack.reporters.CDashConfiguration(
             upload_url=namespace.cdash_upload_url,

--- a/lib/spack/spack/compilers/config.py
+++ b/lib/spack/spack/compilers/config.py
@@ -251,18 +251,18 @@ _EXTRA_ATTRIBUTES_KEY = "extra_attributes"
 def name_os_target(spec: spack.spec.Spec) -> Tuple[str, str, str]:
     if not spec.architecture:
         host_platform = spack.platforms.host()
-        operating_system = host_platform.operating_system("default_os")
-        target = host_platform.target("default_target")
+        operating_system = host_platform.default_operating_system()
+        target = host_platform.default_target()
     else:
         target = spec.architecture.target
         if not target:
-            target = spack.platforms.host().target("default_target")
+            target = spack.platforms.host().default_target()
         target = target.family
 
         operating_system = spec.os
         if not operating_system:
             host_platform = spack.platforms.host()
-            operating_system = host_platform.operating_system("default_os")
+            operating_system = host_platform.default_operating_system()
 
     return spec.name, str(operating_system), str(target)
 

--- a/lib/spack/spack/environment/environment.py
+++ b/lib/spack/spack/environment/environment.py
@@ -1333,7 +1333,7 @@ class Environment:
 
     def _sync_speclists(self):
         self._spec_lists_parser = SpecListParser(
-            user_input=spack.spec_parser.UserInput.from_config(spack.config.CONFIG)
+            context=spack.spec_parser.ParseContext.from_config(spack.config.CONFIG)
         )
         self.spec_lists = {}
         self.spec_lists.update(
@@ -3368,15 +3368,13 @@ class EnvironmentManifestFile(collections.abc.Mapping):
             ValueError: if no equivalent match is found
         """
         # both sides are user input: evaluate them the same way before comparing
-        user_input = spack.spec_parser.UserInput.from_config(spack.config.CONFIG)
-        wanted = spack.spec_parser.parse_one_or_raise(user_spec, user_input=user_input)
-        result = []
-        for yaml_spec_str in self.configuration["specs"]:
-            if (
-                spack.spec_parser.parse_one_or_raise(yaml_spec_str, user_input=user_input)
-                == wanted
-            ):
-                result.append(yaml_spec_str)
+        context = spack.spec_parser.ParseContext.from_config(spack.config.CONFIG)
+        wanted = spack.spec_parser.parse_one_or_raise(user_spec, context=context)
+        result = [
+            yaml_spec_str
+            for yaml_spec_str in self.configuration["specs"]
+            if spack.spec_parser.parse_one_or_raise(yaml_spec_str, context=context) == wanted
+        ]
 
         if not result:
             raise ValueError(f"cannot find a spec equivalent to {user_spec}")

--- a/lib/spack/spack/environment/environment.py
+++ b/lib/spack/spack/environment/environment.py
@@ -43,6 +43,7 @@ import spack.repo
 import spack.schema.env
 import spack.schema.spec_list
 import spack.spec
+import spack.spec_parser
 import spack.store
 import spack.user_environment as uenv
 import spack.util.environment
@@ -1332,7 +1333,7 @@ class Environment:
 
     def _sync_speclists(self):
         self._spec_lists_parser = SpecListParser(
-            toolchains=spack.config.CONFIG.get("toolchains", {})
+            user_input=spack.spec_parser.UserInput.from_config(spack.config.CONFIG)
         )
         self.spec_lists = {}
         self.spec_lists.update(
@@ -3366,9 +3367,15 @@ class EnvironmentManifestFile(collections.abc.Mapping):
         Raises:
             ValueError: if no equivalent match is found
         """
+        # both sides are user input: evaluate them the same way before comparing
+        user_input = spack.spec_parser.UserInput.from_config(spack.config.CONFIG)
+        wanted = spack.spec_parser.parse_one_or_raise(user_spec, user_input=user_input)
         result = []
         for yaml_spec_str in self.configuration["specs"]:
-            if Spec(yaml_spec_str) == Spec(user_spec):
+            if (
+                spack.spec_parser.parse_one_or_raise(yaml_spec_str, user_input=user_input)
+                == wanted
+            ):
                 result.append(yaml_spec_str)
 
         if not result:

--- a/lib/spack/spack/environment/list.py
+++ b/lib/spack/spack/environment/list.py
@@ -9,12 +9,17 @@ import spack.util.spack_yaml
 import spack.variant
 from spack.error import SpackError
 from spack.spec import Spec
-from spack.spec_parser import expand_toolchains
+from spack.spec_parser import UserInput, evaluate, parse_one_or_raise
 
 
 class SpecList:
     def __init__(
-        self, *, name: str = "specs", yaml_list=None, expanded_list=None, toolchains=None
+        self,
+        *,
+        name: str = "specs",
+        yaml_list=None,
+        expanded_list=None,
+        user_input: Optional[UserInput] = None,
     ):
         self.name = name
         self.yaml_list = yaml_list[:] if yaml_list is not None else []
@@ -23,7 +28,7 @@ class SpecList:
         self.specs_as_yaml_list = expanded_list or []
         self._constraints = None
         self._specs: Optional[List[Spec]] = None
-        self._toolchains = toolchains
+        self._user_input = user_input or UserInput()
 
     @property
     def is_matrix(self):
@@ -49,14 +54,14 @@ class SpecList:
     def specs(self) -> List[Spec]:
         if self._specs is None:
             specs: List[Spec] = []
+            toolchain_cache: Dict[str, Spec] = {}
             # This could be slightly faster done directly from yaml_list,
             # but this way is easier to maintain.
             for constraint_list in self.specs_as_constraints:
                 spec = constraint_list[0].copy()
                 for const in constraint_list[1:]:
                     spec.constrain(const)
-                if self._toolchains:
-                    expand_toolchains(spec, self._toolchains)
+                evaluate(spec, self._user_input, _cache=toolchain_cache)
                 specs.append(spec)
             self._specs = specs
 
@@ -75,11 +80,15 @@ class SpecList:
         self._specs = None
 
     def remove(self, spec):
-        # Get spec to remove from list
+        # Get spec to remove from list: the yaml entries are user input, so evaluate them
+        # like the incoming spec has been
+        to_remove = Spec(spec)
         remove = [
             s
             for s in self.yaml_list
-            if (isinstance(s, str) and not s.startswith("$")) and Spec(s) == Spec(spec)
+            if isinstance(s, str)
+            and not s.startswith("$")
+            and parse_one_or_raise(s, user_input=self._user_input) == to_remove
         ]
         if not remove:
             msg = f"Cannot remove {spec} from SpecList {self.name}.\n"
@@ -187,9 +196,9 @@ class Definition(NamedTuple):
 class SpecListParser:
     """Parse definitions and user specs from data in environments"""
 
-    def __init__(self, *, toolchains=None):
+    def __init__(self, *, user_input: Optional[UserInput] = None):
         self.definitions: Dict[str, SpecList] = {}
-        self._toolchains = toolchains
+        self._user_input = user_input or UserInput()
 
     def parse_definitions(self, *, data: List[Dict[str, Any]]) -> Dict[str, SpecList]:
         definitions_from_yaml: Dict[str, List[Definition]] = {}
@@ -239,7 +248,7 @@ class SpecListParser:
             name=name,
             yaml_list=combined_yaml_list,
             expanded_list=expanded_list,
-            toolchains=self._toolchains,
+            user_input=self._user_input,
         )
 
     def _expand_yaml_list(self, raw_yaml_list):

--- a/lib/spack/spack/environment/list.py
+++ b/lib/spack/spack/environment/list.py
@@ -54,14 +54,13 @@ class SpecList:
     def specs(self) -> List[Spec]:
         if self._specs is None:
             specs: List[Spec] = []
-            toolchain_cache: Dict[str, Spec] = {}
             # This could be slightly faster done directly from yaml_list,
             # but this way is easier to maintain.
             for constraint_list in self.specs_as_constraints:
                 spec = constraint_list[0].copy()
                 for const in constraint_list[1:]:
                     spec.constrain(const)
-                evaluate(spec, self._user_input, _cache=toolchain_cache)
+                evaluate(spec, self._user_input)
                 specs.append(spec)
             self._specs = specs
 

--- a/lib/spack/spack/environment/list.py
+++ b/lib/spack/spack/environment/list.py
@@ -9,7 +9,7 @@ import spack.util.spack_yaml
 import spack.variant
 from spack.error import SpackError
 from spack.spec import Spec
-from spack.spec_parser import UserInput, evaluate, parse_one_or_raise
+from spack.spec_parser import ParseContext, evaluate, parse_one_or_raise
 
 
 class SpecList:
@@ -19,7 +19,7 @@ class SpecList:
         name: str = "specs",
         yaml_list=None,
         expanded_list=None,
-        user_input: Optional[UserInput] = None,
+        context: Optional[ParseContext] = None,
     ):
         self.name = name
         self.yaml_list = yaml_list[:] if yaml_list is not None else []
@@ -28,7 +28,7 @@ class SpecList:
         self.specs_as_yaml_list = expanded_list or []
         self._constraints = None
         self._specs: Optional[List[Spec]] = None
-        self._user_input = user_input or UserInput()
+        self._context = context or ParseContext()
 
     @property
     def is_matrix(self):
@@ -60,7 +60,7 @@ class SpecList:
                 spec = constraint_list[0].copy()
                 for const in constraint_list[1:]:
                     spec.constrain(const)
-                evaluate(spec, self._user_input)
+                evaluate(spec, self._context)
                 specs.append(spec)
             self._specs = specs
 
@@ -87,7 +87,7 @@ class SpecList:
             for s in self.yaml_list
             if isinstance(s, str)
             and not s.startswith("$")
-            and parse_one_or_raise(s, user_input=self._user_input) == to_remove
+            and parse_one_or_raise(s, context=self._context) == to_remove
         ]
         if not remove:
             msg = f"Cannot remove {spec} from SpecList {self.name}.\n"
@@ -195,9 +195,9 @@ class Definition(NamedTuple):
 class SpecListParser:
     """Parse definitions and user specs from data in environments"""
 
-    def __init__(self, *, user_input: Optional[UserInput] = None):
+    def __init__(self, *, context: Optional[ParseContext] = None):
         self.definitions: Dict[str, SpecList] = {}
-        self._user_input = user_input or UserInput()
+        self._context = context or ParseContext()
 
     def parse_definitions(self, *, data: List[Dict[str, Any]]) -> Dict[str, SpecList]:
         definitions_from_yaml: Dict[str, List[Definition]] = {}
@@ -247,7 +247,7 @@ class SpecListParser:
             name=name,
             yaml_list=combined_yaml_list,
             expanded_list=expanded_list,
-            user_input=self._user_input,
+            context=self._context,
         )
 
     def _expand_yaml_list(self, raw_yaml_list):

--- a/lib/spack/spack/externals.py
+++ b/lib/spack/spack/externals.py
@@ -26,6 +26,7 @@ import spack.archspec
 import spack.deptypes
 import spack.repo
 import spack.spec
+import spack.spec_parser
 import spack.variant as vt
 from spack.error import SpackError
 from spack.util import tty
@@ -70,8 +71,11 @@ def node_from_dict(external_dict: ExternalDict) -> spack.spec.Spec:
         )
 
     result.extra_attributes = extra_attributes
+    spack.spec_parser.resolve_host_aliases(result)
     if "required_target" in external_dict:
-        result.constrain(f"target={external_dict['required_target']}")
+        required = spack.spec.Spec(f"target={external_dict['required_target']}")
+        spack.spec_parser.resolve_host_aliases(required)
+        result.constrain(required)
     return result
 
 

--- a/lib/spack/spack/externals.py
+++ b/lib/spack/spack/externals.py
@@ -71,6 +71,8 @@ def node_from_dict(external_dict: ExternalDict) -> spack.spec.Spec:
         )
 
     result.extra_attributes = extra_attributes
+    # packages.yaml is user input, but Spec() parses purely: resolve default_os/default_target
+    # on both sides before constraining, or e.g. target=m4 and target=default_target conflict
     spack.spec_parser.resolve_host_aliases(result)
     if "required_target" in external_dict:
         required = spack.spec.Spec(f"target={external_dict['required_target']}")

--- a/lib/spack/spack/platforms/_platform.py
+++ b/lib/spack/spack/platforms/_platform.py
@@ -48,11 +48,7 @@ class Platform:
             self.add_target(name, microarchitecture)
 
     def target(self, name):
-        name = str(name)
-        if name in Platform.reserved_targets:
-            name = self.default
-
-        return self.targets.get(name, None)
+        return self.targets.get(str(name), None)
 
     def add_operating_system(self, name, os_class):
         if name in Platform.reserved_oss:
@@ -67,9 +63,6 @@ class Platform:
         return self.operating_system(self.default_os)
 
     def operating_system(self, name):
-        if name in Platform.reserved_oss:
-            name = self.default_os
-
         return self.operating_sys.get(name, None)
 
     def buildable_oses(self):

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -55,7 +55,6 @@ import spack.platforms
 import spack.repo
 import spack.solver.splicing
 import spack.spec
-import spack.spec_parser
 import spack.traverse
 import spack.util.crypto
 import spack.util.filesystem as fs
@@ -2311,13 +2310,6 @@ class SpackSolverSetup:
 
         for root in specs:
             for s in root.traverse():
-                arch = s.architecture
-                if arch and spack.spec_parser.has_host_aliases(arch):
-                    raise spack.error.SpecError(
-                        f"cannot concretize '{root}': default_os and default_target are only "
-                        f"resolved in user input (see spack.spec_parser.UserInput)"
-                    )
-
                 if repo.is_virtual(s.name):
                     # Constraints beyond versions could refer to the virtual or its provider;
                     # the solver supports neither interpretation.

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -55,6 +55,7 @@ import spack.platforms
 import spack.repo
 import spack.solver.splicing
 import spack.spec
+import spack.spec_parser
 import spack.traverse
 import spack.util.crypto
 import spack.util.filesystem as fs
@@ -2310,6 +2311,13 @@ class SpackSolverSetup:
 
         for root in specs:
             for s in root.traverse():
+                arch = s.architecture
+                if arch and spack.spec_parser.has_host_aliases(arch):
+                    raise spack.error.SpecError(
+                        f"cannot concretize '{root}': default_os and default_target are only "
+                        f"resolved in user input (see spack.spec_parser.UserInput)"
+                    )
+
                 if repo.is_virtual(s.name):
                     # Constraints beyond versions could refer to the virtual or its provider;
                     # the solver supports neither interpretation.

--- a/lib/spack/spack/solver/requirements.py
+++ b/lib/spack/spack/solver/requirements.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 import enum
 import warnings
-from typing import List, NamedTuple, Optional, Sequence, Tuple, Union
+from typing import Dict, List, NamedTuple, Optional, Sequence, Tuple, Union
 
 import spack.vendor.archspec.cpu
 
@@ -177,13 +177,13 @@ class RequirementParser:
         self.runtime_pkgs = repo.packages_with_tags("runtime")
         self.compiler_pkgs = repo.packages_with_tags("compiler")
         self.preferences_from_input: List[Tuple[spack.spec.Spec, str]] = []
-        self.toolchains = configuration.get_config("toolchains")
+        self.user_input = spack.spec_parser.UserInput.from_config(configuration)
+        self._toolchain_cache: Dict[str, spack.spec.Spec] = {}
         self._warned_compiler_all: set = set()
 
     def _parse_and_expand(self, string: str, *, named: bool = False) -> spack.spec.Spec:
         result = parse_spec_from_yaml_string(string, named=named)
-        if self.toolchains:
-            spack.spec_parser.expand_toolchains(result, self.toolchains)
+        spack.spec_parser.evaluate(result, self.user_input, _cache=self._toolchain_cache)
         return result
 
     def rules(self, pkg: spack.package_base.PackageBase) -> List[RequirementRule]:

--- a/lib/spack/spack/solver/requirements.py
+++ b/lib/spack/spack/solver/requirements.py
@@ -177,12 +177,12 @@ class RequirementParser:
         self.runtime_pkgs = repo.packages_with_tags("runtime")
         self.compiler_pkgs = repo.packages_with_tags("compiler")
         self.preferences_from_input: List[Tuple[spack.spec.Spec, str]] = []
-        self.user_input = spack.spec_parser.UserInput.from_config(configuration)
+        self.parse_context = spack.spec_parser.ParseContext.from_config(configuration)
         self._warned_compiler_all: set = set()
 
     def _parse_and_expand(self, string: str, *, named: bool = False) -> spack.spec.Spec:
         result = parse_spec_from_yaml_string(string, named=named)
-        spack.spec_parser.evaluate(result, self.user_input)
+        spack.spec_parser.evaluate(result, self.parse_context)
         return result
 
     def rules(self, pkg: spack.package_base.PackageBase) -> List[RequirementRule]:

--- a/lib/spack/spack/solver/requirements.py
+++ b/lib/spack/spack/solver/requirements.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 import enum
 import warnings
-from typing import Dict, List, NamedTuple, Optional, Sequence, Tuple, Union
+from typing import List, NamedTuple, Optional, Sequence, Tuple, Union
 
 import spack.vendor.archspec.cpu
 
@@ -178,12 +178,11 @@ class RequirementParser:
         self.compiler_pkgs = repo.packages_with_tags("compiler")
         self.preferences_from_input: List[Tuple[spack.spec.Spec, str]] = []
         self.user_input = spack.spec_parser.UserInput.from_config(configuration)
-        self._toolchain_cache: Dict[str, spack.spec.Spec] = {}
         self._warned_compiler_all: set = set()
 
     def _parse_and_expand(self, string: str, *, named: bool = False) -> spack.spec.Spec:
         result = parse_spec_from_yaml_string(string, named=named)
-        spack.spec_parser.evaluate(result, self.user_input, _cache=self._toolchain_cache)
+        spack.spec_parser.evaluate(result, self.user_input)
         return result
 
     def rules(self, pkg: spack.package_base.PackageBase) -> List[RequirementRule]:

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -641,28 +641,8 @@ class ArchSpec:
 
     @os.setter
     def os(self, value):
-        # The OS of the architecture spec will update the platform field
-        # if the OS is set to one of the reserved OS types so that the
-        # default OS type can be resolved.  Since the reserved OS
-        # information is only available for the host machine, the platform
-        # will assumed to be the host machine's platform.
-        value = str(value) if value is not None else None
-
-        if value in spack.platforms.Platform.reserved_oss:
-            curr_platform = str(spack.platforms.host())
-            self.platform = self.platform or curr_platform
-
-            if self.platform != curr_platform:
-                raise ValueError(
-                    "Can't set arch spec OS to reserved value '%s' when the "
-                    "arch platform (%s) isn't the current platform (%s)"
-                    % (value, self.platform, curr_platform)
-                )
-
-            spec_platform = spack.platforms.by_name(self.platform)
-            value = str(spec_platform.operating_system(value))
-
-        self._os = value
+        # default_os is kept as is: spack.spec_parser.resolve_host_aliases resolves it
+        self._os = str(value) if value is not None else None
 
     @property
     def target(self):
@@ -671,36 +651,13 @@ class ArchSpec:
 
     @target.setter
     def target(self, value):
-        # The target of the architecture spec will update the platform field
-        # if the target is set to one of the reserved target types so that
-        # the default target type can be resolved.  Since the reserved target
-        # information is only available for the host machine, the platform
-        # will assumed to be the host machine's platform.
-
-        def target_or_none(t):
-            if isinstance(t, spack.vendor.archspec.cpu.Microarchitecture):
-                return t
-            if t and t != "None":
-                return _make_microarchitecture(t)
-            return None
-
-        value = target_or_none(value)
-
-        if str(value) in spack.platforms.Platform.reserved_targets:
-            curr_platform = str(spack.platforms.host())
-            self.platform = self.platform or curr_platform
-
-            if self.platform != curr_platform:
-                raise ValueError(
-                    "Can't set arch spec target to reserved value '%s' when "
-                    "the arch platform (%s) isn't the current platform (%s)"
-                    % (value, self.platform, curr_platform)
-                )
-
-            spec_platform = spack.platforms.by_name(self.platform)
-            value = spec_platform.target(value)
-
-        self._target = value
+        # default_target is kept as is: spack.spec_parser.resolve_host_aliases resolves it
+        if isinstance(value, spack.vendor.archspec.cpu.Microarchitecture):
+            self._target = value
+        elif value and value != "None":
+            self._target = _make_microarchitecture(value)
+        else:
+            self._target = None
 
     def satisfies(self, other: "ArchSpec") -> bool:
         """Return True if all concrete specs matching self also match other, otherwise False.

--- a/lib/spack/spack/spec_parser.py
+++ b/lib/spack/spack/spec_parser.py
@@ -198,21 +198,17 @@ def evaluate(
     resolve_host_aliases(spec)
 
 
-def has_host_aliases(arch: "spack.spec.ArchSpec") -> bool:
-    """Whether ``arch`` uses ``os=default_os`` or ``target=default_target``."""
-    return (
-        arch.os in spack.platforms.Platform.reserved_oss
-        or str(arch.target) in spack.platforms.Platform.reserved_targets
-    )
-
-
 def resolve_host_aliases(spec: "spack.spec.Spec") -> None:
     """Replace ``os=default_os`` and ``target=default_target`` by the host's defaults."""
     # most specs are a single node: the traversal machinery costs more than the check itself
     nodes = spec.traverse() if spec._dependencies else (spec,)
     for node in nodes:
         arch = node.architecture
-        if arch is None or not has_host_aliases(arch):
+        if arch is None:
+            continue
+        is_os = arch.os in spack.platforms.Platform.reserved_oss
+        is_target = str(arch.target) in spack.platforms.Platform.reserved_targets
+        if not is_os and not is_target:
             continue
         host = spack.platforms.host()  # memoized
         host_name = str(host)
@@ -223,9 +219,9 @@ def resolve_host_aliases(spec: "spack.spec.Spec") -> None:
                 f"cannot use default_os or default_target in '{node}': its platform "
                 f"{arch.platform} is not the current platform {host_name}"
             )
-        if arch.os in spack.platforms.Platform.reserved_oss:
+        if is_os:
             arch.os = str(host.default_operating_system())
-        if str(arch.target) in spack.platforms.Platform.reserved_targets:
+        if is_target:
             arch.target = host.default_target()
 
 

--- a/lib/spack/spack/spec_parser.py
+++ b/lib/spack/spack/spec_parser.py
@@ -170,8 +170,14 @@ class SpecTokenizationError(spack.error.SpecSyntaxError):
         super().__init__(message)
 
 
-class UserInput:
-    """How to evaluate specs written by users, unlike the pure specs in package repositories."""
+class ParseContext:
+    """Context for parsing user input: the command line, ``spack.yaml``, ``packages.yaml``, ...
+
+    Without a context, parsing is pure and does not depend on the machine, as required for specs
+    in package repositories. With a context, the text is user input: toolchains are expanded,
+    ``default_os`` and ``default_target`` are resolved to the host's defaults, and spec files are
+    read from the filesystem if ``specfiles`` is True.
+    """
 
     __slots__ = ("toolchains", "specfiles", "_toolchain_cache")
 
@@ -184,14 +190,14 @@ class UserInput:
     @staticmethod
     def from_config(
         config: "spack.config.Configuration", *, specfiles: bool = False
-    ) -> "UserInput":
-        return UserInput(toolchains=config.get("toolchains"), specfiles=specfiles)
+    ) -> "ParseContext":
+        return ParseContext(toolchains=config.get("toolchains"), specfiles=specfiles)
 
 
-def evaluate(spec: "spack.spec.Spec", user_input: UserInput) -> None:
+def evaluate(spec: "spack.spec.Spec", context: ParseContext) -> None:
     """Evaluate a parsed user spec in place: substitute toolchains, then resolve host aliases."""
-    if user_input.toolchains:
-        expand_toolchains(spec, user_input.toolchains, _cache=user_input._toolchain_cache)
+    if context.toolchains:
+        expand_toolchains(spec, context.toolchains, _cache=context._toolchain_cache)
     resolve_host_aliases(spec)
 
 
@@ -219,20 +225,20 @@ def resolve_host_aliases(spec: "spack.spec.Spec") -> None:
             arch.target = host.default_target()
 
 
-def parse(text: str, *, user_input: Optional[UserInput] = None) -> List["spack.spec.Spec"]:
+def parse(text: str, *, context: Optional[ParseContext] = None) -> List["spack.spec.Spec"]:
     """Parse text into a list of specs
 
     Args:
         text: text to be parsed
-        user_input: if given, the text is user input, and the specs are evaluated accordingly
+        context: if given, the text is user input, and the specs are evaluated in it
 
     Return:
         List of specs
     """
-    specs = SpecParser(text, specfiles=bool(user_input and user_input.specfiles)).all_specs()
-    if user_input is not None:
+    specs = SpecParser(text, specfiles=bool(context and context.specfiles)).all_specs()
+    if context is not None:
         for spec in specs:
-            evaluate(spec, user_input)
+            evaluate(spec, context)
     return specs
 
 
@@ -240,16 +246,16 @@ def parse_one_or_raise(
     text: str,
     initial_spec: Optional["spack.spec.Spec"] = None,
     *,
-    user_input: Optional[UserInput] = None,
+    context: Optional[ParseContext] = None,
 ) -> "spack.spec.Spec":
     """Parse exactly one spec from text and return it, or raise
 
     Args:
         text: text to be parsed
         initial_spec: buffer where to parse the spec. If None a new one will be created.
-        user_input: if given, the text is user input, and the spec is evaluated accordingly
+        context: if given, the text is user input, and the spec is evaluated in it
     """
-    parser = SpecParser(text, specfiles=bool(user_input and user_input.specfiles))
+    parser = SpecParser(text, specfiles=bool(context and context.specfiles))
     result = parser.next_spec(initial_spec)
 
     if parser.curr:
@@ -267,8 +273,8 @@ def parse_one_or_raise(
     if result is None:
         raise ValueError("expected a single spec, but got none")
 
-    if user_input is not None:
-        evaluate(result, user_input)
+    if context is not None:
+        evaluate(result, context)
 
     return result
 

--- a/lib/spack/spack/spec_parser.py
+++ b/lib/spack/spack/spec_parser.py
@@ -75,6 +75,7 @@ from typing import TYPE_CHECKING, Dict, List, Optional, Tuple, Type, Union
 
 import spack.deptypes
 import spack.error
+import spack.platforms
 import spack.version
 from spack.aliases import LEGACY_COMPILER_TO_BUILTIN
 from spack.enums import PropagationPolicy
@@ -82,6 +83,7 @@ from spack.tokenize import fast_regex
 from spack.util.tty import color
 
 if TYPE_CHECKING:
+    import spack.config
     import spack.spec
 
 # Cannot use from spack.spec import Spec due to circularities, so we lazily
@@ -168,21 +170,80 @@ class SpecTokenizationError(spack.error.SpecSyntaxError):
         super().__init__(message)
 
 
-def parse(text: str, *, toolchains: Optional[Dict] = None) -> List["spack.spec.Spec"]:
-    """Parse text into a list of strings
+class UserInput:
+    """How to evaluate specs written by users, unlike the pure specs in package repositories."""
+
+    __slots__ = ("toolchains", "specfiles")
+
+    def __init__(self, *, toolchains: Optional[Dict] = None, specfiles: bool = False) -> None:
+        self.toolchains = toolchains or {}
+        self.specfiles = specfiles
+
+    @staticmethod
+    def from_config(
+        config: "spack.config.Configuration", *, specfiles: bool = False
+    ) -> "UserInput":
+        return UserInput(toolchains=config.get("toolchains"), specfiles=specfiles)
+
+
+def evaluate(
+    spec: "spack.spec.Spec",
+    user_input: UserInput,
+    *,
+    _cache: Optional[Dict[str, "spack.spec.Spec"]] = None,
+) -> None:
+    """Evaluate a parsed user spec in place: substitute toolchains, then resolve host aliases."""
+    if user_input.toolchains:
+        expand_toolchains(spec, user_input.toolchains, _cache=_cache)
+    resolve_host_aliases(spec)
+
+
+def has_host_aliases(arch: "spack.spec.ArchSpec") -> bool:
+    """Whether ``arch`` uses ``os=default_os`` or ``target=default_target``."""
+    return (
+        arch.os in spack.platforms.Platform.reserved_oss
+        or str(arch.target) in spack.platforms.Platform.reserved_targets
+    )
+
+
+def resolve_host_aliases(spec: "spack.spec.Spec") -> None:
+    """Replace ``os=default_os`` and ``target=default_target`` by the host's defaults."""
+    # most specs are a single node: the traversal machinery costs more than the check itself
+    nodes = spec.traverse() if spec._dependencies else (spec,)
+    for node in nodes:
+        arch = node.architecture
+        if arch is None or not has_host_aliases(arch):
+            continue
+        host = spack.platforms.host()  # memoized
+        host_name = str(host)
+        if arch.platform is None:
+            arch.platform = host_name
+        elif arch.platform != host_name:
+            raise spack.error.SpecError(
+                f"cannot use default_os or default_target in '{node}': its platform "
+                f"{arch.platform} is not the current platform {host_name}"
+            )
+        if arch.os in spack.platforms.Platform.reserved_oss:
+            arch.os = str(host.default_operating_system())
+        if str(arch.target) in spack.platforms.Platform.reserved_targets:
+            arch.target = host.default_target()
+
+
+def parse(text: str, *, user_input: Optional[UserInput] = None) -> List["spack.spec.Spec"]:
+    """Parse text into a list of specs
 
     Args:
         text: text to be parsed
-        toolchains: optional toolchain definitions to expand after parsing
+        user_input: if given, the text is user input, and the specs are evaluated accordingly
 
     Return:
         List of specs
     """
-    specs = SpecParser(text).all_specs()
-    if toolchains:
+    specs = SpecParser(text, specfiles=bool(user_input and user_input.specfiles)).all_specs()
+    if user_input is not None:
         cache: Dict[str, "spack.spec.Spec"] = {}
         for spec in specs:
-            expand_toolchains(spec, toolchains, _cache=cache)
+            evaluate(spec, user_input, _cache=cache)
     return specs
 
 
@@ -190,16 +251,16 @@ def parse_one_or_raise(
     text: str,
     initial_spec: Optional["spack.spec.Spec"] = None,
     *,
-    toolchains: Optional[Dict] = None,
+    user_input: Optional[UserInput] = None,
 ) -> "spack.spec.Spec":
     """Parse exactly one spec from text and return it, or raise
 
     Args:
         text: text to be parsed
         initial_spec: buffer where to parse the spec. If None a new one will be created.
-        toolchains: optional toolchain definitions to expand after parsing
+        user_input: if given, the text is user input, and the spec is evaluated accordingly
     """
-    parser = SpecParser(text)
+    parser = SpecParser(text, specfiles=bool(user_input and user_input.specfiles))
     result = parser.next_spec(initial_spec)
 
     if parser.curr:
@@ -217,8 +278,8 @@ def parse_one_or_raise(
     if result is None:
         raise ValueError("expected a single spec, but got none")
 
-    if toolchains:
-        expand_toolchains(result, toolchains)
+    if user_input is not None:
+        evaluate(result, user_input)
 
     return result
 
@@ -452,10 +513,12 @@ class SpecParser:
       where the token cannot appear at the current point in the grammar.
     """
 
-    __slots__ = "literal_str", "scanner", "curr", "next"
+    __slots__ = "literal_str", "scanner", "curr", "next", "specfiles"
 
-    def __init__(self, literal_str: str):
+    def __init__(self, literal_str: str, *, specfiles: bool = False):
         self.literal_str = literal_str.rstrip()
+        #: whether spec files are read, or rejected
+        self.specfiles = specfiles
         self.scanner = FAST_SPEC_REGEX.scanner(self.literal_str)  # type: ignore[attr-defined]
         self.curr = self.scanner.match()
         self.next = self.scanner.match()
@@ -739,6 +802,9 @@ class SpecParser:
                 next = scanner.match() if curr is not None else None
             elif kind == _FILENAME:
                 # A spec file is a complete node: read it and return
+                if not self.specfiles:
+                    self.curr = curr
+                    self._raise_parsing_error("spec files are only accepted on the command line")
                 if not os.path.exists(value):
                     raise spack.error.NoSuchSpecFileError(f"No such spec file: '{value}'")
                 spec._dup(spack.spec.Spec.from_specfile(value))

--- a/lib/spack/spack/spec_parser.py
+++ b/lib/spack/spack/spec_parser.py
@@ -173,11 +173,13 @@ class SpecTokenizationError(spack.error.SpecSyntaxError):
 class UserInput:
     """How to evaluate specs written by users, unlike the pure specs in package repositories."""
 
-    __slots__ = ("toolchains", "specfiles")
+    __slots__ = ("toolchains", "specfiles", "_toolchain_cache")
 
     def __init__(self, *, toolchains: Optional[Dict] = None, specfiles: bool = False) -> None:
         self.toolchains = toolchains or {}
         self.specfiles = specfiles
+        #: toolchain name -> parsed toolchain spec, filled lazily by expand_toolchains
+        self._toolchain_cache: Dict[str, "spack.spec.Spec"] = {}
 
     @staticmethod
     def from_config(
@@ -186,15 +188,10 @@ class UserInput:
         return UserInput(toolchains=config.get("toolchains"), specfiles=specfiles)
 
 
-def evaluate(
-    spec: "spack.spec.Spec",
-    user_input: UserInput,
-    *,
-    _cache: Optional[Dict[str, "spack.spec.Spec"]] = None,
-) -> None:
+def evaluate(spec: "spack.spec.Spec", user_input: UserInput) -> None:
     """Evaluate a parsed user spec in place: substitute toolchains, then resolve host aliases."""
     if user_input.toolchains:
-        expand_toolchains(spec, user_input.toolchains, _cache=_cache)
+        expand_toolchains(spec, user_input.toolchains, _cache=user_input._toolchain_cache)
     resolve_host_aliases(spec)
 
 
@@ -237,9 +234,8 @@ def parse(text: str, *, user_input: Optional[UserInput] = None) -> List["spack.s
     """
     specs = SpecParser(text, specfiles=bool(user_input and user_input.specfiles)).all_specs()
     if user_input is not None:
-        cache: Dict[str, "spack.spec.Spec"] = {}
         for spec in specs:
-            evaluate(spec, user_input, _cache=cache)
+            evaluate(spec, user_input)
     return specs
 
 

--- a/lib/spack/spack/spec_parser.py
+++ b/lib/spack/spack/spec_parser.py
@@ -197,9 +197,7 @@ def evaluate(spec: "spack.spec.Spec", user_input: UserInput) -> None:
 
 def resolve_host_aliases(spec: "spack.spec.Spec") -> None:
     """Replace ``os=default_os`` and ``target=default_target`` by the host's defaults."""
-    # most specs are a single node: the traversal machinery costs more than the check itself
-    nodes = spec.traverse() if spec._dependencies else (spec,)
-    for node in nodes:
+    for node in spec.traverse():
         arch = node.architecture
         if arch is None:
             continue
@@ -207,14 +205,13 @@ def resolve_host_aliases(spec: "spack.spec.Spec") -> None:
         is_target = str(arch.target) in spack.platforms.Platform.reserved_targets
         if not is_os and not is_target:
             continue
-        host = spack.platforms.host()  # memoized
-        host_name = str(host)
+        host = spack.platforms.host()
         if arch.platform is None:
-            arch.platform = host_name
-        elif arch.platform != host_name:
+            arch.platform = str(host)
+        elif arch.platform != str(host):
             raise spack.error.SpecError(
                 f"cannot use default_os or default_target in '{node}': its platform "
-                f"{arch.platform} is not the current platform {host_name}"
+                f"{arch.platform} is not the current platform {host}"
             )
         if is_os:
             arch.os = str(host.default_operating_system())

--- a/lib/spack/spack/test/architecture.py
+++ b/lib/spack/spack/test/architecture.py
@@ -11,6 +11,7 @@ import spack.concretize
 import spack.error
 import spack.operating_systems
 import spack.platforms
+import spack.spec_parser
 from spack.spec import ArchSpec, Spec
 
 
@@ -60,9 +61,19 @@ def test_user_input_combination(config, target_str, os_str):
     """Test for all the valid user input combinations that both the target and
     the operating system match.
     """
-    spec = Spec(f"libelf os={os_str} target={target_str}")
-    assert spec.architecture.os == str(TEST_PLATFORM.operating_system(os_str))
-    assert spec.architecture.target == TEST_PLATFORM.target(target_str)
+    spec = spack.spec_parser.parse_one_or_raise(
+        f"libelf os={os_str} target={target_str}", user_input=spack.spec_parser.UserInput()
+    )
+    expected_os = TEST_PLATFORM.default_os if os_str == "default_os" else os_str
+    expected_target = TEST_PLATFORM.default if target_str == "default_target" else target_str
+    assert spec.architecture.os == str(TEST_PLATFORM.operating_system(expected_os))
+    assert spec.architecture.target == TEST_PLATFORM.target(expected_target)
+
+
+def test_solver_rejects_host_aliases(config, mock_packages):
+    """Host aliases are resolved in user input only: unresolved ones must not reach the solver."""
+    with pytest.raises(spack.error.SpecError, match="only resolved in user input"):
+        spack.concretize.concretize_one(Spec("libelf target=default_target"))
 
 
 def test_default_os_and_target(config, mock_packages):

--- a/lib/spack/spack/test/architecture.py
+++ b/lib/spack/spack/test/architecture.py
@@ -12,7 +12,7 @@ import spack.error
 import spack.operating_systems
 import spack.platforms
 import spack.spec_parser
-from spack.spec import ArchSpec, Spec
+from spack.spec import ArchSpec
 
 
 @pytest.fixture(scope="module")
@@ -68,12 +68,6 @@ def test_user_input_combination(config, target_str, os_str):
     expected_target = TEST_PLATFORM.default if target_str == "default_target" else target_str
     assert spec.architecture.os == str(TEST_PLATFORM.operating_system(expected_os))
     assert spec.architecture.target == TEST_PLATFORM.target(expected_target)
-
-
-def test_solver_rejects_host_aliases(config, mock_packages):
-    """Host aliases are resolved in user input only: unresolved ones must not reach the solver."""
-    with pytest.raises(spack.error.SpecError, match="only resolved in user input"):
-        spack.concretize.concretize_one(Spec("libelf target=default_target"))
 
 
 def test_default_os_and_target(config, mock_packages):

--- a/lib/spack/spack/test/architecture.py
+++ b/lib/spack/spack/test/architecture.py
@@ -62,7 +62,7 @@ def test_user_input_combination(config, target_str, os_str):
     the operating system match.
     """
     spec = spack.spec_parser.parse_one_or_raise(
-        f"libelf os={os_str} target={target_str}", user_input=spack.spec_parser.UserInput()
+        f"libelf os={os_str} target={target_str}", context=spack.spec_parser.ParseContext()
     )
     expected_os = TEST_PLATFORM.default_os if os_str == "default_os" else os_str
     expected_target = TEST_PLATFORM.default if target_str == "default_target" else target_str

--- a/lib/spack/spack/test/cmd/env.py
+++ b/lib/spack/spack/test/cmd/env.py
@@ -25,6 +25,7 @@ import spack.paths
 import spack.repo
 import spack.schema.env
 import spack.solver.asp
+import spack.spec_parser
 import spack.stage
 import spack.store
 import spack.util.environment
@@ -735,6 +736,16 @@ def test_remove_before_concretize(mutable_config):
         e.remove("mpileaks")
         e.concretize()
         assert not e.concretized_roots
+
+
+def test_remove_spec_with_host_alias(tmp_path: pathlib.Path):
+    """Manifest entries using default_os/default_target are matched after evaluation, since the
+    spec on the command line is evaluated too."""
+    manifest = tmp_path / "spack.yaml"
+    manifest.write_text("spack:\n  specs: [mpileaks target=default_target]\n")
+    with ev.Environment(tmp_path):
+        remove("mpileaks", "target=default_target")
+    assert "mpileaks" not in manifest.read_text()
 
 
 def test_remove_command():
@@ -2807,7 +2818,9 @@ spack:
 
             assert before_user == after_user
 
-            mpileaks_spec = Spec("mpileaks target=default_target")
+            mpileaks_spec = spack.spec_parser.parse_one_or_raise(
+                "mpileaks target=default_target", user_input=spack.spec_parser.UserInput()
+            )
             assert mpileaks_spec in {x.root for x in concretized_roots_before}
             assert mpileaks_spec not in {x.root for x in concretized_roots_after}
 

--- a/lib/spack/spack/test/cmd/env.py
+++ b/lib/spack/spack/test/cmd/env.py
@@ -2819,7 +2819,7 @@ spack:
             assert before_user == after_user
 
             mpileaks_spec = spack.spec_parser.parse_one_or_raise(
-                "mpileaks target=default_target", user_input=spack.spec_parser.UserInput()
+                "mpileaks target=default_target", context=spack.spec_parser.ParseContext()
             )
             assert mpileaks_spec in {x.root for x in concretized_roots_before}
             assert mpileaks_spec not in {x.root for x in concretized_roots_after}

--- a/lib/spack/spack/test/concretization/core.py
+++ b/lib/spack/spack/test/concretization/core.py
@@ -2749,7 +2749,7 @@ packages:
         json_file.write_text(build_dep.to_json())
         s = spack.concretize.concretize_one(
             spack.spec_parser.parse_one_or_raise(
-                f"dtuse ^{json_file}", user_input=spack.spec_parser.UserInput(specfiles=True)
+                f"dtuse ^{json_file}", context=spack.spec_parser.ParseContext(specfiles=True)
             )
         )
         assert s["dttop"].dag_hash() == build_dep.dag_hash()

--- a/lib/spack/spack/test/concretization/core.py
+++ b/lib/spack/spack/test/concretization/core.py
@@ -44,6 +44,7 @@ import spack.solver.result
 import spack.solver.reuse
 import spack.spec
 import spack.spec_filter
+import spack.spec_parser
 import spack.store
 import spack.traverse
 import spack.util.file_cache
@@ -2746,7 +2747,11 @@ packages:
         build_dep = spack.concretize.concretize_one("dttop")
         json_file = tmp_path / "build.json"
         json_file.write_text(build_dep.to_json())
-        s = spack.concretize.concretize_one(f"dtuse ^{str(json_file)}")
+        s = spack.concretize.concretize_one(
+            spack.spec_parser.parse_one_or_raise(
+                f"dtuse ^{json_file}", user_input=spack.spec_parser.UserInput(specfiles=True)
+            )
+        )
         assert s["dttop"].dag_hash() == build_dep.dag_hash()
 
     @pytest.mark.regression("44040")

--- a/lib/spack/spack/test/env.py
+++ b/lib/spack/spack/test/env.py
@@ -1733,8 +1733,8 @@ spack:
     manifest.write_text(spack_yaml)
     with ev.Environment(tmp_path):
         # We rely on this behavior when emitting facts for the solver
-        user_input = spack.spec_parser.UserInput.from_config(mutable_config)
-        s = spack.spec_parser.parse("mpileaks %gnu ^callpath %gnu", user_input=user_input)[0]
+        context = spack.spec_parser.ParseContext.from_config(mutable_config)
+        s = spack.spec_parser.parse("mpileaks %gnu ^callpath %gnu", context=context)[0]
         assert id(s["gcc"]) != id(s["callpath"]["gcc"])
 
 

--- a/lib/spack/spack/test/env.py
+++ b/lib/spack/spack/test/env.py
@@ -1733,8 +1733,8 @@ spack:
     manifest.write_text(spack_yaml)
     with ev.Environment(tmp_path):
         # We rely on this behavior when emitting facts for the solver
-        toolchains = mutable_config.get("toolchains", {})
-        s = spack.spec_parser.parse("mpileaks %gnu ^callpath %gnu", toolchains=toolchains)[0]
+        user_input = spack.spec_parser.UserInput.from_config(mutable_config)
+        s = spack.spec_parser.parse("mpileaks %gnu ^callpath %gnu", user_input=user_input)[0]
         assert id(s["gcc"]) != id(s["callpath"]["gcc"])
 
 

--- a/lib/spack/spack/test/spec_syntax.py
+++ b/lib/spack/spack/test/spec_syntax.py
@@ -28,10 +28,10 @@ from spack.externals import (
 from spack.spec_parser import (
     UNIX_FILENAME,
     WINDOWS_FILENAME,
+    ParseContext,
     SpecParser,
     SpecParsingError,
     SpecTokenizationError,
-    UserInput,
     expand_toolchains,
     parse,
     parse_one_or_raise,
@@ -1905,7 +1905,7 @@ def test_specfiles_are_rejected_by_default(specfile_for, tmp_path: pathlib.Path)
     with pytest.raises(SpecParsingError, match="only accepted on the command line"):
         spack.spec.Spec("libdwarf").satisfies(f"libdwarf ^{specfile}")
 
-    assert parse(str(specfile), user_input=UserInput(specfiles=True)) == [s]
+    assert parse(str(specfile), context=ParseContext(specfiles=True)) == [s]
 
 
 def test_resolve_host_aliases(monkeypatch):
@@ -1926,7 +1926,7 @@ def test_resolve_host_aliases(monkeypatch):
     assert spec.architecture.target == host.default_target()
 
     # parsing user input resolves them in dependencies too
-    spec = parse_one_or_raise("x ^y target=default_target", user_input=UserInput())
+    spec = parse_one_or_raise("x ^y target=default_target", context=ParseContext())
     assert spec["y"].architecture.target == host.default_target()
 
     with pytest.raises(spack.error.SpecError, match="not the current platform"):

--- a/lib/spack/spack/test/spec_syntax.py
+++ b/lib/spack/spack/test/spec_syntax.py
@@ -14,7 +14,7 @@ import spack.cmd
 import spack.concretize
 import spack.error
 import spack.hash_lookup
-import spack.platforms.test
+import spack.platforms
 import spack.repo
 import spack.solver.asp
 import spack.spec
@@ -31,8 +31,11 @@ from spack.spec_parser import (
     SpecParser,
     SpecParsingError,
     SpecTokenizationError,
+    UserInput,
     expand_toolchains,
+    parse,
     parse_one_or_raise,
+    resolve_host_aliases,
 )
 
 SKIP_ON_WINDOWS = pytest.mark.skipif(sys.platform == "win32", reason="Unix style path on Windows")
@@ -372,15 +375,12 @@ def specfile_for(config, mock_packages):
         ),
         # version range and list
         ("@1.6,1.2:1.4", [Token("VERSION", value="@1.6,1.2:1.4")], r"@1.2:1.4,1.6"),
-        (
-            r"os=default_os",  # Various translations associated with the architecture
-            [Token("KEY_VALUE_PAIR", value="os=default_os")],
-            "platform=test os=debian6",
-        ),
+        # host aliases are kept as is, see test_resolve_host_aliases
+        (r"os=default_os", [Token("KEY_VALUE_PAIR", value="os=default_os")], "os=default_os"),
         (
             r"target=default_target",
             [Token("KEY_VALUE_PAIR", value="target=default_target")],
-            f"platform=test target={spack.platforms.test.Test.default}",
+            "target=default_target",
         ),
         (r"platform=linux", [Token("KEY_VALUE_PAIR", value="platform=linux")], r"platform=linux"),
         # Version hash pair
@@ -1652,7 +1652,7 @@ def test_disambiguate_hash_by_spec(spec1, spec2, constraint, mock_packages, monk
         ("x platform=test platform=test", "'platform'"),
         # TODO: these two seem wrong: need to change how arch is initialized (should fail on os)
         ("x os=debian6 platform=test target=default_target os=redhat6", "two architectures"),
-        ("x target=default_target platform=test os=redhat6 os=debian6", "'platform'"),
+        ("x target=default_target platform=test os=redhat6 os=debian6", "two architectures"),
         # Dependencies
         ("^[@foo] zlib", "expected an edge attribute or `]`"),
         # TODO: Remove this as soon as use variants are added and we can parse custom attributes
@@ -1766,7 +1766,7 @@ def test_error_conditions(text, match_string):
 )
 def test_specfile_error_conditions_windows(text, exc_cls):
     with pytest.raises(exc_cls):
-        SpecParser(text).all_specs()
+        SpecParser(text, specfiles=True).all_specs()
 
 
 @pytest.mark.parametrize(
@@ -1790,11 +1790,11 @@ def test_parse_specfile_simple(specfile_for, tmp_path: pathlib.Path):
     specfile = tmp_path / "libdwarf.json"
     s = specfile_for("libdwarf", specfile)
 
-    spec = SpecParser(str(specfile)).next_spec()
+    spec = SpecParser(str(specfile), specfiles=True).next_spec()
     assert spec == s
 
     # Check we can mix literal and spec-file in text
-    specs = SpecParser(f"mvapich_foo {str(specfile)}").all_specs()
+    specs = SpecParser(f"mvapich_foo {str(specfile)}", specfiles=True).all_specs()
     assert len(specs) == 2
 
 
@@ -1841,17 +1841,18 @@ def test_parse_specfile_dependency(config, mock_packages, tmp_path: pathlib.Path
 
     # Make sure we can use yaml path as dependency, e.g.:
     #     "spack spec libdwarf ^ /path/to/libelf.json"
-    spec = SpecParser(f"libdwarf ^ {str(specfile)}").next_spec()
+    spec = SpecParser(f"libdwarf ^ {str(specfile)}", specfiles=True).next_spec()
     assert spec and spec["libelf"] == s["libelf"]
 
     with fs.working_dir(str(tmp_path)):
         # Make sure this also works: "spack spec ./libelf.yaml"
-        spec = SpecParser(f"libdwarf^.{os.path.sep}{specfile.name}").next_spec()
+        spec = SpecParser(f"libdwarf^.{os.path.sep}{specfile.name}", specfiles=True).next_spec()
         assert spec and spec["libelf"] == s["libelf"]
 
         # Should also be accepted: "spack spec ../<cur-dir>/libelf.yaml"
         spec = SpecParser(
-            f"libdwarf^..{os.path.sep}{specfile.parent.name}{os.path.sep}{specfile.name}"
+            f"libdwarf^..{os.path.sep}{specfile.parent.name}{os.path.sep}{specfile.name}",
+            specfiles=True,
         ).next_spec()
         assert spec and spec["libelf"] == s["libelf"]
 
@@ -1865,17 +1866,19 @@ def test_parse_specfile_relative_paths(specfile_for, tmp_path: pathlib.Path):
 
     with fs.working_dir(str(parent_dir)):
         # Make sure this also works: "spack spec ./libelf.yaml"
-        spec = SpecParser(f".{os.path.sep}{basename}").next_spec()
+        spec = SpecParser(f".{os.path.sep}{basename}", specfiles=True).next_spec()
         assert spec == s
 
         # Should also be accepted: "spack spec ../<cur-dir>/libelf.yaml"
-        spec = SpecParser(f"..{os.path.sep}{parent_dir.name}{os.path.sep}{basename}").next_spec()
+        spec = SpecParser(
+            f"..{os.path.sep}{parent_dir.name}{os.path.sep}{basename}", specfiles=True
+        ).next_spec()
         assert spec == s
 
         # Should also handle mixed clispecs and relative paths, e.g.:
         #     "spack spec mvapich_foo ../<cur-dir>/libelf.yaml"
         specs = SpecParser(
-            f"mvapich_foo ..{os.path.sep}{parent_dir.name}{os.path.sep}{basename}"
+            f"mvapich_foo ..{os.path.sep}{parent_dir.name}{os.path.sep}{basename}", specfiles=True
         ).all_specs()
         assert len(specs) == 2
         assert specs[1] == s
@@ -1888,8 +1891,46 @@ def test_parse_specfile_relative_subdir_path(specfile_for, tmp_path: pathlib.Pat
     s = specfile_for("libdwarf", specfile)
 
     with fs.working_dir(str(tmp_path)):
-        spec = SpecParser(f"subdir{os.path.sep}{specfile.name}").next_spec()
+        spec = SpecParser(f"subdir{os.path.sep}{specfile.name}", specfiles=True).next_spec()
         assert spec == s
+
+
+def test_specfiles_are_rejected_by_default(specfile_for, tmp_path: pathlib.Path):
+    """Spec files are read only when enabled, so that Spec(str) does not touch the filesystem."""
+    specfile = tmp_path / "libdwarf.json"
+    s = specfile_for("libdwarf", specfile)
+
+    with pytest.raises(SpecParsingError, match="only accepted on the command line"):
+        spack.spec.Spec(str(specfile))
+    with pytest.raises(SpecParsingError, match="only accepted on the command line"):
+        spack.spec.Spec("libdwarf").satisfies(f"libdwarf ^{specfile}")
+
+    assert parse(str(specfile), user_input=UserInput(specfiles=True)) == [s]
+
+
+def test_resolve_host_aliases(monkeypatch):
+    """Parsing keeps default_os and default_target, evaluating user input resolves them."""
+
+    def fail():
+        raise AssertionError("parsing must not query the host")
+
+    with monkeypatch.context() as m:
+        m.setattr(spack.platforms, "host", fail)
+        spec = spack.spec.Spec("x os=default_os target=default_target")
+        assert str(spec) == "x os=default_os target=default_target"
+
+    host = spack.platforms.host()
+    resolve_host_aliases(spec)
+    assert spec.architecture.platform == str(host)
+    assert spec.architecture.os == str(host.default_operating_system())
+    assert spec.architecture.target == host.default_target()
+
+    # parsing user input resolves them in dependencies too
+    spec = parse_one_or_raise("x ^y target=default_target", user_input=UserInput())
+    assert spec["y"].architecture.target == host.default_target()
+
+    with pytest.raises(spack.error.SpecError, match="not the current platform"):
+        resolve_host_aliases(spack.spec.Spec("x platform=other os=default_os"))
 
 
 @pytest.mark.regression("20310")


### PR DESCRIPTION
* `default_os` etc are machine dependent, so they should be resolved
  from user input only (not in spack-packages)
* `foo ^./x.json` too should be evaluated only from user input and not
  in spack-packages

This is a simple generalization of the toolchain refactor by @alalazo in the past.

I've also pushed a second commit that allows `Spec(..., context=...)` to replace `parse_one_or_raise` which was more or less a standalone `Spec` constructor.