### PR TITLE
spec.py: ImmutableSpec -> CachedSpec

### DIFF
--- a/lib/spack/spack/directives.py
+++ b/lib/spack/spack/directives.py
@@ -136,7 +136,7 @@ def _make_when_spec(value: Union[WhenType, Tuple[str, ...]]) -> Optional[spack.s
         combined_spec = _WHEN_STACK_CACHE.get(value)
         if combined_spec is None:
             # reduce the when-stack to a single spec by combining all constraints.
-            combined_spec = spack.spec.Spec(value[0])
+            combined_spec = spack.spec._CachedSpec(value[0])
             for cond in value[1:]:
                 combined_spec._constrain_symbolically(get_spec(cond))
             _WHEN_STACK_CACHE[value] = combined_spec

--- a/lib/spack/spack/directives_meta.py
+++ b/lib/spack/spack/directives_meta.py
@@ -25,7 +25,7 @@ SPEC_CACHE: Dict[str, spack.spec.Spec] = {}
 def get_spec(spec_str: str) -> spack.spec.Spec:
     """Get a spec from the cache, or create it if not present."""
     if spec_str not in SPEC_CACHE:
-        SPEC_CACHE[spec_str] = spack.spec._ImmutableSpec(spec_str)
+        SPEC_CACHE[spec_str] = spack.spec._CachedSpec(spec_str)
     return SPEC_CACHE[spec_str]
 
 

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -6156,9 +6156,9 @@ class MissingSpecHashError(spack.error.SpecError):
     """Raised when a serialized spec node references a hash not present in a node list."""
 
 
-class _ImmutableSpec(Spec):
+class _CachedSpec(Spec):
     """A Spec that is immutable by convention: it is interned in caches and shared across
-    package classes, so callers copy before mutating. Immutability is not enforced."""
+    package classes. Immutability is not enforced."""
 
     _str_cache: str
 
@@ -6173,4 +6173,4 @@ class _ImmutableSpec(Spec):
 
 
 #: Immutable empty spec, for fast comparisons and reduced memory usage.
-EMPTY_SPEC = _ImmutableSpec()
+EMPTY_SPEC = _CachedSpec()


### PR DESCRIPTION
* Rename ImmutableSpec -> CachedSpec since that's currently a more
  accurate name
* Use it also when constructing a `when=` stack, which *is* a mutating
  operation, but can be considered part of construction of an immutable
  instance.

This speeds up the trigger/effect bits in the solver, which dedupe by
`str(spec)`.

About 3-4% faster to a concretization cache hit, which is not much, but
it's also a bit sad to skip.