### PR TITLE
error messages: list available compilers when none can be selected

### DIFF
--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -1801,6 +1801,19 @@ class SpackSolverSetup:
             if not data.get("buildable", True):
                 self.gen.h2(f"External package: {pkg_name}")
                 self.gen.fact(fn.buildable_false(pkg_name))
+                # Record what is on offer, so that a failure can name the external that was
+                # rejected instead of only "no externals satisfy the request": the spec as
+                # written, and its versions as written for the version-mismatch message.
+                for entry in data.get("externals", []):
+                    try:
+                        versions = spack.spec.Spec(entry["spec"]).versions
+                    except Exception:  # noqa: BLE001
+                        continue
+                    # packages_with_externals is deepcopy_as_builtin(..., line_info=True), so
+                    # each entry carries its YAML mark as line_info
+                    location = getattr(entry, "line_info", "")
+                    as_written = f"'{entry['spec']}'" + (f" from {location}" if location else "")
+                    self.gen.pkg_fact(pkg_name, fn.external_declared(as_written, str(versions)))
 
     def preferred_variants(self, pkg_name):
         """Facts on concretization preferences, as read from packages.yaml"""

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -2515,6 +2515,20 @@ class SpackSolverSetup:
         self.virtual_requirements_and_weights()
         self.external_packages(packages_with_externals)
 
+        # Compilers are never built in a solve, so these are all it can pick from. They are only
+        # used to explain a failure.
+        for c in self.possible_compilers:
+            if c.name not in self.pkgs:
+                continue
+            kind = "external" if c.external else "installed"
+            where = f"{kind} at {c.external_path}" if c.external else kind
+            offer = f"'{c.format('{name}{@version}{/hash:7}')}' ({where})"
+            self.gen.pkg_fact(c.name, fn.compiler_on_offer(offer, str(c.version), kind))
+        for c in self.rejected_compilers:
+            if c.name in self.pkgs:
+                offer = f"'{c.format('{name}{@version}')}' (external at {c.external_path})"
+                self.gen.pkg_fact(c.name, fn.compiler_rejected(offer))
+
         # TODO: make a config option for this undocumented feature
         checksummed = "SPACK_CONCRETIZER_REQUIRE_CHECKSUM" in os.environ
         self.define_package_versions_and_validate_preferences(

--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -1996,10 +1996,10 @@ language("fortran").
 language("hip-lang").
 language_runtime("fortran-rt").
 
-error(10, "Only external, or concrete, compilers are allowed for the {0} language", Language)
-  :- provider(ProviderNode, node(_, Language)),
+error(10, "Cannot build {1} as the {0} compiler: only external or installed compilers can be used", Language, Provider)
+  :- provider(node(ID, Provider), node(_, Language)),
      language(Language),
-     build(ProviderNode).
+     build(node(ID, Provider)).
 
 error(10, "{0} compiler '{2}@{3}' incompatible with 'target={1}'", Package, Target, Compiler, Version)
   :- attr("node_target", node(X, Package), Target),

--- a/lib/spack/spack/solver/display.lp
+++ b/lib/spack/spack/solver/display.lp
@@ -50,5 +50,6 @@
 #show variant_single_value/2.
 #show has_provider/1.
 #show buildable_false/1.
+#show language/1.
 
 % debug

--- a/lib/spack/spack/solver/display.lp
+++ b/lib/spack/spack/solver/display.lp
@@ -49,5 +49,6 @@
 #show imposed_nodes/2.
 #show variant_single_value/2.
 #show has_provider/1.
+#show buildable_false/1.
 
 % debug

--- a/lib/spack/spack/solver/error_messages.lp
+++ b/lib/spack/spack/solver/error_messages.lp
@@ -147,6 +147,29 @@ error(0, "'{0}' requires conflicting variant values 'Spec({1}={2})' and 'Spec({1
      condition_holds(Cause2, node(X, TriggerPkg2)),
      Value1 < Value2. % see[1] in concretize.lp
 
+% A `buildable:false` package that has to be built: name what is on offer. This line is true
+% whatever the mismatch turns out to be -- a variant or a target just as easily as a version.
+error(0, "Cannot build {0}, since it is configured `buildable:false`; the external declared for it is {1}", Package, ExternalSpec)
+  :- buildable_false(Package),
+     attr("node", node(ID, Package)),
+     build(node(ID, Package)),
+     pkg_fact(Package, external_declared(ExternalSpec, _)).
+
+% ... and when its version is the mismatch, say which constraint it failed. The version check is
+% what keeps this from blaming the version for a variant mismatch. ":" is an external declared
+% without a version, which cannot fail on it.
+error(0, "Cannot build {0}, since it is configured `buildable:false` and the external {0}@{1} does not satisfy '{0}@{2}'", Package, ExternalVersion, Constraint, startcauses, Cause, CauseID)
+  :- buildable_false(Package),
+     attr("node", node(ID, Package)),
+     build(node(ID, Package)),
+     pkg_fact(Package, external_declared(_, ExternalVersion)),
+     ExternalVersion != ":",
+     attr("node_version_satisfies", node(ID, Package), Constraint),
+     not pkg_fact(Package, version_satisfies(Constraint, ExternalVersion)),
+     pkg_fact(TriggerPkg, condition_effect(Cause, EffectID)),
+     imposed_constraint(EffectID, "node_version_satisfies", Package, Constraint),
+     condition_holds(Cause, node(CauseID, TriggerPkg)).
+
 % error message with causes for conflicts
 error(0, Msg, startcauses, TriggerID, ID1, ConstraintID, ID2)
   :- attr("node", node(ID, Package)),
@@ -209,6 +232,7 @@ pkg_fact(Package, version_satisfies(Constraint, Version)) :-
 #defined external/1.
 #defined trigger_and_effect/3.
 #defined build/1.
+#defined buildable_false/1.
 #defined node_has_variant/3.
 #defined provider/2.
 #defined variant_single_value/2.

--- a/lib/spack/spack/solver/error_messages.lp
+++ b/lib/spack/spack/solver/error_messages.lp
@@ -170,6 +170,52 @@ error(0, "Cannot build {0}, since it is configured `buildable:false` and the ext
      imposed_constraint(EffectID, "node_version_satisfies", Package, Constraint),
      condition_holds(Cause, node(CauseID, TriggerPkg)).
 
+% A compiler that would have to be built. Compilers are never built in a solve: whatever provides a
+% language must be external or installed, so this is the compiler twin of `buildable:false`, and
+% the messages name the compilers the solve could have used instead.
+compiler_to_build(node(ID, Package))
+  :- provider(node(ID, Package), node(_, Language)),
+     language(Language),
+     build(node(ID, Package)).
+
+% With `buildable:false`, the rule above already quotes the externals as written in packages.yaml.
+compiler_offer_named(Package, "external") :- buildable_false(Package).
+
+error(0, "Cannot build compiler {0}, only external or installed compilers can be used; available is {1}", Package, Offer)
+  :- compiler_to_build(node(ID, Package)),
+     pkg_fact(Package, compiler_on_offer(Offer, _, Kind)),
+     not compiler_offer_named(Package, Kind).
+
+error(0, "Cannot build compiler {0}, only external or installed compilers can be used, and none are available", Package)
+  :- compiler_to_build(node(ID, Package)),
+     not pkg_fact(Package, compiler_on_offer(_, _, _)).
+
+error(0, "Ignored compiler {1}: it is configured, but failed the sanity checks (run with `spack -d` for details)", Package, Offer)
+  :- compiler_to_build(node(ID, Package)),
+     pkg_fact(Package, compiler_rejected(Offer)).
+
+% ... and when the version is the mismatch, say which constraint it failed and who asked for it.
+% The constraint is imposed on the compiler node itself, or on a direct dependency, which is how
+% `%gcc@11.4.0` is encoded.
+compiler_version_cause(Package, Constraint, Cause, CauseID)
+  :- compiler_to_build(node(_, Package)),
+     pkg_fact(TriggerPkg, condition_effect(Cause, EffectID)),
+     imposed_constraint(EffectID, "node_version_satisfies", Package, Constraint),
+     condition_holds(Cause, node(CauseID, TriggerPkg)).
+
+compiler_version_cause(Package, Constraint, Cause, CauseID)
+  :- compiler_to_build(node(_, Package)),
+     pkg_fact(TriggerPkg, condition_effect(Cause, EffectID)),
+     imposed_constraint(EffectID, "direct_dependency", _, node_requirement("node_version_satisfies", Package, Constraint)),
+     condition_holds(Cause, node(CauseID, TriggerPkg)).
+
+error(0, "Cannot use compiler {1}, since it does not satisfy '{0}@{2}'", Package, Offer, Constraint, startcauses, Cause, CauseID)
+  :- compiler_to_build(node(ID, Package)),
+     pkg_fact(Package, compiler_on_offer(Offer, Version, _)),
+     attr("node_version_satisfies", node(ID, Package), Constraint),
+     not pkg_fact(Package, version_satisfies(Constraint, Version)),
+     compiler_version_cause(Package, Constraint, Cause, CauseID).
+
 % error message with causes for conflicts
 error(0, Msg, startcauses, TriggerID, ID1, ConstraintID, ID2)
   :- attr("node", node(ID, Package)),
@@ -233,6 +279,7 @@ pkg_fact(Package, version_satisfies(Constraint, Version)) :-
 #defined trigger_and_effect/3.
 #defined build/1.
 #defined buildable_false/1.
+#defined language/1.
 #defined node_has_variant/3.
 #defined provider/2.
 #defined variant_single_value/2.

--- a/lib/spack/spack/test/concretization/errors.py
+++ b/lib/spack/spack/test/concretization/errors.py
@@ -348,6 +348,35 @@ def test_buildable_false_names_the_external_on_a_variant_mismatch(
     assert "does not satisfy" not in str(exc_info.value)
 
 
+def test_unavailable_compiler_names_the_compilers_on_offer(mock_packages, config):
+    """Compilers are never built, so asking for a compiler version that is neither external nor
+    installed must name the ones that are, and who asked for the missing one."""
+    with pytest.raises(spack.error.SpackError) as exc_info:
+        spack.concretize.concretize_one("callpath %gcc@12.1.0")
+    assert_actionable_error(
+        exc_info,
+        "Cannot build gcc as the c compiler",
+        "Cannot use compiler 'gcc@10.2.1",
+        "does not satisfy 'gcc@12.1.0'",
+        "required because callpath %gcc@12.1.0 requested explicitly",
+        "available is 'gcc@10.2.1",
+    )
+
+
+def test_unavailable_compiler_with_buildable_false_names_the_external_once(
+    mock_packages, mutable_config: Configuration
+):
+    """With `buildable: false` the external is already quoted as written in packages.yaml, so it
+    must not be listed a second time as available."""
+    mutable_config.set("packages:gcc:buildable", False)
+    with pytest.raises(spack.error.SpackError) as exc_info:
+        spack.concretize.concretize_one("callpath %gcc@12.1.0")
+    assert_actionable_error(
+        exc_info, "the external declared for it is 'gcc@10.2.1", "does not satisfy 'gcc@12.1.0'"
+    )
+    assert "available is" not in str(exc_info.value)
+
+
 @pytest.mark.parametrize(
     "input_spec,expected_handles",
     [

--- a/lib/spack/spack/test/concretization/errors.py
+++ b/lib/spack/spack/test/concretization/errors.py
@@ -316,6 +316,38 @@ def test_config_driven_errors(
     assert_actionable_error(exc_info, *expected_parts)
 
 
+def test_buildable_false_names_the_external_and_the_constraint(
+    mock_packages, mutable_config: Configuration
+):
+    """`buildable: false` with an external that is too old must name the external on offer and
+    the constraint it failed, not just "no externals satisfy the request"."""
+    mutable_config.set(
+        "packages:libelf",
+        {"buildable": False, "externals": [{"spec": "libelf@0.8.10", "prefix": "/usr"}]},
+    )
+    with pytest.raises(spack.error.SpackError) as exc_info:
+        spack.concretize.concretize_one("libelf@0.8.13:")
+    assert_actionable_error(exc_info, "libelf@0.8.10", "0.8.13:")
+
+
+def test_buildable_false_names_the_external_on_a_variant_mismatch(
+    mock_packages, mutable_config: Configuration
+):
+    """When the external fails on something other than its version, the message must still name
+    it, and must not claim the version is at fault."""
+    mutable_config.set(
+        "packages:quantum-espresso",
+        {
+            "buildable": False,
+            "externals": [{"spec": "quantum-espresso@1.0~veritas", "prefix": "/u"}],
+        },
+    )
+    with pytest.raises(spack.error.SpackError) as exc_info:
+        spack.concretize.concretize_one("quantum-espresso+veritas")
+    assert_actionable_error(exc_info, "quantum-espresso@1.0~veritas")
+    assert "does not satisfy" not in str(exc_info.value)
+
+
 @pytest.mark.parametrize(
     "input_spec,expected_handles",
     [


### PR DESCRIPTION
(note: unfiltered llm content)

Compilers are never built in a solve: whatever provides a language must be
external or installed. Asking for one that is neither, as in

    $ spack spec boost %gcc@11.4.0     # with only gcc@11.5.0 available

said only

    1. Only external, or concrete, compilers are allowed for the cxx language
    2. Only external, or concrete, compilers are allowed for the c language

which names neither the compiler nor the version, and depending on the rest of
the configuration the solver could settle on something even less related, like
'Cannot select a single "version" for package "gcc"'. Now:

    1. Cannot build gcc as the cxx compiler: only external or installed compilers can be used
    2. Cannot build gcc as the c compiler: only external or installed compilers can be used
    3. Cannot use compiler 'gcc@11.5.0/qkcujen' (installed), since it does not satisfy 'gcc@11.4.0'
       required because boost@1.81.0 %gcc@11.4.0 requested explicitly
    4. Cannot build compiler gcc, only external or installed compilers can be used; available is 'gcc@11.5.0/qkcujen' (installed)

This is the compiler twin of the `buildable:false` message: the compilers the
solve can pick from (externals, the local store, and reused specs) are
recorded as facts, and the lines naming them are in error_messages.lp, so they
run on the failing model only and do not affect the main solve. Compilers that
were configured but failed the sanity checks are listed as ignored.

With `buildable:false` on the compiler, the external is already quoted as
written in packages.yaml, so it is not listed a second time.

