### PR TITLE
bin/spack: skip garbage collection at exit

### DIFF
--- a/bin/spack
+++ b/bin/spack
@@ -24,6 +24,8 @@ exit 1
 # Line above is a shell no-op, and ends a python multi-line comment.
 # The code above runs this file with our preferred python interpreter.
 
+import atexit
+import gc
 import os
 import sys
 
@@ -46,4 +48,7 @@ from spack.main import main  # noqa: E402
 
 # Once we've set up the system path, run the spack main method
 if __name__ == "__main__":
+    # Skip the costly garbage collection of all objects at interpreter shutdown
+    if hasattr(gc, "freeze"):  # Python 3.7+
+        atexit.register(gc.freeze)
     sys.exit(main())


### PR DESCRIPTION
Spack spends lot of time exiting, which is something you can better leave to
the kernel.

Calling `gc.freeze()` from an atexit handler moves all objects to the
permanent generation, so shutdown skips collecting them. Unlike
`os._exit`, atexit handlers, `weakref.finalize` callbacks and flushing
of stdout/stderr still happen. What is skipped are finalizers of objects
that are alive at exit or part of uncollected cycles, which [Python does
not guarantee][1] to run anyway.

Median of 10 runs, with `spack spec` on a concretizer cache hit:

```
spack --version       0.206s -> 0.175s  (-14.9%)
spack list            0.382s -> 0.328s  (-14.0%)
spack find            0.274s -> 0.221s  (-19.2%)
spack info trilinos   0.449s -> 0.401s  (-10.8%)
spack spec trilinos   5.353s -> 4.714s  (-11.9%)
```

[1]: https://docs.python.org/3/reference/datamodel.html#object.__del__