### PR TITLE
web: read network settings from an injected configuration

### DIFF
--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -356,7 +356,9 @@ class BinaryIndexCache:
 
         supported_mirror_versions = {
             (m.fetch_url, m.fetch_view): m.supported_layout_versions
-            for m in spack.mirrors.mirror.MirrorCollection(binary=True, config=config).values()
+            for m in spack.mirrors.mirror.MirrorCollection.from_config(
+                config, binary=True
+            ).values()
         }
 
         # If we have a cached index for a mirror which is no longer configured, remove it
@@ -427,7 +429,9 @@ class BinaryIndexCache:
                 )
 
             try:
-                regenerate = self._fetch_and_cache_index(meta, cache_entry=cache_entry or {})
+                regenerate = self._fetch_and_cache_index(
+                    meta, cache_entry=cache_entry or {}, config=config
+                )
                 self._last_fetch_times[meta] = _LastFetch(time=now, succeeded=True)
                 return _MirrorIndexResult(
                     succeeded=True,
@@ -473,7 +477,13 @@ class BinaryIndexCache:
 
         return clear, regenerate
 
-    def _fetch_and_cache_index(self, mirror_metadata: MirrorMetadata, cache_entry={}):
+    def _fetch_and_cache_index(
+        self,
+        mirror_metadata: MirrorMetadata,
+        cache_entry={},
+        *,
+        config: spack.config.Configuration,
+    ):
         """Fetch a buildcache index file from a remote mirror and cache it.
 
         If we already have a cached index from this mirror, then we first
@@ -483,6 +493,7 @@ class BinaryIndexCache:
             mirror_metadata: Contains mirror base url and target binary cache layout version
             cache_entry (dict): Old cache metadata with keys ``index_hash``, ``index_path``,
                 ``etag``
+            config: configuration to read the connection settings from
 
         Returns:
             True if the local index.json was updated.
@@ -501,10 +512,12 @@ class BinaryIndexCache:
         if scheme != "oci":
             cache_class = get_url_buildcache_class(layout_version=layout_version)
             index_url = cache_class.get_index_url(mirror_url, mirror_view)
-            if not web_util.url_exists(index_url):
+            if not web_util.url_exists(index_url, config=config):
                 raise BuildcacheIndexNotExists(f"Index not found in cache {index_url}")
 
-        fetcher: IndexHandler = get_index_fetcher(scheme, mirror_metadata, cache_entry)
+        fetcher: IndexHandler = _get_index_fetcher(
+            scheme, mirror_metadata, cache_entry, config=config
+        )
         result = fetcher.conditional_fetch()
 
         # Nothing to do
@@ -797,7 +810,7 @@ def generate_key_index(mirror_url: str, tmpdir: str) -> None:
     try:
         fingerprints = (
             entry[:-18]
-            for entry in web_util.list_url(key_prefix, recursive=False)
+            for entry in web_util.list_url(key_prefix, recursive=False, config=spack.config.CONFIG)
             if entry.endswith(".key.manifest.json")
         )
     except Exception as e:
@@ -1281,7 +1294,9 @@ def _oci_upload_success_msg(spec: spack.spec.Spec, digest: Digest, size: int, el
 def _oci_get_blob_info(image_ref: ImageReference) -> Optional[spack.oci.oci.Blob]:
     """Get the spack tarball layer digests and size if it exists"""
     try:
-        manifest, config = get_manifest_and_config_with_retry(image_ref)
+        manifest, config = get_manifest_and_config_with_retry(
+            image_ref, urlopen=spack.oci.opener.opener_for(spack.config.CONFIG)
+        )
 
         return spack.oci.oci.Blob(
             compressed_digest=Digest.from_string(manifest["layers"][-1]["digest"]),
@@ -1309,7 +1324,12 @@ def _oci_push_pkg_blob(
 
     # Upload the blob
     start = time.time()
-    upload_blob_with_retry(image_ref, file=filename, digest=blob.compressed_digest)
+    upload_blob_with_retry(
+        image_ref,
+        file=filename,
+        digest=blob.compressed_digest,
+        urlopen=spack.oci.opener.opener_for(spack.config.CONFIG),
+    )
     elapsed = time.time() - start
 
     # delete the file
@@ -1406,7 +1426,10 @@ def _oci_put_manifest(
     )
 
     # Upload the config file
-    upload_blob_with_retry(image_ref, file=config_file, digest=config_file_checksum)
+    urlopen = spack.oci.opener.opener_for(spack.config.CONFIG)
+    upload_blob_with_retry(
+        image_ref, file=config_file, digest=config_file_checksum, urlopen=urlopen
+    )
 
     manifest = {
         "mediaType": base_manifest_mediaType,
@@ -1438,7 +1461,7 @@ def _oci_put_manifest(
         manifest["annotations"] = annotations
 
     # Finally upload the manifest
-    upload_manifest_with_retry(image_ref, manifest=manifest)
+    upload_manifest_with_retry(image_ref, manifest=manifest, urlopen=urlopen)
 
     # delete the config file
     os.unlink(config_file)
@@ -1464,7 +1487,10 @@ def _oci_update_base_images(
         )
     else:
         base_image_cache[architecture] = copy_missing_layers_with_retry(
-            base_image, target_image, architecture
+            base_image,
+            target_image,
+            architecture,
+            urlopen=spack.oci.opener.opener_for(spack.config.CONFIG),
         )
 
 
@@ -1615,7 +1641,12 @@ def _oci_config_from_tag(image_ref_and_tag: Tuple[ImageReference, str]) -> Optio
     image_ref, tag = image_ref_and_tag
     # Don't allow recursion here, since Spack itself always uploads
     # vnd.oci.image.manifest.v1+json, not vnd.oci.image.index.v1+json
-    _, config = get_manifest_and_config_with_retry(image_ref.with_tag(tag), tag, recurse=0)
+    _, config = get_manifest_and_config_with_retry(
+        image_ref.with_tag(tag),
+        tag,
+        recurse=0,
+        urlopen=spack.oci.opener.opener_for(spack.config.CONFIG),
+    )
 
     # Do very basic validation: if "spec" is a key in the config, it
     # must be a Spec object too.
@@ -1629,8 +1660,9 @@ def _oci_update_index(
     *,
     timer=timer.NULL_TIMER,
 ) -> None:
+    urlopen = spack.oci.opener.opener_for(spack.config.CONFIG)
     with timer.measure("list"):
-        tags = list_tags(image_ref)
+        tags = list_tags(image_ref, urlopen=urlopen)
 
     with timer.measure("read"):
         # Fetch all image config files in parallel
@@ -1662,13 +1694,17 @@ def _oci_update_index(
         index_shasum = Digest.from_sha256(
             spack.util.crypto.checksum(hashlib.sha256, index_json_path)
         )
-        upload_blob_with_retry(image_ref, file=index_json_path, digest=index_shasum)
+        upload_blob_with_retry(
+            image_ref, file=index_json_path, digest=index_shasum, urlopen=urlopen
+        )
 
         # Upload the config.json file
         empty_config_digest = Digest.from_sha256(
             spack.util.crypto.checksum(hashlib.sha256, empty_config_json_path)
         )
-        upload_blob_with_retry(image_ref, file=empty_config_json_path, digest=empty_config_digest)
+        upload_blob_with_retry(
+            image_ref, file=empty_config_json_path, digest=empty_config_digest, urlopen=urlopen
+        )
 
         # Push a manifest file that references the index.json file as a layer
         # Notice that we push this as if it is an image, which it of course is not.
@@ -1694,7 +1730,9 @@ def _oci_update_index(
             ],
         }
 
-        upload_manifest_with_retry(image_ref.with_tag(default_index_tag), oci_manifest)
+        upload_manifest_with_retry(
+            image_ref.with_tag(default_index_tag), oci_manifest, urlopen=urlopen
+        )
 
 
 def download_tarball(
@@ -1716,7 +1754,9 @@ def download_tarball(
         containing the downloaded tarball.
     """
     configured_mirrors: Iterable[spack.mirrors.mirror.Mirror] = (
-        spack.mirrors.mirror.MirrorCollection(binary=True).values()
+        spack.mirrors.mirror.MirrorCollection.from_config(
+            spack.config.CONFIG, binary=True
+        ).values()
     )
     if not configured_mirrors:
         raise NoConfiguredBinaryMirrors()
@@ -1767,9 +1807,11 @@ def download_tarball(
         if spack.oci.image.is_oci_url(fetch_url):
             ref = ImageReference.from_url(fetch_url).with_tag(_oci_default_tag(spec))
 
+            urlopen = spack.oci.opener.opener_for(spack.config.CONFIG)
+
             # Fetch the manifest
             try:
-                with spack.oci.opener.urlopen(
+                with urlopen(
                     urllib.request.Request(
                         url=ref.manifest_url(),
                         headers={"Accept": ", ".join(spack.oci.oci.manifest_content_type)},
@@ -1789,7 +1831,7 @@ def download_tarball(
                 continue
 
             with spack.oci.oci.make_stage(
-                ref.blob_url(spec_digest), spec_digest, keep=True
+                ref.blob_url(spec_digest), spec_digest, keep=True, urlopen=urlopen
             ) as local_specfile_stage:
                 try:
                     local_specfile_stage.fetch()
@@ -1812,7 +1854,7 @@ def download_tarball(
             local_specfile_stage.destroy()
 
             with spack.oci.oci.make_stage(
-                ref.blob_url(tarball_digest), tarball_digest, keep=True
+                ref.blob_url(tarball_digest), tarball_digest, keep=True, urlopen=urlopen
             ) as tarball_stage:
                 try:
                     tarball_stage.fetch()
@@ -2191,7 +2233,9 @@ def install_single_spec(spec, unsigned=False, force=False):
 def try_direct_fetch(spec: spack.spec.Spec) -> List[MirrorMetadata]:
     """Try to find the spec directly on the configured mirrors"""
     found_specs: List[MirrorMetadata] = []
-    binary_mirrors = spack.mirrors.mirror.MirrorCollection(binary=True).values()
+    binary_mirrors = spack.mirrors.mirror.MirrorCollection.from_config(
+        spack.config.CONFIG, binary=True
+    ).values()
 
     for mirror in binary_mirrors:
         # TODO: OCI-support
@@ -2230,7 +2274,7 @@ def get_mirrors_for_spec(spec: spack.spec.Spec, index_only: bool = False) -> Lis
         index_only: When ``index_only`` is set to ``True``, only the local cache is checked, no
             requests are made.
     """
-    if not spack.mirrors.mirror.MirrorCollection(binary=True):
+    if not spack.mirrors.mirror.MirrorCollection.from_config(spack.config.CONFIG, binary=True):
         tty.debug("No Spack mirrors are currently configured")
         return []
 
@@ -2285,7 +2329,9 @@ def trust_keys(
     mirrors: Optional[Mapping[str, spack.mirrors.mirror.Mirror]] = None,
 ) -> None:
     """Get pgp public keys available on mirror with suffix .pub"""
-    mirror_collection = mirrors or spack.mirrors.mirror.MirrorCollection(binary=True)
+    mirror_collection = mirrors or spack.mirrors.mirror.MirrorCollection.from_config(
+        spack.config.CONFIG, binary=True
+    )
 
     if not mirror_collection:
         tty.die("Please add a spack mirror to allow " + "download of build caches.")
@@ -2367,10 +2413,10 @@ def _trust_keys_v2(mirror_url, yes_to_all=False, install=False, trust=False, for
     tty.debug("Finding public keys in {0}".format(url_util.format(mirror_url)))
 
     try:
-        json_index = web_util.read_json(keys_index)
+        json_index = web_util.read_json(keys_index, config=spack.config.CONFIG)
     except (web_util.SpackWebError, OSError, ValueError) as url_err:
         # TODO: avoid repeated request
-        if web_util.url_exists(keys_index):
+        if web_util.url_exists(keys_index, config=spack.config.CONFIG):
             tty.error(
                 f"Unable to find public keys in {url_util.format(mirror_url)},"
                 f" caught exception attempting to read from {url_util.format(keys_index)}."
@@ -2511,7 +2557,9 @@ def download_single_spec(
         destination (str): path where to put the downloaded buildcache
         mirror_url (str): url of the mirror from which to download
     """
-    if not mirror_url and not spack.mirrors.mirror.MirrorCollection(binary=True):
+    if not mirror_url and not spack.mirrors.mirror.MirrorCollection.from_config(
+        spack.config.CONFIG, binary=True
+    ):
         tty.die(
             "Please provide or add a spack mirror to allow " + "download of buildcache entries."
         )
@@ -2521,7 +2569,9 @@ def download_single_spec(
         if mirror_url
         else [
             mirror.fetch_url
-            for mirror in spack.mirrors.mirror.MirrorCollection(binary=True).values()
+            for mirror in spack.mirrors.mirror.MirrorCollection.from_config(
+                spack.config.CONFIG, binary=True
+            ).values()
         ]
     )
 
@@ -2641,7 +2691,7 @@ class IndexHandler:
 class DefaultIndexHandlerV2(IndexHandler):
     """Fetcher for index.json, using separate index.json.hash as cache invalidation strategy"""
 
-    def __init__(self, mirror_metadata, local_hash, urlopen=web_util.urlopen):
+    def __init__(self, mirror_metadata, local_hash, *, urlopen: web_util.OpenType):
         self.url = mirror_metadata.url
         self.local_hash = local_hash
         self.urlopen = urlopen
@@ -2712,7 +2762,7 @@ class DefaultIndexHandlerV2(IndexHandler):
 class EtagIndexHandlerV2(IndexHandler):
     """Fetcher for index.json, using ETags headers as cache invalidation strategy"""
 
-    def __init__(self, mirror_metadata, etag, urlopen=web_util.urlopen):
+    def __init__(self, mirror_metadata, etag, *, urlopen: web_util.OpenType):
         self.url = mirror_metadata.url
         self.etag = etag
         self.urlopen = urlopen
@@ -2753,10 +2803,12 @@ class EtagIndexHandlerV2(IndexHandler):
 
 
 class OCIIndexHandler(IndexHandler):
-    def __init__(self, mirror_metadata: MirrorMetadata, local_hash, urlopen=None) -> None:
+    def __init__(
+        self, mirror_metadata: MirrorMetadata, local_hash, *, urlopen: spack.oci.opener.OpenType
+    ) -> None:
         self.local_hash = local_hash
         self.ref = spack.oci.image.ImageReference.from_url(mirror_metadata.url)
-        self.urlopen = urlopen or spack.oci.opener.urlopen
+        self.urlopen = urlopen
 
     def conditional_fetch(self) -> FetchIndexResult:
         """Download an index from an OCI registry type mirror."""
@@ -2809,7 +2861,7 @@ class OCIIndexHandler(IndexHandler):
 class DefaultIndexHandler(IndexHandler):
     """Fetcher for buildcache index, cache invalidation via manifest contents"""
 
-    def __init__(self, mirror_metadata: MirrorMetadata, local_hash, urlopen=web_util.urlopen):
+    def __init__(self, mirror_metadata: MirrorMetadata, local_hash, *, urlopen: web_util.OpenType):
         self.url = mirror_metadata.url
         self.view = mirror_metadata.view
         self.layout_version = mirror_metadata.version
@@ -2869,7 +2921,7 @@ class EtagIndexHandler(IndexHandler):
     4. If it needs to actually read the manifest, it does not need to do any checks of the url
     scheme to determine whether an etag should be included in the return value."""
 
-    def __init__(self, mirror_metadata: MirrorMetadata, etag, urlopen=web_util.urlopen):
+    def __init__(self, mirror_metadata: MirrorMetadata, etag, *, urlopen: web_util.OpenType):
         self.url = mirror_metadata.url
         self.view = mirror_metadata.view
         self.layout_version = mirror_metadata.version
@@ -2912,27 +2964,32 @@ class EtagIndexHandler(IndexHandler):
         )
 
 
-def get_index_fetcher(
-    scheme: str, mirror_metadata: MirrorMetadata, cache_entry: Dict[str, str]
+def _get_index_fetcher(
+    scheme: str,
+    mirror_metadata: MirrorMetadata,
+    cache_entry: Dict[str, str],
+    *,
+    config: spack.config.Configuration,
 ) -> IndexHandler:
     if scheme == "oci":
         # TODO: Actually etag and OCI are not mutually exclusive...
-        return OCIIndexHandler(mirror_metadata, cache_entry.get("index_hash", None))
-    elif cache_entry.get("etag"):
-        if mirror_metadata.version < 3:
-            return EtagIndexHandlerV2(mirror_metadata, cache_entry["etag"])
-        else:
-            return EtagIndexHandler(mirror_metadata, cache_entry["etag"])
+        return OCIIndexHandler(
+            mirror_metadata,
+            cache_entry.get("index_hash", None),
+            urlopen=spack.oci.opener.opener_for(config),
+        )
 
-    else:
-        if mirror_metadata.version < 3:
-            return DefaultIndexHandlerV2(
-                mirror_metadata, local_hash=cache_entry.get("index_hash", None)
-            )
-        else:
-            return DefaultIndexHandler(
-                mirror_metadata, local_hash=cache_entry.get("index_hash", None)
-            )
+    urlopen = web_util.opener_for(config)
+    is_v2 = mirror_metadata.version < 3
+
+    if cache_entry.get("etag"):
+        etag_handler = EtagIndexHandlerV2 if is_v2 else EtagIndexHandler
+        return etag_handler(mirror_metadata, cache_entry["etag"], urlopen=urlopen)
+
+    default_handler = DefaultIndexHandlerV2 if is_v2 else DefaultIndexHandler
+    return default_handler(
+        mirror_metadata, local_hash=cache_entry.get("index_hash", None), urlopen=urlopen
+    )
 
 
 class NoOverwriteException(spack.error.SpackError):

--- a/lib/spack/spack/buildcache_migrate.py
+++ b/lib/spack/spack/buildcache_migrate.py
@@ -9,6 +9,7 @@ import tempfile
 from typing import NamedTuple
 
 import spack.binary_distribution
+import spack.config
 import spack.database as spack_db
 import spack.error
 import spack.mirrors.mirror
@@ -104,7 +105,7 @@ def _migrate_spec(
 
     for meta_url in v2_metadata_urls:
         try:
-            spec_contents = web_util.read_text(meta_url)
+            spec_contents = web_util.read_text(meta_url, config=spack.config.CONFIG)
             v2_spec_url = meta_url
             break
         except (web_util.SpackWebError, OSError):
@@ -202,7 +203,9 @@ def _migrate_spec(
     tty.debug(f"Pushing {local_tarfile_path} to {v3_archive_url}")
 
     try:
-        web_util.push_to_url(local_tarfile_path, v3_archive_url, keep_original=True)
+        web_util.push_to_url(
+            local_tarfile_path, v3_archive_url, keep_original=True, config=spack.config.CONFIG
+        )
     except Exception:
         return MigrateSpecResult(False, f"Failed to push archive for {print_spec}")
 
@@ -210,7 +213,9 @@ def _migrate_spec(
     tty.debug(f"Pushing {spec_json_path} to {v3_spec_url}")
 
     try:
-        web_util.push_to_url(spec_json_path, v3_spec_url, keep_original=True)
+        web_util.push_to_url(
+            spec_json_path, v3_spec_url, keep_original=True, config=spack.config.CONFIG
+        )
     except Exception:
         return MigrateSpecResult(False, f"Failed to push spec metadata for {print_spec}")
 
@@ -236,7 +241,9 @@ def _migrate_spec(
 
     # Push the manifest
     try:
-        web_util.push_to_url(manifest_path, v3_manifest_url, keep_original=True)
+        web_util.push_to_url(
+            manifest_path, v3_manifest_url, keep_original=True, config=spack.config.CONFIG
+        )
     except Exception:
         return MigrateSpecResult(False, f"Failed to push manifest for {print_spec}")
 
@@ -278,7 +285,7 @@ def migrate(
     contents = None
 
     try:
-        contents = web_util.read_text(index_url)
+        contents = web_util.read_text(index_url, config=spack.config.CONFIG)
     except (web_util.SpackWebError, OSError):
         raise MigrationException("Buildcache migration requires a buildcache index")
 
@@ -347,6 +354,6 @@ def migrate(
         if delete_existing:
             delete_prefix = url_util.join(mirror_url, "build_cache")
             tty.msg(f"Recursively deleting {delete_prefix}")
-            web_util.remove_url(delete_prefix, recursive=True)
+            web_util.remove_url(delete_prefix, recursive=True, config=spack.config.CONFIG)
 
     tty.msg("Migration complete")

--- a/lib/spack/spack/buildcache_prune.py
+++ b/lib/spack/spack/buildcache_prune.py
@@ -11,6 +11,7 @@ from pathlib import Path
 from typing import Callable, Dict, Iterable, Iterator, List, Optional, Set, Tuple, cast
 
 import spack.binary_distribution
+import spack.config
 import spack.error
 import spack.stage
 import spack.util.parallel
@@ -43,7 +44,7 @@ def _fetch_manifests(
         mirror.fetch_url, spack.binary_distribution.buildcache_relative_blobs_path()
     )
     tty.debug(f"Listing blobs in {url_to_list}")
-    blobs = web_util.list_url(url_to_list, recursive=True) or []
+    blobs = web_util.list_url(url_to_list, recursive=True, config=spack.config.CONFIG) or []
     if not blobs:
         tty.warn(f"Unable to list blobs in {url_to_list}")
     blobs = [
@@ -78,7 +79,7 @@ def _delete_object(url: str, dry_run: bool) -> int:
         if dry_run:
             tty.info(f"Would have removed object {url}")
         else:
-            web_util.remove_url(url=url)
+            web_util.remove_url(url=url, config=spack.config.CONFIG)
             tty.info(f"Removed object {url}")
         return 1
     except Exception as e:
@@ -92,7 +93,7 @@ def _object_has_prunable_mtime(url: str, pruning_started_at: float) -> Tuple[str
     Objects modified after pruning started should not be pruned to avoid
     race conditions with concurrent uploads.
     """
-    stat_result = web_util.stat_url(url)
+    stat_result = web_util.stat_url(url, config=spack.config.CONFIG)
     assert stat_result is not None
     if stat_result[1] > pruning_started_at:
         tty.info(f"Skipping deletion of {url} because it was modified after pruning started")
@@ -384,14 +385,17 @@ def get_buildcache_normalized_time(mirror: Mirror) -> float:
         remote_path = url_util.join(mirror.push_url, touch_file.name)
 
         web_util.push_to_url(
-            local_file_path=str(touch_file), remote_path=remote_path, keep_original=True
+            local_file_path=str(touch_file),
+            remote_path=remote_path,
+            keep_original=True,
+            config=spack.config.CONFIG,
         )
 
-        stat_info = web_util.stat_url(remote_path)
+        stat_info = web_util.stat_url(remote_path, config=spack.config.CONFIG)
         assert stat_info is not None
         start_time = stat_info[1]
 
-        web_util.remove_url(remote_path)
+        web_util.remove_url(remote_path, config=spack.config.CONFIG)
 
         return start_time
 
@@ -409,7 +413,7 @@ def prune_buildcache(mirror: Mirror, keeplist: Optional[str] = None, dry_run: bo
     # If a cache index exists, use that time. Otherwise, use the current time (normalized
     # to the buildcache's time zone).
     cache_index_url = URLBuildcacheEntry.get_index_url(mirror_url=mirror.fetch_url)
-    stat_result = web_util.stat_url(cache_index_url)
+    stat_result = web_util.stat_url(cache_index_url, config=spack.config.CONFIG)
     if stat_result is not None:
         started_at = stat_result[1]
     else:

--- a/lib/spack/spack/ci/__init__.py
+++ b/lib/spack/spack/ci/__init__.py
@@ -63,7 +63,9 @@ spack_compiler = spack.main.SpackCommand("compiler")
 
 PushResult = namedtuple("PushResult", "success url")
 
-urlopen = web_util.urlopen  # alias for mocking in tests
+
+def urlopen(request, **kwargs):  # module-level for mocking in tests
+    return web_util.opener_for(cfg.CONFIG)(request, **kwargs)
 
 
 def get_git_root(path: str) -> Optional[str]:
@@ -332,7 +334,7 @@ def check_for_broken_specs(pipeline_specs: List[spack.spec.Spec], broken_specs_u
         tty.msg("Cannot use an http(s) url for broken specs, ignoring")
         return False
 
-    broken_spec_urls = web_util.list_url(broken_specs_url)
+    broken_spec_urls = web_util.list_url(broken_specs_url, config=cfg.CONFIG)
 
     if broken_spec_urls is None:
         return False
@@ -354,7 +356,7 @@ def check_for_broken_specs(pipeline_specs: List[spack.spec.Spec], broken_specs_u
 def collect_pipeline_options(env: ev.Environment, args) -> PipelineOptions:
     """Gather pipeline options from cli args, spack environment, and
     os environment variables"""
-    pipeline_mirrors = spack.mirrors.mirror.MirrorCollection(binary=True)
+    pipeline_mirrors = spack.mirrors.mirror.MirrorCollection.from_config(cfg.CONFIG, binary=True)
     if "buildcache-destination" not in pipeline_mirrors:
         raise SpackCIError("spack ci generate requires a mirror named 'buildcache-destination'")
 
@@ -876,7 +878,9 @@ def reproduce_ci_job(url, work_dir, autostart, gpg_url, runtime, use_local_head)
 
     gpg_path = None
     if gpg_url:
-        gpg_path = web_util.fetch_url_text(gpg_url, dest_dir=os.path.join(work_dir, "_pgp"))
+        gpg_path = web_util.fetch_url_text(
+            gpg_url, dest_dir=os.path.join(work_dir, "_pgp"), config=cfg.CONFIG
+        )
         rel_gpg_path = gpg_path.replace(work_dir, "").lstrip(os.path.sep)
 
     lock_file = fs.find(work_dir, "spack.lock")[0]
@@ -1287,7 +1291,9 @@ def write_broken_spec(url, pkg_name, stack_name, job_url, pipeline_url, spec_dic
         try:
             with open(file_path, "w", encoding="utf-8") as fd:
                 syaml.dump(broken_spec_details, fd)
-            web_util.push_to_url(file_path, url, keep_original=False, content_type="text/plain")
+            web_util.push_to_url(
+                file_path, url, keep_original=False, content_type="text/plain", config=cfg.CONFIG
+            )
         except Exception as err:
             # If there is an S3 error (e.g., access denied or connection
             # error), the first non boto-specific class in the exception
@@ -1301,7 +1307,7 @@ def read_broken_spec(broken_spec_url):
     object.
     """
     try:
-        broken_spec_contents = web_util.read_text(broken_spec_url)
+        broken_spec_contents = web_util.read_text(broken_spec_url, config=cfg.CONFIG)
     except web_util.SpackWebError:
         tty.warn(f"Unable to read broken spec from {broken_spec_url}")
         return None

--- a/lib/spack/spack/ci/common.py
+++ b/lib/spack/spack/ci/common.py
@@ -38,8 +38,10 @@ from spack.util.lang import memoized
 IS_WINDOWS = sys.platform == "win32"
 SPACK_RESERVED_TAGS = ["public", "protected", "notary"]
 
+
 # this exists purely for testing purposes
-_urlopen = web_util.urlopen
+def _urlopen(request, **kwargs):
+    return web_util.opener_for(cfg.CONFIG)(request, **kwargs)
 
 
 def copy_gzipped(glob_or_path: str, dest: str) -> None:
@@ -592,7 +594,9 @@ class SpackCIConfig:
             {"noop-job": {"script": ['echo "All specs already up to date, nothing to rebuild."']}},
         ]
 
-        pipeline_mirrors = spack.mirrors.mirror.MirrorCollection(binary=True)
+        pipeline_mirrors = spack.mirrors.mirror.MirrorCollection.from_config(
+            cfg.CONFIG, binary=True
+        )
         buildcache_destination = pipeline_mirrors["buildcache-destination"]
         update_index_extra_args = []
         if buildcache_destination.push_view:

--- a/lib/spack/spack/ci/gitlab.py
+++ b/lib/spack/spack/ci/gitlab.py
@@ -341,7 +341,9 @@ def generate_gitlab_yaml(pipeline: PipelineDag, spack_ci: SpackCIConfig, options
             }
         )
 
-        pipeline_mirrors = spack.mirrors.mirror.MirrorCollection(binary=True)
+        pipeline_mirrors = spack.mirrors.mirror.MirrorCollection.from_config(
+            spack.config.CONFIG, binary=True
+        )
         if "buildcache-source" not in pipeline_mirrors:
             raise SpackCIError("Copy-only pipelines require a mirror named 'buildcache-source'")
 

--- a/lib/spack/spack/cmd/buildcache.py
+++ b/lib/spack/spack/cmd/buildcache.py
@@ -772,7 +772,9 @@ def copy_buildcache_entry(cache_entry: URLBuildcacheEntry, destination_url: str)
     tarball_dest_url = cache_entry.get_blob_url(destination_url, tarball_blob_record)
 
     try:
-        web_util.push_to_url(local_tarball_path, tarball_dest_url, keep_original=True)
+        web_util.push_to_url(
+            local_tarball_path, tarball_dest_url, keep_original=True, config=spack.config.CONFIG
+        )
     except Exception as e:
         tty.warn(f"Failed to push {local_tarball_path} to {tarball_dest_url} due to {e}")
         cache_entry.destroy()
@@ -786,7 +788,9 @@ def copy_buildcache_entry(cache_entry: URLBuildcacheEntry, destination_url: str)
     spec_dest_url = cache_entry.get_blob_url(destination_url, spec_blob_record)
 
     try:
-        web_util.push_to_url(local_spec_path, spec_dest_url, keep_original=True)
+        web_util.push_to_url(
+            local_spec_path, spec_dest_url, keep_original=True, config=spack.config.CONFIG
+        )
     except Exception as e:
         tty.warn(f"Failed to push {local_spec_path} to {spec_dest_url} due to {e}")
         cache_entry.destroy()
@@ -812,7 +816,9 @@ def copy_buildcache_entry(cache_entry: URLBuildcacheEntry, destination_url: str)
     local_manifest_path = manifest_stage.save_filename
 
     try:
-        web_util.push_to_url(local_manifest_path, manifest_dest_url, keep_original=True)
+        web_util.push_to_url(
+            local_manifest_path, manifest_dest_url, keep_original=True, config=spack.config.CONFIG
+        )
     except Exception as e:
         tty.warn(f"Failed to push manifest to {manifest_dest_url} due to {e}")
 
@@ -989,7 +995,7 @@ def update_view(
     # local cache.
     index_exists = True
     try:
-        BINARY_INDEX._fetch_and_cache_index(mirror_metadata)
+        BINARY_INDEX._fetch_and_cache_index(mirror_metadata, config=spack.config.CONFIG)
     except spack.binary_distribution.BuildcacheIndexNotExists:
         index_exists = False
 
@@ -1058,7 +1064,7 @@ def check_index_fn(args):
     index_exists = True
     missing_index_blob = False
     try:
-        BINARY_INDEX._fetch_and_cache_index(mirror_metadata)
+        BINARY_INDEX._fetch_and_cache_index(mirror_metadata, config=spack.config.CONFIG)
     except spack.binary_distribution.BuildcacheIndexNotExists:
         index_exists = False
     except spack.binary_distribution.FetchIndexError:

--- a/lib/spack/spack/cmd/checksum.py
+++ b/lib/spack/spack/cmd/checksum.py
@@ -7,6 +7,7 @@ import re
 import sys
 from typing import Dict, Optional, Tuple
 
+import spack.config
 import spack.repo
 import spack.spec
 import spack.stage
@@ -144,7 +145,7 @@ def checksum(parser, args):
         possible_urls = pkg.all_urls_for_version(version)
         if url not in possible_urls:
             for possible_url in possible_urls:
-                if web_util.url_exists(possible_url):
+                if web_util.url_exists(possible_url, config=spack.config.CONFIG):
                     url_dict[version] = possible_url
                     break
             else:

--- a/lib/spack/spack/cmd/ci.py
+++ b/lib/spack/spack/cmd/ci.py
@@ -359,7 +359,7 @@ def ci_rebuild(args):
 
     full_rebuild = True if rebuild_everything and rebuild_everything.lower() == "true" else False
 
-    pipeline_mirrors = spack.mirrors.mirror.MirrorCollection(binary=True)
+    pipeline_mirrors = spack.mirrors.mirror.MirrorCollection.from_config(cfg.CONFIG, binary=True)
     buildcache_destination = None
     if "buildcache-destination" not in pipeline_mirrors:
         tty.die("spack ci rebuild requires a mirror named 'buildcache-destination")
@@ -612,10 +612,10 @@ def ci_rebuild(args):
             broken_specs_url = ci_config["broken-specs-url"]
             just_built_hash = job_spec.dag_hash()
             broken_spec_path = url_util.join(broken_specs_url, just_built_hash)
-            if web_util.url_exists(broken_spec_path):
+            if web_util.url_exists(broken_spec_path, config=cfg.CONFIG):
                 tty.msg("Removing {0} from the list of broken specs".format(broken_spec_path))
                 try:
-                    web_util.remove_url(broken_spec_path)
+                    web_util.remove_url(broken_spec_path, config=cfg.CONFIG)
                 except Exception as err:
                     # If there is an S3 error (e.g., access denied or connection
                     # error), the first non boto-specific class in the exception

--- a/lib/spack/spack/cmd/gpg.py
+++ b/lib/spack/spack/cmd/gpg.py
@@ -7,6 +7,7 @@ import os
 import tempfile
 
 import spack.binary_distribution
+import spack.config
 import spack.mirrors.mirror
 import spack.paths
 import spack.stage
@@ -201,7 +202,9 @@ def gpg_publish(args):
         url = spack.util.url.path_to_file_url(args.directory)
         mirror = spack.mirrors.mirror.Mirror(url, url)
     elif args.mirror_name:
-        mirror = spack.mirrors.mirror.MirrorCollection(binary=True).lookup(args.mirror_name)
+        mirror = spack.mirrors.mirror.MirrorCollection.from_config(
+            spack.config.CONFIG, binary=True
+        ).lookup(args.mirror_name)
     elif args.mirror_url:
         mirror = spack.mirrors.mirror.Mirror(args.mirror_url, args.mirror_url)
 

--- a/lib/spack/spack/cmd/mirror.py
+++ b/lib/spack/spack/cmd/mirror.py
@@ -460,7 +460,9 @@ def mirror_set_url(args):
 def mirror_list(args):
     """print out available mirrors to the console"""
 
-    mirrors = spack.mirrors.mirror.MirrorCollection(scope=args.scope)
+    mirrors = spack.mirrors.mirror.MirrorCollection.from_config(
+        spack.config.CONFIG, scope=args.scope
+    )
     if not mirrors:
         tty.msg("No mirrors configured.")
         return
@@ -734,12 +736,14 @@ def mirror_destroy(args):
     mirror_url = None
 
     if args.mirror_name:
-        result = spack.mirrors.mirror.MirrorCollection().lookup(args.mirror_name)
+        result = spack.mirrors.mirror.MirrorCollection.from_config(spack.config.CONFIG).lookup(
+            args.mirror_name
+        )
         mirror_url = result.push_url
     elif args.mirror_url:
         mirror_url = args.mirror_url
 
-    web_util.remove_url(mirror_url, recursive=True)
+    web_util.remove_url(mirror_url, recursive=True, config=spack.config.CONFIG)
 
 
 def mirror(parser, args):

--- a/lib/spack/spack/cmd/repo.py
+++ b/lib/spack/spack/cmd/repo.py
@@ -258,10 +258,10 @@ def _add_repo(
             raise SpackError("The 'destination' argument is only valid for git repositories")
         elif paths:
             raise SpackError("The --paths flag is only valid for git repositories")
-        entry = spack.config.canonicalize_path(path_or_repo)
+        entry = spack.config.canonicalize_path(path_or_repo, config=config)
 
     descriptor = spack.repo.parse_config_descriptor(
-        name or "<unnamed>", entry, lock=spack.repo.package_repository_lock(spack.config.CONFIG)
+        name or "<unnamed>", entry, lock=spack.repo.package_repository_lock(config)
     )
     descriptor.initialize(git=spack.util.executable.which("git"))
 

--- a/lib/spack/spack/config.py
+++ b/lib/spack/spack/config.py
@@ -1452,7 +1452,7 @@ class IncludePath(OptionalInclude):
         tty.debug(f"Local base directory for {self.path} is {base}")
 
         canonical_path = canonicalize_path(self.path, base)
-        config_path = rfc_util.local_path(canonical_path, self.sha256, base)
+        config_path = rfc_util.local_path(canonical_path, self.sha256, base, config=CONFIG)
         assert config_path
         self.destination = config_path
 

--- a/lib/spack/spack/fetch_strategy.py
+++ b/lib/spack/spack/fetch_strategy.py
@@ -366,7 +366,7 @@ class URLFetchStrategy(FetchStrategy):
     @property
     def curl(self) -> Executable:
         if not self._curl:
-            self._curl = web_util.require_curl()
+            self._curl = web_util.require_curl(config=spack.config.CONFIG)
         return self._curl
 
     def source_id(self):
@@ -436,10 +436,11 @@ class URLFetchStrategy(FetchStrategy):
             url, headers={"User-Agent": web_util.SPACK_USER_AGENT, "Accept": "*/*"}
         )
 
+        urlopen = web_util.opener_for(spack.config.CONFIG)
         response_headers_str = None
         for attempt in range(retries):
             try:
-                with web_util.urlopen(request) as response:
+                with urlopen(request) as response:
                     tty.verbose(f"Fetching {url}")
                     progress = FetchProgress.from_headers(
                         response.headers, enabled=sys.stdout.isatty()
@@ -504,7 +505,7 @@ class URLFetchStrategy(FetchStrategy):
 
             timeout = self.extra_options.get("timeout")
 
-        base_args = web_util.base_curl_fetch_args(url, timeout)
+        base_args = web_util.base_curl_fetch_args(url, timeout, config=spack.config.CONFIG)
         curl_args = config_args + save_args + base_args + cookie_args
 
         # Run curl but grab the mime type from the http headers
@@ -582,7 +583,10 @@ class URLFetchStrategy(FetchStrategy):
             raise NoArchiveFileError("Cannot call archive() before fetching.")
 
         web_util.push_to_url(
-            self.archive_file, url_util.path_to_file_url(destination), keep_original=True
+            self.archive_file,
+            url_util.path_to_file_url(destination),
+            keep_original=True,
+            config=spack.config.CONFIG,
         )
 
     @_needs_stage
@@ -658,7 +662,7 @@ class OCIRegistryFetchStrategy(URLFetchStrategy):
     def __init__(self, *, url: str, checksum: Optional[str] = None, **kwargs):
         super().__init__(url=url, checksum=checksum, **kwargs)
 
-        self._urlopen = kwargs.get("_urlopen", spack.oci.opener.urlopen)
+        self._urlopen: Optional[spack.oci.opener.OpenType] = kwargs.get("_urlopen")
 
     @_needs_stage
     def fetch(self):
@@ -668,7 +672,8 @@ class OCIRegistryFetchStrategy(URLFetchStrategy):
             os.remove(file)
 
         try:
-            response = self._urlopen(self.url)
+            urlopen = self._urlopen or spack.oci.opener.opener_for(spack.config.CONFIG)
+            response = urlopen(self.url)
             tty.verbose(f"Fetching {self.url}")
             with open(file, "wb") as f:
                 shutil.copyfileobj(response, f)

--- a/lib/spack/spack/hooks/autopush.py
+++ b/lib/spack/spack/hooks/autopush.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 import spack.binary_distribution
+import spack.config
 import spack.mirrors.mirror
 from spack.util import tty
 
@@ -20,7 +21,9 @@ def post_install(spec, explicit):
         return
 
     # Push the package to all autopush mirrors
-    for mirror in spack.mirrors.mirror.MirrorCollection(binary=True, autopush=True).values():
+    for mirror in spack.mirrors.mirror.MirrorCollection.from_config(
+        spack.config.CONFIG, binary=True, autopush=True
+    ).values():
         if not mirror.matches_binary(spec, direction="push"):
             tty.debug(
                 f"{spec.name}: Skipped push to '{mirror.name}' due to include/exclude filters"

--- a/lib/spack/spack/installer/build.py
+++ b/lib/spack/spack/installer/build.py
@@ -309,7 +309,9 @@ def install_from_buildcache(
     # Skip if no configured mirror accepts this spec (select/exclude filters)
     if not any(
         m.matches_binary(spec, direction="fetch")
-        for m in spack.mirrors.mirror.MirrorCollection(binary=True).values()
+        for m in spack.mirrors.mirror.MirrorCollection.from_config(
+            spack.config.CONFIG, binary=True
+        ).values()
     ):
         return False
 

--- a/lib/spack/spack/installer/core.py
+++ b/lib/spack/spack/installer/core.py
@@ -211,7 +211,9 @@ class PackageInstaller:
 
         specs = [pkg.spec for pkg in packages]
 
-        self.has_mirrors = bool(spack.mirrors.mirror.MirrorCollection(binary=True))
+        self.has_mirrors = bool(
+            spack.mirrors.mirror.MirrorCollection.from_config(spack.config.CONFIG, binary=True)
+        )
         self.root_policy: InstallPolicy = root_policy
         self.dependencies_policy: InstallPolicy = dependencies_policy
         self.include_build_deps = include_build_deps

--- a/lib/spack/spack/mirrors/mirror.py
+++ b/lib/spack/spack/mirrors/mirror.py
@@ -447,19 +447,16 @@ class MirrorCollection(Mapping[str, Mirror]):
 
     def __init__(
         self,
-        mirrors: Optional[Mapping[str, Any]] = None,
-        scope: Optional[str] = None,
+        mirrors: Mapping[str, Any],
+        *,
         binary: Optional[bool] = None,
         source: Optional[bool] = None,
         autopush: Optional[bool] = None,
-        *,
-        config: Optional[spack.config.Configuration] = None,
     ):
         """Initialize a mirror collection.
 
         Args:
             mirrors: A name-to-mirror mapping to initialize the collection with.
-            scope: The scope to use when looking up mirrors from the config.
             binary: If True, only include binary mirrors.
                     If False, omit binary mirrors.
                     If None, do not filter on binary mirrors.
@@ -468,17 +465,7 @@ class MirrorCollection(Mapping[str, Mirror]):
                     If None, do not filter on source mirrors.
             autopush: If True, only include mirrors that have autopush enabled.
                       If False, omit mirrors that have autopush enabled.
-                      If None, do not filter on autopush.
-            config: configuration to look up mirrors from when ``mirrors`` is None. If None, the
-                    global ``spack.config.CONFIG`` is used."""
-        if config is None:
-            config = spack.config.CONFIG
-        mirrors_data = (
-            mirrors.items()
-            if mirrors is not None
-            else config.get_config("mirrors", scope=scope).items()
-        )
-        mirrors = (Mirror(data=mirror, name=name) for name, mirror in mirrors_data)
+                      If None, do not filter on autopush."""
 
         def _filter(m: Mirror):
             if source is not None and m.source != source:
@@ -489,7 +476,28 @@ class MirrorCollection(Mapping[str, Mirror]):
                 return False
             return True
 
-        self._mirrors = {m.name: m for m in mirrors if _filter(m)}
+        all_mirrors = (Mirror(data=mirror, name=name) for name, mirror in mirrors.items())
+        self._mirrors = {m.name: m for m in all_mirrors if _filter(m)}
+
+    @staticmethod
+    def from_config(
+        config: spack.config.Configuration,
+        *,
+        scope: Optional[str] = None,
+        binary: Optional[bool] = None,
+        source: Optional[bool] = None,
+        autopush: Optional[bool] = None,
+    ) -> "MirrorCollection":
+        """Returns the mirrors in ``config``, or in one of its scopes if ``scope`` is given.
+
+        The ``binary``, ``source`` and ``autopush`` filters are those of the constructor.
+        """
+        return MirrorCollection(
+            config.get_config("mirrors", scope=scope),
+            binary=binary,
+            source=source,
+            autopush=autopush,
+        )
 
     def __eq__(self, other: object) -> bool:
         if not isinstance(other, MirrorCollection):

--- a/lib/spack/spack/mirrors/utils.py
+++ b/lib/spack/spack/mirrors/utils.py
@@ -235,7 +235,7 @@ def create_mirror_from_package_object(
 
 def require_mirror_name(mirror_name):
     """Find a mirror by name and raise if it does not exist"""
-    mirror = MirrorCollection().get(mirror_name)
+    mirror = MirrorCollection.from_config(spack.config.CONFIG).get(mirror_name)
     if not mirror:
         raise ValueError(f'no mirror named "{mirror_name}"')
     return mirror

--- a/lib/spack/spack/oci/oci.py
+++ b/lib/spack/spack/oci/oci.py
@@ -49,16 +49,15 @@ def with_query_param(url: str, param: str, value: str) -> str:
     )
 
 
-def list_tags(ref: ImageReference, _urlopen: spack.oci.opener.MaybeOpen = None) -> List[str]:
+def list_tags(ref: ImageReference, *, urlopen: spack.oci.opener.OpenType) -> List[str]:
     """Retrieves the list of tags associated with an image, handling pagination."""
-    _urlopen = _urlopen or spack.oci.opener.urlopen
     tags = set()
     fetch_url = ref.tags_url()
 
     while True:
         # Fetch tags
         request = Request(url=fetch_url)
-        with _urlopen(request) as response:
+        with urlopen(request) as response:
             spack.oci.opener.ensure_status(request, response, 200)
             tags.update(json.load(response)["tags"])
 
@@ -91,7 +90,8 @@ def upload_blob(
     digest: Digest,
     force: bool = False,
     small_file_size: int = 0,
-    _urlopen: spack.oci.opener.MaybeOpen = None,
+    *,
+    urlopen: spack.oci.opener.OpenType,
 ) -> bool:
     """Uploads a blob to an OCI registry
 
@@ -110,14 +110,13 @@ def upload_blob(
             Some registries do no support single requests, and others
             do not specify what size they support in single POST.
             For now this feature is disabled by default (0KB)
+        urlopen: function used to open URLs
 
     Returns:
         True if the blob was uploaded, False if it already existed.
     """
-    _urlopen = _urlopen or spack.oci.opener.urlopen
-
     # Test if the blob already exists, if so, early exit.
-    if not force and blob_exists(ref, digest, _urlopen):
+    if not force and blob_exists(ref, digest, urlopen=urlopen):
         return False
 
     with open(file, "rb") as f:
@@ -140,7 +139,7 @@ def upload_blob(
                 url=ref.uploads_url(), method="POST", headers={"Content-Length": "0"}
             )
 
-        with _urlopen(request) as response:
+        with urlopen(request) as response:
             # Created the blob in one go.
             if response.status == 201:
                 return True
@@ -163,17 +162,14 @@ def upload_blob(
             headers={"Content-Type": "application/octet-stream", "Content-Length": str(file_size)},
         )
 
-        with _urlopen(request) as response:
+        with urlopen(request) as response:
             spack.oci.opener.ensure_status(request, response, 201)
 
     return True
 
 
 def upload_manifest(
-    ref: ImageReference,
-    manifest: dict,
-    tag: bool = True,
-    _urlopen: spack.oci.opener.MaybeOpen = None,
+    ref: ImageReference, manifest: dict, tag: bool = True, *, urlopen: spack.oci.opener.OpenType
 ):
     """Uploads a manifest/index to a registry
 
@@ -183,12 +179,11 @@ def upload_manifest(
         tag: When true, use the tag, otherwise use the digest,
             this is relevant for multi-arch images, where the
             tag is an index, referencing the manifests by digest.
+        urlopen: function used to open URLs
 
     Returns:
         The digest and size of the uploaded manifest.
     """
-    _urlopen = _urlopen or spack.oci.opener.urlopen
-
     data = json.dumps(manifest, separators=(",", ":")).encode()
     digest = Digest.from_sha256(hashlib.sha256(data).hexdigest())
     size = len(data)
@@ -203,7 +198,7 @@ def upload_manifest(
         headers={"Content-Type": manifest["mediaType"]},
     )
 
-    with _urlopen(request) as response:
+    with urlopen(request) as response:
         spack.oci.opener.ensure_status(request, response, 201)
     return digest, size
 
@@ -214,12 +209,11 @@ def image_from_mirror(mirror: spack.mirrors.mirror.Mirror) -> ImageReference:
 
 
 def blob_exists(
-    ref: ImageReference, digest: Digest, _urlopen: spack.oci.opener.MaybeOpen = None
+    ref: ImageReference, digest: Digest, *, urlopen: spack.oci.opener.OpenType
 ) -> bool:
     """Checks if a blob exists in an OCI registry"""
     try:
-        _urlopen = _urlopen or spack.oci.opener.urlopen
-        with _urlopen(Request(url=ref.blob_url(digest), method="HEAD")) as response:
+        with urlopen(Request(url=ref.blob_url(digest), method="HEAD")) as response:
             return response.status == 200
     except urllib.error.HTTPError as e:
         if e.getcode() == 404:
@@ -231,7 +225,8 @@ def copy_missing_layers(
     src: ImageReference,
     dst: ImageReference,
     architecture: str,
-    _urlopen: spack.oci.opener.MaybeOpen = None,
+    *,
+    urlopen: spack.oci.opener.OpenType,
 ) -> Tuple[dict, dict]:
     """Copy image layers from src to dst for given architecture.
 
@@ -239,19 +234,19 @@ def copy_missing_layers(
         src: The source image reference.
         dst: The destination image reference.
         architecture: The architecture (when referencing an index)
+        urlopen: function used to open URLs
 
     Returns:
         Tuple of manifest and config of the base image.
     """
-    _urlopen = _urlopen or spack.oci.opener.urlopen
-    manifest, config = get_manifest_and_config(src, architecture, _urlopen=_urlopen)
+    manifest, config = get_manifest_and_config(src, architecture, urlopen=urlopen)
 
     # Get layer digests
     digests = [Digest.from_string(layer["digest"]) for layer in manifest["layers"]]
 
     # Filter digests that are don't exist in the registry
     missing_digests = [
-        digest for digest in digests if not blob_exists(dst, digest, _urlopen=_urlopen)
+        digest for digest in digests if not blob_exists(dst, digest, urlopen=urlopen)
     ]
 
     if not missing_digests:
@@ -259,7 +254,7 @@ def copy_missing_layers(
 
     # Pull missing blobs, push them to the registry
     with spack.stage.StageComposite.from_iterable(
-        make_stage(url=src.blob_url(digest), digest=digest, _urlopen=_urlopen)
+        make_stage(url=src.blob_url(digest), digest=digest, urlopen=urlopen)
         for digest in missing_digests
     ) as stages:
         stages.fetch()
@@ -268,9 +263,7 @@ def copy_missing_layers(
 
         for stage, digest in zip(stages, missing_digests):
             # No need to check existence again, force=True.
-            upload_blob(
-                dst, file=stage.save_filename, force=True, digest=digest, _urlopen=_urlopen
-            )
+            upload_blob(dst, file=stage.save_filename, force=True, digest=digest, urlopen=urlopen)
 
     return manifest, config
 
@@ -292,10 +285,7 @@ all_content_type = manifest_content_type + index_content_type
 
 
 def get_manifest_and_config(
-    ref: ImageReference,
-    architecture="amd64",
-    recurse=3,
-    _urlopen: spack.oci.opener.MaybeOpen = None,
+    ref: ImageReference, architecture="amd64", recurse=3, *, urlopen: spack.oci.opener.OpenType
 ) -> Tuple[dict, dict]:
     """Recursively fetch manifest and config for a given image reference
     with a given architecture.
@@ -304,14 +294,13 @@ def get_manifest_and_config(
         ref: The image reference.
         architecture: The architecture (when referencing an index)
         recurse: How many levels of index to recurse into.
+        urlopen: function used to open URLs
 
     Returns:
         A tuple of (manifest, config)"""
 
-    _urlopen = _urlopen or spack.oci.opener.urlopen
-
     # Get manifest
-    with _urlopen(
+    with urlopen(
         Request(url=ref.manifest_url(), headers={"Accept": ", ".join(all_content_type)})
     ) as response:
         # Recurse when we find an index
@@ -330,7 +319,7 @@ def get_manifest_and_config(
                 ref.with_digest(manifest_meta["digest"]),
                 architecture=architecture,
                 recurse=recurse - 1,
-                _urlopen=_urlopen,
+                urlopen=urlopen,
             )
 
         # Otherwise, require a manifest
@@ -341,7 +330,7 @@ def get_manifest_and_config(
 
     # Download, verify and cache config file
     config_digest = Digest.from_string(manifest["config"]["digest"])
-    with make_stage(ref.blob_url(config_digest), config_digest, _urlopen=_urlopen) as stage:
+    with make_stage(ref.blob_url(config_digest), config_digest, urlopen=urlopen) as stage:
         stage.fetch()
         stage.check()
         stage.cache_local()
@@ -365,11 +354,10 @@ copy_missing_layers_with_retry = spack.oci.opener.default_retry(copy_missing_lay
 
 
 def make_stage(
-    url: str, digest: Digest, keep: bool = False, _urlopen: spack.oci.opener.MaybeOpen = None
+    url: str, digest: Digest, keep: bool = False, *, urlopen: spack.oci.opener.OpenType
 ) -> spack.stage.Stage:
-    _urlopen = _urlopen or spack.oci.opener.urlopen
     fetch_strategy = spack.fetch_strategy.OCIRegistryFetchStrategy(
-        url=url, checksum=digest.digest, _urlopen=_urlopen
+        url=url, checksum=digest.digest, _urlopen=urlopen
     )
     # Use blobs/<alg>/<encoded> as the cache path, which follows
     # the OCI Image Layout Specification. What's missing though,

--- a/lib/spack/spack/oci/opener.py
+++ b/lib/spack/spack/oci/opener.py
@@ -5,6 +5,7 @@
 """All the logic for OCI fetching and authentication"""
 
 import base64
+import functools
 import json
 import re
 import urllib.error
@@ -12,33 +13,35 @@ import urllib.parse
 import urllib.request
 from enum import Enum, auto
 from http.client import HTTPResponse
-from typing import Callable, Dict, Iterable, List, NamedTuple, Optional, Tuple
+from typing import Callable, Dict, Iterable, List, NamedTuple, Optional, Tuple, Union
 from urllib.request import Request
 
 import spack.config
 import spack.mirrors.mirror
 import spack.tokenize
-import spack.util.lang
 import spack.util.web
 
 from .image import ImageReference
 
-
-def _urlopen():
-    opener = create_opener()
-
-    def dispatch_open(fullurl, data=None, timeout=None):
-        timeout = timeout or spack.config.CONFIG.get("config:connect_timeout", 10)
-        return opener.open(fullurl, data, timeout)
-
-    return dispatch_open
+#: Openers returned by :func:`opener_for`
+OpenType = spack.util.web.Opener[HTTPResponse]
 
 
-OpenType = Callable[..., HTTPResponse]
-MaybeOpen = Optional[OpenType]
+def opener_for(config: spack.config.Configuration) -> OpenType:
+    """Returns a function opening URLs with OCI authentication from the mirrors in ``config``.
 
-#: Opener that automatically uses OCI authentication based on mirror config
-urlopen: OpenType = spack.util.lang.Singleton(_urlopen)
+    The function has the signature of ``OpenerDirector.open``. Its ``timeout`` defaults to
+    ``config:connect_timeout``.
+    """
+    opener = _create_opener(config)
+    default_timeout = config.get("config:connect_timeout", 10)
+
+    def urlopen(
+        fullurl: Union[str, Request], data: Optional[bytes] = None, timeout: Optional[float] = None
+    ) -> HTTPResponse:
+        return opener.open(fullurl, data, timeout or default_timeout)
+
+    return urlopen
 
 
 SP = r" "
@@ -238,16 +241,26 @@ def _get_basic_challenge(challenges: List[Challenge]) -> Optional[str]:
     return challenge.get_param("realm")
 
 
+AuthHeaders = Dict[Tuple[str, Optional[UsernamePassword]], str]
+
+#: Authorization headers obtained by the openers of :func:`opener_for`
+_AUTH_HEADERS: AuthHeaders = {}
+
+
 class OCIAuthHandler(urllib.request.BaseHandler):
-    def __init__(self, credentials_provider: Callable[[str], Optional[UsernamePassword]]):
+    def __init__(
+        self,
+        credentials_provider: Callable[[str], Optional[UsernamePassword]],
+        auth_headers: Optional[AuthHeaders] = None,
+    ):
         """
         Args:
             credentials_provider: A function that takes a domain and may return a UsernamePassword.
+            auth_headers: Authorization headers keyed by (domain, credentials), updated on login.
+                A new, empty mapping if not given.
         """
         self.credentials_provider = credentials_provider
-
-        # Cached authorization headers for a given domain.
-        self.cached_auth_headers: Dict[str, str] = {}
+        self.cached_auth_headers: AuthHeaders = {} if auth_headers is None else auth_headers
 
     def https_request(self, req: Request):
         # Eagerly add the bearer token to the request if no
@@ -259,8 +272,8 @@ class OCIAuthHandler(urllib.request.BaseHandler):
         if req.has_header("Authorization"):
             return req
 
-        parsed = urllib.parse.urlparse(req.full_url)
-        auth_header = self.cached_auth_headers.get(parsed.netloc)
+        registry = urllib.parse.urlparse(req.full_url).netloc
+        auth_header = self.cached_auth_headers.get((registry, self.credentials_provider(registry)))
 
         if not auth_header:
             return req
@@ -370,7 +383,7 @@ class OCIAuthHandler(urllib.request.BaseHandler):
                 fp,
             )
 
-        self.cached_auth_headers[registry] = auth_header
+        self.cached_auth_headers[(registry, credentials)] = auth_header
 
         # Add the authorization header to the request
         req.add_unredirected_header("Authorization", auth_header)
@@ -380,12 +393,9 @@ class OCIAuthHandler(urllib.request.BaseHandler):
 
 
 def credentials_from_mirrors(
-    domain: str, *, mirrors: Optional[Iterable[spack.mirrors.mirror.Mirror]] = None
+    domain: str, *, mirrors: Iterable[spack.mirrors.mirror.Mirror]
 ) -> Optional[UsernamePassword]:
     """Filter out OCI registry credentials from a list of mirrors."""
-
-    mirrors = mirrors or spack.mirrors.mirror.MirrorCollection().values()
-
     for mirror in mirrors:
         # Prefer push credentials over fetch. Unlikely that those are different
         # but our config format allows it.
@@ -404,18 +414,21 @@ def credentials_from_mirrors(
     return None
 
 
-def create_opener():
+def _create_opener(config: spack.config.Configuration) -> urllib.request.OpenerDirector:
     """Create an opener that can handle OCI authentication."""
+    mirrors = list(spack.mirrors.mirror.MirrorCollection.from_config(config).values())
     opener = urllib.request.OpenerDirector()
     for handler in [
         urllib.request.ProxyHandler(),
         urllib.request.UnknownHandler(),
         urllib.request.HTTPHandler(),
-        spack.util.web.SpackHTTPSHandler(context=spack.util.web.ssl_create_default_context()),
+        spack.util.web.SpackHTTPSHandler(context=spack.util.web.default_ssl_context(config)),
         spack.util.web.SpackHTTPDefaultErrorHandler(),
         urllib.request.HTTPRedirectHandler(),
         urllib.request.HTTPErrorProcessor(),
-        OCIAuthHandler(credentials_from_mirrors),
+        OCIAuthHandler(
+            functools.partial(credentials_from_mirrors, mirrors=mirrors), _AUTH_HEADERS
+        ),
     ]:
         opener.add_handler(handler)
     return opener

--- a/lib/spack/spack/old_installer.py
+++ b/lib/spack/spack/old_installer.py
@@ -452,7 +452,9 @@ def _try_install_from_binary_cache(
     # Early exit if no binary mirror accepts this spec (select/exclude filters).
     if not any(
         m.matches_binary(pkg.spec, direction="fetch")
-        for m in spack.mirrors.mirror.MirrorCollection(binary=True).values()
+        for m in spack.mirrors.mirror.MirrorCollection.from_config(
+            spack.config.CONFIG, binary=True
+        ).values()
     ):
         return False
 

--- a/lib/spack/spack/package_base.py
+++ b/lib/spack/spack/package_base.py
@@ -1149,7 +1149,7 @@ class PackageBase(WindowsRPath, PackageViewMixin, metaclass=PackageMeta):
         urls = self.all_urls_for_version(version)
 
         for u in urls:
-            if spack.util.web.url_exists(u):
+            if spack.util.web.url_exists(u, config=spack.config.CONFIG):
                 return u
 
         return None
@@ -1164,7 +1164,9 @@ class PackageBase(WindowsRPath, PackageViewMixin, metaclass=PackageMeta):
             mirror_paths=spack.mirrors.layout.default_mirror_layout(
                 resource.fetcher, os.path.join(self.name, pretty_resource_name)
             ),
-            mirrors=spack.mirrors.mirror.MirrorCollection(source=True).values(),
+            mirrors=spack.mirrors.mirror.MirrorCollection.from_config(
+                spack.config.CONFIG, source=True
+            ).values(),
             path=self.path,
         )
 
@@ -1185,7 +1187,9 @@ class PackageBase(WindowsRPath, PackageViewMixin, metaclass=PackageMeta):
         stage = stg.Stage(
             fetcher,
             mirror_paths=mirror_paths,
-            mirrors=spack.mirrors.mirror.MirrorCollection(source=True).values(),
+            mirrors=spack.mirrors.mirror.MirrorCollection.from_config(
+                spack.config.CONFIG, source=True
+            ).values(),
             name=stage_name,
             path=self.path,
             search_fn=self._download_search,
@@ -1245,7 +1249,9 @@ class PackageBase(WindowsRPath, PackageViewMixin, metaclass=PackageMeta):
                 fetcher,
                 name=f"{stg.stage_prefix}-{uniqe_part}-patch-{fetch_digest}",
                 mirror_paths=mirror_ref,
-                mirrors=spack.mirrors.mirror.MirrorCollection(source=True).values(),
+                mirrors=spack.mirrors.mirror.MirrorCollection.from_config(
+                    spack.config.CONFIG, source=True
+                ).values(),
             )
 
         if self.spec.concrete:

--- a/lib/spack/spack/reporters/cdash.py
+++ b/lib/spack/spack/reporters/cdash.py
@@ -17,6 +17,7 @@ from urllib.parse import urlencode
 from urllib.request import Request
 
 import spack
+import spack.config
 import spack.paths
 import spack.platforms
 import spack.spec
@@ -459,8 +460,9 @@ class CDash(Reporter):
             request.add_header("Content-Length", os.path.getsize(filename))
             if self.authtoken:
                 request.add_header("Authorization", "Bearer {0}".format(self.authtoken))
+            urlopen = web_util.opener_for(spack.config.CONFIG)
             try:
-                with web_util.urlopen(request, timeout=SPACK_CDASH_TIMEOUT) as response:
+                with urlopen(request, timeout=SPACK_CDASH_TIMEOUT) as response:
                     if self.current_package_name not in self.buildIds:
                         resp_value = io.TextIOWrapper(response, encoding="utf-8").read()
                         match = self.buildid_regexp.search(resp_value)

--- a/lib/spack/spack/subprocess_context.py
+++ b/lib/spack/spack/subprocess_context.py
@@ -116,14 +116,12 @@ class GlobalStateMarshaler:
 
     def restore(self):
         if self.is_forked:
-            # Erase singletons that hold open SSL contexts / boto3 clients, since OpenSSL
-            # and botocore connection pools are not fork-safe.
-            from spack.oci import opener
+            # Erase cached SSL contexts / boto3 clients, since OpenSSL and botocore
+            # connection pools are not fork-safe.
             from spack.util import web
             from spack.util.s3 import s3_client_cache
 
-            web.urlopen._instance = None
-            opener.urlopen._instance = None
+            web.clear_ssl_contexts()
             s3_client_cache.clear()
             return
         spack.config.CONFIG = self.config

--- a/lib/spack/spack/test/binary_distribution.py
+++ b/lib/spack/spack/test/binary_distribution.py
@@ -221,7 +221,9 @@ def test_download_tarball_reports_signature_verification_failure(
             pass
 
     monkeypatch.setattr(
-        spack.mirrors.mirror, "MirrorCollection", lambda binary=True: {"test": MockMirror()}
+        spack.mirrors.mirror.MirrorCollection,
+        "from_config",
+        lambda config, binary=True: {"test": MockMirror()},
     )
     monkeypatch.setattr(
         spack.binary_distribution,
@@ -424,7 +426,7 @@ def test_use_bin_index_with_view(
 
 
 def test_generate_key_index_failure(monkeypatch, tmp_path: pathlib.Path):
-    def list_url(url, recursive=False):
+    def list_url(url, recursive=False, *, config):
         if "fails-listing" in url:
             raise Exception("Couldn't list the directory")
         return ["first.pub", "second.pub"]
@@ -447,7 +449,7 @@ def test_generate_key_index_failure(monkeypatch, tmp_path: pathlib.Path):
 
 
 def test_generate_package_index_failure(monkeypatch, tmp_path: pathlib.Path, capfd):
-    def mock_list_url(url, recursive=False):
+    def mock_list_url(url, recursive=False, *, config):
         raise Exception("Some HTTP error")
 
     monkeypatch.setattr(web_util, "list_url", mock_list_url)
@@ -464,7 +466,7 @@ def test_generate_package_index_failure(monkeypatch, tmp_path: pathlib.Path, cap
 
 
 def test_generate_indices_exception(monkeypatch, tmp_path: pathlib.Path, capfd):
-    def mock_list_url(url, recursive=False):
+    def mock_list_url(url, recursive=False, *, config):
         raise Exception("Test Exception handling")
 
     monkeypatch.setattr(web_util, "list_url", mock_list_url)

--- a/lib/spack/spack/test/cmd/buildcache.py
+++ b/lib/spack/spack/test/cmd/buildcache.py
@@ -842,10 +842,10 @@ def test_buildcache_prune_orphaned_blobs(tmp_path, mutable_database, mock_gnupgh
     manifest_url = URLBuildcacheEntry.get_manifest_url(
         spec, mirror_url=f"file://{mirror_directory}"
     )
-    web_util.remove_url(manifest_url)
+    web_util.remove_url(manifest_url, config=spack.config.CONFIG)
 
     # Ensure the blobs are still there before pruning
-    assert all(web_util.url_exists(blob_url) for blob_url in blob_urls)
+    assert all(web_util.url_exists(blob_url, config=spack.config.CONFIG) for blob_url in blob_urls)
 
     cmd_args = ["prune", "my-mirror"]
     if dry_run:
@@ -853,7 +853,10 @@ def test_buildcache_prune_orphaned_blobs(tmp_path, mutable_database, mock_gnupgh
     output = buildcache(*cmd_args)
 
     # Ensure the blobs are gone after pruning (or not if dry_run is True)
-    assert all(web_util.url_exists(blob_url) == dry_run for blob_url in blob_urls)
+    assert all(
+        web_util.url_exists(blob_url, config=spack.config.CONFIG) == dry_run
+        for blob_url in blob_urls
+    )
 
     assert "Found 2 blob(s) with no manifest" in output
 
@@ -881,7 +884,7 @@ def test_buildcache_prune_orphaned_manifest(tmp_path, mutable_database, mock_gnu
     # Remove the blobs from the cache, orphaning the manifest
     for blob_file in manifest.data:
         blob_url = cache_entry.get_blob_url(mirror_url=mirror_directory, record=blob_file)
-        web_util.remove_url(url=f"file://{blob_url}")
+        web_util.remove_url(url=f"file://{blob_url}", config=spack.config.CONFIG)
 
     cmd_args = ["prune", "my-mirror"]
     if dry_run:
@@ -889,7 +892,7 @@ def test_buildcache_prune_orphaned_manifest(tmp_path, mutable_database, mock_gnu
     output = buildcache(*cmd_args)
 
     # Ensure the manifest is gone after pruning (or not if dry_run is True)
-    assert web_util.url_exists(manifest_url) == dry_run
+    assert web_util.url_exists(manifest_url, config=spack.config.CONFIG) == dry_run
 
     assert "Found 1 manifest(s) that are missing blobs" in output
 
@@ -927,7 +930,7 @@ def test_buildcache_prune_direct_with_keeplist(
     output = buildcache(*cmd_args)
 
     # Since all packages are in the keeplist, nothing should be pruned
-    assert web_util.url_exists(manifest_url)
+    assert web_util.url_exists(manifest_url, config=spack.config.CONFIG)
     assert "No specs to prune - all specs are in the keeplist" in output
 
 
@@ -953,7 +956,7 @@ def test_buildcache_prune_direct_removes_unlisted(
     )
     manifest_url = cache_entry.get_manifest_url(spec1, f"file://{mirror_directory}")
 
-    assert web_util.url_exists(manifest_url)
+    assert web_util.url_exists(manifest_url, config=spack.config.CONFIG)
 
     # Run direct pruning
     cmd_args = ["prune", "my-mirror", "--keeplist", str(keeplist_file)]
@@ -961,7 +964,7 @@ def test_buildcache_prune_direct_removes_unlisted(
         cmd_args.append("--dry-run")
     buildcache(*cmd_args)
 
-    assert web_util.url_exists(manifest_url) == dry_run
+    assert web_util.url_exists(manifest_url, config=spack.config.CONFIG) == dry_run
 
 
 def test_buildcache_prune_direct_empty_keeplist_fails(
@@ -1015,7 +1018,7 @@ def test_buildcache_prune_new_specs_race_condition(
     )
     manifest_url = cache_entry.get_manifest_url(spec, f"file://{mirror_directory}")
 
-    def mock_stat_url(url: str):
+    def mock_stat_url(url: str, *, config):
         """
         Mock the stat_url function for testing.
 
@@ -1035,9 +1038,9 @@ def test_buildcache_prune_new_specs_race_condition(
 
     # Run end-to-end buildcache prune - this should not delete `libelf`, despite it
     # not being in the keeplist, because its mtime is after the pruning started
-    assert web_util.url_exists(manifest_url)
+    assert web_util.url_exists(manifest_url, config=spack.config.CONFIG)
     buildcache("prune", "my-mirror", "--keeplist", str(keeplist_file))
-    assert web_util.url_exists(manifest_url)
+    assert web_util.url_exists(manifest_url, config=spack.config.CONFIG)
 
 
 def create_env_from_concrete_spec(spec: spack.spec.Spec):
@@ -1082,7 +1085,9 @@ def read_specs_in_index(mirror_directory, view):
     mirror_metadata = spack.binary_distribution.MirrorMetadata(
         f"file://{mirror_directory}", spack.mirrors.mirror.SUPPORTED_URL_LAYOUT_VERSIONS[0], view
     )
-    fetcher = spack.binary_distribution.DefaultIndexHandler(mirror_metadata, None)
+    fetcher = spack.binary_distribution.DefaultIndexHandler(
+        mirror_metadata, None, urlopen=web_util.opener_for(spack.config.CONFIG)
+    )
     result = fetcher.conditional_fetch()
     db_dict = json.loads(result.data)
     return set([h for h in db_dict["database"]["installs"]])

--- a/lib/spack/spack/test/cmd/checksum.py
+++ b/lib/spack/spack/test/cmd/checksum.py
@@ -43,7 +43,7 @@ def can_fetch_versions(monkeypatch, no_add):
             for v in url_by_version
         }
 
-    def url_exists(url, curl=None):
+    def url_exists(url, curl=None, *, config):
         return True
 
     monkeypatch.setattr(
@@ -63,7 +63,7 @@ def cannot_fetch_versions(monkeypatch, no_add):
     def get_checksums_for_versions(url_by_version, package_name, **kwargs):
         return {}
 
-    def url_exists(url, curl=None):
+    def url_exists(url, curl=None, *, config):
         return False
 
     monkeypatch.setattr(

--- a/lib/spack/spack/test/cmd/ci.py
+++ b/lib/spack/spack/test/cmd/ci.py
@@ -15,6 +15,7 @@ import spack.binary_distribution
 import spack.cmd
 import spack.cmd.ci
 import spack.concretize
+import spack.config
 import spack.environment as ev
 import spack.main
 import spack.paths
@@ -914,7 +915,9 @@ spack:
             # Validate resulting buildcache (database) index
             layout_version = spack.binary_distribution.CURRENT_BUILD_CACHE_LAYOUT_VERSION
             mirror_metadata = spack.binary_distribution.MirrorMetadata(mirror_url, layout_version)
-            index_fetcher = spack.binary_distribution.DefaultIndexHandler(mirror_metadata, None)
+            index_fetcher = spack.binary_distribution.DefaultIndexHandler(
+                mirror_metadata, None, urlopen=spack.util.web.opener_for(spack.config.CONFIG)
+            )
             result = index_fetcher.conditional_fetch()
             spack.vendor.jsonschema.validate(json.loads(result.data), db_idx_schema)
 
@@ -2040,7 +2043,7 @@ spack:
 @pytest.fixture
 def fetch_url_exists(monkeypatch):
     """Force URLs to always be valid without attempting to fetch."""
-    monkeypatch.setattr(spack.util.web, "url_exists", lambda url: True)
+    monkeypatch.setattr(spack.util.web, "url_exists", lambda url, *, config: True)
 
 
 @pytest.fixture

--- a/lib/spack/spack/test/conftest.py
+++ b/lib/spack/spack/test/conftest.py
@@ -24,7 +24,7 @@ import tempfile
 import textwrap
 import xml.etree.ElementTree
 from pathlib import Path
-from typing import List, Optional, Tuple, Union
+from typing import Any, Dict, List, Optional, Tuple, Union
 
 import pytest
 
@@ -1091,6 +1091,20 @@ def mutable_empty_config(tmp_path_factory: pytest.TempPathFactory, configuration
 
     with _use_configuration_and_store(*scopes) as cfg:
         yield cfg
+
+
+@pytest.fixture
+def inactive_config():
+    """Returns a factory of Configuration objects that are never activated as the global
+    ``spack.config.CONFIG``, to test that code uses the configuration it is given.
+    """
+
+    def _factory(data: Dict[str, Any]) -> spack.config.Configuration:
+        config = spack.config.Configuration()
+        config.push_scope(spack.config.InternalConfigScope("inactive", data))
+        return config
+
+    return _factory
 
 
 # From  https://github.com/pytest-dev/pytest/issues/363#issuecomment-1335631998
@@ -2276,7 +2290,7 @@ def mock_curl_configs(mock_config_data, monkeypatch):
     config_data_dir, config_files = mock_config_data
 
     class MockCurl:
-        def __init__(self):
+        def __init__(self, *, config):
             self.returncode = None
 
         def __call__(self, *args, **kwargs):
@@ -2306,7 +2320,7 @@ def mock_fetch_url_text(mock_config_data, monkeypatch):
 
     stage_dir, config_files = mock_config_data
 
-    def _fetch_text_file(url, dest_dir):
+    def _fetch_text_file(url, dest_dir, *, config):
         raw_url = raw_github_gitlab_url(url)
         mkdirp(dest_dir)
         basename = os.path.basename(raw_url)

--- a/lib/spack/spack/test/mirror.py
+++ b/lib/spack/spack/test/mirror.py
@@ -490,3 +490,20 @@ def test_mirror_matches(mock_packages, mutable_config):
     )
     assert m.matches_binary(spec, direction="fetch") is False
     assert m.matches_binary(spec, direction="push") is True
+
+
+def test_mirror_collection_from_config_uses_given_config(
+    mutable_config: Configuration, inactive_config
+):
+    """Tests that mirrors are read from the configuration passed as an argument, and not from
+    the global one."""
+    mutable_config.set("mirrors", {"global-mirror": "file:///global"})
+    other = inactive_config({"mirrors": {"other-mirror": "file:///other"}})
+
+    from_other = spack.mirrors.mirror.MirrorCollection.from_config(other)
+    assert "other-mirror" in from_other
+    assert "global-mirror" not in from_other
+
+    from_global = spack.mirrors.mirror.MirrorCollection.from_config(mutable_config)
+    assert "global-mirror" in from_global
+    assert "other-mirror" not in from_global

--- a/lib/spack/spack/test/oci/integration_test.py
+++ b/lib/spack/spack/test/oci/integration_test.py
@@ -38,10 +38,11 @@ install = SpackCommand("install")
 
 @contextmanager
 def oci_servers(*servers: DummyServer):
-    old_opener = spack.oci.opener.urlopen
-    spack.oci.opener.urlopen = create_opener(*servers).open
-    yield
-    spack.oci.opener.urlopen = old_opener
+    urlopen = create_opener(*servers).open
+    old_opener_for = spack.oci.opener.opener_for
+    spack.oci.opener.opener_for = lambda config: urlopen
+    yield urlopen
+    spack.oci.opener.opener_for = old_opener_for
 
 
 def test_buildcache_push_command(mutable_database: Database):
@@ -76,7 +77,7 @@ def test_buildcache_tag(install_mockery, mock_fetch, mutable_mock_env_path):
 
     registry = InMemoryOCIRegistry("example.com")
 
-    with oci_servers(registry):
+    with oci_servers(registry) as urlopen:
         mirror("add", "oci-test", "oci://example.com/image")
 
         with ev.read("test"):
@@ -93,7 +94,7 @@ def test_buildcache_tag(install_mockery, mock_fetch, mutable_mock_env_path):
                 if not x.external
             ]
 
-        manifest, config = get_manifest_and_config(name)
+        manifest, _ = get_manifest_and_config(name, urlopen=urlopen)
 
         # without a base image, we should have one layer per spec
         assert len(manifest["layers"]) == len(specs)
@@ -107,7 +108,7 @@ def test_buildcache_tag(install_mockery, mock_fetch, mutable_mock_env_path):
             buildcache("push", "--tag", "single_spec", "oci-test", libelf.format("libelf{/hash}"))
 
         name = ImageReference.from_string("example.com/image:single_spec")
-        manifest, config = get_manifest_and_config(name)
+        manifest, _ = get_manifest_and_config(name, urlopen=urlopen)
         assert len(manifest["layers"]) == len(
             [x for x in libelf.traverse(deptype=dt.LINK | dt.RUN) if not x.external]
         )
@@ -123,7 +124,7 @@ def test_buildcache_push_with_base_image_command(mutable_database, tmp_path: pat
 
     base_image = ImageReference.from_string("src.example.com/my-base-image:latest")
 
-    with oci_servers(registry_src, registry_dst):
+    with oci_servers(registry_src, registry_dst) as urlopen:
         mirror("add", "oci-test", "oci://dst.example.com/image")
 
         # TODO: simplify creation of images...
@@ -165,11 +166,11 @@ def test_buildcache_push_with_base_image_command(mutable_database, tmp_path: pat
         manifest["config"]["size"] = config_file.stat().st_size
 
         # Upload the layer and config file
-        upload_blob(base_image, str(tarball), tar_gz_digest)
-        upload_blob(base_image, str(config_file), config_digest)
+        upload_blob(base_image, str(tarball), tar_gz_digest, urlopen=urlopen)
+        upload_blob(base_image, str(config_file), config_digest, urlopen=urlopen)
 
         # Upload the manifest
-        upload_manifest(base_image, manifest)
+        upload_manifest(base_image, manifest, urlopen=urlopen)
 
         # END TODO
 
@@ -182,7 +183,7 @@ def test_buildcache_push_with_base_image_command(mutable_database, tmp_path: pat
 
         # Fetch the manifest and config
         dst_image = ImageReference.from_string(f"dst.example.com/image:{tag}")
-        retrieved_manifest, retrieved_config = get_manifest_and_config(dst_image)
+        retrieved_manifest, retrieved_config = get_manifest_and_config(dst_image, urlopen=urlopen)
 
         # Check that the media type is OCI
         assert retrieved_manifest["mediaType"] == "application/vnd.oci.image.manifest.v1+json"
@@ -206,7 +207,9 @@ def test_buildcache_push_with_base_image_command(mutable_database, tmp_path: pat
 
         # And verify that all layers including the base layer are present
         for layer in retrieved_manifest["layers"]:
-            assert blob_exists(dst_image, digest=Digest.from_string(layer["digest"]))
+            assert blob_exists(
+                dst_image, digest=Digest.from_string(layer["digest"]), urlopen=urlopen
+            )
             assert layer["mediaType"] == "application/vnd.oci.image.layer.v1.tar+gzip"
 
 
@@ -222,7 +225,7 @@ def test_uploading_with_base_image_in_docker_image_manifest_v2_format(
 
     base_image = ImageReference.from_string("src.example.com/my-base-image:latest")
 
-    with oci_servers(registry_src, registry_dst):
+    with oci_servers(registry_src, registry_dst) as urlopen:
         mirror("add", "oci-test", "oci://dst.example.com/image")
 
         # Create a dummy base image (blob, config, manifest) in registry A in the Docker Image
@@ -235,7 +238,7 @@ def test_uploading_with_base_image_in_docker_image_manifest_v2_format(
             tar.add(rootfs, arcname=".")
         tar_gz_digest = Digest.from_sha256(tar_gz_checksum.hexdigest())
         tar_digest = Digest.from_sha256(tar_checksum.hexdigest())
-        upload_blob(base_image, str(tarball), tar_gz_digest)
+        upload_blob(base_image, str(tarball), tar_gz_digest, urlopen=urlopen)
         config = {
             "created": "2015-10-31T22:22:56.015925234Z",
             "author": "Foo <example@example.com>",
@@ -264,7 +267,7 @@ def test_uploading_with_base_image_in_docker_image_manifest_v2_format(
         config_file = tmp_path / "config.json"
         config_file.write_text(json.dumps(config))
         config_digest = Digest.from_sha256(hashlib.sha256(config_file.read_bytes()).hexdigest())
-        upload_blob(base_image, str(config_file), config_digest)
+        upload_blob(base_image, str(config_file), config_digest, urlopen=urlopen)
         manifest = {
             "schemaVersion": 2,
             "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
@@ -281,7 +284,7 @@ def test_uploading_with_base_image_in_docker_image_manifest_v2_format(
                 }
             ],
         }
-        upload_manifest(base_image, manifest)
+        upload_manifest(base_image, manifest, urlopen=urlopen)
 
         # Finally upload some package to registry B with registry A's image as base
         buildcache("push", "--base-image", str(base_image), "oci-test", "mpileaks^mpich")
@@ -329,7 +332,7 @@ def test_best_effort_upload(mutable_database: spack.database.Database, monkeypat
     registry = InMemoryOCIRegistry("example.com")
     image = ImageReference.from_string("example.com/image")
 
-    with oci_servers(registry):
+    with oci_servers(registry) as urlopen:
         with pytest.raises(spack.error.SpackError, match="The following 2 errors occurred") as e:
             buildcache("push", "--update-index", "oci-test", "mpileaks^mpich")
 
@@ -345,7 +348,7 @@ def test_best_effort_upload(mutable_database: spack.database.Database, monkeypat
         for name in without_manifest:
             tagged_img = image.with_tag(spack.binary_distribution._oci_default_tag(mpileaks[name]))
             with pytest.raises(urllib.error.HTTPError, match="404"):
-                get_manifest_and_config(tagged_img)
+                get_manifest_and_config(tagged_img, urlopen=urlopen)
 
         # Collect the layer digests of successfully uploaded packages. Every package should refer
         # to its own tarballs and those of its runtime deps that were uploaded.
@@ -360,7 +363,7 @@ def test_best_effort_upload(mutable_database: spack.database.Database, monkeypat
 
             # This should not raise a 404.
             manifest, _ = get_manifest_and_config(
-                image.with_tag(spack.binary_distribution._oci_default_tag(s))
+                image.with_tag(spack.binary_distribution._oci_default_tag(s)), urlopen=urlopen
             )
 
             # Collect layer digests

--- a/lib/spack/spack/test/oci/mock_registry.py
+++ b/lib/spack/spack/test/oci/mock_registry.py
@@ -418,9 +418,9 @@ class MockBearerTokenServer(DummyServer):
         return MockHTTPResponse.with_json(200, "OK", body={"token": "private_token"})
 
 
-def create_opener(*servers: DummyServer, credentials_provider=None):
+def create_opener(*servers: DummyServer, credentials_provider=None, auth_headers=None):
     """Creates a mock opener, that can be used to fake requests to a list
-    of servers."""
+    of servers. ``auth_headers`` is passed to the ``OCIAuthHandler``."""
     opener = urllib.request.OpenerDirector()
     handler = DummyServerUrllibHandler()
     for server in servers:
@@ -429,5 +429,5 @@ def create_opener(*servers: DummyServer, credentials_provider=None):
     opener.add_handler(urllib.request.HTTPDefaultErrorHandler())
     opener.add_handler(urllib.request.HTTPErrorProcessor())
     if credentials_provider is not None:
-        opener.add_handler(OCIAuthHandler(credentials_provider))
+        opener.add_handler(OCIAuthHandler(credentials_provider, auth_headers))
     return opener

--- a/lib/spack/spack/test/oci/urlopen.py
+++ b/lib/spack/spack/test/oci/urlopen.py
@@ -450,7 +450,7 @@ def test_oci_registry_upload(tmp_path: pathlib.Path, client_single_request, serv
         file=str(blob),
         digest=digest,
         small_file_size=small_file_size,
-        _urlopen=opener.open,
+        urlopen=opener.open,
     )
 
     # Second time should exit as it exists
@@ -459,7 +459,7 @@ def test_oci_registry_upload(tmp_path: pathlib.Path, client_single_request, serv
         file=str(blob),
         digest=digest,
         small_file_size=small_file_size,
-        _urlopen=opener.open,
+        urlopen=opener.open,
     )
 
     # Force upload should upload again
@@ -469,7 +469,7 @@ def test_oci_registry_upload(tmp_path: pathlib.Path, client_single_request, serv
         digest=digest,
         force=True,
         small_file_size=small_file_size,
-        _urlopen=opener.open,
+        urlopen=opener.open,
     )
 
 
@@ -502,14 +502,14 @@ def test_copy_missing_layers(tmp_path: pathlib.Path, config):
 
     digests = [Digest.from_sha256(hashlib.sha256(blob.read_bytes()).hexdigest()) for blob in blobs]
 
-    config = default_config(architecture="amd64", os="linux")
+    image_config = default_config(architecture="amd64", os="linux")
     configfile = tmp_path / "config.json"
-    configfile.write_text(json.dumps(config))
+    configfile.write_text(json.dumps(image_config))
     config_digest = Digest.from_sha256(hashlib.sha256(configfile.read_bytes()).hexdigest())
 
     for blob, digest in zip(blobs, digests):
-        upload_blob(src, str(blob), digest, _urlopen=urlopen)
-    upload_blob(src, str(configfile), config_digest, _urlopen=urlopen)
+        upload_blob(src, str(blob), digest, urlopen=urlopen)
+    upload_blob(src, str(configfile), config_digest, urlopen=urlopen)
 
     # Then create a manifest referencing them
     manifest = default_manifest()
@@ -529,10 +529,10 @@ def test_copy_missing_layers(tmp_path: pathlib.Path, config):
         "size": configfile.stat().st_size,
     }
 
-    upload_manifest(src, manifest, _urlopen=urlopen)
+    upload_manifest(src, manifest, urlopen=urlopen)
 
     # Finally, copy the image from src to dst
-    copy_missing_layers(src, dst, architecture="amd64", _urlopen=urlopen)
+    copy_missing_layers(src, dst, architecture="amd64", urlopen=urlopen)
 
     # Check that all layers (not config) were copied and identical
     assert len(dst_registry.blobs) == len(blobs)
@@ -549,7 +549,7 @@ def test_copy_missing_layers(tmp_path: pathlib.Path, config):
 
     # Check that re-uploading skips existing layers.
     dst_registry.clear_log()
-    copy_missing_layers(src, dst, architecture="amd64", _urlopen=urlopen)
+    copy_missing_layers(src, dst, architecture="amd64", urlopen=urlopen)
 
     # Check that no uploads were initiated, only existence checks were done.
     assert sum(is_upload(method, path) for method, path in dst_registry.requests) == 0
@@ -655,7 +655,7 @@ def test_manifest_index(tmp_path: pathlib.Path):
         config = default_config(architecture=arch, os="linux")
         file.write_text(json.dumps(config))
         config_digest = Digest.from_sha256(hashlib.sha256(file.read_bytes()).hexdigest())
-        assert upload_blob(img, str(file), config_digest, _urlopen=urlopen)
+        assert upload_blob(img, str(file), config_digest, urlopen=urlopen)
         manifest = {
             "schemaVersion": 2,
             "mediaType": "application/vnd.oci.image.manifest.v1+json",
@@ -666,9 +666,7 @@ def test_manifest_index(tmp_path: pathlib.Path):
             },
             "layers": [],
         }
-        manifest_digest, manifest_size = upload_manifest(
-            img, manifest, tag=False, _urlopen=urlopen
-        )
+        manifest_digest, manifest_size = upload_manifest(img, manifest, tag=False, urlopen=urlopen)
 
         manifest_descriptors.append(
             {
@@ -688,18 +686,18 @@ def test_manifest_index(tmp_path: pathlib.Path):
         "manifests": manifest_descriptors,
     }
 
-    upload_manifest(img, index, tag=True, _urlopen=urlopen)
+    upload_manifest(img, index, tag=True, urlopen=urlopen)
 
     # Check that we fetcht the correct manifest and config for each architecture
     for arch in ("amd64", "arm64"):
         assert (
-            get_manifest_and_config(img, architecture=arch, _urlopen=urlopen)
+            get_manifest_and_config(img, architecture=arch, urlopen=urlopen)
             == manifest_and_config[arch]
         )
 
     # Also test max recursion
     with pytest.raises(Exception, match="Maximum recursion depth reached"):
-        get_manifest_and_config(img, architecture="amd64", recurse=0, _urlopen=urlopen)
+        get_manifest_and_config(img, architecture="amd64", recurse=0, urlopen=urlopen)
 
 
 class BrokenServer(DummyServer):
@@ -773,10 +771,10 @@ def test_list_tags():
     _tags_to_create = [to_tag(i) for i in range(N)]
     random.shuffle(_tags_to_create)
     for tag in _tags_to_create:
-        upload_manifest(image.with_tag(tag), default_manifest(), tag=True, _urlopen=urlopen)
+        upload_manifest(image.with_tag(tag), default_manifest(), tag=True, urlopen=urlopen)
 
     # list_tags should return all tags from all pages in order
-    tags = list_tags(image, urlopen)
+    tags = list_tags(image, urlopen=urlopen)
     assert len(tags) == N
     assert [to_tag(i) for i in range(N)] == tags
 
@@ -787,3 +785,32 @@ def test_list_tags():
     assert json.loads(urlopen(image.tags_url() + f"?last={to_tag(N - 3)}").read())["tags"] == [
         to_tag(i) for i in range(N - 2, N)
     ]
+
+
+def test_openers_sharing_auth_headers_log_in_once_per_credentials():
+    """Tests that openers sharing authorization headers reuse a token obtained with the same
+    credentials, and do not reuse it for different ones."""
+    image = ImageReference.from_string("private.example.com/spack-registry:latest")
+    registry = InMemoryOCIRegistryWithBearerAuth(
+        image.domain, token="private_token", realm="https://auth.example.com/login"
+    )
+    auth_server = MockBearerTokenServer("auth.example.com")
+    auth_headers: dict = {}
+
+    def open_with(credentials: UsernamePassword):
+        opener = create_opener(
+            registry,
+            auth_server,
+            credentials_provider=lambda domain: credentials,
+            auth_headers=auth_headers,
+        )
+        assert opener.open(image.endpoint()).status == 200
+
+    open_with(UsernamePassword("user", "pass"))
+    open_with(UsernamePassword("user", "pass"))
+    assert len(auth_server.requests) == 1
+
+    # The token server rejects these credentials, so the login must be attempted
+    with pytest.raises(urllib.error.HTTPError, match="Cannot login to registry"):
+        open_with(UsernamePassword("wrong", "wrong"))
+    assert len(auth_server.requests) == 2

--- a/lib/spack/spack/test/url_fetch.py
+++ b/lib/spack/spack/test/url_fetch.py
@@ -27,7 +27,7 @@ from spack.util.filesystem import is_exe, working_dir
 
 @pytest.fixture
 def missing_curl(monkeypatch):
-    def require_curl():
+    def require_curl(*, config):
         raise spack.error.FetchError("curl is required but not found")
 
     monkeypatch.setattr(web_util, "require_curl", require_curl)
@@ -361,16 +361,16 @@ def test_missing_curl(tmp_path: pathlib.Path, missing_curl, mutable_config, monk
             stage.fetch()
 
 
-def test_url_fetch_text_without_url():
+def test_url_fetch_text_without_url(config):
     with pytest.raises(spack.error.FetchError, match="URL is required"):
-        web_util.fetch_url_text(None)
+        web_util.fetch_url_text(None, config=config)
 
 
 def test_url_fetch_text_curl_failures(mutable_config, missing_curl, monkeypatch):
     """Check fetch_url_text if URL's curl is missing."""
     mutable_config.set("config:url_fetch_method", "curl")
     with pytest.raises(spack.error.FetchError, match="curl is required but not found"):
-        web_util.fetch_url_text("https://example.com/")
+        web_util.fetch_url_text("https://example.com/", config=mutable_config)
 
 
 def test_url_check_curl_errors():
@@ -388,7 +388,7 @@ def test_url_missing_curl(mutable_config, missing_curl, monkeypatch):
     """Check url_exists failures if URL's curl is missing."""
     mutable_config.set("config:url_fetch_method", "curl")
     with pytest.raises(spack.error.FetchError, match="curl is required but not found"):
-        web_util.url_exists("https://example.com/")
+        web_util.url_exists("https://example.com/", config=mutable_config)
 
 
 def test_url_fetch_text_urllib_web_error(mutable_config, monkeypatch):
@@ -399,4 +399,16 @@ def test_url_fetch_text_urllib_web_error(mutable_config, monkeypatch):
     mutable_config.set("config:url_fetch_method", "urllib")
 
     with pytest.raises(spack.error.FetchError, match="fetch failed"):
-        web_util.fetch_url_text("https://example.com/")
+        web_util.fetch_url_text("https://example.com/", config=mutable_config)
+
+
+def test_url_exists_uses_given_fetch_method(
+    mutable_config: Configuration, inactive_config, missing_curl
+):
+    """Tests that the fetch method is read from the configuration passed as an argument, and not
+    from the global one."""
+    mutable_config.set("config:url_fetch_method", "urllib")
+    with_curl = inactive_config({"config": {"url_fetch_method": "curl"}})
+
+    with pytest.raises(spack.error.FetchError, match="curl is required but not found"):
+        web_util.url_exists("https://example.com/", config=with_curl)

--- a/lib/spack/spack/test/util/remote_file_cache.py
+++ b/lib/spack/spack/test/util/remote_file_cache.py
@@ -7,6 +7,7 @@ import sys
 
 import pytest
 
+import spack.config
 import spack.util.remote_file_cache as rfc_util
 from spack.util import tty
 from spack.util.filesystem import join_path
@@ -24,14 +25,19 @@ gitlab_url = "https://gitlab.fake.io/user/repo/-/blob/config/defaults"
 )
 def test_rfc_local_path_bad_scheme(path, err):
     with pytest.raises(ValueError, match=err):
-        _ = rfc_util.local_path(path, "")
+        _ = rfc_util.local_path(path, "", config=spack.config.CONFIG)
 
 
 @pytest.mark.not_on_windows("Unix path")
 def test_rfc_local_file_unix():
-    assert rfc_util.local_path("/a/b/c/d/e/config.py", "") == "/a/b/c/d/e/config.py"
     assert (
-        rfc_util.local_path("file:///this/is/a/file/url/include.yaml", "")
+        rfc_util.local_path("/a/b/c/d/e/config.py", "", config=spack.config.CONFIG)
+        == "/a/b/c/d/e/config.py"
+    )
+    assert (
+        rfc_util.local_path(
+            "file:///this/is/a/file/url/include.yaml", "", config=spack.config.CONFIG
+        )
         == "/this/is/a/file/url/include.yaml"
     )
 
@@ -39,13 +45,15 @@ def test_rfc_local_file_unix():
 @pytest.mark.only_windows("Windows path")
 def test_rfc_local_file_windows():
     assert rfc_util.local_path(r"C:\Files (x86)\Windows\10", "") == r"C:\Files (x86)\Windows\10"
-    assert rfc_util.local_path(r"D:/spack stage", "") == r"D:\spack stage"
+    assert (
+        rfc_util.local_path(r"D:/spack stage", "", config=spack.config.CONFIG) == r"D:\spack stage"
+    )
 
 
 def test_rfc_remote_local_path_no_dest():
     path = f"{gitlab_url}/packages.yaml"
     with pytest.raises(ValueError, match="Requires the destination argument"):
-        _ = rfc_util.local_path(path, "")
+        _ = rfc_util.local_path(path, "", config=spack.config.CONFIG)
 
 
 packages_yaml_sha256 = (
@@ -92,10 +100,10 @@ def test_rfc_remote_local_path(
     if err is not None:
         with mutable_empty_config.override("config:url_fetch_method", "curl"):
             with pytest.raises(err, match=msg):
-                rfc_util.local_path(url, sha256, dest_dir)
+                rfc_util.local_path(url, sha256, dest_dir, config=spack.config.CONFIG)
     else:
         with mutable_empty_config.override("config:url_fetch_method", "curl"):
-            path = rfc_util.local_path(url, sha256, dest_dir)
+            path = rfc_util.local_path(url, sha256, dest_dir, config=spack.config.CONFIG)
             assert os.path.exists(path)
             # Ensure correct file is "fetched"
             assert os.path.basename(path) == os.path.basename(url)

--- a/lib/spack/spack/test/web.py
+++ b/lib/spack/spack/test/web.py
@@ -105,8 +105,12 @@ class MockS3Client:
 @pytest.fixture
 def mock_s3_client(monkeypatch):
     client = MockS3Client("s3://my-bucket/")
-    monkeypatch.setattr(spack.util.s3, "get_s3_session", lambda url, method="fetch": client)
-    monkeypatch.setattr(spack.util.web, "get_s3_session", lambda url, method="fetch": client)
+    monkeypatch.setattr(
+        spack.util.s3, "get_s3_session", lambda url, method="fetch", *, config: client
+    )
+    monkeypatch.setattr(
+        spack.util.web, "get_s3_session", lambda url, method="fetch", *, config: client
+    )
     return client
 
 
@@ -148,8 +152,8 @@ def mock_s3_client(monkeypatch):
         ),
     ],
 )
-def test_spider(depth, expected_found, expected_not_found, expected_text):
-    pages, links = spack.util.web.spider(root, depth=depth)
+def test_spider(depth, expected_found, expected_not_found, expected_text, config):
+    pages, links = spack.util.web.spider(root, depth=depth, config=config)
 
     for page in expected_found["pages"]:
         assert page in pages
@@ -167,10 +171,14 @@ def test_spider(depth, expected_found, expected_not_found, expected_text):
         assert text in pages[page]
 
 
-def test_spider_no_response(monkeypatch):
+def test_spider_no_response(monkeypatch, config):
     # Mock the absence of a response
-    monkeypatch.setattr(spack.util.web, "read_from_url", lambda x, y: (None, None, None))
-    pages, links, _, _ = spack.util.web._spider(root, collect_nested=False, _visited=set())
+    monkeypatch.setattr(
+        spack.util.web, "read_from_url", lambda x, y, *, urlopen: (None, None, None)
+    )
+    pages, links, _, _ = spack.util.web._spider(
+        root, collect_nested=False, _visited=set(), config=config
+    )
     assert not pages and not links
 
 
@@ -277,7 +285,7 @@ def test_etag_parser():
     assert spack.util.web.parse_etag("abc def") is None
 
 
-def test_list_url(tmp_path: pathlib.Path):
+def test_list_url(tmp_path: pathlib.Path, config):
     testpath = str(tmp_path)
     testpath_url = url_util.path_to_file_url(testpath)
 
@@ -294,7 +302,7 @@ def test_list_url(tmp_path: pathlib.Path):
         pass
 
     list_url = lambda recursive: list(
-        sorted(spack.util.web.list_url(testpath_url, recursive=recursive))
+        sorted(spack.util.web.list_url(testpath_url, recursive=recursive, config=config))
     )
 
     assert list_url(False) == ["file-0.txt", "file-1.txt", "file-2.txt"]
@@ -302,7 +310,7 @@ def test_list_url(tmp_path: pathlib.Path):
     assert list_url(True) == ["dir/another-file.txt", "file-0.txt", "file-1.txt", "file-2.txt"]
 
 
-def test_gather_s3_information(monkeypatch):
+def test_gather_s3_information(monkeypatch, config):
     mirror = spack.mirrors.mirror.Mirror(
         {
             "fetch": {
@@ -320,7 +328,9 @@ def test_gather_s3_information(monkeypatch):
         }
     )
 
-    session_args, client_args = spack.util.s3.get_mirror_s3_connection_info(mirror, "push")
+    session_args, client_args = spack.util.s3.get_mirror_s3_connection_info(
+        mirror, "push", config=config
+    )
 
     # Session args are used to create the S3 Session object
     assert "aws_session_token" in session_args
@@ -337,13 +347,13 @@ def test_gather_s3_information(monkeypatch):
     assert "endpoint_url" in client_args
 
 
-def test_remove_s3_url(mock_s3_client, capfd):
+def test_remove_s3_url(mock_s3_client, capfd, config):
     fake_s3_url = "s3://my-bucket/subdirectory/mirror"
 
     current_debug_level = tty.debug_level()
     tty.set_debug(1)
 
-    spack.util.web.remove_url(fake_s3_url, recursive=True)
+    spack.util.web.remove_url(fake_s3_url, recursive=True, config=config)
     err = capfd.readouterr()[1]
 
     tty.set_debug(current_debug_level)
@@ -353,12 +363,12 @@ def test_remove_s3_url(mock_s3_client, capfd):
     assert "Deleted keytwo" in err
 
 
-def test_s3_url_exists(mock_s3_client):
+def test_s3_url_exists(mock_s3_client, config):
     fake_s3_url_exists = "s3://my-bucket/subdirectory/my-file"
-    assert spack.util.web.url_exists(fake_s3_url_exists)
+    assert spack.util.web.url_exists(fake_s3_url_exists, config=config)
 
     fake_s3_url_does_not_exist = "s3://my-bucket/subdirectory/my-notfound-file"
-    assert not spack.util.web.url_exists(fake_s3_url_does_not_exist)
+    assert not spack.util.web.url_exists(fake_s3_url_does_not_exist, config=config)
 
 
 def test_s3_url_parsing():
@@ -442,7 +452,7 @@ def test_ssl_urllib(
 
         assert mock_cert == mutable_config.get("config:ssl_certs", None)
 
-        ssl_context = spack.util.web.ssl_create_default_context()
+        ssl_context = spack.util.web.default_ssl_context(mutable_config)
         assert ssl_context.verify_mode == ssl.CERT_REQUIRED
 
 
@@ -465,7 +475,7 @@ def test_ssl_curl_cert_file(
         if cert_exists:
             open(mock_cert, "w", encoding="utf-8").close()
             assert os.path.isfile(mock_cert)
-        curl = spack.util.web.require_curl()
+        curl = spack.util.web.require_curl(config=mutable_config)
 
         # arbitrary call to query the run env
         dump_env: Dict[str, str] = {}
@@ -606,7 +616,7 @@ def test_retry_on_transient_error_reuse(mock_sleep):
 
 
 @pytest.mark.parametrize("keep_original", [True, False])
-def test_push_to_url_s3_if_match(keep_original, mock_s3_client, tmp_path):
+def test_push_to_url_s3_if_match(keep_original, mock_s3_client, tmp_path, config):
     """Test that using if_match with s3 calls put_object."""
     local_data = tmp_path / "data.txt"
     local_data.write_text("hello")
@@ -617,6 +627,7 @@ def test_push_to_url_s3_if_match(keep_original, mock_s3_client, tmp_path):
         keep_original=keep_original,
         content_type="text/plain",
         if_match="etag1234",
+        config=config,
     )
 
     assert 1 == len(mock_s3_client.put_object_calls)
@@ -636,7 +647,7 @@ def test_push_to_url_s3_if_match(keep_original, mock_s3_client, tmp_path):
 
 
 @pytest.mark.parametrize("keep_original", [True, False])
-def test_push_to_url_s3(keep_original, mock_s3_client, tmp_path):
+def test_push_to_url_s3(keep_original, mock_s3_client, tmp_path, config):
     """Test that using if_match with s3 calls put_object."""
     local_data = tmp_path / "data.txt"
     local_data.write_text("hello")
@@ -646,6 +657,7 @@ def test_push_to_url_s3(keep_original, mock_s3_client, tmp_path):
         "s3://bucket/and/path/data.txt",
         keep_original=keep_original,
         content_type="text/plain",
+        config=config,
     )
 
     assert 0 == len(mock_s3_client.put_object_calls)
@@ -656,3 +668,52 @@ def test_push_to_url_s3(keep_original, mock_s3_client, tmp_path):
     call = mock_s3_client.upload_file_calls[0]
     assert 3 == len(call[0])
     assert {"ContentType": "text/plain"} == call[1]["ExtraArgs"]
+
+
+def test_base_curl_fetch_args_uses_given_config(mutable_config: Configuration, inactive_config):
+    """Tests that curl arguments come from the configuration passed as an argument, and not
+    from the global one."""
+    mutable_config.set("config:verify_ssl", True)
+    mutable_config.set("config:connect_timeout", 10)
+    unverified = inactive_config({"config": {"verify_ssl": False, "connect_timeout": 42}})
+
+    args = spack.util.web.base_curl_fetch_args("https://example.com", config=unverified)
+    assert "-k" in args
+    assert args[args.index("--connect-timeout") + 1] == "42"
+
+    args = spack.util.web.base_curl_fetch_args("https://example.com", config=mutable_config)
+    assert "-k" not in args
+    assert args[args.index("--connect-timeout") + 1] == "10"
+
+
+def test_s3_connection_info_uses_given_config(mutable_config: Configuration, inactive_config):
+    """Tests that S3 clients are configured from the configuration passed as an argument, and
+    not from the global one."""
+    mutable_config.set("config:verify_ssl", True)
+    unverified = inactive_config({"config": {"verify_ssl": False}})
+
+    _, client_args = spack.util.s3.get_mirror_s3_connection_info(None, "fetch", config=unverified)
+    assert client_args["use_ssl"] is False
+
+    _, client_args = spack.util.s3.get_mirror_s3_connection_info(
+        None, "fetch", config=mutable_config
+    )
+    assert client_args["use_ssl"] is True
+
+
+def test_require_curl_uses_given_config(
+    tmp_path: pathlib.Path, ssl_scrubbed_env, mutable_config: Configuration, inactive_config
+):
+    """Tests that curl gets the custom certificates of the configuration passed as an argument,
+    and not those of the global one."""
+    mock_cert = tmp_path / "mock_cert.crt"
+    mock_cert.write_text("")
+    with_certs = inactive_config({"config": {"ssl_certs": str(mock_cert)}})
+
+    certs_env: Dict[str, str] = {}
+    spack.util.web.require_curl(config=with_certs)("--help", output=str, _dump_env=certs_env)
+    assert certs_env["CURL_CA_BUNDLE"] == str(mock_cert)
+
+    global_env: Dict[str, str] = {}
+    spack.util.web.require_curl(config=mutable_config)("--help", output=str, _dump_env=global_env)
+    assert "CURL_CA_BUNDLE" not in global_env

--- a/lib/spack/spack/url.py
+++ b/lib/spack/spack/url.py
@@ -35,6 +35,7 @@ import pathlib
 import re
 from typing import Any, Dict, Optional, Sequence, Tuple, Union
 
+import spack.config
 import spack.error
 import spack.util.url
 import spack.util.web
@@ -656,7 +657,9 @@ def find_versions_of_archive(
     list_urls |= additional_list_urls
 
     # Grab some web pages to scrape.
-    _, links = spack.util.web.spider(list_urls, depth=list_depth, concurrency=concurrency)
+    _, links = spack.util.web.spider(
+        list_urls, depth=list_depth, concurrency=concurrency, config=spack.config.CONFIG
+    )
 
     # Scrape them for archive URLs
     regexes = []

--- a/lib/spack/spack/url_buildcache.py
+++ b/lib/spack/spack/url_buildcache.py
@@ -19,6 +19,7 @@ from typing import Any, Callable, Dict, List, Optional, Tuple, Type
 
 import spack.vendor.jsonschema
 
+import spack.config
 import spack.database
 import spack.error
 import spack.mirrors.mirror
@@ -29,7 +30,6 @@ import spack.util.filesystem as fsys
 import spack.util.gpg
 import spack.util.url as url_util
 import spack.util.web as web_util
-from spack import config
 from spack.mirrors.mirror import BINARY_MEDIA_TYPE_VERSION
 from spack.schema.url_buildcache_manifest import schema as buildcache_manifest_schema
 from spack.util import tty
@@ -228,7 +228,7 @@ class URLBuildcacheEntry:
         layout_json_url = url_util.join(
             mirror_url, *cls.get_relative_path_components(BuildcacheComponent.LAYOUT_JSON)
         )
-        return web_util.url_exists(layout_json_url)
+        return web_util.url_exists(layout_json_url, config=spack.config.CONFIG)
 
     @classmethod
     def maybe_push_layout_json(cls, mirror_url: str) -> None:
@@ -246,7 +246,12 @@ class URLBuildcacheEntry:
             remote_layout_url = url_util.join(
                 mirror_url, *cls.get_relative_path_components(BuildcacheComponent.LAYOUT_JSON)
             )
-            web_util.push_to_url(local_layout_path, remote_layout_url, keep_original=False)
+            web_util.push_to_url(
+                local_layout_path,
+                remote_layout_url,
+                keep_original=False,
+                config=spack.config.CONFIG,
+            )
 
     @classmethod
     def get_base_url(cls, manifest_url: str) -> str:
@@ -362,7 +367,7 @@ class URLBuildcacheEntry:
     def check_blob_exists(self, record: BlobRecord) -> bool:
         """Return True if the blob given by record exists on the mirror, False otherwise"""
         blob_url = self.get_blob_url(self.mirror_url, record)
-        return web_util.url_exists(blob_url)
+        return web_util.url_exists(blob_url, config=spack.config.CONFIG)
 
     @classmethod
     def get_blob_path_components(cls, record: BlobRecord) -> List[str]:
@@ -482,7 +487,7 @@ class URLBuildcacheEntry:
         manifest_contents = ""
 
         try:
-            manifest_contents = web_util.read_text(manifest_url)
+            manifest_contents = web_util.read_text(manifest_url, config=spack.config.CONFIG)
         except (web_util.SpackWebError, OSError) as e:
             raise BuildcacheEntryError(f"Error reading manifest at {manifest_url}") from e
 
@@ -534,7 +539,7 @@ class URLBuildcacheEntry:
         manifest from the mirror."""
         if self.manifest:
             try:
-                web_util.remove_url(self.remote_manifest_url)
+                web_util.remove_url(self.remote_manifest_url, config=spack.config.CONFIG)
             except Exception as e:
                 tty.debug(f"Failed to remove previous manfifest: {e}")
 
@@ -542,7 +547,8 @@ class URLBuildcacheEntry:
                 web_util.remove_url(
                     self.get_blob_url(
                         self.mirror_url, self.get_blob_record(BuildcacheComponent.TARBALL)
-                    )
+                    ),
+                    config=spack.config.CONFIG,
                 )
             except Exception as e:
                 tty.debug(f"Failed to remove previous archive: {e}")
@@ -551,7 +557,8 @@ class URLBuildcacheEntry:
                 web_util.remove_url(
                     self.get_blob_url(
                         self.mirror_url, self.get_blob_record(BuildcacheComponent.SPEC)
-                    )
+                    ),
+                    config=spack.config.CONFIG,
                 )
             except Exception as e:
                 tty.debug(f"Failed to remove previous metadata: {e}")
@@ -563,7 +570,9 @@ class URLBuildcacheEntry:
         """Push the blob_path file to mirror as a blob represented by the given
         record"""
         blob_destination_url = cls.get_blob_url(mirror_url, record)
-        web_util.push_to_url(blob_path, blob_destination_url, keep_original=False)
+        web_util.push_to_url(
+            blob_path, blob_destination_url, keep_original=False, config=spack.config.CONFIG
+        )
 
     @classmethod
     def push_manifest(
@@ -598,7 +607,12 @@ class URLBuildcacheEntry:
             mirror_url, *cls.get_relative_path_components(component_type), manifest_file_name
         )
 
-        web_util.push_to_url(manifest_path, manifest_destination_url, keep_original=False)
+        web_util.push_to_url(
+            manifest_path,
+            manifest_destination_url,
+            keep_original=False,
+            config=spack.config.CONFIG,
+        )
 
     @classmethod
     def push_local_file_as_blob(
@@ -679,7 +693,9 @@ class URLBuildcacheEntry:
         )
 
         # push the archive/tarball blob to the remote
-        web_util.push_to_url(tarball_path, remote_archive_url, keep_original=False)
+        web_util.push_to_url(
+            tarball_path, remote_archive_url, keep_original=False, config=spack.config.CONFIG
+        )
 
         # Clear out the previous data, then add a record for the new blob
         blobs: List[BlobRecord] = []
@@ -709,7 +725,9 @@ class URLBuildcacheEntry:
         )
 
         # push the metadata/spec blob to the remote
-        web_util.push_to_url(specfile, remote_spec_url, keep_original=False)
+        web_util.push_to_url(
+            specfile, remote_spec_url, keep_original=False, config=spack.config.CONFIG
+        )
 
         blobs.append(
             BlobRecord(
@@ -743,7 +761,12 @@ class URLBuildcacheEntry:
         # Push the manifest file to the remote. The remote manifest url for
         # a given concrete spec is fixed, so we don't have to recompute it,
         # even if we deleted the pre-existing one.
-        web_util.push_to_url(manifest_path, self.remote_manifest_url, keep_original=False)
+        web_util.push_to_url(
+            manifest_path,
+            self.remote_manifest_url,
+            keep_original=False,
+            config=spack.config.CONFIG,
+        )
 
     def destroy(self):
         """Destroy any existing stages"""
@@ -843,14 +866,14 @@ class URLBuildcacheEntryV2(URLBuildcacheEntry):
 
         if not self._checked_signed:
             signed_url = self._get_spec_url(self.spec, self.mirror_url, ext=".spec.json.sig")
-            if web_util.url_exists(signed_url):
+            if web_util.url_exists(signed_url, config=spack.config.CONFIG):
                 self.remote_spec_url = signed_url
                 self.has_signed = True
             self._checked_signed = True
 
         if not self.has_signed and not self._checked_unsigned:
             unsigned_url = self._get_spec_url(self.spec, self.mirror_url, ext=".spec.json")
-            if web_util.url_exists(unsigned_url):
+            if web_util.url_exists(unsigned_url, config=spack.config.CONFIG):
                 self.remote_spec_url = unsigned_url
                 self.has_unsigned = True
             self._checked_unsigned = True
@@ -870,7 +893,9 @@ class URLBuildcacheEntryV2(URLBuildcacheEntry):
         if not self.has_signed and not self.has_unsigned:
             return False
 
-        if not web_util.url_exists(self._get_tarball_url(self.spec, self.mirror_url)):
+        if not web_util.url_exists(
+            self._get_tarball_url(self.spec, self.mirror_url), config=spack.config.CONFIG
+        ):
             return False
 
         return True
@@ -1205,10 +1230,12 @@ def _entries_from_cache_fallback(url: str, tmpspecsdir: str, component_type: Bui
         component_path_parts = cache_class.get_relative_path_components(component_type)
         component_prefix: str = url_util.join(url, *component_path_parts)
         component_pattern = cache_class.get_buildcache_component_include_pattern(component_type)
-        for entry in web_util.list_url(component_prefix, recursive=True):
+        for entry in web_util.list_url(
+            component_prefix, recursive=True, config=spack.config.CONFIG
+        ):
             if fnmatch.fnmatch(entry, component_pattern):
                 entry_url = url_util.join(component_prefix, entry)
-                stat_result = web_util.stat_url(entry_url)
+                stat_result = web_util.stat_url(entry_url, config=spack.config.CONFIG)
                 if stat_result is not None:
                     filename_to_mtime[entry_url] = stat_result[1]  # mtime is second element
         read_fn = url_read_method
@@ -1358,7 +1385,7 @@ def try_verify(specfile_path):
     Returns:
         ``True`` if the signature could be verified, ``False`` otherwise.
     """
-    suppress = config.CONFIG.get("config:suppress_gpg_warnings", False)
+    suppress = spack.config.CONFIG.get("config:suppress_gpg_warnings", False)
 
     try:
         spack.util.gpg.verify(specfile_path, suppress_warnings=suppress)

--- a/lib/spack/spack/util/remote_file_cache.py
+++ b/lib/spack/spack/util/remote_file_cache.py
@@ -9,12 +9,15 @@ import shutil
 import tempfile
 import urllib.parse
 import urllib.request
-from typing import Optional
+from typing import TYPE_CHECKING, Optional
 
 import spack.util.crypto
 from spack.util import tty
 from spack.util.filesystem import copy, join_path, mkdirp
 from spack.util.url import validate_scheme
+
+if TYPE_CHECKING:
+    import spack.config
 
 
 def raw_github_gitlab_url(url: str) -> str:
@@ -35,12 +38,15 @@ def raw_github_gitlab_url(url: str) -> str:
     return url
 
 
-def fetch_remote_text_file(url: str, dest_dir: str) -> str:
+def _fetch_remote_text_file(
+    url: str, dest_dir: str, *, config: "spack.config.Configuration"
+) -> str:
     """Retrieve the text file from the url into the destination directory.
 
     Arguments:
         url: URL for the remote text file
         dest_dir: destination directory in which to stage the file locally
+        config: configuration to read the fetch method and connection settings from
 
     Returns:
         Path to the fetched file
@@ -56,16 +62,19 @@ def fetch_remote_text_file(url: str, dest_dir: str) -> str:
     raw_url = raw_github_gitlab_url(url)
     tty.debug(f"Fetching file from {raw_url} into {dest_dir}")
 
-    return fetch_url_text(raw_url, dest_dir=dest_dir)
+    return fetch_url_text(raw_url, dest_dir=dest_dir, config=config)
 
 
-def local_path(path: str, sha256: str, dest: Optional[str] = None) -> str:
+def local_path(
+    path: str, sha256: str, dest: Optional[str] = None, *, config: "spack.config.Configuration"
+) -> str:
     """Determine the actual path and, if remote, stage its contents locally.
 
     Args:
         path: the resolved configuration path
         sha256: the expected sha256 if the file is remote
         dest: destination path
+        config: configuration to read the fetch settings from, if the file is remote
 
     Returns: normalized local path
 
@@ -104,7 +113,7 @@ def local_path(path: str, sha256: str, dest: Optional[str] = None) -> str:
             # Stage the remote configuration file
             tmpdir = tempfile.mkdtemp()
             try:
-                staged_path = fetch_remote_text_file(path, tmpdir)
+                staged_path = _fetch_remote_text_file(path, tmpdir, config=config)
 
                 # Ensure the sha256 is expected.
                 checksum = spack.util.crypto.checksum(hashlib.sha256, staged_path)

--- a/lib/spack/spack/util/s3.py
+++ b/lib/spack/spack/util/s3.py
@@ -7,15 +7,18 @@ import urllib.parse
 import urllib.request
 import urllib.response
 from io import BufferedReader, BytesIO, IOBase
-from typing import Any, Dict, Tuple
+from typing import Any, Dict, Tuple, Union
 
 import spack.config
 
-#: Map (mirror name, method) tuples to s3 client instances.
-s3_client_cache: Dict[Tuple[str, str], Any] = dict()
+#: Session and client arguments an s3 client is created with, each sorted by name.
+S3ClientKey = Tuple[Tuple[Tuple[str, Any], ...], Tuple[Tuple[str, Any], ...]]
+
+#: Map the arguments an s3 client is created with to the client.
+s3_client_cache: Dict[S3ClientKey, Any] = {}
 
 
-def get_s3_session(url, method="fetch"):
+def get_s3_session(url, method="fetch", *, config: spack.config.Configuration):
     # import boto and friends as late as possible.  We don't want to require boto as a
     # dependency unless the user actually wants to access S3 mirrors.
     from boto3 import Session
@@ -26,8 +29,6 @@ def get_s3_session(url, method="fetch"):
     # Circular dependency
     from spack.mirrors.mirror import MirrorCollection
 
-    global s3_client_cache
-
     # Parse the URL if not already done.
     if not isinstance(url, urllib.parse.ParseResult):
         url = urllib.parse.urlparse(url)
@@ -37,31 +38,22 @@ def get_s3_session(url, method="fetch"):
         return mirror.fetch_url if method == "fetch" else mirror.push_url
 
     # Get all configured mirrors that could match.
-    all_mirrors = MirrorCollection()
+    all_mirrors = MirrorCollection.from_config(config)
     mirrors = [
-        (name, mirror)
-        for name, mirror in all_mirrors.items()
-        if url_str.startswith(get_mirror_url(mirror))
+        mirror for mirror in all_mirrors.values() if url_str.startswith(get_mirror_url(mirror))
     ]
 
-    if not mirrors:
-        name, mirror = None, {}
-    else:
-        # In case we have more than one mirror, we pick the longest matching url.
-        # The heuristic being that it's more specific, and you can have different
-        # credentials for a sub-bucket (if that is a thing).
-        name, mirror = max(
-            mirrors, key=lambda name_and_mirror: len(get_mirror_url(name_and_mirror[1]))
-        )
+    # In case we have more than one mirror, we pick the longest matching url.
+    # The heuristic being that it's more specific, and you can have different
+    # credentials for a sub-bucket (if that is a thing).
+    mirror = max(mirrors, key=lambda m: len(get_mirror_url(m))) if mirrors else None
 
-    key = (name, method)
+    s3_connection, s3_client_args = get_mirror_s3_connection_info(mirror, method, config=config)
+    key = (tuple(sorted(s3_connection.items())), tuple(sorted(s3_client_args.items())))
 
     # Did we already create a client for this? Then return it.
     if key in s3_client_cache:
         return s3_client_cache[key]
-
-    # Otherwise, create it.
-    s3_connection, s3_client_args = get_mirror_s3_connection_info(mirror, method)
 
     session = Session(**s3_connection)
     # if no access credentials provided above, then access anonymously
@@ -83,13 +75,13 @@ def _parse_s3_endpoint_url(endpoint_url):
     return endpoint_url
 
 
-def get_mirror_s3_connection_info(mirror, method):
+def get_mirror_s3_connection_info(mirror, method, *, config: spack.config.Configuration):
     """Create s3 config for session/client from a Mirror instance (or just set defaults
     when no mirror is given.)"""
     from spack.mirrors.mirror import Mirror
 
     s3_connection = {}
-    s3_client_args = {"use_ssl": spack.config.CONFIG.get("config:verify_ssl")}
+    s3_client_args = {"use_ssl": config.get("config:verify_ssl")}
 
     # access token
     if isinstance(mirror, Mirror):
@@ -146,9 +138,9 @@ class WrapStream(BufferedReader):
         return getattr(self.raw, key)
 
 
-def _s3_open(url, method="GET"):
+def _s3_open(url, method="GET", *, config: spack.config.Configuration):
     parsed = urllib.parse.urlparse(url)
-    s3 = get_s3_session(url, method="fetch")
+    s3 = get_s3_session(url, method="fetch", config=config)
 
     bucket = parsed.netloc
     key = parsed.path
@@ -161,6 +153,7 @@ def _s3_open(url, method="GET"):
             "Only GET and HEAD verbs are currently supported for the s3:// scheme"
         )
 
+    stream: Union[WrapStream, BytesIO]
     try:
         if method == "GET":
             obj = s3.get_object(Bucket=bucket, Key=key)
@@ -178,7 +171,10 @@ def _s3_open(url, method="GET"):
 
 
 class UrllibS3Handler(urllib.request.BaseHandler):
+    def __init__(self, config: spack.config.Configuration) -> None:
+        self.config = config
+
     def s3_open(self, req):
         orig_url = req.get_full_url()
-        url, headers, stream = _s3_open(orig_url, method=req.get_method())
+        url, headers, stream = _s3_open(orig_url, method=req.get_method(), config=self.config)
         return urllib.response.addinfourl(stream, headers, url)

--- a/lib/spack/spack/util/web.py
+++ b/lib/spack/spack/util/web.py
@@ -18,15 +18,16 @@ import sys
 import time
 import traceback
 import urllib.parse
+import urllib.response
 import warnings
 from html.parser import HTMLParser
-from http.client import IncompleteRead
+from http.client import HTTPResponse, IncompleteRead
 from pathlib import Path, PurePosixPath
 from typing import IO, Callable, Dict, Iterable, List, Optional, Set, Tuple, TypeVar, Union
 from urllib.error import HTTPError, URLError
 from urllib.request import HTTPDefaultErrorHandler, HTTPSHandler, Request, build_opener
 
-from spack.vendor.typing_extensions import ParamSpec
+from spack.vendor.typing_extensions import ParamSpec, Protocol
 
 import spack
 import spack.config
@@ -205,12 +206,31 @@ class SpackHTTPSHandler(HTTPSHandler):
             raise DetailedURLError(req, e.reason) from e
 
 
-def custom_ssl_certs() -> Optional[Tuple[bool, str]]:
-    """Returns a tuple (is_file, path) if custom SSL certifates are configured and valid."""
-    ssl_certs = spack.config.CONFIG.get("config:ssl_certs")
+_Response = TypeVar("_Response", covariant=True)
+
+
+class Opener(Protocol[_Response]):
+    """Function opening URLs, with the signature of ``OpenerDirector.open``."""
+
+    def __call__(
+        self,
+        fullurl: Union[str, Request],
+        data: Optional[bytes] = None,
+        timeout: Optional[float] = None,
+    ) -> _Response: ...
+
+
+#: Openers returned by :func:`opener_for`. HTTP(S) responses are ``HTTPResponse``, while file,
+#: S3 and GCS responses are ``addinfourl``.
+OpenType = Opener[Union[HTTPResponse, urllib.response.addinfourl]]
+
+
+def _custom_ssl_certs(config: spack.config.Configuration) -> Optional[Tuple[bool, str]]:
+    """Returns a tuple (is_file, path) if custom SSL certificates are configured and valid."""
+    ssl_certs = config.get("config:ssl_certs")
     if not ssl_certs:
         return None
-    path = spack.config.substitute_path_variables(ssl_certs)
+    path = spack.config.substitute_path_variables(ssl_certs, config=config)
     if not os.path.isabs(path):
         tty.debug(f"certs: relative path not allowed: {path}")
         return None
@@ -229,24 +249,35 @@ def custom_ssl_certs() -> Optional[Tuple[bool, str]]:
     return (file_type == stat.S_IFREG, path)
 
 
-def ssl_create_default_context():
-    """Create the default SSL context for urllib with custom certificates if configured."""
-    certs = custom_ssl_certs()
+@lang.memoized
+def _verifying_ssl_context(certs: Optional[Tuple[bool, str]]) -> ssl.SSLContext:
+    """Returns an SSL context verifying against ``certs``, or against the system certificates if
+    None. Contexts are memoized, since loading certificates is slow.
+    """
     if certs is None:
         return ssl.create_default_context()
     is_file, path = certs
     if is_file:
         tty.debug(f"urllib: certs: using cafile {path}")
         return ssl.create_default_context(cafile=path)
-    else:
-        tty.debug(f"urllib: certs: using capath {path}")
-        return ssl.create_default_context(capath=path)
+    tty.debug(f"urllib: certs: using capath {path}")
+    return ssl.create_default_context(capath=path)
 
 
-def set_curl_env_for_ssl_certs(curl: Executable) -> None:
+def clear_ssl_contexts() -> None:
+    """Drop the SSL contexts created so far, e.g. in a forked child process."""
+    _verifying_ssl_context.cache_clear()
+
+
+def default_ssl_context(config: spack.config.Configuration) -> ssl.SSLContext:
+    """Returns the verifying SSL context for urllib, with the custom certificates in ``config``."""
+    return _verifying_ssl_context(_custom_ssl_certs(config))
+
+
+def _set_curl_env_for_ssl_certs(curl: Executable, config: spack.config.Configuration) -> None:
     """configure curl to use custom certs in a file at runtime. See:
     https://curl.se/docs/sslcerts.html item 4"""
-    certs = custom_ssl_certs()
+    certs = _custom_ssl_certs(config)
     if certs is None:
         return
     is_file, path = certs
@@ -257,32 +288,31 @@ def set_curl_env_for_ssl_certs(curl: Executable) -> None:
     curl.add_default_env("CURL_CA_BUNDLE", path)
 
 
-def _urlopen():
-    s3 = UrllibS3Handler()
-    gcs = GCSHandler()
-    error_handler = SpackHTTPDefaultErrorHandler()
+def opener_for(config: spack.config.Configuration) -> OpenType:
+    """Returns a function that opens URLs with the SSL, timeout and S3 settings in ``config``.
 
-    # One opener with HTTPS ssl enabled
-    with_ssl = build_opener(
-        s3, gcs, SpackHTTPSHandler(context=ssl_create_default_context()), error_handler
+    The function has the signature of ``OpenerDirector.open``. Its ``timeout`` defaults to
+    ``config:connect_timeout``.
+    """
+    if config.get("config:verify_ssl", True):
+        context = default_ssl_context(config)
+    else:
+        context = ssl._create_unverified_context()
+    opener = build_opener(
+        UrllibS3Handler(config),
+        GCSHandler(),
+        SpackHTTPSHandler(context=context),
+        SpackHTTPDefaultErrorHandler(),
     )
+    default_timeout = config.get("config:connect_timeout", 10)
 
-    # One opener with HTTPS ssl disabled
-    without_ssl = build_opener(
-        s3, gcs, SpackHTTPSHandler(context=ssl._create_unverified_context()), error_handler
-    )
+    def urlopen(
+        fullurl: Union[str, Request], data: Optional[bytes] = None, timeout: Optional[float] = None
+    ) -> Union[HTTPResponse, urllib.response.addinfourl]:
+        return opener.open(fullurl, data, timeout or default_timeout)
 
-    # And dynamically dispatch based on the config:verify_ssl.
-    def dispatch_open(fullurl, data=None, timeout=None):
-        opener = with_ssl if spack.config.CONFIG.get("config:verify_ssl", True) else without_ssl
-        timeout = timeout or spack.config.CONFIG.get("config:connect_timeout", 10)
-        return opener.open(fullurl, data, timeout)
+    return urlopen
 
-    return dispatch_open
-
-
-#: Dispatches to the correct OpenerDirector.open, based on Spack configuration.
-urlopen = lang.Singleton(_urlopen)
 
 #: User-Agent used in Request objects
 SPACK_USER_AGENT = "Spackbot/{0}".format(spack.spack_version)
@@ -342,7 +372,7 @@ class ExtractMetadataParser(HTMLParser):
                     self.base_url = val
 
 
-def read_from_url(url, accept_content_type=None):
+def read_from_url(url, accept_content_type=None, *, urlopen: OpenType):
     if isinstance(url, str):
         url = urllib.parse.urlparse(url)
 
@@ -372,13 +402,13 @@ def read_from_url(url, accept_content_type=None):
     return response.url, response.headers, response
 
 
-def _read_text(url: str) -> str:
+def _read_text(url: str, urlopen: OpenType) -> str:
     request = Request(url, headers={"User-Agent": SPACK_USER_AGENT})
     with urlopen(request) as response:
         return io.TextIOWrapper(response, encoding="utf-8").read()
 
 
-def _read_json(url: str):
+def _read_json(url: str, urlopen: OpenType):
     request = Request(url, headers={"User-Agent": SPACK_USER_AGENT})
     with urlopen(request) as response:
         return json.load(response)
@@ -388,18 +418,18 @@ _read_text_with_retry = retry_on_transient_error(_read_text)
 _read_json_with_retry = retry_on_transient_error(_read_json)
 
 
-def read_text(url: str) -> str:
+def read_text(url: str, *, config: spack.config.Configuration) -> str:
     """Fetch url and return the response body decoded as UTF-8 text."""
     try:
-        return _read_text_with_retry(url)
+        return _read_text_with_retry(url, opener_for(config))
     except Exception as e:
         raise SpackWebError(f"Download of {url} failed: {e.__class__.__name__}: {e}")
 
 
-def read_json(url: str):
+def read_json(url: str, *, config: spack.config.Configuration):
     """Fetch url and return the response body parsed as JSON."""
     try:
-        return _read_json_with_retry(url)
+        return _read_json_with_retry(url, opener_for(config))
     except Exception as e:
         raise SpackWebError(f"Download of {url} failed: {e.__class__.__name__}: {e}")
 
@@ -410,6 +440,8 @@ def push_to_url(
     keep_original=True,
     content_type: Optional[str] = None,
     if_match: Optional[str] = None,
+    *,
+    config: spack.config.Configuration,
 ):
     remote_url = urllib.parse.urlparse(remote_path)
     if if_match and remote_url.scheme != "s3":
@@ -449,7 +481,7 @@ def push_to_url(
         while remote_path.startswith("/"):
             remote_path = remote_path[1:]
 
-        s3 = get_s3_session(remote_url, method="push")
+        s3 = get_s3_session(remote_url, method="push", config=config)
         if if_match is not None:
             # IfMatch is only supported by put_object which has additional limitations
             if os.stat(local_file_path).st_size >= 5e9:
@@ -473,7 +505,7 @@ def push_to_url(
         raise NotImplementedError(f"Unrecognized URL scheme: {remote_url.scheme}")
 
 
-def base_curl_fetch_args(url, timeout=0):
+def base_curl_fetch_args(url, timeout=0, *, config: spack.config.Configuration):
     """Return the basic fetch arguments typically used in calls to curl.
 
     The arguments include those for ensuring behaviors such as failing on
@@ -490,6 +522,7 @@ def base_curl_fetch_args(url, timeout=0):
         url (str): URL whose contents will be fetched
         timeout (int): Connection timeout, which is only used if higher than
             config:connect_timeout
+        config: configuration to read the options above from
 
     Returns (list): list of argument strings
     """
@@ -500,7 +533,7 @@ def base_curl_fetch_args(url, timeout=0):
         "-L",  # resolve 3xx redirects
         url,
     ]
-    if not spack.config.CONFIG.get("config:verify_ssl"):
+    if not config.get("config:verify_ssl"):
         curl_args.append("-k")
 
     if sys.stdout.isatty() and tty.msg_enabled():
@@ -508,7 +541,7 @@ def base_curl_fetch_args(url, timeout=0):
     else:
         curl_args.append("-sS")  # show errors if fail
 
-    connect_timeout = spack.config.CONFIG.get("config:connect_timeout", 10)
+    connect_timeout = config.get("config:connect_timeout", 10)
     if timeout:
         connect_timeout = max(int(connect_timeout), int(timeout))
     if connect_timeout > 0:
@@ -544,17 +577,19 @@ def check_curl_code(returncode: int) -> None:
     raise spack.error.FetchError(f"Curl failed with error {returncode}")
 
 
-def require_curl() -> Executable:
+def require_curl(*, config: spack.config.Configuration) -> Executable:
     try:
         path = spack.util.executable.which_string("curl", required=True)
     except CommandNotFoundError as e:
         raise spack.error.FetchError(f"curl is required but not found: {e}") from e
     curl = spack.util.executable.Executable(path)
-    set_curl_env_for_ssl_certs(curl)
+    _set_curl_env_for_ssl_certs(curl, config)
     return curl
 
 
-def fetch_url_text(url, curl: Optional[Executable] = None, dest_dir="."):
+def fetch_url_text(
+    url, curl: Optional[Executable] = None, dest_dir=".", *, config: spack.config.Configuration
+):
     """Retrieves text-only URL content using the configured fetch method.
     It determines the fetch method from:
 
@@ -572,6 +607,7 @@ def fetch_url_text(url, curl: Optional[Executable] = None, dest_dir="."):
             executable if curl is the configured fetch method
         dest_dir (str): (optional) destination directory for fetched text
             file
+        config: configuration to read the options above from
 
     Returns (str or None): path to the fetched file
 
@@ -585,12 +621,12 @@ def fetch_url_text(url, curl: Optional[Executable] = None, dest_dir="."):
     filename = os.path.basename(url)
     path = os.path.join(dest_dir, filename)
 
-    fetch_method = spack.config.CONFIG.get("config:url_fetch_method")
+    fetch_method = config.get("config:url_fetch_method")
     tty.debug("Using '{0}' to fetch {1} into {2}".format(fetch_method, url, path))
     if fetch_method and fetch_method.startswith("curl"):
-        curl_exe = curl or require_curl()
+        curl_exe = curl or require_curl(config=config)
         curl_args = fetch_method.split()[1:] + ["-O"]
-        curl_args.extend(base_curl_fetch_args(url))
+        curl_args.extend(base_curl_fetch_args(url, config=config))
 
         # Curl automatically downloads file contents as filename
         with working_dir(dest_dir, create=True):
@@ -601,7 +637,7 @@ def fetch_url_text(url, curl: Optional[Executable] = None, dest_dir="."):
 
     else:
         try:
-            output = read_text(url)
+            output = read_text(url, config=config)
             if output:
                 with working_dir(dest_dir, create=True):
                     with open(filename, "w", encoding="utf-8") as f:
@@ -615,18 +651,15 @@ def fetch_url_text(url, curl: Optional[Executable] = None, dest_dir="."):
     return None
 
 
-def _url_exists_urllib_impl(url):
-    with urlopen(
-        Request(url, method="HEAD", headers={"User-Agent": SPACK_USER_AGENT}),
-        timeout=spack.config.CONFIG.get("config:connect_timeout", 10),
-    ) as _:
+def _url_exists_urllib_impl(url, urlopen: OpenType):
+    with urlopen(Request(url, method="HEAD", headers={"User-Agent": SPACK_USER_AGENT})) as _:
         pass
 
 
 _url_exists_urllib = retry_on_transient_error(_url_exists_urllib_impl)
 
 
-def url_exists(url, curl=None):
+def url_exists(url, curl=None, *, config: spack.config.Configuration):
     """Determines whether url exists.
 
     A scheme-specific process is used for Google Storage (``gs``) and Amazon
@@ -637,6 +670,7 @@ def url_exists(url, curl=None):
         url (str): URL whose existence is being checked
         curl (spack.util.executable.Executable or None): (optional) curl
             executable if curl is the configured fetch method
+        config: configuration to read the fetch method and connection settings from
 
     Returns (bool): True if it exists; False otherwise.
     """
@@ -644,22 +678,22 @@ def url_exists(url, curl=None):
     url_result = urllib.parse.urlparse(url)
 
     # Use curl if configured to do so
-    fetch_method = spack.config.CONFIG.get("config:url_fetch_method", "urllib")
+    fetch_method = config.get("config:url_fetch_method", "urllib")
     use_curl = fetch_method.startswith("curl") and url_result.scheme not in ("gs", "s3")
     if use_curl:
-        curl_exe = curl or require_curl()
+        curl_exe = curl or require_curl(config=config)
 
         # Telling curl to fetch the first byte (-r 0-0) is supposed to be
         # portable.
         curl_args = fetch_method.split()[1:] + ["--stderr", "-", "-s", "-f", "-r", "0-0", url]
-        if not spack.config.CONFIG.get("config:verify_ssl"):
+        if not config.get("config:verify_ssl"):
             curl_args.append("-k")
         _ = curl_exe(*curl_args, fail_on_error=False, output=os.devnull)
         return curl_exe.returncode == 0
 
     # Otherwise use urllib.
     try:
-        _url_exists_urllib(url)
+        _url_exists_urllib(url, opener_for(config))
         return True
     except Exception as e:
         tty.debug(f"Failure reading {url}: {e}")
@@ -675,7 +709,7 @@ def _debug_print_delete_results(result):
             tty.debug("Failed to delete {0} ({1})".format(e["Key"], e["Message"]))
 
 
-def remove_url(url, recursive=False):
+def remove_url(url, recursive=False, *, config: spack.config.Configuration):
     url = urllib.parse.urlparse(url)
 
     local_path = url_util.local_file_path(url)
@@ -688,7 +722,7 @@ def remove_url(url, recursive=False):
 
     if url.scheme == "s3":
         # Try to find a mirror for potential connection information
-        s3 = get_s3_session(url, method="push")
+        s3 = get_s3_session(url, method="push", config=config)
         bucket = url.netloc
         if recursive:
             # Because list_objects_v2 can only return up to 1000 items
@@ -697,7 +731,7 @@ def remove_url(url, recursive=False):
             paginator = s3.get_paginator("list_objects_v2")
             pages = paginator.paginate(Bucket=bucket, Prefix=prefix)
 
-            delete_request = {"Objects": []}
+            delete_request: Dict[str, List[Dict[str, str]]] = {"Objects": []}
             for item in pages.search("Contents"):
                 if not item:
                     continue
@@ -784,7 +818,7 @@ def _iter_local_prefix(path):
             yield os.path.relpath(os.path.join(root, f), path)
 
 
-def list_url(url, recursive=False):
+def list_url(url, recursive=False, *, config: spack.config.Configuration):
     url = urllib.parse.urlparse(url)
     local_path = url_util.local_file_path(url)
 
@@ -799,7 +833,7 @@ def list_url(url, recursive=False):
         ]
 
     if url.scheme == "s3":
-        s3 = get_s3_session(url, method="fetch")
+        s3 = get_s3_session(url, method="fetch", config=config)
         if recursive:
             return list(_iter_s3_prefix(s3, url))
 
@@ -810,11 +844,12 @@ def list_url(url, recursive=False):
         return gcs.get_all_blobs(recursive=recursive)
 
 
-def stat_url(url: str) -> Optional[Tuple[int, float]]:
+def stat_url(url: str, *, config: spack.config.Configuration) -> Optional[Tuple[int, float]]:
     """Get stat result for a URL.
 
     Args:
         url: URL to get stat result for
+        config: configuration to look up S3 mirror credentials in
     Returns:
         A tuple of (size, mtime) if the URL exists, None otherwise.
     """
@@ -833,7 +868,7 @@ def stat_url(url: str) -> Optional[Tuple[int, float]]:
         s3_bucket = parsed_url.netloc
         s3_key = parsed_url.path.lstrip("/")
 
-        s3 = get_s3_session(url, method="fetch")
+        s3 = get_s3_session(url, method="fetch", config=config)
 
         try:
             head_request = s3.head_object(Bucket=s3_bucket, Key=s3_key)
@@ -851,7 +886,11 @@ def stat_url(url: str) -> Optional[Tuple[int, float]]:
 
 
 def spider(
-    root_urls: Union[str, Iterable[str]], depth: int = 0, concurrency: Optional[int] = None
+    root_urls: Union[str, Iterable[str]],
+    depth: int = 0,
+    concurrency: Optional[int] = None,
+    *,
+    config: spack.config.Configuration,
 ):
     """Get web pages from root URLs.
 
@@ -862,6 +901,7 @@ def spider(
         root_urls: root urls used as a starting point for spidering
         depth: level of recursion into links
         concurrency: number of simultaneous requests that can be sent
+        config: configuration to read the connection settings from
 
     Returns:
         A dict of pages visited (URL) mapped to their full text and the set of visited links.
@@ -883,7 +923,10 @@ def spider(
             tty.debug(
                 f"SPIDER: [depth={current_depth}, max_depth={depth}, urls={len(spider_args)}]"
             )
-            results = [tp.submit(_spider, *one_search_args) for one_search_args in spider_args]
+            results = [
+                tp.submit(_spider, *one_search_args, config=config)
+                for one_search_args in spider_args
+            ]
             spider_args = []
             go_deeper = current_depth < depth
             for future in results:
@@ -899,7 +942,13 @@ def spider(
     return pages, links
 
 
-def _spider(url: urllib.parse.ParseResult, collect_nested: bool, _visited: Set[str]):
+def _spider(
+    url: urllib.parse.ParseResult,
+    collect_nested: bool,
+    _visited: Set[str],
+    *,
+    config: spack.config.Configuration,
+):
     """Fetches URL and any pages it links to.
 
     Prints out a warning only if the root can't be fetched; it ignores errors with pages
@@ -910,6 +959,7 @@ def _spider(url: urllib.parse.ParseResult, collect_nested: bool, _visited: Set[s
         collect_nested: whether we want to collect arguments for nested spidering on the
             links found in this url
         _visited: links already visited
+        config: configuration to read the connection settings from
 
     Returns:
         A tuple of:
@@ -921,9 +971,10 @@ def _spider(url: urllib.parse.ParseResult, collect_nested: bool, _visited: Set[s
     pages: Dict[str, str] = {}  # dict from page URL -> text content.
     links: Set[str] = set()  # set of all links seen on visited pages.
     subcalls: List[str] = []
+    urlopen = opener_for(config)
 
     try:
-        response_url, _, response = read_from_url(url, "text/html")
+        response_url, _, response = read_from_url(url, "text/html", urlopen=urlopen)
         if not response_url or not response:
             return pages, links, subcalls, _visited
 
@@ -947,7 +998,9 @@ def _spider(url: urllib.parse.ParseResult, collect_nested: bool, _visited: Set[s
             fragment_response_url = None
             try:
                 # This seems to be text/html, though text/fragment+html is also used
-                fragment_response_url, _, fragment_response = read_from_url(abs_link, "text/html")
+                fragment_response_url, _, fragment_response = read_from_url(
+                    abs_link, "text/html", urlopen=urlopen
+                )
             except Exception as e:
                 msg = f"Error reading fragment: {(type(e), str(e))}:{traceback.format_exc()}"
                 tty.debug(msg)


### PR DESCRIPTION
_Part of a series of PRs to get rid of globals in Spack_

The Python modules:

* `spack.util.web`
* `spack.util.s3`
* `spack.oci.opener`

read `verify_ssl`, `connect_timeout`, `ssl_certs`, `url_fetch_method` and the mirrors section from the global configuration, and kept the openers built from it in two process-wide singletons.

They now receive a `NetworkClient`, whose settings are read once by `NetworkClient.from_config()`. The client builds its URL opener on first use in each process.

`MirrorCollection` gets a `from_config()` constructor in place of its optional fallback to the global configuration.

**Out of scope (will be solved later)**
- Callers outside these modules still build the client from `spack.config.CONFIG`.
- Mirror URLs containing `$env` are still resolved against the global configuration in `spack.mirrors.mirror`, even for a client built from another configuration. 