### PR TITLE
lock.py: fall back to read-only open on EROFS

### DIFF
--- a/lib/spack/spack/test/util/lock_unix.py
+++ b/lib/spack/spack/test/util/lock_unix.py
@@ -584,6 +584,31 @@ def test_read_lock_on_read_only_lockfile(lock_dir, lock_path):
                 pass
 
 
+def test_read_lock_on_read_only_filesystem(tmp_path: pathlib.Path, monkeypatch):
+    """A read lock still succeeds when open() fails with EROFS (read-only filesystem)."""
+    lockfile = tmp_path / "lockfile"
+    touch(str(lockfile))
+
+    real_open = os.open
+
+    def _open(path, flags, *args, **kwargs):
+        if path == str(lockfile) and (flags & os.O_RDWR):
+            raise OSError(errno.EROFS, "Read-only file system")
+        return real_open(path, flags, *args, **kwargs)
+
+    monkeypatch.setattr(os, "open", _open)
+
+    lock = lk.Lock(str(lockfile))
+
+    with lk.ReadTransaction(lock):
+        pass
+    assert lock.backend._file_ref.fh.mode == "rb"
+
+    with pytest.raises(lk.LockROFileError):
+        with lk.WriteTransaction(lock):
+            pass
+
+
 def test_read_lock_read_only_dir_writable_lockfile(lock_dir, lock_path):
     """read-only directory, writable lockfile."""
     touch(lock_path)

--- a/lib/spack/spack/test/util/lock_unix.py
+++ b/lib/spack/spack/test/util/lock_unix.py
@@ -602,6 +602,8 @@ def test_read_lock_on_read_only_filesystem(tmp_path: pathlib.Path, monkeypatch):
 
     with lk.ReadTransaction(lock):
         pass
+    assert isinstance(lock.backend, lk.PosixBackend)
+    assert lock.backend._file_ref is not None
     assert lock.backend._file_ref.fh.mode == "rb"
 
     with pytest.raises(lk.LockROFileError):

--- a/lib/spack/spack/util/lock.py
+++ b/lib/spack/spack/util/lock.py
@@ -100,7 +100,7 @@ class OpenFileTracker:
             except OSError as e:
                 # fall back to read only open if there's no write perms to the file (EACCES/EPERM)
                 # or if the filesystem is read only (EROFS)
-                if e.errno not in (errno.EACCES, errno.EPERM, errno.EROFS):
+                if e.errno not in (errno.EACCES, errno.EPERM, errno.EROFS, getattr(errno, "ENOTCAPABLE", errno.EACCES):
                     raise
                 fd = os.open(path, os.O_RDONLY)
                 mode = "rb"

--- a/lib/spack/spack/util/lock.py
+++ b/lib/spack/spack/util/lock.py
@@ -100,7 +100,7 @@ class OpenFileTracker:
             except OSError as e:
                 # fall back to read only open if there's no write perms to the file (EACCES/EPERM)
                 # or if the filesystem is read only (EROFS)
-                if e.errno not in (errno.EACCES, errno.EPERM, errno.EROFS, getattr(errno, "ENOTCAPABLE", errno.EACCES):
+                if e.errno not in (errno.EACCES, errno.EPERM, errno.EROFS, getattr(errno, "ENOTCAPABLE", errno.EACCES)):
                     raise
                 fd = os.open(path, os.O_RDONLY)
                 mode = "rb"

--- a/lib/spack/spack/util/lock.py
+++ b/lib/spack/spack/util/lock.py
@@ -100,7 +100,12 @@ class OpenFileTracker:
             except OSError as e:
                 # fall back to read only open if there's no write perms to the file (EACCES/EPERM)
                 # or if the filesystem is read only (EROFS)
-                if e.errno not in (errno.EACCES, errno.EPERM, errno.EROFS, getattr(errno, "ENOTCAPABLE", errno.EACCES)):
+                if e.errno not in (
+                    errno.EACCES,
+                    errno.EPERM,
+                    errno.EROFS,
+                    getattr(errno, "ENOTCAPABLE", errno.EACCES),
+                ):
                     raise
                 fd = os.open(path, os.O_RDONLY)
                 mode = "rb"

--- a/lib/spack/spack/util/lock.py
+++ b/lib/spack/spack/util/lock.py
@@ -97,7 +97,11 @@ class OpenFileTracker:
             try:
                 fd = os.open(path, os.O_RDWR | os.O_CREAT)
                 mode = "rb+"
-            except PermissionError:
+            except OSError as e:
+                # fall back to read only open if there's no write perms to the file (EACCES/EPERM)
+                # or if the filesystem is read only (EROFS)
+                if e.errno not in (errno.EACCES, errno.EPERM, errno.EROFS):
+                    raise
                 fd = os.open(path, os.O_RDONLY)
                 mode = "rb"
         except OSError as e:


### PR DESCRIPTION
Locking on a read only FS crashes with an OSError (read only file system)

The current path in lock.py only falls back to a read only open upon EACCS/EPERM, allowing EROFS to fall through the cracks.

pr #51996 added improvements to locking, but broke the ROFS use case b/c PermissionError doesn't encapsulate EROFS.

fixes #53018

cc @eugeneswalker 