### PR TITLE
spec: add --deptype to filter the printed tree

### DIFF
--- a/lib/spack/spack/cmd/spec.py
+++ b/lib/spack/spack/cmd/spec.py
@@ -72,6 +72,7 @@ for further documentation regarding the spec syntax, see:
     subparser.add_argument(
         "-t", "--types", action="store_true", default=False, help="show dependency types"
     )
+    arguments.add_common_arguments(subparser, ["deptype"])
     arguments.add_common_arguments(subparser, ["specs"])
     arguments.add_concretizer_args(subparser)
 
@@ -124,6 +125,7 @@ def spec(parser, args):
                 cover=args.cover,
                 format=fmt,
                 hashlen=None if args.very_long else 7,
+                deptypes=args.deptype,
                 show_types=args.types,
                 status_fn=status_fn,
                 hashes=args.long or args.very_long,

--- a/lib/spack/spack/test/cmd/spec.py
+++ b/lib/spack/spack/test/cmd/spec.py
@@ -147,6 +147,43 @@ def test_spec_deptypes_edges():
     assert types["dt-diamond-bottom"] == ["b   ", "blr "]
 
 
+def test_spec_deptype_filters_build_only():
+    """``--deptype=link,run`` omits build-only deps and their subgraphs."""
+    output = spec(
+        "--types",
+        "--cover",
+        "edges",
+        "--no-install-status",
+        "--deptype=link,run",
+        "dtbuild1",
+    )
+    types = _parse_types(output)
+
+    assert "dtbuild1" in types
+    assert "dtlink2" in types
+    assert "dtrun2" in types
+    assert "dtbuild2" not in types
+
+
+def test_spec_deptype_edges_omits_build_only_edge():
+    """Build-only edges are not shown even when the same node is also a link/run dep."""
+    output = spec(
+        "--types",
+        "--cover",
+        "edges",
+        "--no-install-status",
+        "--deptype=link,run",
+        "dt-diamond",
+    )
+    types = _parse_types(output)
+
+    assert types["dt-diamond"] == ["    "]
+    assert types["dt-diamond-left"] == ["bl  "]
+    assert types["dt-diamond-right"] == ["bl  "]
+    # left -> bottom is build-only, so only the right -> bottom edge remains
+    assert types["dt-diamond-bottom"] == ["blr "]
+
+
 def test_spec_returncode():
     with pytest.raises(SpackCommandError):
         spec()


### PR DESCRIPTION
`spack spec` currently always prints the full DAG. `spack graph` and
`spack dependencies` already accept `--deptype` to restrict which
edges are walked. This wires the same shared flag through to
`spack.spec.tree()`.

Concretization is unchanged: `--deptype` is display-only. `--yaml` /
`--json` / `--format` still dump the full concrete spec.

Example:

```console
$ spack spec -t -c edges --deptype=link,run hdf5
```

That omits build-only nodes (cmake, gmake, compiler packages, …) and
anything reachable only through them, while still showing `%c=…` on
remaining nodes.

## Tests

- `test_spec_deptype_filters_build_only`: `--deptype=link,run` drops
  `dtbuild2` from `dtbuild1`
- `test_spec_deptype_edges_omits_build_only_edge`: diamond build-only
  edge is omitted; the link/run edge to the same node remains